### PR TITLE
feat: add api mode to opencode runner with go/zen subscriptions

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -28,25 +28,57 @@ runners:
       #   claude-opus-4-8: claude-4-20250514
       #   claude-sonnet-4-6: claude-3-5-sonnet-20241022
 
-  # OpenCode CLI runner (invokes opencode as a subprocess)
-  # Requires opencode to be installed and authenticated on the host machine.
-  - id: my-opencode
+  # ── OpenCode runners ────────────────────────────────────────────────────────
+  # OpenCode has two subscription tiers (Go and Zen), each available in two
+  # execution modes (CLI and API). Choose the combination that fits your setup.
+  #
+  #   CLI mode:   invokes the opencode binary as a subprocess.
+  #               Requires opencode installed on the host.
+  #
+  #   API mode:   calls the opencode HTTP API directly.
+  #               Requires an API key from the respective subscription.
+
+  # OpenCode Go — CLI mode (uses the local opencode binary with Go subscription)
+  - id: opencode-go-cli
     type: opencode
     config:
-      # Path to the opencode binary (default: "opencode")
+      mode: cli
+      subscription: go
       binary: opencode
-      # Which opencode agent profile to use (optional)
       agent: backend-dev
-      # Flag to pass the model name (default: "--model")
       model_flag: --model
-      # Flag to pass the prompt text (default: "--prompt")
       prompt_flag: --prompt
-      # Flag for max turns (default: "--max-turns")
       turns_flag: --max-turns
-      # Flag to select an agent (default: "--agent")
       agent_flag: --agent
-      # Additional static arguments (optional)
-      extra_args: []
+
+  # OpenCode Go — API mode (calls the Go API directly)
+  - id: opencode-go-api
+    type: opencode
+    config:
+      mode: api
+      subscription: go
+      api_key: ${OPENCODE_GO_API_KEY}
+
+  # OpenCode Zen — CLI mode (uses the local opencode binary with Zen subscription)
+  - id: opencode-zen-cli
+    type: opencode
+    config:
+      mode: cli
+      subscription: zen
+      binary: opencode
+      agent: backend-dev
+      model_flag: --model
+      prompt_flag: --prompt
+      turns_flag: --max-turns
+      agent_flag: --agent
+
+  # OpenCode Zen — API mode (calls the Zen API directly)
+  - id: opencode-zen-api
+    type: opencode
+    config:
+      mode: api
+      subscription: zen
+      api_key: ${OPENCODE_ZEN_API_KEY}
 
 # Default runner used by agents if not overridden
 default_runner: claude-cli
@@ -110,12 +142,33 @@ agents:
     preferred_models: [claude-sonnet-4-6, claude-haiku-4-5]
     skills: [e2e-before-pr, changelog-contexto]
 
-  # === OpenCode-based agent ===
-  - id: agent-opencode
-    description: "OpenCode agent — runs tasks via the opencode CLI"
+  # === OpenCode-based agents ===
+  - id: agent-go-cli
+    description: "OpenCode Go — runs tasks via the opencode CLI"
     soul_file: .apiary/souls/engineer.md
-    runner: my-opencode
-    preferred_models: [openai/gpt-4o, deepseek/deepseek-chat]
+    runner: opencode-go-cli
+    preferred_models: [opencode-go/deepseek-v4-flash, opencode-go/kimi-k2.5]
+    skills: [git-workflow, gitnexus-codebase]
+
+  - id: agent-go-api
+    description: "OpenCode Go — runs tasks via the Go API"
+    soul_file: .apiary/souls/engineer.md
+    runner: opencode-go-api
+    preferred_models: [opencode-go/deepseek-v4-pro, opencode-go/minimax-m3]
+    skills: [git-workflow, gitnexus-codebase]
+
+  - id: agent-zen-cli
+    description: "OpenCode Zen — runs tasks via the opencode CLI"
+    soul_file: .apiary/souls/engineer.md
+    runner: opencode-zen-cli
+    preferred_models: [opencode/gpt-5.5, opencode/claude-sonnet-4-6]
+    skills: [git-workflow, gitnexus-codebase]
+
+  - id: agent-zen-api
+    description: "OpenCode Zen — runs tasks via the Zen API"
+    soul_file: .apiary/souls/engineer.md
+    runner: opencode-zen-api
+    preferred_models: [opencode/gpt-5.4, opencode/claude-opus-4.8]
     skills: [git-workflow, gitnexus-codebase]
 
 # ── Routes ─────────────────────────────────────────────────────────────────────

--- a/src/internal/runner/opencode/runner.go
+++ b/src/internal/runner/opencode/runner.go
@@ -4,7 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,7 +22,25 @@ func init() {
 	runner.Register("opencode", func() runner.Adapter { return &Runner{} })
 }
 
+type Mode string
+
+const (
+	ModeCLI Mode = "cli"
+	ModeAPI Mode = "api"
+)
+
+type Subscription string
+
+const (
+	SubGo  Subscription = "go"
+	SubZen Subscription = "zen"
+)
+
 type Runner struct {
+	mode         Mode
+	subscription Subscription
+
+	// CLI mode fields
 	binary     string
 	agent      string
 	modelFlag  string
@@ -28,11 +49,43 @@ type Runner struct {
 	agentFlag  string
 	skillFlag  string
 	extraArgs  []string
+
+	// API mode fields
+	apiKey     string
+	apiBaseURL string
 }
 
 func (r *Runner) ID() string { return "opencode" }
 
 func (r *Runner) Configure(config map[string]any) error {
+	mode, _ := config["mode"].(string)
+	switch mode {
+	case "api":
+		r.mode = ModeAPI
+	case "", "cli":
+		r.mode = ModeCLI
+	default:
+		return fmt.Errorf("opencode runner: invalid mode %q (expected cli or api)", mode)
+	}
+
+	sub, _ := config["subscription"].(string)
+	switch sub {
+	case "go":
+		r.subscription = SubGo
+	case "zen":
+		r.subscription = SubZen
+	case "", "cli":
+	default:
+		return fmt.Errorf("opencode runner: invalid subscription %q (expected go or zen)", sub)
+	}
+
+	if r.mode == ModeCLI {
+		return r.configureCLI(config)
+	}
+	return r.configureAPI(config)
+}
+
+func (r *Runner) configureCLI(config map[string]any) error {
 	if v, ok := config["binary"].(string); ok && v != "" {
 		r.binary = v
 	} else {
@@ -84,9 +137,38 @@ func (r *Runner) Configure(config map[string]any) error {
 	return nil
 }
 
-func (r *Runner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
-	start := time.Now()
+func (r *Runner) configureAPI(config map[string]any) error {
+	key, ok := config["api_key"].(string)
+	if !ok || key == "" {
+		return fmt.Errorf("opencode runner: config.api_key is required in api mode")
+	}
+	r.apiKey = key
 
+	switch r.subscription {
+	case SubGo:
+		r.apiBaseURL = "https://opencode.ai/zen/go/v1"
+	case SubZen:
+		r.apiBaseURL = "https://opencode.ai/zen/v1"
+	default:
+		return fmt.Errorf("opencode runner: subscription %q requires api_key", r.subscription)
+	}
+
+	if v, ok := config["base_url"].(string); ok && v != "" {
+		r.apiBaseURL = v
+	}
+
+	return nil
+}
+
+func (r *Runner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	if r.mode == ModeCLI {
+		return r.runCLI(ctx, req)
+	}
+	return r.runAPI(ctx, req)
+}
+
+func (r *Runner) runCLI(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	start := time.Now()
 	prompt := buildPrompt(req)
 
 	argv := []string{}
@@ -95,22 +177,18 @@ func (r *Runner) Run(ctx context.Context, req model.RunRequest) (model.RunResult
 	if r.agentFlag != "" && r.agent != "" {
 		argv = append(argv, r.agentFlag, r.agent)
 	}
-
 	if r.modelFlag != "" && req.Model != "" {
 		argv = append(argv, r.modelFlag, req.Model)
 	}
-
 	if r.turnsFlag != "" && req.MaxTurns > 0 {
 		argv = append(argv, r.turnsFlag, fmt.Sprintf("%d", req.MaxTurns))
 	}
-
 	if r.promptFlag != "" {
 		argv = append(argv, r.promptFlag, prompt)
 	}
 
 	cmd := exec.CommandContext(ctx, r.binary, argv...)
 	cmd.Dir = req.WorkingDir
-
 	cmd.Env = os.Environ()
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
@@ -181,7 +259,6 @@ func (r *Runner) Run(ctx context.Context, req model.RunRequest) (model.RunResult
 	runErr := cmd.Wait()
 
 	output := strings.TrimSpace(outBuf.String())
-
 	result := model.RunResult{
 		WorkerID: req.WorkerID,
 		Success:  runErr == nil,
@@ -200,6 +277,155 @@ func (r *Runner) Run(ctx context.Context, req model.RunRequest) (model.RunResult
 	}
 
 	return result, nil
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Temperature float64       `json:"temperature,omitempty"`
+}
+
+type chatResponse struct {
+	ID      string       `json:"id"`
+	Choices []chatChoice `json:"choices"`
+	Usage   *chatUsage   `json:"usage,omitempty"`
+	Error   *chatError   `json:"error,omitempty"`
+}
+
+type chatChoice struct {
+	Index   int         `json:"index"`
+	Message chatMessage `json:"message"`
+}
+
+type chatUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type chatError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+}
+
+func (r *Runner) runAPI(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	start := time.Now()
+	prompt := buildPrompt(req)
+
+	modelID := r.resolveModelID(req.Model)
+
+	messages := []chatMessage{
+		{Role: "system", Content: "You are an AI coding agent. Complete the following task based on the instructions provided."},
+		{Role: "user", Content: prompt},
+	}
+
+	if req.SystemAppend != "" {
+		messages[0].Content += "\n\n" + req.SystemAppend
+	}
+
+	body := chatRequest{
+		Model:     modelID,
+		Messages:  messages,
+		MaxTokens: req.MaxTurns * 4096,
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return model.RunResult{}, fmt.Errorf("opencode runner: marshal request: %w", err)
+	}
+
+	apiURL := r.apiBaseURL + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(raw))
+	if err != nil {
+		return model.RunResult{}, fmt.Errorf("opencode runner: create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+r.apiKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return model.RunResult{}, fmt.Errorf("opencode runner: api request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respRaw, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return model.RunResult{}, fmt.Errorf("opencode runner: read response: %w", err)
+	}
+
+	var resp chatResponse
+	if err := json.Unmarshal(respRaw, &resp); err != nil {
+		return model.RunResult{}, fmt.Errorf("opencode runner: parse response: %w", err)
+	}
+
+	if resp.Error != nil {
+		return model.RunResult{
+			WorkerID: req.WorkerID,
+			Success:  false,
+			Duration: time.Since(start),
+			Error:    fmt.Errorf("opencode api: %s (%s)", resp.Error.Message, resp.Error.Type),
+		}, nil
+	}
+
+	var logs []model.LogEntry
+	emit := func(level, msg string) {
+		entry := model.LogEntry{Level: level, Message: msg, Timestamp: time.Now()}
+		logs = append(logs, entry)
+		if req.LogSink != nil {
+			req.LogSink(entry)
+		}
+	}
+
+	emit("debug", fmt.Sprintf("POST %s model=%s", apiURL, modelID))
+
+	var output string
+	for _, choice := range resp.Choices {
+		if choice.Message.Content != "" {
+			output += choice.Message.Content
+			emit("assistant", choice.Message.Content)
+		}
+	}
+
+	if resp.Usage != nil {
+		emit("debug", fmt.Sprintf("tokens: %d prompt + %d completion = %d total",
+			resp.Usage.PromptTokens, resp.Usage.CompletionTokens, resp.Usage.TotalTokens))
+	}
+
+	result := model.RunResult{
+		WorkerID: req.WorkerID,
+		Success:  true,
+		Output:   strings.TrimSpace(output),
+		Logs:     logs,
+		Duration: time.Since(start),
+	}
+
+	if httpResp.StatusCode >= 400 {
+		result.Success = false
+		result.Error = fmt.Errorf("opencode api: HTTP %d", httpResp.StatusCode)
+	}
+
+	return result, nil
+}
+
+func (r *Runner) resolveModelID(model string) string {
+	if model == "" {
+		return "default"
+	}
+
+	parts := strings.SplitN(model, "/", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+
+	return model
 }
 
 func buildPrompt(req model.RunRequest) string {


### PR DESCRIPTION
## Summary
- Refactor opencode runner to support `mode: cli` and `mode: api`
- Each mode works with both subscription tiers (`go` and `zen`)
- API mode calls `/chat/completions` (OpenAI-compatible) directly
- Model ID prefixes (`opencode-go/`, `opencode/`) are stripped automatically

## Configuration matrix
| | CLI | API |
|---|---|---|
| **Go** | `opencode-go-cli` | `opencode-go-api` |
| **Zen** | `opencode-zen-cli` | `opencode-zen-api` |

## Test plan
- [x] Build succeeds
- [ ] Example config validates against schema