### PR TITLE
fix: agent task logs header shows task ID instead of number and title

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -67,6 +67,7 @@ type agentActivityMsg struct {
 type agentTaskLogsMsg struct {
 	taskID string
 	logs   []LogEntry
+	detail *TaskItem
 }
 type logsDataMsg struct{ logs []LogEntry }
 
@@ -153,6 +154,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case agentTaskLogsMsg:
 		if a.model.agentsTab != nil {
 			a.model.agentsTab.LogsTaskID = msg.taskID
+			a.model.agentsTab.LogsTask = msg.detail
 			a.model.agentsTab.TaskLogs = msg.logs
 			a.model.agentsTab.TaskLogIdx = 0
 			a.model.agentsTab.View = AgentViewTaskLogs
@@ -702,8 +704,26 @@ func (a *App) fetchAgentTaskLogs(taskID string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
 
+		var detail *TaskItem
 		logs := make([]LogEntry, 0)
 		if dbConn != nil {
+			if r, err := dbConn.GetTaskDetail(ctx, taskID); err == nil && r != nil {
+				detail = &TaskItem{
+					TaskID:      r.TaskID,
+					Number:      r.Number,
+					URL:         r.URL,
+					Title:       r.Title,
+					Agent:       r.AgentID,
+					Model:       r.Model,
+					Runner:      r.Runner,
+					Status:      r.Status,
+					Attempt:     r.Attempt,
+					Duration:    time.Duration(r.DurationMs) * time.Millisecond,
+					StartedAt:   r.StartedAt,
+					CompletedAt: r.CompletedAt,
+					Error:       r.Error,
+				}
+			}
 			if rows, err := dbConn.GetTaskLogs(ctx, taskID, 5000); err == nil {
 				for _, l := range rows {
 					logs = append(logs, LogEntry{
@@ -714,7 +734,7 @@ func (a *App) fetchAgentTaskLogs(taskID string) tea.Cmd {
 				}
 			}
 		}
-		return agentTaskLogsMsg{taskID: taskID, logs: logs}
+		return agentTaskLogsMsg{taskID: taskID, logs: logs, detail: detail}
 	}
 }
 
@@ -1386,6 +1406,9 @@ func (a *App) renderAgentActivity(ag *AgentsTab, height int) string {
 // agent's activity list — the same view the Tasks tab offers.
 func (a *App) renderAgentTaskLogs(ag *AgentsTab, height int) string {
 	title := "TASK LOGS — " + valueOr(ag.LogsTaskID, "")
+	if ag.LogsTask != nil {
+		title = taskDetailLabel(ag.LogsTask)
+	}
 	if len(ag.TaskLogs) == 0 {
 		return a.box(title, StyleMuted.Render("No logs recorded for this task.")+"\n", height)
 	}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -93,6 +93,7 @@ type AgentsTab struct {
 
 	// Drill-down: logs of the task selected in the activity list.
 	LogsTaskID string
+	LogsTask   *TaskItem   // task detail for the logs header
 	TaskLogs   []LogEntry
 	TaskLogIdx int // vertical scroll within TaskLogs (visual lines)
 }


### PR DESCRIPTION
## Summary
- Add `LogsTask` field to `AgentsTab` to hold task detail
- `fetchAgentTaskLogs` now fetches task detail alongside logs
- `renderAgentTaskLogs` uses `taskDetailLabel` for the header

## Test plan
- [x] Build succeeds