### PR TITLE
feat: workflow-mode Phase 3a — DAG scheduler + expression evaluator

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -95,19 +95,22 @@ Implement `WorkflowEngine` behind `settings.experimental.workflow_mode: true`. S
 
 Multi-step workflows, parallel steps, split steps, foreach, sub-workflows, per-step model override. Enable by default (remove feature flag).
 
-### 3.1 DAG Executor
+> **Delivery note:** Phase 3 ships across PRs. **PR-3a** delivers the DAG scheduler (depends_on ordering, split routing, on_fail.goto loops, skip propagation) + the expression evaluator. **PR-3b** foreach; **PR-3c** sub-workflows + remove the experimental flag (default-on).
 
-- [ ] 3.1.1 Implement topological sort of steps by `depends_on` in `WorkflowEngine`
-- [ ] 3.1.2 Implement parallel step dispatch: steps ready at the same time run concurrently up to global concurrency limit
-- [ ] 3.1.3 Implement `on_fail.goto` loop-back with `retry_counts` tracking and `max_retries` enforcement
-- [ ] 3.1.4 Implement cascade reset: when a loop-back fires, reset all downstream steps to `pending`
+### 3.1 DAG Executor — PR-3a
 
-### 3.2 Split Steps
+- [x] 3.1.1 Dependency-driven scheduler over `depends_on` (`dag.go`), replacing the sequential loop in `RunInstance`
+- [~] 3.1.2 Parallel step dispatch — deferred. The scheduler runs ready steps one-at-a-time in deterministic order; concurrent execution of independent steps is a pure performance optimization (same results), layered on later with the global semaphore
+- [x] 3.1.3 `on_fail.goto` loop-back with per-step `retries` tracking and `max_retries` enforcement
+- [x] 3.1.4 Cascade reset: a loop-back resets the goto target and all transitive dependents to `pending` (clearing their memory contributions)
 
-- [ ] 3.2.1 Implement expression evaluator in `src/internal/workflow/expr.go` — see [proposal expression language](proposal.md#expression-language)
-- [ ] 3.2.2 Implement split step execution: evaluate branches, activate matching step(s)
-- [ ] 3.2.3 Support `multi: true` fan-out
-- [ ] 3.2.4 Unit tests: all expression operators, multi-branch split, fallback branch, unmatched split error
+### 3.2 Split Steps — PR-3a
+
+- [x] 3.2.1 Expression evaluator in `src/internal/workflow/expr.go` (recursive-descent parser + AST eval; `cell.*`/`memory.*`/`steps.*`, `==`/`!=`/`contains`/`matches`, `and`/`or`/`not`, parens)
+- [x] 3.2.2 Split step execution: evaluate branches, activate matching target(s), skip + cascade the rest
+- [x] 3.2.3 Support `multi: true` fan-out
+- [x] 3.2.4 Unit tests: all operators, precedence, parse + eval errors; first-match, fallback, multi, skip cascade
+- [~] 3.2.5 Config-load validation of `branches[].if` syntax — deferred (needs an expr package config can import without a cycle); runtime treats an unparseable condition as non-match and logs it
 
 ### 3.3 Foreach Steps
 

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -1,0 +1,370 @@
+package workflow
+
+import (
+	"context"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// step execution states within a DAG run.
+const (
+	stPending = "pending"
+	stPassed  = "passed"
+	stFailed  = "failed"
+	stSkipped = "skipped"
+)
+
+// dagRun holds the mutable state of one workflow instance's step graph as the
+// scheduler walks it.
+type dagRun struct {
+	instID string
+	wf     config.WorkflowConfig
+	cell   model.Cell
+
+	byID  map[string]config.StepConfig
+	order []string // step ids in declaration order (deterministic scheduling)
+
+	state       map[string]string // step id → st* state
+	activated   map[string]bool   // control-flow has reached this step
+	splitTarget map[string]bool   // step id is the goto target of some split branch
+	retries     map[string]int    // on_fail.goto loop counter per failing step
+
+	stepStates  map[string]StepState  // terminal states for expression context
+	contrib     map[string]MemoryStep // memory contribution per passed step
+	passedOrder []string              // step ids in the order they passed
+}
+
+// runDAG executes the workflow's step graph and returns whether the instance
+// failed along with the final memory contributions (for the completion comment).
+// It is the Phase 3 replacement for the sequential loop: it honors depends_on
+// ordering, split routing, on_fail.goto loops, and skip propagation.
+func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.Cell) (bool, []MemoryStep) {
+	r := &dagRun{
+		instID:      instID,
+		wf:          wf,
+		cell:        cell,
+		byID:        map[string]config.StepConfig{},
+		state:       map[string]string{},
+		activated:   map[string]bool{},
+		splitTarget: map[string]bool{},
+		retries:     map[string]int{},
+		stepStates:  map[string]StepState{},
+		contrib:     map[string]MemoryStep{},
+	}
+	for _, s := range wf.Steps {
+		r.byID[s.ID] = s
+		r.order = append(r.order, s.ID)
+		r.state[s.ID] = stPending
+	}
+	// Identify split targets: they are activated only when their split chooses
+	// them, never at workflow start.
+	for _, s := range wf.Steps {
+		if s.StepType() == config.StepTypeSplit {
+			for _, b := range s.Branches {
+				if b.Goto != "" {
+					r.splitTarget[b.Goto] = true
+				}
+			}
+		}
+	}
+	// Activate every non-split-target step up front; depends_on still gates them.
+	for _, id := range r.order {
+		if !r.splitTarget[id] {
+			r.activated[id] = true
+		}
+	}
+
+	for {
+		next := r.pickRunnable()
+		if next == "" {
+			if r.skipUnreachable() {
+				continue
+			}
+			break // nothing else can run
+		}
+		if failed := e.runDAGStep(ctx, r, next); failed {
+			return true, r.memSteps()
+		}
+	}
+
+	// The instance fails if any step ended failed.
+	for _, id := range r.order {
+		if r.state[id] == stFailed {
+			return true, r.memSteps()
+		}
+	}
+	return false, r.memSteps()
+}
+
+// pickRunnable returns the next runnable step id (activated, pending, all
+// dependencies passed), in declaration order, or "" when none is ready.
+func (r *dagRun) pickRunnable() string {
+	for _, id := range r.order {
+		if r.state[id] != stPending || !r.activated[id] {
+			continue
+		}
+		if r.depsPassed(id) {
+			return id
+		}
+	}
+	return ""
+}
+
+func (r *dagRun) depsPassed(id string) bool {
+	for _, dep := range r.byID[id].DependsOn {
+		if r.state[dep] != stPassed {
+			return false
+		}
+	}
+	return true
+}
+
+// skipUnreachable marks pending steps that can never run as skipped, returning
+// whether it made progress. A step is unreachable when a dependency is terminal
+// non-passed (skipped/failed), or it is an un-activated split target whose
+// feeding splits have all finished.
+func (r *dagRun) skipUnreachable() bool {
+	progress := false
+	for _, id := range r.order {
+		if r.state[id] != stPending {
+			continue
+		}
+		// A dependency ended skipped/failed → this step can never run.
+		for _, dep := range r.byID[id].DependsOn {
+			if r.state[dep] == stSkipped || r.state[dep] == stFailed {
+				r.markSkipped(id)
+				progress = true
+				break
+			}
+		}
+		if r.state[id] != stPending {
+			continue
+		}
+		// An un-activated split target whose every feeding split is terminal
+		// will never be chosen.
+		if r.splitTarget[id] && !r.activated[id] && r.feedingSplitsDone(id) {
+			r.markSkipped(id)
+			progress = true
+		}
+	}
+	return progress
+}
+
+// feedingSplitsDone reports whether every split that can goto id has finished.
+func (r *dagRun) feedingSplitsDone(id string) bool {
+	for _, s := range r.wf.Steps {
+		if s.StepType() != config.StepTypeSplit {
+			continue
+		}
+		for _, b := range s.Branches {
+			if b.Goto == id {
+				st := r.state[s.ID]
+				if st == stPending {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// markSkipped sets a step skipped and cascades to pending dependents.
+func (r *dagRun) markSkipped(id string) {
+	if r.state[id] == stSkipped {
+		return
+	}
+	r.state[id] = stSkipped
+	for _, other := range r.order {
+		if r.state[other] != stPending {
+			continue
+		}
+		for _, dep := range r.byID[other].DependsOn {
+			if dep == id {
+				r.markSkipped(other)
+				break
+			}
+		}
+	}
+}
+
+// runDAGStep executes one step and updates graph state. Returns true if the
+// instance must fail (an agent step failed with no retry left).
+func (e *Engine) runDAGStep(ctx context.Context, r *dagRun, id string) bool {
+	step := r.byID[id]
+	switch step.StepType() {
+	case config.StepTypeSplit:
+		return e.runSplitStep(r, step)
+	case config.StepTypeAgent:
+		return e.runAgentDAGStep(ctx, r, step)
+	default:
+		// approval/foreach/workflow are not executed by the Phase 3a scheduler;
+		// treat as a no-op pass so they don't block the graph.
+		aplog.Debug("workflow %s: step %q type %q not yet executable, passing through", r.wf.ID, step.ID, step.StepType())
+		r.state[id] = stPassed
+		return false
+	}
+}
+
+// runSplitStep evaluates a split's branches and activates the chosen target(s),
+// skipping the rest.
+func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) bool {
+	ctx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
+
+	chosen := map[string]bool{}
+	for _, b := range step.Branches {
+		match := b.IsFallback()
+		if !match {
+			expr, err := ParseExpr(b.If)
+			if err != nil {
+				aplog.Error("workflow %s: split %q: bad condition %q: %v", r.wf.ID, step.ID, b.If, err)
+				continue
+			}
+			ok, err := expr.Eval(ctx)
+			if err != nil {
+				aplog.Error("workflow %s: split %q: eval %q: %v", r.wf.ID, step.ID, b.If, err)
+				continue
+			}
+			match = ok
+		}
+		if match {
+			chosen[b.Goto] = true
+			if !step.Multi {
+				break // first match wins
+			}
+		}
+	}
+
+	r.state[step.ID] = stPassed
+	r.stepStates[step.ID] = StepState{State: stPassed}
+
+	// Activate chosen targets; skip the rest of this split's branch targets.
+	for _, b := range step.Branches {
+		if b.Goto == "" {
+			continue
+		}
+		if chosen[b.Goto] {
+			r.activated[b.Goto] = true
+		}
+	}
+	for _, b := range step.Branches {
+		if b.Goto != "" && !chosen[b.Goto] && !r.activated[b.Goto] && r.feedingSplitsDone(b.Goto) {
+			r.markSkipped(b.Goto)
+		}
+	}
+	return false
+}
+
+// runAgentDAGStep runs an agent step, threading memory, and handles on_pass.next
+// activation and on_fail.goto loops.
+func (e *Engine) runAgentDAGStep(ctx context.Context, r *dagRun, step config.StepConfig) bool {
+	res := e.runStep(ctx, r.instID, step, r.cell, r.memSteps())
+
+	r.stepStates[step.ID] = StepState{
+		State:  passFail(res.Success),
+		Output: res.Output,
+	}
+
+	if e.resultCommentMode(r.wf) == config.ResultCommentPerStep && e.side != nil {
+		_ = e.side.PostComment(ctx, r.cell, perStepComment(step, res))
+	}
+
+	if res.Success {
+		r.state[step.ID] = stPassed
+		r.contrib[step.ID] = MemoryStep{
+			StepID:      step.ID,
+			WriteFields: step.MemoryWriteFields(),
+			Structured:  res.StructuredOutput,
+			Summary:     res.Summary,
+		}
+		r.passedOrder = append(r.passedOrder, step.ID)
+		if step.OnPass != nil && step.OnPass.Next != "" {
+			r.activated[step.OnPass.Next] = true
+		}
+		return false
+	}
+
+	// Failure: attempt an on_fail.goto loop if retries remain.
+	if step.OnFail != nil && step.OnFail.Goto != "" {
+		if r.retries[step.ID] < step.OnFail.MaxRetries {
+			r.retries[step.ID]++
+			aplog.Info("workflow %s: step %q failed, looping back to %q (retry %d/%d)",
+				r.wf.ID, step.ID, step.OnFail.Goto, r.retries[step.ID], step.OnFail.MaxRetries)
+			r.resetLoop(step.OnFail.Goto)
+			return false
+		}
+		aplog.Info("workflow %s: step %q exhausted %d retries", r.wf.ID, step.ID, step.OnFail.MaxRetries)
+	}
+
+	r.state[step.ID] = stFailed
+	return true
+}
+
+// resetLoop resets the goto target and all its transitive dependents back to
+// pending so the branch re-runs, clearing their memory contributions.
+func (r *dagRun) resetLoop(target string) {
+	reset := map[string]bool{}
+	var mark func(id string)
+	mark = func(id string) {
+		if reset[id] {
+			return
+		}
+		reset[id] = true
+		for _, other := range r.order {
+			for _, dep := range r.byID[other].DependsOn {
+				if dep == id {
+					mark(other)
+				}
+			}
+		}
+	}
+	mark(target)
+
+	for id := range reset {
+		r.state[id] = stPending
+		delete(r.stepStates, id)
+		delete(r.contrib, id)
+	}
+	// Rebuild passedOrder excluding reset steps.
+	kept := r.passedOrder[:0]
+	for _, id := range r.passedOrder {
+		if !reset[id] {
+			kept = append(kept, id)
+		}
+	}
+	r.passedOrder = kept
+}
+
+// memSteps returns the ordered memory contributions of passed steps.
+func (r *dagRun) memSteps() []MemoryStep {
+	out := make([]MemoryStep, 0, len(r.passedOrder))
+	for _, id := range r.passedOrder {
+		if c, ok := r.contrib[id]; ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// memoryValues returns the flattened Step Data map for expression evaluation
+// (memory.<key>), honoring last-write-wins in passed order.
+func (r *dagRun) memoryValues() map[string]string {
+	vals := map[string]string{}
+	for _, ms := range r.memSteps() {
+		for _, field := range ms.WriteFields {
+			if v, ok := ms.Structured[field]; ok {
+				vals[field] = renderValue(v)
+			}
+		}
+	}
+	return vals
+}
+
+func passFail(success bool) string {
+	if success {
+		return stPassed
+	}
+	return stFailed
+}

--- a/src/internal/workflow/dag_test.go
+++ b/src/internal/workflow/dag_test.go
@@ -1,0 +1,302 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// seqExecutor returns a different scripted result per call to the same step,
+// for testing retry loops. Falls back to the last scripted result, then to ok.
+type seqExecutor struct {
+	scripts map[string][]StepResult
+	calls   map[string]int
+	seen    []string
+}
+
+func newSeqExecutor() *seqExecutor {
+	return &seqExecutor{scripts: map[string][]StepResult{}, calls: map[string]int{}}
+}
+
+func (s *seqExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResult {
+	s.seen = append(s.seen, req.Step.ID)
+	i := s.calls[req.Step.ID]
+	s.calls[req.Step.ID]++
+	list := s.scripts[req.Step.ID]
+	switch {
+	case i < len(list):
+		return list[i]
+	case len(list) > 0:
+		return list[len(list)-1]
+	default:
+		return StepResult{Success: true, Output: "ok"}
+	}
+}
+
+func (s *seqExecutor) ran(stepID string) int { return s.calls[stepID] }
+
+func executedIDs(seen []StepRequest) []string {
+	out := make([]string, 0, len(seen))
+	for _, r := range seen {
+		out = append(out, r.Step.ID)
+	}
+	return out
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDAG_DiamondParallelJoin(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	// A → {B, C} → D
+	wf := config.WorkflowConfig{ID: "diamond", Steps: []config.StepConfig{
+		{ID: "A", Agent: "architect"},
+		{ID: "B", Agent: "backend-dev", DependsOn: []string{"A"}},
+		{ID: "C", Agent: "backend-dev", DependsOn: []string{"A"}},
+		{ID: "D", Agent: "architect", DependsOn: []string{"B", "C"}},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	ids := executedIDs(exec.seen)
+	if len(ids) != 4 {
+		t.Fatalf("expected 4 steps to run, got %v", ids)
+	}
+	// A runs first, D runs last (after B and C).
+	if ids[0] != "A" || ids[len(ids)-1] != "D" {
+		t.Errorf("unexpected execution order: %v", ids)
+	}
+}
+
+func TestDAG_SplitFirstMatch(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan": {Success: true, StructuredOutput: map[string]any{"level": "high"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "split", Steps: []config.StepConfig{
+		{
+			ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"level": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"level"}},
+		},
+		{ID: "route", Type: config.StepTypeSplit, DependsOn: []string{"plan"}, Branches: []config.SplitBranch{
+			{If: `memory.level == "high"`, Goto: "senior"},
+			{Else: true, Goto: "junior"},
+		}},
+		{ID: "senior", Agent: "architect"},
+		{ID: "junior", Agent: "backend-dev"},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "senior") {
+		t.Errorf("expected senior branch to run, got %v", ids)
+	}
+	if contains(ids, "junior") {
+		t.Errorf("junior branch should have been skipped, got %v", ids)
+	}
+}
+
+func TestDAG_SplitFallback(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan": {Success: true, StructuredOutput: map[string]any{"level": "low"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "split", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"level": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"level"}}},
+		{ID: "route", Type: config.StepTypeSplit, DependsOn: []string{"plan"}, Branches: []config.SplitBranch{
+			{If: `memory.level == "high"`, Goto: "senior"},
+			{Else: true, Goto: "junior"},
+		}},
+		{ID: "senior", Agent: "architect"},
+		{ID: "junior", Agent: "backend-dev"},
+	}}
+
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "junior") || contains(ids, "senior") {
+		t.Errorf("expected fallback junior only, got %v", ids)
+	}
+}
+
+func TestDAG_SplitMultiFanOut(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "split", Steps: []config.StepConfig{
+		{ID: "route", Type: config.StepTypeSplit, Multi: true, Branches: []config.SplitBranch{
+			{If: `cell.labels contains "backend"`, Goto: "be"},
+			{If: `cell.labels contains "frontend"`, Goto: "fe"},
+		}},
+		{ID: "be", Agent: "backend-dev"},
+		{ID: "fe", Agent: "architect"},
+	}}
+
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1", Labels: []string{"backend", "frontend"}})
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "be") || !contains(ids, "fe") {
+		t.Errorf("expected both branches via multi, got %v", ids)
+	}
+}
+
+func TestDAG_SplitSkipCascadesDownstream(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	// route picks "a"; "b" and its dependent "b2" must be skipped.
+	wf := config.WorkflowConfig{ID: "split", Steps: []config.StepConfig{
+		{ID: "route", Type: config.StepTypeSplit, Branches: []config.SplitBranch{
+			{If: `cell.priority == "high"`, Goto: "a"},
+			{Else: true, Goto: "b"},
+		}},
+		{ID: "a", Agent: "architect"},
+		{ID: "b", Agent: "backend-dev"},
+		{ID: "b2", Agent: "architect", DependsOn: []string{"b"}},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1", Priority: "high"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "a") {
+		t.Errorf("expected 'a' to run, got %v", ids)
+	}
+	if contains(ids, "b") || contains(ids, "b2") {
+		t.Errorf("expected b and b2 skipped, got %v", ids)
+	}
+}
+
+func TestDAG_OnFailLoopSucceedsOnRetry(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["review"] = []StepResult{
+		{Success: false, Output: "changes requested"}, // first attempt fails
+		{Success: true, Output: "LGTM"},               // retry passes
+	}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "loop", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "review", Agent: "architect", DependsOn: []string{"implement"},
+			OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 2}},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success after retry")
+	}
+	if exec.ran("implement") != 2 {
+		t.Errorf("expected implement to run twice (loop), got %d", exec.ran("implement"))
+	}
+	if exec.ran("review") != 2 {
+		t.Errorf("expected review to run twice, got %d", exec.ran("review"))
+	}
+}
+
+func TestDAG_OnFailLoopExhaustsRetries(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["review"] = []StepResult{{Success: false}} // always fails
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "loop", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "review", Agent: "architect", DependsOn: []string{"implement"},
+			OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 1}},
+	}}
+
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure after exhausting retries")
+	}
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed instance, got %s", store.instances[instID].State)
+	}
+	// review: attempt 1 (fail, retry) + attempt 2 (fail, exhausted) = 2 runs.
+	if exec.ran("review") != 2 {
+		t.Errorf("expected review to run twice, got %d", exec.ran("review"))
+	}
+	if exec.ran("implement") != 2 {
+		t.Errorf("expected implement to run twice (one loop), got %d", exec.ran("implement"))
+	}
+}
+
+func TestDAG_FailureWithoutLoopStopsGraph(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"build": {Success: false, Output: "compile error"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "chain", Steps: []config.StepConfig{
+		{ID: "build", Agent: "backend-dev"},
+		{ID: "deploy", Agent: "architect", DependsOn: []string{"build"}},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure")
+	}
+	ids := executedIDs(exec.seen)
+	if contains(ids, "deploy") {
+		t.Errorf("deploy should not run after build failed, got %v", ids)
+	}
+}
+
+func TestDAG_LinearChainOrder(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{
+		{ID: "a", Agent: "architect"},
+		{ID: "b", Agent: "backend-dev", DependsOn: []string{"a"}},
+		{ID: "c", Agent: "architect", DependsOn: []string{"b"}},
+	}}
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	ids := executedIDs(exec.seen)
+	want := []string{"a", "b", "c"}
+	if len(ids) != 3 || ids[0] != want[0] || ids[1] != want[1] || ids[2] != want[2] {
+		t.Errorf("expected order %v, got %v", want, ids)
+	}
+}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -126,33 +126,9 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell
 		_ = e.side.StateLock(ctx, cell)
 	}
 
-	var memSteps []MemoryStep
-	failed := false
-
-	for _, step := range wf.Steps {
-		// Phase 2 executes only agent steps; routing/approval/foreach steps are
-		// handled by the Phase 3 DAG executor.
-		if step.StepType() != config.StepTypeAgent {
-			continue
-		}
-
-		res := e.runStep(ctx, instID, step, cell, memSteps)
-		memSteps = append(memSteps, MemoryStep{
-			StepID:      step.ID,
-			WriteFields: step.MemoryWriteFields(),
-			Structured:  res.StructuredOutput,
-			Summary:     res.Summary,
-		})
-
-		if e.resultCommentMode(wf) == config.ResultCommentPerStep && e.side != nil {
-			_ = e.side.PostComment(ctx, cell, perStepComment(step, res))
-		}
-
-		if !res.Success {
-			failed = true
-			break
-		}
-	}
+	// Execute the step graph: depends_on ordering, split routing, on_fail.goto
+	// loops, and skip propagation are all handled by the DAG scheduler.
+	failed, memSteps := e.runDAG(ctx, instID, wf, cell)
 
 	finalState := db.InstanceStateDone
 	if failed {

--- a/src/internal/workflow/expr.go
+++ b/src/internal/workflow/expr.go
@@ -1,0 +1,464 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// EvalContext provides the data a split condition is evaluated against.
+type EvalContext struct {
+	Cell   model.Cell
+	Memory map[string]string    // workflow-memory Step Data keys → rendered values
+	Steps  map[string]StepState // step id → terminal state info
+}
+
+// StepState exposes a completed step's outcome to expressions.
+type StepState struct {
+	State    string // passed | failed
+	ExitCode int
+	Output   string
+}
+
+// Expr is a parsed, reusable condition expression.
+type Expr struct {
+	root exprNode
+	src  string
+}
+
+// ParseExpr parses a condition expression (used in split branches). It returns a
+// reusable Expr or a parse error — call at config-load time to validate.
+func ParseExpr(src string) (*Expr, error) {
+	toks, err := lex(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &exprParser{toks: toks}
+	node, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().kind != tEOF {
+		return nil, fmt.Errorf("unexpected token %q in expression %q", p.peek().val, src)
+	}
+	return &Expr{root: node, src: src}, nil
+}
+
+// Eval evaluates the expression against ctx.
+func (e *Expr) Eval(ctx EvalContext) (bool, error) {
+	return e.root.eval(ctx)
+}
+
+// String returns the original source.
+func (e *Expr) String() string { return e.src }
+
+// ── lexer ───────────────────────────────────────────────────────────────────
+
+type tokKind int
+
+const (
+	tEOF tokKind = iota
+	tIdent
+	tString
+	tNumber
+	tDot
+	tLParen
+	tRParen
+	tEq
+	tNeq
+)
+
+type token struct {
+	kind tokKind
+	val  string
+}
+
+func lex(s string) ([]token, error) {
+	var toks []token
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '(':
+			toks = append(toks, token{tLParen, "("})
+			i++
+		case c == ')':
+			toks = append(toks, token{tRParen, ")"})
+			i++
+		case c == '.':
+			toks = append(toks, token{tDot, "."})
+			i++
+		case c == '=':
+			if i+1 < len(s) && s[i+1] == '=' {
+				toks = append(toks, token{tEq, "=="})
+				i += 2
+			} else {
+				return nil, fmt.Errorf("unexpected '=' (did you mean '=='?) at position %d", i)
+			}
+		case c == '!':
+			if i+1 < len(s) && s[i+1] == '=' {
+				toks = append(toks, token{tNeq, "!="})
+				i += 2
+			} else {
+				return nil, fmt.Errorf("unexpected '!' (did you mean '!='?) at position %d", i)
+			}
+		case c == '"' || c == '\'':
+			quote := c
+			j := i + 1
+			var b strings.Builder
+			for j < len(s) && s[j] != quote {
+				b.WriteByte(s[j])
+				j++
+			}
+			if j >= len(s) {
+				return nil, fmt.Errorf("unterminated string literal in expression")
+			}
+			toks = append(toks, token{tString, b.String()})
+			i = j + 1
+		case c >= '0' && c <= '9' || (c == '-' && i+1 < len(s) && s[i+1] >= '0' && s[i+1] <= '9'):
+			j := i + 1
+			for j < len(s) && (s[j] >= '0' && s[j] <= '9' || s[j] == '.') {
+				j++
+			}
+			toks = append(toks, token{tNumber, s[i:j]})
+			i = j
+		case isIdentStart(c):
+			j := i + 1
+			for j < len(s) && isIdentChar(s[j]) {
+				j++
+			}
+			toks = append(toks, token{tIdent, s[i:j]})
+			i = j
+		default:
+			return nil, fmt.Errorf("unexpected character %q at position %d", string(c), i)
+		}
+	}
+	toks = append(toks, token{tEOF, ""})
+	return toks, nil
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentChar(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+// ── parser ──────────────────────────────────────────────────────────────────
+
+type exprParser struct {
+	toks []token
+	pos  int
+}
+
+func (p *exprParser) peek() token { return p.toks[p.pos] }
+func (p *exprParser) next() token {
+	t := p.toks[p.pos]
+	if p.pos < len(p.toks)-1 {
+		p.pos++
+	}
+	return t
+}
+
+func (p *exprParser) parseOr() (exprNode, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.isKeyword("or") {
+		p.next()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = orNode{left, right}
+	}
+	return left, nil
+}
+
+func (p *exprParser) parseAnd() (exprNode, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for p.isKeyword("and") {
+		p.next()
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = andNode{left, right}
+	}
+	return left, nil
+}
+
+func (p *exprParser) parseNot() (exprNode, error) {
+	if p.isKeyword("not") {
+		p.next()
+		x, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return notNode{x}, nil
+	}
+	return p.parseAtom()
+}
+
+func (p *exprParser) parseAtom() (exprNode, error) {
+	if p.peek().kind == tLParen {
+		p.next()
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if p.peek().kind != tRParen {
+			return nil, fmt.Errorf("expected ')' in expression")
+		}
+		p.next()
+		return inner, nil
+	}
+	return p.parseComparison()
+}
+
+func (p *exprParser) parseComparison() (exprNode, error) {
+	// accessor: IDENT ("." IDENT)*
+	if p.peek().kind != tIdent {
+		return nil, fmt.Errorf("expected accessor, got %q", p.peek().val)
+	}
+	var path []string
+	path = append(path, p.next().val)
+	for p.peek().kind == tDot {
+		p.next()
+		if p.peek().kind != tIdent {
+			return nil, fmt.Errorf("expected identifier after '.'")
+		}
+		path = append(path, p.next().val)
+	}
+
+	// operator
+	var op string
+	switch {
+	case p.peek().kind == tEq:
+		op = "=="
+		p.next()
+	case p.peek().kind == tNeq:
+		op = "!="
+		p.next()
+	case p.isKeyword("contains"):
+		op = "contains"
+		p.next()
+	case p.isKeyword("matches"):
+		op = "matches"
+		p.next()
+	default:
+		return nil, fmt.Errorf("expected operator (==, !=, contains, matches) after accessor %q, got %q",
+			strings.Join(path, "."), p.peek().val)
+	}
+
+	// operand
+	operandTok := p.peek()
+	switch operandTok.kind {
+	case tString:
+		p.next()
+		return cmpNode{path: path, op: op, operand: operandTok.val}, nil
+	case tNumber:
+		p.next()
+		return cmpNode{path: path, op: op, operand: operandTok.val, isNumber: true}, nil
+	default:
+		return nil, fmt.Errorf("expected string or number operand, got %q", operandTok.val)
+	}
+}
+
+func (p *exprParser) isKeyword(kw string) bool {
+	t := p.peek()
+	return t.kind == tIdent && t.val == kw
+}
+
+// ── AST + eval ──────────────────────────────────────────────────────────────
+
+type exprNode interface {
+	eval(EvalContext) (bool, error)
+}
+
+type orNode struct{ l, r exprNode }
+
+func (n orNode) eval(ctx EvalContext) (bool, error) {
+	lv, err := n.l.eval(ctx)
+	if err != nil {
+		return false, err
+	}
+	if lv {
+		return true, nil
+	}
+	return n.r.eval(ctx)
+}
+
+type andNode struct{ l, r exprNode }
+
+func (n andNode) eval(ctx EvalContext) (bool, error) {
+	lv, err := n.l.eval(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !lv {
+		return false, nil
+	}
+	return n.r.eval(ctx)
+}
+
+type notNode struct{ x exprNode }
+
+func (n notNode) eval(ctx EvalContext) (bool, error) {
+	v, err := n.x.eval(ctx)
+	if err != nil {
+		return false, err
+	}
+	return !v, nil
+}
+
+type valueKind int
+
+const (
+	kString valueKind = iota
+	kList
+	kNumber
+	kMissing
+)
+
+type resolvedValue struct {
+	kind valueKind
+	s    string
+	list []string
+	n    float64
+}
+
+type cmpNode struct {
+	path     []string
+	op       string
+	operand  string
+	isNumber bool
+}
+
+func (n cmpNode) eval(ctx EvalContext) (bool, error) {
+	v, err := resolveAccessor(n.path, ctx)
+	if err != nil {
+		return false, err
+	}
+
+	switch n.op {
+	case "matches":
+		if v.kind == kList {
+			return false, fmt.Errorf("'matches' is not supported on list %q", strings.Join(n.path, "."))
+		}
+		re, err := regexp.Compile(n.operand)
+		if err != nil {
+			return false, fmt.Errorf("invalid regex %q: %w", n.operand, err)
+		}
+		return re.MatchString(v.s), nil
+
+	case "contains":
+		switch v.kind {
+		case kList:
+			for _, item := range v.list {
+				if item == n.operand {
+					return true, nil
+				}
+			}
+			return false, nil
+		case kString:
+			return strings.Contains(v.s, n.operand), nil
+		default:
+			return false, fmt.Errorf("'contains' is not supported on %q", strings.Join(n.path, "."))
+		}
+
+	case "==", "!=":
+		eq, err := equals(v, n)
+		if err != nil {
+			return false, err
+		}
+		if n.op == "!=" {
+			return !eq, nil
+		}
+		return eq, nil
+	}
+	return false, fmt.Errorf("unknown operator %q", n.op)
+}
+
+func equals(v resolvedValue, n cmpNode) (bool, error) {
+	if v.kind == kList {
+		return false, fmt.Errorf("'%s' is not supported on list %q (use 'contains')", n.op, strings.Join(n.path, "."))
+	}
+	if v.kind == kNumber && n.isNumber {
+		want, err := strconv.ParseFloat(n.operand, 64)
+		if err != nil {
+			return false, fmt.Errorf("invalid number operand %q", n.operand)
+		}
+		return v.n == want, nil
+	}
+	// String comparison (covers kString and kMissing → "").
+	return v.s == n.operand, nil
+}
+
+// resolveAccessor maps an accessor path to a value within the EvalContext.
+func resolveAccessor(path []string, ctx EvalContext) (resolvedValue, error) {
+	if len(path) == 0 {
+		return resolvedValue{}, fmt.Errorf("empty accessor")
+	}
+	switch path[0] {
+	case "cell":
+		if len(path) != 2 {
+			return resolvedValue{}, fmt.Errorf("invalid cell accessor %q", strings.Join(path, "."))
+		}
+		switch path[1] {
+		case "labels":
+			return resolvedValue{kind: kList, list: ctx.Cell.Labels}, nil
+		case "priority":
+			return resolvedValue{kind: kString, s: ctx.Cell.Priority}, nil
+		case "type":
+			return resolvedValue{kind: kString, s: ctx.Cell.Type}, nil
+		case "title":
+			return resolvedValue{kind: kString, s: ctx.Cell.Title}, nil
+		case "source":
+			return resolvedValue{kind: kString, s: ctx.Cell.SourceID}, nil
+		case "state":
+			return resolvedValue{kind: kString, s: ctx.Cell.State}, nil
+		default:
+			return resolvedValue{}, fmt.Errorf("unknown cell field %q", path[1])
+		}
+	case "memory":
+		if len(path) != 2 {
+			return resolvedValue{}, fmt.Errorf("invalid memory accessor %q", strings.Join(path, "."))
+		}
+		v, ok := ctx.Memory[path[1]]
+		if !ok {
+			return resolvedValue{kind: kMissing}, nil
+		}
+		return resolvedValue{kind: kString, s: v}, nil
+	case "steps":
+		if len(path) != 3 {
+			return resolvedValue{}, fmt.Errorf("invalid steps accessor %q (want steps.<id>.<field>)", strings.Join(path, "."))
+		}
+		st, ok := ctx.Steps[path[1]]
+		if !ok {
+			return resolvedValue{kind: kMissing}, nil
+		}
+		switch path[2] {
+		case "state":
+			return resolvedValue{kind: kString, s: st.State}, nil
+		case "output":
+			return resolvedValue{kind: kString, s: st.Output}, nil
+		case "exit_code":
+			return resolvedValue{kind: kNumber, n: float64(st.ExitCode)}, nil
+		default:
+			return resolvedValue{}, fmt.Errorf("unknown step field %q", path[2])
+		}
+	default:
+		return resolvedValue{}, fmt.Errorf("unknown accessor root %q (want cell, memory, or steps)", path[0])
+	}
+}

--- a/src/internal/workflow/expr_test.go
+++ b/src/internal/workflow/expr_test.go
@@ -1,0 +1,176 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func evalExpr(t *testing.T, src string, ctx EvalContext) bool {
+	t.Helper()
+	e, err := ParseExpr(src)
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	v, err := e.Eval(ctx)
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	return v
+}
+
+func TestExpr_CellFields(t *testing.T) {
+	ctx := EvalContext{Cell: model.Cell{
+		Title: "hotfix login", Priority: "urgent", Type: "bug",
+		Labels: []string{"backend", "bug"}, SourceID: "main-plane", State: "todo",
+	}}
+
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		{`cell.priority == "urgent"`, true},
+		{`cell.priority == "low"`, false},
+		{`cell.priority != "low"`, true},
+		{`cell.type == "bug"`, true},
+		{`cell.source == "main-plane"`, true},
+		{`cell.state == "todo"`, true},
+		{`cell.labels contains "bug"`, true},
+		{`cell.labels contains "frontend"`, false},
+		{`cell.title matches ".*hotfix.*"`, true},
+		{`cell.title matches "^feature"`, false},
+	}
+	for _, c := range cases {
+		if got := evalExpr(t, c.src, ctx); got != c.want {
+			t.Errorf("%q = %v, want %v", c.src, got, c.want)
+		}
+	}
+}
+
+func TestExpr_MemoryFields(t *testing.T) {
+	ctx := EvalContext{Memory: map[string]string{"complexity": "high", "approach": "jwt"}}
+	if !evalExpr(t, `memory.complexity == "high"`, ctx) {
+		t.Error("expected memory.complexity == high")
+	}
+	if evalExpr(t, `memory.complexity == "low"`, ctx) {
+		t.Error("expected false")
+	}
+	// Missing memory key compares as empty string.
+	if !evalExpr(t, `memory.missing == ""`, ctx) {
+		t.Error("missing key should equal empty string")
+	}
+	if !evalExpr(t, `memory.approach contains "jw"`, ctx) {
+		t.Error("expected substring match on memory value")
+	}
+}
+
+func TestExpr_StepFields(t *testing.T) {
+	ctx := EvalContext{Steps: map[string]StepState{
+		"review": {State: "passed", ExitCode: 0, Output: "LGTM, ship it"},
+		"build":  {State: "failed", ExitCode: 2},
+	}}
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		{`steps.review.state == "passed"`, true},
+		{`steps.build.state == "failed"`, true},
+		{`steps.review.exit_code == 0`, true},
+		{`steps.build.exit_code == 2`, true},
+		{`steps.build.exit_code != 0`, true},
+		{`steps.review.output contains "LGTM"`, true},
+		{`steps.review.output contains "nope"`, false},
+		{`steps.missing.state == ""`, true},
+	}
+	for _, c := range cases {
+		if got := evalExpr(t, c.src, ctx); got != c.want {
+			t.Errorf("%q = %v, want %v", c.src, got, c.want)
+		}
+	}
+}
+
+func TestExpr_BooleanCombinators(t *testing.T) {
+	ctx := EvalContext{Cell: model.Cell{
+		Priority: "urgent", Labels: []string{"feature"}, Type: "feature",
+	}}
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		{`cell.labels contains "feature" and cell.priority == "urgent"`, true},
+		{`cell.labels contains "feature" and cell.priority == "low"`, false},
+		{`cell.labels contains "bug" or cell.type == "feature"`, true},
+		{`cell.labels contains "bug" or cell.type == "chore"`, false},
+		{`not cell.labels contains "bug"`, true},
+		{`not cell.type == "feature"`, false},
+		{`(cell.labels contains "bug" or cell.type == "feature") and cell.priority == "urgent"`, true},
+		{`cell.labels contains "bug" or cell.type == "feature" and cell.priority == "low"`, false}, // and binds tighter
+	}
+	for _, c := range cases {
+		if got := evalExpr(t, c.src, ctx); got != c.want {
+			t.Errorf("%q = %v, want %v", c.src, got, c.want)
+		}
+	}
+}
+
+func TestExpr_PrecedenceAndOverOr(t *testing.T) {
+	// false or (true and false) = false ; (false or true) and false = false
+	// Use distinct values to detect grouping: A or B and C  ==  A or (B and C)
+	ctx := EvalContext{Memory: map[string]string{"a": "1", "b": "1", "c": "0"}}
+	// a==1 or (b==1 and c==1) → true or (true and false) → true
+	if !evalExpr(t, `memory.a == "1" or memory.b == "1" and memory.c == "1"`, ctx) {
+		t.Error("expected and to bind tighter than or → true")
+	}
+	// (a==0 or b==1) and c==1 → forced grouping → (false or true) and false → false
+	if evalExpr(t, `(memory.a == "0" or memory.b == "1") and memory.c == "1"`, ctx) {
+		t.Error("expected grouped expression → false")
+	}
+}
+
+func TestExpr_ParseErrors(t *testing.T) {
+	bad := []string{
+		`cell.priority =`,              // dangling
+		`cell.priority == `,            // missing operand
+		`cell.priority "urgent"`,       // missing operator
+		`(cell.priority == "x"`,        // unbalanced paren
+		`cell.priority == "x" garbage`, // trailing tokens
+		`== "x"`,                       // missing accessor
+		`cell.priority ~ "x"`,          // unknown operator char
+	}
+	for _, src := range bad {
+		if _, err := ParseExpr(src); err == nil {
+			t.Errorf("expected parse error for %q, got nil", src)
+		}
+	}
+}
+
+func TestExpr_EvalErrors(t *testing.T) {
+	ctx := EvalContext{Cell: model.Cell{Labels: []string{"a"}}}
+	// 'matches' on a list is an error.
+	e, _ := ParseExpr(`cell.labels matches ".*"`)
+	if _, err := e.Eval(ctx); err == nil {
+		t.Error("expected error for matches on list")
+	}
+	// '==' on a list is an error.
+	e, _ = ParseExpr(`cell.labels == "a"`)
+	if _, err := e.Eval(ctx); err == nil {
+		t.Error("expected error for == on list")
+	}
+	// unknown cell field.
+	e, _ = ParseExpr(`cell.bogus == "x"`)
+	if _, err := e.Eval(ctx); err == nil {
+		t.Error("expected error for unknown cell field")
+	}
+	// unknown root.
+	e, _ = ParseExpr(`foo.bar == "x"`)
+	if _, err := e.Eval(ctx); err == nil {
+		t.Error("expected error for unknown accessor root")
+	}
+}
+
+func TestExpr_SingleQuotes(t *testing.T) {
+	ctx := EvalContext{Cell: model.Cell{Priority: "high"}}
+	if !evalExpr(t, `cell.priority == 'high'`, ctx) {
+		t.Error("single-quoted strings should work")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the engine's sequential loop with a real **DAG scheduler** and adds the **expression evaluator** for `split` steps. Still behind the `experimental.workflow_mode` flag.

### Expression evaluator (`expr.go`)
Recursive-descent parser + AST, with a separate `Eval` against an `EvalContext`:
- Accessors: `cell.{labels,priority,type,title,source,state}`, `memory.<key>`, `steps.<id>.{state,output,exit_code}`
- Operators: `==`, `!=`, `contains` (list membership / substring), `matches` (regex)
- Combinators: `and`, `or`, `not`, parentheses — `and` binds tighter than `or`
- `ParseExpr` validates the syntax; parse and evaluation errors are distinct

### DAG scheduler (`dag.go`)
Replaces the sequential loop in `RunInstance`:
- Ordering by `depends_on` (steps run when their dependencies pass)
- **Split**: evaluates branches (first-match or `multi`), activates the chosen target(s); unchosen branches and their dependents are marked `skipped` in cascade
- **`on_fail.goto` loops**: per-step retry counting, `max_retries`, and a cascading reset (the target and all transitive dependents go back to `pending`, clearing memory contributions) — the branch re-runs
- Memory threading between steps in the order they pass; `memory.<key>` is accessible in split conditions

Execution is deterministically sequential (one ready step at a time). Real parallelism of independent steps is a deferred optimization — same results, just faster — and lands together with the global semaphore.

## Test plan
- [x] `go test ./...` — green. New: `expr_test.go` (operators, precedence, parse/eval errors, single quotes) and `dag_test.go` (diamond with join, split first-match/fallback/multi, skip cascade, loop succeeding on retry, loop exhausting retries → instance fails, failure with no loop halting the graph, linear chain).
- [x] Regression: all Phase 2 engine tests still pass through the new DAG path.
- [x] `go vet` clean; `make build` ok.

## Deferred
- Parallel execution of independent steps (3.1.2) — optimization, same results.
- Validation of `branches[].if` syntax at config load (3.2.5) — needs an expr package that `config` can import without a cycle; at runtime an invalid condition is treated as a non-match and logged.