### PR TITLE
feat(workflow): apiary resume command + replay of cached steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3601 symbols, 7677 relationships, 240 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3712 symbols, 7978 relationships, 252 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3601 symbols, 7677 relationships, 240 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3712 symbols, 7978 relationships, 252 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -168,9 +168,9 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 ### 4.3 Resume Command
 
-- [ ] 4.3.1 Implement `apiary resume <instance-id>` CLI command — see [CLI spec](../../specs/cli/spec.md) (PR-4c)
+- [x] 4.3.1 Implement `apiary resume <instance-id>` CLI command (and `apiary resume --workflow <id>` to target the most recent failed/interrupted instance) — engine `ResumeInstance` replays already-passed steps from cache (no re-execution, no re-fired side effects), re-evaluates splits, and continues from the failure point; daemon IPC `GET /resume/{id}` (preview) + `POST /resume/{id}` (execute on the daemon-lifetime ctx). Exit codes 2/3/4 for not-found/not-resumable/workflow-changed (PR-4c)
 - [x] 4.3.2 Implement `apiary instances` CLI command — list (filters: `--workflow`/`--state`/`--limit`/`--json`) and `apiary instances <id>` step-level detail, served by daemon IPC (`GET /instances`, `GET /instances/{id}`) reading `workflow_instances` + `step_runs` (PR-4b)
-- [ ] 4.3.3 Show resume confirmation prompt listing skipped steps and their side effects (PR-4c)
+- [x] 4.3.3 Show resume confirmation prompt listing skipped steps and their side effects — `ResumePreview` returns skip (already passed) / run lists; CLI prints them and prompts `[y/N]` unless `--yes` (PR-4c)
 
 ### 4.4 TUI Updates
 
@@ -182,7 +182,7 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 - [ ] 4.5.1 Integration test: approval step posts comment, workflow pauses, resumes on matching comment
 - [ ] 4.5.2 Integration test: approval timeout aborts workflow
-- [ ] 4.5.3 Integration test: `apiary resume` replays cached steps, continues from failure point
+- [~] 4.5.3 `apiary resume` replays cached steps, continues from failure point — covered by engine unit tests (`resume_test.go`: skips-cached-and-continues, cached-memory-available-downstream, marks-prior-step-cached, re-evaluates-split) rather than a full daemon integration test (PR-4c)
 - [ ] 4.5.4 Run full test suite: `go test ./...`
 
 ---

--- a/src/internal/cli/resume.go
+++ b/src/internal/cli/resume.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+func newResumeCmd() *cobra.Command {
+	var (
+		yes      bool
+		workflow string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "resume [instance-id]",
+		Short: "Resume a failed or interrupted workflow instance",
+		Long: "Resume a failed or interrupted workflow instance from its last completed step. " +
+			"Completed steps are replayed from cache (not re-executed); the run continues from the failure point.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runResume(id, workflow, yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	cmd.Flags().StringVar(&workflow, "workflow", "", "resume the most recent failed/interrupted instance of this workflow")
+	return cmd
+}
+
+func runResume(id, workflow string, yes bool) error {
+	if (id == "") == (workflow == "") {
+		fmt.Println(instErr.Render("Provide exactly one of <instance-id> or --workflow."))
+		os.Exit(1)
+	}
+
+	// Resolve the target instance from --workflow if no id was given.
+	if workflow != "" {
+		var res struct {
+			InstanceID string `json:"instance_id"`
+		}
+		status, err := ipcDo(http.MethodGet, "/resume/?"+url.Values{"workflow": {workflow}}.Encode(), &res)
+		if err != nil {
+			return resumeFail(status, err, "workflow "+workflow)
+		}
+		id = res.InstanceID
+	}
+
+	// Preview (also validates resumability and maps exit codes).
+	var preview daemon.ResumePreview
+	status, err := ipcDo(http.MethodGet, "/resume/"+url.PathEscape(id), &preview)
+	if err != nil {
+		return resumeFail(status, err, id)
+	}
+
+	if !yes {
+		printResumePreview(preview)
+		if !confirm("Proceed? [y/N] ") {
+			fmt.Println(instMuted.Render("Aborted."))
+			return nil
+		}
+	}
+
+	// Execute.
+	status, err = ipcDo(http.MethodPost, "/resume/"+url.PathEscape(id), nil)
+	if err != nil {
+		return resumeFail(status, err, id)
+	}
+	fmt.Println(instOK.Render("✓") + " Resume queued for " + id + " — the daemon will pick it up.")
+	return nil
+}
+
+func printResumePreview(p daemon.ResumePreview) {
+	cell := p.CellID
+	if p.Title != "" {
+		cell += " — " + p.Title
+	}
+	fmt.Printf("\nResuming instance %s (%s / %s)\n\n", p.InstanceID, p.Workflow, cell)
+
+	if len(p.Skip) > 0 {
+		fmt.Println(instHeader.Render("Steps to skip (already completed):"))
+		for _, s := range p.Skip {
+			note := ""
+			if s.Note != "" {
+				note = instMuted.Render(" — " + s.Note)
+			}
+			fmt.Printf("  %s %-12s %-14s%s\n", instOK.Render("✓"), s.StepID, s.Agent, note)
+		}
+		fmt.Println()
+	}
+
+	fmt.Println(instHeader.Render("Steps to run:"))
+	for _, s := range p.Run {
+		fmt.Printf("  %s %-12s %s\n", instMuted.Render("○"), s.StepID, s.Agent)
+	}
+	fmt.Println()
+}
+
+// resumeFail prints a message and exits with the code mapped from the IPC status.
+// A status of 0 means a transport failure (daemon not reachable).
+func resumeFail(status int, err error, subject string) error {
+	switch status {
+	case http.StatusNotFound:
+		fmt.Println(instErr.Render("Not found: ") + subject)
+		os.Exit(2)
+	case http.StatusConflict:
+		fmt.Println(instErr.Render("Not resumable: ") + subject +
+			instMuted.Render(" (only failed or interrupted instances can be resumed)"))
+		os.Exit(3)
+	case http.StatusUnprocessableEntity:
+		fmt.Println(instErr.Render("Workflow definition changed or removed for ") + subject)
+		os.Exit(4)
+	case 0:
+		return daemonDownHint()
+	default:
+		fmt.Println(instErr.Render("Error: ") + err.Error())
+		os.Exit(1)
+	}
+	return nil
+}
+
+func confirm(prompt string) bool {
+	fmt.Print(prompt)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	return line == "y" || line == "yes"
+}
+
+// ipcDo performs an HTTP request against the daemon's Unix socket and decodes a
+// JSON response into out (when non-nil). It returns the HTTP status code (0 on
+// transport failure) so callers can map distinct exit codes.
+func ipcDo(method, path string, out any) (int, error) {
+	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+	}
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+
+	req, err := http.NewRequest(method, "http://apiary"+path, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return resp.StatusCode, fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return resp.StatusCode, err
+		}
+	}
+	return resp.StatusCode, nil
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -47,6 +47,7 @@ func init() {
 		newValidateCmd(),
 		newCellsCmd(),
 		newInstancesCmd(),
+		newResumeCmd(),
 		newDispatchCmd(),
 		newServiceCmd(),
 		newInitCmd(),

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -611,6 +611,46 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(detail)
 	})
+	mux.HandleFunc("/resume/", func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/resume/")
+		if id == "" {
+			// `apiary resume --workflow <id>`: resolve the most recent
+			// resumable instance for the workflow.
+			wfID := r.URL.Query().Get("workflow")
+			if wfID == "" {
+				http.Error(w, "missing instance id", http.StatusBadRequest)
+				return
+			}
+			instID, err := d.ResolveResumeTarget(r.Context(), wfID)
+			if err != nil {
+				http.Error(w, err.Error(), resumeHTTPStatus(err))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"instance_id": instID})
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			preview, err := d.ResumePreview(r.Context(), id)
+			if err != nil {
+				http.Error(w, err.Error(), resumeHTTPStatus(err))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(preview)
+		case http.MethodPost:
+			// Launch on the daemon-lifetime ctx so the run outlives the request.
+			if err := d.StartResume(ctx, id); err != nil {
+				http.Error(w, err.Error(), resumeHTTPStatus(err))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"queued": true, "instance_id": id})
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
 	mux.HandleFunc("/clearlogs/", func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/clearlogs/")
 		if cellID == "" {

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// Resume error sentinels. They map to CLI exit codes / HTTP statuses:
+// not-found → 2/404, not-resumable → 3/409, workflow-changed → 4/422.
+var (
+	ErrInstanceNotFound     = errors.New("instance not found")
+	ErrInstanceNotResumable = errors.New("instance is not resumable")
+	ErrWorkflowChanged      = errors.New("workflow definition changed or removed")
+)
+
+// ResumeStep is one entry in a resume preview's skip/run list.
+type ResumeStep struct {
+	StepID string `json:"step_id"`
+	Agent  string `json:"agent"`
+	Note   string `json:"note,omitempty"`
+}
+
+// ResumePreview describes what a resume would skip (already passed) and run.
+type ResumePreview struct {
+	InstanceID string       `json:"instance_id"`
+	Workflow   string       `json:"workflow"`
+	CellID     string       `json:"cell_id"`
+	Title      string       `json:"title"`
+	State      string       `json:"state"`
+	Skip       []ResumeStep `json:"skip"`
+	Run        []ResumeStep `json:"run"`
+}
+
+// resumableState reports whether an instance in this state can be resumed.
+// Only failed and interrupted instances qualify; done/running/approval_waiting/
+// pending are rejected (approval_waiting resumes via the polling loop, not here).
+func resumableState(state string) bool {
+	return state == db.InstanceStateFailed || state == db.InstanceStateInterrupted
+}
+
+// workflowByID resolves a workflow definition by id, covering both declared
+// workflows and plain routes (synthesized into single-step workflows).
+func (d *Dispatcher) workflowByID(id string) (config.WorkflowConfig, bool) {
+	for i := range d.cfg.Workflows {
+		if d.cfg.Workflows[i].ID == id {
+			return d.cfg.Workflows[i], true
+		}
+	}
+	for i := range d.cfg.Routes {
+		if d.cfg.Routes[i].ID == id {
+			return workflow.SynthesizeWorkflow(d.cfg.Routes[i]), true
+		}
+	}
+	return config.WorkflowConfig{}, false
+}
+
+// ResumePreview validates resumability and computes the skip/run breakdown for
+// the confirmation prompt. It returns a typed error for each rejection reason.
+func (d *Dispatcher) ResumePreview(ctx context.Context, id string) (*ResumePreview, error) {
+	if d.db == nil {
+		return nil, ErrInstanceNotFound
+	}
+	inst, err := d.db.GetWorkflowInstance(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if inst == nil {
+		return nil, ErrInstanceNotFound
+	}
+	if !resumableState(inst.State) {
+		return nil, ErrInstanceNotResumable
+	}
+	wf, ok := d.workflowByID(inst.WorkflowID)
+	if !ok {
+		return nil, ErrWorkflowChanged
+	}
+
+	steps, err := d.db.ListStepRuns(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	passed := map[string]bool{}
+	for _, s := range steps {
+		if s.State == db.StepStatePassed {
+			passed[s.StepID] = true
+		}
+	}
+
+	title, _ := d.db.GetTaskTitle(ctx, inst.CellID)
+	preview := &ResumePreview{
+		InstanceID: inst.ID,
+		Workflow:   inst.WorkflowID,
+		CellID:     inst.CellID,
+		Title:      title,
+		State:      inst.State,
+	}
+	for _, st := range wf.Steps {
+		// Splits are re-evaluated on resume; list them under "run" since they
+		// re-execute (cheaply, with no side effects).
+		if passed[st.ID] && st.StepType() != config.StepTypeSplit {
+			preview.Skip = append(preview.Skip, ResumeStep{StepID: st.ID, Agent: st.Agent, Note: "already passed"})
+		} else {
+			preview.Run = append(preview.Run, ResumeStep{StepID: st.ID, Agent: st.Agent})
+		}
+	}
+	return preview, nil
+}
+
+// StartResume validates the instance and launches the resume on the supplied
+// (daemon-lifetime) context. It returns promptly; the engine replays cached
+// steps and continues the run in the background. ctx must outlive the request.
+func (d *Dispatcher) StartResume(ctx context.Context, id string) error {
+	if d.db == nil {
+		return ErrInstanceNotFound
+	}
+	inst, err := d.db.GetWorkflowInstance(ctx, id)
+	if err != nil {
+		return err
+	}
+	if inst == nil {
+		return ErrInstanceNotFound
+	}
+	if !resumableState(inst.State) {
+		return ErrInstanceNotResumable
+	}
+	wf, ok := d.workflowByID(inst.WorkflowID)
+	if !ok {
+		return ErrWorkflowChanged
+	}
+	steps, err := d.db.ListStepRuns(ctx, id)
+	if err != nil {
+		return err
+	}
+	cell := d.cellForInstance(ctx, inst)
+
+	go func() {
+		success, rerr := d.workflowEngine().ResumeInstance(ctx, id, wf, cell, steps)
+		if rerr != nil {
+			aplog.Error("resume %s: %v", id, rerr)
+			return
+		}
+		aplog.Info("resume %s: finished (success=%v; may be awaiting approval)", id, success)
+	}()
+	return nil
+}
+
+// ResolveResumeTarget finds the most recent resumable instance of a workflow,
+// for the `apiary resume --workflow <id>` form.
+func (d *Dispatcher) ResolveResumeTarget(ctx context.Context, workflowID string) (string, error) {
+	if d.db == nil {
+		return "", ErrInstanceNotFound
+	}
+	inst, err := d.db.LatestResumableInstance(ctx, workflowID)
+	if err != nil {
+		return "", err
+	}
+	if inst == nil {
+		return "", ErrInstanceNotFound
+	}
+	return inst.ID, nil
+}
+
+// resumeHTTPStatus maps a resume error to its IPC HTTP status.
+func resumeHTTPStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrInstanceNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrInstanceNotResumable):
+		return http.StatusConflict
+	case errors.Is(err, ErrWorkflowChanged):
+		return http.StatusUnprocessableEntity
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// cellForInstance rebuilds the cell to resume against: a fresh poll when the
+// source supports it, otherwise a minimal cell from the stored id/title.
+func (d *Dispatcher) cellForInstance(ctx context.Context, inst *db.WorkflowInstance) model.Cell {
+	if adapter, ok := d.sources[inst.SourceID]; ok {
+		if poller, ok := adapter.(source.TaskPoller); ok {
+			if c, err := poller.PollTask(ctx, inst.CellID); err == nil {
+				return c
+			}
+		}
+	}
+	title, _ := d.db.GetTaskTitle(ctx, inst.CellID)
+	return model.Cell{ID: inst.CellID, SourceID: inst.SourceID, Title: title}
+}

--- a/src/internal/daemon/workflow_resume_test.go
+++ b/src/internal/daemon/workflow_resume_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func TestResumableState(t *testing.T) {
+	cases := map[string]bool{
+		db.InstanceStateFailed:          true,
+		db.InstanceStateInterrupted:     true,
+		db.InstanceStateDone:            false,
+		db.InstanceStateRunning:         false,
+		db.InstanceStateApprovalWaiting: false,
+		db.InstanceStatePending:         false,
+	}
+	for state, want := range cases {
+		if got := resumableState(state); got != want {
+			t.Errorf("resumableState(%q) = %v, want %v", state, got, want)
+		}
+	}
+}
+
+func TestResumeHTTPStatus(t *testing.T) {
+	cases := []struct {
+		err  error
+		want int
+	}{
+		{ErrInstanceNotFound, http.StatusNotFound},
+		{ErrInstanceNotResumable, http.StatusConflict},
+		{ErrWorkflowChanged, http.StatusUnprocessableEntity},
+		{errOther{}, http.StatusInternalServerError},
+	}
+	for _, c := range cases {
+		if got := resumeHTTPStatus(c.err); got != c.want {
+			t.Errorf("resumeHTTPStatus(%v) = %d, want %d", c.err, got, c.want)
+		}
+	}
+}
+
+type errOther struct{}
+
+func (errOther) Error() string { return "other" }
+
+func TestWorkflowByID(t *testing.T) {
+	d := &Dispatcher{cfg: &config.Config{
+		Workflows: []config.WorkflowConfig{{ID: "feature-development"}},
+		Routes:    []config.RouteConfig{{ID: "backend-bugs", Agent: "backend-dev"}},
+	}}
+
+	if wf, ok := d.workflowByID("feature-development"); !ok || wf.ID != "feature-development" {
+		t.Errorf("declared workflow not resolved: %+v ok=%v", wf, ok)
+	}
+	// A plain route resolves to a synthesized single-step workflow.
+	if wf, ok := d.workflowByID("backend-bugs"); !ok || len(wf.Steps) != 1 {
+		t.Errorf("route not synthesized into a workflow: %+v ok=%v", wf, ok)
+	}
+	if _, ok := d.workflowByID("ghost"); ok {
+		t.Error("unknown id should not resolve")
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -125,6 +125,23 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 	return scanInstances(rows)
 }
 
+// LatestResumableInstance returns the most recent failed or interrupted
+// instance of a workflow, or (nil, nil) when none exists.
+func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {
+	row := c.db.QueryRowContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		FROM workflow_instances
+		WHERE workflow_id = ? AND state IN ('failed','interrupted')
+		ORDER BY created_at DESC LIMIT 1
+	`, workflowID)
+	inst, err := scanInstance(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return inst, err
+}
+
 // WorkflowInstanceView is a WorkflowInstance enriched with the cell's title,
 // used by the `apiary instances` listing.
 type WorkflowInstanceView struct {

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -1,0 +1,83 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// ResumeInstance continues an existing failed or interrupted instance by
+// replaying its already-passed steps from cache and running the rest. It reuses
+// the instance id, restores cached steps' memory and expression context without
+// re-executing them or re-firing their side effects, and drives the DAG for the
+// remaining steps.
+//
+// priorSteps are the instance's persisted step runs in execution order. Split
+// steps are intentionally re-evaluated (they are side-effect-free and their
+// branch routing must re-activate the chosen target), while agent, foreach,
+// sub-workflow, and approval steps that passed are carried over untouched.
+func (e *Engine) ResumeInstance(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.Cell, priorSteps []db.StepRun) (success bool, err error) {
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateRunning)
+
+	r := e.initDAG(instID, wf, cell, nil, 0)
+	e.seedResume(ctx, r, priorSteps)
+
+	aplog.Info("workflow %s: resuming instance %s (%d cached step(s))", wf.ID, instID, len(r.passedOrder))
+	outcome := e.driveDAG(ctx, r)
+	return e.settle(ctx, r, outcome), nil
+}
+
+// seedResume restores the graph state of already-passed steps so a resumed run
+// continues from the first incomplete step. It returns nothing; on completion
+// r.passedOrder/contrib/stepStates reflect the cached steps.
+func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.StepRun) {
+	seen := map[string]bool{}
+	for i := range priorSteps {
+		sr := priorSteps[i]
+		if sr.State != db.StepStatePassed {
+			continue // failed/running/pending steps re-run
+		}
+		step, ok := r.byID[sr.StepID]
+		if !ok {
+			continue // step no longer exists in the workflow definition
+		}
+		// Splits carry no side effects and must re-route; let driveDAG re-run
+		// them so the chosen branch target is re-activated against restored
+		// memory. Leaving them pending is correct and free.
+		if step.StepType() == config.StepTypeSplit {
+			continue
+		}
+
+		var structured map[string]any
+		if sr.StructuredOutput != "" {
+			_ = json.Unmarshal([]byte(sr.StructuredOutput), &structured)
+		}
+
+		r.state[step.ID] = stPassed
+		r.stepStates[step.ID] = StepState{State: stPassed, Output: sr.Output}
+		if !seen[step.ID] {
+			r.contrib[step.ID] = MemoryStep{
+				StepID:      step.ID,
+				WriteFields: step.MemoryWriteFields(),
+				Structured:  structured,
+				Summary:     sr.Summary,
+			}
+			r.passedOrder = append(r.passedOrder, step.ID)
+			seen[step.ID] = true
+		}
+		if step.OnPass != nil && step.OnPass.Next != "" {
+			r.activated[step.OnPass.Next] = true
+		}
+
+		// Record that this run was carried over a resume (display only).
+		if !sr.SkippedCached {
+			sr.SkippedCached = true
+			_ = e.store.UpdateStepRun(ctx, &sr)
+		}
+	}
+}

--- a/src/internal/workflow/resume_test.go
+++ b/src/internal/workflow/resume_test.go
@@ -1,0 +1,165 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// linearWF is plan → implement → review, all agent steps.
+func linearWF() config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "feature", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"approach": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"approach"}}},
+		{ID: "implement", Agent: "backend-dev", DependsOn: []string{"plan"}},
+		{ID: "review", Agent: "architect", DependsOn: []string{"implement"}},
+	}}
+}
+
+func TestResume_SkipsCachedAndContinues(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID := "wf_resume_1"
+	store.CreateWorkflowInstance(context.Background(), &db.WorkflowInstance{ //nolint:errcheck
+		ID: instID, WorkflowID: "feature", CellID: "c1", State: db.InstanceStateFailed})
+
+	// plan passed earlier, implement failed; review never ran.
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed,
+			StructuredOutput: `{"approach":"layered"}`, Summary: "chose layered"},
+		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
+	}
+
+	success, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.Cell{ID: "c1"}, prior)
+	if err != nil {
+		t.Fatalf("ResumeInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected resume to succeed")
+	}
+
+	ids := executedIDs(exec.seen)
+	if contains(ids, "plan") {
+		t.Errorf("plan should be replayed from cache, not re-executed: %v", ids)
+	}
+	if !contains(ids, "implement") || !contains(ids, "review") {
+		t.Errorf("expected implement and review to run, got %v", ids)
+	}
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected final state done, got %s", store.instances[instID].State)
+	}
+}
+
+func TestResume_CachedMemoryAvailableDownstream(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID := "wf_resume_2"
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed,
+			StructuredOutput: `{"approach":"event-sourced"}`, Summary: "use events"},
+		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
+	}
+
+	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.Cell{ID: "c1"}, prior); err != nil {
+		t.Fatalf("ResumeInstance: %v", err)
+	}
+
+	// The implement step (first to re-run) must see the plan's cached memory.
+	var implReq *StepRequest
+	for i := range exec.seen {
+		if exec.seen[i].Step.ID == "implement" {
+			implReq = &exec.seen[i]
+			break
+		}
+	}
+	if implReq == nil {
+		t.Fatal("implement step did not run")
+	}
+	if !strings.Contains(implReq.MemoryDoc, "event-sourced") {
+		t.Errorf("cached plan memory missing from downstream memory doc:\n%s", implReq.MemoryDoc)
+	}
+}
+
+func TestResume_MarksPriorStepCached(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID := "wf_resume_3"
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed,
+			StructuredOutput: `{"approach":"layered"}`},
+		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
+	}
+
+	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.Cell{ID: "c1"}, prior); err != nil {
+		t.Fatalf("ResumeInstance: %v", err)
+	}
+	if sr := store.stepRuns["sr-plan"]; sr == nil || !sr.SkippedCached {
+		t.Errorf("expected sr-plan to be marked skipped_cached, got %+v", sr)
+	}
+}
+
+func TestResume_ReevaluatesSplit(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		// plan re-runs? no — plan is cached. senior re-runs and now passes.
+		"senior": {Success: true, Output: "ok"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "split", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"level": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"level"}}},
+		{ID: "route", Type: config.StepTypeSplit, DependsOn: []string{"plan"}, Branches: []config.SplitBranch{
+			{If: `memory.level == "high"`, Goto: "senior"},
+			{Else: true, Goto: "junior"},
+		}},
+		{ID: "senior", Agent: "architect"},
+		{ID: "junior", Agent: "backend-dev"},
+	}}
+
+	instID := "wf_resume_4"
+	// plan passed (level=high), route passed, senior failed.
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed,
+			StructuredOutput: `{"level":"high"}`},
+		{ID: "sr-route", WorkflowInstanceID: instID, StepID: "route", State: db.StepStatePassed},
+		{ID: "sr-senior", WorkflowInstanceID: instID, StepID: "senior", State: db.StepStateFailed},
+	}
+
+	success, err := eng.ResumeInstance(context.Background(), instID, wf, model.Cell{ID: "c1"}, prior)
+	if err != nil {
+		t.Fatalf("ResumeInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected resume to succeed")
+	}
+
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "senior") {
+		t.Errorf("expected senior to re-run after split re-evaluation, got %v", ids)
+	}
+	if contains(ids, "junior") {
+		t.Errorf("junior should not run — split routes to senior: %v", ids)
+	}
+	if contains(ids, "plan") {
+		t.Errorf("plan should be cached, not re-run: %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `apiary resume` to resume **failed** or **interrupted** workflow instances from the last completed step.
- **Engine** (`workflow.ResumeInstance`): reuses the instance id, restores the already-passed steps into the graph (state + memory + structured output) **without re-executing them or redoing side effects**, re-evaluates `split` steps (at no cost, re-activating the chosen branch) and drives the DAG from the first incomplete step. Marks the reused step runs as `skipped_cached`.
- **Daemon IPC**: `GET /resume/{id}` (preview: *skip* / *run* lists), `POST /resume/{id}` (executes in the daemon's lifetime ctx, returns immediately), `GET /resume/?workflow=<id>` (resolves the most recent resumable instance). Typed errors → 404/409/422.
- **CLI**: `apiary resume <instance-id>` and `apiary resume --workflow <id>`, with a confirmation prompt listing the steps to skip/run (`--yes` skips). Exit codes: `2` not-found, `3` not-resumable, `4` workflow-changed.
- New DB helpers: `LatestResumableInstance`.

Completes Phase 4.3 of the `workflow-mode` change (4.3.1, 4.3.2 already in #31, 4.3.3).

## Test plan
- `go test ./...` — green.
- Engine `resume_test.go`: skips-cached-and-continues, cached-memory-available-downstream, marks-prior-step-cached, re-evaluates-split.
- Daemon `workflow_resume_test.go`: resumableState, resumeHTTPStatus, workflowByID (declared workflow + synthesized route).
- Smoke: `apiary resume --help`; mutually-exclusive flag validation (exit 1); without the daemon shows a hint.
- `go build`/`go vet` clean; new files gofmt-clean.