### PR TITLE
fix: include skills in opencode agent config

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1050,6 +1050,7 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		"description": ac.Description,
 		"mode":        "primary",
 		"prompt":      "{file:./agents/" + ac.ID + ".md}",
+		"skills":      ac.Skills,
 		"permission": map[string]any{
 			"edit":  "allow",
 			"bash":  "allow",


### PR DESCRIPTION
## Summary
- Add `skills` field to agent entry in `registerAgentInConfig`
- Remove skill file path from engineer soul to prevent opencode from misparsing it
- opencode now loads skills by name from the agent config instead of parsing markdown

## Test plan
- [x] Build succeeds