### PR TITLE
feat: workflow-mode — specification + Phase 1 (parsing and validation)

### DIFF
--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -5,6 +5,7 @@
 | Change | Descrição | Status |
 |---|---|---|
 | [foundation](changes/foundation/) | Especificação inicial do projeto | in-progress |
+| [workflow-mode](changes/workflow-mode/) | Substituir pool/router flat por pipelines multi-step declarativos | proposed |
 
 ## Arquivadas
 

--- a/openspec/changes/workflow-mode/design.md
+++ b/openspec/changes/workflow-mode/design.md
@@ -1,0 +1,270 @@
+# Design: Workflow Mode
+
+## Core Model
+
+A **Workflow** is a directed acyclic graph (DAG) of Steps with a single entry point. Each Step invokes one Agent. The graph edges encode sequencing (`depends_on`) and conditional routing (`condition`, `next_on_pass`, `next_on_fail`).
+
+Back-edges are permitted only as explicit `next_on_pass` / `next_on_fail` jump targets. They must point to an ancestor step (validated at config load), and only one level of loop-back is allowed per step to prevent unbounded cycles.
+
+### State Machine per Workflow Instance
+
+```
+          ┌────────────────────────────────────────────────┐
+          │                Workflow Instance               │
+          │                                                │
+  Cell    │  pending ──► running ──► (all steps done)     │
+  enters  │                │                    │          │
+ ────────►│                │               ─────┴──────   │
+          │                ▼              ╱              ╲ │
+          │           step_running ──► done           failed│
+          │                │              ╲              ╱ │
+          │                │               ──────────────  │
+          │                ▼                               │
+          │           approval_waiting                         │
+          │           (approval step)                         │
+          └────────────────────────────────────────────────┘
+```
+
+Each Step has its own state: `pending | running | passed | failed | skipped`.
+
+### Step Execution Flow
+
+```
+WorkflowEngine
+  1. Receive Cell from Router (as WorkflowID + Cell)
+  2. Create WorkflowInstance in SQLite (state: pending)
+  3. Identify ready steps (no unmet depends_on)
+  4. For each ready step:
+       a. Build StepContext (cell + prior step outputs)
+       b. Invoke StepRunner → RunnerAdapter (same as today)
+       c. Persist StepRun (output, exit code, duration)
+       d. Evaluate conditions → compute next ready steps
+  5. On all steps terminal: mark instance done/failed
+  6. Execute on_complete / on_fail hooks
+```
+
+## Config Structs (Go)
+
+```go
+type WorkflowConfig struct {
+    ID          string        `yaml:"id"`
+    Description string        `yaml:"description"`
+    Trigger     TriggerConfig `yaml:"trigger"`
+    Steps       []StepConfig  `yaml:"steps"`
+    OnComplete  *HookConfig   `yaml:"on_complete"`
+    OnFail      *HookConfig   `yaml:"on_fail"`
+}
+
+type TriggerConfig struct {
+    Priority int         `yaml:"priority"`
+    Match    MatchConfig `yaml:"match"` // reuses existing MatchConfig
+}
+
+type StepConfig struct {
+    ID          string   `yaml:"id"`
+    Type        string   `yaml:"type"`        // "agent" (default) | "approval"
+    Agent       string   `yaml:"agent"`        // agent ID (when type=agent)
+    Prompt      string   `yaml:"prompt"`       // extra prompt override
+    DependsOn   []string `yaml:"depends_on"`
+    MemoryRead  bool     `yaml:"memory_read"`   // default true; false = no memory injected
+    MemoryWrite []string `yaml:"memory_write"`  // output_schema field names to persist
+    Condition   string   `yaml:"condition"`    // go-template expression
+    NextOnPass  string   `yaml:"next_on_pass"` // step ID (back-edge only)
+    NextOnFail  string   `yaml:"next_on_fail"` // step ID
+
+    // Approval-only fields
+    Message   string      `yaml:"message"`
+    ResumeOn  *ApprovalTrigger `yaml:"resume_on"`
+    AbortOn   *ApprovalTrigger `yaml:"abort_on"`
+    Timeout   string       `yaml:"timeout"` // duration; "" = no timeout
+}
+
+type ApprovalTrigger struct {
+    CommentContains string `yaml:"comment_contains"`
+    LabelAdded      string `yaml:"label_added"`
+    StateChanged    string `yaml:"state_changed"`
+}
+
+type SplitBranch struct {
+    If   string `yaml:"if"`   // condition expression; empty = else
+    Else bool   `yaml:"else"` // marks the fallback branch
+    Goto string `yaml:"goto"` // step ID to activate
+}
+
+// StepConfig extended fields for split and agent steps:
+//
+// type: "agent" (default)
+//   Agent, Prompt, DependsOn, ContextFrom, OnPass, OnFail fields apply
+//
+// type: "split"
+//   Multi, Branches fields apply
+//
+// type: "approval"
+//   Message, ResumeOn, AbortOn, Timeout fields apply
+
+type StepOutcome struct {
+    Goto       string `yaml:"goto"`        // step ID
+    MaxRetries int    `yaml:"max_retries"` // 0 = unlimited
+}
+
+```
+
+## SQLite Schema
+
+```sql
+CREATE TABLE workflow_instances (
+    id          TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    cell_id     TEXT NOT NULL,
+    source_id   TEXT NOT NULL,
+    state       TEXT NOT NULL,  -- pending|running|approval_waiting|done|failed
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+
+CREATE TABLE step_runs (
+    id                  TEXT PRIMARY KEY,
+    workflow_instance_id TEXT NOT NULL REFERENCES workflow_instances(id),
+    step_id             TEXT NOT NULL,
+    agent_id            TEXT,
+    state               TEXT NOT NULL,  -- pending|running|passed|failed|skipped
+    output              TEXT,
+    exit_code           INTEGER,
+    started_at          INTEGER,
+    finished_at         INTEGER
+);
+```
+
+## Context Injection: Workflow Memory
+
+Steps do not receive raw prior outputs. Context flows through the **workflow memory object** — see [workflow-memory spec](specs/workflow-memory/spec.md) for the full reference.
+
+The engine builds the memory document and injects it as `system_prompt_prepend` (new field in RunnerInput alongside the existing `system_prompt_append`):
+
+```
+=== Workflow Memory ===
+
+[Cell]
+title:    Fix user auth bug #142
+labels:   backend, bug
+priority: high
+
+[Step Data]
+complexity: high
+approach: Refactor auth middleware to use JWT
+
+[Summaries]
+plan: |
+  - JWT is the right replacement
+  - Two files need changes: middleware.go, handler.go
+  - No blockers
+
+======================
+
+[soul file content]
+[step-level prompt override, if any]
+```
+
+`MemoryBuilder` constructs this document from:
+1. The Cell (always)
+2. Fields declared in `memory.write` for each completed step (from `step_runs.structured_output`)
+3. Summaries extracted from `step_runs.summary` for each completed step
+
+A `memory_max_chars` limit (default: `4000`) applies. When exceeded, summaries are truncated oldest-first. The Cell section and Step Data keys are never truncated.
+
+## Routing
+
+The Router is extended to return either a `WorkflowID` or a `(WorkflowID="__simple__", AgentID)` for plain routes. The WorkflowEngine synthesizes a single-step workflow for plain routes, so the execution path is identical:
+
+```
+Router.Match(cell) → RouteResult{WorkflowID, AgentID}
+WorkflowEngine.Dispatch(RouteResult, cell) → WorkflowInstance
+```
+
+## Split Step Execution
+
+A split step is evaluated synchronously by the WorkflowEngine (no runner invocation):
+
+```
+WorkflowEngine.executeStep(step: split, instance)
+  for each branch in step.Branches (in order):
+    if branch.Else or eval(branch.If, instance.EvalContext()) == true:
+      if step.Multi:
+        activate(branch.Goto)   // may activate multiple
+      else:
+        activate(branch.Goto)
+        return                  // first-match-wins
+  // if no branch matched and no else: workflow fails with "unmatched split"
+```
+
+`EvalContext` exposes:
+- `cell` — the normalised Cell struct (labels, priority, type, title, source)
+- `steps` — map of step ID → `{state, exit_code, output}` for completed steps
+
+### Expression Evaluator
+
+A small hand-written recursive-descent parser handles the expression language. No external dependency. Grammar (simplified):
+
+```
+expr     = or_expr
+or_expr  = and_expr ( "or" and_expr )*
+and_expr = not_expr ( "and" not_expr )*
+not_expr = "not" atom | atom
+atom     = "(" expr ")" | comparison
+comparison = accessor op value
+accessor = "cell" "." field | "steps" "." id "." field
+op       = "==" | "!=" | "contains" | "matches"
+value    = QUOTED_STRING | NUMBER
+```
+
+The evaluator returns `(bool, error)`. A parse or evaluation error causes the split step to fail, which marks the workflow instance as failed.
+
+### `on_fail` / `on_pass` Loop Tracking
+
+Each `WorkflowInstance` holds a `retry_counts` map (`step_id → int`). When `on_fail.goto` triggers a loop-back:
+1. Increment `retry_counts[step_id]`
+2. If `retry_counts[step_id] > max_retries` (and `max_retries > 0`): fail the instance
+3. Reset the target step's state to `pending` and re-enqueue it
+
+Steps that are downstream of the reset step are also reset to `pending` (cascade reset), so the loop reruns the full branch.
+
+## Validation Rules
+
+1. All `depends_on` references must point to a step ID within the same workflow.
+2. All `branches[].goto` and `on_fail.goto` / `on_pass.next` references must point to a step ID within the same workflow.
+2. The step graph must be a DAG (no cycles except explicitly declared back-edges via `next_on_pass`/`next_on_fail`).
+3. Back-edge targets must be ancestors of the declaring step.
+4. All `agent` references in steps must point to a defined agent ID.
+5. Fields in `memory_write` must exist as top-level properties in the step's `output_schema`. A step without `output_schema` cannot declare `memory_write`.
+6. Each workflow `id` must be unique across all workflows and all route `id` values.
+7. An approval step must not have an `agent` field, and a non-approval step must have an `agent` field.
+8. A split step must not have an `agent` field and must have at least one branch.
+9. A split step with `multi: false` (default) must have exactly one `else` branch (the fallback). A split with `multi: true` may omit the `else`.
+10. `on_fail.goto` back-edges must target a step that is topologically before the declaring step (ancestor in the DAG). `max_retries` must be ≥ 1 when set.
+11. Conditions in `branches[].if` must parse successfully under the expression grammar at config load time.
+
+## TUI Changes
+
+The **Task Detail** panel gains a step-progress view when the run belongs to a multi-step workflow:
+
+```
+╔═ Task: Implement user auth #142 ════════════════════╗
+║ Workflow: feature-development    State: running      ║
+║                                                      ║
+║  Steps                                               ║
+║  ✓ plan         architect       2m 14s               ║
+║  ● implement    backend-dev     running (4m 02s)      ║
+║  ○ review       code-reviewer   waiting               ║
+║  ○ fix          backend-dev     waiting               ║
+╚══════════════════════════════════════════════════════╝
+```
+
+The existing **Runs** tab becomes a **Workflow Instances** tab showing instance-level state. Step-level runs are nested under each instance.
+
+## Migration Plan
+
+1. **Phase 1 — Schema only**: add `workflows:` parsing alongside existing `routes:`. No execution change. Warn if a workflow is defined but not yet executed.
+2. **Phase 2 — Engine**: implement `WorkflowEngine` behind a feature flag (`settings.experimental.workflow_mode: true`). Single-step workflows only.
+3. **Phase 3 — Full DAG**: multi-step, parallel steps, conditions. Enable by default.
+4. **Phase 4 — Approvals**: approval steps. Requires source-write-back polling.
+5. **Deprecation**: `routes:` syntax remains supported indefinitely as sugar for single-step workflows.

--- a/openspec/changes/workflow-mode/proposal.md
+++ b/openspec/changes/workflow-mode/proposal.md
@@ -1,0 +1,336 @@
+# Proposal: Workflow Mode
+
+## Why
+
+The current pool/router model is a **flat dispatch**: one task enters, one agent executes it, done. This works well for simple, atomic tasks but breaks down as real-world usage grows more complex:
+
+- **Sequential handoffs are manual**: a backend agent implements a feature, but triggering a code-review agent on the result requires a human or a second task entry in the source system.
+- **No shared context between agents**: each agent invocation starts from scratch with only the original task description. Agents cannot build on each other's output.
+- **No branching or retry logic per task**: if the reviewer rejects the implementation, there is no way to loop back to the implementer — the human must re-queue the task.
+- **Human-in-the-loop is impossible**: there is no place to pause a run and require approval before continuing.
+
+Workflow mode addresses all of this by promoting the dispatch model from **single-shot** to **multi-step pipeline**.
+
+## What Changes
+
+The router remains. Routes become **workflow triggers** — they select which workflow handles a matching task. The workflow then orchestrates one or more agents across multiple steps, with context flowing from step to step.
+
+### New Concepts
+
+| Term | Description |
+|---|---|
+| **Workflow** | A named, declarative graph of steps with a trigger condition |
+| **Step** | One agent invocation within a workflow |
+| **Step context** | Accumulated outputs from previous steps, injected into the next agent's prompt |
+| **Approval** | A human approval checkpoint that pauses the workflow until someone responds |
+| **Split** | A routing node that evaluates multiple `if` branches and activates one or more paths |
+| **Condition** | A boolean expression evaluated against cell metadata or prior step outcomes |
+| **Workflow Instance** | A single execution of a workflow bound to a specific Cell (task) |
+
+### What Stays
+
+- **Sources** — unchanged; they produce Cells as before.
+- **Agents** — unchanged; they are the execution units, now invoked per-step rather than directly.
+- **Router** — unchanged in matching logic; it now returns a workflow ID instead of an agent ID.
+
+## New Schema
+
+```yaml
+workflows:
+  - id: feature-development
+    description: "Full feature implementation pipeline"
+    trigger:
+      priority: 10
+      match:
+        source: main-plane
+        labels: [feature, ai-ready]
+    steps:
+      - id: plan
+        agent: architect
+        prompt: |
+          Analyze this task and produce a detailed implementation plan.
+          Output the plan as a markdown list.
+
+      - id: implement
+        agent: backend-dev
+        depends_on: plan
+        # step context: plan output is automatically injected
+
+      - id: review
+        agent: code-reviewer
+        depends_on: implement
+
+      - id: fix
+        agent: backend-dev
+        depends_on: review
+        condition: "{{ steps.review.outcome == 'changes_requested' }}"
+        next_on_pass: review   # loop back to reviewer
+
+    on_complete:
+      set_state: in_review
+    on_fail:
+      set_state: blocked
+      add_labels: [workflow-failed]
+```
+
+### Parallel Steps
+
+Steps without a `depends_on` relationship to each other run in parallel when they share the same upstream dependency:
+
+```yaml
+steps:
+  - id: implement
+    agent: backend-dev
+
+  - id: write-tests
+    agent: test-engineer
+    depends_on: implement
+
+  - id: write-docs
+    agent: docs-writer
+    depends_on: implement
+
+  # write-tests and write-docs run in parallel after implement completes
+
+  - id: review
+    agent: code-reviewer
+    depends_on: [write-tests, write-docs]   # waits for both
+```
+
+### Approval Steps
+
+An approval step pauses the workflow and posts a message to the source task. A human reacts (e.g., adds a label, changes state, posts a comment with a keyword) to resume or abort.
+
+```yaml
+steps:
+  - id: propose-plan
+    agent: architect
+
+  - id: human-approval
+    type: approval
+    depends_on: propose-plan
+    message: |
+      Implementation plan is ready. Reply "approve" to continue or "reject" to abort.
+    resume_on:
+      comment_contains: "approve"
+    abort_on:
+      comment_contains: "reject"
+
+  - id: implement
+    agent: backend-dev
+    depends_on: human-approval
+```
+
+## Context Propagation: Workflow Memory
+
+Steps do not receive raw prior outputs. Instead, context flows through a **workflow memory object** — a shared, enrichable document that each step can read from and write to.
+
+Memory always contains the original Cell. Steps enrich it by declaring which structured output fields to persist (`memory.write`) and optionally producing a brief summary (`summary_prompt`). Full raw output is stored in SQLite for audit and resume but never forwarded.
+
+```yaml
+- id: plan
+  agent: architect
+  output_schema:
+    type: object
+    properties:
+      complexity: {type: string, enum: [low, medium, high]}
+      approach:   {type: string}
+    required: [complexity, approach]
+  summary_prompt: |
+    In 3-5 bullet points: what you concluded and what the next agent needs to know.
+  memory:
+    write: [complexity, approach]   # these fields become available to all downstream steps
+
+- id: implement
+  agent: backend-dev
+  depends_on: plan
+  memory:
+    read: true    # sees: cell + complexity + approach + plan summary
+```
+
+See [workflow-memory spec](specs/workflow-memory/spec.md) for the full reference.
+
+## Backward Compatibility: Simple Route Mode
+
+The existing `routes` + `workers`/`agents` model is preserved. Internally it is treated as a single-step workflow with no explicit workflow definition:
+
+```yaml
+# Old (still valid)
+routes:
+  - id: backend-bugs
+    priority: 10
+    match: {labels: [bug]}
+    agent: backend-dev
+    on_complete:
+      set_state: in_review
+
+# Equivalent in workflow mode
+workflows:
+  - id: backend-bugs
+    trigger:
+      priority: 10
+      match: {labels: [bug]}
+    steps:
+      - id: fix
+        agent: backend-dev
+    on_complete:
+      set_state: in_review
+```
+
+Both notations will be supported in `apiary.yaml`. A hive may mix simple routes and full workflows.
+
+## Architecture Impact
+
+| Component | Change |
+|---|---|
+| `router.go` | Returns `WorkflowID` (or synthesizes a single-step workflow for plain routes) |
+| `dispatcher.go` | Replaced by `WorkflowEngine` — manages step sequencing, concurrency, and context |
+| `config.go` | New `WorkflowConfig`, `StepConfig`, `ApprovalConfig` structs |
+| `validate.go` | Validate step graph for cycles, dangling `depends_on`, agent references |
+| SQLite schema | New `workflow_instances` and `step_runs` tables alongside existing `runs` |
+| TUI | Workflow instance view: step-by-step progress within a running task |
+
+## Branching: Split Steps and Conditions
+
+### Problem with Binary Branching
+
+The `next_on_pass`/`next_on_fail` fields on agent steps only handle two outcomes. Real workflows need:
+- **Multi-way routing** based on task metadata (`bug` vs `feature` vs `docs`)
+- **Agent-outcome routing** based on what the agent decided (reject → retry, approve → continue)
+- **Parallel fan-out with selective join** (run A and B in parallel; proceed only when both pass)
+
+### `type: split` — Multi-Way Conditional Branch
+
+A split step is a routing node, not an agent invocation. It evaluates a list of `if` branches in order and activates the first match. An optional `else` branch catches the rest.
+
+```yaml
+steps:
+  - id: triage
+    type: split
+    depends_on: []   # entry point — or omit to trigger on workflow start
+    branches:
+      - if: "cell.labels contains 'bug'"
+        goto: fix-bug
+      - if: "cell.labels contains 'feature' and cell.priority == 'urgent'"
+        goto: fast-track-feature
+      - if: "cell.labels contains 'feature'"
+        goto: standard-feature
+      - else: true
+        goto: analyze-first
+
+  - id: fix-bug
+    agent: backend-dev
+    prompt: "Fix this bug."
+
+  - id: fast-track-feature
+    agent: senior-dev
+    prompt: "Implement urgently."
+
+  - id: standard-feature
+    agent: backend-dev
+    prompt: "Implement this feature."
+
+  - id: analyze-first
+    agent: architect
+    prompt: "Analyze and plan."
+```
+
+A split step has no agent output and contributes nothing to step context.
+
+### `type: split` with `multi: true` — Fan-Out
+
+When `multi: true`, all branches whose `if` evaluates to true are activated in parallel (not just the first):
+
+```yaml
+- id: notify-all
+  type: split
+  multi: true
+  depends_on: review
+  branches:
+    - if: "cell.labels contains 'backend'"
+      goto: update-backend-docs
+    - if: "cell.labels contains 'frontend'"
+      goto: update-frontend-docs
+    - if: "cell.labels contains 'api'"
+      goto: update-api-docs
+```
+
+### `on_fail: goto` on Agent Steps — Retry Loops
+
+Agent steps can declare `on_fail` with a `goto` to loop back to an earlier step. This replaces the less explicit `next_on_fail` field and makes retry intent clear:
+
+```yaml
+steps:
+  - id: implement
+    agent: backend-dev
+
+  - id: review
+    agent: code-reviewer
+    depends_on: implement
+    on_fail:
+      goto: implement      # reviewer rejected → loop back to implementer
+      max_retries: 3       # abort if this loop runs more than 3 times
+    on_pass:
+      next: finalize       # explicit happy path (optional; inferred from depends_on otherwise)
+
+  - id: finalize
+    agent: backend-dev
+    depends_on: review
+    prompt: "Apply final touches and open PR."
+```
+
+`on_pass.next` is optional. When omitted, the step flows naturally to whatever depends on it.
+
+### Expression Language
+
+Conditions are simple attribute expressions — not Go templates. The evaluator supports:
+
+| Expression | Description |
+|---|---|
+| `cell.labels contains "bug"` | Cell has label "bug" |
+| `cell.priority == "urgent"` | Cell priority equals value |
+| `cell.type == "feature"` | Cell type matches |
+| `cell.title matches ".*hotfix.*"` | Cell title matches regex |
+| `steps.<id>.state == "passed"` | Step completed successfully |
+| `steps.<id>.state == "failed"` | Step failed |
+| `steps.<id>.exit_code == 0` | Step exit code |
+| `steps.<id>.output contains "LGTM"` | Step stdout contains string |
+| `A and B`, `A or B`, `not A` | Boolean combinators |
+| `(A or B) and C` | Grouping with parens |
+
+Structured JSON output from agents is **not** supported in v1 — branching on agent output is limited to string matching (`output contains`) and exit codes.
+
+### Summary: Step Types and Their Roles
+
+| Step type | Invokes agent? | Branching | Spec |
+|---|---|---|---|
+| `agent` (default) | Yes | Optional `on_fail.goto` / `on_pass.next` | this doc |
+| `split` | No | Multi-branch `if/else` (or `multi: true` fan-out) | this doc |
+| `approval` | No | `resume_on` / `abort_on` | this doc |
+| `foreach` | Yes (one per item) | None; `fail_fast` optional | [foreach-step](specs/foreach-step/spec.md) |
+| `workflow` | No (delegates to child) | None | [sub-workflows](specs/sub-workflows/spec.md) |
+
+## Capability Specs
+
+| Spec | Description |
+|---|---|
+| [workflow](specs/workflow/spec.md) | **Complete schema reference** — all fields, all step types, annotated example |
+| [workflow-memory](specs/workflow-memory/spec.md) | Shared memory object; `memory.write`, `summary_prompt`, memory injection format |
+| [structured-output](specs/structured-output/spec.md) | Opt-in last-line JSON contract for typed agent output; enables field-level conditions |
+| [foreach-step](specs/foreach-step/spec.md) | Dynamic fan-out over a runtime list from a prior step's output |
+| [resume](specs/resume/spec.md) | Restart a failed instance from the last completed step |
+| [per-step-model](specs/per-step-model/spec.md) | Override the agent's preferred model for a specific step |
+| [sub-workflows](specs/sub-workflows/spec.md) | Invoke another named workflow as a step; one level of nesting |
+| [source-adapter-watch](specs/source-adapter-watch/spec.md) | `PollTask` extension to `SourceAdapter` for approval step polling |
+| [runner-interface](specs/runner-interface/spec.md) | `RunRequest`/`RunResult` changes: memory injection, summary, structured output |
+| [concurrency-model](specs/concurrency-model/spec.md) | Global semaphore model across instances, parallel steps, and foreach |
+| [workflow-hooks](specs/workflow-hooks/spec.md) | `state_lock` and `result_comment` behavior in multi-step workflows |
+| [orphan-recovery](specs/orphan-recovery/spec.md) | Interrupted instance recovery on daemon restart |
+
+## Resolved Questions
+
+1. **How is step output structured?** ✓ — Opt-in `APIARY_OUTPUT:` last-line JSON contract; unstructured steps use `summary_prompt`. See [structured-output](specs/structured-output/spec.md) and [workflow-memory](specs/workflow-memory/spec.md).
+2. **Cycle detection** ✓ — DAG enforced at config load; only explicit `on_fail.goto` back-edges to ancestor steps are permitted. See validation rules in `design.md`.
+3. **Approval timeouts** ✓ — `timeout` field on approval steps; aborts the instance when elapsed. See [workflow/spec.md](specs/workflow/spec.md).
+4. **Workflow versioning** ✓ — Config changes require a daemon restart. In-flight instances always run to completion on the config snapshot they started with (stored in SQLite at instance creation). If the workflow definition changes and an instance is later resumed, resume is blocked and the operator must re-trigger. See [orphan-recovery](specs/orphan-recovery/spec.md).
+5. **Cross-source workflows** — Deferred to post-v1. A workflow always writes back to the source that triggered it (`cell.SourceID`). Multi-source orchestration requires a separate design.

--- a/openspec/changes/workflow-mode/specs/concurrency-model/spec.md
+++ b/openspec/changes/workflow-mode/specs/concurrency-model/spec.md
@@ -1,0 +1,76 @@
+# Specification: Concurrency Model
+
+Define how `settings.concurrency` applies across workflow instances, parallel steps, and foreach sub-runs.
+
+## Problem
+
+The current model is simple: `settings.concurrency` limits how many worker runs execute simultaneously. Workflow mode introduces three levels of concurrency:
+
+1. **Workflow instances** — multiple tasks being worked on at the same time
+2. **Parallel steps** — multiple steps within one instance running at the same time
+3. **Foreach sub-runs** — multiple items within one foreach step running at the same time
+
+Without a clear model, these levels interact unpredictably. A `foreach` with `concurrency: 8` inside a 3-instance-parallel hive could spawn 24 simultaneous agent invocations against a single working directory.
+
+## Decision: One Global Agent Invocation Semaphore
+
+`settings.concurrency` is a single global cap on the total number of **simultaneous agent invocations** across the entire hive — regardless of which instance, step, or foreach they belong to.
+
+```yaml
+settings:
+  concurrency: 4   # at most 4 agents running at any moment, across all instances and steps
+```
+
+Every `RunnerAdapter.Run(...)` call acquires one slot from this semaphore before executing and releases it on completion. Callers that cannot acquire a slot block until one becomes available.
+
+This is the simplest model: one knob, one guarantee, predictable resource usage.
+
+## What This Means in Practice
+
+| Scenario | concurrency: 4 | behavior |
+|---|---|---|
+| 4 independent tasks arrive simultaneously | 4 instances start, each runs step 1 | all 4 slots used |
+| 5th task arrives | 5th instance queued | waits for a slot |
+| One instance has 2 parallel steps ready | both try to acquire slots | each needs 1 slot; runs if available |
+| foreach with `concurrency: 8`, global limit is 4 | foreach respects the lower of its own limit and available global slots | at most 4 sub-runs at once |
+
+## Interaction with `foreach.concurrency`
+
+`foreach.concurrency` is a **per-step upper bound**, not a reservation. The effective concurrency for a foreach step is:
+
+```
+effective = min(foreach.concurrency, available_global_slots)
+```
+
+The foreach step spawns sub-runs up to `effective` at a time, blocking when all global slots are occupied.
+
+## Workflow Instance Queuing
+
+When a new Cell is matched to a workflow and all global slots are occupied, the instance is created in SQLite with state `pending` and waits. The engine re-checks pending instances on each poll cycle and starts them as slots free up. Pending instances are dispatched oldest-first (by `created_at`).
+
+This replaces the previous dispatcher queue behavior. The semantics are the same; the mechanism moves to the WorkflowEngine.
+
+## Step-Level Queuing Within an Instance
+
+When a step is ready (all `depends_on` passed) but no global slot is available, the step waits in memory. The engine uses a per-instance ready queue. Steps in the queue are dispatched as slots free up, in topological order (steps with no dependencies between them dispatch in declaration order as a tiebreaker).
+
+## Starvation Prevention
+
+A pathological case: one instance with a `foreach` of 200 items (capped to `max_items: 200`) monopolizes all slots indefinitely, starving other instances.
+
+Mitigation: the engine interleaves slot acquisition across instances using a round-robin dispatch strategy. When multiple instances have ready steps competing for the same slot, the engine picks from each instance in turn rather than draining one instance completely.
+
+This is a best-effort fairness guarantee — it does not guarantee equal throughput per instance, only that no instance is permanently starved.
+
+## Recommended Settings
+
+| Use case | `concurrency` suggestion |
+|---|---|
+| Single developer machine, one project | `2` (default) |
+| CI environment, dedicated runner | `4–8` |
+| Multi-project hive | `8–16` |
+| Foreach-heavy workflows | Keep `concurrency` ≥ `foreach.concurrency` to avoid artificial throttling |
+
+## No Per-Workflow Concurrency Limit (v1)
+
+There is no per-workflow or per-instance concurrency limit in v1. All instances share the global semaphore equally. A future `settings.max_instances` field could cap the number of simultaneously active instances independently of the per-invocation limit — deferred to v2.

--- a/openspec/changes/workflow-mode/specs/foreach-step/spec.md
+++ b/openspec/changes/workflow-mode/specs/foreach-step/spec.md
@@ -1,0 +1,110 @@
+# Specification: Foreach Step
+
+Enable dynamic fan-out over a list produced by a prior step, spawning one sub-run per item.
+
+## Problem
+
+Workflow steps are declared statically. If an analysis agent returns a list of files to fix, or a triage agent returns a list of sub-tasks, there is no way to spawn one agent per item without pre-declaring every branch. The number of items is only known at runtime.
+
+## Schema
+
+```yaml
+steps:
+  - id: find-issues
+    agent: analyzer
+    output_schema:
+      type: object
+      properties:
+        issues:
+          type: array
+          items:
+            type: object
+            properties:
+              file: {type: string}
+              description: {type: string}
+            required: [file, description]
+      required: [issues]
+
+  - id: fix-each
+    type: foreach
+    depends_on: find-issues
+    items: "steps.find-issues.output.issues"   # dot-path to the array
+    as: issue                                   # variable name inside the step
+    concurrency: 4                              # max parallel sub-runs (default: 2)
+    max_items: 20                               # safety cap; fail if exceeded (default: 50)
+    step:
+      agent: backend-dev
+      prompt: |
+        Fix the issue in file {{ issue.file }}:
+        {{ issue.description }}
+      output_schema:
+        type: object
+        properties:
+          fixed: {type: boolean}
+          summary: {type: string}
+        required: [fixed]
+
+  - id: summarize
+    agent: docs-writer
+    depends_on: fix-each
+    prompt: |
+      All issues have been processed. Write a summary of what was fixed.
+```
+
+## How It Works
+
+1. When `fix-each` is ready to run, the engine reads `steps.find-issues.output.issues`.
+2. It creates one **foreach sub-run** per item. Each sub-run is a scoped agent invocation with:
+   - The item value bound to the `as` variable (`issue` in the example)
+   - The step's `prompt` rendered with `{{ issue.<field> }}` template substitution
+   - Its own entry in `step_runs` keyed as `fix-each[0]`, `fix-each[1]`, etc.
+3. Sub-runs execute concurrently up to `concurrency`.
+4. `fix-each` is marked `passed` when all sub-runs pass; `failed` if any sub-run fails (configurable with `fail_fast`).
+5. Downstream steps (`summarize`) see `fix-each` as a single step dependency.
+
+## Output of a Foreach Step
+
+The foreach step exposes its sub-run outputs as an array:
+
+```
+steps.fix-each.outputs          # array of each sub-run's output object
+steps.fix-each.outputs[0].fixed # first sub-run's structured output field
+steps.fix-each.passed_count     # number of sub-runs that passed
+steps.fix-each.failed_count     # number that failed
+```
+
+In expressions (conditions/prompts), array indexing (`[0]`) is supported only for foreach outputs in v1.
+
+## Configuration Fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `items` | string | required | Dot-path to an array in a prior step's structured output |
+| `as` | string | `item` | Variable name for the current item in prompt templates |
+| `concurrency` | int | `2` | Max parallel sub-runs |
+| `max_items` | int | `50` | Abort if the array exceeds this length |
+| `fail_fast` | bool | `false` | Fail the foreach step as soon as one sub-run fails |
+| `step` | StepConfig | required | The agent step definition to replicate per item |
+
+## Prompt Templating
+
+Inside a `foreach` step's `prompt`, the `as` variable is available as a Go template:
+
+```
+Fix {{ issue.file }}: {{ issue.description }}
+```
+
+String fields are supported. Nested objects are rendered as JSON. The full cell and prior step context is also available as usual.
+
+## Constraints
+
+1. `items` must reference a step that declares `output_schema` with the target field as an array. Referencing unstructured output is not supported.
+2. Nested `foreach` steps (a `foreach` inside a `foreach`) are not supported in v1.
+3. `max_items` is a hard cap — if the array length exceeds it, the foreach step fails immediately. This prevents runaway fan-out.
+4. The `step` inside a `foreach` cannot be of type `split`, `approval`, or `foreach`.
+
+## Validation
+
+- `items` dot-path must resolve to an `array` type in the referenced step's `output_schema`.
+- `concurrency` must be between 1 and 16.
+- `max_items` must be between 1 and 200.

--- a/openspec/changes/workflow-mode/specs/orphan-recovery/spec.md
+++ b/openspec/changes/workflow-mode/specs/orphan-recovery/spec.md
@@ -1,0 +1,89 @@
+# Specification: Orphaned Instance Recovery
+
+Define what happens to in-flight workflow instances when the daemon restarts after a crash or deliberate stop.
+
+## Problem
+
+When the daemon stops (crash, SIGKILL, `systemctl stop`) while workflow instances are executing, SQLite may contain instances in `running` or `approval_waiting` state with no live goroutine behind them. Without a defined recovery policy, these instances are permanently stuck — they never complete and never show up as failed.
+
+## Instance States on Restart
+
+The engine checks the following states in SQLite during startup, before accepting any new tasks:
+
+| State at shutdown | Recovery action |
+|---|---|
+| `running` | Transition to `interrupted`. Log a warning per instance. |
+| `approval_waiting` | Leave unchanged. The approval polling loop will resume checking these on the next cycle. |
+| `pending` | Leave unchanged. The engine will pick them up normally. |
+| `done` / `failed` / `interrupted` | No action. |
+
+## `interrupted` State
+
+`interrupted` is a terminal-like state — the instance will not resume automatically unless the workflow declares `resume: auto` or the operator runs `apiary resume`.
+
+On startup, if any instances were transitioned to `interrupted`, the daemon logs a warning at the `warn` level and exits with code `5` (non-fatal — the daemon continues running):
+
+```
+WARN  3 workflow instance(s) were interrupted and require attention.
+WARN  Run `apiary instances --state interrupted` to review.
+WARN  Use `apiary resume <id>` to resume, or the instances will remain interrupted.
+```
+
+## Auto-Resume on Restart
+
+Workflows with `resume: auto` are resumed automatically during startup recovery, without operator intervention:
+
+```yaml
+workflows:
+  - id: analysis-pipeline
+    resume: auto        # all steps must be idempotent: true
+    steps: [...]
+```
+
+The engine re-queues these instances immediately after marking their in-progress steps as `pending`. They enter the normal dispatch queue and run as slots become available.
+
+`resume: auto` is only valid when all steps are `idempotent: true` (enforced at config load time). The risk of unintended side-effect duplication is the operator's responsibility when enabling this.
+
+## Step-Level Recovery
+
+When an instance is being resumed (manually or via `resume: auto`), steps in the following states are handled:
+
+| Step state at shutdown | Recovery action |
+|---|---|
+| `running` | Reset to `pending`. The step will re-run. |
+| `passed` | Left as `passed`. Cached output is replayed into memory. Step is not re-run. |
+| `failed` | Left as `failed`. The workflow resumes from the failure point (same as a normal `on_fail` evaluation). |
+| `pending` / `skipped_cached` | No change. |
+
+## Partial Foreach Recovery
+
+If a foreach step was `running` at shutdown, its sub-runs are inspected individually:
+- Sub-runs in `passed` state: cached, not re-run.
+- Sub-runs in `running` or `pending` state: reset to `pending` and re-dispatched.
+
+This means a foreach step may re-run some sub-runs even with `resume: auto`. For this reason, foreach inner steps should be `idempotent: true` for `resume: auto` to be safe.
+
+## Approval Waiting — No Recovery Needed
+
+Instances in `approval_waiting` at shutdown are left unchanged. When the daemon restarts, the approval polling loop resumes checking them on the next poll cycle. No data is lost — the approval step is stateless (the condition is re-evaluated against the live source task each time).
+
+If the approval `timeout` would have expired during the downtime, it is evaluated on the first poll cycle after restart and the instance is aborted at that point.
+
+## Startup Sequence
+
+```
+WorkflowEngine.Start():
+  1. Query instances WHERE state = 'running' → transition to 'interrupted'
+  2. For each 'interrupted' instance with resume: auto → re-queue
+  3. Log warning if any 'interrupted' instances remain
+  4. Resume approval polling for 'approval_waiting' instances
+  5. Begin accepting new tasks from Router
+```
+
+Step 1 and 2 run inside a SQLite transaction — either all instances are recovered or none are, preventing partial state.
+
+## No Automatic Retry for `interrupted` Without `resume: auto`
+
+Automatically re-running interrupted instances without operator knowledge could cause unintended side effects (duplicate commits, duplicate comments, duplicate state transitions). The default is therefore conservative: interrupt and warn, let the operator decide.
+
+The `resume: auto` flag is the explicit opt-in for fully automated recovery.

--- a/openspec/changes/workflow-mode/specs/per-step-model/spec.md
+++ b/openspec/changes/workflow-mode/specs/per-step-model/spec.md
@@ -1,0 +1,43 @@
+# Specification: Per-Step Model Override
+
+Allow individual workflow steps to specify a model, overriding the agent's `preferred_models` list for that step only.
+
+## Problem
+
+An agent's `preferred_models` is a static list set at the agent level. In a multi-step workflow, the same agent may be appropriate for multiple steps but the optimal model varies by step — a planning step benefits from a large reasoning model, while a formatting step only needs a small, fast model. Changing the agent's `preferred_models` affects all routes and workflows that use it.
+
+## Schema
+
+```yaml
+steps:
+  - id: plan
+    agent: backend-dev
+    model: claude-opus-4-8          # override: use the largest model for planning
+
+  - id: implement
+    agent: backend-dev
+    # no model override: uses backend-dev's first preferred_models entry
+
+  - id: format-output
+    agent: backend-dev
+    model: claude-haiku-4-5         # override: small model for a cheap formatting pass
+```
+
+The `model` field on a step is optional. When present, it is passed directly to the runner adapter as the model identifier, bypassing `preferred_models` entirely. The same opaque-string contract from ADR-006 applies: Apiary does not validate or interpret the model ID.
+
+## Interaction with Agent Definition
+
+| `step.model` | `agent.preferred_models` | Resolved model |
+|---|---|---|
+| set | any | `step.model` |
+| not set | non-empty | `agent.preferred_models[0]` |
+| not set | empty | runner default |
+
+## Validation
+
+1. `step.model` is an opaque string — no format validation.
+2. If both `step.model` and `agent.preferred_models` are unset, the runner decides the model (runner default). This is valid but logged as a warning at startup.
+
+## Rationale
+
+This keeps agent definitions stable (the agent's identity and soul file are unchanged) while giving workflow authors fine-grained control over cost and capability per step. It does not require a new agent definition for each model variant.

--- a/openspec/changes/workflow-mode/specs/resume/spec.md
+++ b/openspec/changes/workflow-mode/specs/resume/spec.md
@@ -1,0 +1,87 @@
+# Specification: Workflow Resume
+
+Allow a failed or interrupted workflow instance to restart from the last successfully completed step, skipping already-completed work.
+
+## Problem
+
+A 5-step workflow that fails at step 4 currently has no recovery path — the operator must wait for the task to re-enter the queue (which may never happen) or manually re-trigger it. All prior agent work is discarded. For long-running workflows with expensive agent steps, this is unacceptable.
+
+## Approach
+
+Resume is an explicit operator action, not automatic. The engine never auto-retries a failed instance — a human (or a future automation layer) decides to resume. This avoids uncontrolled loops when a workflow fails due to a systematic problem (bad config, broken agent, wrong task).
+
+### How Resume Works
+
+1. A workflow instance is in state `failed` or `interrupted` (process killed mid-run).
+2. The operator runs `apiary resume <instance-id>` (or uses the TUI).
+3. The engine loads the instance from SQLite, finds all steps in state `passed`, and marks them as `skipped_cached`.
+4. Steps in state `running` (interrupted) are reset to `pending`.
+5. Execution continues from the first non-passed step.
+
+Passed steps are not re-run. Their stored outputs are replayed into the step context for downstream steps exactly as if they had just completed.
+
+## Idempotency Caveats
+
+Steps are **not** guaranteed idempotent. Resume is safe only for steps whose side effects have not yet occurred or are safe to repeat. Apiary surfaces a warning at resume time listing which steps will be skipped and what side effects they may have caused:
+
+```
+Warning: resuming instance wf_abc123 from step "review".
+The following steps will be skipped (already completed):
+  ✓ plan       — no on_complete hooks
+  ✓ implement  — on_complete: set_state=in_progress (already applied)
+Steps to run: review, finalize
+Proceed? [y/N]
+```
+
+The operator confirms before the engine proceeds.
+
+## Schema: Step-Level Resume Hints
+
+Steps can declare `idempotent: true` to suppress the warning for that step:
+
+```yaml
+steps:
+  - id: generate-plan
+    agent: architect
+    idempotent: true   # re-running produces the same output; no external side effects
+
+  - id: implement
+    agent: backend-dev
+    idempotent: false  # default; re-running would create duplicate commits
+```
+
+`idempotent: true` is a hint to the operator — the engine does not enforce it. It affects only the resume warning display.
+
+## Schema: Workflow-Level Resume Policy
+
+```yaml
+workflows:
+  - id: feature-development
+    resume: allowed       # default; operator can resume via CLI
+    # resume: forbidden   # instance cannot be resumed; must re-trigger from scratch
+    # resume: auto        # engine automatically resumes on next poll if instance is failed
+    steps: [...]
+```
+
+`resume: auto` is the closest to Claude workflows' behavior. It should be used only for workflows with fully idempotent steps (e.g., read-only analysis workflows).
+
+## CLI
+
+```
+apiary resume <instance-id>          # resume a specific instance
+apiary resume --workflow <id>        # resume the latest failed instance of a workflow
+apiary instances                     # list all instances with state and resume eligibility
+```
+
+## SQLite Changes
+
+The `step_runs` table gains a `skipped_cached` boolean. When a step is skipped on resume, its prior row is marked `skipped_cached = true` and its `output` is reused by the context builder.
+
+The `workflow_instances` table gains a `resumed_from` column (nullable instance ID) to track resume lineage.
+
+## Constraints
+
+1. Only instances in state `failed` or `interrupted` can be resumed.
+2. `done` instances cannot be resumed.
+3. If the workflow definition has changed since the instance was created (step IDs added/removed), resume is blocked with an error. The operator must re-trigger from scratch.
+4. `resume: auto` is only valid if all steps in the workflow are marked `idempotent: true`. Config validation enforces this.

--- a/openspec/changes/workflow-mode/specs/runner-interface/spec.md
+++ b/openspec/changes/workflow-mode/specs/runner-interface/spec.md
@@ -1,0 +1,128 @@
+# Specification: Runner Interface Changes
+
+Update `RunRequest` and `RunResult` to support workflow memory injection, summary extraction, and structured output parsing.
+
+## Current Interface
+
+```go
+type RunRequest struct {
+    Cell         Cell
+    WorkerID     string
+    Model        string
+    MaxTurns     int
+    SystemAppend string
+    WorkingDir   string
+    Env          map[string]string
+    Timeout      time.Duration
+}
+
+type RunResult struct {
+    WorkerID string
+    Success  bool
+    Output   string
+    Logs     []LogEntry
+    Duration time.Duration
+    Error    error
+}
+```
+
+## Updated Interface
+
+```go
+type RunRequest struct {
+    Cell              Cell
+    WorkerID          string          // kept for backward compat; set to agent ID in workflow mode
+    Model             string
+    MaxTurns          int
+    SystemPrepend     string          // NEW: injected before soul file (workflow memory block)
+    SystemAppend      string          // unchanged: soul file content + step prompt override
+    SummaryPrompt     string          // NEW: instruction appended at end of prompt; agent produces summary
+    WorkingDir        string
+    Env               map[string]string
+    Timeout           time.Duration
+    StepID            string          // NEW: step ID within the workflow (empty for plain routes)
+    WorkflowInstanceID string         // NEW: instance ID for logging/tracing (empty for plain routes)
+}
+
+type RunResult struct {
+    WorkerID         string
+    Success          bool
+    Output           string          // unchanged: full raw stdout (stored in SQLite, not forwarded)
+    StructuredOutput map[string]any  // NEW: parsed from APIARY_OUTPUT: last line (nil if absent)
+    Summary          string          // NEW: extracted summary block (empty if no SummaryPrompt)
+    Logs             []LogEntry
+    Duration         time.Duration
+    Error            error
+}
+```
+
+## Field Semantics
+
+### `RunRequest.SystemPrepend`
+
+Prepended to the agent's full system prompt before everything else — before the soul file, before `SystemAppend`, before the step `prompt` override. Contains the formatted workflow memory document:
+
+```
+=== Workflow Memory ===
+...
+======================
+```
+
+Empty string for plain routes (no memory to inject).
+
+### `RunRequest.SummaryPrompt`
+
+When non-empty, the runner appends this instruction at the very end of the system prompt, after `SystemAppend`. The runner is responsible for instructing the agent to emit its summary in a recognizable format.
+
+The runner appends the following to the prompt:
+
+```
+---
+When you are done, write a brief summary of your work using this exact format:
+
+APIARY_SUMMARY_START
+[your summary here — 3-5 bullet points]
+APIARY_SUMMARY_END
+```
+
+The engine extracts the content between the markers and stores it as `RunResult.Summary`.
+
+### `RunResult.StructuredOutput`
+
+Parsed from the `APIARY_OUTPUT: {...}` sentinel on the last line of stdout. The runner strips this line from `Output` before storing it — it should not appear in the human-readable output. If no sentinel is found, `StructuredOutput` is `nil`.
+
+Parsing is the runner's responsibility — it knows the stdout format of its underlying tool. Apiary validates the parsed object against `output_schema` after receiving the `RunResult`.
+
+### `RunResult.Summary`
+
+Extracted from the `APIARY_SUMMARY_START` / `APIARY_SUMMARY_END` markers in stdout. The runner strips these markers from `Output`. If no markers are found (agent did not follow the instruction), `Summary` is empty. The engine stores an empty summary without error — `SummaryPrompt` is best-effort.
+
+## Runner Adapter Responsibilities
+
+Each runner must:
+
+1. Inject `SystemPrepend` at the start of the system prompt it passes to the underlying tool.
+2. Append the `SummaryPrompt` instruction block at the end of the system prompt when `SummaryPrompt` is non-empty.
+3. Scan stdout for `APIARY_OUTPUT:` on the last non-empty line; parse the JSON and set `StructuredOutput`; remove the line from `Output`.
+4. Scan stdout for `APIARY_SUMMARY_START` / `APIARY_SUMMARY_END` markers; extract the content and set `Summary`; remove the markers from `Output`.
+
+Steps 3 and 4 are post-processing on the raw stdout — no changes to how the runner invokes the underlying CLI.
+
+## Backward Compatibility
+
+`SystemPrepend` and `SummaryPrompt` are empty strings for plain routes (no workflow). Runners that do not yet implement steps 1–4 continue to work — they just never produce `StructuredOutput` or `Summary`. The engine treats both as absent (nil / empty) and logs a debug message if `output_schema` was declared but `StructuredOutput` is nil.
+
+`WorkerID` is preserved for all existing log messages and SQLite records. In workflow mode it is set to the agent ID. No callers need to change.
+
+## `script` Runner: Environment Variables
+
+The script runner exposes the new fields as environment variables:
+
+| Variable | Value |
+|---|---|
+| `APIARY_SYSTEM_PREPEND` | `RunRequest.SystemPrepend` |
+| `APIARY_SUMMARY_PROMPT` | `RunRequest.SummaryPrompt` |
+| `APIARY_STEP_ID` | `RunRequest.StepID` |
+| `APIARY_WORKFLOW_INSTANCE_ID` | `RunRequest.WorkflowInstanceID` |
+
+The script is responsible for parsing `APIARY_OUTPUT:` and `APIARY_SUMMARY_START/END` from its own output if it wants to use structured output or summaries.

--- a/openspec/changes/workflow-mode/specs/source-adapter-watch/spec.md
+++ b/openspec/changes/workflow-mode/specs/source-adapter-watch/spec.md
@@ -1,0 +1,99 @@
+# Specification: Source Adapter — PollTask
+
+Extend `SourceAdapter` with a `PollTask` method so the workflow engine can check the current state of a specific task during approval steps.
+
+## Problem
+
+The current `SourceAdapter` interface only fetches *new* tasks via `Poll(ctx, since)`. Approval steps require the engine to detect changes on an *existing* task (a new comment, a label addition, a state change) after the workflow has paused. There is no mechanism for this today.
+
+## Solution
+
+Add a single new method `PollTask` to the interface. It returns the current state of one task by ID. The engine calls it on each poll cycle for every workflow instance in `approval_waiting` state and evaluates the approval trigger conditions against the returned Cell.
+
+This fits the existing poll-first model (ADR-002) and requires no streaming infrastructure.
+
+## Interface Change
+
+```go
+type SourceAdapter interface {
+    ID() string
+    Connect(ctx context.Context, config map[string]any) error
+    Poll(ctx context.Context, since time.Time) ([]Cell, error)
+    PollTask(ctx context.Context, cellID string) (Cell, error)   // NEW
+    Acknowledge(ctx context.Context, cell Cell, action AckAction) error
+    WriteResult(ctx context.Context, cell Cell, result RunResult) error
+    WebhookHandler() http.Handler
+}
+```
+
+### `PollTask(ctx, cellID string) (Cell, error)`
+
+Returns the current state of the task with the given native ID. The returned Cell must include:
+- `State` — current state name in the source system
+- `Labels` — current label list
+- `Comments []Comment` — comments added since the workflow instance was created (see below)
+
+Adapters that do not support per-task polling return `ErrNotSupported`. The engine treats `ErrNotSupported` as "approval cannot proceed on this source" and fails the workflow instance immediately with a descriptive error.
+
+## Cell Extension: Comments
+
+To support `comment_contains` approval triggers, `Cell` gains a `Comments` field:
+
+```go
+type Cell struct {
+    // ... existing fields ...
+    Comments []Comment   // NEW: populated only by PollTask, not by Poll
+}
+
+type Comment struct {
+    ID        string
+    Body      string
+    CreatedAt time.Time
+}
+```
+
+`Poll` implementations leave `Comments` empty (not needed for task discovery). `PollTask` implementations populate it with comments added after the workflow instance `created_at` timestamp, to avoid matching comments that pre-date the approval step.
+
+## Engine Behavior
+
+On each source poll cycle, after calling `Poll` for new tasks, the engine:
+
+1. Queries SQLite for all `workflow_instances` in state `approval_waiting` for this source.
+2. For each instance, calls `source.PollTask(ctx, instance.CellID)`.
+3. Evaluates the approval step's `resume_on` and `abort_on` conditions against the returned Cell.
+4. If `resume_on` matches: marks the approval step `passed`, resumes the workflow.
+5. If `abort_on` matches: marks the instance `failed`, applies `on_fail` hooks.
+6. If `timeout` is set and elapsed: same as `abort_on`.
+7. Otherwise: no action; checked again on the next cycle.
+
+`PollTask` is called once per `approval_waiting` instance per poll cycle. The poll interval for approval checking is the source's configured `poll_interval` — no separate interval.
+
+## Approval Condition Evaluation
+
+Conditions are evaluated against the Cell returned by `PollTask`:
+
+| Trigger field | Evaluated against |
+|---|---|
+| `comment_contains: "approve"` | Any comment body containing the string (case-insensitive) |
+| `label_added: "approved"` | `cell.Labels` contains the label |
+| `state_changed: "in_review"` | `cell.State == "in_review"` |
+
+Multiple fields within a single `resume_on` or `abort_on` block are OR-conditions: any one match is sufficient to trigger.
+
+## Adapter Implementations
+
+### Plane
+
+Use the Plane REST API: `GET /api/v1/workspaces/{slug}/projects/{id}/issues/{issue_id}/` for state/labels, and `GET /api/v1/workspaces/{slug}/projects/{id}/issues/{issue_id}/comments/` for comments.
+
+### GitHub Issues
+
+Use the GitHub REST API: `GET /repos/{owner}/{repo}/issues/{issue_number}` for state/labels, and `GET /repos/{owner}/{repo}/issues/{issue_number}/comments` for comments. Filter comments created after `instance.created_at`.
+
+### Other Adapters (Jira, Linear, future)
+
+Return `ErrNotSupported` until implemented. The workflow engine logs a warning and fails the instance.
+
+## Validation
+
+At config load time: if any workflow contains a `type: approval` step and the workflow's trigger source does not support `PollTask`, emit a warning (not an error — the source may be added later). At runtime when an approval step is reached: if `PollTask` returns `ErrNotSupported`, fail the instance immediately.

--- a/openspec/changes/workflow-mode/specs/structured-output/spec.md
+++ b/openspec/changes/workflow-mode/specs/structured-output/spec.md
@@ -65,7 +65,7 @@ Unstructured steps continue to expose `steps.<id>.output` as the full stdout str
 
 ## Validation
 
-1. `output_schema` must be a valid JSON Schema (subset: `object`, `string`, `number`, `boolean`, `enum`, `required`). Arrays and `$ref` are not supported in v1.
+1. `output_schema` must be a valid JSON Schema (subset: `object`, `string`, `number`, `integer`, `boolean`, `array`, `enum`, `required`). The top level must be an `object`. Arrays are supported (an `array` property requires an `items` definition) and are consumed by [foreach-step](../foreach-step/spec.md); `$ref` is not supported in v1. `enum` is only valid on `string` fields.
 2. At runtime, if the last line matches `APIARY_OUTPUT:` but the JSON fails schema validation, the step fails.
 3. Conditions referencing `steps.<id>.output.<field>` on a step without `output_schema` fail config validation.
 4. Conditions referencing `steps.<id>.output` (no field path) on a step with `output_schema` return the raw string (backward compatible).

--- a/openspec/changes/workflow-mode/specs/structured-output/spec.md
+++ b/openspec/changes/workflow-mode/specs/structured-output/spec.md
@@ -1,0 +1,86 @@
+# Specification: Structured Output
+
+Enable agent steps to emit typed JSON that the workflow engine can read and expose in conditions, replacing fragile string matching.
+
+## Problem
+
+The current expression language can only match against the raw stdout string of an agent step (`steps.<id>.output contains "COMPLEX"`). This is brittle — the agent must emit a specific sentinel word, and any formatting change breaks the branch.
+
+## Approach: Opt-In Last-Line JSON Contract
+
+Apiary does not parse the body of agent output (preserving ADR-006). Instead, a runner that supports structured output emits a single JSON object as the **last line** of stdout, preceded by a sentinel prefix:
+
+```
+APIARY_OUTPUT: {"complexity":"high","action":"implement","confidence":0.9}
+```
+
+Everything before this line is treated as human-readable log output and stored as-is. If no `APIARY_OUTPUT:` line is present, the step is treated as unstructured (existing behavior).
+
+Runners opt in — Apiary never requires it. Steps that declare `output_schema` and receive unstructured output fail validation at runtime (configurable: `on_missing_output: fail | warn | ignore`).
+
+## Schema
+
+```yaml
+steps:
+  - id: analyze
+    agent: architect
+    output_schema:
+      type: object
+      properties:
+        complexity:
+          type: string
+          enum: [low, medium, high]
+        action:
+          type: string
+          enum: [implement, escalate, reject]
+        confidence:
+          type: number
+      required: [complexity, action]
+    on_missing_output: warn   # default: warn
+
+  - id: route
+    type: split
+    depends_on: analyze
+    branches:
+      - if: "steps.analyze.output.complexity == 'high'"
+        goto: senior-dev
+      - if: "steps.analyze.output.action == 'reject'"
+        goto: close-task
+      - else: true
+        goto: standard-dev
+```
+
+## Expression Access
+
+When a step has `output_schema` and the output was successfully parsed, its fields are accessible in conditions as:
+
+```
+steps.<id>.output.<field>        # top-level field
+steps.<id>.output.<field>.<sub>  # nested field
+```
+
+Dot-path access on arrays is not supported in v1 (use `contains` on the raw string for array membership checks).
+
+Unstructured steps continue to expose `steps.<id>.output` as the full stdout string.
+
+## Validation
+
+1. `output_schema` must be a valid JSON Schema (subset: `object`, `string`, `number`, `boolean`, `enum`, `required`). Arrays and `$ref` are not supported in v1.
+2. At runtime, if the last line matches `APIARY_OUTPUT:` but the JSON fails schema validation, the step fails.
+3. Conditions referencing `steps.<id>.output.<field>` on a step without `output_schema` fail config validation.
+4. Conditions referencing `steps.<id>.output` (no field path) on a step with `output_schema` return the raw string (backward compatible).
+
+## Runner Responsibility
+
+The runner adapter is responsible for instructing the underlying agent to emit the `APIARY_OUTPUT:` line. For the OpenCode runner, this becomes an append to `system_prompt_append`:
+
+```
+When you are done, output the following as the last line of your response:
+APIARY_OUTPUT: <JSON matching this schema: {schema}>
+```
+
+This prompt injection is automatic when the step declares `output_schema`. The runner adapter generates it; the agent author does not need to know about the sentinel format.
+
+## Compatibility
+
+Steps without `output_schema` are unaffected. The `APIARY_OUTPUT:` prefix is chosen to be unlikely to appear in normal agent output. If it does appear in the middle of output (not the last line), it is ignored.

--- a/openspec/changes/workflow-mode/specs/sub-workflows/spec.md
+++ b/openspec/changes/workflow-mode/specs/sub-workflows/spec.md
@@ -1,0 +1,89 @@
+# Specification: Sub-Workflows
+
+Allow a workflow step to invoke another named workflow, enabling composition and reuse of common pipelines.
+
+## Problem
+
+Common patterns (plan → implement → review) get duplicated across multiple workflows. There is no way to extract a shared sub-pipeline and reference it by name. As the number of workflows grows, maintenance diverges — a fix to the review logic must be applied to every workflow individually.
+
+## Schema
+
+```yaml
+workflows:
+  # Reusable sub-workflow
+  - id: standard-review
+    description: "Code review pipeline: review → fix if needed → finalize"
+    steps:
+      - id: review
+        agent: code-reviewer
+
+      - id: fix
+        agent: backend-dev
+        depends_on: review
+        on_fail:
+          goto: review
+          max_retries: 2
+
+      - id: finalize
+        agent: backend-dev
+        depends_on: fix
+
+  # Main workflow referencing the sub-workflow
+  - id: feature-development
+    trigger:
+      priority: 10
+      match:
+        labels: [feature, ai-ready]
+    steps:
+      - id: plan
+        agent: architect
+
+      - id: implement
+        agent: backend-dev
+        depends_on: plan
+
+      - id: review-phase
+        type: workflow
+        workflow: standard-review      # sub-workflow ID
+        depends_on: implement
+        # context from implement is passed into the sub-workflow automatically
+
+    on_complete:
+      set_state: in_review
+```
+
+## How It Works
+
+A `type: workflow` step is a proxy — when it becomes ready, the engine instantiates the referenced workflow as a **child instance** linked to the parent:
+
+- The child instance receives the same Cell as the parent.
+- Step context accumulated up to the `type: workflow` step is injected as the sub-workflow's initial context (same format as normal step context injection).
+- The child's steps appear in the TUI nested under the parent step.
+- When the child instance reaches `done`, the `type: workflow` step is marked `passed`.
+- When the child instance reaches `failed`, the `type: workflow` step is marked `failed`.
+- The child's final step outputs are exposed as the sub-workflow step's output in the parent context: `steps.review-phase.output`.
+
+## Nesting Limit
+
+Sub-workflows may not themselves contain `type: workflow` steps. One level of nesting only. This prevents arbitrarily deep recursion and keeps instance tracking manageable.
+
+## Sub-Workflow Triggers
+
+A sub-workflow referenced via `type: workflow` does not use its own `trigger` block — it is invoked by the parent step. The `trigger` is only used when the workflow is matched directly by the Router. A workflow may be used both ways (as a standalone triggered workflow and as a sub-workflow of another).
+
+## Input Passing
+
+Sub-workflows receive the parent's **workflow memory snapshot** at the point the `type: workflow` step executes. The child starts with a copy of that memory and may enrich it further. When the child completes, its final memory state is not merged back into the parent — the parent's memory continues from where it was.
+
+This is intentional: sub-workflows are isolated pipelines. Any data the parent needs from the child must flow through the child's final step output, exposed as `steps.<child-step-id>.output` in the parent.
+
+## SQLite
+
+Child instances are stored in `workflow_instances` with a `parent_instance_id` column linking them to the parent. Step runs within the child are stored normally under the child instance ID.
+
+## Validation
+
+1. The `workflow` field must reference a workflow ID defined in the same `apiary.yaml`.
+2. The referenced workflow must not contain any `type: workflow` steps (no nesting).
+3. A workflow may not reference itself (direct or indirect cycle detection at config load).
+4. Sub-workflows with a `trigger` block are valid — the trigger is simply ignored when the workflow is invoked as a sub-workflow.

--- a/openspec/changes/workflow-mode/specs/workflow-hooks/spec.md
+++ b/openspec/changes/workflow-mode/specs/workflow-hooks/spec.md
@@ -1,0 +1,127 @@
+# Specification: State Lock and Result Comment in Workflow Context
+
+Define when `state_lock` and `result_comment` fire in multi-step workflows.
+
+## Current Behavior (Plain Routes)
+
+| Setting | When it fires |
+|---|---|
+| `state_lock: true` | Before the single agent run — moves task to "in_progress" |
+| `result_comment: true` | After the single agent run — posts agent output as a comment |
+
+Both are global settings in `apiary.yaml` under `settings:`.
+
+## Problem
+
+In a workflow, "before the run" and "after the run" are ambiguous:
+- A 5-step workflow with `result_comment: true` would post 5 comments — one per step — flooding the task.
+- `state_lock` should lock the task for the duration of the whole workflow, not per step.
+- Different workflows may want different comment behavior.
+
+## Decision
+
+### `state_lock`
+
+Fires **once at workflow instance start**, not per step. The task moves to "in_progress" before the first step executes and remains there for the entire workflow duration. On instance completion (`done` or `failed`), the `on_complete`/`on_fail` hooks control the final state via `set_state`.
+
+This is unchanged from the current behavior for plain routes — the difference is only that it no longer fires per step in multi-step workflows.
+
+### `result_comment`
+
+`result_comment` becomes a per-workflow setting with three modes, configurable in the workflow definition:
+
+```yaml
+workflows:
+  - id: feature-development
+    result_comment: on_complete   # default
+    steps: [...]
+```
+
+| Mode | Behavior |
+|---|---|
+| `on_complete` | Posts one comment when the workflow instance finishes (done or failed). Content: the final workflow memory document. This is the **default**. |
+| `per_step` | Posts one comment after each agent step completes. Content: the step's raw output. Useful for long workflows where visibility matters. |
+| `off` | No comments posted. |
+
+The global `settings.result_comment: true/false` remains as a hive-wide default:
+- `true` (default) → workflows without an explicit `result_comment` field use `on_complete`
+- `false` → workflows without an explicit `result_comment` field use `off`
+
+A workflow-level `result_comment` always overrides the global setting.
+
+### Comment Content
+
+**`on_complete` mode** — posts the final workflow memory document plus a status line:
+
+```
+**Workflow: feature-development — ✓ Done** (5 steps, 14m 32s)
+
+=== Workflow Memory ===
+
+[Cell]
+title: Implement user auth
+labels: feature, backend
+
+[Step Data]
+complexity: high
+approach: JWT-based auth middleware
+
+[Summaries]
+plan: |
+  - JWT chosen over sessions: stateless, fits existing infra
+  - Two files to change
+implement: |
+  - Added JwtMiddleware to middleware.go
+  - Updated auth handler, added tests
+review: |
+  - LGTM — no security issues found
+  - Suggested minor refactor in handler (addressed)
+
+======================
+```
+
+**`per_step` mode** — posts the step's raw `RunResult.Output` with a header:
+
+```
+**Step: implement (backend-dev) — ✓ passed** (4m 12s)
+
+[raw agent output]
+```
+
+### Approval Step Comments
+
+Approval steps always post their `message` to the task regardless of `result_comment` mode. This is separate from result comments — it is the mechanism by which the approval step communicates with the human.
+
+### Failed Workflow Comments
+
+When a workflow instance fails, `on_complete` mode posts a failure summary:
+
+```
+**Workflow: feature-development — ✗ Failed** at step "review" (3 steps completed, 8m 11s)
+
+Failure reason: step "review" failed after 2 retries.
+
+=== Workflow Memory (at failure) ===
+...
+======================
+```
+
+## Schema
+
+```yaml
+settings:
+  result_comment: true    # hive-wide default: true = on_complete, false = off
+  state_lock: true        # unchanged
+
+workflows:
+  - id: feature-development
+    result_comment: on_complete   # on_complete | per_step | off
+                                  # overrides settings.result_comment for this workflow
+    steps: [...]
+```
+
+## Backward Compatibility
+
+Plain routes (not using `workflows:`) use the global `settings.result_comment` and `settings.state_lock` with their original single-step semantics. No behavior change for existing configurations.
+
+Single-step workflows synthesized from plain routes inherit the global settings: `state_lock` fires before the step, `result_comment` posts the step output after — identical to the current behavior.

--- a/openspec/changes/workflow-mode/specs/workflow-memory/spec.md
+++ b/openspec/changes/workflow-mode/specs/workflow-memory/spec.md
@@ -1,0 +1,144 @@
+# Specification: Workflow Memory
+
+A shared, enrichable document that travels through a workflow instance. Each step reads the current state of memory and optionally writes structured fields or a summary back to it. Only what is explicitly written to memory is forwarded — full raw output is stored in SQLite for audit and resume, but never injected into downstream agents.
+
+## Mental Model
+
+Memory is a baton passed through a relay race. Each runner reads the current state, does their work, and hands the baton forward — enriched with only what the next runner needs to know. The full history of each leg is recorded in the database, not on the baton.
+
+## Structure
+
+Memory always contains two sections:
+
+```
+=== Workflow Memory ===
+
+[Cell]
+title:    Fix user auth bug #142
+labels:   backend, bug
+priority: high
+source:   main-plane
+
+[Step Data]
+complexity: high
+approach: Refactor auth middleware to use JWT instead of sessions
+files_to_touch:
+  - src/auth/middleware.go
+  - src/auth/handler.go
+
+[Summaries]
+plan: |
+  - Analyzed the auth flow and identified session storage as the root issue
+  - JWT is the right replacement: stateless, already used in other services
+  - Two files need changes; no migration required
+  - No blockers
+
+======================
+```
+
+- **Cell section** — always present; populated from the original task at workflow start.
+- **Step Data section** — structured fields written by steps via `memory.write`.
+- **Summaries section** — plain-text summaries written by steps via `summary_prompt`.
+
+## Schema
+
+### On any `agent` step
+
+```yaml
+steps:
+  - id: plan
+    agent: architect
+    output_schema:
+      type: object
+      properties:
+        complexity:     {type: string, enum: [low, medium, high]}
+        approach:       {type: string}
+        files_to_touch: {type: array, items: {type: string}}
+      required: [complexity, approach]
+    summary_prompt: |
+      In 3-5 bullet points: what you concluded, what the next agent needs to know, any risks.
+    memory:
+      read: true          # inject current memory into this step's context (default: true)
+      write: [complexity, approach, files_to_touch]   # fields from output_schema to persist
+      # "summary" is implicitly written when summary_prompt is set — no need to declare it
+
+  - id: implement
+    agent: backend-dev
+    summary_prompt: |
+      In 3-5 bullet points: what you changed, which files, any remaining work or blockers.
+    memory:
+      read: true
+      write: []           # no structured fields to persist; summary is still written
+```
+
+### `memory` field reference
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `read` | bool | `true` | Inject the current memory document into this step's system prompt |
+| `write` | string[] | `[]` | Field names from `output_schema` to persist into memory. Each becomes a top-level key. |
+
+`summary_prompt` is a sibling of `memory`, not nested inside it. When set, the agent is instructed to produce a brief summary as the second-to-last output block (before the optional `APIARY_OUTPUT:` line). The engine extracts and stores it under `<step-id>` in the Summaries section.
+
+## Key Naming
+
+- Structured fields from `memory.write` are stored as flat top-level keys. Example: `write: [complexity]` adds `complexity: high` to Step Data.
+- If two steps write to the same key, last-write-wins. A warning is emitted at runtime.
+- Summaries are always namespaced by step ID (`plan:`, `implement:`) — no collisions.
+
+## Memory Read: What the Agent Sees
+
+When `memory.read: true` (default), the formatted memory document is prepended to the agent's system prompt before the soul file content and the step-level `prompt` override:
+
+```
+=== Workflow Memory ===
+... (current memory state) ...
+======================
+
+[soul file content]
+
+[step prompt override, if any]
+```
+
+When `memory.read: false`, no memory is injected. Use this for steps that must make an independent judgment uninfluenced by prior context (e.g., an adversarial review step).
+
+## Memory Without output_schema
+
+Steps that do not declare `output_schema` cannot use `memory.write` for structured fields. They can still contribute a summary via `summary_prompt`. If neither is set, the step contributes nothing to memory — the document passes through unchanged.
+
+## Memory Size
+
+Memory stays small by design — each step only writes what it declares. There is no automatic accumulation of raw output. The full text of each step's output is stored in the `step_runs` SQLite table and accessible via `apiary instances <id>` for debugging, but it never flows into downstream prompts.
+
+A `memory_max_chars` setting (default: `4000`) truncates the injected memory block if the total document exceeds the limit. Truncation removes the oldest summaries first, then truncates long string values. The Cell section and Step Data keys are never truncated.
+
+## Interaction with Structured Output
+
+`memory.write` only works when the step also declares `output_schema`. The fields listed in `write` must exist as top-level properties in the schema. The engine validates this at config load time.
+
+If `output_schema` is declared but `memory.write` is empty, structured output is still validated and stored — it just is not forwarded to downstream steps.
+
+## Interaction with `type: split` Conditions
+
+Memory fields are accessible in split conditions using the same dot-path syntax as step outputs:
+
+```yaml
+- id: route
+  type: split
+  branches:
+    - if: "memory.complexity == 'high'"
+      goto: senior-dev
+    - else: true
+      goto: standard-dev
+```
+
+`memory.<key>` reads from the current Step Data section of memory at the time the split is evaluated.
+
+## Summary: What Goes Where
+
+| Data | Stored in | Forwarded to next step |
+|---|---|---|
+| Full agent stdout | SQLite `step_runs.output` | Never (only for audit/resume) |
+| Structured output fields | SQLite + memory (if `write` declared) | Only declared fields |
+| Summary | SQLite + memory (if `summary_prompt` set) | Always (under step ID key) |
+| Cell metadata | Memory (always) | Always |

--- a/openspec/changes/workflow-mode/specs/workflow/spec.md
+++ b/openspec/changes/workflow-mode/specs/workflow/spec.md
@@ -1,0 +1,294 @@
+# Specification: Workflow Schema
+
+Complete schema reference for the `workflows:` block in `apiary.yaml`. This is the canonical definition of how workflows, triggers, and steps fit together.
+
+## Structure Overview
+
+```
+Workflow
+ ├── trigger          — which tasks start this workflow
+ └── steps[]          — ordered list of steps (the DAG)
+      ├── type: agent     — invokes one agent
+      ├── type: split     — conditional routing node
+      ├── type: approval      — human approval checkpoint
+      ├── type: foreach   — dynamic fan-out over a list
+      └── type: workflow  — delegates to a child workflow
+```
+
+Steps are children of a workflow. The engine builds a DAG from their `depends_on` relationships and executes them in topological order. Steps without `depends_on` run immediately when the workflow starts. Multiple steps with no shared dependency run in parallel.
+
+---
+
+## Full Annotated Example
+
+```yaml
+workflows:
+  - id: feature-development                     # unique across all workflows and routes
+    description: "Full feature implementation"  # shown in TUI and logs
+    resume: allowed                             # allowed | forbidden | auto
+    trigger:
+      priority: 10                              # lower = evaluated first (same as routes)
+      match:                                    # all fields must match (AND logic)
+        source: main-plane                      # restrict to this source ID (optional)
+        labels: [feature, ai-ready]            # task must have ALL these labels
+        types: [feature, improvement]           # task type must be one of these
+        title_regex: ".*"                       # task title regex (optional)
+        priority: [urgent, high]               # task priority must be one of these
+
+    steps:
+      # ── Agent step ──────────────────────────────────────────────────────────
+      - id: plan
+        type: agent                             # default; can be omitted
+        agent: architect                        # agent ID defined in agents:
+        model: claude-opus-4-8                  # optional: override agent's preferred_models
+        prompt: |                               # optional: extra prompt appended to agent's soul
+          Produce a structured implementation plan.
+        summary_prompt: |                       # optional: agent produces a brief handoff note
+          In 3-5 bullets: conclusions, risks, what the next agent needs to know.
+        idempotent: false                       # hint for resume warnings (default: false)
+        output_schema:                          # optional: expect structured JSON on last line
+          type: object
+          properties:
+            complexity: {type: string, enum: [low, medium, high]}
+            approach:   {type: string}
+          required: [complexity, approach]
+        on_missing_output: warn                 # warn | fail | ignore (default: warn)
+        memory:
+          read: true                            # inject memory doc into prompt (default: true)
+          write: [complexity, approach]         # output_schema fields to persist in memory
+        on_pass:
+          next: implement                       # optional: explicit next step on success
+        on_fail:
+          goto: plan                            # optional: loop-back step ID
+          max_retries: 2                        # required when goto is set
+
+      # ── Agent step (depends on plan) ────────────────────────────────────────
+      - id: implement
+        agent: backend-dev
+        depends_on: [plan]                      # list of step IDs that must pass first
+        summary_prompt: |
+          In 3-5 bullets: what you changed, files modified, any blockers.
+        memory:
+          read: true    # sees: cell + complexity + approach + plan summary
+          write: []     # no structured fields to add; summary is still written
+
+      # ── Split step ──────────────────────────────────────────────────────────
+      - id: route-by-complexity
+        type: split
+        depends_on: [plan]
+        multi: false                            # false = first match wins (default)
+                                                # true  = all matching branches activate
+        branches:
+          - if: "memory.complexity == 'high'"   # memory fields accessible in conditions
+            goto: senior-review
+          - if: "memory.complexity == 'medium'"
+            goto: standard-review
+          - else: true                          # required when multi: false
+            goto: fast-review
+
+      # ── Approval step ────────────────────────────────────────────────────────
+      - id: human-approval
+        type: approval
+        depends_on: [plan]
+        message: |
+          Plan is ready. Reply "approve" to continue or "reject" to abort.
+        resume_on:
+          comment_contains: "approve"           # resumes the workflow
+          label_added: "approved"               # alternative trigger
+          state_changed: "in_review"            # alternative trigger
+        abort_on:
+          comment_contains: "reject"            # marks instance as failed
+        timeout: 48h                            # optional: abort if no response (default: none)
+
+      # ── Foreach step ────────────────────────────────────────────────────────
+      - id: fix-issues
+        type: foreach
+        depends_on: [implement]
+        items: "steps.implement.output.issues"  # dot-path to array in structured output
+        as: issue                               # variable name inside the inner step
+        concurrency: 4                          # max parallel sub-runs (default: 2)
+        max_items: 20                           # hard cap; fail if exceeded (default: 50)
+        fail_fast: false                        # stop on first sub-run failure (default: false)
+        step:                                   # the agent step run once per item
+          agent: backend-dev
+          model: claude-haiku-4-5               # optional per-item model override
+          prompt: |
+            Fix issue in {{ issue.file }}:
+            {{ issue.description }}
+          output_schema:
+            type: object
+            properties:
+              fixed:   {type: boolean}
+              summary: {type: string}
+            required: [fixed]
+
+      # ── Sub-workflow step ────────────────────────────────────────────────────
+      - id: review-phase
+        type: workflow
+        workflow: standard-review               # ID of another workflow defined in this file
+        depends_on: [fix-issues]
+        # child workflow receives the current memory snapshot at this point
+
+    on_complete:                                # side-effects when all steps pass
+      set_state: in_review
+      add_labels: [implemented]
+    on_fail:                                    # side-effects when any step fails
+      set_state: blocked
+      add_labels: [workflow-failed]
+```
+
+---
+
+## `workflows[]` — Top-Level Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | ✓ | Unique identifier. Must not conflict with any route `id`. |
+| `description` | string | — | Human-readable label shown in TUI and logs. |
+| `resume` | enum | — | `allowed` (default) \| `forbidden` \| `auto`. See [resume spec](../resume/spec.md). |
+| `trigger` | object | — | Omit to create a sub-workflow-only workflow (no Router matching). |
+| `steps` | StepConfig[] | ✓ | At least one step required. |
+| `on_complete` | HookConfig | — | Applied when the instance reaches `done`. |
+| `on_fail` | HookConfig | — | Applied when the instance reaches `failed`. |
+
+---
+
+## `trigger` Fields
+
+Identical to route `match` plus `priority`. The Router evaluates workflow triggers in `priority` order; first match wins.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `priority` | int | ✓ | Evaluation order — lower = first. |
+| `match.source` | string | — | Restrict to a specific source ID. |
+| `match.labels` | string[] | — | Task must have ALL listed labels. |
+| `match.types` | string[] | — | Task type must be one of these values. |
+| `match.title_regex` | string | — | Task title must match this regex. |
+| `match.priority` | string[] | — | Task priority must be one of these values. |
+
+---
+
+## `steps[]` — Common Fields (all step types)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | ✓ | Unique within the workflow. Used in `depends_on` and expressions. |
+| `type` | enum | — | `agent` (default) \| `split` \| `approval` \| `foreach` \| `workflow` |
+| `depends_on` | string[] | — | Step IDs that must be in state `passed` before this step runs. Omit to run at workflow start. |
+
+---
+
+## Step Type: `agent`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `agent` | string | ✓ | Agent ID from `agents:`. |
+| `model` | string | — | Model override for this step. Opaque string passed to runner. See [per-step-model spec](../per-step-model/spec.md). |
+| `prompt` | string | — | Extra text appended to the agent's soul file content and memory. |
+| `summary_prompt` | string | — | Instruction for the agent to produce a brief handoff note. Stored in memory under `<step-id>`. |
+| `idempotent` | bool | — | Resume hint. `false` by default. |
+| `output_schema` | JSON Schema | — | Expected structured output schema. See [structured-output spec](../structured-output/spec.md). |
+| `on_missing_output` | enum | — | `warn` (default) \| `fail` \| `ignore`. Applies when `output_schema` is set but no `APIARY_OUTPUT:` line found. |
+| `memory.read` | bool | — | Inject current memory into this step's prompt. Default: `true`. Set `false` for independent judgment steps. |
+| `memory.write` | string[] | — | Fields from `output_schema` to persist in memory. Requires `output_schema`. |
+| `on_pass.next` | string | — | Explicit next step ID on success. Normally inferred from the DAG; use only to override. |
+| `on_fail.goto` | string | — | Step ID to loop back to on failure. Must be an ancestor step. |
+| `on_fail.max_retries` | int | — | Required when `on_fail.goto` is set. Max times this loop may repeat before the instance fails. |
+
+---
+
+## Step Type: `split`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `multi` | bool | — | `false` (default): first matching branch wins. `true`: all matching branches activate in parallel. |
+| `branches` | Branch[] | ✓ | Ordered list of branches. |
+| `branches[].if` | string | — | Condition expression. Omit (with `else: true`) for the fallback branch. |
+| `branches[].else` | bool | — | Marks the fallback branch. Exactly one required when `multi: false`. |
+| `branches[].goto` | string | ✓ | Step ID to activate when this branch matches. |
+
+**Expression language** available in `if`: `cell.*`, `memory.*`, and `steps.<id>.state` / `steps.<id>.exit_code`. See [proposal](../../proposal.md#expression-language).
+
+---
+
+## Step Type: `approval`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `message` | string | ✓ | Posted as a comment on the source task when the approval step is reached. |
+| `resume_on` | ApprovalTrigger | ✓ | Condition that resumes the workflow. |
+| `abort_on` | ApprovalTrigger | — | Condition that fails the workflow. |
+| `timeout` | duration | — | If set, aborts the workflow after this duration with no human response. |
+
+**ApprovalTrigger fields** (at least one required per trigger):
+
+| Field | Type | Description |
+|---|---|---|
+| `comment_contains` | string | A comment on the task containing this string. |
+| `label_added` | string | This label is added to the task. |
+| `state_changed` | string | The task moves to this state. |
+
+---
+
+## Step Type: `foreach`
+
+See [foreach-step spec](../foreach-step/spec.md) for full details.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `items` | string | ✓ | Dot-path to an array in a prior step's structured output. |
+| `as` | string | — | Variable name for the current item in prompt templates. Default: `item`. |
+| `concurrency` | int | — | Max parallel sub-runs. Default: `2`. Range: 1–16. |
+| `max_items` | int | — | Hard cap on array length. Default: `50`. Range: 1–200. |
+| `fail_fast` | bool | — | Fail immediately when any sub-run fails. Default: `false`. |
+| `step` | StepConfig | ✓ | The `agent` step definition to run per item. Must be `type: agent`. |
+
+---
+
+## Step Type: `workflow`
+
+See [sub-workflows spec](../sub-workflows/spec.md) for full details.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `workflow` | string | ✓ | ID of another workflow defined in `apiary.yaml`. |
+| _(no extra fields)_ | — | — | Child receives the current memory snapshot automatically. |
+
+---
+
+## `on_complete` / `on_fail` — Hook Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `set_state` | string | Move the task to this state in the source system. |
+| `add_labels` | string[] | Add these labels to the task. |
+
+---
+
+## Step Execution Order
+
+The engine computes a topological sort of steps by `depends_on`. Steps at the same depth (no dependency between them) run in parallel. Explicit `on_pass.next` overrides this only for the declaring step — it does not affect other steps that `depends_on` the same node.
+
+```
+Example DAG:
+
+  plan ──► route-by-complexity ──► senior-review ─┐
+                               └──► fast-review   ─┤
+                                                   ▼
+  implement ─────────────────────────────────► finalize
+```
+
+`finalize` runs when all its `depends_on` entries have passed.
+
+---
+
+## Related Specs
+
+| Spec | Description |
+|---|---|
+| [workflow-memory](../workflow-memory/spec.md) | Memory object, `memory.write`, `summary_prompt` |
+| [structured-output](../structured-output/spec.md) | `output_schema` and `APIARY_OUTPUT:` contract |
+| [foreach-step](../foreach-step/spec.md) | Dynamic fan-out |
+| [resume](../resume/spec.md) | Resuming failed instances |
+| [per-step-model](../per-step-model/spec.md) | Step-level model override |
+| [sub-workflows](../sub-workflows/spec.md) | `type: workflow` child invocation |

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -10,36 +10,38 @@ Parse the `workflows:` block alongside existing `routes:`. No execution changes.
 
 ### 1.1 Config Structs
 
-- [ ] 1.1.1 Add `WorkflowConfig`, `StepConfig`, `TriggerConfig`, `SplitBranch`, `ApprovalConfig`, `ApprovalTrigger`, `StepOutcome`, `MemoryConfig` structs to `src/internal/config/config.go`
-- [ ] 1.1.2 Add `Workflows []WorkflowConfig` field to top-level `Config` struct
-- [ ] 1.1.3 Update YAML unmarshaling to parse `workflows:` block
+- [x] 1.1.1 Add `WorkflowConfig`, `StepConfig`, `TriggerConfig`, `SplitBranch`, `ApprovalTrigger`, `StepOutcome`, `MemoryConfig`, `OutputSchema`, `SchemaField` structs (in new file `src/internal/config/workflow.go` to keep `config.go` focused)
+- [x] 1.1.2 Add `Workflows []WorkflowConfig` field to top-level `Config` struct
+- [x] 1.1.3 Update YAML unmarshaling to parse `workflows:` block (struct tags + parse round-trip test)
 
 ### 1.2 Config Validation
 
-- [ ] 1.2.1 Validate workflow IDs are unique and do not conflict with route IDs (`src/internal/config/validate.go`)
-- [ ] 1.2.2 Validate step graph: all `depends_on` references point to existing step IDs within the same workflow
-- [ ] 1.2.3 Validate step graph is a DAG (cycle detection); allow only declared `on_fail.goto` back-edges pointing to ancestors
-- [ ] 1.2.4 Validate all `agent` fields in steps reference a defined agent ID
-- [ ] 1.2.5 Validate all `branches[].goto` and `on_fail.goto` references point to existing step IDs
-- [ ] 1.2.6 Validate `memory.write` fields exist as top-level properties in the step's `output_schema`
-- [ ] 1.2.7 Validate `output_schema` is a supported JSON Schema subset (object, string, number, boolean, enum, required — no arrays at top level, no `$ref`)
-- [ ] 1.2.8 Validate split steps: `multi: false` requires exactly one `else` branch; `type: agent` steps require `agent` field; `type: approval` steps must not have `agent` field
-- [ ] 1.2.9 Validate `on_fail.max_retries` is present and ≥ 1 when `on_fail.goto` is set
-- [ ] 1.2.10 Validate `foreach.items` dot-path resolves to an `array` type in the referenced step's `output_schema`
-- [ ] 1.2.11 Validate sub-workflow references: `type: workflow` step must reference an existing workflow ID; referenced workflow must not contain `type: workflow` steps; no self-reference
-- [ ] 1.2.12 Validate `resume: auto` only when all steps are `idempotent: true`
-- [ ] 1.2.13 Write validation unit tests covering all new cases
+(in new files `workflow_validate.go` + `workflow_graph.go`, hooked into `Config.Validate()`)
+
+- [x] 1.2.1 Validate workflow IDs are unique and do not conflict with route IDs
+- [x] 1.2.2 Validate step graph: all `depends_on` references point to existing step IDs within the same workflow
+- [x] 1.2.3 Validate step graph is a DAG (cycle detection); allow only declared `on_fail.goto` back-edges pointing to ancestors
+- [x] 1.2.4 Validate all `agent` fields in steps reference a defined agent ID
+- [x] 1.2.5 Validate all `branches[].goto`, `on_fail.goto`, and `on_pass.next` references point to existing step IDs
+- [x] 1.2.6 Validate `memory.write` fields exist as top-level properties in the step's `output_schema`
+- [x] 1.2.7 Validate `output_schema` is a supported JSON Schema subset (top-level object; string, number, integer, boolean, array, object properties; enum on string only; arrays require `items` — arrays ARE supported because foreach consumes them; no `$ref`)
+- [x] 1.2.8 Validate split steps: `multi: false` requires exactly one `else`/fallback branch; `type: agent` steps require `agent` field; `type: approval`/`split`/`workflow` steps must not have `agent` field
+- [x] 1.2.9 Validate `on_fail.max_retries` is present and ≥ 1 when `on_fail.goto` is set
+- [x] 1.2.10 Validate `foreach.items` dot-path resolves to an `array` type in the referenced step's `output_schema`; concurrency 1–16; max_items 1–200; inner step must be `agent`
+- [x] 1.2.11 Validate sub-workflow references: `type: workflow` step must reference an existing workflow ID; referenced workflow must not contain `type: workflow` steps; no self-reference
+- [x] 1.2.12 Validate `resume: auto` only when all steps are `idempotent: true`
+- [x] 1.2.13 Write validation unit tests covering all new cases (44 cases)
 
 ### 1.3 `apiary validate` Update
 
-- [ ] 1.3.1 Update `apiary validate` to report workflow validation errors with step-level context (e.g. `workflow "feature-dev", step "implement": agent "backend" not found`)
-- [ ] 1.3.2 Update `apiary validate` to warn when a workflow is defined but no trigger is set and it is not referenced as a sub-workflow
+- [x] 1.3.1 Update `apiary validate` to report workflow validation errors with step-level context (e.g. `workflows[1] "bad-wf": step "s1": agent "ghost-agent" not defined`)
+- [x] 1.3.2 Update `apiary validate` to warn when a workflow is defined but no trigger is set and it is not referenced as a sub-workflow (`Config.WorkflowWarnings()`)
 
 ### 1.4 Tests
 
-- [ ] 1.4.1 Unit tests: valid workflow parses correctly
-- [ ] 1.4.2 Unit tests: all validation error cases produce correct messages
-- [ ] 1.4.3 Run full test suite: `go test ./...`
+- [x] 1.4.1 Unit tests: valid workflow parses correctly (`workflow_parse_test.go` — full YAML round-trip)
+- [x] 1.4.2 Unit tests: all validation error cases produce correct messages
+- [x] 1.4.3 Run full test suite: `go test ./...`
 
 ---
 

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: Workflow Mode
+
+Implementation follows the 4-phase plan from `design.md`. Complete each phase fully before starting the next — each phase produces a shippable state.
+
+---
+
+## Phase 1 — Schema Parsing
+
+Parse the `workflows:` block alongside existing `routes:`. No execution changes. A defined workflow that is not yet executed emits a startup warning.
+
+### 1.1 Config Structs
+
+- [ ] 1.1.1 Add `WorkflowConfig`, `StepConfig`, `TriggerConfig`, `SplitBranch`, `ApprovalConfig`, `ApprovalTrigger`, `StepOutcome`, `MemoryConfig` structs to `src/internal/config/config.go`
+- [ ] 1.1.2 Add `Workflows []WorkflowConfig` field to top-level `Config` struct
+- [ ] 1.1.3 Update YAML unmarshaling to parse `workflows:` block
+
+### 1.2 Config Validation
+
+- [ ] 1.2.1 Validate workflow IDs are unique and do not conflict with route IDs (`src/internal/config/validate.go`)
+- [ ] 1.2.2 Validate step graph: all `depends_on` references point to existing step IDs within the same workflow
+- [ ] 1.2.3 Validate step graph is a DAG (cycle detection); allow only declared `on_fail.goto` back-edges pointing to ancestors
+- [ ] 1.2.4 Validate all `agent` fields in steps reference a defined agent ID
+- [ ] 1.2.5 Validate all `branches[].goto` and `on_fail.goto` references point to existing step IDs
+- [ ] 1.2.6 Validate `memory.write` fields exist as top-level properties in the step's `output_schema`
+- [ ] 1.2.7 Validate `output_schema` is a supported JSON Schema subset (object, string, number, boolean, enum, required — no arrays at top level, no `$ref`)
+- [ ] 1.2.8 Validate split steps: `multi: false` requires exactly one `else` branch; `type: agent` steps require `agent` field; `type: approval` steps must not have `agent` field
+- [ ] 1.2.9 Validate `on_fail.max_retries` is present and ≥ 1 when `on_fail.goto` is set
+- [ ] 1.2.10 Validate `foreach.items` dot-path resolves to an `array` type in the referenced step's `output_schema`
+- [ ] 1.2.11 Validate sub-workflow references: `type: workflow` step must reference an existing workflow ID; referenced workflow must not contain `type: workflow` steps; no self-reference
+- [ ] 1.2.12 Validate `resume: auto` only when all steps are `idempotent: true`
+- [ ] 1.2.13 Write validation unit tests covering all new cases
+
+### 1.3 `apiary validate` Update
+
+- [ ] 1.3.1 Update `apiary validate` to report workflow validation errors with step-level context (e.g. `workflow "feature-dev", step "implement": agent "backend" not found`)
+- [ ] 1.3.2 Update `apiary validate` to warn when a workflow is defined but no trigger is set and it is not referenced as a sub-workflow
+
+### 1.4 Tests
+
+- [ ] 1.4.1 Unit tests: valid workflow parses correctly
+- [ ] 1.4.2 Unit tests: all validation error cases produce correct messages
+- [ ] 1.4.3 Run full test suite: `go test ./...`
+
+---
+
+## Phase 2 — Single-Step Workflow Engine
+
+Implement `WorkflowEngine` behind `settings.experimental.workflow_mode: true`. Single-step workflows only (no DAG, no split, no approval, no foreach). Plain `routes:` are synthesized as single-step workflows and run through the same engine.
+
+### 2.1 SQLite Schema
+
+- [ ] 2.1.1 Add `workflow_instances` table migration to `src/internal/store/migrations/`
+- [ ] 2.1.2 Add `step_runs` table migration
+- [ ] 2.1.3 Add `summary` and `structured_output` columns to `step_runs`
+- [ ] 2.1.4 Implement `WorkflowStore` in `src/internal/store/workflow_store.go`: CRUD for instances and step runs
+
+### 2.2 Runner Interface Changes
+
+- [ ] 2.2.1 Add `SystemPrepend`, `SummaryPrompt`, `StepID`, `WorkflowInstanceID` fields to `RunRequest` — see [runner-interface spec](specs/runner-interface/spec.md)
+- [ ] 2.2.2 Add `StructuredOutput map[string]any`, `Summary string` fields to `RunResult`
+- [ ] 2.2.3 Update OpenCode runner: inject `SystemPrepend` before soul file; parse `APIARY_OUTPUT:` last line into `StructuredOutput`; extract summary block into `Summary`
+- [ ] 2.2.4 Update script runner: inject `SystemPrepend`; pass `APIARY_SUMMARY_PROMPT` env var; parse `APIARY_OUTPUT:` line
+- [ ] 2.2.5 Update runner interface tests
+
+### 2.3 Memory Builder
+
+- [ ] 2.3.1 Implement `MemoryBuilder` in `src/internal/workflow/memory.go`: builds the memory document from cell + completed step runs
+- [ ] 2.3.2 Implement `memory_max_chars` truncation (oldest summaries first; Cell and Step Data never truncated)
+- [ ] 2.3.3 Unit tests for `MemoryBuilder` with various step combinations
+
+### 2.4 Workflow Engine
+
+- [ ] 2.4.1 Implement `WorkflowEngine` in `src/internal/workflow/engine.go`
+- [ ] 2.4.2 Implement route synthesis: plain `routes:` entries produce a single-step `WorkflowConfig` internally
+- [ ] 2.4.3 Implement instance lifecycle: create → run step → complete/fail → apply hooks
+- [ ] 2.4.4 Implement concurrency semaphore — see [concurrency-model spec](specs/concurrency-model/spec.md)
+- [ ] 2.4.5 Implement `state_lock` and `result_comment` workflow behavior — see [workflow-hooks spec](specs/workflow-hooks/spec.md)
+- [ ] 2.4.6 Wire `WorkflowEngine` into daemon; respect `settings.experimental.workflow_mode` flag
+- [ ] 2.4.7 Integration test: plain route dispatches through engine, produces instance + step_run in SQLite
+
+### 2.5 Tests
+
+- [ ] 2.5.1 Unit tests: engine creates instance, runs step, marks done
+- [ ] 2.5.2 Unit tests: `state_lock` fires at workflow start; `result_comment` posts at workflow end
+- [ ] 2.5.3 Integration test: end-to-end with a real source + runner stub
+- [ ] 2.5.4 Run full test suite: `go test ./...`
+
+---
+
+## Phase 3 — Full DAG Execution
+
+Multi-step workflows, parallel steps, split steps, foreach, sub-workflows, per-step model override. Enable by default (remove feature flag).
+
+### 3.1 DAG Executor
+
+- [ ] 3.1.1 Implement topological sort of steps by `depends_on` in `WorkflowEngine`
+- [ ] 3.1.2 Implement parallel step dispatch: steps ready at the same time run concurrently up to global concurrency limit
+- [ ] 3.1.3 Implement `on_fail.goto` loop-back with `retry_counts` tracking and `max_retries` enforcement
+- [ ] 3.1.4 Implement cascade reset: when a loop-back fires, reset all downstream steps to `pending`
+
+### 3.2 Split Steps
+
+- [ ] 3.2.1 Implement expression evaluator in `src/internal/workflow/expr.go` — see [proposal expression language](proposal.md#expression-language)
+- [ ] 3.2.2 Implement split step execution: evaluate branches, activate matching step(s)
+- [ ] 3.2.3 Support `multi: true` fan-out
+- [ ] 3.2.4 Unit tests: all expression operators, multi-branch split, fallback branch, unmatched split error
+
+### 3.3 Foreach Steps
+
+- [ ] 3.3.1 Implement foreach step execution: read items array from step structured output, spawn sub-runs
+- [ ] 3.3.2 Implement `concurrency` cap and `max_items` guard
+- [ ] 3.3.3 Implement prompt template rendering (`{{ item.field }}` substitution)
+- [ ] 3.3.4 Implement `fail_fast` behavior
+- [ ] 3.3.5 Expose `steps.<id>.outputs`, `steps.<id>.passed_count`, `steps.<id>.failed_count` in memory/expressions
+- [ ] 3.3.6 Unit tests: foreach with structured output, concurrency cap, max_items abort, fail_fast
+
+### 3.4 Sub-Workflows
+
+- [ ] 3.4.1 Implement `type: workflow` step: create child instance, pass memory snapshot, link via `parent_instance_id`
+- [ ] 3.4.2 Implement child instance completion: mark parent step passed/failed based on child outcome
+- [ ] 3.4.3 Unit tests: child instance created and linked; parent step waits for child
+
+### 3.5 Per-Step Model Override
+
+- [ ] 3.5.1 Read `step.model` field in engine; pass to `RunRequest.Model` overriding agent's `preferred_models[0]`
+- [ ] 3.5.2 Unit test: step with `model` override uses correct model
+
+### 3.6 Remove Feature Flag
+
+- [ ] 3.6.1 Remove `settings.experimental.workflow_mode` flag; engine always active
+- [ ] 3.6.2 Update `apiary validate` and `apiary status` to show workflow info unconditionally
+
+### 3.7 Tests
+
+- [ ] 3.7.1 Integration test: 3-step sequential workflow completes, memory populated correctly
+- [ ] 3.7.2 Integration test: parallel steps run concurrently, fan-in step waits for both
+- [ ] 3.7.3 Integration test: split routes to correct branch based on memory field
+- [ ] 3.7.4 Integration test: `on_fail.goto` loops back, respects `max_retries`
+- [ ] 3.7.5 Run full test suite: `go test ./...`
+
+---
+
+## Phase 4 — Approvals
+
+Approval steps. Requires source-write-back polling (new `PollTask` on `SourceAdapter`).
+
+### 4.1 Source Adapter Extension
+
+- [ ] 4.1.1 Add `PollTask(ctx, cellID string) (Cell, error)` to `SourceAdapter` interface — see [source-adapter-watch spec](specs/source-adapter-watch/spec.md)
+- [ ] 4.1.2 Implement `PollTask` in Plane adapter
+- [ ] 4.1.3 Implement `PollTask` in GitHub Issues adapter
+- [ ] 4.1.4 Add stub `PollTask` (returns `ErrNotSupported`) to all other adapters
+
+### 4.2 Approval Engine
+
+- [ ] 4.2.1 Implement approval step execution: post message via `WriteResult`, set instance to `approval_waiting`
+- [ ] 4.2.2 Implement approval polling loop in `WorkflowEngine`: on each poll cycle, call `PollTask` for all `approval_waiting` instances and evaluate `resume_on` / `abort_on` conditions
+- [ ] 4.2.3 Implement approval timeout: abort instance when `timeout` expires
+- [ ] 4.2.4 Unit tests: approval posts message, waits, resumes on matching comment, aborts on abort condition, aborts on timeout
+
+### 4.3 Resume Command
+
+- [ ] 4.3.1 Implement `apiary resume <instance-id>` CLI command — see [CLI spec](../../specs/cli/spec.md)
+- [ ] 4.3.2 Implement `apiary instances` CLI command
+- [ ] 4.3.3 Show resume confirmation prompt listing skipped steps and their side effects
+
+### 4.4 TUI Updates
+
+- [ ] 4.4.1 Add step-progress panel to Task Detail view (step ID, agent, state, duration)
+- [ ] 4.4.2 Show `approval_waiting` state with message in Task Detail
+- [ ] 4.4.3 Update Runs tab to show workflow instances with nested step runs
+
+### 4.5 Tests
+
+- [ ] 4.5.1 Integration test: approval step posts comment, workflow pauses, resumes on matching comment
+- [ ] 4.5.2 Integration test: approval timeout aborts workflow
+- [ ] 4.5.3 Integration test: `apiary resume` replays cached steps, continues from failure point
+- [ ] 4.5.4 Run full test suite: `go test ./...`
+
+---
+
+## Cross-Cutting
+
+- [ ] X.1 Update `openspec/specs/plugin-api/spec.md` with new `SourceAdapter.PollTask` and updated `RunRequest`/`RunResult`
+- [ ] X.2 Update `openspec/specs/schema/spec.md` with `workflows:` block and new step types
+- [ ] X.3 Update `openspec/specs/cli/spec.md` with `apiary instances` and `apiary resume` commands
+- [ ] X.4 Update example `apiary.yaml` in `.apiary/` to show a sample workflow
+- [ ] X.5 Run `npx gitnexus analyze` after each phase to keep the knowledge graph current

--- a/openspec/specs/arquitetura/spec.md
+++ b/openspec/specs/arquitetura/spec.md
@@ -85,3 +85,17 @@ deepseek/deepseek-r1
 mistral/mistral-large-2411
 meta/llama-3.3-70b
 ```
+
+---
+
+### ADR-007: `apiary.yaml` stays at `version: "1"` for workflow mode
+
+**Status:** Accepted
+
+**Decision:** The `workflows:` block and all related fields (`memory`, `summary_prompt`, `output_schema`, etc.) are added to `version: "1"`. No version bump.
+
+**Rationale:** The changes are fully additive — existing configs without `workflows:` continue to parse and run without modification. A config validator that understands `version: "1"` with workflows will accept old configs unchanged. Bumping to `version: "2"` would require every existing user to edit their config file for no functional benefit.
+
+**Version semantics going forward:** The `version` field will only increment when a breaking change is made to the schema — a field is removed, renamed, or its meaning changes in a backward-incompatible way. Additive changes (new optional fields, new top-level blocks) do not require a version bump.
+
+**Consequence:** If a user runs an old binary against a config that uses `workflows:`, the old binary emits an "unknown field" warning (not an error) and ignores the block. This is acceptable for a developer tool — users upgrading Apiary get workflow mode; users who haven't upgraded are unaffected.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -43,13 +43,14 @@ Sources
   main-plane    plane      polling (last: 12s ago)  3 pending
   main-jira     jira       webhook                  1 pending
 
-Active runs
-  #PLANE-142  backend-bugs   backend-dev   openai/gpt-4o          running  01:23
-  #PLANE-137  docs-tasks     docs-writer   mistral/mistral-large  running  00:45
+Active instances
+  wf_a1b2c3  PLANE-142  feature-development  step 2/4: implement (backend-dev)  02:14
+  wf_d4e5f6  PLANE-137  feature-development  approval_waiting (awaiting human)  18:00
 
 Recent
-  #PLANE-134  ✓  frontend-features  frontend-dev  01:12  done
-  #PLANE-130  ✗  backend-bugs       backend-dev   00:34  error: max_turns reached
+  wf_j1k2l3  ✓  PLANE-121  feature-development  4 steps  14:32  done
+  wf_m4n5o6  ✗  PLANE-118  feature-development  failed at step "review"  08:11
+  wf_g7h8i9  ⚠  PLANE-130  backend-bug-fix      interrupted (resumable)  —
 ```
 
 ---
@@ -86,13 +87,99 @@ apiary cells [--source id] [--unmatched] [--limit n]
 
 ### `apiary dispatch`
 
-Manually dispatch a specific task to a worker, bypassing routing rules.
+Manually dispatch a specific task to a worker or workflow, bypassing routing rules.
 
 ```
-apiary dispatch --cell <source-id>/<task-id> --worker <worker-id>
+apiary dispatch --cell <source-id>/<task-id> [--worker <worker-id>] [--workflow <workflow-id>]
 ```
 
-Useful for testing a worker configuration or replaying a failed run.
+Useful for testing a worker configuration or replaying a failed run. Exactly one of `--worker` or `--workflow` must be provided.
+
+---
+
+### `apiary instances`
+
+List workflow instances with their state, steps, and resume eligibility.
+
+```
+apiary instances [--workflow id] [--state state] [--limit n] [--json]
+```
+
+| Flag | Description |
+|---|---|
+| `--workflow` | Filter by workflow ID |
+| `--state` | Filter by state: `pending`, `running`, `approval_waiting`, `interrupted`, `done`, `failed` |
+| `--limit` | Max rows (default: `20`) |
+| `--json` | Output as JSON (one object per line) |
+
+Example output:
+
+```
+ID            WORKFLOW              CELL          STATE               STARTED       DURATION
+wf_a1b2c3    feature-development   PLANE-142     running             2m 14s ago    2m 14s
+wf_d4e5f6    feature-development   PLANE-137     approval_waiting    18m ago       18m
+wf_g7h8i9    backend-bug-fix       PLANE-130     interrupted         1h ago        —
+wf_j1k2l3    feature-development   PLANE-121     done                3h ago        14m 32s
+wf_m4n5o6    feature-development   PLANE-118     failed              5h ago        8m 11s
+```
+
+Use `apiary instances <id>` to show step-level detail for a single instance:
+
+```
+apiary instances wf_a1b2c3
+```
+
+```
+Instance:  wf_a1b2c3
+Workflow:  feature-development
+Cell:      PLANE-142 — Implement user auth
+State:     running
+Started:   2m 14s ago
+
+Steps
+  ✓  plan          architect       2m 14s   passed
+  ●  implement     backend-dev     running  (0m 42s)
+  ○  review        code-reviewer   waiting  —
+  ○  finalize      backend-dev     waiting  —
+```
+
+Exit codes: `0` success, `1` general error, `2` instance ID not found.
+
+---
+
+### `apiary resume`
+
+Resume a failed or interrupted workflow instance from the last completed step.
+
+```
+apiary resume <instance-id> [--yes]
+apiary resume --workflow <workflow-id> [--yes]
+```
+
+| Flag | Description |
+|---|---|
+| `--yes` | Skip the confirmation prompt |
+| `--workflow` | Resume the most recent failed or interrupted instance of this workflow |
+
+Without `--yes`, prints a confirmation listing which steps will be skipped and their side effects, then prompts before proceeding:
+
+```
+Resuming instance wf_g7h8i9 (feature-development / PLANE-130)
+
+Steps to skip (already completed):
+  ✓ plan       architect     — no on_complete hooks
+  ✓ implement  backend-dev   — on_complete: set_state=in_progress (already applied)
+
+Steps to run:
+  ○ review     code-reviewer
+  ○ finalize   backend-dev
+
+Proceed? [y/N]
+```
+
+On confirmation, the instance is re-queued. The daemon picks it up on its next cycle.
+
+Exit codes: `0` resume queued, `1` general error, `2` instance not found, `3` instance not resumable (state is `done` or `running`), `4` workflow definition changed since instance was created.
 
 ---
 
@@ -101,8 +188,16 @@ Useful for testing a worker configuration or replaying a failed run.
 Stream or tail structured run logs.
 
 ```
-apiary logs [--run-id id] [--follow] [--level debug|info|warn|error]
+apiary logs [--run-id id] [--instance-id id] [--step id] [--follow] [--level debug|info|warn|error]
 ```
+
+| Flag | Description |
+|---|---|
+| `--run-id` | Filter logs by a specific step run ID |
+| `--instance-id` | Filter logs by workflow instance ID (shows all step logs for that instance) |
+| `--step` | Combined with `--instance-id`: show logs for a specific step only |
+| `--follow` | Stream new log lines as they arrive |
+| `--level` | Minimum log level to show |
 
 ---
 
@@ -137,3 +232,4 @@ Prompts for source type, runner, basic routing rules, and generates a starter co
 | `2` | Config validation error |
 | `3` | Source connection error |
 | `4` | One or more runs failed (only in `--once` mode) |
+| `5` | One or more workflow instances are in `interrupted` state on startup (warning, not fatal) |

--- a/src/internal/cli/validate.go
+++ b/src/internal/cli/validate.go
@@ -3,8 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/spf13/cobra"
 )
 
 func newValidateCmd() *cobra.Command {
@@ -25,6 +25,10 @@ func newValidateCmd() *cobra.Command {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  ✗ %s\n", e)
 				}
 				return fmt.Errorf("%d validation error(s)", len(errs))
+			}
+
+			for _, w := range cfg.WorkflowWarnings() {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  ⚠ %s\n", w)
 			}
 
 			fmt.Println("✓ config is valid")

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -11,14 +11,15 @@ import (
 )
 
 type Config struct {
-	Version       string         `yaml:"version"`
-	Runners       []RunnerConfig `yaml:"runners"`
-	DefaultRunner string         `yaml:"default_runner"`
-	Sources       []SourceConfig `yaml:"sources"`
-	Agents        []AgentConfig  `yaml:"agents"`
-	Workers       []WorkerConfig `yaml:"workers"`
-	Routes        []RouteConfig  `yaml:"routes"`
-	Settings      Settings       `yaml:"settings"`
+	Version       string           `yaml:"version"`
+	Runners       []RunnerConfig   `yaml:"runners"`
+	DefaultRunner string           `yaml:"default_runner"`
+	Sources       []SourceConfig   `yaml:"sources"`
+	Agents        []AgentConfig    `yaml:"agents"`
+	Workers       []WorkerConfig   `yaml:"workers"`
+	Routes        []RouteConfig    `yaml:"routes"`
+	Workflows     []WorkflowConfig `yaml:"workflows"`
+	Settings      Settings         `yaml:"settings"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 }

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -104,5 +104,7 @@ func (c *Config) Validate() []error {
 		routeIDs[r.ID] = true
 	}
 
+	errs = append(errs, c.validateWorkflows()...)
+
 	return errs
 }

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -1,0 +1,208 @@
+package config
+
+import "time"
+
+// Step type identifiers. A step with an empty Type is treated as StepTypeAgent.
+const (
+	StepTypeAgent    = "agent"
+	StepTypeSplit    = "split"
+	StepTypeApproval = "approval"
+	StepTypeForeach  = "foreach"
+	StepTypeWorkflow = "workflow"
+)
+
+// Resume policy values for a workflow.
+const (
+	ResumeAllowed   = "allowed"
+	ResumeForbidden = "forbidden"
+	ResumeAuto      = "auto"
+)
+
+// Result comment modes for a workflow.
+const (
+	ResultCommentOnComplete = "on_complete"
+	ResultCommentPerStep    = "per_step"
+	ResultCommentOff        = "off"
+)
+
+// on_missing_output policy values for an agent step that declares output_schema.
+const (
+	OnMissingOutputWarn   = "warn"
+	OnMissingOutputFail   = "fail"
+	OnMissingOutputIgnore = "ignore"
+)
+
+// WorkflowConfig defines a multi-step pipeline triggered by matching tasks.
+// A plain route is equivalent to a single-step workflow; both are executed by
+// the workflow engine.
+type WorkflowConfig struct {
+	ID          string `yaml:"id"`
+	Description string `yaml:"description,omitempty"`
+	// Resume controls how a failed/interrupted instance may be restarted:
+	// allowed (default), forbidden, or auto. Empty means allowed.
+	Resume string `yaml:"resume,omitempty"`
+	// ResultComment overrides settings.result_comment for this workflow:
+	// on_complete (default), per_step, or off. Empty inherits the global default.
+	ResultComment string         `yaml:"result_comment,omitempty"`
+	Trigger       *TriggerConfig `yaml:"trigger,omitempty"`
+	Steps         []StepConfig   `yaml:"steps"`
+	OnComplete    *OnComplete    `yaml:"on_complete,omitempty"`
+	OnFail        *OnComplete    `yaml:"on_fail,omitempty"`
+}
+
+// ResumePolicy returns the effective resume policy, defaulting to ResumeAllowed.
+func (w WorkflowConfig) ResumePolicy() string {
+	if w.Resume == "" {
+		return ResumeAllowed
+	}
+	return w.Resume
+}
+
+// TriggerConfig selects which tasks start a workflow. It mirrors route matching:
+// priority ordering plus a RouteMatch condition.
+type TriggerConfig struct {
+	Priority int        `yaml:"priority"`
+	Match    RouteMatch `yaml:"match"`
+}
+
+// StepConfig is one node in a workflow graph. The active fields depend on Type.
+type StepConfig struct {
+	ID        string   `yaml:"id"`
+	Type      string   `yaml:"type,omitempty"` // agent(default)|split|approval|foreach|workflow
+	DependsOn []string `yaml:"depends_on,omitempty"`
+
+	// ── agent step ────────────────────────────────────────────────
+	Agent           string        `yaml:"agent,omitempty"`
+	Model           string        `yaml:"model,omitempty"` // overrides agent's model for this step
+	Prompt          string        `yaml:"prompt,omitempty"`
+	SummaryPrompt   string        `yaml:"summary_prompt,omitempty"`
+	Idempotent      bool          `yaml:"idempotent,omitempty"`
+	OutputSchema    *OutputSchema `yaml:"output_schema,omitempty"`
+	OnMissingOutput string        `yaml:"on_missing_output,omitempty"` // warn(default)|fail|ignore
+	Memory          *MemoryConfig `yaml:"memory,omitempty"`
+	OnPass          *StepNext     `yaml:"on_pass,omitempty"`
+	OnFail          *StepOutcome  `yaml:"on_fail,omitempty"`
+
+	// ── split step ────────────────────────────────────────────────
+	Multi    bool          `yaml:"multi,omitempty"`
+	Branches []SplitBranch `yaml:"branches,omitempty"`
+
+	// ── approval step ─────────────────────────────────────────────
+	Message  string           `yaml:"message,omitempty"`
+	ResumeOn *ApprovalTrigger `yaml:"resume_on,omitempty"`
+	AbortOn  *ApprovalTrigger `yaml:"abort_on,omitempty"`
+	Timeout  string           `yaml:"timeout,omitempty"`
+
+	// ── foreach step ──────────────────────────────────────────────
+	Items       string      `yaml:"items,omitempty"`
+	As          string      `yaml:"as,omitempty"`
+	Concurrency int         `yaml:"concurrency,omitempty"`
+	MaxItems    int         `yaml:"max_items,omitempty"`
+	FailFast    bool        `yaml:"fail_fast,omitempty"`
+	Step        *StepConfig `yaml:"step,omitempty"`
+
+	// ── sub-workflow step ─────────────────────────────────────────
+	Workflow string `yaml:"workflow,omitempty"`
+}
+
+// StepType returns the step's type, defaulting to StepTypeAgent when unset.
+func (s StepConfig) StepType() string {
+	if s.Type == "" {
+		return StepTypeAgent
+	}
+	return s.Type
+}
+
+// MemoryReadEnabled reports whether the workflow memory document should be
+// injected into this step. Defaults to true; only an explicit `memory.read: false`
+// disables it.
+func (s StepConfig) MemoryReadEnabled() bool {
+	if s.Memory == nil || s.Memory.Read == nil {
+		return true
+	}
+	return *s.Memory.Read
+}
+
+// MemoryWriteFields returns the output_schema field names this step persists to
+// workflow memory, or nil when none are declared.
+func (s StepConfig) MemoryWriteFields() []string {
+	if s.Memory == nil {
+		return nil
+	}
+	return s.Memory.Write
+}
+
+// ParsedTimeout returns the approval-step timeout, or 0 when unset/invalid
+// (meaning no timeout).
+func (s StepConfig) ParsedTimeout() time.Duration {
+	if s.Timeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s.Timeout)
+	if err != nil {
+		return 0
+	}
+	return d
+}
+
+// MemoryConfig controls how a step interacts with the workflow memory object.
+type MemoryConfig struct {
+	// Read is a pointer so an explicit `read: false` is distinguishable from an
+	// unset value (which defaults to true). Use StepConfig.MemoryReadEnabled().
+	Read  *bool    `yaml:"read,omitempty"`
+	Write []string `yaml:"write,omitempty"`
+}
+
+// StepNext is the explicit success edge of an agent step (on_pass.next).
+type StepNext struct {
+	Next string `yaml:"next,omitempty"`
+}
+
+// StepOutcome is the failure edge of an agent step (on_fail.goto + max_retries).
+type StepOutcome struct {
+	Goto       string `yaml:"goto,omitempty"`
+	MaxRetries int    `yaml:"max_retries,omitempty"`
+}
+
+// SplitBranch is one conditional edge of a split step. A branch is the fallback
+// ("else") when Else is true or when If is empty.
+type SplitBranch struct {
+	If   string `yaml:"if,omitempty"`
+	Else bool   `yaml:"else,omitempty"`
+	Goto string `yaml:"goto"`
+}
+
+// IsFallback reports whether this branch is the catch-all/else branch.
+func (b SplitBranch) IsFallback() bool {
+	return b.Else || b.If == ""
+}
+
+// ApprovalTrigger is a resume/abort condition for an approval step. Any single
+// populated field that matches the live task is sufficient (OR semantics).
+type ApprovalTrigger struct {
+	CommentContains string `yaml:"comment_contains,omitempty"`
+	LabelAdded      string `yaml:"label_added,omitempty"`
+	StateChanged    string `yaml:"state_changed,omitempty"`
+}
+
+// IsEmpty reports whether the trigger declares no condition at all.
+func (t ApprovalTrigger) IsEmpty() bool {
+	return t.CommentContains == "" && t.LabelAdded == "" && t.StateChanged == ""
+}
+
+// OutputSchema is the supported JSON Schema subset for structured step output.
+type OutputSchema struct {
+	Type       string                 `yaml:"type"`
+	Properties map[string]SchemaField `yaml:"properties,omitempty"`
+	Required   []string               `yaml:"required,omitempty"`
+}
+
+// SchemaField describes one property within an OutputSchema. Items is set for
+// arrays; Properties/Required are set for nested objects.
+type SchemaField struct {
+	Type       string                 `yaml:"type"`
+	Enum       []string               `yaml:"enum,omitempty"`
+	Items      *SchemaField           `yaml:"items,omitempty"`
+	Properties map[string]SchemaField `yaml:"properties,omitempty"`
+	Required   []string               `yaml:"required,omitempty"`
+}

--- a/src/internal/config/workflow_graph.go
+++ b/src/internal/config/workflow_graph.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validateStepGraph validates the depends_on graph of a workflow: reference
+// integrity, acyclicity, and on_fail.goto back-edge ancestry.
+func validateStepGraph(ctx string, wf WorkflowConfig, stepIDs map[string]bool) []error {
+	var errs []error
+
+	adj := map[string][]string{}  // dependency -> dependents (forward edges)
+	deps := map[string][]string{} // step -> its direct dependencies
+
+	for _, s := range wf.Steps {
+		for _, d := range s.DependsOn {
+			if !stepIDs[d] {
+				errs = append(errs, fmt.Errorf("%s: step %q depends_on unknown step %q", ctx, s.ID, d))
+				continue
+			}
+			if d == s.ID {
+				errs = append(errs, fmt.Errorf("%s: step %q depends on itself", ctx, s.ID))
+				continue
+			}
+			adj[d] = append(adj[d], s.ID)
+			deps[s.ID] = append(deps[s.ID], d)
+		}
+	}
+
+	if cyc := findCycle(wf, adj); cyc != "" {
+		errs = append(errs, fmt.Errorf("%s: dependency cycle detected involving step %q", ctx, cyc))
+	}
+
+	// on_fail.goto back-edges must target an ancestor (a transitive dependency).
+	for _, s := range wf.Steps {
+		if s.OnFail == nil || s.OnFail.Goto == "" || !stepIDs[s.OnFail.Goto] {
+			continue
+		}
+		if !isAncestor(s.ID, s.OnFail.Goto, deps) {
+			errs = append(errs, fmt.Errorf("%s: step %q on_fail.goto %q must target an ancestor step (a transitive dependency)", ctx, s.ID, s.OnFail.Goto))
+		}
+	}
+
+	return errs
+}
+
+// findCycle returns the ID of a step participating in a dependency cycle, or ""
+// when the depends_on graph is acyclic. Standard white/gray/black DFS.
+func findCycle(wf WorkflowConfig, adj map[string][]string) string {
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := map[string]int{}
+	for _, s := range wf.Steps {
+		color[s.ID] = white
+	}
+
+	var visit func(node string) string
+	visit = func(node string) string {
+		color[node] = gray
+		for _, next := range adj[node] {
+			switch color[next] {
+			case gray:
+				return next
+			case white:
+				if c := visit(next); c != "" {
+					return c
+				}
+			}
+		}
+		color[node] = black
+		return ""
+	}
+
+	for _, s := range wf.Steps {
+		if color[s.ID] == white {
+			if c := visit(s.ID); c != "" {
+				return c
+			}
+		}
+	}
+	return ""
+}
+
+// isAncestor reports whether candidate is a transitive dependency of node,
+// following the deps (step -> dependencies) relation. A visited set guards
+// against cycles so this terminates even on malformed graphs.
+func isAncestor(node, candidate string, deps map[string][]string) bool {
+	visited := map[string]bool{}
+	queue := append([]string{}, deps[node]...)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur == candidate {
+			return true
+		}
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		queue = append(queue, deps[cur]...)
+	}
+	return false
+}
+
+// foreachItemsResolveToArray reports whether the items expression
+// (e.g. "steps.find-issues.output.issues") resolves to an array-typed field in
+// the referenced step's output_schema within the same workflow.
+func foreachItemsResolveToArray(items string, wf WorkflowConfig) bool {
+	parts := strings.Split(items, ".")
+	if len(parts) < 4 || parts[0] != "steps" || parts[2] != "output" {
+		return false
+	}
+	stepID := parts[1]
+	fieldPath := parts[3:]
+
+	var schema *OutputSchema
+	for _, s := range wf.Steps {
+		if s.ID == stepID {
+			schema = s.OutputSchema
+			break
+		}
+	}
+	if schema == nil {
+		return false
+	}
+
+	props := schema.Properties
+	var field SchemaField
+	for i, p := range fieldPath {
+		f, ok := props[p]
+		if !ok {
+			return false
+		}
+		field = f
+		if i < len(fieldPath)-1 {
+			if f.Type != "object" {
+				return false
+			}
+			props = f.Properties
+		}
+	}
+	return field.Type == "array"
+}

--- a/src/internal/config/workflow_parse_test.go
+++ b/src/internal/config/workflow_parse_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWorkflowYAMLParsing verifies that a representative workflows: block in
+// apiary.yaml unmarshals into the expected struct shape (all step types, memory,
+// output_schema, split branches with else: true) and passes validation.
+func TestWorkflowYAMLParsing(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `version: "1"
+sources:
+  - id: main-plane
+    type: plane
+agents:
+  - id: architect
+    model: claude-opus-4-8
+  - id: backend-dev
+    model: claude-sonnet-4-6
+workflows:
+  - id: feature-development
+    description: "Full feature pipeline"
+    resume: allowed
+    result_comment: on_complete
+    trigger:
+      priority: 10
+      match:
+        source: main-plane
+        labels: [feature, ai-ready]
+    steps:
+      - id: plan
+        agent: architect
+        model: claude-opus-4-8
+        summary_prompt: "Summarize the plan."
+        output_schema:
+          type: object
+          properties:
+            complexity: {type: string, enum: [low, medium, high]}
+            issues:
+              type: array
+              items:
+                type: object
+                properties:
+                  file: {type: string}
+          required: [complexity]
+        memory:
+          read: true
+          write: [complexity]
+      - id: route
+        type: split
+        depends_on: [plan]
+        branches:
+          - if: "memory.complexity == 'high'"
+            goto: implement
+          - else: true
+            goto: implement
+      - id: implement
+        agent: backend-dev
+        depends_on: [plan]
+        memory:
+          read: false
+      - id: review
+        agent: backend-dev
+        depends_on: [implement]
+        on_fail:
+          goto: implement
+          max_retries: 2
+      - id: fix-each
+        type: foreach
+        depends_on: [plan]
+        items: "steps.plan.output.issues"
+        as: issue
+        concurrency: 4
+        max_items: 20
+        step:
+          agent: backend-dev
+      - id: human-approval
+        type: approval
+        depends_on: [review]
+        message: "Approve?"
+        resume_on:
+          comment_contains: "approve"
+        abort_on:
+          comment_contains: "reject"
+        timeout: 48h
+    on_complete:
+      set_state: in_review
+    on_fail:
+      set_state: blocked
+      add_labels: [workflow-failed]
+`
+	path := filepath.Join(dir, "apiary.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(cfg.Workflows) != 1 {
+		t.Fatalf("expected 1 workflow, got %d", len(cfg.Workflows))
+	}
+	wf := cfg.Workflows[0]
+
+	if wf.ID != "feature-development" {
+		t.Errorf("workflow id = %q", wf.ID)
+	}
+	if wf.ResumePolicy() != ResumeAllowed {
+		t.Errorf("resume policy = %q", wf.ResumePolicy())
+	}
+	if wf.Trigger == nil || wf.Trigger.Priority != 10 || wf.Trigger.Match.Source != "main-plane" {
+		t.Errorf("trigger parsed incorrectly: %+v", wf.Trigger)
+	}
+	if len(wf.Steps) != 6 {
+		t.Fatalf("expected 6 steps, got %d", len(wf.Steps))
+	}
+
+	// plan: agent step with output_schema + memory.write
+	plan := wf.Steps[0]
+	if plan.StepType() != StepTypeAgent {
+		t.Errorf("plan type = %q", plan.StepType())
+	}
+	if plan.Model != "claude-opus-4-8" {
+		t.Errorf("plan model override = %q", plan.Model)
+	}
+	if plan.OutputSchema == nil || plan.OutputSchema.Properties["complexity"].Type != "string" {
+		t.Errorf("plan output_schema parsed incorrectly: %+v", plan.OutputSchema)
+	}
+	if len(plan.OutputSchema.Properties["complexity"].Enum) != 3 {
+		t.Errorf("plan complexity enum = %v", plan.OutputSchema.Properties["complexity"].Enum)
+	}
+	issues := plan.OutputSchema.Properties["issues"]
+	if issues.Type != "array" || issues.Items == nil || issues.Items.Type != "object" {
+		t.Errorf("plan issues array parsed incorrectly: %+v", issues)
+	}
+	if !plan.MemoryReadEnabled() {
+		t.Error("plan memory.read should default/parse to true")
+	}
+	if got := plan.MemoryWriteFields(); len(got) != 1 || got[0] != "complexity" {
+		t.Errorf("plan memory.write = %v", got)
+	}
+
+	// route: split step, second branch is the fallback
+	route := wf.Steps[1]
+	if route.StepType() != StepTypeSplit {
+		t.Errorf("route type = %q", route.StepType())
+	}
+	if len(route.Branches) != 2 || !route.Branches[1].IsFallback() {
+		t.Errorf("route branches parsed incorrectly: %+v", route.Branches)
+	}
+	if route.Branches[0].IsFallback() {
+		t.Error("first branch should not be a fallback")
+	}
+
+	// implement: memory.read explicitly false
+	implement := wf.Steps[2]
+	if implement.MemoryReadEnabled() {
+		t.Error("implement memory.read should parse to false")
+	}
+
+	// review: on_fail back-edge
+	review := wf.Steps[3]
+	if review.OnFail == nil || review.OnFail.Goto != "implement" || review.OnFail.MaxRetries != 2 {
+		t.Errorf("review on_fail parsed incorrectly: %+v", review.OnFail)
+	}
+
+	// fix-each: foreach with inner step
+	fe := wf.Steps[4]
+	if fe.StepType() != StepTypeForeach || fe.Items != "steps.plan.output.issues" || fe.Step == nil {
+		t.Errorf("fix-each parsed incorrectly: %+v", fe)
+	}
+	if fe.Step.Agent != "backend-dev" {
+		t.Errorf("fix-each inner agent = %q", fe.Step.Agent)
+	}
+
+	// human-approval: approval step
+	ap := wf.Steps[5]
+	if ap.StepType() != StepTypeApproval || ap.ResumeOn == nil || ap.ResumeOn.CommentContains != "approve" {
+		t.Errorf("approval parsed incorrectly: %+v", ap)
+	}
+	if ap.ParsedTimeout().Hours() != 48 {
+		t.Errorf("approval timeout = %v", ap.ParsedTimeout())
+	}
+
+	// on_complete / on_fail hooks
+	if wf.OnComplete == nil || wf.OnComplete.SetState != "in_review" {
+		t.Errorf("on_complete parsed incorrectly: %+v", wf.OnComplete)
+	}
+	if wf.OnFail == nil || wf.OnFail.SetState != "blocked" || len(wf.OnFail.AddLabels) != 1 {
+		t.Errorf("on_fail parsed incorrectly: %+v", wf.OnFail)
+	}
+
+	// And the whole thing must validate cleanly.
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Fatalf("expected valid config, got errors: %v", errs)
+	}
+}

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -1,0 +1,426 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// supported output_schema property types (JSON Schema subset).
+var supportedSchemaTypes = map[string]bool{
+	"object":  true,
+	"string":  true,
+	"number":  true,
+	"integer": true,
+	"boolean": true,
+	"array":   true,
+}
+
+// validateWorkflows checks all workflow definitions for structural errors. It is
+// called from Config.Validate(). Errors are accumulated (not fail-fast) so a
+// single run surfaces every problem.
+func (c *Config) validateWorkflows() []error {
+	var errs []error
+	if len(c.Workflows) == 0 {
+		return errs
+	}
+
+	agentIDs := c.agentIDSet()
+	sourceIDs := c.sourceIDSet()
+	routeIDs := c.routeIDSet()
+
+	// First pass: index workflows by ID and detect ID-level problems so later
+	// passes (sub-workflow references) can rely on the map.
+	wfByID := make(map[string]WorkflowConfig, len(c.Workflows))
+	seen := map[string]bool{}
+	for i, wf := range c.Workflows {
+		if wf.ID == "" {
+			errs = append(errs, fmt.Errorf("workflows[%d]: id is required", i))
+			continue
+		}
+		if seen[wf.ID] {
+			errs = append(errs, fmt.Errorf("workflows[%d]: duplicate id %q", i, wf.ID))
+		}
+		if routeIDs[wf.ID] {
+			errs = append(errs, fmt.Errorf("workflows[%d] %q: id conflicts with a route of the same id", i, wf.ID))
+		}
+		seen[wf.ID] = true
+		wfByID[wf.ID] = wf
+	}
+
+	for i, wf := range c.Workflows {
+		errs = append(errs, c.validateWorkflow(i, wf, agentIDs, sourceIDs, wfByID)...)
+	}
+
+	return errs
+}
+
+// validateWorkflow validates a single workflow definition.
+func (c *Config) validateWorkflow(
+	idx int,
+	wf WorkflowConfig,
+	agentIDs, sourceIDs map[string]bool,
+	wfByID map[string]WorkflowConfig,
+) []error {
+	var errs []error
+	ctx := fmt.Sprintf("workflows[%d] %q", idx, wf.ID)
+
+	// Resume policy.
+	switch wf.Resume {
+	case "", ResumeAllowed, ResumeForbidden, ResumeAuto:
+	default:
+		errs = append(errs, fmt.Errorf("%s: invalid resume %q (want allowed|forbidden|auto)", ctx, wf.Resume))
+	}
+
+	// Result comment mode.
+	switch wf.ResultComment {
+	case "", ResultCommentOnComplete, ResultCommentPerStep, ResultCommentOff:
+	default:
+		errs = append(errs, fmt.Errorf("%s: invalid result_comment %q (want on_complete|per_step|off)", ctx, wf.ResultComment))
+	}
+
+	// Trigger source reference.
+	if wf.Trigger != nil && wf.Trigger.Match.Source != "" && !sourceIDs[wf.Trigger.Match.Source] {
+		errs = append(errs, fmt.Errorf("%s: trigger source %q not defined", ctx, wf.Trigger.Match.Source))
+	}
+
+	if len(wf.Steps) == 0 {
+		errs = append(errs, fmt.Errorf("%s: at least one step is required", ctx))
+		return errs
+	}
+
+	// Index step IDs (detect duplicates).
+	stepIDs := map[string]bool{}
+	for i, s := range wf.Steps {
+		if s.ID == "" {
+			errs = append(errs, fmt.Errorf("%s: steps[%d]: id is required", ctx, i))
+			continue
+		}
+		if stepIDs[s.ID] {
+			errs = append(errs, fmt.Errorf("%s: duplicate step id %q", ctx, s.ID))
+		}
+		stepIDs[s.ID] = true
+	}
+
+	// Per-step structural validation.
+	for i, s := range wf.Steps {
+		errs = append(errs, c.validateStep(ctx, i, s, wf, agentIDs, stepIDs, wfByID)...)
+	}
+
+	// Graph: depends_on references + cycle detection + back-edge ancestry.
+	errs = append(errs, validateStepGraph(ctx, wf, stepIDs)...)
+
+	// resume: auto requires every step to be idempotent.
+	if wf.Resume == ResumeAuto {
+		for _, s := range wf.Steps {
+			if s.StepType() == StepTypeAgent && !s.Idempotent {
+				errs = append(errs, fmt.Errorf("%s: resume: auto requires all steps idempotent, but step %q is not", ctx, s.ID))
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateStep validates one step according to its type.
+func (c *Config) validateStep(
+	ctx string,
+	i int,
+	s StepConfig,
+	wf WorkflowConfig,
+	agentIDs, stepIDs map[string]bool,
+	wfByID map[string]WorkflowConfig,
+) []error {
+	var errs []error
+	sctx := fmt.Sprintf("%s: step %q", ctx, s.ID)
+
+	switch s.StepType() {
+	case StepTypeAgent:
+		errs = append(errs, c.validateAgentStep(sctx, s, agentIDs, stepIDs)...)
+	case StepTypeSplit:
+		errs = append(errs, validateSplitStep(sctx, s, stepIDs)...)
+	case StepTypeApproval:
+		errs = append(errs, validateApprovalStep(sctx, s)...)
+	case StepTypeForeach:
+		errs = append(errs, c.validateForeachStep(sctx, s, wf, agentIDs)...)
+	case StepTypeWorkflow:
+		errs = append(errs, validateWorkflowStep(sctx, s, wf, wfByID)...)
+	default:
+		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
+	}
+
+	return errs
+}
+
+// validateAgentStep validates a type: agent step.
+func (c *Config) validateAgentStep(sctx string, s StepConfig, agentIDs, stepIDs map[string]bool) []error {
+	var errs []error
+
+	if s.Agent == "" {
+		errs = append(errs, fmt.Errorf("%s: agent step requires an agent field", sctx))
+	} else if !agentIDs[s.Agent] {
+		errs = append(errs, fmt.Errorf("%s: agent %q not defined", sctx, s.Agent))
+	}
+
+	if s.OutputSchema != nil {
+		errs = append(errs, validateOutputSchema(sctx, s.OutputSchema)...)
+	}
+
+	switch s.OnMissingOutput {
+	case "", OnMissingOutputWarn, OnMissingOutputFail, OnMissingOutputIgnore:
+	default:
+		errs = append(errs, fmt.Errorf("%s: invalid on_missing_output %q (want warn|fail|ignore)", sctx, s.OnMissingOutput))
+	}
+
+	// memory.write requires output_schema with matching top-level fields.
+	if w := s.MemoryWriteFields(); len(w) > 0 {
+		if s.OutputSchema == nil {
+			errs = append(errs, fmt.Errorf("%s: memory.write requires output_schema", sctx))
+		} else {
+			for _, field := range w {
+				if _, ok := s.OutputSchema.Properties[field]; !ok {
+					errs = append(errs, fmt.Errorf("%s: memory.write field %q not present in output_schema properties", sctx, field))
+				}
+			}
+		}
+	}
+
+	// on_pass.next must reference an existing step.
+	if s.OnPass != nil && s.OnPass.Next != "" && !stepIDs[s.OnPass.Next] {
+		errs = append(errs, fmt.Errorf("%s: on_pass.next references unknown step %q", sctx, s.OnPass.Next))
+	}
+
+	// on_fail.goto must reference an existing step and set max_retries >= 1.
+	if s.OnFail != nil && s.OnFail.Goto != "" {
+		if !stepIDs[s.OnFail.Goto] {
+			errs = append(errs, fmt.Errorf("%s: on_fail.goto references unknown step %q", sctx, s.OnFail.Goto))
+		}
+		if s.OnFail.MaxRetries < 1 {
+			errs = append(errs, fmt.Errorf("%s: on_fail.max_retries must be >= 1 when goto is set", sctx))
+		}
+	}
+
+	return errs
+}
+
+// validateSplitStep validates a type: split step.
+func validateSplitStep(sctx string, s StepConfig, stepIDs map[string]bool) []error {
+	var errs []error
+
+	if s.Agent != "" {
+		errs = append(errs, fmt.Errorf("%s: split step must not have an agent field", sctx))
+	}
+	if len(s.Branches) == 0 {
+		errs = append(errs, fmt.Errorf("%s: split step requires at least one branch", sctx))
+		return errs
+	}
+
+	fallbacks := 0
+	for j, b := range s.Branches {
+		if b.Goto == "" {
+			errs = append(errs, fmt.Errorf("%s: branches[%d]: goto is required", sctx, j))
+		} else if !stepIDs[b.Goto] {
+			errs = append(errs, fmt.Errorf("%s: branches[%d]: goto references unknown step %q", sctx, j, b.Goto))
+		}
+		if b.IsFallback() {
+			fallbacks++
+		}
+	}
+
+	// A single-match split (multi: false) must have exactly one fallback.
+	if !s.Multi && fallbacks != 1 {
+		errs = append(errs, fmt.Errorf("%s: split with multi: false requires exactly one else/fallback branch (found %d)", sctx, fallbacks))
+	}
+
+	return errs
+}
+
+// validateApprovalStep validates a type: approval step.
+func validateApprovalStep(sctx string, s StepConfig) []error {
+	var errs []error
+
+	if s.Agent != "" {
+		errs = append(errs, fmt.Errorf("%s: approval step must not have an agent field", sctx))
+	}
+	if s.Message == "" {
+		errs = append(errs, fmt.Errorf("%s: approval step requires a message", sctx))
+	}
+	if s.ResumeOn == nil || s.ResumeOn.IsEmpty() {
+		errs = append(errs, fmt.Errorf("%s: approval step requires resume_on with at least one condition", sctx))
+	}
+	if s.Timeout != "" {
+		if _, err := time.ParseDuration(s.Timeout); err != nil {
+			errs = append(errs, fmt.Errorf("%s: invalid timeout %q: %v", sctx, s.Timeout, err))
+		}
+	}
+
+	return errs
+}
+
+// validateForeachStep validates a type: foreach step.
+func (c *Config) validateForeachStep(sctx string, s StepConfig, wf WorkflowConfig, agentIDs map[string]bool) []error {
+	var errs []error
+
+	if s.Items == "" {
+		errs = append(errs, fmt.Errorf("%s: foreach step requires items", sctx))
+	} else if !foreachItemsResolveToArray(s.Items, wf) {
+		errs = append(errs, fmt.Errorf("%s: foreach items %q does not resolve to an array field in a prior step's output_schema", sctx, s.Items))
+	}
+
+	if s.Concurrency != 0 && (s.Concurrency < 1 || s.Concurrency > 16) {
+		errs = append(errs, fmt.Errorf("%s: foreach concurrency must be between 1 and 16", sctx))
+	}
+	if s.MaxItems != 0 && (s.MaxItems < 1 || s.MaxItems > 200) {
+		errs = append(errs, fmt.Errorf("%s: foreach max_items must be between 1 and 200", sctx))
+	}
+
+	if s.Step == nil {
+		errs = append(errs, fmt.Errorf("%s: foreach step requires an inner step", sctx))
+		return errs
+	}
+	// The inner step must be an agent step.
+	inner := *s.Step
+	if inner.Type != "" && inner.Type != StepTypeAgent {
+		errs = append(errs, fmt.Errorf("%s: foreach inner step must be type agent, got %q", sctx, inner.Type))
+	}
+	if inner.Agent == "" {
+		errs = append(errs, fmt.Errorf("%s: foreach inner step requires an agent field", sctx))
+	} else if !agentIDs[inner.Agent] {
+		errs = append(errs, fmt.Errorf("%s: foreach inner step agent %q not defined", sctx, inner.Agent))
+	}
+	if inner.OutputSchema != nil {
+		errs = append(errs, validateOutputSchema(sctx+" (inner step)", inner.OutputSchema)...)
+	}
+
+	return errs
+}
+
+// validateWorkflowStep validates a type: workflow (sub-workflow) step.
+func validateWorkflowStep(sctx string, s StepConfig, parent WorkflowConfig, wfByID map[string]WorkflowConfig) []error {
+	var errs []error
+
+	if s.Agent != "" {
+		errs = append(errs, fmt.Errorf("%s: workflow step must not have an agent field", sctx))
+	}
+	if s.Workflow == "" {
+		errs = append(errs, fmt.Errorf("%s: workflow step requires a workflow reference", sctx))
+		return errs
+	}
+	if s.Workflow == parent.ID {
+		errs = append(errs, fmt.Errorf("%s: workflow step cannot reference its own workflow", sctx))
+		return errs
+	}
+	child, ok := wfByID[s.Workflow]
+	if !ok {
+		errs = append(errs, fmt.Errorf("%s: workflow %q not defined", sctx, s.Workflow))
+		return errs
+	}
+	// One level of nesting only: the child must not itself contain workflow steps.
+	for _, cs := range child.Steps {
+		if cs.StepType() == StepTypeWorkflow {
+			errs = append(errs, fmt.Errorf("%s: referenced workflow %q contains a sub-workflow step %q; nesting is not allowed", sctx, s.Workflow, cs.ID))
+			break
+		}
+	}
+
+	return errs
+}
+
+// validateOutputSchema validates the supported JSON Schema subset.
+func validateOutputSchema(sctx string, sch *OutputSchema) []error {
+	var errs []error
+	if sch.Type != "object" {
+		errs = append(errs, fmt.Errorf("%s: output_schema type must be \"object\", got %q", sctx, sch.Type))
+	}
+	for name, field := range sch.Properties {
+		errs = append(errs, validateSchemaField(fmt.Sprintf("%s: output_schema.%s", sctx, name), field)...)
+	}
+	for _, req := range sch.Required {
+		if _, ok := sch.Properties[req]; !ok {
+			errs = append(errs, fmt.Errorf("%s: output_schema required field %q not present in properties", sctx, req))
+		}
+	}
+	return errs
+}
+
+// validateSchemaField validates one property type within an output schema.
+func validateSchemaField(fctx string, f SchemaField) []error {
+	var errs []error
+	if !supportedSchemaTypes[f.Type] {
+		errs = append(errs, fmt.Errorf("%s: unsupported type %q", fctx, f.Type))
+		return errs
+	}
+	if len(f.Enum) > 0 && f.Type != "string" {
+		errs = append(errs, fmt.Errorf("%s: enum is only supported on string fields", fctx))
+	}
+	if f.Type == "array" {
+		if f.Items == nil {
+			errs = append(errs, fmt.Errorf("%s: array field requires items", fctx))
+		} else {
+			errs = append(errs, validateSchemaField(fctx+".items", *f.Items)...)
+		}
+	}
+	if f.Type == "object" {
+		for name, sub := range f.Properties {
+			errs = append(errs, validateSchemaField(fmt.Sprintf("%s.%s", fctx, name), sub)...)
+		}
+	}
+	return errs
+}
+
+// WorkflowWarnings returns non-fatal advisories about workflow definitions. A
+// workflow with no trigger that is never referenced as a sub-workflow can never
+// run, which is almost always a mistake worth surfacing.
+func (c *Config) WorkflowWarnings() []string {
+	if len(c.Workflows) == 0 {
+		return nil
+	}
+
+	referenced := map[string]bool{}
+	for _, wf := range c.Workflows {
+		for _, s := range wf.Steps {
+			if s.StepType() == StepTypeWorkflow && s.Workflow != "" {
+				referenced[s.Workflow] = true
+			}
+		}
+	}
+
+	var warnings []string
+	for _, wf := range c.Workflows {
+		if wf.ID == "" {
+			continue
+		}
+		if wf.Trigger == nil && !referenced[wf.ID] {
+			warnings = append(warnings, fmt.Sprintf(
+				"workflow %q has no trigger and is not referenced as a sub-workflow; it will never run",
+				wf.ID))
+		}
+	}
+	return warnings
+}
+
+// agentIDSet returns the set of defined agent IDs.
+func (c *Config) agentIDSet() map[string]bool {
+	set := make(map[string]bool, len(c.Agents))
+	for _, a := range c.Agents {
+		set[a.ID] = true
+	}
+	return set
+}
+
+// sourceIDSet returns the set of defined source IDs.
+func (c *Config) sourceIDSet() map[string]bool {
+	set := make(map[string]bool, len(c.Sources))
+	for _, s := range c.Sources {
+		set[s.ID] = true
+	}
+	return set
+}
+
+// routeIDSet returns the set of defined route IDs.
+func (c *Config) routeIDSet() map[string]bool {
+	set := make(map[string]bool, len(c.Routes))
+	for _, r := range c.Routes {
+		set[r.ID] = true
+	}
+	return set
+}

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -1,0 +1,703 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// boolPtr returns a pointer to b, for MemoryConfig.Read.
+func boolPtr(b bool) *bool { return &b }
+
+// baseWorkflowConfig returns a Config with one source and two agents, ready to
+// have a Workflows slice attached for testing.
+func baseWorkflowConfig() *config.Config {
+	return &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
+		Agents: []config.AgentConfig{
+			{ID: "architect", Model: "claude-opus-4-8"},
+			{ID: "backend-dev", Model: "claude-sonnet-4-6"},
+		},
+	}
+}
+
+// assertNoError fails if the config produces any validation error.
+func assertNoError(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Fatalf("expected no validation errors, got: %v", errs)
+	}
+}
+
+func TestWorkflow_ValidFullPipeline(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{
+			ID:     "feature-development",
+			Resume: config.ResumeAllowed,
+			Trigger: &config.TriggerConfig{
+				Priority: 10,
+				Match:    config.RouteMatch{Source: "src-1", Labels: []string{"feature"}},
+			},
+			Steps: []config.StepConfig{
+				{
+					ID:    "plan",
+					Agent: "architect",
+					OutputSchema: &config.OutputSchema{
+						Type: "object",
+						Properties: map[string]config.SchemaField{
+							"complexity": {Type: "string", Enum: []string{"low", "high"}},
+							"issues": {Type: "array", Items: &config.SchemaField{
+								Type: "object",
+								Properties: map[string]config.SchemaField{
+									"file": {Type: "string"},
+								},
+							}},
+						},
+						Required: []string{"complexity"},
+					},
+					Memory: &config.MemoryConfig{Write: []string{"complexity"}},
+				},
+				{
+					ID:        "route",
+					Type:      config.StepTypeSplit,
+					DependsOn: []string{"plan"},
+					Branches: []config.SplitBranch{
+						{If: "memory.complexity == 'high'", Goto: "implement"},
+						{Else: true, Goto: "implement"},
+					},
+				},
+				{
+					ID:        "implement",
+					Agent:     "backend-dev",
+					DependsOn: []string{"plan"},
+				},
+				{
+					ID:        "review",
+					Agent:     "backend-dev",
+					DependsOn: []string{"implement"},
+					OnFail:    &config.StepOutcome{Goto: "implement", MaxRetries: 2},
+				},
+				{
+					ID:          "fix-each",
+					Type:        config.StepTypeForeach,
+					DependsOn:   []string{"plan"},
+					Items:       "steps.plan.output.issues",
+					As:          "issue",
+					Concurrency: 4,
+					MaxItems:    20,
+					Step: &config.StepConfig{
+						Agent: "backend-dev",
+					},
+				},
+				{
+					ID:        "approval",
+					Type:      config.StepTypeApproval,
+					DependsOn: []string{"review"},
+					Message:   "Approve?",
+					ResumeOn:  &config.ApprovalTrigger{CommentContains: "approve"},
+					Timeout:   "48h",
+				},
+			},
+		},
+	}
+	assertNoError(t, cfg)
+}
+
+func TestWorkflow_DuplicateID(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "dup", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+		{ID: "dup", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+	}
+	assertError(t, cfg, "duplicate id")
+}
+
+func TestWorkflow_IDConflictsWithRoute(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Routes = []config.RouteConfig{
+		{ID: "shared", Priority: 1, Agent: "architect", Match: config.RouteMatch{Source: "src-1"}},
+	}
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "shared", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+	}
+	assertError(t, cfg, "conflicts with a route")
+}
+
+func TestWorkflow_InvalidResume(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Resume: "maybe", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+	}
+	assertError(t, cfg, "invalid resume")
+}
+
+func TestWorkflow_InvalidResultComment(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", ResultComment: "always", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+	}
+	assertError(t, cfg, "invalid result_comment")
+}
+
+func TestWorkflow_TriggerSourceNotDefined(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{
+			ID:      "wf",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "ghost"}},
+			Steps:   []config.StepConfig{{ID: "s1", Agent: "architect"}},
+		},
+	}
+	assertError(t, cfg, "trigger source")
+}
+
+func TestWorkflow_NoSteps(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{{ID: "wf"}}
+	assertError(t, cfg, "at least one step is required")
+}
+
+func TestWorkflow_DuplicateStepID(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s1", Agent: "architect"},
+			{ID: "s1", Agent: "backend-dev"},
+		}},
+	}
+	assertError(t, cfg, "duplicate step id")
+}
+
+func TestWorkflow_DependsOnUnknownStep(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s1", Agent: "architect", DependsOn: []string{"ghost"}},
+		}},
+	}
+	assertError(t, cfg, "depends_on unknown step")
+}
+
+func TestWorkflow_DependencyCycle(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect", DependsOn: []string{"b"}},
+			{ID: "b", Agent: "backend-dev", DependsOn: []string{"a"}},
+		}},
+	}
+	assertError(t, cfg, "cycle detected")
+}
+
+func TestWorkflow_AgentStepMissingAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{{ID: "s1"}}},
+	}
+	assertError(t, cfg, "agent step requires an agent")
+}
+
+func TestWorkflow_AgentStepUnknownAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{{ID: "s1", Agent: "ghost"}}},
+	}
+	assertError(t, cfg, "agent \"ghost\" not defined")
+}
+
+func TestWorkflow_MemoryWriteWithoutSchema(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s1", Agent: "architect", Memory: &config.MemoryConfig{Write: []string{"x"}}},
+		}},
+	}
+	assertError(t, cfg, "memory.write requires output_schema")
+}
+
+func TestWorkflow_MemoryWriteFieldNotInSchema(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "s1",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type:       "object",
+					Properties: map[string]config.SchemaField{"complexity": {Type: "string"}},
+				},
+				Memory: &config.MemoryConfig{Write: []string{"missing"}},
+			},
+		}},
+	}
+	assertError(t, cfg, "not present in output_schema")
+}
+
+func TestWorkflow_OnFailGotoUnknownStep(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s1", Agent: "architect", OnFail: &config.StepOutcome{Goto: "ghost", MaxRetries: 1}},
+		}},
+	}
+	assertError(t, cfg, "on_fail.goto references unknown step")
+}
+
+func TestWorkflow_OnFailMissingMaxRetries(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "b", Agent: "backend-dev", DependsOn: []string{"a"}, OnFail: &config.StepOutcome{Goto: "a"}},
+		}},
+	}
+	assertError(t, cfg, "on_fail.max_retries must be >= 1")
+}
+
+func TestWorkflow_OnFailGotoNotAncestor(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "b", Agent: "backend-dev"},
+			// b does not depend on a, so goto a is not an ancestor back-edge.
+			{ID: "c", Agent: "architect", DependsOn: []string{"b"}, OnFail: &config.StepOutcome{Goto: "a", MaxRetries: 1}},
+		}},
+	}
+	assertError(t, cfg, "must target an ancestor")
+}
+
+func TestWorkflow_OnPassNextUnknownStep(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s1", Agent: "architect", OnPass: &config.StepNext{Next: "ghost"}},
+		}},
+	}
+	assertError(t, cfg, "on_pass.next references unknown step")
+}
+
+func TestWorkflow_SplitMustNotHaveAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "target", Agent: "architect"},
+			{ID: "s", Type: config.StepTypeSplit, Agent: "architect", Branches: []config.SplitBranch{
+				{Else: true, Goto: "target"},
+			}},
+		}},
+	}
+	assertError(t, cfg, "split step must not have an agent")
+}
+
+func TestWorkflow_SplitNoBranches(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeSplit},
+		}},
+	}
+	assertError(t, cfg, "requires at least one branch")
+}
+
+func TestWorkflow_SplitSingleMatchRequiresOneFallback(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "target", Agent: "architect"},
+			{ID: "s", Type: config.StepTypeSplit, Branches: []config.SplitBranch{
+				{If: "cell.priority == 'high'", Goto: "target"},
+			}},
+		}},
+	}
+	assertError(t, cfg, "exactly one else/fallback")
+}
+
+func TestWorkflow_SplitBranchGotoUnknown(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeSplit, Branches: []config.SplitBranch{
+				{Else: true, Goto: "ghost"},
+			}},
+		}},
+	}
+	assertError(t, cfg, "goto references unknown step")
+}
+
+func TestWorkflow_SplitMultiAllowsNoFallback(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "b", Agent: "backend-dev"},
+			{ID: "s", Type: config.StepTypeSplit, Multi: true, Branches: []config.SplitBranch{
+				{If: "cell.labels contains 'x'", Goto: "a"},
+				{If: "cell.labels contains 'y'", Goto: "b"},
+			}},
+		}},
+	}
+	assertNoError(t, cfg)
+}
+
+func TestWorkflow_ApprovalMustNotHaveAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeApproval, Agent: "architect", Message: "ok",
+				ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"}},
+		}},
+	}
+	assertError(t, cfg, "approval step must not have an agent")
+}
+
+func TestWorkflow_ApprovalMissingMessage(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeApproval, ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"}},
+		}},
+	}
+	assertError(t, cfg, "requires a message")
+}
+
+func TestWorkflow_ApprovalMissingResumeOn(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeApproval, Message: "ok"},
+		}},
+	}
+	assertError(t, cfg, "requires resume_on")
+}
+
+func TestWorkflow_ApprovalInvalidTimeout(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeApproval, Message: "ok",
+				ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"}, Timeout: "soon"},
+		}},
+	}
+	assertError(t, cfg, "invalid timeout")
+}
+
+func TestWorkflow_ForeachMissingItems(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeForeach, Step: &config.StepConfig{Agent: "architect"}},
+		}},
+	}
+	assertError(t, cfg, "foreach step requires items")
+}
+
+func TestWorkflow_ForeachItemsNotArray(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "plan",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type:       "object",
+					Properties: map[string]config.SchemaField{"name": {Type: "string"}},
+				},
+			},
+			{ID: "s", Type: config.StepTypeForeach, DependsOn: []string{"plan"},
+				Items: "steps.plan.output.name", Step: &config.StepConfig{Agent: "architect"}},
+		}},
+	}
+	assertError(t, cfg, "does not resolve to an array")
+}
+
+func TestWorkflow_ForeachConcurrencyOutOfRange(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "plan",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"items": {Type: "array", Items: &config.SchemaField{Type: "string"}},
+					},
+				},
+			},
+			{ID: "s", Type: config.StepTypeForeach, DependsOn: []string{"plan"},
+				Items: "steps.plan.output.items", Concurrency: 99,
+				Step: &config.StepConfig{Agent: "architect"}},
+		}},
+	}
+	assertError(t, cfg, "concurrency must be between 1 and 16")
+}
+
+func TestWorkflow_ForeachMaxItemsOutOfRange(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "plan",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"items": {Type: "array", Items: &config.SchemaField{Type: "string"}},
+					},
+				},
+			},
+			{ID: "s", Type: config.StepTypeForeach, DependsOn: []string{"plan"},
+				Items: "steps.plan.output.items", MaxItems: 9999,
+				Step: &config.StepConfig{Agent: "architect"}},
+		}},
+	}
+	assertError(t, cfg, "max_items must be between 1 and 200")
+}
+
+func TestWorkflow_ForeachInnerStepNotAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "plan",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"items": {Type: "array", Items: &config.SchemaField{Type: "string"}},
+					},
+				},
+			},
+			{ID: "s", Type: config.StepTypeForeach, DependsOn: []string{"plan"},
+				Items: "steps.plan.output.items",
+				Step:  &config.StepConfig{Type: config.StepTypeSplit, Agent: "architect"}},
+		}},
+	}
+	assertError(t, cfg, "foreach inner step must be type agent")
+}
+
+func TestWorkflow_ForeachInnerMissingAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{
+				ID:    "plan",
+				Agent: "architect",
+				OutputSchema: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"items": {Type: "array", Items: &config.SchemaField{Type: "string"}},
+					},
+				},
+			},
+			{ID: "s", Type: config.StepTypeForeach, DependsOn: []string{"plan"},
+				Items: "steps.plan.output.items", Step: &config.StepConfig{}},
+		}},
+	}
+	assertError(t, cfg, "foreach inner step requires an agent")
+}
+
+func TestWorkflow_StepMustNotHaveAgent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "sub", Steps: []config.StepConfig{{ID: "x", Agent: "architect"}}},
+		{ID: "main", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow, Agent: "architect", Workflow: "sub"},
+		}},
+	}
+	assertError(t, cfg, "workflow step must not have an agent")
+}
+
+func TestWorkflow_StepMissingWorkflowRef(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "main", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow},
+		}},
+	}
+	assertError(t, cfg, "requires a workflow reference")
+}
+
+func TestWorkflow_StepSelfReference(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "main", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow, Workflow: "main"},
+		}},
+	}
+	assertError(t, cfg, "cannot reference its own workflow")
+}
+
+func TestWorkflow_StepUnknownWorkflowRef(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "main", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow, Workflow: "ghost"},
+		}},
+	}
+	assertError(t, cfg, "workflow \"ghost\" not defined")
+}
+
+func TestWorkflow_SubWorkflowNestingNotAllowed(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "leaf", Steps: []config.StepConfig{{ID: "x", Agent: "architect"}}},
+		{ID: "mid", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow, Workflow: "leaf"},
+		}},
+		{ID: "top", Steps: []config.StepConfig{
+			{ID: "s", Type: config.StepTypeWorkflow, Workflow: "mid"},
+		}},
+	}
+	assertError(t, cfg, "nesting is not allowed")
+}
+
+func TestWorkflow_OutputSchemaTypeNotObject(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", OutputSchema: &config.OutputSchema{Type: "string"}},
+		}},
+	}
+	assertError(t, cfg, "type must be \"object\"")
+}
+
+func TestWorkflow_OutputSchemaUnsupportedType(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", OutputSchema: &config.OutputSchema{
+				Type:       "object",
+				Properties: map[string]config.SchemaField{"x": {Type: "decimal"}},
+			}},
+		}},
+	}
+	assertError(t, cfg, "unsupported type")
+}
+
+func TestWorkflow_OutputSchemaRequiredNotInProperties(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", OutputSchema: &config.OutputSchema{
+				Type:       "object",
+				Properties: map[string]config.SchemaField{"x": {Type: "string"}},
+				Required:   []string{"y"},
+			}},
+		}},
+	}
+	assertError(t, cfg, "required field \"y\" not present")
+}
+
+func TestWorkflow_OutputSchemaEnumOnNonString(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", OutputSchema: &config.OutputSchema{
+				Type:       "object",
+				Properties: map[string]config.SchemaField{"x": {Type: "number", Enum: []string{"1", "2"}}},
+			}},
+		}},
+	}
+	assertError(t, cfg, "enum is only supported on string")
+}
+
+func TestWorkflow_OutputSchemaArrayWithoutItems(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", OutputSchema: &config.OutputSchema{
+				Type:       "object",
+				Properties: map[string]config.SchemaField{"x": {Type: "array"}},
+			}},
+		}},
+	}
+	assertError(t, cfg, "array field requires items")
+}
+
+func TestWorkflow_ResumeAutoRequiresIdempotent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Resume: config.ResumeAuto, Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", Idempotent: false},
+		}},
+	}
+	assertError(t, cfg, "resume: auto requires all steps idempotent")
+}
+
+func TestWorkflow_ResumeAutoAllIdempotent(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Resume: config.ResumeAuto, Steps: []config.StepConfig{
+			{ID: "s", Agent: "architect", Idempotent: true},
+		}},
+	}
+	assertNoError(t, cfg)
+}
+
+func TestWorkflow_UnknownStepType(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{{ID: "s", Type: "frobnicate"}}},
+	}
+	assertError(t, cfg, "unknown step type")
+}
+
+func TestWorkflow_MemoryReadDefaultsTrue(t *testing.T) {
+	s := config.StepConfig{ID: "s", Agent: "a"}
+	if !s.MemoryReadEnabled() {
+		t.Error("expected MemoryReadEnabled() to default to true")
+	}
+	s.Memory = &config.MemoryConfig{Read: boolPtr(false)}
+	if s.MemoryReadEnabled() {
+		t.Error("expected MemoryReadEnabled() to be false when read: false")
+	}
+}
+
+func TestWorkflow_WarnsOnOrphanWorkflow(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		// no trigger, not referenced anywhere → orphan
+		{ID: "orphan", Steps: []config.StepConfig{{ID: "s", Agent: "architect"}}},
+	}
+	warnings := cfg.WorkflowWarnings()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !containsStr(warnings[0], "will never run") {
+		t.Errorf("unexpected warning text: %q", warnings[0])
+	}
+}
+
+func TestWorkflow_NoWarnForTriggeredOrSubWorkflow(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{
+			ID:      "triggered",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "src-1"}},
+			Steps: []config.StepConfig{
+				{ID: "call", Type: config.StepTypeWorkflow, Workflow: "sub"},
+			},
+		},
+		// referenced as a sub-workflow → not an orphan despite having no trigger
+		{ID: "sub", Steps: []config.StepConfig{{ID: "s", Agent: "architect"}}},
+	}
+	if w := cfg.WorkflowWarnings(); len(w) != 0 {
+		t.Errorf("expected no warnings, got: %v", w)
+	}
+}
+
+func TestWorkflow_NoWorkflowsStillValid(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
+		Agents:  []config.AgentConfig{{ID: "a-1", Model: "claude-sonnet-4-6"}},
+		Routes: []config.RouteConfig{
+			{ID: "r-1", Priority: 1, Agent: "a-1", Match: config.RouteMatch{Source: "src-1"}},
+		},
+	}
+	assertNoError(t, cfg)
+}


### PR DESCRIPTION
## Summary

Introduces **workflow-mode**: the evolution from the pool/router model to declarative multi-step pipelines. This PR delivers the full OpenSpec specification and **Phase 1** of the implementation (parsing + validation of the `workflows:` block in `apiary.yaml`). No execution change — the engine comes in the following phases.

### Specification (OpenSpec)
- `proposal.md`, `design.md`, `tasks.md` (4-phase plan) and 14 capability specs: workflow schema, workflow-memory, structured-output, foreach-step, resume, per-step-model, sub-workflows, source-adapter-watch, runner-interface, concurrency-model, workflow-hooks, orphan-recovery.
- ADR-007 (architecture): `apiary.yaml` stays at `version: "1"` — additive change.
- CLI spec: `apiary instances` and `apiary resume` commands.

### Phase 1 — Schema + Validation
- Structs in `internal/config/workflow.go`: `WorkflowConfig`, `StepConfig`, `TriggerConfig`, `SplitBranch`, `ApprovalTrigger`, `StepOutcome`, `MemoryConfig`, `OutputSchema`, `SchemaField`. `Workflows` field on `Config`.
- Validation in `workflow_validate.go` + `workflow_graph.go`: id uniqueness and collision with route id; `depends_on`/`agent`/`goto`/`next` references; DAG cycle detection; `on_fail.goto` back-edge ancestry; supported subset of `output_schema`; per-step-type rules (agent/split/approval/foreach/workflow); `foreach.items` resolves to an array; sub-workflow with no nesting; `resume: auto` requires idempotent steps.
- `apiary validate`: errors with step context + orphan-workflow warning (`WorkflowWarnings()`).

## Test plan
- [x] `go test ./...` — green (config: 44 validation cases + YAML parsing round-trip)
- [x] `go vet ./...` and `gofmt` clean
- [x] `make build` ok
- [x] Manual smoke of `apiary validate`: non-existent agent error with step context + orphan-workflow warning on a valid config
- [x] Regression: configs without `workflows:` stay valid