### PR TITLE
feat: add force-restart for stale tasks

### DIFF
--- a/src/internal/cli/dashboard_cmd.go
+++ b/src/internal/cli/dashboard_cmd.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
 	"github.com/orlandoburli/apiary/internal/dashboard"
 	"github.com/orlandoburli/apiary/internal/db"
 )
@@ -37,7 +39,8 @@ func runDashboard(ctx context.Context) error {
 	}
 	defer dbConn.Close()
 
-	app := dashboard.New(dbConn)
+	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	app := dashboard.New(dbConn, socketPath)
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("dashboard error: %w", err)
 	}

--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+func newRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart <cell-id>",
+		Short: "Force-restart a stale task",
+		Long: `Kill the running dispatch for the given cell, reset its state, and 
+re-queue it so the next poll picks it up again.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cellID := strings.TrimSpace(args[0])
+			if cellID == "" {
+				return fmt.Errorf("cell id is required")
+			}
+
+			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			transport := &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+				},
+			}
+			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+
+			url := fmt.Sprintf("http://apiary/restart/%s", cellID)
+			resp, err := client.Post(url, "application/json", nil)
+			if err != nil {
+				return fmt.Errorf("cannot reach daemon: %w", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("restart failed: HTTP %d", resp.StatusCode)
+			}
+
+			fmt.Printf("✓ Restarted cell %s\n", cellID)
+			return nil
+		},
+	}
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -48,6 +48,7 @@ func init() {
 		newServiceCmd(),
 		newInitCmd(),
 		newVersionCmd(),
+		newRestartCmd(),
 	)
 }
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -63,6 +63,7 @@ type Dispatcher struct {
 	active     atomic.Int32  // number of goroutines currently running
 	inFlight   sync.Map      // cell id → struct{}: prevents double-dispatch
 	activeRuns sync.Map      // run id → model.ActiveRun
+	runCancel  sync.Map      // cell id → context.CancelFunc: cancel running dispatch
 	retryQueue sync.Map      // cell id → retryQueueEntry: cells pending retry
 
 	stats  map[string]*sourceStat // source id → stats
@@ -402,6 +403,63 @@ func (d *Dispatcher) Status() StatusResponse {
 	return resp
 }
 
+// ForceRestart cancels a running dispatch for the given cell, removes it from
+// tracking maps, marks the execution as interrupted in the DB, and resets the
+// source state so the cell can be picked up on the next poll.
+func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
+	// Cancel the running dispatch, if any
+	if val, ok := d.runCancel.LoadAndDelete(cellID); ok {
+		cancel := val.(context.CancelFunc)
+		cancel()
+	}
+
+	// Remove from in-flight tracking so the cell can be re-dispatched
+	d.inFlight.Delete(cellID)
+
+	// Remove from active runs
+	d.activeRuns.Range(func(key, val any) bool {
+		run := val.(model.ActiveRun)
+		if run.Cell.ID == cellID {
+			d.activeRuns.Delete(key)
+		}
+		return true
+	})
+
+	// Release one semaphore slot if the task was running
+	select {
+	case <-d.sem:
+		d.active.Add(-1)
+	default:
+	}
+
+	// Mark the running execution as interrupted in DB
+	if d.db != nil {
+		lastExec, err := d.db.GetLastExecution(ctx, cellID)
+		if err == nil && lastExec != nil && lastExec.Status == "running" {
+			now := time.Now()
+			lastExec.Status = "interrupted"
+			lastExec.CompletedAt = &now
+			lastExec.ErrorMsg = "force-restarted by user"
+			_ = d.db.UpdateExecution(ctx, lastExec)
+		}
+
+		// Reset task state so it can be re-dispatched
+		_ = d.db.UpdateTaskState(ctx, cellID, "pending")
+	}
+
+	// Reset the source state (set back to todo) so the next poll picks it up
+	for _, sc := range d.cfg.Sources {
+		if adapter, ok := d.sources[sc.ID]; ok {
+			if ss, ok := adapter.(source.StateSetter); ok {
+				_ = ss.SetState(ctx, model.Cell{ID: cellID}, "todo")
+			}
+		}
+	}
+
+	aplog.Info("force-restarted cell %s", cellID)
+	return nil
+}
+
 // StartServer starts an HTTP server on the Unix socket for IPC.
 // It removes any stale socket file before binding.
 func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error {
@@ -423,6 +481,18 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		_ = json.NewEncoder(w).Encode(d.Status())
 	})
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/restart/", func(w http.ResponseWriter, r *http.Request) {
+		cellID := strings.TrimPrefix(r.URL.Path, "/restart/")
+		if cellID == "" {
+			http.Error(w, "missing cell id", http.StatusBadRequest)
+			return
+		}
+		if err := d.ForceRestart(ctx, cellID); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -641,7 +711,11 @@ func (d *Dispatcher) dispatch(ctx context.Context, cell model.Cell, adapter sour
 	}
 
 	runCtx, cancel := context.WithTimeout(ctx, req.Timeout)
-	defer cancel()
+	d.runCancel.Store(cell.ID, cancel)
+	defer func() {
+		cancel()
+		d.runCancel.Delete(cell.ID)
+	}()
 
 	// Track execution attempt in database
 	var exec *db.Execution

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -3,6 +3,8 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -28,15 +30,17 @@ const queryTimeout = 2 * time.Second
 // event-loop goroutine) is allowed to mutate the model. This is what keeps
 // the data-fetching goroutines from racing with View.
 type App struct {
-	model  *Model
-	dbConn *db.Client
+	model      *Model
+	dbConn     *db.Client
+	socketPath string
 }
 
 // New creates a new dashboard app backed by the given database client.
-func New(dbConn *db.Client) *App {
+func New(dbConn *db.Client, socketPath string) *App {
 	return &App{
-		model:  NewModel(),
-		dbConn: dbConn,
+		model:      NewModel(),
+		dbConn:     dbConn,
+		socketPath: socketPath,
 	}
 }
 
@@ -184,6 +188,14 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if key == "o" {
 		if u, ok := a.focusedTaskURL(); ok {
 			return a, openURLCmd(u)
+		}
+		return a, nil
+	}
+
+	// Force-restart the focused task: cancel and re-dispatch.
+	if key == "R" {
+		if id, ok := a.focusedTaskID(); ok {
+			return a, a.restartTaskCmd(id)
 		}
 		return a, nil
 	}
@@ -563,6 +575,54 @@ func (a *App) focusedTaskURL() (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// focusedTaskID returns the task ID the user is currently focused on.
+func (a *App) focusedTaskID() (string, bool) {
+	switch a.model.ActiveTab() {
+	case "Tasks":
+		t := a.model.tasksTab
+		if t == nil {
+			return "", false
+		}
+		if t.View == TaskViewDetail && t.Detail != nil {
+			return t.Detail.TaskID, true
+		}
+		if t.SelectedIdx >= 0 && t.SelectedIdx < len(t.History) {
+			return t.History[t.SelectedIdx].TaskID, true
+		}
+	case "Agents":
+		ag := a.model.agentsTab
+		if ag == nil {
+			return "", false
+		}
+		if ag.View == AgentViewActivity || ag.View == AgentViewTaskLogs {
+			if ag.ActivityIdx >= 0 && ag.ActivityIdx < len(ag.Activity) {
+				return ag.Activity[ag.ActivityIdx].TaskID, true
+			}
+		}
+	}
+	return "", false
+}
+
+// restartTaskCmd sends a force-restart request to the daemon via the IPC socket.
+func (a *App) restartTaskCmd(taskID string) tea.Cmd {
+	return func() tea.Msg {
+		socketPath := a.socketPath
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		}
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		url := fmt.Sprintf("http://apiary/restart/%s", taskID)
+		resp, err := client.Post(url, "application/json", nil)
+		if err != nil {
+			return nil
+		}
+		resp.Body.Close()
+		return nil
+	}
 }
 
 // openURLCmd opens a URL in the user's default browser without blocking the UI.
@@ -1573,7 +1633,7 @@ func (a *App) footerKeys() []fkey {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewDetail:
-				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"R", "restart"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
 				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"q", "quit"}}
 			}


### PR DESCRIPTION
## Summary
- New `apiary restart <cell-id>` CLI command
- `R` keybinding in dashboard to restart the focused task
- Daemon cancels running dispatch, resets DB and source state, re-queues

## Test plan
- [x] Build succeeds