### PR TITLE
feat: workflow-mode Phase 4a — approval steps (suspend/resume) + GitHub PollTask

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -149,21 +149,22 @@ Multi-step workflows, parallel steps, split steps, foreach, sub-workflows, per-s
 
 ## Phase 4 — Approvals
 
-Approval steps. Requires source-write-back polling (new `PollTask` on `SourceAdapter`).
+Approval steps that suspend a workflow instance until a human responds, driven by per-task polling. Built on the workflow engine (legacy path is not involved).
 
-### 4.1 Source Adapter Extension
+### 4.1 Source Adapter Extension — PR-4a
 
-- [ ] 4.1.1 Add `PollTask(ctx, cellID string) (Cell, error)` to `SourceAdapter` interface — see [source-adapter-watch spec](specs/source-adapter-watch/spec.md)
-- [ ] 4.1.2 Implement `PollTask` in Plane adapter
-- [ ] 4.1.3 Implement `PollTask` in GitHub Issues adapter
-- [ ] 4.1.4 Add stub `PollTask` (returns `ErrNotSupported`) to all other adapters
+- [x] 4.1.1 `TaskPoller` optional interface (`PollTask(ctx, cellID) (Cell, error)`) — modeled like `StateSetter`/`LabelAdder` so it doesn't break existing adapters; `model.Cell` gains `Comments []Comment`
+- [~] 4.1.2 Plane `PollTask` — deferred (GitHub covers the primary case; Plane is a focused follow-up)
+- [x] 4.1.3 GitHub Issues `PollTask`: fetches the issue + its comments (`get` client helper, `comment` type), compile-time `TaskPoller` assertion, httptest-backed tests
+- [x] 4.1.4 Sources without `TaskPoller` simply cannot host approvals — the engine poll func returns an error and the instance stays parked (no stub needed thanks to the optional-interface pattern)
 
-### 4.2 Approval Engine
+### 4.2 Approval Engine — PR-4a
 
-- [ ] 4.2.1 Implement approval step execution: post message via `WriteResult`, set instance to `approval_waiting`
-- [ ] 4.2.2 Implement approval polling loop in `WorkflowEngine`: on each poll cycle, call `PollTask` for all `approval_waiting` instances and evaluate `resume_on` / `abort_on` conditions
-- [ ] 4.2.3 Implement approval timeout: abort instance when `timeout` expires
-- [ ] 4.2.4 Unit tests: approval posts message, waits, resumes on matching comment, aborts on abort condition, aborts on timeout
+- [x] 4.2.1 Approval step suspends the run: posts the message, sets the instance to `approval_waiting`, parks the in-memory run (`enterApproval`; DAG refactored into `initDAG` + re-entrant `driveDAG`)
+- [x] 4.2.2 `CheckParkedApprovals(poll)` evaluates each parked instance against the live task (`EvaluateApproval`: `comment_contains`/`label_added`/`state_changed`, resume-wins-over-abort) and resumes/aborts; daemon drives it once per poll cycle via the source's `TaskPoller` against a single long-lived engine
+- [x] 4.2.3 Approval timeout: `CheckParkedApprovals` aborts the instance when `step.timeout` elapses
+- [x] 4.2.4 Unit tests: condition matrix, suspend, resume-continues, abort-fails, resolve-unknown errors, check-resumes-on-comment, check-times-out, check-waits-when-no-signal
+- [~] 4.2.5 Restart survival — parked runs are in-memory; on daemon restart they are reconciled to `interrupted`. DB-reconstruction resume across restarts is a follow-up (acceptable given the "reset and create new flows" direction)
 
 ### 4.3 Resume Command
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -29,6 +29,7 @@ import (
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
 	"github.com/orlandoburli/apiary/internal/version"
+	"github.com/orlandoburli/apiary/internal/workflow"
 )
 
 // sourceStat tracks per-source poll metadata.
@@ -77,6 +78,11 @@ type Dispatcher struct {
 
 	mu     sync.Mutex
 	runSeq int
+
+	// workflow engine (experimental.workflow_mode). Built once and long-lived so
+	// instances parked at approval steps survive across dispatch cycles.
+	engine     *workflow.Engine
+	engineOnce sync.Once
 }
 
 // New builds and connects a Dispatcher from the given config.
@@ -636,6 +642,12 @@ func (d *Dispatcher) pollLoop(ctx context.Context, sc config.SourceConfig, adapt
 }
 
 func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter source.Adapter, since time.Time) {
+	// Re-evaluate any workflows parked at approval steps against their live tasks
+	// on each poll cycle (resume/abort/timeout) before fetching new work.
+	if d.cfg.Settings.Experimental.WorkflowMode {
+		d.checkApprovals(ctx)
+	}
+
 	aplog.Debug("polling source %s (since %s)", sc.ID, since.Format(time.RFC3339))
 	cells, err := adapter.Poll(ctx, since)
 	if err != nil {

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -13,9 +13,20 @@ import (
 	"github.com/orlandoburli/apiary/internal/workflow"
 )
 
-// dispatchWorkflow runs a matched cell through the workflow engine instead of
-// the legacy single-shot path. In Phase 2 the route is synthesized into a
-// single-step workflow; multi-step workflow definitions arrive in Phase 3.
+// workflowEngine returns the dispatcher's long-lived workflow engine, building it
+// on first use. A single engine instance is essential so that workflows parked at
+// approval steps survive across dispatch and poll cycles.
+func (d *Dispatcher) workflowEngine() *workflow.Engine {
+	d.engineOnce.Do(func() {
+		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d},
+			workflow.WithSideEffects(&wfSideEffects{d: d}))
+	})
+	return d.engine
+}
+
+// dispatchWorkflow runs a matched cell through the workflow engine. The route is
+// matched to a defined workflow when one shares the route's id; otherwise the
+// route is synthesized into a single-step workflow.
 //
 // It is gated behind settings.experimental.workflow_mode and only reached when a
 // run-history DB is available (the engine persists instances and step runs).
@@ -25,19 +36,46 @@ func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.Cell, adap
 		return model.RunResult{Success: false}
 	}
 
-	wf := workflow.SynthesizeWorkflow(match.Route)
-
-	side := &wfSideEffects{adapter: adapter}
-	exec := &wfStepExecutor{d: d}
-	eng := workflow.NewEngine(d.cfg, d.db, exec, workflow.WithSideEffects(side))
-
-	instID, success, err := eng.RunInstance(ctx, wf, cell)
+	wf := d.resolveWorkflow(match)
+	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, cell)
 	if err != nil {
 		aplog.Error("cell %s: workflow run failed: %v", cell.ID, err)
 		return model.RunResult{Success: false, WorkerID: match.Route.Agent}
 	}
-	aplog.Info("cell %s: workflow instance %s finished success=%v", cell.ID, instID, success)
+	aplog.Info("cell %s: workflow instance %s started (success=%v; may be awaiting approval)", cell.ID, instID, success)
 	return model.RunResult{Success: success, WorkerID: match.Route.Agent}
+}
+
+// resolveWorkflow returns the workflow to run for a matched route: a workflow
+// whose id equals the route id (a full multi-step definition), or a synthesized
+// single-step workflow for a plain route.
+func (d *Dispatcher) resolveWorkflow(match router.Match) config.WorkflowConfig {
+	for i := range d.cfg.Workflows {
+		if d.cfg.Workflows[i].ID == match.Route.ID {
+			return d.cfg.Workflows[i]
+		}
+	}
+	return workflow.SynthesizeWorkflow(match.Route)
+}
+
+// checkApprovals drives the engine's parked-approval evaluation using each
+// source's TaskPoller. Called once per poll cycle. Sources that do not implement
+// TaskPoller cannot resolve approvals (the instance stays parked).
+func (d *Dispatcher) checkApprovals(ctx context.Context) {
+	if d.db == nil || d.engine == nil {
+		return
+	}
+	d.engine.CheckParkedApprovals(ctx, func(sourceID, cellID string) (model.Cell, error) {
+		adapter, ok := d.sources[sourceID]
+		if !ok {
+			return model.Cell{}, fmt.Errorf("source %q not found", sourceID)
+		}
+		poller, ok := adapter.(source.TaskPoller)
+		if !ok {
+			return model.Cell{}, fmt.Errorf("source %q does not support per-task polling (approvals)", sourceID)
+		}
+		return poller.PollTask(ctx, cellID)
+	})
 }
 
 // wfStepExecutor adapts the dispatcher's runner machinery to the workflow
@@ -105,30 +143,48 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 	}
 }
 
-// wfSideEffects applies source-facing actions for a workflow instance against
-// the cell's source adapter.
+// wfSideEffects applies source-facing actions for a workflow instance. It
+// resolves the adapter per cell (via the cell's SourceID) so a single long-lived
+// engine can serve cells from any configured source.
 type wfSideEffects struct {
-	adapter source.Adapter
+	d *Dispatcher
+}
+
+// adapterFor returns the source adapter that produced the cell, or nil.
+func (s *wfSideEffects) adapterFor(cell model.Cell) source.Adapter {
+	return s.d.sources[cell.SourceID]
 }
 
 func (s *wfSideEffects) StateLock(ctx context.Context, cell model.Cell) error {
-	return s.adapter.Acknowledge(ctx, cell, model.AckActionInProgress)
+	adapter := s.adapterFor(cell)
+	if adapter == nil {
+		return fmt.Errorf("no adapter for source %q", cell.SourceID)
+	}
+	return adapter.Acknowledge(ctx, cell, model.AckActionInProgress)
 }
 
 func (s *wfSideEffects) PostComment(ctx context.Context, cell model.Cell, comment string) error {
-	return s.adapter.WriteResult(ctx, cell, model.RunResult{Success: true, Output: comment})
+	adapter := s.adapterFor(cell)
+	if adapter == nil {
+		return fmt.Errorf("no adapter for source %q", cell.SourceID)
+	}
+	return adapter.WriteResult(ctx, cell, model.RunResult{Success: true, Output: comment})
 }
 
 func (s *wfSideEffects) ApplyHook(ctx context.Context, cell model.Cell, hook config.OnComplete) error {
+	adapter := s.adapterFor(cell)
+	if adapter == nil {
+		return fmt.Errorf("no adapter for source %q", cell.SourceID)
+	}
 	if len(hook.AddLabels) > 0 {
-		if la, ok := s.adapter.(source.LabelAdder); ok {
+		if la, ok := adapter.(source.LabelAdder); ok {
 			if err := la.AddLabels(ctx, cell, hook.AddLabels); err != nil {
 				aplog.Error("cell %s: add labels %v: %v", cell.ID, hook.AddLabels, err)
 			}
 		}
 	}
 	if hook.SetState != "" {
-		if ss, ok := s.adapter.(source.StateSetter); ok {
+		if ss, ok := adapter.(source.StateSetter); ok {
 			if err := ss.SetState(ctx, cell, hook.SetState); err != nil {
 				aplog.Error("cell %s: set_state %q: %v", cell.ID, hook.SetState, err)
 			}

--- a/src/internal/model/cell.go
+++ b/src/internal/model/cell.go
@@ -17,6 +17,18 @@ type Cell struct {
 	Metadata    map[string]any
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// Comments is populated only by a TaskPoller (per-task fetch used for
+	// approval steps), not by Poll. It holds comments relevant to evaluating an
+	// approval condition.
+	Comments []Comment
+}
+
+// Comment is a single comment on a source task, used to evaluate approval-step
+// resume/abort conditions (comment_contains).
+type Comment struct {
+	ID        string
+	Body      string
+	CreatedAt time.Time
 }
 
 type AckAction string

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +17,14 @@ import (
 func init() {
 	source.Register("github", func() source.Adapter { return &Adapter{} })
 }
+
+// Compile-time checks: the GitHub adapter supports the optional source
+// capabilities used by the dispatcher and the workflow engine.
+var (
+	_ source.StateSetter = (*Adapter)(nil)
+	_ source.LabelAdder  = (*Adapter)(nil)
+	_ source.TaskPoller  = (*Adapter)(nil)
+)
 
 type Adapter struct {
 	id         string
@@ -150,6 +159,49 @@ func (a *Adapter) WriteResult(ctx context.Context, cell model.Cell, result model
 }
 
 func (a *Adapter) WebhookHandler() http.Handler { return nil }
+
+// PollTask fetches the current state of a single issue plus its comments, for
+// the workflow engine to evaluate approval-step conditions. Implements
+// source.TaskPoller.
+func (a *Adapter) PollTask(ctx context.Context, cellID string) (model.Cell, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return model.Cell{}, fmt.Errorf("github: poll task %s: %w", cellID, err)
+	}
+	var item issue
+	if err := json.Unmarshal(body, &item); err != nil {
+		return model.Cell{}, fmt.Errorf("github: decoding issue %s: %w", cellID, err)
+	}
+
+	cell := a.toCell(item)
+	comments, err := a.fetchComments(ctx, cellID)
+	if err != nil {
+		aplog.Debug("github: fetch comments for %s: %v", cellID, err)
+	} else {
+		cell.Comments = comments
+	}
+	return cell, nil
+}
+
+// fetchComments retrieves an issue's comments as model.Comment values.
+func (a *Adapter) fetchComments(ctx context.Context, issueNo string) ([]model.Comment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", a.owner, a.repo, issueNo)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	var raw []comment
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("github: decoding comments for %s: %w", issueNo, err)
+	}
+	out := make([]model.Comment, 0, len(raw))
+	for _, c := range raw {
+		created, _ := time.Parse(time.RFC3339, c.CreatedAt)
+		out = append(out, model.Comment{ID: fmt.Sprintf("%d", c.ID), Body: c.Body, CreatedAt: created})
+	}
+	return out, nil
+}
 
 func (a *Adapter) SetState(ctx context.Context, cell model.Cell, stateName string) error {
 	issueNo := cell.ID

--- a/src/internal/source/github/client.go
+++ b/src/internal/source/github/client.go
@@ -79,6 +79,14 @@ func (c *client) do(ctx context.Context, req *http.Request) ([]byte, error) {
 	return body, nil
 }
 
+func (c *client) get(ctx context.Context, path string) ([]byte, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
 func (c *client) patch(ctx context.Context, path string, payload any) ([]byte, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/src/internal/source/github/polltask_test.go
+++ b/src/internal/source/github/polltask_test.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPollTask_FetchesIssueAndComments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/issues/42/comments"):
+			_, _ = w.Write([]byte(`[
+				{"id": 1, "body": "needs work", "created_at": "2025-01-01T10:00:00Z"},
+				{"id": 2, "body": "looks good, approve", "created_at": "2025-01-02T10:00:00Z"}
+			]`))
+		case strings.HasSuffix(r.URL.Path, "/issues/42"):
+			_, _ = w.Write([]byte(`{
+				"number": 42, "title": "Add auth", "state": "open",
+				"labels": [{"id": 1, "name": "feature"}],
+				"html_url": "https://github.com/o/r/issues/42",
+				"created_at": "2025-01-01T09:00:00Z", "updated_at": "2025-01-02T11:00:00Z"
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+
+	cell, err := a.PollTask(context.Background(), "42")
+	if err != nil {
+		t.Fatalf("PollTask: %v", err)
+	}
+	if cell.ID != "42" || cell.Title != "Add auth" || cell.State != "open" {
+		t.Errorf("issue fields wrong: %+v", cell)
+	}
+	if len(cell.Comments) != 2 {
+		t.Fatalf("expected 2 comments, got %d", len(cell.Comments))
+	}
+	if cell.Comments[1].Body != "looks good, approve" {
+		t.Errorf("comment body wrong: %q", cell.Comments[1].Body)
+	}
+	if cell.Comments[0].CreatedAt.IsZero() {
+		t.Error("comment created_at not parsed")
+	}
+}
+
+func TestPollTask_IssueErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	if _, err := a.PollTask(context.Background(), "999"); err == nil {
+		t.Error("expected error when issue fetch fails")
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -1,16 +1,16 @@
 package github
 
 type issue struct {
-	Number    int        `json:"number"`
-	Title     string     `json:"title"`
-	Body      string     `json:"body"`
-	State     string     `json:"state"`
-	Labels    []label    `json:"labels"`
-	HTMLURL   string     `json:"html_url"`
-	CreatedAt string     `json:"created_at"`
-	UpdatedAt string     `json:"updated_at"`
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	Body        string    `json:"body"`
+	State       string    `json:"state"`
+	Labels      []label   `json:"labels"`
+	HTMLURL     string    `json:"html_url"`
+	CreatedAt   string    `json:"created_at"`
+	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
-	User      user       `json:"user"`
+	User        user      `json:"user"`
 }
 
 type user struct {
@@ -29,6 +29,13 @@ type issueRequest struct {
 
 type commentRequest struct {
 	Body string `json:"body"`
+}
+
+// comment is a GitHub issue comment, fetched by PollTask for approval steps.
+type comment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
 type labelListRequest struct {

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -50,6 +50,14 @@ type LabelAdder interface {
 	AddLabels(ctx context.Context, cell model.Cell, labels []string) error
 }
 
+// TaskPoller is an optional interface that sources may implement to fetch the
+// current state of a single task by ID, including its comments. The workflow
+// engine uses it to evaluate approval-step resume/abort conditions against the
+// live task. Sources that do not implement it cannot host approval steps.
+type TaskPoller interface {
+	PollTask(ctx context.Context, cellID string) (model.Cell, error)
+}
+
 // Factory creates a new, unconfigured Adapter instance.
 type Factory func() Adapter
 

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -1,0 +1,147 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// ApprovalDecision is the result of evaluating an approval step's conditions
+// against the live task.
+type ApprovalDecision int
+
+const (
+	// ApprovalWait means neither resume nor abort conditions matched yet.
+	ApprovalWait ApprovalDecision = iota
+	// ApprovalResume means a resume_on condition matched — continue the workflow.
+	ApprovalResume
+	// ApprovalAbort means an abort_on condition matched — fail the workflow.
+	ApprovalAbort
+)
+
+// EvaluateApproval decides whether an approval step should resume, abort, or keep
+// waiting, given the live task. resume_on takes precedence over abort_on when
+// both would match (an explicit approval wins).
+func EvaluateApproval(step config.StepConfig, cell model.Cell) ApprovalDecision {
+	if step.ResumeOn != nil && matchApprovalTrigger(*step.ResumeOn, cell) {
+		return ApprovalResume
+	}
+	if step.AbortOn != nil && matchApprovalTrigger(*step.AbortOn, cell) {
+		return ApprovalAbort
+	}
+	return ApprovalWait
+}
+
+// matchApprovalTrigger reports whether any populated field of the trigger matches
+// the cell (OR semantics across fields).
+func matchApprovalTrigger(t config.ApprovalTrigger, cell model.Cell) bool {
+	if t.CommentContains != "" && commentContains(cell, t.CommentContains) {
+		return true
+	}
+	if t.LabelAdded != "" && labelPresent(cell, t.LabelAdded) {
+		return true
+	}
+	if t.StateChanged != "" && strings.EqualFold(cell.State, t.StateChanged) {
+		return true
+	}
+	return false
+}
+
+// commentContains reports whether any comment body contains the substring
+// (case-insensitive).
+func commentContains(cell model.Cell, sub string) bool {
+	needle := strings.ToLower(sub)
+	for _, c := range cell.Comments {
+		if strings.Contains(strings.ToLower(c.Body), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// labelPresent reports whether the cell carries the label (case-insensitive).
+func labelPresent(cell model.Cell, label string) bool {
+	for _, l := range cell.Labels {
+		if strings.EqualFold(l, label) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParkedApproval describes an instance suspended at an approval step.
+type ParkedApproval struct {
+	InstanceID string
+	Cell       model.Cell
+	Step       config.StepConfig // the waiting approval step (resume_on/abort_on/timeout)
+	ParkedAt   time.Time
+}
+
+// ParkedApprovals returns a snapshot of all instances currently awaiting approval.
+func (e *Engine) ParkedApprovals() []ParkedApproval {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]ParkedApproval, 0, len(e.parked))
+	for id, r := range e.parked {
+		out = append(out, ParkedApproval{
+			InstanceID: id,
+			Cell:       r.cell,
+			Step:       r.byID[r.waitingStep],
+			ParkedAt:   r.parkedAt,
+		})
+	}
+	return out
+}
+
+// ResolveApproval resumes (or aborts) a parked instance and drives it to its next
+// terminal or suspended state. Returns whether the instance then completed
+// successfully. It errors if the instance is not currently awaiting approval.
+func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decision ApprovalDecision) (bool, error) {
+	e.mu.Lock()
+	r, ok := e.parked[instanceID]
+	if ok {
+		delete(e.parked, instanceID)
+	}
+	e.mu.Unlock()
+	if !ok {
+		return false, fmt.Errorf("instance %q is not awaiting approval", instanceID)
+	}
+
+	r.resolveApproval(decision)
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
+	outcome := e.driveDAG(ctx, r)
+	return e.settle(ctx, r, outcome), nil
+}
+
+// CheckParkedApprovals evaluates every parked instance against its live task
+// (fetched via poll) and resumes, aborts, or times it out as conditions dictate.
+// poll returns the current Cell for a (sourceID, cellID); when poll errors the
+// instance is left parked for the next cycle.
+func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, cellID string) (model.Cell, error)) {
+	for _, p := range e.ParkedApprovals() {
+		if to := p.Step.ParsedTimeout(); to > 0 && e.now().Sub(p.ParkedAt) >= to {
+			aplog.Info("workflow: approval on instance %s timed out after %s — aborting", p.InstanceID, to)
+			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
+			continue
+		}
+		cell, err := poll(p.Cell.SourceID, p.Cell.ID)
+		if err != nil {
+			aplog.Debug("workflow: poll task %s for approval check failed: %v", p.Cell.ID, err)
+			continue
+		}
+		switch EvaluateApproval(p.Step, cell) {
+		case ApprovalResume:
+			aplog.Info("workflow: approval on instance %s resumed", p.InstanceID)
+			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalResume)
+		case ApprovalAbort:
+			aplog.Info("workflow: approval on instance %s aborted by condition", p.InstanceID)
+			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
+		}
+	}
+}

--- a/src/internal/workflow/approval_test.go
+++ b/src/internal/workflow/approval_test.go
@@ -1,0 +1,207 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestEvaluateApproval_Conditions(t *testing.T) {
+	step := config.StepConfig{
+		Type:     config.StepTypeApproval,
+		ResumeOn: &config.ApprovalTrigger{CommentContains: "approve", LabelAdded: "approved"},
+		AbortOn:  &config.ApprovalTrigger{CommentContains: "reject", StateChanged: "cancelled"},
+	}
+
+	cases := []struct {
+		name string
+		cell model.Cell
+		want ApprovalDecision
+	}{
+		{"no signal", model.Cell{}, ApprovalWait},
+		{"resume by comment", model.Cell{Comments: []model.Comment{{Body: "looks good, APPROVE"}}}, ApprovalResume},
+		{"resume by label", model.Cell{Labels: []string{"approved"}}, ApprovalResume},
+		{"abort by comment", model.Cell{Comments: []model.Comment{{Body: "please reject this"}}}, ApprovalAbort},
+		{"abort by state", model.Cell{State: "cancelled"}, ApprovalAbort},
+		{"resume wins over abort", model.Cell{Comments: []model.Comment{{Body: "approve"}, {Body: "reject"}}}, ApprovalResume},
+		{"unrelated comment waits", model.Cell{Comments: []model.Comment{{Body: "what about tests?"}}}, ApprovalWait},
+	}
+	for _, c := range cases {
+		if got := EvaluateApproval(step, c.cell); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// approvalWorkflow: plan → approval → implement.
+func approvalWorkflow() config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "feature", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect"},
+		{ID: "gate", Type: config.StepTypeApproval, DependsOn: []string{"plan"},
+			Message:  "Plan ready. Reply approve or reject.",
+			ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"},
+			AbortOn:  &config.ApprovalTrigger{CommentContains: "reject"},
+			Timeout:  "48h"},
+		{ID: "implement", Agent: "backend-dev", DependsOn: []string{"gate"}},
+	}}
+}
+
+func TestApproval_SuspendsAtApprovalStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	instID, success, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("a parked instance should not report success")
+	}
+	// Instance is parked in approval_waiting.
+	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+		t.Errorf("instance state = %q, want approval_waiting", store.instances[instID].State)
+	}
+	// The approval message was posted.
+	if len(side.comments) != 1 || side.comments[0] != "Plan ready. Reply approve or reject." {
+		t.Errorf("expected approval message posted, got %v", side.comments)
+	}
+	// "implement" must not have run yet; "plan" did.
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "plan") || contains(ids, "implement") {
+		t.Errorf("unexpected execution before approval: %v", ids)
+	}
+	// It shows up as a parked approval.
+	parked := eng.ParkedApprovals()
+	if len(parked) != 1 || parked[0].InstanceID != instID || parked[0].Step.ID != "gate" {
+		t.Fatalf("expected one parked approval for gate, got %+v", parked)
+	}
+}
+
+func TestApproval_ResumeContinuesWorkflow(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1"})
+
+	success, err := eng.ResolveApproval(context.Background(), instID, ApprovalResume)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success after resume")
+	}
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec.seen), "implement") {
+		t.Error("implement should run after approval resumed")
+	}
+	// No longer parked.
+	if len(eng.ParkedApprovals()) != 0 {
+		t.Error("instance should no longer be parked")
+	}
+}
+
+func TestApproval_AbortFailsWorkflow(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1"})
+
+	success, _ := eng.ResolveApproval(context.Background(), instID, ApprovalAbort)
+	if success {
+		t.Fatal("expected failure after abort")
+	}
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+	if contains(executedIDs(exec.seen), "implement") {
+		t.Error("implement must not run after abort")
+	}
+}
+
+func TestApproval_ResolveUnknownInstanceErrors(t *testing.T) {
+	eng := testEngine(baseCfg(), newFakeStore(), &fakeExecutor{}, &fakeSide{})
+	if _, err := eng.ResolveApproval(context.Background(), "ghost", ApprovalResume); err == nil {
+		t.Error("expected error resolving an unparked instance")
+	}
+}
+
+func TestApproval_CheckResumesOnComment(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1", SourceID: "s1"})
+
+	// Poll returns a cell with an approving comment.
+	poll := func(sourceID, cellID string) (model.Cell, error) {
+		return model.Cell{ID: cellID, SourceID: sourceID,
+			Comments: []model.Comment{{Body: "approve please"}}}, nil
+	}
+	eng.CheckParkedApprovals(context.Background(), poll)
+
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected done after check resumed it, got %q", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec.seen), "implement") {
+		t.Error("implement should have run after the check resumed the approval")
+	}
+}
+
+func TestApproval_CheckTimesOut(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+
+	// Controllable clock: park at t0, then advance well past the 48h timeout.
+	clock := time.Unix(0, 0)
+	eng := NewEngine(cfg, store, exec,
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return clock }),
+		WithIDGen(func(p string) string { return p + "-1" }),
+	)
+
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1", SourceID: "s1"})
+
+	// Advance clock past 48h; poll returns nothing actionable.
+	clock = time.Unix(0, 0).Add(49 * time.Hour)
+	noSignal := func(sourceID, cellID string) (model.Cell, error) {
+		return model.Cell{ID: cellID}, nil
+	}
+	eng.CheckParkedApprovals(context.Background(), noSignal)
+
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed after timeout, got %q", store.instances[instID].State)
+	}
+}
+
+func TestApproval_CheckWaitsWhenNoSignal(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
+
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.Cell{ID: "c1", SourceID: "s1"})
+
+	poll := func(sourceID, cellID string) (model.Cell, error) {
+		return model.Cell{ID: cellID, Comments: []model.Comment{{Body: "still thinking"}}}, nil
+	}
+	eng.CheckParkedApprovals(context.Background(), poll)
+
+	// Still parked, still approval_waiting.
+	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+		t.Errorf("expected still approval_waiting, got %q", store.instances[instID].State)
+	}
+	if len(eng.ParkedApprovals()) != 1 {
+		t.Error("instance should remain parked")
+	}
+}

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"time"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
 
@@ -15,6 +16,16 @@ const (
 	stPassed  = "passed"
 	stFailed  = "failed"
 	stSkipped = "skipped"
+	stWaiting = "waiting" // an approval step parked awaiting a human response
+)
+
+// dagOutcome is the terminal (or suspended) result of driving a DAG run.
+type dagOutcome int
+
+const (
+	outcomeDone dagOutcome = iota
+	outcomeFailed
+	outcomeWaiting // suspended at an approval step
 )
 
 // dagRun holds the mutable state of one workflow instance's step graph as the
@@ -37,14 +48,14 @@ type dagRun struct {
 	stepStates  map[string]StepState  // terminal states for expression context
 	contrib     map[string]MemoryStep // memory contribution per passed step
 	passedOrder []string              // step ids in the order they passed
+
+	waitingStep string    // id of the approval step currently parked, if any
+	parkedAt    time.Time // when the current approval parked (for timeout)
 }
 
-// runDAG executes the workflow's step graph and returns whether the instance
-// failed along with the final memory contributions (for the completion comment).
-// It is the Phase 3 replacement for the sequential loop: it honors depends_on
-// ordering, split routing, on_fail.goto loops, and skip propagation. seed is the
-// inherited memory for a sub-workflow child; depth tracks nesting.
-func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.Cell, seed []MemoryStep, depth int) (bool, []MemoryStep) {
+// initDAG builds the in-memory state for a workflow instance's step graph. seed
+// is inherited memory for a sub-workflow child; depth tracks nesting.
+func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, cell model.Cell, seed []MemoryStep, depth int) *dagRun {
 	r := &dagRun{
 		instID:      instID,
 		wf:          wf,
@@ -81,7 +92,13 @@ func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowCo
 			r.activated[id] = true
 		}
 	}
+	return r
+}
 
+// driveDAG runs the scheduler until the graph completes, fails, or suspends at
+// an approval step. It honors depends_on ordering, split routing, on_fail.goto
+// loops, and skip propagation, and may be re-entered after an approval resolves.
+func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 	for {
 		next := r.pickRunnable()
 		if next == "" {
@@ -90,18 +107,49 @@ func (e *Engine) runDAG(ctx context.Context, instID string, wf config.WorkflowCo
 			}
 			break // nothing else can run
 		}
+		step := r.byID[next]
+		if step.StepType() == config.StepTypeApproval {
+			e.enterApproval(ctx, r, step)
+			return outcomeWaiting
+		}
 		if failed := e.runDAGStep(ctx, r, next); failed {
-			return true, r.memSteps()
+			return outcomeFailed
 		}
 	}
 
 	// The instance fails if any step ended failed.
 	for _, id := range r.order {
 		if r.state[id] == stFailed {
-			return true, r.memSteps()
+			return outcomeFailed
 		}
 	}
-	return false, r.memSteps()
+	return outcomeDone
+}
+
+// enterApproval parks the run at an approval step: it posts the step message to
+// the task and records the waiting step. The polling loop later resumes or
+// aborts it via the engine's approval handling.
+func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepConfig) {
+	if e.side != nil && step.Message != "" {
+		_ = e.side.PostComment(ctx, r.cell, step.Message)
+	}
+	r.state[step.ID] = stWaiting
+	r.waitingStep = step.ID
+	r.parkedAt = e.now()
+	aplog.Info("workflow %s: instance %s parked at approval step %q", r.wf.ID, r.instID, step.ID)
+}
+
+// resolveApproval applies an approval decision to the parked step so the run can
+// continue: a resume marks it passed, an abort marks it failed.
+func (r *dagRun) resolveApproval(decision ApprovalDecision) {
+	step := r.waitingStep
+	r.waitingStep = ""
+	if decision == ApprovalResume {
+		r.state[step] = stPassed
+		r.stepStates[step] = StepState{State: stPassed}
+	} else {
+		r.state[step] = stFailed
+	}
 }
 
 // pickRunnable returns the next runnable step id (activated, pending, all

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -72,6 +73,9 @@ type Engine struct {
 
 	now   func() time.Time
 	newID func(prefix string) string
+
+	mu     sync.Mutex         // guards parked
+	parked map[string]*dagRun // instances suspended at an approval step, by id
 }
 
 // Option customizes an Engine.
@@ -92,10 +96,11 @@ func WithMemoryBuilder(b MemoryBuilder) Option { return func(e *Engine) { e.mem 
 // NewEngine builds an Engine. cfg, store, and exec are required.
 func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {
 	e := &Engine{
-		cfg:   cfg,
-		store: store,
-		exec:  exec,
-		now:   time.Now,
+		cfg:    cfg,
+		store:  store,
+		exec:   exec,
+		now:    time.Now,
+		parked: map[string]*dagRun{},
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -106,9 +111,11 @@ func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Optio
 	return e
 }
 
-// RunInstance executes a workflow for a cell from start to finish. It returns the
-// created instance ID and whether the instance completed successfully. Errors
-// creating the instance are returned; per-step failures are recorded and
+// RunInstance executes a workflow for a cell. It returns the created instance ID
+// and whether the instance completed successfully. An instance that suspends at
+// an approval step returns success=false with no error — it is parked in state
+// approval_waiting until ResolveApproval (driven by the polling loop) resumes it.
+// Errors creating the instance are returned; per-step failures are recorded and
 // reflected in the final instance state and the success flag, not returned.
 func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell model.Cell) (instanceID string, success bool, err error) {
 	instID := e.newID("wf")
@@ -129,18 +136,34 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell
 		_ = e.side.StateLock(ctx, cell)
 	}
 
-	// Execute the step graph: depends_on ordering, split routing, on_fail.goto
-	// loops, and skip propagation are all handled by the DAG scheduler.
-	failed, memSteps := e.runDAG(ctx, instID, wf, cell, nil, 0)
+	r := e.initDAG(instID, wf, cell, nil, 0)
+	outcome := e.driveDAG(ctx, r)
+	return instID, e.settle(ctx, r, outcome), nil
+}
 
+// settle persists the terminal state of a run and applies completion hooks, or
+// parks the run when it suspended at an approval step. It returns whether the
+// instance completed successfully (false for failed or waiting).
+func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool {
+	if outcome == outcomeWaiting {
+		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, db.InstanceStateApprovalWaiting)
+		e.mu.Lock()
+		e.parked[r.instID] = r
+		e.mu.Unlock()
+		return false
+	}
+
+	failed := outcome == outcomeFailed
 	finalState := db.InstanceStateDone
 	if failed {
 		finalState = db.InstanceStateFailed
 	}
-	_ = e.store.UpdateWorkflowInstanceState(ctx, instID, finalState)
-
-	e.applyCompletion(ctx, wf, cell, failed, memSteps)
-	return instID, !failed, nil
+	_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, finalState)
+	e.mu.Lock()
+	delete(e.parked, r.instID)
+	e.mu.Unlock()
+	e.applyCompletion(ctx, r.wf, r.cell, failed, r.memSteps())
+	return !failed
 }
 
 // runStep executes one agent step, persisting its step run, and returns the result.

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -71,14 +71,22 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 		return "", false
 	}
 
-	failed, _ := e.runDAG(ctx, childID, child, cell, seed, depth)
+	r := e.initDAG(childID, child, cell, seed, depth)
+	outcome := e.driveDAG(ctx, r)
+	// A sub-workflow cannot park independently in Phase 4: an approval step inside
+	// a child is treated as a failure (unsupported). Top-level approvals are the
+	// supported case.
+	if outcome == outcomeWaiting {
+		aplog.Error("sub-workflow %s: approval steps inside a sub-workflow are not supported", child.ID)
+		outcome = outcomeFailed
+	}
 
 	finalState := db.InstanceStateDone
-	if failed {
+	if outcome == outcomeFailed {
 		finalState = db.InstanceStateFailed
 	}
 	_ = e.store.UpdateWorkflowInstanceState(ctx, childID, finalState)
-	return childID, !failed
+	return childID, outcome == outcomeDone
 }
 
 // findWorkflow looks up a workflow definition by ID in the config.


### PR DESCRIPTION
## Summary

Implements **approval steps**: a `type: approval` suspends the workflow instance until a human responds on the task. Built on the engine (without involving the legacy path). Still behind `experimental.workflow_mode`.

### Engine — suspend/resume
- DAG refactored into `initDAG` (builds state) + `driveDAG` **reentrant** (loop); `outcome` gains `waiting`.
- On reaching an `approval`, `enterApproval` posts the message, marks the instance `approval_waiting` and **parks the run in memory**.
- `EvaluateApproval` (pure): `comment_contains` / `label_added` / `state_changed`, with **resume beating abort**.
- `CheckParkedApprovals(poll)` re-evaluates each parked instance against the live task and **resumes / aborts / expires** (timeout). `ResolveApproval` resumes and drives to the next terminal/suspended state. `ParkedApprovals` lists the parked ones.

### Source
- `model.Cell` gains `Comments []Comment`.
- `source.TaskPoller` — an **optional** interface (`StateSetter`/`LabelAdder` style), so it doesn't break existing adapters: `PollTask(ctx, cellID) (Cell, error)`.
- The **GitHub adapter** implements `PollTask` (issue + comments; `get` helper on the client; `comment` type); compile-time assertions; `httptest` tests.

### Daemon
- A **single, long-lived** engine (`engineOnce`) — essential so that parks survive across poll cycles. `wfSideEffects` resolves the adapter by `cell.SourceID`. `checkApprovals` runs once per poll cycle, using the source's `TaskPoller`. `dispatchWorkflow` resolves the real workflow by route id, or synthesizes a single-step one.

## Test plan
- [x] `go test ./...` — green. `approval_test.go`: condition matrix, suspends at the approval, resume continues the flow, abort fails, resolving an unknown instance errors, check resume by comment, check timeout, check wait with no signal. `polltask_test.go`: GitHub fetches the issue + comments and propagates the error.
- [x] Regression: the whole workflow/daemon/source suite green.
- [x] `go vet` clean; `make build` ok. (dispatcher.go: only 3 real additions — import, engine fields, the checkApprovals call; no gofmt churn.)

## Deferred
- Restart survival of parks (in memory → `interrupted` on restart); reconstruction via the DB is a follow-up.
- Plane `PollTask` (GitHub covers the primary case).
- CLI `apiary instances`/`resume` (4.3) and TUI (4.4) — next.