### PR TITLE
feat: add clear-logs for tasks

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -495,6 +495,20 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("/clearlogs/", func(w http.ResponseWriter, r *http.Request) {
+		cellID := strings.TrimPrefix(r.URL.Path, "/clearlogs/")
+		if cellID == "" {
+			http.Error(w, "missing cell id", http.StatusBadRequest)
+			return
+		}
+		if d.db != nil {
+			if err := d.db.ClearTaskLogs(r.Context(), cellID); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
 
 	srv := &http.Server{Handler: mux}
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -200,6 +200,14 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	// Clear logs for the focused task.
+	if key == "C" {
+		if id, ok := a.focusedTaskID(); ok {
+			return a, a.clearLogsCmd(id)
+		}
+		return a, nil
+	}
+
 	// While a Tasks sub-view (detail/logs) is open, keys are scoped to it.
 	if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View != TaskViewList {
 		return a.handleTaskSubViewKey(key)
@@ -616,6 +624,25 @@ func (a *App) restartTaskCmd(taskID string) tea.Cmd {
 		}
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 		url := fmt.Sprintf("http://apiary/restart/%s", taskID)
+		resp, err := client.Post(url, "application/json", nil)
+		if err != nil {
+			return nil
+		}
+		resp.Body.Close()
+		return nil
+	}
+}
+
+func (a *App) clearLogsCmd(taskID string) tea.Cmd {
+	return func() tea.Msg {
+		socketPath := a.socketPath
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		}
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		url := fmt.Sprintf("http://apiary/clearlogs/%s", taskID)
 		resp, err := client.Post(url, "application/json", nil)
 		if err != nil {
 			return nil
@@ -1633,9 +1660,9 @@ func (a *App) footerKeys() []fkey {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewDetail:
-				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"R", "restart"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
-				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"C", "clear"}, {"q", "quit"}}
 			}
 		}
 		return []fkey{{"↑/↓", "select"}, {"enter/l", "logs"}, {"d", "details"}, {"o", "open"}, {"tab", "switch"}, {"q", "quit"}}

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -186,6 +186,16 @@ func (c *Client) ShouldRetry(ctx context.Context, taskID string) (bool, *time.Ti
 	return true, lastExec.NextRetryAt
 }
 
+// ClearTaskLogs removes all logs and execution records for a given task.
+func (c *Client) ClearTaskLogs(ctx context.Context, taskID string) error {
+	_, err := c.db.ExecContext(ctx, `DELETE FROM task_logs WHERE task_id = ?`, taskID)
+	if err != nil {
+		return err
+	}
+	_, err = c.db.ExecContext(ctx, `DELETE FROM task_executions WHERE task_id = ?`, taskID)
+	return err
+}
+
 // Logging
 
 func (c *Client) WriteTaskLog(ctx context.Context, taskID, level, message string) error {


### PR DESCRIPTION
## Summary
- `C` key in dashboard clears logs and execution history for the focused task
- New endpoint on daemon socket
- New DB method to clean up logs and executions

## Test plan
- [x] Build succeeds