### PR TITLE
feat: workflow-mode Phase 3c — sub-workflows (type: workflow)

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -121,21 +121,21 @@ Multi-step workflows, parallel steps, split steps, foreach, sub-workflows, per-s
 - [~] 3.3.5 Aggregate exposure — `steps.<id>.exit_code` carries the failed count (so `== 0` means all passed) and a summary in memory; full `outputs[i]` array indexing in expressions deferred
 - [x] 3.3.6 Unit tests: one-run-per-item, rendered prompt reaches executor, max_items guard, fail_fast, downstream-after-pass, invalid items path, template edge cases
 
-### 3.4 Sub-Workflows
+### 3.4 Sub-Workflows — PR-3c
 
-- [ ] 3.4.1 Implement `type: workflow` step: create child instance, pass memory snapshot, link via `parent_instance_id`
-- [ ] 3.4.2 Implement child instance completion: mark parent step passed/failed based on child outcome
-- [ ] 3.4.3 Unit tests: child instance created and linked; parent step waits for child
+- [x] 3.4.1 `type: workflow` step (`subworkflow.go`): create a linked child instance (`parent_instance_id`), seeded with the parent's memory snapshot; runtime depth guard backs up the config no-nesting rule
+- [x] 3.4.2 Child completion: parent step passes iff the child instance reaches `done`; child memory is not merged back (isolated)
+- [x] 3.4.3 Unit tests: child runs + links to parent, child failure fails the parent step (downstream skipped), unknown reference fails, parent memory seeds child, nesting beyond depth 1 refused
 
-### 3.5 Per-Step Model Override
+### 3.5 Per-Step Model Override — done in PR-2b
 
-- [ ] 3.5.1 Read `step.model` field in engine; pass to `RunRequest.Model` overriding agent's `preferred_models[0]`
-- [ ] 3.5.2 Unit test: step with `model` override uses correct model
+- [x] 3.5.1 `step.model` resolved in `runStep` (overrides the agent's model); also applies to foreach inner steps
+- [x] 3.5.2 Unit test: `TestEngine_PerStepModelOverride`
 
-### 3.6 Remove Feature Flag
+### 3.6 Remove Feature Flag — DEFERRED (needs legacy parity first)
 
-- [ ] 3.6.1 Remove `settings.experimental.workflow_mode` flag; engine always active
-- [ ] 3.6.2 Update `apiary validate` and `apiary status` to show workflow info unconditionally
+- [ ] 3.6.1 Remove `settings.experimental.workflow_mode` — **blocked**: flipping default-on would regress legacy `dispatch()` features the engine does not yet replicate (retry scheduling, PR-review directive, classifier `assign_from_output`, `task_executions` dashboard rows). Port these into the engine path before default-on.
+- [ ] 3.6.2 Update `apiary validate`/`status` to show workflow info unconditionally (after 3.6.1)
 
 ### 3.7 Tests
 

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -23,6 +23,8 @@ type dagRun struct {
 	instID string
 	wf     config.WorkflowConfig
 	cell   model.Cell
+	depth  int          // nesting depth (0 = top-level; >0 = sub-workflow child)
+	seed   []MemoryStep // inherited memory (sub-workflow snapshot from the parent)
 
 	byID  map[string]config.StepConfig
 	order []string // step ids in declaration order (deterministic scheduling)
@@ -40,12 +42,15 @@ type dagRun struct {
 // runDAG executes the workflow's step graph and returns whether the instance
 // failed along with the final memory contributions (for the completion comment).
 // It is the Phase 3 replacement for the sequential loop: it honors depends_on
-// ordering, split routing, on_fail.goto loops, and skip propagation.
-func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.Cell) (bool, []MemoryStep) {
+// ordering, split routing, on_fail.goto loops, and skip propagation. seed is the
+// inherited memory for a sub-workflow child; depth tracks nesting.
+func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.Cell, seed []MemoryStep, depth int) (bool, []MemoryStep) {
 	r := &dagRun{
 		instID:      instID,
 		wf:          wf,
 		cell:        cell,
+		depth:       depth,
+		seed:        seed,
 		byID:        map[string]config.StepConfig{},
 		state:       map[string]string{},
 		activated:   map[string]bool{},
@@ -201,8 +206,10 @@ func (e *Engine) runDAGStep(ctx context.Context, r *dagRun, id string) bool {
 		return e.runAgentDAGStep(ctx, r, step)
 	case config.StepTypeForeach:
 		return e.runForeachStep(ctx, r, step)
+	case config.StepTypeWorkflow:
+		return e.runSubWorkflowStep(ctx, r, step)
 	default:
-		// approval/workflow are not executed by this scheduler yet; treat as a
+		// approval steps are not executed by this scheduler yet; treat as a
 		// no-op pass so they don't block the graph.
 		aplog.Debug("workflow %s: step %q type %q not yet executable, passing through", r.wf.ID, step.ID, step.StepType())
 		r.state[id] = stPassed
@@ -339,9 +346,11 @@ func (r *dagRun) resetLoop(target string) {
 	r.passedOrder = kept
 }
 
-// memSteps returns the ordered memory contributions of passed steps.
+// memSteps returns the ordered memory contributions: inherited seed (for a
+// sub-workflow) first, then this run's passed steps.
 func (r *dagRun) memSteps() []MemoryStep {
-	out := make([]MemoryStep, 0, len(r.passedOrder))
+	out := make([]MemoryStep, 0, len(r.seed)+len(r.passedOrder))
+	out = append(out, r.seed...)
 	for _, id := range r.passedOrder {
 		if c, ok := r.contrib[id]; ok {
 			out = append(out, c)

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -131,7 +131,7 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell
 
 	// Execute the step graph: depends_on ordering, split routing, on_fail.goto
 	// loops, and skip propagation are all handled by the DAG scheduler.
-	failed, memSteps := e.runDAG(ctx, instID, wf, cell)
+	failed, memSteps := e.runDAG(ctx, instID, wf, cell, nil, 0)
 
 	finalState := db.InstanceStateDone
 	if failed {

--- a/src/internal/workflow/foreach.go
+++ b/src/internal/workflow/foreach.go
@@ -20,7 +20,7 @@ func (e *Engine) runForeachStep(ctx context.Context, r *dagRun, step config.Step
 	items, err := resolveItems(step.Items, r)
 	if err != nil {
 		aplog.Error("workflow %s: foreach %q: %v", r.wf.ID, step.ID, err)
-		r.failForeach(step.ID)
+		r.failStep(step.ID)
 		return true
 	}
 
@@ -31,13 +31,13 @@ func (e *Engine) runForeachStep(ctx context.Context, r *dagRun, step config.Step
 	if len(items) > maxItems {
 		aplog.Error("workflow %s: foreach %q: %d items exceeds max_items %d",
 			r.wf.ID, step.ID, len(items), maxItems)
-		r.failForeach(step.ID)
+		r.failStep(step.ID)
 		return true
 	}
 
 	if step.Step == nil {
 		aplog.Error("workflow %s: foreach %q: missing inner step", r.wf.ID, step.ID)
-		r.failForeach(step.ID)
+		r.failStep(step.ID)
 		return true
 	}
 
@@ -88,8 +88,9 @@ func (e *Engine) runForeachStep(ctx context.Context, r *dagRun, step config.Step
 	return true
 }
 
-// failForeach marks a foreach step failed in the run state.
-func (r *dagRun) failForeach(id string) {
+// failStep marks a step failed in the run state (used by foreach and
+// sub-workflow steps that fail before producing a normal step result).
+func (r *dagRun) failStep(id string) {
 	r.state[id] = stFailed
 	r.stepStates[id] = StepState{State: stFailed}
 }

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -1,0 +1,92 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// maxSubWorkflowDepth bounds sub-workflow nesting at runtime. Config validation
+// already forbids nesting (a referenced workflow may not contain workflow
+// steps), so depth 1 is the only legal level; this is a backstop.
+const maxSubWorkflowDepth = 1
+
+// runSubWorkflowStep executes a `type: workflow` step by running the referenced
+// workflow as a linked child instance, seeded with the parent's current memory.
+// The parent step passes iff the child instance completes successfully. The
+// child's memory is NOT merged back into the parent (sub-workflows are isolated).
+func (e *Engine) runSubWorkflowStep(ctx context.Context, r *dagRun, step config.StepConfig) bool {
+	if r.depth >= maxSubWorkflowDepth {
+		aplog.Error("workflow %s: step %q: sub-workflow nesting beyond depth %d is not allowed",
+			r.wf.ID, step.ID, maxSubWorkflowDepth)
+		r.failStep(step.ID)
+		return true
+	}
+
+	child := e.findWorkflow(step.Workflow)
+	if child == nil {
+		aplog.Error("workflow %s: step %q: referenced workflow %q not found", r.wf.ID, step.ID, step.Workflow)
+		r.failStep(step.ID)
+		return true
+	}
+
+	seed := r.memSteps() // snapshot of the parent's memory at this point
+	_, success := e.runChildInstance(ctx, r.instID, *child, r.cell, seed, r.depth+1)
+
+	r.state[step.ID] = passFail(success)
+	r.stepStates[step.ID] = StepState{State: passFail(success)}
+	if success {
+		r.contrib[step.ID] = MemoryStep{
+			StepID:  step.ID,
+			Summary: fmt.Sprintf("sub-workflow %q completed", child.ID),
+		}
+		r.passedOrder = append(r.passedOrder, step.ID)
+		return false
+	}
+	return true
+}
+
+// runChildInstance creates and runs a linked child workflow instance. It does
+// not apply state_lock or result_comment (those belong to the top-level
+// instance) and does not apply the child's on_complete/on_fail hooks against the
+// shared cell — the child is an isolated pipeline whose only outward signal is
+// success/failure.
+func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, child config.WorkflowConfig, cell model.Cell, seed []MemoryStep, depth int) (string, bool) {
+	childID := e.newID("wf")
+	inst := &db.WorkflowInstance{
+		ID:               childID,
+		WorkflowID:       child.ID,
+		CellID:           cell.ID,
+		SourceID:         cell.SourceID,
+		State:            db.InstanceStateRunning,
+		ParentInstanceID: parentInstID,
+		CreatedAt:        e.now(),
+	}
+	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
+		aplog.Error("sub-workflow %s: create child instance: %v", child.ID, err)
+		return "", false
+	}
+
+	failed, _ := e.runDAG(ctx, childID, child, cell, seed, depth)
+
+	finalState := db.InstanceStateDone
+	if failed {
+		finalState = db.InstanceStateFailed
+	}
+	_ = e.store.UpdateWorkflowInstanceState(ctx, childID, finalState)
+	return childID, !failed
+}
+
+// findWorkflow looks up a workflow definition by ID in the config.
+func (e *Engine) findWorkflow(id string) *config.WorkflowConfig {
+	for i := range e.cfg.Workflows {
+		if e.cfg.Workflows[i].ID == id {
+			return &e.cfg.Workflows[i]
+		}
+	}
+	return nil
+}

--- a/src/internal/workflow/subworkflow_test.go
+++ b/src/internal/workflow/subworkflow_test.go
@@ -1,0 +1,162 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// cfgWithWorkflows returns a config whose Workflows slice is populated so the
+// engine can resolve sub-workflow references.
+func cfgWithWorkflows(wfs ...config.WorkflowConfig) *config.Config {
+	c := baseCfg()
+	c.Workflows = wfs
+	return c
+}
+
+func TestSubWorkflow_ChildRunsAndLinks(t *testing.T) {
+	child := config.WorkflowConfig{ID: "standard-review", Steps: []config.StepConfig{
+		{ID: "review", Agent: "architect"},
+		{ID: "fix", Agent: "backend-dev", DependsOn: []string{"review"}},
+	}}
+	parent := config.WorkflowConfig{ID: "feature", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "review-phase", Type: config.StepTypeWorkflow, Workflow: "standard-review", DependsOn: []string{"implement"}},
+	}}
+
+	cfg := cfgWithWorkflows(child, parent)
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	parentID, success, _ := eng.RunInstance(context.Background(), parent, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+
+	// Child steps ran.
+	ids := executedIDs(exec.seen)
+	for _, want := range []string{"implement", "review", "fix"} {
+		if !contains(ids, want) {
+			t.Errorf("expected %q to run, got %v", want, ids)
+		}
+	}
+
+	// A child instance exists, linked to the parent.
+	var childInst *db.WorkflowInstance
+	for _, inst := range store.instances {
+		if inst.WorkflowID == "standard-review" {
+			childInst = inst
+		}
+	}
+	if childInst == nil {
+		t.Fatal("expected a child instance for standard-review")
+	}
+	if childInst.ParentInstanceID != parentID {
+		t.Errorf("child parent_instance_id = %q, want %q", childInst.ParentInstanceID, parentID)
+	}
+	if childInst.State != db.InstanceStateDone {
+		t.Errorf("child state = %q, want done", childInst.State)
+	}
+}
+
+func TestSubWorkflow_ChildFailureFailsParentStep(t *testing.T) {
+	child := config.WorkflowConfig{ID: "review", Steps: []config.StepConfig{
+		{ID: "check", Agent: "architect"},
+	}}
+	parent := config.WorkflowConfig{ID: "main", Steps: []config.StepConfig{
+		{ID: "sub", Type: config.StepTypeWorkflow, Workflow: "review"},
+		{ID: "after", Agent: "backend-dev", DependsOn: []string{"sub"}},
+	}}
+
+	cfg := cfgWithWorkflows(child, parent)
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"check": {Success: false}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected parent to fail when child fails")
+	}
+	// "after" depends on the failed sub-workflow step → must not run.
+	if contains(executedIDs(exec.seen), "after") {
+		t.Error("step after a failed sub-workflow should not run")
+	}
+}
+
+func TestSubWorkflow_UnknownReferenceFails(t *testing.T) {
+	parent := config.WorkflowConfig{ID: "main", Steps: []config.StepConfig{
+		{ID: "sub", Type: config.StepTypeWorkflow, Workflow: "ghost"},
+	}}
+	cfg := cfgWithWorkflows(parent)
+	store := newFakeStore()
+	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
+
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure for unknown sub-workflow reference")
+	}
+}
+
+func TestSubWorkflow_ParentMemorySeedsChild(t *testing.T) {
+	child := config.WorkflowConfig{ID: "child", Steps: []config.StepConfig{
+		{ID: "use", Agent: "architect"},
+	}}
+	parent := config.WorkflowConfig{ID: "parent", Steps: []config.StepConfig{
+		{
+			ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"complexity": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"complexity"}},
+		},
+		{ID: "delegate", Type: config.StepTypeWorkflow, Workflow: "child", DependsOn: []string{"plan"}},
+	}}
+
+	cfg := cfgWithWorkflows(child, parent)
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"plan": {Success: true, StructuredOutput: map[string]any{"complexity": "high"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+
+	// The child's "use" step should see the parent's memory (complexity: high).
+	var useMem string
+	for _, req := range exec.seen {
+		if req.Step.ID == "use" {
+			useMem = req.MemoryDoc
+		}
+	}
+	if !strings.Contains(useMem, "complexity: high") {
+		t.Errorf("child step should inherit parent memory, got:\n%s", useMem)
+	}
+}
+
+func TestSubWorkflow_NoNestingBeyondDepth(t *testing.T) {
+	// Build a child that itself contains a workflow step; runtime must refuse it
+	// (config validation also forbids this, but the engine guards independently).
+	grandchild := config.WorkflowConfig{ID: "gc", Steps: []config.StepConfig{{ID: "x", Agent: "architect"}}}
+	child := config.WorkflowConfig{ID: "child", Steps: []config.StepConfig{
+		{ID: "nested", Type: config.StepTypeWorkflow, Workflow: "gc"},
+	}}
+	parent := config.WorkflowConfig{ID: "parent", Steps: []config.StepConfig{
+		{ID: "sub", Type: config.StepTypeWorkflow, Workflow: "child"},
+	}}
+
+	cfg := cfgWithWorkflows(grandchild, child, parent)
+	store := newFakeStore()
+	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
+
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure: nesting beyond one level must be refused")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `type: workflow` step: delegates to another named workflow as a **chained child instance**. Closes the bulk of Phase 3 (full DAG: splits, loops, foreach, sub-workflows). Still behind the `experimental.workflow_mode` flag.

- **`subworkflow.go`**: the step runs the referenced workflow as a child instance, linked via `parent_instance_id` and **seeded with the parent's memory snapshot**. The parent step passes iff the child reaches `done`. The child's memory is **not** merged back (isolated pipelines). A runtime depth guard enforces the no-nesting rule (config validation already forbids it; max depth = 1).
- **DAG**: `runDAG` now propagates `seed` (inherited memory) and `depth`; `memSteps()` includes the seed before the local contributions. `findWorkflow` resolves in `cfg.Workflows`.
- **Per-step model (3.5)**: already came from PR-2b (resolved in `runStep`); test present, marked done.

## Test plan
- [x] `go test ./...` — green. `subworkflow_test.go`: the child runs and links to the parent (`parent_instance_id`, `done` state), a child failure fails the parent step (downstream skipped), a non-existent reference fails, the parent's memory seeds the child (`complexity: high` visible in the child's step), nesting beyond depth 1 refused.
- [x] Regression: the whole workflow suite (engine/DAG/expr/foreach) and daemon stay green.
- [x] `go vet` clean; `make build` ok.

## Important — 3.6 (remove the flag / default-on) is **NOT** in here
Turning workflow mode on by default would regress legacy `dispatch()` features the engine doesn't yet replicate: retry scheduling, the PR-review directive, the classifier's `assign_from_output`, and `task_executions` rows (dashboard). Parity is needed before default-on — left as follow-up work, documented in `tasks.md` §3.6.

## Deferred (already recorded)
- Parallel execution of independent steps + global `concurrency` cap.
- Validation of `branches[].if` syntax at load (needs an expr package without an import cycle).
- `outputs[i]` indexing of foreach in expressions.