### PR TITLE
feat(workflow): workflow steps panel in the Task Detail (TUI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3712 symbols, 7978 relationships, 252 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3750 symbols, 8072 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3712 symbols, 7978 relationships, 252 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3750 symbols, 8072 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -174,16 +174,16 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 ### 4.4 TUI Updates
 
-- [ ] 4.4.1 Add step-progress panel to Task Detail view (step ID, agent, state, duration)
-- [ ] 4.4.2 Show `approval_waiting` state with message in Task Detail
-- [ ] 4.4.3 Update Runs tab to show workflow instances with nested step runs
+- [x] 4.4.1 Add step-progress panel to Task Detail view (step ID, agent, state, duration) — `renderWorkflowSteps` appended to the Tasks-tab detail; `fetchTaskDetail` loads the bound instance via `db.GetLatestInstanceByCell` + `ListStepRuns` (PR-4d)
+- [x] 4.4.2 Show `approval_waiting` state with message in Task Detail — instance badge + a `⏸` banner when parked (PR-4d)
+- [~] 4.4.3 Workflow instances with nested step runs — surfaced in the Task Detail step panel (a task's instance + its steps) and via the `apiary instances`/`apiary instances <id>` CLI; a dedicated standalone Runs tab was not added since the detail panel + CLI cover the need (PR-4d)
 
 ### 4.5 Tests
 
 - [ ] 4.5.1 Integration test: approval step posts comment, workflow pauses, resumes on matching comment
 - [ ] 4.5.2 Integration test: approval timeout aborts workflow
 - [~] 4.5.3 `apiary resume` replays cached steps, continues from failure point — covered by engine unit tests (`resume_test.go`: skips-cached-and-continues, cached-memory-available-downstream, marks-prior-step-cached, re-evaluates-split) rather than a full daemon integration test (PR-4c)
-- [ ] 4.5.4 Run full test suite: `go test ./...`
+- [x] 4.5.4 Run full test suite: `go test ./...` — green on `main` after each phase PR
 
 ---
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -61,8 +61,9 @@ type tickMsg time.Time
 type overviewDataMsg struct{ data OverviewTab }
 type tasksDataMsg struct{ items []TaskItem }
 type taskDetailMsg struct {
-	taskID string
-	detail *TaskItem
+	taskID   string
+	detail   *TaskItem
+	instance *WorkflowInstanceItem
 }
 type taskLogsMsg struct {
 	taskID string
@@ -131,6 +132,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case taskDetailMsg:
 		if a.model.tasksTab != nil {
 			a.model.tasksTab.Detail = msg.detail
+			a.model.tasksTab.DetailInstance = msg.instance
 			a.model.tasksTab.View = TaskViewDetail
 		}
 		a.model.loading = false
@@ -1207,8 +1209,59 @@ func (a *App) fetchTaskDetail(taskID string) tea.Cmd {
 				}
 			}
 		}
-		return taskDetailMsg{taskID: taskID, detail: detail}
+
+		instance := a.fetchWorkflowInstance(ctx, dbConn, taskID)
+		return taskDetailMsg{taskID: taskID, detail: detail, instance: instance}
 	}
+}
+
+// fetchWorkflowInstance loads the workflow instance (and its steps) bound to a
+// task, returning nil when the task ran through the legacy single-shot path.
+func (a *App) fetchWorkflowInstance(ctx context.Context, dbConn *db.Client, taskID string) *WorkflowInstanceItem {
+	if dbConn == nil {
+		return nil
+	}
+	inst, err := dbConn.GetLatestInstanceByCell(ctx, taskID)
+	if err != nil || inst == nil {
+		return nil
+	}
+	item := &WorkflowInstanceItem{ID: inst.ID, Workflow: inst.WorkflowID, State: inst.State}
+	if inst.State == db.InstanceStateApprovalWaiting {
+		item.Message = "Awaiting human approval — reply on the task to resume or abort."
+	}
+
+	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
+	if err != nil {
+		return item
+	}
+	now := time.Now()
+	for _, s := range steps {
+		item.Steps = append(item.Steps, WorkflowStepItem{
+			StepID:   s.StepID,
+			Agent:    s.AgentID,
+			State:    s.State,
+			Duration: wfStepDuration(s, now),
+			Cached:   s.SkippedCached,
+		})
+	}
+	return item
+}
+
+// wfStepDuration renders a short duration for a step run: final span for a
+// finished step, live elapsed for a running one, "—" when not yet started.
+func wfStepDuration(s db.StepRun, now time.Time) string {
+	if s.StartedAt == nil {
+		return "—"
+	}
+	end := now
+	if s.FinishedAt != nil {
+		end = *s.FinishedAt
+	}
+	d := end.Sub(*s.StartedAt).Round(time.Second)
+	if d < 0 {
+		return "—"
+	}
+	return d.String()
 }
 
 func (a *App) fetchTaskLogs(taskID string) tea.Cmd {
@@ -1871,8 +1924,88 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 		b.WriteString("  " + StyleError.Render("Error:") + "\n")
 		b.WriteString("  " + StyleError.Render(truncate(d.Error, a.model.width-4)) + "\n")
 	}
+	if t.DetailInstance != nil {
+		b.WriteString(renderWorkflowSteps(t.DetailInstance))
+	}
 	label := taskDetailLabel(d)
 	return a.box(label, b.String(), height)
+}
+
+// renderWorkflowSteps renders the step-progress panel for a task that ran
+// through the workflow engine: the workflow id + instance state, an
+// approval-waiting banner when parked, and one row per step.
+func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
+	var b strings.Builder
+	b.WriteString("\n  " + StyleLabel.Render("Workflow") + "      " +
+		StyleValueStrong.Render(valueOr(inst.Workflow, "—")) + "  " +
+		wfInstanceBadge(inst.State) + "\n")
+
+	if inst.State == db.InstanceStateApprovalWaiting && inst.Message != "" {
+		b.WriteString("  " + StyleWarning.Render("⏸ "+inst.Message) + "\n")
+	}
+
+	if len(inst.Steps) == 0 {
+		return b.String()
+	}
+	b.WriteString("\n  " + StyleLabel.Render("Steps") + "\n")
+	for _, s := range inst.Steps {
+		state := s.State
+		if s.Cached {
+			state += " (cached)"
+		}
+		b.WriteString(fmt.Sprintf("    %s  %s  %s  %s\n",
+			wfStepGlyph(s.State),
+			pad(truncate(s.StepID, 16), 16),
+			pad(truncate(s.Agent, 16), 16),
+			StyleMuted.Render(pad(s.Duration, 8))+"  "+wfStateStyle(s.State).Render(state),
+		))
+	}
+	return b.String()
+}
+
+func wfInstanceBadge(state string) string {
+	switch state {
+	case db.InstanceStateDone:
+		return StyleSuccess.Render("done")
+	case db.InstanceStateFailed:
+		return StyleError.Render("failed")
+	case db.InstanceStateRunning:
+		return StyleWarning.Render("running")
+	case db.InstanceStateApprovalWaiting:
+		return StyleWarning.Render("approval_waiting")
+	case db.InstanceStateInterrupted:
+		return StyleError.Render("interrupted")
+	default:
+		return StyleMuted.Render(state)
+	}
+}
+
+func wfStepGlyph(state string) string {
+	switch state {
+	case db.StepStatePassed:
+		return StyleSuccess.Render("✓")
+	case db.StepStateFailed:
+		return StyleError.Render("✗")
+	case db.StepStateRunning:
+		return StyleWarning.Render("●")
+	case db.StepStateSkipped, db.StepStateSkippedCached:
+		return StyleMuted.Render("⊘")
+	default:
+		return StyleMuted.Render("○")
+	}
+}
+
+func wfStateStyle(state string) lipgloss.Style {
+	switch state {
+	case db.StepStatePassed:
+		return StyleSuccess
+	case db.StepStateFailed:
+		return StyleError
+	case db.StepStateRunning:
+		return StyleWarning
+	default:
+		return StyleMuted
+	}
 }
 
 func taskDetailLabel(d *TaskItem) string {

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -65,10 +65,11 @@ type TasksTab struct {
 	History     []TaskItem // running + past tasks, newest first
 	SelectedIdx int
 
-	View      TaskView
-	Detail    *TaskItem  // populated when View == TaskViewDetail
-	Logs      []LogEntry // populated when View == TaskViewLogs
-	LogScroll int
+	View           TaskView
+	Detail         *TaskItem             // populated when View == TaskViewDetail
+	DetailInstance *WorkflowInstanceItem // workflow instance for Detail, if any
+	Logs           []LogEntry            // populated when View == TaskViewLogs
+	LogScroll      int
 
 	// Scroll / filter / sort
 	ScrollOffset int    // first visible row index
@@ -76,6 +77,25 @@ type TasksTab struct {
 	FilterActive bool   // true while typing a filter
 	SortField    string // "time" | "status" | "agent"  (default "time")
 	SortAsc      bool
+}
+
+// WorkflowInstanceItem is a workflow instance bound to a task, with its steps,
+// shown in the Task Detail view.
+type WorkflowInstanceItem struct {
+	ID       string
+	Workflow string
+	State    string // pending, running, approval_waiting, interrupted, done, failed
+	Message  string // approval message when State == approval_waiting
+	Steps    []WorkflowStepItem
+}
+
+// WorkflowStepItem is one step row within a WorkflowInstanceItem.
+type WorkflowStepItem struct {
+	StepID   string
+	Agent    string
+	State    string // pending, running, passed, failed, skipped, skipped_cached
+	Duration string
+	Cached   bool
 }
 
 // TaskItem is one task row (its latest execution attempt).

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -1,0 +1,59 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderWorkflowSteps(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_1",
+		Workflow: "feature-development",
+		State:    "running",
+		Steps: []WorkflowStepItem{
+			{StepID: "plan", Agent: "architect", State: "passed", Duration: "12s"},
+			{StepID: "implement", Agent: "backend-dev", State: "running", Duration: "3s"},
+			{StepID: "review", Agent: "reviewer", State: "pending", Duration: "—"},
+			{StepID: "cached-step", Agent: "architect", State: "passed", Duration: "5s", Cached: true},
+		},
+	}
+
+	out := stripANSI(renderWorkflowSteps(inst))
+
+	for _, want := range []string{"feature-development", "running", "Steps", "plan", "implement", "review", "(cached)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered steps missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_2",
+		Workflow: "feature-development",
+		State:    "approval_waiting",
+		Message:  "Awaiting human approval — reply on the task to resume or abort.",
+		Steps: []WorkflowStepItem{
+			{StepID: "gate", Agent: "", State: "running", Duration: "—"},
+		},
+	}
+
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "approval_waiting") {
+		t.Errorf("expected approval_waiting badge:\n%s", out)
+	}
+	if !strings.Contains(out, "Awaiting human approval") {
+		t.Errorf("expected approval message banner:\n%s", out)
+	}
+}
+
+func TestRenderWorkflowSteps_NoSteps(t *testing.T) {
+	inst := &WorkflowInstanceItem{ID: "wf_3", Workflow: "single", State: "done"}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "single") || !strings.Contains(out, "done") {
+		t.Errorf("expected workflow id and state even with no steps:\n%s", out)
+	}
+	if strings.Contains(out, "Steps") {
+		t.Errorf("should not render a Steps header when there are no steps:\n%s", out)
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -125,6 +125,21 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 	return scanInstances(rows)
 }
 
+// GetLatestInstanceByCell returns the most recent workflow instance bound to a
+// cell, or (nil, nil) when the cell has no workflow instance.
+func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*WorkflowInstance, error) {
+	row := c.db.QueryRowContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC LIMIT 1
+	`, cellID)
+	inst, err := scanInstance(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return inst, err
+}
+
 // LatestResumableInstance returns the most recent failed or interrupted
 // instance of a workflow, or (nil, nil) when none exists.
 func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {


### PR DESCRIPTION
## Summary
- In the **Tasks → detail** tab, when the task ran through the workflow engine, a step-progress panel now appears.
- Shows: workflow id + **instance-state badge**, a **⏸** banner when `approval_waiting`, and one line per step with a state glyph (✓/✗/●/⊘/○), agent, duration and `(cached)` flag.
- `fetchTaskDetail` loads the instance linked to the cell via the new `db.GetLatestInstanceByCell` + `ListStepRuns`; legacy (single-shot) tasks simply have no panel.
- Completes Phase 4.4 (4.4.1 steps panel, 4.4.2 approval_waiting); 4.4.3 (instances with nested steps) is covered by the detail panel + the `apiary instances` CLI.

## Test plan
- `go test ./...` — green (new `workflow_render_test.go`: step render, approval banner, no-steps).
- `go build`/`go vet` clean; new/edited files gofmt-clean (pre-existing churn in app.go/models.go untouched).