### PR TITLE
feat: workflow-mode Phase 3b — foreach (dynamic fan-out)

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -112,14 +112,14 @@ Multi-step workflows, parallel steps, split steps, foreach, sub-workflows, per-s
 - [x] 3.2.4 Unit tests: all operators, precedence, parse + eval errors; first-match, fallback, multi, skip cascade
 - [~] 3.2.5 Config-load validation of `branches[].if` syntax — deferred (needs an expr package config can import without a cycle); runtime treats an unparseable condition as non-match and logs it
 
-### 3.3 Foreach Steps
+### 3.3 Foreach Steps — PR-3b
 
-- [ ] 3.3.1 Implement foreach step execution: read items array from step structured output, spawn sub-runs
-- [ ] 3.3.2 Implement `concurrency` cap and `max_items` guard
-- [ ] 3.3.3 Implement prompt template rendering (`{{ item.field }}` substitution)
-- [ ] 3.3.4 Implement `fail_fast` behavior
-- [ ] 3.3.5 Expose `steps.<id>.outputs`, `steps.<id>.passed_count`, `steps.<id>.failed_count` in memory/expressions
-- [ ] 3.3.6 Unit tests: foreach with structured output, concurrency cap, max_items abort, fail_fast
+- [x] 3.3.1 Foreach execution (`foreach.go`): resolve the items array from a prior step's structured output, run the inner agent step once per item
+- [~] 3.3.2 `max_items` guard implemented (fails the step when exceeded); `concurrency` cap deferred with DAG parallelism — items run sequentially
+- [x] 3.3.3 Prompt template rendering: `{{ as }}` / `{{ as.field }}` substitution (`renderItemTemplate`), wired through new `StepRequest.Prompt` → executor `composeSystemAppend`
+- [x] 3.3.4 `fail_fast` behavior (stop after the first failing item)
+- [~] 3.3.5 Aggregate exposure — `steps.<id>.exit_code` carries the failed count (so `== 0` means all passed) and a summary in memory; full `outputs[i]` array indexing in expressions deferred
+- [x] 3.3.6 Unit tests: one-run-per-item, rendered prompt reaches executor, max_items guard, fail_fast, downstream-after-pass, invalid items path, template edge cases
 
 ### 3.4 Sub-Workflows
 

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -65,7 +65,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		Model:              req.Model,
 		MaxTurns:           15,
 		SystemPrepend:      req.MemoryDoc,
-		SystemAppend:       readSoulFile(req.Agent, req.Cell.ID),
+		SystemAppend:       composeSystemAppend(req.Prompt, readSoulFile(req.Agent, req.Cell.ID)),
 		SummaryPrompt:      req.Step.SummaryPrompt,
 		StepID:             req.Step.ID,
 		WorkflowInstanceID: req.InstanceID,
@@ -135,6 +135,20 @@ func (s *wfSideEffects) ApplyHook(ctx context.Context, cell model.Cell, hook con
 		}
 	}
 	return nil
+}
+
+// composeSystemAppend combines a step-level prompt with the agent's soul file.
+// The step prompt comes first so per-step (and foreach per-item) instructions
+// lead, followed by the agent's standing guidance.
+func composeSystemAppend(stepPrompt, soul string) string {
+	switch {
+	case stepPrompt == "":
+		return soul
+	case soul == "":
+		return stepPrompt
+	default:
+		return stepPrompt + "\n\n" + soul
+	}
 }
 
 // readSoulFile loads an agent's soul file, returning "" (and logging) on error.

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -199,9 +199,11 @@ func (e *Engine) runDAGStep(ctx context.Context, r *dagRun, id string) bool {
 		return e.runSplitStep(r, step)
 	case config.StepTypeAgent:
 		return e.runAgentDAGStep(ctx, r, step)
+	case config.StepTypeForeach:
+		return e.runForeachStep(ctx, r, step)
 	default:
-		// approval/foreach/workflow are not executed by the Phase 3a scheduler;
-		// treat as a no-op pass so they don't block the graph.
+		// approval/workflow are not executed by this scheduler yet; treat as a
+		// no-op pass so they don't block the graph.
 		aplog.Debug("workflow %s: step %q type %q not yet executable, passing through", r.wf.ID, step.ID, step.StepType())
 		r.state[id] = stPassed
 		return false

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -29,6 +29,9 @@ type StepRequest struct {
 	Agent      config.AgentConfig
 	Model      string // resolved model (step override or agent default)
 	MemoryDoc  string // workflow memory document to prepend (empty if memory.read is false)
+	// Prompt is the step-level instruction (step.prompt) with any foreach item
+	// templates already rendered. The executor folds it into the agent's prompt.
+	Prompt string
 }
 
 // StepResult is the outcome of executing one agent step.
@@ -175,6 +178,7 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 		Agent:      ag,
 		Model:      resolvedModel,
 		MemoryDoc:  memDoc,
+		Prompt:     step.Prompt,
 	})
 
 	finished := e.now()

--- a/src/internal/workflow/foreach.go
+++ b/src/internal/workflow/foreach.go
@@ -1,0 +1,156 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+// defaultForeachMaxItems caps fan-out when the step omits max_items.
+const defaultForeachMaxItems = 50
+
+// runForeachStep expands a foreach step over the array resolved from a prior
+// step's structured output, running its inner agent step once per item. It
+// returns true if the instance must fail (an item failed and no recovery).
+func (e *Engine) runForeachStep(ctx context.Context, r *dagRun, step config.StepConfig) bool {
+	items, err := resolveItems(step.Items, r)
+	if err != nil {
+		aplog.Error("workflow %s: foreach %q: %v", r.wf.ID, step.ID, err)
+		r.failForeach(step.ID)
+		return true
+	}
+
+	maxItems := step.MaxItems
+	if maxItems == 0 {
+		maxItems = defaultForeachMaxItems
+	}
+	if len(items) > maxItems {
+		aplog.Error("workflow %s: foreach %q: %d items exceeds max_items %d",
+			r.wf.ID, step.ID, len(items), maxItems)
+		r.failForeach(step.ID)
+		return true
+	}
+
+	if step.Step == nil {
+		aplog.Error("workflow %s: foreach %q: missing inner step", r.wf.ID, step.ID)
+		r.failForeach(step.ID)
+		return true
+	}
+
+	as := step.As
+	if as == "" {
+		as = "item"
+	}
+
+	memSteps := r.memSteps() // snapshot: all sub-runs read the same memory
+	passed, failed := 0, 0
+
+	for i, item := range items {
+		sub := *step.Step
+		sub.ID = fmt.Sprintf("%s[%d]", step.ID, i)
+		sub.Type = config.StepTypeAgent
+		sub.DependsOn = nil
+		sub.Prompt = renderItemTemplate(step.Step.Prompt, as, item)
+
+		res := e.runStep(ctx, r.instID, sub, r.cell, memSteps)
+		if res.Success {
+			passed++
+		} else {
+			failed++
+			if step.FailFast {
+				aplog.Info("workflow %s: foreach %q: fail_fast after item %d", r.wf.ID, step.ID, i)
+				break
+			}
+		}
+	}
+
+	allOK := failed == 0
+	r.state[step.ID] = passFail(allOK)
+	// Expose aggregate via the step state: exit_code carries the failed count, so
+	// `steps.<id>.exit_code == 0` reads as "all items passed".
+	r.stepStates[step.ID] = StepState{
+		State:    passFail(allOK),
+		ExitCode: failed,
+		Output:   fmt.Sprintf("foreach: %d passed, %d failed", passed, failed),
+	}
+	if allOK {
+		r.contrib[step.ID] = MemoryStep{
+			StepID:  step.ID,
+			Summary: fmt.Sprintf("%s: processed %d item(s)", step.ID, passed),
+		}
+		r.passedOrder = append(r.passedOrder, step.ID)
+		return false
+	}
+	return true
+}
+
+// failForeach marks a foreach step failed in the run state.
+func (r *dagRun) failForeach(id string) {
+	r.state[id] = stFailed
+	r.stepStates[id] = StepState{State: stFailed}
+}
+
+// resolveItems resolves a foreach `items` path (steps.<id>.output.<field...>) to
+// an array within a prior passed step's structured output.
+func resolveItems(path string, r *dagRun) ([]any, error) {
+	parts := strings.Split(path, ".")
+	if len(parts) < 4 || parts[0] != "steps" || parts[2] != "output" {
+		return nil, fmt.Errorf("invalid items path %q (want steps.<id>.output.<field>)", path)
+	}
+	id := parts[1]
+	fields := parts[3:]
+
+	contrib, ok := r.contrib[id]
+	if !ok || contrib.Structured == nil {
+		return nil, fmt.Errorf("step %q has no structured output to read items from", id)
+	}
+
+	var cur any = contrib.Structured
+	for _, f := range fields {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("items path %q: %q is not an object", path, f)
+		}
+		cur, ok = obj[f]
+		if !ok {
+			return nil, fmt.Errorf("items path %q: field %q not found", path, f)
+		}
+	}
+
+	arr, ok := cur.([]any)
+	if !ok {
+		return nil, fmt.Errorf("items path %q does not resolve to an array", path)
+	}
+	return arr, nil
+}
+
+// itemTemplateRe matches {{ var }} and {{ var.field }} with optional whitespace.
+var itemTemplateRe = regexp.MustCompile(`\{\{\s*(\w+)(?:\.(\w+))?\s*\}\}`)
+
+// renderItemTemplate substitutes {{ as }} / {{ as.field }} placeholders in a
+// prompt with values from the current foreach item.
+func renderItemTemplate(tmpl, as string, item any) string {
+	if tmpl == "" {
+		return ""
+	}
+	return itemTemplateRe.ReplaceAllStringFunc(tmpl, func(match string) string {
+		sub := itemTemplateRe.FindStringSubmatch(match)
+		name, field := sub[1], sub[2]
+		if name != as {
+			return match // not our variable — leave untouched
+		}
+		if field == "" {
+			return renderValue(item)
+		}
+		if obj, ok := item.(map[string]any); ok {
+			if v, ok := obj[field]; ok {
+				return renderValue(v)
+			}
+		}
+		return ""
+	})
+}

--- a/src/internal/workflow/foreach_test.go
+++ b/src/internal/workflow/foreach_test.go
@@ -1,0 +1,212 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestRenderItemTemplate(t *testing.T) {
+	item := map[string]any{"file": "auth.go", "desc": "null deref"}
+	got := renderItemTemplate("Fix {{ issue.file }}: {{ issue.desc }}", "issue", item)
+	if got != "Fix auth.go: null deref" {
+		t.Errorf("got %q", got)
+	}
+	// scalar item with bare {{ as }}
+	if g := renderItemTemplate("Value is {{ x }}", "x", "hello"); g != "Value is hello" {
+		t.Errorf("scalar render got %q", g)
+	}
+	// unknown var left untouched
+	if g := renderItemTemplate("{{ other }}", "issue", item); g != "{{ other }}" {
+		t.Errorf("unknown var should be left as-is, got %q", g)
+	}
+	// missing field renders empty
+	if g := renderItemTemplate("[{{ issue.missing }}]", "issue", item); g != "[]" {
+		t.Errorf("missing field should render empty, got %q", g)
+	}
+}
+
+// foreachWorkflow builds a workflow whose first step emits an items array and a
+// foreach step over it.
+func foreachWorkflow(foreach config.StepConfig) config.WorkflowConfig {
+	plan := config.StepConfig{
+		ID: "plan", Agent: "architect",
+		OutputSchema: &config.OutputSchema{Type: "object",
+			Properties: map[string]config.SchemaField{
+				"issues": {Type: "array", Items: &config.SchemaField{Type: "object"}},
+			}},
+		Memory: &config.MemoryConfig{Write: []string{"issues"}},
+	}
+	foreach.ID = "fix-each"
+	foreach.Type = config.StepTypeForeach
+	foreach.DependsOn = []string{"plan"}
+	foreach.Items = "steps.plan.output.issues"
+	return config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{plan, foreach}}
+}
+
+func planWithIssues(n int) StepResult {
+	issues := make([]any, n)
+	for i := 0; i < n; i++ {
+		issues[i] = map[string]any{"file": "f" + itoa(i) + ".go"}
+	}
+	return StepResult{Success: true, StructuredOutput: map[string]any{"issues": issues}}
+}
+
+func TestForeach_RunsOnePerItem(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["plan"] = []StepResult{planWithIssues(3)}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{
+		As:   "issue",
+		Step: &config.StepConfig{Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
+	})
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+
+	// Three sub-runs, one per item, with rendered prompts.
+	subRuns := 0
+	for _, r := range exec.seen {
+		if strings.HasPrefix(r, "fix-each[") {
+			subRuns++
+		}
+	}
+	if subRuns != 3 {
+		t.Fatalf("expected 3 sub-runs, got %d (seen=%v)", subRuns, exec.seen)
+	}
+}
+
+func TestForeach_RenderedPromptReachesExecutor(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	// capture executor records full StepRequest
+	exec := &fakeExecutor{results: map[string]StepResult{"plan": planWithIssues(2)}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{
+		As:   "issue",
+		Step: &config.StepConfig{Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
+	})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+
+	var prompts []string
+	for _, req := range exec.seen {
+		if strings.HasPrefix(req.Step.ID, "fix-each[") {
+			prompts = append(prompts, req.Prompt)
+		}
+	}
+	if len(prompts) != 2 {
+		t.Fatalf("expected 2 rendered prompts, got %v", prompts)
+	}
+	if prompts[0] != "Fix f0.go" || prompts[1] != "Fix f1.go" {
+		t.Errorf("rendered prompts wrong: %v", prompts)
+	}
+}
+
+func TestForeach_MaxItemsGuard(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"plan": planWithIssues(10)}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{
+		As:       "issue",
+		MaxItems: 5,
+		Step:     &config.StepConfig{Agent: "backend-dev"},
+	})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure when items exceed max_items")
+	}
+	// No sub-runs should have executed.
+	for _, req := range exec.seen {
+		if strings.HasPrefix(req.Step.ID, "fix-each[") {
+			t.Errorf("no sub-runs expected, but %q ran", req.Step.ID)
+		}
+	}
+}
+
+func TestForeach_FailFast(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["plan"] = []StepResult{planWithIssues(4)}
+	// every sub-run fails
+	exec.scripts["fix-each[0]"] = []StepResult{{Success: false}}
+	exec.scripts["fix-each[1]"] = []StepResult{{Success: false}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{
+		As:       "issue",
+		FailFast: true,
+		Step:     &config.StepConfig{Agent: "backend-dev"},
+	})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure")
+	}
+	// fail_fast: stop after the first failing item → only 1 sub-run.
+	subRuns := 0
+	for _, id := range exec.seen {
+		if strings.HasPrefix(id, "fix-each[") {
+			subRuns++
+		}
+	}
+	if subRuns != 1 {
+		t.Errorf("expected 1 sub-run with fail_fast, got %d", subRuns)
+	}
+}
+
+func TestForeach_AllPassDownstreamRuns(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"plan": planWithIssues(2)}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{
+		As:   "issue",
+		Step: &config.StepConfig{Agent: "backend-dev"},
+	})
+	// Add a downstream step depending on the foreach.
+	wf.Steps = append(wf.Steps, config.StepConfig{
+		ID: "summarize", Agent: "architect", DependsOn: []string{"fix-each"},
+	})
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	ran := false
+	for _, req := range exec.seen {
+		if req.Step.ID == "summarize" {
+			ran = true
+		}
+	}
+	if !ran {
+		t.Error("expected summarize to run after foreach passed")
+	}
+}
+
+func TestForeach_InvalidItemsPathFails(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan": {Success: true, StructuredOutput: map[string]any{"notarray": "x"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := foreachWorkflow(config.StepConfig{As: "i", Step: &config.StepConfig{Agent: "backend-dev"}})
+	wf.Steps[1].Items = "steps.plan.output.notarray" // not an array
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure when items path is not an array")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `type: foreach` step: dynamic fan-out over an array produced by a previous step. Still behind the `experimental.workflow_mode` flag.

- **Item resolution** (`foreach.go`): `items: steps.<id>.output.<field>` reads the structured output of a passed step and expects an array; runs the inner step (`step:`, agent) once per item.
- **`max_items`** (default 50): fails the step if the array exceeds the limit — no sub-run is dispatched.
- **`fail_fast`**: stops after the first failing item. The foreach passes only if no item fails; `steps.<id>.exit_code` carries the number of failures (`== 0` ⇒ all passed).
- **Per-item templating**: `{{ as }}` and `{{ as.field }}` (`renderItemTemplate`), wired by a new `StepRequest.Prompt` field that the executor composes with the soul file (`composeSystemAppend`). Positive side effect: `step.prompt` is now honored on ordinary steps too (it was previously ignored).
- **Per-item model override** already covered by `runStep`.

Items run sequentially; the `concurrency` cap lands together with DAG parallelism (same results).

## Test plan
- [x] `go test ./...` — green. `foreach_test.go`: one run per item, the rendered prompt reaches the executor (`f0.go`/`f1.go`), `max_items` guard, `fail_fast` (1 sub-run), a downstream step runs after the foreach passes, an items path that isn't an array fails, and template edge cases (scalar, unknown var, missing field).
- [x] Regression: Phase 2/3a engine/DAG stay green; the daemon diff is only `workflow.go`.
- [x] `go vet` clean; `make build` ok.

## Deferred
- Per-step `concurrency` cap (3.3.2) — together with parallelism.
- `outputs[i]` indexing in expressions (3.3.5) — exposed aggregated via `exit_code`/summary for now.