### PR TITLE
docs(workflow): cross-cutting specs + workflow example

### DIFF
--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -1,0 +1,119 @@
+version: "1"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Example: Workflow Mode (experimental)
+#
+# This sample shows how to route a task through a multi-step workflow instead of
+# single-shot dispatch. Enable it with settings.experimental.workflow_mode.
+# A matched task runs through `steps` in dependency order, threading a small
+# enrichable "memory" baton between them. Approval steps suspend the instance
+# until a human responds on the task (GitHub issues support this via comments).
+#
+# Inspect and resume instances from the CLI:
+#   apiary instances                 # list workflow instances
+#   apiary instances <instance-id>   # step-level detail
+#   apiary resume <instance-id>      # replay cached steps, continue from failure
+# ─────────────────────────────────────────────────────────────────────────────
+
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+    config:
+      args: ["--output-format", "stream-json", "--verbose"]
+    models: [claude-opus-4-8, claude-sonnet-4-6]
+
+default_runner: claude
+
+sources:
+  - id: github
+    type: github
+    config:
+      repo: your-org/your-repo
+      api_key: ${GITHUB_TOKEN}
+    poll_interval: 60s
+    filters:
+      states: [open]
+
+agents:
+  - id: investigator
+    description: "Classifies an issue by complexity"
+    soul_file: .apiary/souls/investigator.md
+    model: claude-opus-4-8
+  - id: engineer
+    description: "Implements the change"
+    soul_file: .apiary/souls/engineer.md
+    model: claude-sonnet-4-6
+  - id: reviewer
+    description: "Reviews the change"
+    soul_file: .apiary/souls/reviewer.md
+    model: claude-sonnet-4-6
+
+workflows:
+  - id: feature-development
+    description: "Plan → implement → human approval → review"
+    resume: allowed
+    trigger:
+      priority: 10
+      match:
+        labels: [ai-ready]
+        types: [feature, improvement]
+
+    steps:
+      # 1) Classify and plan. Persist a couple of fields into workflow memory.
+      - id: plan
+        agent: investigator
+        summary_prompt: "In 3-5 bullets: the approach, risks, and what the implementer needs."
+        output_schema:
+          type: object
+          properties:
+            complexity: {type: string, enum: [low, medium, high]}
+            approach: {type: string}
+          required: [complexity, approach]
+        memory:
+          write: [complexity, approach]
+
+      # 2) Route on the planned complexity. High complexity needs sign-off.
+      - id: route
+        type: split
+        depends_on: [plan]
+        branches:
+          - if: 'memory.complexity == "high"'
+            goto: approve
+          - else: true
+            goto: implement
+
+      # 3) Human approval checkpoint (only reached for high-complexity work).
+      #    The engine posts `message` and parks the instance until a maintainer
+      #    comments "approve" (resume) or "reject" (abort), or the timeout fires.
+      - id: approve
+        type: approval
+        message: "High-complexity change planned. Comment `approve` to proceed or `reject` to stop."
+        resume_on: {comment_contains: "approve"}
+        abort_on: {comment_contains: "reject"}
+        timeout: 24h
+        on_pass: {next: implement}
+
+      # 4) Implement, then review. Both read the accumulated memory baton.
+      - id: implement
+        agent: engineer
+        depends_on: [plan]
+        prompt: "Implement the change following the approach captured in memory."
+
+      - id: review
+        agent: reviewer
+        depends_on: [implement]
+        prompt: "Review the implementation for correctness and conventions."
+
+    on_complete:
+      set_state: in_review
+      add_labels: [reviewed]
+    on_fail:
+      add_labels: [needs-attention]
+
+settings:
+  concurrency: 2
+  state_lock: true
+  result_comment: true
+  experimental:
+    workflow_mode: true

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -180,8 +180,8 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 ### 4.5 Tests
 
-- [ ] 4.5.1 Integration test: approval step posts comment, workflow pauses, resumes on matching comment
-- [ ] 4.5.2 Integration test: approval timeout aborts workflow
+- [~] 4.5.1 Approval step posts comment, workflow pauses, resumes on matching comment — covered by `approval_test.go` (`SuspendsAtApprovalStep`, `CheckResumesOnComment`, `ResumeContinuesWorkflow`) at engine level rather than a full daemon+source integration test
+- [~] 4.5.2 Approval timeout aborts workflow — covered by `approval_test.go` `CheckTimesOut`
 - [~] 4.5.3 `apiary resume` replays cached steps, continues from failure point — covered by engine unit tests (`resume_test.go`: skips-cached-and-continues, cached-memory-available-downstream, marks-prior-step-cached, re-evaluates-split) rather than a full daemon integration test (PR-4c)
 - [x] 4.5.4 Run full test suite: `go test ./...` — green on `main` after each phase PR
 
@@ -189,8 +189,8 @@ Approval steps that suspend a workflow instance until a human responds, driven b
 
 ## Cross-Cutting
 
-- [ ] X.1 Update `openspec/specs/plugin-api/spec.md` with new `SourceAdapter.PollTask` and updated `RunRequest`/`RunResult`
-- [ ] X.2 Update `openspec/specs/schema/spec.md` with `workflows:` block and new step types
-- [ ] X.3 Update `openspec/specs/cli/spec.md` with `apiary instances` and `apiary resume` commands
-- [ ] X.4 Update example `apiary.yaml` in `.apiary/` to show a sample workflow
-- [ ] X.5 Run `npx gitnexus analyze` after each phase to keep the knowledge graph current
+- [x] X.1 Update `openspec/specs/plugin-api/spec.md` — added "Workflow Mode extensions (experimental)": optional `TaskPoller` interface, `Cell.Comments`, and the workflow `RunRequest`/`RunResult` fields (PR-4e)
+- [x] X.2 Update `openspec/specs/schema/spec.md` — added `settings.experimental.workflow_mode` and a `workflows[]` (experimental) section with the step-type table (PR-4e)
+- [x] X.3 Update `openspec/specs/cli/spec.md` with `apiary instances` and `apiary resume` commands — the spec already documents both (authored ahead of implementation); commands now match it
+- [x] X.4 Add a sample workflow config — `.apiary/example-workflow.yaml` (validates with `apiary validate`), demonstrating agent/split/approval steps, memory, and `experimental.workflow_mode` (PR-4e)
+- [x] X.5 Run `gitnexus analyze` after each phase to keep the knowledge graph current — done in every phase PR's git workflow

--- a/openspec/specs/plugin-api/spec.md
+++ b/openspec/specs/plugin-api/spec.md
@@ -91,6 +91,58 @@ type RunResult struct {
 }
 ```
 
+## Workflow Mode extensions (experimental)
+
+When `settings.experimental.workflow_mode` is enabled, the engine drives tasks
+through multi-step workflows. Adapters opt into the extra capabilities through
+**optional** interfaces — existing adapters keep working unchanged.
+
+### `TaskPoller` (optional) — required to host `approval` steps
+
+An `approval` step suspends a workflow until a human responds on the task. The
+engine re-reads the live task (and its comments) once per poll cycle to decide
+whether to resume or abort. A source can only host approvals if its adapter
+implements `TaskPoller`; otherwise the instance stays parked.
+
+```go
+// TaskPoller fetches a single task's current state, including its comments.
+// Implemented by adapters that can host approval steps.
+type TaskPoller interface {
+    PollTask(ctx context.Context, cellID string) (Cell, error)
+}
+```
+
+`PollTask` populates `Cell.Comments` so the engine can evaluate approval
+conditions (`comment_contains`, `label_added`, `state_changed`):
+
+```go
+type Comment struct {
+    ID        string
+    Body      string
+    CreatedAt time.Time
+}
+// Cell gains: Comments []Comment  // populated by TaskPoller; empty otherwise
+```
+
+The built-in **GitHub** adapter implements `TaskPoller` (issue + comments).
+
+### `RunRequest` / `RunResult` workflow fields
+
+Agent steps reuse the same `RunnerAdapter.Run`. Workflow mode adds these fields,
+all optional and ignored by runners that do not use them:
+
+```go
+// RunRequest, additional fields:
+SystemPrepend      string  // workflow memory document injected ahead of the prompt
+SummaryPrompt      string  // ask the agent for a short handoff note (memory baton)
+StepID             string  // the workflow step id (for logging / persistence)
+WorkflowInstanceID string  // the owning instance id
+
+// RunResult, additional fields:
+StructuredOutput map[string]any // parsed APIARY_OUTPUT: JSON (per output_schema)
+Summary          string         // the agent's handoff summary (APIARY_SUMMARY block)
+```
+
 ## Built-in Adapters (v1)
 
 ### Source Adapters

--- a/openspec/specs/schema/spec.md
+++ b/openspec/specs/schema/spec.md
@@ -182,6 +182,38 @@ settings:
 | `result_comment` | bool | `true` | Post agent output as a comment on the source task |
 | `telemetry.enabled` | bool | `false` | Emit OTLP traces |
 | `telemetry.endpoint` | string | — | OTLP collector endpoint |
+| `experimental.workflow_mode` | bool | `false` | Route matched tasks through the multi-step workflow engine instead of single-shot dispatch |
+
+### `workflows[]` (experimental)
+
+Enabled by `settings.experimental.workflow_mode`. A workflow is a multi-step DAG
+that replaces single-shot dispatch: a task that matches a workflow's `trigger`
+runs through its `steps` in dependency order, threading a small enrichable
+**memory** baton between them. Routes and workflows share an id namespace; a
+plain route is treated as a single-step workflow. See the full annotated
+reference in the `workflow-mode` change specs (`specs/workflow/spec.md`).
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | ✓ | Unique across all workflows and routes |
+| `description` | string | — | Shown in the TUI and logs |
+| `resume` | string | — | `allowed` \| `forbidden` \| `auto` (resume eligibility) |
+| `trigger` | object | ✓ | Same matcher as `routes[].match`, plus `priority` |
+| `steps[]` | object[] | ✓ | Ordered steps forming the DAG |
+| `on_complete` / `on_fail` | object | — | Side-effects on terminal success/failure (`set_state`, `add_labels`) |
+
+**Step types** (`steps[].type`, default `agent`):
+
+| Type | Purpose | Key fields |
+|---|---|---|
+| `agent` | Invoke one agent | `agent`, `model`, `prompt`, `summary_prompt`, `output_schema`, `memory`, `depends_on`, `on_pass.next`, `on_fail.goto`/`max_retries` |
+| `split` | Conditional routing | `branches[].if` (expression) / `else`, `branches[].goto`, `multi` |
+| `approval` | Human checkpoint (suspends the instance) | `message`, `resume_on`, `abort_on`, `timeout` |
+| `foreach` | Fan-out over a prior step's array | `items`, `as`, `agent`, `max_items`, `fail_fast` |
+| `workflow` | Delegate to a child workflow | `workflow` (child id) |
+
+Split/approval conditions use a small expression language over `cell.*`,
+`memory.*`, and `steps.*` with `==`/`!=`/`contains`/`matches` and `and`/`or`/`not`.
 
 ## Environment Variable Interpolation
 


### PR DESCRIPTION
## Summary
- **plugin-api spec**: new *Workflow Mode extensions (experimental)* section — optional `TaskPoller` interface (hosts approval steps), `Cell.Comments`, and the `RunRequest`/`RunResult` fields used by the workflow (SystemPrepend, SummaryPrompt, StepID, WorkflowInstanceID, StructuredOutput, Summary).
- **schema spec**: `settings.experimental.workflow_mode` + a `workflows[]` (experimental) section with the step-type table (agent/split/approval/foreach/workflow).
- **example**: `.apiary/example-workflow.yaml` — a complete and **valid** config (`apiary validate` → `✓ config is valid`) demonstrating plan → split → approval → implement → review, with memory and `workflow_mode: true`.
- Closes the cross-cutting items X.1/X.2/X.4 of the `workflow-mode` change (X.3 was already documented; X.5 done each phase).

## Test plan
- `apiary validate --config .apiary/example-workflow.yaml` from the root → `✓ config is valid`.
- Docs-only: no Go code change.