### PR TITLE
feat: workflow-mode Phase 2a — engine foundations (store, runner, memory)

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -49,28 +49,30 @@ Parse the `workflows:` block alongside existing `routes:`. No execution changes.
 
 Implement `WorkflowEngine` behind `settings.experimental.workflow_mode: true`. Single-step workflows only (no DAG, no split, no approval, no foreach). Plain `routes:` are synthesized as single-step workflows and run through the same engine.
 
-### 2.1 SQLite Schema
+> **Delivery note:** Phase 2 is shipped as two PRs. **PR-2a (foundations)** delivers the SQLite store, runner-interface changes, and the memory builder — all additive, fully unit-tested, zero behavior change. **PR-2b (engine)** delivers the `WorkflowEngine` and its daemon wiring (2.4–2.5), isolated because it touches the mature dispatcher. Real layout differs from the original task notes: the store lives in the existing `internal/db` package (not `internal/store`), and schema is defined inline in `db/schema.go`.
 
-- [ ] 2.1.1 Add `workflow_instances` table migration to `src/internal/store/migrations/`
-- [ ] 2.1.2 Add `step_runs` table migration
-- [ ] 2.1.3 Add `summary` and `structured_output` columns to `step_runs`
-- [ ] 2.1.4 Implement `WorkflowStore` in `src/internal/store/workflow_store.go`: CRUD for instances and step runs
+### 2.1 SQLite Schema — PR-2a
 
-### 2.2 Runner Interface Changes
+- [x] 2.1.1 Add `workflow_instances` table (in `src/internal/db/schema.go`)
+- [x] 2.1.2 Add `step_runs` table
+- [x] 2.1.3 `step_runs` includes `summary` and `structured_output` columns
+- [x] 2.1.4 Implement `WorkflowStore` in `src/internal/db/workflow_store.go`: CRUD for instances and step runs (+ `ReconcileOrphanWorkflowInstances`)
 
-- [ ] 2.2.1 Add `SystemPrepend`, `SummaryPrompt`, `StepID`, `WorkflowInstanceID` fields to `RunRequest` — see [runner-interface spec](specs/runner-interface/spec.md)
-- [ ] 2.2.2 Add `StructuredOutput map[string]any`, `Summary string` fields to `RunResult`
-- [ ] 2.2.3 Update OpenCode runner: inject `SystemPrepend` before soul file; parse `APIARY_OUTPUT:` last line into `StructuredOutput`; extract summary block into `Summary`
-- [ ] 2.2.4 Update script runner: inject `SystemPrepend`; pass `APIARY_SUMMARY_PROMPT` env var; parse `APIARY_OUTPUT:` line
-- [ ] 2.2.5 Update runner interface tests
+### 2.2 Runner Interface Changes — PR-2a
 
-### 2.3 Memory Builder
+- [x] 2.2.1 Add `SystemPrepend`, `SummaryPrompt`, `StepID`, `WorkflowInstanceID` fields to `RunRequest`
+- [x] 2.2.2 Add `StructuredOutput map[string]any`, `Summary string` fields to `RunResult`
+- [x] 2.2.3 Inject `SystemPrepend` before cell details in `buildPrompt`; parse `APIARY_OUTPUT:` into `StructuredOutput` and `APIARY_SUMMARY_START/END` into `Summary` (shared `structured.go`, applied by cli + api runners)
+- [~] 2.2.4 Script runner env vars (`APIARY_SYSTEM_PREPEND`, etc.) — deferred; the shared prompt/parse path already covers cli + api runners
+- [x] 2.2.5 Runner interface tests (`structured_test.go`)
 
-- [ ] 2.3.1 Implement `MemoryBuilder` in `src/internal/workflow/memory.go`: builds the memory document from cell + completed step runs
-- [ ] 2.3.2 Implement `memory_max_chars` truncation (oldest summaries first; Cell and Step Data never truncated)
-- [ ] 2.3.3 Unit tests for `MemoryBuilder` with various step combinations
+### 2.3 Memory Builder — PR-2a
 
-### 2.4 Workflow Engine
+- [x] 2.3.1 Implement `MemoryBuilder` in `src/internal/workflow/memory.go`: builds the memory document from cell + completed step contributions
+- [x] 2.3.2 Implement `memory_max_chars` truncation (oldest summaries first; Cell and Step Data never truncated)
+- [x] 2.3.3 Unit tests for `MemoryBuilder` with various step combinations
+
+### 2.4 Workflow Engine — PR-2b
 
 - [ ] 2.4.1 Implement `WorkflowEngine` in `src/internal/workflow/engine.go`
 - [ ] 2.4.2 Implement route synthesis: plain `routes:` entries produce a single-step `WorkflowConfig` internally

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -103,6 +103,36 @@ CREATE TABLE IF NOT EXISTS dispatcher_state (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Workflow instances: one execution of a workflow bound to a Cell.
+CREATE TABLE IF NOT EXISTS workflow_instances (
+  id TEXT PRIMARY KEY,
+  workflow_id TEXT NOT NULL,
+  cell_id TEXT NOT NULL,
+  source_id TEXT,
+  state TEXT NOT NULL,            -- pending|running|approval_waiting|interrupted|done|failed
+  parent_instance_id TEXT,       -- set for sub-workflow child instances
+  resumed_from TEXT,             -- instance id this was resumed from
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Step runs: one row per step execution within a workflow instance.
+CREATE TABLE IF NOT EXISTS step_runs (
+  id TEXT PRIMARY KEY,
+  workflow_instance_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  agent_id TEXT,
+  state TEXT NOT NULL,           -- pending|running|passed|failed|skipped|skipped_cached
+  output TEXT,
+  structured_output TEXT,        -- JSON-encoded structured output
+  summary TEXT,
+  exit_code INTEGER,
+  skipped_cached BOOLEAN DEFAULT 0,
+  started_at TIMESTAMP,
+  finished_at TIMESTAMP,
+  FOREIGN KEY(workflow_instance_id) REFERENCES workflow_instances(id)
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_executions_task ON task_executions(task_id);
 CREATE INDEX IF NOT EXISTS idx_executions_retry ON task_executions(next_retry_at) WHERE status='failed';
@@ -111,6 +141,10 @@ CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
 CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_task_logs_task ON task_logs(task_id);
 CREATE INDEX IF NOT EXISTS idx_service_logs_timestamp ON service_logs(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
+CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);
+CREATE INDEX IF NOT EXISTS idx_wf_instances_parent ON workflow_instances(parent_instance_id);
+CREATE INDEX IF NOT EXISTS idx_step_runs_instance ON step_runs(workflow_instance_id);
 `
 
 // migrations are idempotent ALTER statements applied to databases created

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -1,0 +1,231 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// Workflow instance states.
+const (
+	InstanceStatePending         = "pending"
+	InstanceStateRunning         = "running"
+	InstanceStateApprovalWaiting = "approval_waiting"
+	InstanceStateInterrupted     = "interrupted"
+	InstanceStateDone            = "done"
+	InstanceStateFailed          = "failed"
+)
+
+// Step run states.
+const (
+	StepStatePending       = "pending"
+	StepStateRunning       = "running"
+	StepStatePassed        = "passed"
+	StepStateFailed        = "failed"
+	StepStateSkipped       = "skipped"
+	StepStateSkippedCached = "skipped_cached"
+)
+
+// WorkflowInstance is a single execution of a workflow bound to a Cell.
+type WorkflowInstance struct {
+	ID               string
+	WorkflowID       string
+	CellID           string
+	SourceID         string
+	State            string
+	ParentInstanceID string
+	ResumedFrom      string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// StepRun records one step execution within a workflow instance.
+type StepRun struct {
+	ID                 string
+	WorkflowInstanceID string
+	StepID             string
+	AgentID            string
+	State              string
+	Output             string
+	StructuredOutput   string // JSON-encoded
+	Summary            string
+	ExitCode           int
+	SkippedCached      bool
+	StartedAt          *time.Time
+	FinishedAt         *time.Time
+}
+
+// CreateWorkflowInstance inserts a new workflow instance. The caller supplies
+// the ID (the engine generates it) so persistence stays deterministic.
+func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInstance) error {
+	now := time.Now()
+	if inst.CreatedAt.IsZero() {
+		inst.CreatedAt = now
+	}
+	inst.UpdatedAt = now
+	_, err := c.db.ExecContext(ctx, `
+		INSERT INTO workflow_instances
+		  (id, workflow_id, cell_id, source_id, state, parent_instance_id, resumed_from, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, inst.ID, inst.WorkflowID, inst.CellID, nullStr(inst.SourceID), inst.State,
+		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.CreatedAt, inst.UpdatedAt)
+	return err
+}
+
+// UpdateWorkflowInstanceState transitions an instance to a new state.
+func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state string) error {
+	_, err := c.db.ExecContext(ctx, `
+		UPDATE workflow_instances SET state = ?, updated_at = ? WHERE id = ?
+	`, state, time.Now(), id)
+	return err
+}
+
+// GetWorkflowInstance fetches an instance by ID, or (nil, nil) if not found.
+func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowInstance, error) {
+	row := c.db.QueryRowContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		FROM workflow_instances WHERE id = ?
+	`, id)
+	inst, err := scanInstance(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return inst, err
+}
+
+// ListWorkflowInstancesByState returns all instances in the given state, oldest first.
+func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		FROM workflow_instances WHERE state = ? ORDER BY created_at ASC
+	`, state)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
+// ListWorkflowInstances returns the most recent instances, newest first.
+func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]WorkflowInstance, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		FROM workflow_instances ORDER BY created_at DESC LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
+// ReconcileOrphanWorkflowInstances marks any instance left in the 'running'
+// state by a previously-killed process as 'interrupted'. Returns the count.
+// approval_waiting instances are intentionally left untouched — their condition
+// is re-evaluated against the live task on the next poll.
+func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, error) {
+	res, err := c.db.ExecContext(ctx, `
+		UPDATE workflow_instances
+		SET state = 'interrupted', updated_at = ?
+		WHERE state = 'running'
+	`, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// CreateStepRun inserts a new step run row.
+func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
+	_, err := c.db.ExecContext(ctx, `
+		INSERT INTO step_runs
+		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
+		   summary, exit_code, skipped_cached, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
+		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
+		sr.ExitCode, sr.SkippedCached, sr.StartedAt, sr.FinishedAt)
+	return err
+}
+
+// UpdateStepRun persists the mutable fields of a step run (state, output,
+// structured output, summary, exit code, skipped flag, finished timestamp).
+func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
+	_, err := c.db.ExecContext(ctx, `
+		UPDATE step_runs
+		SET state = ?, output = ?, structured_output = ?, summary = ?,
+		    exit_code = ?, skipped_cached = ?, started_at = ?, finished_at = ?
+		WHERE id = ?
+	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
+		sr.ExitCode, sr.SkippedCached, sr.StartedAt, sr.FinishedAt, sr.ID)
+	return err
+}
+
+// ListStepRuns returns all step runs for an instance, in insertion order.
+func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_instance_id, step_id, COALESCE(agent_id,''), state,
+		       COALESCE(output,''), COALESCE(structured_output,''), COALESCE(summary,''),
+		       COALESCE(exit_code,0), COALESCE(skipped_cached,0), started_at, finished_at
+		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
+	`, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []StepRun
+	for rows.Next() {
+		var sr StepRun
+		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
+			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
+			&sr.StartedAt, &sr.FinishedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, sr)
+	}
+	return out, rows.Err()
+}
+
+// scanner abstracts *sql.Row and *sql.Rows for shared scanning.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanInstance(s scanner) (*WorkflowInstance, error) {
+	var inst WorkflowInstance
+	err := s.Scan(&inst.ID, &inst.WorkflowID, &inst.CellID, &inst.SourceID, &inst.State,
+		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &inst, nil
+}
+
+func scanInstances(rows *sql.Rows) ([]WorkflowInstance, error) {
+	var out []WorkflowInstance
+	for rows.Next() {
+		inst, err := scanInstance(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *inst)
+	}
+	return out, rows.Err()
+}
+
+// nullStr converts an empty string to a SQL NULL so optional columns stay null
+// rather than storing empty strings.
+func nullStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -1,0 +1,192 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	c, err := New(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestWorkflowInstance_CRUD(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	inst := &WorkflowInstance{
+		ID:         "wf_1",
+		WorkflowID: "feature-development",
+		CellID:     "PLANE-142",
+		SourceID:   "main-plane",
+		State:      InstanceStatePending,
+	}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := c.GetWorkflowInstance(ctx, "wf_1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected instance, got nil")
+	}
+	if got.WorkflowID != "feature-development" || got.CellID != "PLANE-142" || got.State != InstanceStatePending {
+		t.Errorf("instance fields wrong: %+v", got)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at not set")
+	}
+
+	if err := c.UpdateWorkflowInstanceState(ctx, "wf_1", InstanceStateRunning); err != nil {
+		t.Fatalf("update state: %v", err)
+	}
+	got, _ = c.GetWorkflowInstance(ctx, "wf_1")
+	if got.State != InstanceStateRunning {
+		t.Errorf("state not updated: %s", got.State)
+	}
+}
+
+func TestWorkflowInstance_NotFound(t *testing.T) {
+	c := newTestClient(t)
+	got, err := c.GetWorkflowInstance(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing instance, got: %+v", got)
+	}
+}
+
+func TestWorkflowInstance_ListByState(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	for i, st := range []string{InstanceStateApprovalWaiting, InstanceStateRunning, InstanceStateApprovalWaiting} {
+		inst := &WorkflowInstance{
+			ID:         "wf_" + string(rune('a'+i)),
+			WorkflowID: "wf",
+			CellID:     "c",
+			State:      st,
+			CreatedAt:  time.Unix(int64(1000+i), 0),
+		}
+		if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	waiting, err := c.ListWorkflowInstancesByState(ctx, InstanceStateApprovalWaiting)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(waiting) != 2 {
+		t.Fatalf("expected 2 approval_waiting, got %d", len(waiting))
+	}
+	// oldest first
+	if !waiting[0].CreatedAt.Before(waiting[1].CreatedAt) {
+		t.Error("expected oldest-first ordering")
+	}
+}
+
+func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "r1", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "r2", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "w1", WorkflowID: "w", CellID: "c", State: InstanceStateApprovalWaiting})
+
+	n, err := c.ReconcileOrphanWorkflowInstances(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 reconciled, got %d", n)
+	}
+
+	// approval_waiting is left untouched.
+	w1, _ := c.GetWorkflowInstance(ctx, "w1")
+	if w1.State != InstanceStateApprovalWaiting {
+		t.Errorf("approval_waiting should be untouched, got %s", w1.State)
+	}
+	r1, _ := c.GetWorkflowInstance(ctx, "r1")
+	if r1.State != InstanceStateInterrupted {
+		t.Errorf("running should become interrupted, got %s", r1.State)
+	}
+}
+
+func TestStepRun_CRUD(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "wf_1", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
+
+	started := time.Unix(2000, 0)
+	sr := &StepRun{
+		ID:                 "sr_1",
+		WorkflowInstanceID: "wf_1",
+		StepID:             "plan",
+		AgentID:            "architect",
+		State:              StepStateRunning,
+		StartedAt:          &started,
+	}
+	if err := c.CreateStepRun(ctx, sr); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+
+	finished := time.Unix(2100, 0)
+	sr.State = StepStatePassed
+	sr.Output = "did the work"
+	sr.StructuredOutput = `{"complexity":"high"}`
+	sr.Summary = "- planned it"
+	sr.FinishedAt = &finished
+	if err := c.UpdateStepRun(ctx, sr); err != nil {
+		t.Fatalf("update step run: %v", err)
+	}
+
+	runs, err := c.ListStepRuns(ctx, "wf_1")
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 step run, got %d", len(runs))
+	}
+	got := runs[0]
+	if got.State != StepStatePassed || got.Output != "did the work" {
+		t.Errorf("step run not updated: %+v", got)
+	}
+	if got.StructuredOutput != `{"complexity":"high"}` {
+		t.Errorf("structured output wrong: %q", got.StructuredOutput)
+	}
+	if got.Summary != "- planned it" {
+		t.Errorf("summary wrong: %q", got.Summary)
+	}
+	if got.FinishedAt == nil {
+		t.Error("finished_at not persisted")
+	}
+}
+
+func TestStepRun_OrderedByInsertion(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "wf_1", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
+
+	for _, id := range []string{"plan", "implement", "review"} {
+		if err := c.CreateStepRun(ctx, &StepRun{ID: "sr-" + id, WorkflowInstanceID: "wf_1", StepID: id, State: StepStatePending}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runs, _ := c.ListStepRuns(ctx, "wf_1")
+	if len(runs) != 3 || runs[0].StepID != "plan" || runs[2].StepID != "review" {
+		t.Errorf("unexpected step run order: %+v", runs)
+	}
+}

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -13,6 +13,20 @@ type RunRequest struct {
 	Timeout       time.Duration
 	AgentMetadata map[string]any
 
+	// SystemPrepend is injected at the very start of the prompt, before the cell
+	// details and SystemAppend. In workflow mode it carries the formatted
+	// workflow memory document. Empty for plain routes.
+	SystemPrepend string
+	// SummaryPrompt, when set, instructs the agent to emit a short handoff
+	// summary delimited by APIARY_SUMMARY_START/END markers, extracted into
+	// RunResult.Summary. Empty for plain routes.
+	SummaryPrompt string
+	// StepID is the workflow step this run belongs to (empty for plain routes).
+	StepID string
+	// WorkflowInstanceID identifies the owning workflow instance, for
+	// logging/tracing (empty for plain routes).
+	WorkflowInstanceID string
+
 	// LogSink receives log entries in real time as the runner produces them.
 	// Must be safe to call from multiple goroutines.
 	LogSink func(LogEntry) `json:"-"`
@@ -43,6 +57,14 @@ type RunResult struct {
 	Duration time.Duration
 	Error    error
 	Usage    *Usage // populated by runners that support usage reporting
+
+	// StructuredOutput is the parsed JSON object from the APIARY_OUTPUT: sentinel
+	// line, when present. Nil for runs that emit no structured output. The
+	// sentinel line is stripped from Output.
+	StructuredOutput map[string]any
+	// Summary is the text extracted from the APIARY_SUMMARY_START/END markers,
+	// when present. Empty otherwise. The markers are stripped from Output.
+	Summary string
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/api.go
+++ b/src/internal/runner/execution/api.go
@@ -119,14 +119,17 @@ func (r *ApiRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	emit("debug", output)
 	usage := parseUsage(respRaw)
-	return model.RunResult{
+	result := model.RunResult{
 		WorkerID: req.WorkerID,
 		Success:  true,
 		Output:   strings.TrimSpace(output),
 		Logs:     logs,
 		Duration: time.Since(start),
 		Usage:    usage,
-	}, nil
+	}
+	// Extract APIARY_OUTPUT / APIARY_SUMMARY sentinels into structured fields.
+	applyStructured(&result)
+	return result, nil
 }
 
 func defaultBuildBody(prompt, model string, maxTokens int) ([]byte, error) {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -208,6 +208,8 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 			result.Error = runErr
 		}
 	}
+	// Extract APIARY_OUTPUT / APIARY_SUMMARY sentinels into structured fields.
+	applyStructured(&result)
 	return result, nil
 }
 
@@ -327,7 +329,7 @@ func formatStreamLine(line string) (string, bool) {
 			}
 		}
 		out := fmt.Sprintf("[result:%s] turns=%d duration=%s", status, ev.NumTurns,
-			(time.Duration(ev.DurationMs)*time.Millisecond).Round(time.Millisecond))
+			(time.Duration(ev.DurationMs) * time.Millisecond).Round(time.Millisecond))
 		if ev.TotalCostUSD > 0 {
 			out += fmt.Sprintf(" cost=$%.4f", ev.TotalCostUSD)
 		}
@@ -368,6 +370,10 @@ func truncateInput(raw json.RawMessage) string {
 
 func buildPrompt(req model.RunRequest) string {
 	var b strings.Builder
+	if req.SystemPrepend != "" {
+		b.WriteString(req.SystemPrepend)
+		b.WriteString("\n\n")
+	}
 	fmt.Fprintf(&b, "Task: %s\n", req.Cell.Title)
 	if req.Cell.Type != "" {
 		fmt.Fprintf(&b, "Type: %s\n", req.Cell.Type)
@@ -390,6 +396,9 @@ func buildPrompt(req model.RunRequest) string {
 		b.WriteString("\n")
 		b.WriteString(req.SystemAppend)
 		b.WriteString("\n")
+	}
+	if req.SummaryPrompt != "" {
+		b.WriteString(summaryInstruction(req.SummaryPrompt))
 	}
 	return b.String()
 }

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -1,0 +1,78 @@
+package execution
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// Sentinels the workflow engine uses to extract structured output and a handoff
+// summary from an agent's raw stdout. Runners strip these from the visible
+// Output and surface the parsed values on RunResult.
+const (
+	apiaryOutputPrefix = "APIARY_OUTPUT:"
+	summaryStartMarker = "APIARY_SUMMARY_START"
+	summaryEndMarker   = "APIARY_SUMMARY_END"
+)
+
+// extractStructured scans an agent's raw output for the APIARY_OUTPUT: sentinel
+// and the APIARY_SUMMARY_START/END block. It returns the cleaned output (with
+// those lines removed), the parsed structured object (nil when absent or
+// unparseable), and the summary text (empty when absent). The last valid
+// APIARY_OUTPUT line wins.
+func extractStructured(output string) (cleaned string, structured map[string]any, summary string) {
+	lines := strings.Split(output, "\n")
+	kept := make([]string, 0, len(lines))
+	var summaryLines []string
+	inSummary := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == summaryStartMarker:
+			inSummary = true
+		case trimmed == summaryEndMarker:
+			inSummary = false
+		case inSummary:
+			summaryLines = append(summaryLines, line)
+		case strings.HasPrefix(trimmed, apiaryOutputPrefix):
+			jsonPart := strings.TrimSpace(strings.TrimPrefix(trimmed, apiaryOutputPrefix))
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(jsonPart), &obj); err == nil {
+				structured = obj
+			}
+			// The sentinel line is stripped whether or not it parsed.
+		default:
+			kept = append(kept, line)
+		}
+	}
+
+	cleaned = strings.TrimSpace(strings.Join(kept, "\n"))
+	summary = strings.TrimSpace(strings.Join(summaryLines, "\n"))
+	return cleaned, structured, summary
+}
+
+// applyStructured post-processes a RunResult's Output, moving any structured
+// output and summary into their dedicated fields. Safe to call for plain runs:
+// when no sentinels are present, Output is unchanged and the new fields stay
+// nil/empty.
+func applyStructured(result *model.RunResult) {
+	cleaned, structured, summary := extractStructured(result.Output)
+	result.Output = cleaned
+	result.StructuredOutput = structured
+	result.Summary = summary
+}
+
+// summaryInstruction returns the text appended to a prompt instructing the agent
+// to emit its handoff summary between the recognized markers.
+func summaryInstruction(summaryPrompt string) string {
+	var b strings.Builder
+	b.WriteString("\n---\n")
+	b.WriteString(strings.TrimSpace(summaryPrompt))
+	b.WriteString("\n\nWrite that summary between these exact markers, on their own lines:\n")
+	b.WriteString(summaryStartMarker + "\n")
+	b.WriteString("...your summary here...\n")
+	b.WriteString(summaryEndMarker + "\n")
+	return b.String()
+}

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -1,0 +1,128 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestExtractStructured_OutputAndSummary(t *testing.T) {
+	raw := strings.Join([]string{
+		"I analyzed the task and here is my work.",
+		"Made some changes.",
+		"APIARY_SUMMARY_START",
+		"- Refactored the auth middleware",
+		"- No blockers",
+		"APIARY_SUMMARY_END",
+		`APIARY_OUTPUT: {"complexity":"high","action":"implement"}`,
+	}, "\n")
+
+	cleaned, structured, summary := extractStructured(raw)
+
+	if strings.Contains(cleaned, "APIARY_OUTPUT") || strings.Contains(cleaned, "APIARY_SUMMARY") {
+		t.Errorf("cleaned output still contains sentinels:\n%s", cleaned)
+	}
+	if !strings.Contains(cleaned, "I analyzed the task") || !strings.Contains(cleaned, "Made some changes.") {
+		t.Errorf("cleaned output dropped human text:\n%s", cleaned)
+	}
+	if structured == nil {
+		t.Fatal("expected structured output, got nil")
+	}
+	if structured["complexity"] != "high" || structured["action"] != "implement" {
+		t.Errorf("structured parsed incorrectly: %#v", structured)
+	}
+	if !strings.Contains(summary, "Refactored the auth middleware") || !strings.Contains(summary, "No blockers") {
+		t.Errorf("summary parsed incorrectly: %q", summary)
+	}
+}
+
+func TestExtractStructured_NoSentinels(t *testing.T) {
+	raw := "Just a normal agent response.\nNothing structured here."
+	cleaned, structured, summary := extractStructured(raw)
+	if cleaned != raw {
+		t.Errorf("cleaned should be unchanged, got: %q", cleaned)
+	}
+	if structured != nil {
+		t.Errorf("expected nil structured, got: %#v", structured)
+	}
+	if summary != "" {
+		t.Errorf("expected empty summary, got: %q", summary)
+	}
+}
+
+func TestExtractStructured_LastOutputWins(t *testing.T) {
+	raw := strings.Join([]string{
+		`APIARY_OUTPUT: {"v":1}`,
+		"some text",
+		`APIARY_OUTPUT: {"v":2}`,
+	}, "\n")
+	_, structured, _ := extractStructured(raw)
+	if structured == nil || structured["v"] != float64(2) {
+		t.Errorf("expected last APIARY_OUTPUT to win, got: %#v", structured)
+	}
+}
+
+func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
+	raw := "real output\nAPIARY_OUTPUT: {not valid json}"
+	cleaned, structured, _ := extractStructured(raw)
+	if structured != nil {
+		t.Errorf("expected nil structured for invalid JSON, got: %#v", structured)
+	}
+	if strings.Contains(cleaned, "APIARY_OUTPUT") {
+		t.Errorf("invalid sentinel line should still be stripped:\n%s", cleaned)
+	}
+	if cleaned != "real output" {
+		t.Errorf("unexpected cleaned output: %q", cleaned)
+	}
+}
+
+func TestApplyStructured_MutatesResult(t *testing.T) {
+	result := model.RunResult{
+		Output: "done\nAPIARY_OUTPUT: {\"ok\":true}",
+	}
+	applyStructured(&result)
+	if result.Output != "done" {
+		t.Errorf("output not cleaned: %q", result.Output)
+	}
+	if result.StructuredOutput == nil || result.StructuredOutput["ok"] != true {
+		t.Errorf("structured not populated: %#v", result.StructuredOutput)
+	}
+}
+
+func TestBuildPrompt_PrependAndSummary(t *testing.T) {
+	req := model.RunRequest{
+		Cell:          model.Cell{Title: "Fix bug"},
+		SystemPrepend: "=== Workflow Memory ===\ncomplexity: high\n======================",
+		SystemAppend:  "soul content",
+		SummaryPrompt: "Summarize what you did.",
+	}
+	prompt := buildPrompt(req)
+
+	if !strings.HasPrefix(prompt, "=== Workflow Memory ===") {
+		t.Errorf("expected memory prepended at start, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Task: Fix bug") {
+		t.Error("expected cell title in prompt")
+	}
+	if !strings.Contains(prompt, "soul content") {
+		t.Error("expected SystemAppend in prompt")
+	}
+	if !strings.Contains(prompt, summaryStartMarker) || !strings.Contains(prompt, summaryEndMarker) {
+		t.Error("expected summary markers in prompt")
+	}
+	if !strings.Contains(prompt, "Summarize what you did.") {
+		t.Error("expected summary prompt text")
+	}
+}
+
+func TestBuildPrompt_NoWorkflowFieldsUnchanged(t *testing.T) {
+	req := model.RunRequest{Cell: model.Cell{Title: "Plain task"}}
+	prompt := buildPrompt(req)
+	if strings.Contains(prompt, summaryStartMarker) {
+		t.Error("plain prompt should not contain summary markers")
+	}
+	if !strings.HasPrefix(prompt, "Task: Plain task") {
+		t.Errorf("plain prompt should start with the task line, got:\n%s", prompt)
+	}
+}

--- a/src/internal/workflow/memory.go
+++ b/src/internal/workflow/memory.go
@@ -1,0 +1,162 @@
+// Package workflow implements the workflow-mode execution model: the shared
+// memory object that flows between steps, and (in later phases) the engine that
+// orchestrates steps within a workflow instance.
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// DefaultMemoryMaxChars bounds the injected memory document. When exceeded, the
+// builder drops the oldest summaries first; the Cell and Step Data sections are
+// never truncated.
+const DefaultMemoryMaxChars = 4000
+
+// MemoryStep is one completed step's contribution to workflow memory: the
+// structured-output fields it declared via memory.write, and an optional
+// handoff summary.
+type MemoryStep struct {
+	StepID      string
+	WriteFields []string       // field names from memory.write
+	Structured  map[string]any // parsed structured output (may be nil)
+	Summary     string         // handoff summary (may be empty)
+}
+
+// MemoryBuilder renders the workflow memory document injected into a step's
+// prompt. The zero value is usable (MaxChars defaults to DefaultMemoryMaxChars).
+type MemoryBuilder struct {
+	MaxChars int
+}
+
+// Build assembles the memory document from the originating Cell and the ordered
+// list of completed step contributions. Later steps override earlier ones when
+// they write the same key (last-write-wins).
+func (b MemoryBuilder) Build(cell model.Cell, steps []MemoryStep) string {
+	maxChars := b.MaxChars
+	if maxChars <= 0 {
+		maxChars = DefaultMemoryMaxChars
+	}
+
+	// Step Data: accumulate declared write-fields in first-seen key order with
+	// last-write-wins values.
+	var keyOrder []string
+	values := map[string]string{}
+	for _, s := range steps {
+		for _, field := range s.WriteFields {
+			v, ok := s.Structured[field]
+			if !ok {
+				continue
+			}
+			if _, seen := values[field]; !seen {
+				keyOrder = append(keyOrder, field)
+			}
+			values[field] = renderValue(v)
+		}
+	}
+
+	// Summaries, in step order.
+	type summary struct{ stepID, text string }
+	var summaries []summary
+	for _, s := range steps {
+		if strings.TrimSpace(s.Summary) != "" {
+			summaries = append(summaries, summary{s.StepID, s.Summary})
+		}
+	}
+
+	render := func(includeSummaries int) string {
+		var b strings.Builder
+		b.WriteString("=== Workflow Memory ===\n\n")
+
+		b.WriteString("[Cell]\n")
+		writeKV(&b, "title", cell.Title)
+		if len(cell.Labels) > 0 {
+			writeKV(&b, "labels", strings.Join(cell.Labels, ", "))
+		}
+		if cell.Type != "" {
+			writeKV(&b, "type", cell.Type)
+		}
+		if cell.Priority != "" {
+			writeKV(&b, "priority", cell.Priority)
+		}
+		if cell.SourceID != "" {
+			writeKV(&b, "source", cell.SourceID)
+		}
+
+		if len(keyOrder) > 0 {
+			b.WriteString("\n[Step Data]\n")
+			for _, k := range keyOrder {
+				writeKV(&b, k, values[k])
+			}
+		}
+
+		// includeSummaries < 0 means "all"; otherwise include the last N
+		// (newest) summaries — oldest are dropped first under truncation.
+		shown := summaries
+		if includeSummaries >= 0 && includeSummaries < len(summaries) {
+			shown = summaries[len(summaries)-includeSummaries:]
+		}
+		if len(shown) > 0 {
+			b.WriteString("\n[Summaries]\n")
+			for _, s := range shown {
+				fmt.Fprintf(&b, "%s: |\n", s.stepID)
+				for _, line := range strings.Split(strings.TrimRight(s.text, "\n"), "\n") {
+					b.WriteString("  " + line + "\n")
+				}
+			}
+		}
+
+		b.WriteString("\n======================")
+		return b.String()
+	}
+
+	doc := render(-1)
+	if len(doc) <= maxChars {
+		return doc
+	}
+
+	// Over budget: drop oldest summaries one at a time until it fits.
+	for keep := len(summaries) - 1; keep >= 0; keep-- {
+		doc = render(keep)
+		if len(doc) <= maxChars {
+			return doc
+		}
+	}
+
+	// Even with no summaries it's still over budget (very large Step Data). The
+	// Cell and Step Data sections are never truncated, so return the
+	// summary-free document whole and accept exceeding the soft limit.
+	return render(0)
+}
+
+// writeKV writes an aligned "key: value" line.
+func writeKV(b *strings.Builder, key, value string) {
+	fmt.Fprintf(b, "%s: %s\n", key, value)
+}
+
+// renderValue renders a structured-output value for the memory document.
+// Strings pass through; scalars are formatted; arrays/objects become compact JSON.
+func renderValue(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		return fmt.Sprintf("%t", x)
+	case float64:
+		// JSON numbers decode as float64; render integers without a decimal point.
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+		return fmt.Sprintf("%g", x)
+	case nil:
+		return ""
+	default:
+		if data, err := json.Marshal(x); err == nil {
+			return string(data)
+		}
+		return fmt.Sprintf("%v", x)
+	}
+}

--- a/src/internal/workflow/memory_test.go
+++ b/src/internal/workflow/memory_test.go
@@ -1,0 +1,152 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestMemoryBuilder_FullDocument(t *testing.T) {
+	cell := model.Cell{
+		Title:    "Fix user auth bug",
+		Labels:   []string{"backend", "bug"},
+		Priority: "high",
+		SourceID: "main-plane",
+	}
+	steps := []MemoryStep{
+		{
+			StepID:      "plan",
+			WriteFields: []string{"complexity", "approach"},
+			Structured: map[string]any{
+				"complexity": "high",
+				"approach":   "Refactor auth middleware to use JWT",
+			},
+			Summary: "- JWT chosen over sessions\n- Two files to change",
+		},
+		{
+			StepID:  "implement",
+			Summary: "- Added JwtMiddleware\n- Updated handler",
+		},
+	}
+
+	doc := MemoryBuilder{}.Build(cell, steps)
+
+	for _, want := range []string{
+		"=== Workflow Memory ===",
+		"[Cell]",
+		"title: Fix user auth bug",
+		"labels: backend, bug",
+		"priority: high",
+		"source: main-plane",
+		"[Step Data]",
+		"complexity: high",
+		"approach: Refactor auth middleware to use JWT",
+		"[Summaries]",
+		"plan: |",
+		"  - JWT chosen over sessions",
+		"implement: |",
+		"  - Added JwtMiddleware",
+		"======================",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("memory document missing %q:\n%s", want, doc)
+		}
+	}
+}
+
+func TestMemoryBuilder_OnlyDeclaredFieldsWritten(t *testing.T) {
+	steps := []MemoryStep{
+		{
+			StepID:      "plan",
+			WriteFields: []string{"complexity"}, // approach NOT declared
+			Structured: map[string]any{
+				"complexity": "high",
+				"approach":   "should not appear",
+			},
+		},
+	}
+	doc := MemoryBuilder{}.Build(model.Cell{Title: "t"}, steps)
+	if !strings.Contains(doc, "complexity: high") {
+		t.Error("expected declared field complexity")
+	}
+	if strings.Contains(doc, "should not appear") {
+		t.Errorf("undeclared field leaked into memory:\n%s", doc)
+	}
+}
+
+func TestMemoryBuilder_LastWriteWins(t *testing.T) {
+	steps := []MemoryStep{
+		{StepID: "a", WriteFields: []string{"status"}, Structured: map[string]any{"status": "draft"}},
+		{StepID: "b", WriteFields: []string{"status"}, Structured: map[string]any{"status": "final"}},
+	}
+	doc := MemoryBuilder{}.Build(model.Cell{Title: "t"}, steps)
+	if !strings.Contains(doc, "status: final") {
+		t.Errorf("expected last write to win:\n%s", doc)
+	}
+	if strings.Contains(doc, "status: draft") {
+		t.Errorf("stale value present:\n%s", doc)
+	}
+}
+
+func TestMemoryBuilder_ValueRendering(t *testing.T) {
+	steps := []MemoryStep{
+		{
+			StepID:      "s",
+			WriteFields: []string{"count", "ratio", "ok", "files"},
+			Structured: map[string]any{
+				"count": float64(3),
+				"ratio": float64(0.5),
+				"ok":    true,
+				"files": []any{"a.go", "b.go"},
+			},
+		},
+	}
+	doc := MemoryBuilder{}.Build(model.Cell{Title: "t"}, steps)
+	for _, want := range []string{"count: 3", "ratio: 0.5", "ok: true", `files: ["a.go","b.go"]`} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("missing rendered value %q:\n%s", want, doc)
+		}
+	}
+}
+
+func TestMemoryBuilder_NoStepData(t *testing.T) {
+	doc := MemoryBuilder{}.Build(model.Cell{Title: "lonely"}, nil)
+	if strings.Contains(doc, "[Step Data]") || strings.Contains(doc, "[Summaries]") {
+		t.Errorf("empty sections should be omitted:\n%s", doc)
+	}
+	if !strings.Contains(doc, "title: lonely") {
+		t.Error("cell title should always be present")
+	}
+}
+
+func TestMemoryBuilder_TruncationDropsOldestSummaries(t *testing.T) {
+	big := strings.Repeat("x", 500)
+	steps := []MemoryStep{
+		{StepID: "oldest", Summary: "OLDEST " + big},
+		{StepID: "middle", Summary: "MIDDLE " + big},
+		{StepID: "newest", Summary: "NEWEST " + big},
+	}
+	doc := MemoryBuilder{MaxChars: 800}.Build(model.Cell{Title: "t"}, steps)
+
+	if len(doc) > 800 {
+		t.Errorf("doc exceeds MaxChars: %d", len(doc))
+	}
+	// Newest summary should survive; oldest should be dropped first.
+	if !strings.Contains(doc, "NEWEST") {
+		t.Errorf("newest summary should be retained:\n%s", doc)
+	}
+	if strings.Contains(doc, "OLDEST") {
+		t.Errorf("oldest summary should have been dropped:\n%s", doc)
+	}
+}
+
+func TestMemoryBuilder_CellNeverTruncated(t *testing.T) {
+	// Even with a tiny budget, the Cell section must be present.
+	doc := MemoryBuilder{MaxChars: 10}.Build(model.Cell{Title: "important"}, []MemoryStep{
+		{StepID: "s", Summary: strings.Repeat("y", 1000)},
+	})
+	if !strings.Contains(doc, "=== Workflow Memory ===") {
+		t.Errorf("header missing under tight budget:\n%s", doc)
+	}
+}


### PR DESCRIPTION
## Summary

Foundations of **Phase 2** of workflow-mode. All additive, **no behavior change** — no existing execution path is altered. The engine and the daemon wiring come in the next PR (2b), isolated because they touch the mature dispatcher.

- **SQLite store** (`internal/db`): `workflow_instances` and `step_runs` tables (with `summary` and `structured_output` columns) + `WorkflowStore` with CRUD of instances and step runs and `ReconcileOrphanWorkflowInstances` (running → interrupted at startup).
- **Runner interface** (`internal/model`, `internal/runner/execution`): new `SystemPrepend`/`SummaryPrompt`/`StepID`/`WorkflowInstanceID` fields on `RunRequest` and `StructuredOutput`/`Summary` on `RunResult`. `buildPrompt` injects memory at the start and the summary instruction at the end; parsing of the `APIARY_OUTPUT:` and `APIARY_SUMMARY_START/END` sentinels (`structured.go`, applied by the cli and api runners). Empty fields for ordinary routes ⇒ behavior identical to today.
- **MemoryBuilder** (`internal/workflow`): assembles the memory document from the Cell + step contributions (`memory.write` fields + summaries), with truncation by `memory_max_chars` (oldest summaries first; Cell and Step Data never cut).

## Test plan
- [x] `go test ./...` — green (new: db store CRUD/reconcile, structured extraction + prompt injection, memory builder incl. truncation and last-write-wins)
- [x] `go vet ./...` clean; `make build` ok
- [x] Regression: runs without workflow fields produce identical prompt and Output (absent sentinels ⇒ no-op)

## Notes
- The actual layout differs from the task's original notes: the store lives in the existing `internal/db` package (not `internal/store`); the schema is inline in `db/schema.go`.
- Script runner env vars (2.2.4) deferred — the shared prompt/parse path already covers cli + api.