### PR TITLE
feat(workflow): record per-step task_executions (dashboard parity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3750 symbols, 8072 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3775 symbols, 8156 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3750 symbols, 8072 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3775 symbols, 8156 relationships, 255 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/router"
@@ -127,19 +129,89 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		}
 	}
 
+	// Record a task_executions row for this step so the dashboard (Tasks
+	// history, Usage/cost, agent stats, live "running" status) observes
+	// workflow steps the same way it observed legacy single-shot runs. Each
+	// step is one execution; usage and PID/heartbeat are wired through.
+	exec := x.beginExecution(ctx, req)
+	if exec != nil {
+		execID := exec.ID
+		rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
+		rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
+	}
+
 	runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
-	defer cancel()
+	// Register the cancel func so `apiary restart` / ForceRestart can interrupt
+	// an in-flight step. A single key per cell mirrors legacy behaviour.
+	x.d.runCancel.Store(req.Cell.ID, cancel)
+	defer func() {
+		cancel()
+		x.d.runCancel.Delete(req.Cell.ID)
+	}()
 
 	res, err := ra.Run(runCtx, rr)
 	if err != nil && res.Error == nil {
 		res.Error = err
 	}
+
+	x.finishExecution(ctx, exec, res)
+
 	return workflow.StepResult{
 		Success:          res.Success,
 		Output:           res.Output,
 		StructuredOutput: res.StructuredOutput,
 		Summary:          res.Summary,
 		Err:              res.Error,
+	}
+}
+
+// beginExecution creates the task_executions row for a step run, or returns nil
+// when no run-history DB is configured. The attempt number continues the cell's
+// execution history so retries/steps accumulate rather than reset.
+func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRequest) *db.Execution {
+	if x.d.db == nil {
+		return nil
+	}
+	attempt := 1
+	if last, _ := x.d.db.GetLastExecution(ctx, req.Cell.ID); last != nil {
+		attempt = last.Attempt + 1
+	}
+	runnerType := x.d.agentRunner[req.Step.Agent]
+	exec, err := x.d.db.CreateExecution(ctx, req.Cell.ID, req.Step.Agent, req.Cell.Title,
+		req.Cell.Number, req.Cell.URL, req.Model, runnerType, attempt)
+	if err != nil {
+		aplog.Error("cell %s: create execution record: %v", req.Cell.ID, err)
+		return nil
+	}
+	return exec
+}
+
+// finishExecution flips a step's execution row to its terminal state and records
+// duration and usage. A nil exec (no DB) is a no-op.
+func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution, res model.RunResult) {
+	if exec == nil || x.d.db == nil {
+		return
+	}
+	now := time.Now()
+	exec.CompletedAt = &now
+	exec.DurationMs = res.Duration.Milliseconds()
+	exec.Status = "success"
+	if !res.Success {
+		exec.Status = "failed"
+		if res.Error != nil {
+			exec.ErrorMsg = res.Error.Error()
+		}
+	}
+	if res.Usage != nil {
+		exec.InputTokens = res.Usage.InputTokens
+		exec.OutputTokens = res.Usage.OutputTokens
+		exec.TotalTokens = res.Usage.TotalTokens
+		exec.NumTurns = res.Usage.NumTurns
+		exec.NumToolCalls = res.Usage.NumToolCalls
+		exec.CostUSD = res.Usage.CostUSD
+	}
+	if err := x.d.db.UpdateExecution(ctx, exec); err != nil {
+		aplog.Error("cell %s: update execution record: %v", exec.TaskID, err)
 	}
 }
 

--- a/src/internal/daemon/workflow_executor_test.go
+++ b/src/internal/daemon/workflow_executor_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// fakeRunner returns a scripted result and records that it ran.
+type fakeRunner struct {
+	result model.RunResult
+	ran    bool
+}
+
+func (f *fakeRunner) ID() string                       { return "fake" }
+func (f *fakeRunner) Configure(_ map[string]any) error { return nil }
+func (f *fakeRunner) Run(_ context.Context, _ model.RunRequest) (model.RunResult, error) {
+	f.ran = true
+	return f.result, nil
+}
+
+func TestWfStepExecutor_RecordsExecution(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	runner := &fakeRunner{result: model.RunResult{
+		Success:  true,
+		Output:   "done",
+		Duration: 1200 * time.Millisecond,
+		Usage:    &model.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.02, NumTurns: 3},
+	}}
+
+	d := &Dispatcher{
+		cfg:         &config.Config{},
+		db:          dbc,
+		runners:     map[string]runnerpkg.Runner{"agent-architect": runner},
+		agentRunner: map[string]string{"architect": "claude"},
+	}
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, workflow.StepRequest{
+		InstanceID: "wf_1",
+		Cell:       model.Cell{ID: "c1", Title: "Fix bug", Number: "#42"},
+		Step:       config.StepConfig{ID: "plan", Agent: "architect"},
+		Model:      "claude-opus-4-8",
+	})
+
+	if !runner.ran {
+		t.Fatal("runner was not invoked")
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got %+v", res)
+	}
+
+	// A terminal task_executions row must exist with the recorded usage.
+	exec, err := dbc.GetLastExecution(ctx, "c1")
+	if err != nil {
+		t.Fatalf("GetLastExecution: %v", err)
+	}
+	if exec == nil {
+		t.Fatal("no execution row written for the step")
+	}
+	if exec.Status != "success" {
+		t.Errorf("status = %q, want success", exec.Status)
+	}
+	if exec.AgentID != "architect" {
+		t.Errorf("agent = %q, want architect", exec.AgentID)
+	}
+	if exec.TotalTokens != 150 || exec.CostUSD != 0.02 {
+		t.Errorf("usage not recorded: tokens=%d cost=%.4f", exec.TotalTokens, exec.CostUSD)
+	}
+	if exec.DurationMs != 1200 {
+		t.Errorf("duration = %dms, want 1200", exec.DurationMs)
+	}
+}


### PR DESCRIPTION
## Summary
- `wfStepExecutor` (the workflow-engine path) now writes a `task_executions` row per executed step — `beginExecution` before the run, `finishExecution` after — with **usage** (tokens/cost/turns), **PID/heartbeat** and `runCancel` registration (for `apiary restart`).
- Why: the dashboard (Tasks history, Usage/cost tab, agent stats, live *running* status) reads from `task_executions`, which **only** the legacy `dispatch()` populated. Without this, turning on workflow mode would leave those tabs empty.
- It's the prerequisite for item 3.6 (default-on + flag removal): with observability parity, the engine can become the single dispatch path.

## Test plan
- New `workflow_executor_test.go`: runs `ExecuteStep` with a fake runner + a temporary SQLite db and verifies the `task_executions` row is created with correct status/usage/duration.
- `go test ./...` green; `go build`/`go vet` clean; gofmt-clean.

Next PR (5b): `workflow_mode` default-on, removal of the flag and of the legacy `dispatch()`.