### PR TITLE
fix: pass --agent to opencode from apiary agent ID

### DIFF
--- a/src/internal/runner/opencode/runner.go
+++ b/src/internal/runner/opencode/runner.go
@@ -180,8 +180,14 @@ func (r *Runner) runCLI(ctx context.Context, req model.RunRequest) (model.RunRes
 	argv := []string{}
 	argv = append(argv, r.extraArgs...)
 
-	if r.agentFlag != "" && r.agent != "" {
-		argv = append(argv, r.agentFlag, r.agent)
+	if r.agentFlag != "" {
+		agent := r.agent
+		if agent == "" {
+			agent = req.WorkerID
+		}
+		if agent != "" {
+			argv = append(argv, r.agentFlag, agent)
+		}
 	}
 	if r.modelFlag != "" && req.Model != "" {
 		argv = append(argv, r.modelFlag, req.Model)


### PR DESCRIPTION
## Summary
- When `agent_flag` is set but no `agent` is configured in the runner, use `req.WorkerID` (the apiary agent ID)
- This enables passing `--agent engineer` to opencode, which loads the agent's skills
- Skills listed in apiary agent config (git-workflow, gitnexus-codebase, etc.) must be mirrored in the opencode agent definition

## Test plan
- [x] Build succeeds