### PR TITLE
feat(workflow): apiary instances command (list + detail)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (860 symbols, 1697 relationships, 52 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3601 symbols, 7677 relationships, 240 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -33,7 +33,6 @@ This project is indexed by GitNexus as **apiary** (860 symbols, 1697 relationshi
 
 | Task | Read this skill file |
 |------|---------------------|
-| Configure / use Apiary (runners, sources, routes) | `.claude/skills/apiary-guide/SKILL.md` |
 | Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
 | Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
 | Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (860 symbols, 1697 relationships, 52 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3601 symbols, 7677 relationships, 240 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -168,9 +168,9 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 ### 4.3 Resume Command
 
-- [ ] 4.3.1 Implement `apiary resume <instance-id>` CLI command — see [CLI spec](../../specs/cli/spec.md)
-- [ ] 4.3.2 Implement `apiary instances` CLI command
-- [ ] 4.3.3 Show resume confirmation prompt listing skipped steps and their side effects
+- [ ] 4.3.1 Implement `apiary resume <instance-id>` CLI command — see [CLI spec](../../specs/cli/spec.md) (PR-4c)
+- [x] 4.3.2 Implement `apiary instances` CLI command — list (filters: `--workflow`/`--state`/`--limit`/`--json`) and `apiary instances <id>` step-level detail, served by daemon IPC (`GET /instances`, `GET /instances/{id}`) reading `workflow_instances` + `step_runs` (PR-4b)
+- [ ] 4.3.3 Show resume confirmation prompt listing skipped steps and their side effects (PR-4c)
 
 ### 4.4 TUI Updates
 

--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+var (
+	instHeader = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#DDDDDD"))
+	instMuted  = lipgloss.NewStyle().Foreground(lipgloss.Color("#626262"))
+	instOK     = lipgloss.NewStyle().Foreground(lipgloss.Color("#04B575"))
+	instWarn   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F5A623"))
+	instErr    = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5F87"))
+)
+
+func newInstancesCmd() *cobra.Command {
+	var (
+		workflow string
+		state    string
+		limit    int
+		asJSON   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "instances [instance-id]",
+		Short: "List workflow instances or show one in detail",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				return showInstance(args[0], asJSON)
+			}
+			return listInstances(workflow, state, limit, asJSON)
+		},
+	}
+
+	cmd.Flags().StringVar(&workflow, "workflow", "", "filter by workflow id")
+	cmd.Flags().StringVar(&state, "state", "", "filter by state (pending, running, approval_waiting, interrupted, done, failed)")
+	cmd.Flags().IntVar(&limit, "limit", 20, "max rows")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+func listInstances(workflow, state string, limit int, asJSON bool) error {
+	q := url.Values{}
+	if workflow != "" {
+		q.Set("workflow", workflow)
+	}
+	if state != "" {
+		q.Set("state", state)
+	}
+	q.Set("limit", fmt.Sprintf("%d", limit))
+
+	var resp daemon.InstancesResponse
+	if err := ipcGetJSON("/instances?"+q.Encode(), &resp); err != nil {
+		return daemonDownHint()
+	}
+
+	if asJSON {
+		for _, in := range resp.Instances {
+			line, _ := json.Marshal(in)
+			fmt.Println(string(line))
+		}
+		return nil
+	}
+
+	if len(resp.Instances) == 0 {
+		fmt.Println(instMuted.Render("No workflow instances yet."))
+		return nil
+	}
+
+	fmt.Println(instHeader.Render(fmt.Sprintf("%-26s  %-22s  %-12s  %-18s  %-13s  %s",
+		"ID", "WORKFLOW", "CELL", "STATE", "STARTED", "DURATION")))
+	for _, in := range resp.Instances {
+		fmt.Printf("%-26s  %-22s  %-12s  %s  %-13s  %s\n",
+			in.ID,
+			truncate(in.Workflow, 22),
+			truncate(in.CellID, 12),
+			stateCell(in.State, 18),
+			in.Started,
+			in.Duration,
+		)
+	}
+	return nil
+}
+
+func showInstance(id string, asJSON bool) error {
+	var detail daemon.InstanceDetail
+	if err := ipcGetJSON("/instances/"+url.PathEscape(id), &detail); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			fmt.Println(instErr.Render("Instance not found: ") + id)
+			os.Exit(2)
+		}
+		return daemonDownHint()
+	}
+
+	if asJSON {
+		line, _ := json.MarshalIndent(detail, "", "  ")
+		fmt.Println(string(line))
+		return nil
+	}
+
+	cell := detail.CellID
+	if detail.Title != "" {
+		cell += " — " + detail.Title
+	}
+	fmt.Printf("%s  %s\n", instMuted.Render("Instance:"), detail.ID)
+	fmt.Printf("%s  %s\n", instMuted.Render("Workflow:"), detail.Workflow)
+	fmt.Printf("%s      %s\n", instMuted.Render("Cell:"), cell)
+	fmt.Printf("%s     %s\n", instMuted.Render("State:"), stateGlyph(detail.State)+" "+detail.State)
+	fmt.Printf("%s   %s\n\n", instMuted.Render("Started:"), detail.Started)
+
+	if len(detail.Steps) == 0 {
+		fmt.Println(instMuted.Render("No steps recorded."))
+		return nil
+	}
+	fmt.Println(instHeader.Render("Steps"))
+	for _, s := range detail.Steps {
+		state := s.State
+		if s.Cached {
+			state += " (cached)"
+		}
+		fmt.Printf("  %s  %-14s  %-16s  %-8s  %s\n",
+			stepGlyph(s.State),
+			truncate(s.StepID, 14),
+			truncate(s.AgentID, 16),
+			s.Duration,
+			stateColor(s.State).Render(state),
+		)
+	}
+	return nil
+}
+
+// stateCell renders a state column, color-coded and padded to width.
+func stateCell(state string, width int) string {
+	pad := width - len(state)
+	if pad < 0 {
+		pad = 0
+	}
+	return stateColor(state).Render(state) + strings.Repeat(" ", pad)
+}
+
+func stateColor(state string) lipgloss.Style {
+	switch state {
+	case "passed", "done":
+		return instOK
+	case "failed":
+		return instErr
+	case "running", "approval_waiting":
+		return instWarn
+	default:
+		return instMuted
+	}
+}
+
+func stateGlyph(state string) string {
+	switch state {
+	case "done":
+		return instOK.Render("✓")
+	case "failed":
+		return instErr.Render("✗")
+	case "running":
+		return instWarn.Render("●")
+	case "approval_waiting":
+		return instWarn.Render("⏸")
+	default:
+		return instMuted.Render("○")
+	}
+}
+
+func stepGlyph(state string) string {
+	switch state {
+	case "passed":
+		return instOK.Render("✓")
+	case "failed":
+		return instErr.Render("✗")
+	case "running":
+		return instWarn.Render("●")
+	case "skipped", "skipped_cached":
+		return instMuted.Render("⊘")
+	default:
+		return instMuted.Render("○")
+	}
+}
+
+// ipcGetJSON performs a GET against the daemon's Unix socket and decodes the
+// JSON body into v. A non-2xx response surfaces the body text as the error.
+func ipcGetJSON(path string, v any) error {
+	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+	}
+	client := &http.Client{Transport: transport, Timeout: 3 * time.Second}
+
+	resp, err := client.Get("http://apiary" + path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		var b strings.Builder
+		_, _ = b.WriteString(resp.Status)
+		buf := make([]byte, 256)
+		if n, _ := resp.Body.Read(buf); n > 0 {
+			b.WriteString(": ")
+			b.Write(buf[:n])
+		}
+		return fmt.Errorf("%s", strings.TrimSpace(b.String()))
+	}
+	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+func daemonDownHint() error {
+	fmt.Println(instMuted.Render("Daemon is not running.") +
+		"  Start it with: " + instHeader.Render("apiary run"))
+	return nil
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -46,6 +46,7 @@ func init() {
 		newStatusCmd(),
 		newValidateCmd(),
 		newCellsCmd(),
+		newInstancesCmd(),
 		newDispatchCmd(),
 		newServiceCmd(),
 		newInitCmd(),

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -575,6 +576,40 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"updated": agentID, "model": req.Model, "max_workers": req.MaxWorkers})
+	})
+	mux.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		limit := 20
+		if l := q.Get("limit"); l != "" {
+			if n, err := strconv.Atoi(l); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		resp, err := d.Instances(r.Context(), q.Get("state"), q.Get("workflow"), limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/instances/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/instances/")
+		if id == "" {
+			http.Error(w, "missing instance id", http.StatusBadRequest)
+			return
+		}
+		detail, err := d.InstanceDetail(r.Context(), id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if detail == nil {
+			http.Error(w, "instance not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(detail)
 	})
 	mux.HandleFunc("/clearlogs/", func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/clearlogs/")

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+// InstanceSummary is one row in the `apiary instances` list.
+type InstanceSummary struct {
+	ID       string `json:"id"`
+	Workflow string `json:"workflow"`
+	CellID   string `json:"cell_id"`
+	Title    string `json:"title"`
+	State    string `json:"state"`
+	Started  string `json:"started"`  // human "18m ago"
+	Duration string `json:"duration"` // human "14m 32s" or "—"
+}
+
+// StepRunView is one step row in an instance detail.
+type StepRunView struct {
+	StepID   string `json:"step_id"`
+	AgentID  string `json:"agent_id"`
+	State    string `json:"state"`
+	Duration string `json:"duration"`
+	Cached   bool   `json:"cached"`
+}
+
+// InstanceDetail is the payload for `apiary instances <id>`.
+type InstanceDetail struct {
+	InstanceSummary
+	Steps []StepRunView `json:"steps"`
+}
+
+// InstancesResponse is the JSON payload returned by GET /instances.
+type InstancesResponse struct {
+	Instances []InstanceSummary `json:"instances"`
+}
+
+// Instances returns workflow instances for the IPC list endpoint, optionally
+// filtered by state and/or workflow id.
+func (d *Dispatcher) Instances(ctx context.Context, state, workflowID string, limit int) (InstancesResponse, error) {
+	if d.db == nil {
+		return InstancesResponse{}, nil
+	}
+	views, err := d.db.ListWorkflowInstanceViews(ctx, state, workflowID, limit)
+	if err != nil {
+		return InstancesResponse{}, err
+	}
+	now := time.Now()
+	resp := InstancesResponse{}
+	for _, v := range views {
+		resp.Instances = append(resp.Instances, instanceSummary(v, now))
+	}
+	return resp, nil
+}
+
+// InstanceDetail returns a single instance with its step runs, or (nil, nil)
+// when the instance id is unknown.
+func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDetail, error) {
+	if d.db == nil {
+		return nil, nil
+	}
+	inst, err := d.db.GetWorkflowInstance(ctx, id)
+	if err != nil || inst == nil {
+		return nil, err
+	}
+	title, _ := d.db.GetTaskTitle(ctx, inst.CellID)
+	now := time.Now()
+	view := db.WorkflowInstanceView{WorkflowInstance: *inst, Title: title}
+	detail := &InstanceDetail{InstanceSummary: instanceSummary(view, now)}
+
+	steps, err := d.db.ListStepRuns(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range steps {
+		detail.Steps = append(detail.Steps, StepRunView{
+			StepID:   s.StepID,
+			AgentID:  s.AgentID,
+			State:    s.State,
+			Duration: stepDuration(s, now),
+			Cached:   s.SkippedCached,
+		})
+	}
+	return detail, nil
+}
+
+func instanceSummary(v db.WorkflowInstanceView, now time.Time) InstanceSummary {
+	return InstanceSummary{
+		ID:       v.ID,
+		Workflow: v.WorkflowID,
+		CellID:   v.CellID,
+		Title:    v.Title,
+		State:    v.State,
+		Started:  humanDuration(now.Sub(v.CreatedAt)) + " ago",
+		Duration: instanceDuration(v.WorkflowInstance, now),
+	}
+}
+
+// instanceDuration is the elapsed wall-clock time for an instance: live for
+// running/waiting instances, final for done/failed, and unknown ("—") for
+// interrupted/pending where no meaningful span exists.
+func instanceDuration(inst db.WorkflowInstance, now time.Time) string {
+	switch inst.State {
+	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting:
+		return humanDuration(now.Sub(inst.CreatedAt))
+	case db.InstanceStateDone, db.InstanceStateFailed:
+		return humanDuration(inst.UpdatedAt.Sub(inst.CreatedAt))
+	default:
+		return "—"
+	}
+}
+
+func stepDuration(s db.StepRun, now time.Time) string {
+	if s.StartedAt == nil {
+		return "—"
+	}
+	end := now
+	if s.FinishedAt != nil {
+		end = *s.FinishedAt
+	}
+	return humanDuration(end.Sub(*s.StartedAt))
+}

--- a/src/internal/daemon/workflow_ipc_test.go
+++ b/src/internal/daemon/workflow_ipc_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func TestInstanceDuration(t *testing.T) {
+	base := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	now := base.Add(2 * time.Minute)
+
+	cases := []struct {
+		name    string
+		inst    db.WorkflowInstance
+		wantDur string
+	}{
+		{
+			name:    "running uses now-created",
+			inst:    db.WorkflowInstance{State: db.InstanceStateRunning, CreatedAt: base},
+			wantDur: "02:00",
+		},
+		{
+			name:    "approval_waiting uses now-created",
+			inst:    db.WorkflowInstance{State: db.InstanceStateApprovalWaiting, CreatedAt: base},
+			wantDur: "02:00",
+		},
+		{
+			name:    "done uses updated-created",
+			inst:    db.WorkflowInstance{State: db.InstanceStateDone, CreatedAt: base, UpdatedAt: base.Add(90 * time.Second)},
+			wantDur: "01:30",
+		},
+		{
+			name:    "failed uses updated-created",
+			inst:    db.WorkflowInstance{State: db.InstanceStateFailed, CreatedAt: base, UpdatedAt: base.Add(45 * time.Second)},
+			wantDur: "45s",
+		},
+		{
+			name:    "interrupted has no span",
+			inst:    db.WorkflowInstance{State: db.InstanceStateInterrupted, CreatedAt: base},
+			wantDur: "—",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := instanceDuration(tc.inst, now)
+			if got != tc.wantDur {
+				t.Fatalf("instanceDuration = %q, want %q", got, tc.wantDur)
+			}
+		})
+	}
+}
+
+func TestStepDuration(t *testing.T) {
+	base := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	now := base.Add(time.Minute)
+	started := base
+	finished := base.Add(30 * time.Second)
+
+	t.Run("pending step", func(t *testing.T) {
+		if got := stepDuration(db.StepRun{}, now); got != "—" {
+			t.Fatalf("got %q, want —", got)
+		}
+	})
+	t.Run("finished step uses finished-started", func(t *testing.T) {
+		got := stepDuration(db.StepRun{StartedAt: &started, FinishedAt: &finished}, now)
+		if got != "30s" {
+			t.Fatalf("got %q, want 30s", got)
+		}
+	})
+	t.Run("running step uses now-started", func(t *testing.T) {
+		got := stepDuration(db.StepRun{StartedAt: &started}, now)
+		if got != "01:00" {
+			t.Fatalf("got %q, want 01:00", got)
+		}
+	})
+}
+
+func TestInstanceSummary(t *testing.T) {
+	base := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	now := base.Add(5 * time.Minute)
+	v := db.WorkflowInstanceView{
+		WorkflowInstance: db.WorkflowInstance{
+			ID:         "wf_abc",
+			WorkflowID: "feature-development",
+			CellID:     "PLANE-142",
+			State:      db.InstanceStateRunning,
+			CreatedAt:  base,
+		},
+		Title: "Implement auth",
+	}
+	s := instanceSummary(v, now)
+	if s.ID != "wf_abc" || s.Workflow != "feature-development" || s.CellID != "PLANE-142" {
+		t.Fatalf("unexpected identity fields: %+v", s)
+	}
+	if s.Title != "Implement auth" {
+		t.Fatalf("title = %q", s.Title)
+	}
+	if s.Started != "05:00 ago" {
+		t.Fatalf("started = %q, want 05:00 ago", s.Started)
+	}
+	if s.Duration != "05:00" {
+		t.Fatalf("duration = %q, want 05:00", s.Duration)
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -125,6 +125,66 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 	return scanInstances(rows)
 }
 
+// WorkflowInstanceView is a WorkflowInstance enriched with the cell's title,
+// used by the `apiary instances` listing.
+type WorkflowInstanceView struct {
+	WorkflowInstance
+	Title string
+}
+
+// ListWorkflowInstanceViews returns recent instances (newest first) joined with
+// the cell title, optionally filtered by state and/or workflow id.
+func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowID string, limit int) ([]WorkflowInstanceView, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	q := `
+		SELECT wi.id, wi.workflow_id, wi.cell_id, COALESCE(wi.source_id,''), wi.state,
+		       COALESCE(wi.parent_instance_id,''), COALESCE(wi.resumed_from,''),
+		       wi.created_at, wi.updated_at, COALESCE(t.title,'')
+		FROM workflow_instances wi
+		LEFT JOIN tasks t ON t.id = wi.cell_id
+		WHERE 1=1`
+	var args []any
+	if state != "" {
+		q += " AND wi.state = ?"
+		args = append(args, state)
+	}
+	if workflowID != "" {
+		q += " AND wi.workflow_id = ?"
+		args = append(args, workflowID)
+	}
+	q += " ORDER BY wi.created_at DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := c.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []WorkflowInstanceView
+	for rows.Next() {
+		var v WorkflowInstanceView
+		if err := rows.Scan(&v.ID, &v.WorkflowID, &v.CellID, &v.SourceID, &v.State,
+			&v.ParentInstanceID, &v.ResumedFrom, &v.CreatedAt, &v.UpdatedAt, &v.Title); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// GetTaskTitle returns the stored title for a cell/task id, or "" if unknown.
+func (c *Client) GetTaskTitle(ctx context.Context, id string) (string, error) {
+	var title string
+	err := c.db.QueryRowContext(ctx, `SELECT COALESCE(title,'') FROM tasks WHERE id = ?`, id).Scan(&title)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return title, err
+}
+
 // ReconcileOrphanWorkflowInstances marks any instance left in the 'running'
 // state by a previously-killed process as 'interrupted'. Returns the count.
 // approval_waiting instances are intentionally left untouched — their condition


### PR DESCRIPTION
## Summary
- Adds the `apiary instances` command to inspect workflow instances.
- **List**: `apiary instances` with `--workflow`, `--state`, `--limit` and `--json` filters. Columns: ID, WORKFLOW, CELL, STATE, STARTED, DURATION (color-coded by state).
- **Detail**: `apiary instances <id>` shows the instance + the step runs (state glyph, agent, duration, `cached` flag).
- Served by the daemon via IPC on the Unix socket: `GET /instances` and `GET /instances/{id}`, reading `workflow_instances` + `step_runs`.
- New `db.ListWorkflowInstanceViews` (join with `tasks` for the title) and `db.GetTaskTitle`.
- Durations derived in the daemon: live for running/approval_waiting, final for done/failed, `—` for interrupted/pending.
- Exit code 2 when the instance doesn't exist (per the CLI spec).

Part of Phase 4.3 of the `workflow-mode` change (item 4.3.2). `apiary resume` (4.3.1/4.3.3) comes in the next PR.

## Test plan
- `go test ./...` — green (includes new `instanceDuration`/`stepDuration`/`instanceSummary` tests).
- `go build ./...` and `go vet` clean; new files gofmt-clean.
- Smoke: `apiary instances --help` and `apiary instances` without the daemon (shows a hint).