### PR TITLE
feat: configurable task timeout, default 120m

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -151,8 +151,20 @@ type Settings struct {
 	LogLevel      string      `yaml:"log_level"`
 	StateLock     bool        `yaml:"state_lock"`
 	ResultComment bool        `yaml:"result_comment"`
+	TaskTimeout   string      `yaml:"task_timeout"`
 	RetryPolicy   RetryPolicy `yaml:"retry_policy"`
 	Telemetry     Telemetry   `yaml:"telemetry"`
+}
+
+func (s *Settings) TaskTimeoutDuration() time.Duration {
+	if s.TaskTimeout == "" {
+		return 120 * time.Minute
+	}
+	d, err := time.ParseDuration(s.TaskTimeout)
+	if err != nil {
+		return 120 * time.Minute
+	}
+	return d
 }
 
 type Telemetry struct {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -713,7 +713,7 @@ func (d *Dispatcher) dispatch(ctx context.Context, cell model.Cell, adapter sour
 		SystemAppend: systemAppend,
 		WorkingDir:   "/",
 		Env:          map[string]string{},
-		Timeout:      45 * time.Minute,
+		Timeout:      d.cfg.Settings.TaskTimeoutDuration(),
 	}
 
 	// Stream the runner's live output (prompt, agent conversation, stderr)


### PR DESCRIPTION
## Summary
- Add `task_timeout` setting to `apiary.yaml`
- New default: 120 minutes (up from hardcoded 45)
- Set to 180m in project-erp config for long-running agents

## Test plan
- [x] Build succeeds