### PR TITLE
fix: use issues/uuid URL for plane links

### DIFF
--- a/src/internal/source/plane/adapter.go
+++ b/src/internal/source/plane/adapter.go
@@ -395,7 +395,7 @@ func (a *Adapter) toCell(item workItem) model.Cell {
 		Labels:      labels,
 		Priority:    item.Priority,
 		State:       a.stateIDToName[item.State],
-		URL:         fmt.Sprintf("%s/%s/projects/%s/work-items/%d/", a.webBaseURL, a.workspace, a.project, item.SequenceID),
+		URL:         fmt.Sprintf("%s/%s/projects/%s/issues/%s/", a.webBaseURL, a.workspace, a.project, item.ID),
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 	}

--- a/src/internal/source/plane/adapter_test.go
+++ b/src/internal/source/plane/adapter_test.go
@@ -144,8 +144,8 @@ func TestToCell_MapsFields(t *testing.T) {
 	if len(cell.Labels) != 2 {
 		t.Errorf("Labels len = %d, want 2", len(cell.Labels))
 	}
-	if !strings.Contains(cell.URL, "42") {
-		t.Errorf("URL %q should contain sequence id 42", cell.URL)
+	if !strings.Contains(cell.URL, "item-uuid") {
+		t.Errorf("URL %q should contain issue uuid", cell.URL)
 	}
 	if cell.CreatedAt.IsZero() {
 		t.Error("CreatedAt should not be zero")


### PR DESCRIPTION
## Summary
- Fix the URL generated for plane issue links in `toCell`
- Changed from `work-items/{sequence_id}` to `issues/{uuid}`
- Updated the test assertion to match the new URL format

Fixes the `o` key in the dashboard opening wrong URLs.