### PR TITLE
feat: workflow-mode Phase 2b — single-step engine + daemon wiring

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -74,20 +74,20 @@ Implement `WorkflowEngine` behind `settings.experimental.workflow_mode: true`. S
 
 ### 2.4 Workflow Engine — PR-2b
 
-- [ ] 2.4.1 Implement `WorkflowEngine` in `src/internal/workflow/engine.go`
-- [ ] 2.4.2 Implement route synthesis: plain `routes:` entries produce a single-step `WorkflowConfig` internally
-- [ ] 2.4.3 Implement instance lifecycle: create → run step → complete/fail → apply hooks
-- [ ] 2.4.4 Implement concurrency semaphore — see [concurrency-model spec](specs/concurrency-model/spec.md)
-- [ ] 2.4.5 Implement `state_lock` and `result_comment` workflow behavior — see [workflow-hooks spec](specs/workflow-hooks/spec.md)
-- [ ] 2.4.6 Wire `WorkflowEngine` into daemon; respect `settings.experimental.workflow_mode` flag
-- [ ] 2.4.7 Integration test: plain route dispatches through engine, produces instance + step_run in SQLite
+- [x] 2.4.1 Implement `Engine` in `src/internal/workflow/engine.go` (pure core; `StepExecutor`/`SideEffects`/`Store` interfaces so it's testable in isolation)
+- [x] 2.4.2 Implement route synthesis: `SynthesizeWorkflow(route)` produces a single-step `WorkflowConfig`
+- [x] 2.4.3 Implement instance lifecycle: create instance → run step(s) sequentially with memory threading → mark done/failed → apply on_complete/on_fail hooks
+- [~] 2.4.4 Concurrency semaphore — deferred to Phase 3 (DAG/parallel); Phase 2 reuses the dispatcher's existing per-agent concurrency since each cell still runs one agent step
+- [x] 2.4.5 Implement `state_lock` (once at workflow start) and `result_comment` (`on_complete`/`per_step`/`off`) — see [workflow-hooks spec](specs/workflow-hooks/spec.md)
+- [x] 2.4.6 Wire engine into daemon behind `settings.experimental.workflow_mode` (new `daemon/workflow.go`; single gated branch at top of `dispatch()` — legacy path untouched when off)
+- [x] 2.4.7 Integration test: engine persists instance + step_run to real SQLite (`engine_integration_test.go`)
 
 ### 2.5 Tests
 
-- [ ] 2.5.1 Unit tests: engine creates instance, runs step, marks done
-- [ ] 2.5.2 Unit tests: `state_lock` fires at workflow start; `result_comment` posts at workflow end
-- [ ] 2.5.3 Integration test: end-to-end with a real source + runner stub
-- [ ] 2.5.4 Run full test suite: `go test ./...`
+- [x] 2.5.1 Unit tests: engine creates instance, runs step, marks done
+- [x] 2.5.2 Unit tests: `state_lock` fires at workflow start; `result_comment` on_complete/per_step/off
+- [x] 2.5.3 Integration test: engine against real `db.Client` (real-source end-to-end deferred — needs a fake source adapter, follow-up)
+- [x] 2.5.4 Run full test suite: `go test ./...`
 
 ---
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -166,13 +166,21 @@ type RetryPolicy struct {
 }
 
 type Settings struct {
-	Concurrency   int         `yaml:"concurrency"`
-	LogLevel      string      `yaml:"log_level"`
-	StateLock     bool        `yaml:"state_lock"`
-	ResultComment bool        `yaml:"result_comment"`
-	TaskTimeout   string      `yaml:"task_timeout"`
-	RetryPolicy   RetryPolicy `yaml:"retry_policy"`
-	Telemetry     Telemetry   `yaml:"telemetry"`
+	Concurrency   int          `yaml:"concurrency"`
+	LogLevel      string       `yaml:"log_level"`
+	StateLock     bool         `yaml:"state_lock"`
+	ResultComment bool         `yaml:"result_comment"`
+	TaskTimeout   string       `yaml:"task_timeout"`
+	RetryPolicy   RetryPolicy  `yaml:"retry_policy"`
+	Telemetry     Telemetry    `yaml:"telemetry"`
+	Experimental  Experimental `yaml:"experimental"`
+}
+
+// Experimental gates opt-in, not-yet-stable features.
+type Experimental struct {
+	// WorkflowMode routes matched cells through the workflow engine (instances +
+	// step runs + memory) instead of the legacy single-shot dispatch path.
+	WorkflowMode bool `yaml:"workflow_mode"`
 }
 
 func (s *Settings) TaskTimeoutDuration() time.Duration {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -698,6 +698,13 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 
 // dispatch acknowledges, runs, and writes the result for a single cell.
 func (d *Dispatcher) dispatch(ctx context.Context, cell model.Cell, adapter source.Adapter, match router.Match) model.RunResult {
+	// Experimental workflow mode routes the cell through the workflow engine
+	// (instances + step runs + memory). The legacy path below is untouched and
+	// remains the default when the flag is off.
+	if d.cfg.Settings.Experimental.WorkflowMode {
+		return d.dispatchWorkflow(ctx, cell, adapter, match)
+	}
+
 	// Get the agent ID from the route
 	agentID := match.Route.Agent
 	if agentID == "" {

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -1,0 +1,172 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// dispatchWorkflow runs a matched cell through the workflow engine instead of
+// the legacy single-shot path. In Phase 2 the route is synthesized into a
+// single-step workflow; multi-step workflow definitions arrive in Phase 3.
+//
+// It is gated behind settings.experimental.workflow_mode and only reached when a
+// run-history DB is available (the engine persists instances and step runs).
+func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.Cell, adapter source.Adapter, match router.Match) model.RunResult {
+	if d.db == nil {
+		aplog.Error("cell %s: workflow_mode requires a run-history database", cell.ID)
+		return model.RunResult{Success: false}
+	}
+
+	wf := workflow.SynthesizeWorkflow(match.Route)
+
+	side := &wfSideEffects{adapter: adapter}
+	exec := &wfStepExecutor{d: d}
+	eng := workflow.NewEngine(d.cfg, d.db, exec, workflow.WithSideEffects(side))
+
+	instID, success, err := eng.RunInstance(ctx, wf, cell)
+	if err != nil {
+		aplog.Error("cell %s: workflow run failed: %v", cell.ID, err)
+		return model.RunResult{Success: false, WorkerID: match.Route.Agent}
+	}
+	aplog.Info("cell %s: workflow instance %s finished success=%v", cell.ID, instID, success)
+	return model.RunResult{Success: success, WorkerID: match.Route.Agent}
+}
+
+// wfStepExecutor adapts the dispatcher's runner machinery to the workflow
+// engine's StepExecutor interface: it builds a RunRequest for one agent step and
+// invokes the agent's runner.
+type wfStepExecutor struct {
+	d *Dispatcher
+}
+
+func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepRequest) workflow.StepResult {
+	pseudoWorkerID := fmt.Sprintf("agent-%s", req.Step.Agent)
+	ra, ok := x.d.runners[pseudoWorkerID]
+	if !ok {
+		return workflow.StepResult{Success: false, Err: fmt.Errorf("runner for agent %q not found", req.Step.Agent)}
+	}
+
+	// Per-agent source token for write operations performed by the runner.
+	if req.Agent.SourceToken != "" {
+		ctx = context.WithValue(ctx, source.SourceTokenCtxKey, req.Agent.SourceToken)
+	}
+
+	rr := model.RunRequest{
+		Cell:               req.Cell,
+		WorkerID:           req.Step.Agent,
+		Model:              req.Model,
+		MaxTurns:           15,
+		SystemPrepend:      req.MemoryDoc,
+		SystemAppend:       readSoulFile(req.Agent, req.Cell.ID),
+		SummaryPrompt:      req.Step.SummaryPrompt,
+		StepID:             req.Step.ID,
+		WorkflowInstanceID: req.InstanceID,
+		WorkingDir:         "/",
+		Env:                gitIdentityEnv(req.Agent),
+		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
+	}
+
+	if x.d.logger != nil {
+		cellID := req.Cell.ID
+		rr.LogSink = func(e model.LogEntry) {
+			switch e.Level {
+			case "error":
+				x.d.logger.TaskError(ctx, cellID, e.Message)
+			case "info":
+				x.d.logger.TaskInfo(ctx, cellID, e.Message)
+			default:
+				x.d.logger.TaskDebug(ctx, cellID, e.Message)
+			}
+			aplog.Info("[%s] %s", cellID, e.Message)
+		}
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
+	defer cancel()
+
+	res, err := ra.Run(runCtx, rr)
+	if err != nil && res.Error == nil {
+		res.Error = err
+	}
+	return workflow.StepResult{
+		Success:          res.Success,
+		Output:           res.Output,
+		StructuredOutput: res.StructuredOutput,
+		Summary:          res.Summary,
+		Err:              res.Error,
+	}
+}
+
+// wfSideEffects applies source-facing actions for a workflow instance against
+// the cell's source adapter.
+type wfSideEffects struct {
+	adapter source.Adapter
+}
+
+func (s *wfSideEffects) StateLock(ctx context.Context, cell model.Cell) error {
+	return s.adapter.Acknowledge(ctx, cell, model.AckActionInProgress)
+}
+
+func (s *wfSideEffects) PostComment(ctx context.Context, cell model.Cell, comment string) error {
+	return s.adapter.WriteResult(ctx, cell, model.RunResult{Success: true, Output: comment})
+}
+
+func (s *wfSideEffects) ApplyHook(ctx context.Context, cell model.Cell, hook config.OnComplete) error {
+	if len(hook.AddLabels) > 0 {
+		if la, ok := s.adapter.(source.LabelAdder); ok {
+			if err := la.AddLabels(ctx, cell, hook.AddLabels); err != nil {
+				aplog.Error("cell %s: add labels %v: %v", cell.ID, hook.AddLabels, err)
+			}
+		}
+	}
+	if hook.SetState != "" {
+		if ss, ok := s.adapter.(source.StateSetter); ok {
+			if err := ss.SetState(ctx, cell, hook.SetState); err != nil {
+				aplog.Error("cell %s: set_state %q: %v", cell.ID, hook.SetState, err)
+			}
+		}
+	}
+	return nil
+}
+
+// readSoulFile loads an agent's soul file, returning "" (and logging) on error.
+func readSoulFile(agent config.AgentConfig, cellID string) string {
+	if agent.SoulFile == "" {
+		return ""
+	}
+	data, err := os.ReadFile(agent.SoulFile)
+	if err != nil {
+		aplog.Error("cell %s: reading soul file %q: %v", cellID, agent.SoulFile, err)
+		return ""
+	}
+	return string(data)
+}
+
+// gitIdentityEnv returns the git author/committer identity env vars derived from
+// the agent's source identity, so commits use the agent's account.
+func gitIdentityEnv(agent config.AgentConfig) map[string]string {
+	env := map[string]string{}
+	if agent.SourceName != "" {
+		env["GIT_AUTHOR_NAME"] = agent.SourceName
+		env["GIT_COMMITTER_NAME"] = agent.SourceName
+	}
+	if agent.SourceEmail != "" {
+		env["GIT_AUTHOR_EMAIL"] = agent.SourceEmail
+		env["GIT_COMMITTER_EMAIL"] = agent.SourceEmail
+	}
+	return env
+}
+
+// compile-time interface checks.
+var (
+	_ workflow.StepExecutor = (*wfStepExecutor)(nil)
+	_ workflow.SideEffects  = (*wfSideEffects)(nil)
+)

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -1,0 +1,306 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// Store persists workflow instances and step runs. *db.Client satisfies it.
+type Store interface {
+	CreateWorkflowInstance(ctx context.Context, inst *db.WorkflowInstance) error
+	UpdateWorkflowInstanceState(ctx context.Context, id, state string) error
+	CreateStepRun(ctx context.Context, sr *db.StepRun) error
+	UpdateStepRun(ctx context.Context, sr *db.StepRun) error
+}
+
+// StepRequest is the input to executing one agent step.
+type StepRequest struct {
+	InstanceID string
+	Cell       model.Cell
+	Step       config.StepConfig
+	Agent      config.AgentConfig
+	Model      string // resolved model (step override or agent default)
+	MemoryDoc  string // workflow memory document to prepend (empty if memory.read is false)
+}
+
+// StepResult is the outcome of executing one agent step.
+type StepResult struct {
+	Success          bool
+	Output           string
+	StructuredOutput map[string]any
+	Summary          string
+	Err              error
+}
+
+// StepExecutor performs the actual runner invocation for a single agent step.
+// The engine owns persistence, memory, and hooks; the executor owns execution.
+type StepExecutor interface {
+	ExecuteStep(ctx context.Context, req StepRequest) StepResult
+}
+
+// SideEffects applies source-facing actions. A nil SideEffects disables them.
+type SideEffects interface {
+	// StateLock marks the task in-progress at workflow start.
+	StateLock(ctx context.Context, cell model.Cell) error
+	// PostComment posts a comment (result_comment) on the task.
+	PostComment(ctx context.Context, cell model.Cell, comment string) error
+	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels).
+	ApplyHook(ctx context.Context, cell model.Cell, hook config.OnComplete) error
+}
+
+// Engine orchestrates a workflow instance: it persists the instance and its step
+// runs, threads workflow memory between steps, and applies side effects. In
+// Phase 2 it executes agent steps sequentially in declaration order (single-step
+// and linear chains); the DAG executor with splits/foreach arrives in Phase 3.
+type Engine struct {
+	cfg   *config.Config
+	store Store
+	exec  StepExecutor
+	side  SideEffects
+	mem   MemoryBuilder
+
+	now   func() time.Time
+	newID func(prefix string) string
+}
+
+// Option customizes an Engine.
+type Option func(*Engine)
+
+// WithSideEffects sets the source-facing side-effects implementation.
+func WithSideEffects(s SideEffects) Option { return func(e *Engine) { e.side = s } }
+
+// WithClock overrides the time source (for deterministic tests).
+func WithClock(now func() time.Time) Option { return func(e *Engine) { e.now = now } }
+
+// WithIDGen overrides the ID generator (for deterministic tests).
+func WithIDGen(gen func(prefix string) string) Option { return func(e *Engine) { e.newID = gen } }
+
+// WithMemoryBuilder overrides the memory builder.
+func WithMemoryBuilder(b MemoryBuilder) Option { return func(e *Engine) { e.mem = b } }
+
+// NewEngine builds an Engine. cfg, store, and exec are required.
+func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {
+	e := &Engine{
+		cfg:   cfg,
+		store: store,
+		exec:  exec,
+		now:   time.Now,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	if e.newID == nil {
+		e.newID = defaultIDGen(e.now)
+	}
+	return e
+}
+
+// RunInstance executes a workflow for a cell from start to finish. It returns the
+// created instance ID and whether the instance completed successfully. Errors
+// creating the instance are returned; per-step failures are recorded and
+// reflected in the final instance state and the success flag, not returned.
+func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell model.Cell) (instanceID string, success bool, err error) {
+	instID := e.newID("wf")
+	inst := &db.WorkflowInstance{
+		ID:         instID,
+		WorkflowID: wf.ID,
+		CellID:     cell.ID,
+		SourceID:   cell.SourceID,
+		State:      db.InstanceStateRunning,
+		CreatedAt:  e.now(),
+	}
+	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
+		return "", false, fmt.Errorf("create workflow instance: %w", err)
+	}
+
+	// state_lock fires once at workflow start (not per step).
+	if e.cfg.Settings.StateLock && e.side != nil {
+		_ = e.side.StateLock(ctx, cell)
+	}
+
+	var memSteps []MemoryStep
+	failed := false
+
+	for _, step := range wf.Steps {
+		// Phase 2 executes only agent steps; routing/approval/foreach steps are
+		// handled by the Phase 3 DAG executor.
+		if step.StepType() != config.StepTypeAgent {
+			continue
+		}
+
+		res := e.runStep(ctx, instID, step, cell, memSteps)
+		memSteps = append(memSteps, MemoryStep{
+			StepID:      step.ID,
+			WriteFields: step.MemoryWriteFields(),
+			Structured:  res.StructuredOutput,
+			Summary:     res.Summary,
+		})
+
+		if e.resultCommentMode(wf) == config.ResultCommentPerStep && e.side != nil {
+			_ = e.side.PostComment(ctx, cell, perStepComment(step, res))
+		}
+
+		if !res.Success {
+			failed = true
+			break
+		}
+	}
+
+	finalState := db.InstanceStateDone
+	if failed {
+		finalState = db.InstanceStateFailed
+	}
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instID, finalState)
+
+	e.applyCompletion(ctx, wf, cell, failed, memSteps)
+	return instID, !failed, nil
+}
+
+// runStep executes one agent step, persisting its step run, and returns the result.
+func (e *Engine) runStep(ctx context.Context, instID string, step config.StepConfig, cell model.Cell, memSteps []MemoryStep) StepResult {
+	started := e.now()
+	sr := &db.StepRun{
+		ID:                 e.newID("sr"),
+		WorkflowInstanceID: instID,
+		StepID:             step.ID,
+		AgentID:            step.Agent,
+		State:              db.StepStateRunning,
+		StartedAt:          &started,
+	}
+	_ = e.store.CreateStepRun(ctx, sr)
+
+	agent := e.findAgent(step.Agent)
+	resolvedModel := step.Model
+	if resolvedModel == "" && agent != nil {
+		resolvedModel = agent.Model
+	}
+
+	memDoc := ""
+	if step.MemoryReadEnabled() {
+		memDoc = e.mem.Build(cell, memSteps)
+	}
+
+	var ag config.AgentConfig
+	if agent != nil {
+		ag = *agent
+	}
+	res := e.exec.ExecuteStep(ctx, StepRequest{
+		InstanceID: instID,
+		Cell:       cell,
+		Step:       step,
+		Agent:      ag,
+		Model:      resolvedModel,
+		MemoryDoc:  memDoc,
+	})
+
+	finished := e.now()
+	sr.FinishedAt = &finished
+	sr.Output = res.Output
+	sr.Summary = res.Summary
+	if res.StructuredOutput != nil {
+		if data, err := json.Marshal(res.StructuredOutput); err == nil {
+			sr.StructuredOutput = string(data)
+		}
+	}
+	if res.Success {
+		sr.State = db.StepStatePassed
+	} else {
+		sr.State = db.StepStateFailed
+	}
+	_ = e.store.UpdateStepRun(ctx, sr)
+	return res
+}
+
+// applyCompletion applies the on_complete/on_fail hook and posts the on_complete
+// result comment (the final memory document).
+func (e *Engine) applyCompletion(ctx context.Context, wf config.WorkflowConfig, cell model.Cell, failed bool, memSteps []MemoryStep) {
+	if e.side == nil {
+		return
+	}
+
+	if !failed && e.resultCommentMode(wf) == config.ResultCommentOnComplete {
+		doc := e.mem.Build(cell, memSteps)
+		_ = e.side.PostComment(ctx, cell, finalComment(wf, false, doc))
+	}
+
+	var hook *config.OnComplete
+	if failed {
+		hook = wf.OnFail
+	} else {
+		hook = wf.OnComplete
+	}
+	if hook != nil {
+		_ = e.side.ApplyHook(ctx, cell, *hook)
+	}
+}
+
+// resultCommentMode resolves the effective result-comment mode for a workflow,
+// honoring the workflow override and falling back to the global setting.
+func (e *Engine) resultCommentMode(wf config.WorkflowConfig) string {
+	if wf.ResultComment != "" {
+		return wf.ResultComment
+	}
+	if e.cfg.Settings.ResultComment {
+		return config.ResultCommentOnComplete
+	}
+	return config.ResultCommentOff
+}
+
+// findAgent returns the agent config by ID, or nil.
+func (e *Engine) findAgent(id string) *config.AgentConfig {
+	for i := range e.cfg.Agents {
+		if e.cfg.Agents[i].ID == id {
+			return &e.cfg.Agents[i]
+		}
+	}
+	return nil
+}
+
+// SynthesizeWorkflow builds a single-step workflow equivalent to a plain route,
+// so routes and workflows execute through the same engine path.
+func SynthesizeWorkflow(route config.RouteConfig) config.WorkflowConfig {
+	oc := route.OnComplete
+	return config.WorkflowConfig{
+		ID:         route.ID,
+		Trigger:    &config.TriggerConfig{Priority: route.Priority, Match: route.Match},
+		Steps:      []config.StepConfig{{ID: "run", Agent: route.Agent}},
+		OnComplete: &oc,
+	}
+}
+
+func perStepComment(step config.StepConfig, res StepResult) string {
+	status := "✓ passed"
+	if !res.Success {
+		status = "✗ failed"
+	}
+	return fmt.Sprintf("**Step: %s (%s) — %s**\n\n%s", step.ID, step.Agent, status, res.Output)
+}
+
+func finalComment(wf config.WorkflowConfig, failed bool, memoryDoc string) string {
+	status := "✓ Done"
+	if failed {
+		status = "✗ Failed"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "**Workflow: %s — %s**\n\n", wf.ID, status)
+	b.WriteString(memoryDoc)
+	return b.String()
+}
+
+// defaultIDGen returns an ID generator that combines the clock with an atomic
+// counter so IDs are unique even within the same nanosecond.
+func defaultIDGen(now func() time.Time) func(string) string {
+	var ctr uint64
+	return func(prefix string) string {
+		n := atomic.AddUint64(&ctr, 1)
+		return fmt.Sprintf("%s_%d_%d", prefix, now().UnixNano(), n)
+	}
+}

--- a/src/internal/workflow/engine_integration_test.go
+++ b/src/internal/workflow/engine_integration_test.go
@@ -1,0 +1,117 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestEngine_PersistsToRealSQLite runs the engine against a real db.Client (not a
+// fake store) and verifies the workflow instance and step run land in SQLite with
+// the expected state — the Phase 2 integration checkpoint.
+func TestEngine_PersistsToRealSQLite(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "wf.db")
+	client, err := db.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer client.Close()
+
+	cfg := &config.Config{
+		Agents:   []config.AgentConfig{{ID: "backend-dev", Model: "claude-sonnet-4-6"}},
+		Settings: config.Settings{StateLock: true, ResultComment: false},
+	}
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "completed the task",
+			StructuredOutput: map[string]any{"status": "ok"}, Summary: "did it"},
+	}}
+
+	// Real db.Client satisfies the Store interface.
+	var store Store = client
+	eng := NewEngine(cfg, store, exec)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{
+		ID: "backend-bugs", Agent: "backend-dev",
+		OnComplete: config.OnComplete{SetState: "in_review"},
+	})
+
+	instID, success, err := eng.RunInstance(ctx, wf, model.Cell{ID: "PLANE-1", Title: "Fix it", SourceID: "main-plane"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success")
+	}
+
+	// Instance persisted and marked done.
+	inst, err := client.GetWorkflowInstance(ctx, instID)
+	if err != nil || inst == nil {
+		t.Fatalf("get instance: %v (inst=%v)", err, inst)
+	}
+	if inst.State != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done", inst.State)
+	}
+	if inst.WorkflowID != "backend-bugs" || inst.CellID != "PLANE-1" || inst.SourceID != "main-plane" {
+		t.Errorf("instance fields wrong: %+v", inst)
+	}
+
+	// Step run persisted with structured output + summary.
+	runs, err := client.ListStepRuns(ctx, instID)
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 step run, got %d", len(runs))
+	}
+	sr := runs[0]
+	if sr.State != db.StepStatePassed {
+		t.Errorf("step state = %q, want passed", sr.State)
+	}
+	if sr.Output != "completed the task" {
+		t.Errorf("step output = %q", sr.Output)
+	}
+	if sr.StructuredOutput != `{"status":"ok"}` {
+		t.Errorf("structured output = %q", sr.StructuredOutput)
+	}
+	if sr.Summary != "did it" {
+		t.Errorf("summary = %q", sr.Summary)
+	}
+	if sr.StartedAt == nil || sr.FinishedAt == nil {
+		t.Error("expected started_at and finished_at to be set")
+	}
+}
+
+// TestEngine_FailedStepPersistsFailedState verifies a failed run is recorded
+// with a failed instance and step in real SQLite.
+func TestEngine_FailedStepPersistsFailedState(t *testing.T) {
+	ctx := context.Background()
+	client, err := db.New(ctx, filepath.Join(t.TempDir(), "wf.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer client.Close()
+
+	cfg := &config.Config{Agents: []config.AgentConfig{{ID: "a", Model: "m"}}}
+	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: false, Output: "boom"}}}
+	eng := NewEngine(cfg, client, exec)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "a"})
+	instID, success, _ := eng.RunInstance(ctx, wf, model.Cell{ID: "C1"})
+
+	if success {
+		t.Error("expected failure")
+	}
+	inst, _ := client.GetWorkflowInstance(ctx, instID)
+	if inst.State != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed", inst.State)
+	}
+	runs, _ := client.ListStepRuns(ctx, instID)
+	if len(runs) != 1 || runs[0].State != db.StepStateFailed {
+		t.Errorf("expected 1 failed step run, got %+v", runs)
+	}
+}

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -1,0 +1,364 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// fakeStore records instances and step runs in memory.
+type fakeStore struct {
+	instances map[string]*db.WorkflowInstance
+	stepRuns  map[string]*db.StepRun
+	stepOrder []string
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{instances: map[string]*db.WorkflowInstance{}, stepRuns: map[string]*db.StepRun{}}
+}
+
+func (f *fakeStore) CreateWorkflowInstance(_ context.Context, inst *db.WorkflowInstance) error {
+	cp := *inst
+	f.instances[inst.ID] = &cp
+	return nil
+}
+func (f *fakeStore) UpdateWorkflowInstanceState(_ context.Context, id, state string) error {
+	if inst, ok := f.instances[id]; ok {
+		inst.State = state
+	}
+	return nil
+}
+func (f *fakeStore) CreateStepRun(_ context.Context, sr *db.StepRun) error {
+	cp := *sr
+	f.stepRuns[sr.ID] = &cp
+	f.stepOrder = append(f.stepOrder, sr.ID)
+	return nil
+}
+func (f *fakeStore) UpdateStepRun(_ context.Context, sr *db.StepRun) error {
+	cp := *sr
+	f.stepRuns[sr.ID] = &cp
+	return nil
+}
+
+// fakeExecutor returns scripted results keyed by step ID and records requests.
+type fakeExecutor struct {
+	results map[string]StepResult
+	seen    []StepRequest
+}
+
+func (f *fakeExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResult {
+	f.seen = append(f.seen, req)
+	if r, ok := f.results[req.Step.ID]; ok {
+		return r
+	}
+	return StepResult{Success: true, Output: "ok"}
+}
+
+// fakeSide records side-effect calls.
+type fakeSide struct {
+	stateLocked bool
+	comments    []string
+	hooks       []config.OnComplete
+}
+
+func (f *fakeSide) StateLock(_ context.Context, _ model.Cell) error { f.stateLocked = true; return nil }
+func (f *fakeSide) PostComment(_ context.Context, _ model.Cell, c string) error {
+	f.comments = append(f.comments, c)
+	return nil
+}
+func (f *fakeSide) ApplyHook(_ context.Context, _ model.Cell, h config.OnComplete) error {
+	f.hooks = append(f.hooks, h)
+	return nil
+}
+
+func testEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects) *Engine {
+	seq := 0
+	return NewEngine(cfg, store, exec,
+		WithSideEffects(side),
+		WithClock(func() time.Time { return time.Unix(1000, 0) }),
+		WithIDGen(func(prefix string) string {
+			seq++
+			return prefix + "-" + itoa(seq)
+		}),
+	)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func baseCfg() *config.Config {
+	return &config.Config{
+		Agents: []config.AgentConfig{
+			{ID: "architect", Model: "claude-opus-4-8"},
+			{ID: "backend-dev", Model: "claude-sonnet-4-6"},
+		},
+		Settings: config.Settings{StateLock: true, ResultComment: true},
+	}
+}
+
+func TestEngine_SingleStepSuccess(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{
+		ID: "backend-bugs", Priority: 10, Agent: "backend-dev",
+		OnComplete: config.OnComplete{SetState: "in_review"},
+	})
+
+	instID, _, err := eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1", Title: "Fix bug"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	inst := store.instances[instID]
+	if inst == nil || inst.State != db.InstanceStateDone {
+		t.Fatalf("instance not marked done: %+v", inst)
+	}
+	if len(store.stepOrder) != 1 {
+		t.Fatalf("expected 1 step run, got %d", len(store.stepOrder))
+	}
+	sr := store.stepRuns[store.stepOrder[0]]
+	if sr.State != db.StepStatePassed || sr.Output != "done" {
+		t.Errorf("step run wrong: %+v", sr)
+	}
+	if !side.stateLocked {
+		t.Error("expected state_lock to fire")
+	}
+	if len(side.hooks) != 1 || side.hooks[0].SetState != "in_review" {
+		t.Errorf("expected on_complete hook, got: %+v", side.hooks)
+	}
+	// Model resolves to the agent's model.
+	if exec.seen[0].Model != "claude-sonnet-4-6" {
+		t.Errorf("expected agent model, got %q", exec.seen[0].Model)
+	}
+}
+
+func TestEngine_StepFailureMarksInstanceFailed(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: false, Output: "boom"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev",
+		OnComplete: config.OnComplete{SetState: "in_review"}})
+	wf.OnFail = &config.OnComplete{SetState: "blocked"}
+
+	instID, _, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
+
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed instance, got %s", store.instances[instID].State)
+	}
+	sr := store.stepRuns[store.stepOrder[0]]
+	if sr.State != db.StepStateFailed {
+		t.Errorf("expected failed step, got %s", sr.State)
+	}
+	// on_fail hook applied, not on_complete.
+	if len(side.hooks) != 1 || side.hooks[0].SetState != "blocked" {
+		t.Errorf("expected on_fail hook blocked, got: %+v", side.hooks)
+	}
+}
+
+func TestEngine_SequentialMemoryThreading(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan": {Success: true, Output: "planned",
+			StructuredOutput: map[string]any{"complexity": "high"},
+			Summary:          "decided on JWT"},
+		"implement": {Success: true, Output: "implemented"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := config.WorkflowConfig{
+		ID: "feature",
+		Steps: []config.StepConfig{
+			{
+				ID: "plan", Agent: "architect",
+				OutputSchema: &config.OutputSchema{Type: "object",
+					Properties: map[string]config.SchemaField{"complexity": {Type: "string"}}},
+				Memory: &config.MemoryConfig{Write: []string{"complexity"}},
+			},
+			{ID: "implement", Agent: "backend-dev", DependsOn: []string{"plan"}},
+		},
+	}
+
+	_, _, err := eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1", Title: "Add auth"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	// The implement step should have received memory containing the plan's
+	// written field and summary.
+	if len(exec.seen) != 2 {
+		t.Fatalf("expected 2 step executions, got %d", len(exec.seen))
+	}
+	implMem := exec.seen[1].MemoryDoc
+	if !strings.Contains(implMem, "complexity: high") {
+		t.Errorf("implement step memory missing plan field:\n%s", implMem)
+	}
+	if !strings.Contains(implMem, "decided on JWT") {
+		t.Errorf("implement step memory missing plan summary:\n%s", implMem)
+	}
+	// The plan step (first) gets memory with no prior step data.
+	if strings.Contains(exec.seen[0].MemoryDoc, "complexity: high") {
+		t.Error("plan step should not see its own output in memory")
+	}
+}
+
+func TestEngine_MemoryReadFalseSkipsInjection(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	rd := false
+	wf := config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{
+		{ID: "s", Agent: "architect", Memory: &config.MemoryConfig{Read: &rd}},
+	}}
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1", Title: "t"})
+
+	if exec.seen[0].MemoryDoc != "" {
+		t.Errorf("expected empty memory doc when memory.read is false, got:\n%s", exec.seen[0].MemoryDoc)
+	}
+}
+
+func TestEngine_PerStepModelOverride(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{
+		{ID: "s", Agent: "backend-dev", Model: "claude-haiku-4-5"},
+	}}
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
+
+	if exec.seen[0].Model != "claude-haiku-4-5" {
+		t.Errorf("expected step model override, got %q", exec.seen[0].Model)
+	}
+}
+
+func TestEngine_ResultCommentOnComplete(t *testing.T) {
+	cfg := baseCfg() // ResultComment: true → on_complete default
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true, Output: "x"}}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1", Title: "t"})
+
+	if len(side.comments) != 1 {
+		t.Fatalf("expected 1 on_complete comment, got %d", len(side.comments))
+	}
+	if !strings.Contains(side.comments[0], "Workflow: r — ✓ Done") {
+		t.Errorf("unexpected comment: %q", side.comments[0])
+	}
+}
+
+func TestEngine_ResultCommentPerStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan":      {Success: true, Output: "planned"},
+		"implement": {Success: true, Output: "implemented"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := config.WorkflowConfig{
+		ID: "w", ResultComment: config.ResultCommentPerStep,
+		Steps: []config.StepConfig{
+			{ID: "plan", Agent: "architect"},
+			{ID: "implement", Agent: "backend-dev", DependsOn: []string{"plan"}},
+		},
+	}
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
+
+	if len(side.comments) != 2 {
+		t.Fatalf("expected 2 per-step comments, got %d: %v", len(side.comments), side.comments)
+	}
+	if !strings.Contains(side.comments[0], "Step: plan") || !strings.Contains(side.comments[1], "Step: implement") {
+		t.Errorf("unexpected per-step comments: %v", side.comments)
+	}
+}
+
+func TestEngine_ResultCommentOff(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
+
+	if len(side.comments) != 0 {
+		t.Errorf("expected no comments when result_comment off, got: %v", side.comments)
+	}
+}
+
+func TestEngine_StructuredOutputPersisted(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "x", StructuredOutput: map[string]any{"k": "v"}, Summary: "sum"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
+
+	sr := store.stepRuns[store.stepOrder[0]]
+	if !strings.Contains(sr.StructuredOutput, `"k":"v"`) {
+		t.Errorf("structured output not persisted: %q", sr.StructuredOutput)
+	}
+	if sr.Summary != "sum" {
+		t.Errorf("summary not persisted: %q", sr.Summary)
+	}
+}
+
+func TestSynthesizeWorkflow(t *testing.T) {
+	route := config.RouteConfig{
+		ID: "backend-bugs", Priority: 10, Agent: "backend-dev",
+		Match:      config.RouteMatch{Source: "main-plane", Labels: []string{"bug"}},
+		OnComplete: config.OnComplete{SetState: "in_review"},
+	}
+	wf := SynthesizeWorkflow(route)
+	if wf.ID != "backend-bugs" || len(wf.Steps) != 1 {
+		t.Fatalf("unexpected synthesized workflow: %+v", wf)
+	}
+	if wf.Steps[0].Agent != "backend-dev" {
+		t.Errorf("synthesized step agent wrong: %q", wf.Steps[0].Agent)
+	}
+	if wf.Trigger == nil || wf.Trigger.Priority != 10 || wf.Trigger.Match.Source != "main-plane" {
+		t.Errorf("synthesized trigger wrong: %+v", wf.Trigger)
+	}
+	if wf.OnComplete == nil || wf.OnComplete.SetState != "in_review" {
+		t.Errorf("synthesized on_complete wrong: %+v", wf.OnComplete)
+	}
+}


### PR DESCRIPTION
## Summary

Completes **Phase 2**: the single-step workflow execution `Engine` and its daemon wiring, **behind the flag** `settings.experimental.workflow_mode`. With the flag off (default), the legacy dispatch path is **byte-identical** — the only change in `dispatcher.go` is a 7-line gated branch at the top of `dispatch()`.

### Engine (`internal/workflow/engine.go`) — pure, testable core
- `RunInstance`: creates the instance → executes `agent` steps sequentially with **memory threading** between them → marks `done`/`failed` → applies `on_complete`/`on_fail` hooks.
- `StepExecutor` / `SideEffects` / `Store` interfaces decouple execution, source side effects and persistence — the core is tested in isolation with fakes; `*db.Client` satisfies `Store`.
- `SynthesizeWorkflow(route)` turns an ordinary route into a single-step workflow (routes and workflows run through the same path).
- `state_lock` fires **once** at the start; `result_comment` on `on_complete` (final memory doc) / `per_step` / `off`, with a per-workflow override and a global fallback. Per-step `model` override.

### Config
- `settings.experimental.workflow_mode` (bool, additive).

### Daemon (`internal/daemon/workflow.go`)
- `wfStepExecutor` builds the `RunRequest` (memory in `SystemPrepend`, `summary_prompt`, `StepID`/`WorkflowInstanceID`) and invokes the agent runner.
- `wfSideEffects` applies the state lock, comments and hooks (`set_state`/`add_labels`) via the source adapter.
- A single gated branch at the top of `dispatch()`.

## Test plan
- [x] `go test ./...` — green. New: engine with fakes (success/failure, memory between steps, `memory.read=false`, model override, `result_comment` modes, structured/summary persistence) + **integration with a real SQLite** (instance + step_run with correct states).
- [x] `go vet ./...` clean; `make build` ok.
- [x] Smoke: `apiary validate` accepts `experimental.workflow_mode: true`.
- [x] Regression: the `dispatcher.go` diff is only the gated branch; with the flag off the legacy path doesn't change.

## Notes / deferred
- Global concurrency semaphore (2.4.4) deferred to Phase 3 (DAG/parallel) — in Phase 2 each cell still runs a single agent step under the existing per-agent concurrency.
- End-to-end test with a real source (2.5.3) deferred — needs a fake source adapter; the integration covers the engine against a real `db.Client`.