### PR TITLE
fix(config): triage via split workflow + re-wire trigger dispatch

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -12,7 +12,7 @@ runners:
       - claude-sonnet-4-6
       - claude-haiku-4-5
 
-default_runner: claude-cli
+default_runner: claude
 
 # ── Sources ────────────────────────────────────────────────────────────────────
 sources:
@@ -143,15 +143,86 @@ routes:
     on_complete:
       set_state: closed
 
-  - id: new-issue-classify
-    priority: 100
-    match:
-      source: project-erp
-      exclude_label_prefix: "agent:"
-    agent: investigator
+# (Classification + routing of brand-new issues is handled by the `triage`
+#  workflow below, not a route — the engine routes in one instance instead of
+#  re-labelling and re-polling.)
+
+# ── Workflows ──────────────────────────────────────────────────────────────────
+# A new issue with no `agent:` label runs through `triage`: the investigator
+# classifies it, a split routes on that decision, and the chosen agent does the
+# work — all in a single workflow instance. This replaces the old
+# `assign_from_output` directive, which the engine no longer supports.
+workflows:
+  - id: triage
+    description: "Classify a new issue and route it to the right agent in one instance."
+    resume: allowed
+    trigger:
+      priority: 100
+      match:
+        source: project-erp
+        exclude_label_prefix: "agent:"
+
+    steps:
+      # 1) Classify. The investigator emits a structured `agent` decision, which
+      #    we persist into workflow memory for the split to read.
+      - id: classify
+        agent: investigator
+        summary_prompt: "One line: which agent you chose and the key reason."
+        output_schema:
+          type: object
+          properties:
+            agent: {type: string, enum: [po, staff, engineer, reviewer, qa]}
+          required: [agent]
+        memory:
+          write: [agent]
+
+      # 2) Route on the classified agent. `engineer` is the fallback (the common
+      #    case, and a safe default if classification is missing/unparseable).
+      - id: route
+        type: split
+        depends_on: [classify]
+        branches:
+          - if: 'memory.agent == "po"'
+            goto: spec
+          - if: 'memory.agent == "staff"'
+            goto: design
+          - if: 'memory.agent == "reviewer"'
+            goto: review
+          - if: 'memory.agent == "qa"'
+            goto: validate
+          - else: true
+            goto: implement
+
+      # 3) Exactly one of these runs — whichever the split activates.
+      - id: spec
+        agent: po
+        depends_on: [route]
+        prompt: "Produce the spec / acceptance criteria for this issue."
+
+      - id: design
+        agent: staff
+        depends_on: [route]
+        prompt: "Design the solution and decompose it into smaller tasks."
+
+      - id: implement
+        agent: engineer
+        depends_on: [route]
+        prompt: "Implement the change following project conventions."
+
+      - id: review
+        agent: reviewer
+        depends_on: [route]
+        prompt: "Review the change for correctness and conventions."
+
+      - id: validate
+        agent: qa
+        depends_on: [route]
+        prompt: "Validate the implementation against its acceptance criteria."
+
     on_complete:
-      assign_from_output: true
-      # No set_state — the investigator only labels; the matching agent closes it.
+      set_state: closed
+    on_fail:
+      add_labels: [needs-attention]
 
 # ── Settings ───────────────────────────────────────────────────────────────────
 settings:

--- a/.apiary/souls/investigator.md
+++ b/.apiary/souls/investigator.md
@@ -1,9 +1,10 @@
 # Investigator Agent
 
-You are the **Investigator** in the Apiary pipeline. You receive a newly created
-Plane task and decide **which single agent should handle it next**. You do not
-implement anything, and you do not call the Plane API — Apiary applies your
-decision (label + routing) automatically from the directive you emit.
+You are the **Investigator**, the first step of the Apiary `triage` workflow.
+You receive a newly created issue and decide **which single agent should handle
+it next**. You do not implement anything and you do not call any external API —
+the workflow's split step routes the issue to the agent you choose, in the same
+instance, from the structured decision you emit.
 
 ## What you must do
 
@@ -14,7 +15,7 @@ decision (label + routing) automatically from the directive you emit.
 
 2. **Pick exactly one target agent** from the set below.
 
-3. **End your output with the routing directive** (see "Output contract").
+3. **Emit the structured routing decision** (see "Output contract").
 
 ## Choosing the agent
 
@@ -35,20 +36,22 @@ design or decomposition is needed, otherwise `engineer`.
 Write a short analysis (2–6 sentences) explaining your reasoning: the complexity,
 the affected areas, any risks or dependencies, and why you chose the agent.
 
-Then, as the **very last line**, emit the directive on its own line:
+Then emit your decision as a structured-output line — on its own line, exactly:
 
 ```
-APIARY-ASSIGN: <agent>
+APIARY_OUTPUT: {"agent": "<agent>"}
 ```
 
 where `<agent>` is exactly one of: `po`, `staff`, `engineer`, `reviewer`, `qa`.
+The split step reads this `agent` field to route the issue. If you omit it (or it
+is unparseable), the workflow falls back to `engineer`.
 
 Example ending:
 
 ```
 This is a clear, single-module change to the Go handlers with well-defined
 acceptance criteria and no architectural impact.
-APIARY-ASSIGN: engineer
+APIARY_OUTPUT: {"agent": "engineer"}
 ```
 
 ## Rules
@@ -58,9 +61,10 @@ APIARY-ASSIGN: engineer
   `gh`, `httpie`, or any other HTTP tool. You have no token with sufficient
   permissions, and all the context you need is in the task title, description,
   `gitnexus_query`, and `openspec/CHANGELOG.md`.
-- Apiary handles all external operations (comments, labels, state changes, PR
-  reviews) automatically from your `APIARY-ASSIGN:` directive. Your job is
-  analysis and routing only.
-- Emit **exactly one** `APIARY-ASSIGN:` line, and make it the last line.
+- Apiary handles all external operations (comments, labels, state changes)
+  automatically from the workflow definition. Your job is analysis and routing
+  only — emit the decision and the engine does the rest.
+- Emit **exactly one** `APIARY_OUTPUT:` line. The last valid one wins, so don't
+  emit conflicting ones.
 - Always ground your decision in real context (`gitnexus_query`, the description,
   related specs) — not assumptions.

--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -81,6 +81,7 @@ Implement `WorkflowEngine` behind `settings.experimental.workflow_mode: true`. S
 - [x] 2.4.5 Implement `state_lock` (once at workflow start) and `result_comment` (`on_complete`/`per_step`/`off`) — see [workflow-hooks spec](specs/workflow-hooks/spec.md)
 - [x] 2.4.6 Wire engine into daemon behind `settings.experimental.workflow_mode` (new `daemon/workflow.go`; single gated branch at top of `dispatch()` — legacy path untouched when off)
 - [x] 2.4.7 Integration test: engine persists instance + step_run to real SQLite (`engine_integration_test.go`)
+- [x] 2.4.8 Wire workflow `trigger` into the router so a multi-step workflow actually dispatches (design §177). `router.New` now ingests each workflow's trigger as a synthetic route (id = workflow id, agent = first agent step); `resolveWorkflow` upgrades the match to the full definition. Without this, a `trigger:`-only workflow validated but never ran — only plain routes dispatched.
 
 ### 2.5 Tests
 

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -45,8 +45,24 @@ func New(cfg *config.Config) (*Router, error) {
 		workers[w.ID] = w
 	}
 
-	routes := make([]config.RouteConfig, len(cfg.Routes))
-	copy(routes, cfg.Routes)
+	routes := make([]config.RouteConfig, 0, len(cfg.Routes)+len(cfg.Workflows))
+	routes = append(routes, cfg.Routes...)
+	// A workflow's trigger acts as a route whose id equals the workflow id, so the
+	// dispatcher (resolveWorkflow) can upgrade the match to the full multi-step
+	// definition. Plain routes still synthesize a single-step workflow. The agent
+	// is the workflow's first agent step — representative for semaphore admission
+	// and logging; routing itself only needs a non-empty agent and the id.
+	for _, wf := range cfg.Workflows {
+		if wf.Trigger == nil {
+			continue
+		}
+		routes = append(routes, config.RouteConfig{
+			ID:       wf.ID,
+			Priority: wf.Trigger.Priority,
+			Match:    wf.Trigger.Match,
+			Agent:    firstAgentStep(wf),
+		})
+	}
 	sort.Slice(routes, func(i, j int) bool {
 		return routes[i].Priority < routes[j].Priority
 	})
@@ -63,6 +79,26 @@ func New(cfg *config.Config) (*Router, error) {
 	}
 
 	return &Router{routes: routes, workers: workers, regexes: regexes}, nil
+}
+
+// firstAgentStep returns a representative agent id for a workflow's trigger
+// route — the first agent the workflow will run. It falls back to the workflow
+// id so the synthetic route always has a non-empty agent (Router.Route skips a
+// matched route that has neither an agent nor a resolvable worker).
+func firstAgentStep(wf config.WorkflowConfig) string {
+	for _, s := range wf.Steps {
+		switch s.StepType() {
+		case config.StepTypeAgent:
+			if s.Agent != "" {
+				return s.Agent
+			}
+		case config.StepTypeForeach:
+			if s.Step != nil && s.Step.Agent != "" {
+				return s.Step.Agent
+			}
+		}
+	}
+	return wf.ID
 }
 
 // Route evaluates all rules against the Cell and returns the first match.

--- a/src/internal/router/router_test.go
+++ b/src/internal/router/router_test.go
@@ -359,3 +359,73 @@ func assertMatch(t *testing.T, ok bool, m router.Match, wantWorker string) {
 		t.Errorf("matched worker = %q, want %q", m.Worker.ID, wantWorker)
 	}
 }
+
+// TestRoute_WorkflowTriggerBecomesRoute verifies a workflow's trigger is
+// ingested as a synthetic route whose id equals the workflow id, so the
+// dispatcher can upgrade the match to the multi-step definition. The synthetic
+// route's agent is the workflow's first agent step (used for admission/logging).
+func TestRoute_WorkflowTriggerBecomesRoute(t *testing.T) {
+	c := &config.Config{
+		Version: "1",
+		Workflows: []config.WorkflowConfig{{
+			ID: "triage",
+			Trigger: &config.TriggerConfig{
+				Priority: 100,
+				Match:    config.RouteMatch{Source: "src-a", ExcludeLabelPrefix: "agent:"},
+			},
+			Steps: []config.StepConfig{
+				{ID: "classify", Agent: "investigator"},
+				{ID: "route", Type: config.StepTypeSplit, Branches: []config.SplitBranch{{Else: true, Goto: "classify"}}},
+			},
+		}},
+	}
+	r, err := router.New(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// An unlabeled cell triggers the workflow.
+	m, ok := r.Route(cell(withSource("src-a")))
+	if !ok {
+		t.Fatal("expected unlabeled cell to match the triage trigger")
+	}
+	if m.Route.ID != "triage" {
+		t.Errorf("Route.ID = %q, want %q (so resolveWorkflow upgrades to the workflow)", m.Route.ID, "triage")
+	}
+	if m.Route.Agent != "investigator" {
+		t.Errorf("Route.Agent = %q, want %q (first agent step)", m.Route.Agent, "investigator")
+	}
+
+	// A cell already bearing an agent: label is excluded by the trigger.
+	if _, ok := r.Route(cell(withSource("src-a"), withLabels("agent:engineer"))); ok {
+		t.Error("expected agent-labeled cell to be excluded from the triage trigger")
+	}
+}
+
+// TestRoute_ExplicitRouteWinsOverTriggerByPriority verifies explicit routes and
+// trigger routes are merged into one priority-ordered set.
+func TestRoute_ExplicitRouteWinsOverTriggerByPriority(t *testing.T) {
+	c := &config.Config{
+		Version: "1",
+		Routes: []config.RouteConfig{
+			agentRoute("direct-engineer", 10, "engineer", config.RouteMatch{Source: "src-a", Labels: []string{"agent:engineer"}}),
+		},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "triage",
+			Trigger: &config.TriggerConfig{Priority: 100, Match: config.RouteMatch{Source: "src-a", ExcludeLabelPrefix: "agent:"}},
+			Steps:   []config.StepConfig{{ID: "classify", Agent: "investigator"}},
+		}},
+	}
+	r, err := router.New(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, ok := r.Route(cell(withSource("src-a"), withLabels("agent:engineer")))
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if m.Route.ID != "direct-engineer" {
+		t.Errorf("Route.ID = %q, want the explicit lower-priority route", m.Route.ID)
+	}
+}


### PR DESCRIPTION
## Summary

Updates the `project-erp` config to the engine-only reality and re-wires a missing piece of `workflow-mode`.

- **`default_runner: claude-cli` → `claude`** — the runner is named `claude`; the old value broke validation.
- **`new-issue-classify` (route with `assign_from_output`) → `triage` workflow** — `assign_from_output` was removed in the engine-only flip (PR #36), so the classification route became a dead end (the investigator emitted `APIARY-ASSIGN:` and nothing read it). Triage is now an engine-native workflow: `classify` (investigator) → `split` → `po`/`staff`/`engineer`/`reviewer`/`qa`, all in a single instance (no re-label, no re-poll). `engineer` is the split's fallback.
- **Investigator soul** — now emits `APIARY_OUTPUT: {"agent": "<x>"}` (structured output read by the split) instead of the removed `APIARY-ASSIGN:` directive.
- **Re-wires `trigger` dispatch (design §177, never implemented)** — `router.New` now ingests each workflow's `trigger` as a synthetic route (id = the workflow id, agent = the first agent step) and `resolveWorkflow` upgrades to the multi-step definition. **Without this, any workflow defined only with `trigger:` validated but never ran** — the only dispatch path was the flat routes. Documented in `tasks.md` 2.4.8.

## Test plan

- `go test ./...` — green (9 packages), including 2 new router tests (`TestRoute_WorkflowTriggerBecomesRoute`, `TestRoute_ExplicitRouteWinsOverTriggerByPriority`).
- `gofmt`/`go vet` clean on the touched files.
- `apiary validate --config .apiary/apiary.yaml` → `✓ config is valid`.