### PR TITLE
feat(cli): `apiary clear` command to reset the SQLite database

### DIFF
--- a/src/internal/cli/clear.go
+++ b/src/internal/cli/clear.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+func newClearCmd() *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "clear",
+		Short: "Reset the project's SQLite database",
+		Long: "Delete the project's SQLite database — task history, executions, workflow " +
+			"instances, step runs, and logs. The database is recreated empty on the next run.\n\n" +
+			"Refuses to run while the daemon is up (clearing a live database would corrupt it); " +
+			"stop the daemon first. Pass --yes to skip the confirmation prompt.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runClear(yes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
+	return cmd
+}
+
+func runClear(yes bool) error {
+	dbPath := getDBPath()
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		fmt.Println(instMuted.Render("Nothing to clear — no database at ") + dbPath)
+		return nil
+	}
+
+	// Clearing the database out from under a running daemon would corrupt its
+	// in-flight state. A stale socket with no listener is fine (returns false).
+	if daemonIsRunning() {
+		fmt.Println(instErr.Render("The daemon appears to be running.") +
+			" Stop it first (apiary service stop), then retry.")
+		os.Exit(1)
+	}
+
+	if !yes {
+		fmt.Println(instWarn.Render("This permanently deletes all Apiary state for this project:"))
+		fmt.Println("  " + dbPath)
+		if !confirm(instWarn.Render("Reset the database?") + " [y/N] ") {
+			fmt.Println(instMuted.Render("Aborted."))
+			return nil
+		}
+	}
+
+	removed, err := resetDatabase(dbPath)
+	if err != nil {
+		fmt.Println(instErr.Render("Failed to clear database: ") + err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println(instOK.Render("✓ Database cleared.") + " " +
+		instMuted.Render(fmt.Sprintf("(removed %d file(s); it will be recreated on the next run)", removed)))
+	return nil
+}
+
+// resetDatabase removes the SQLite database file and any WAL/SHM/journal
+// sidecars left by an unclean shutdown. The schema is recreated on the next
+// `apiary run`. Returns the number of files actually removed.
+func resetDatabase(dbPath string) (int, error) {
+	removed := 0
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm", dbPath + "-journal"} {
+		switch err := os.Remove(p); {
+		case err == nil:
+			removed++
+		case os.IsNotExist(err):
+			// sidecar absent — nothing to remove
+		default:
+			return removed, err
+		}
+	}
+	return removed, nil
+}
+
+// daemonIsRunning reports whether a daemon is listening on the project's IPC
+// socket. A missing or stale socket (no listener) returns false.
+func daemonIsRunning() bool {
+	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/src/internal/cli/clear_test.go
+++ b/src/internal/cli/clear_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResetDatabase_RemovesFileAndSidecars(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "apiary.db")
+
+	// Create the DB plus a WAL and SHM sidecar; leave -journal absent.
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+
+	removed, err := resetDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("resetDatabase: %v", err)
+	}
+	if removed != 3 {
+		t.Errorf("removed = %d, want 3 (db + wal + shm)", removed)
+	}
+	for _, p := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", p)
+		}
+	}
+}
+
+func TestResetDatabase_NoFiles(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "absent.db")
+	removed, err := resetDatabase(dbPath)
+	if err != nil {
+		t.Fatalf("resetDatabase: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0 when nothing exists", removed)
+	}
+}
+
+func TestDaemonIsRunning_NoListener(t *testing.T) {
+	// Point the socket at a path with no listener.
+	t.Setenv("APIARY_SOCKET", filepath.Join(t.TempDir(), "absent.sock"))
+	if daemonIsRunning() {
+		t.Error("daemonIsRunning() = true, want false (no listener)")
+	}
+}
+
+func TestDaemonIsRunning_WithListener(t *testing.T) {
+	// Unix socket paths are length-limited (~104 bytes on macOS), so use a short
+	// /tmp dir rather than the long t.TempDir() path.
+	dir, err := os.MkdirTemp("/tmp", "apiary-clear")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	sock := filepath.Join(dir, "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	t.Setenv("APIARY_SOCKET", sock)
+
+	if !daemonIsRunning() {
+		t.Error("daemonIsRunning() = false, want true (listener present)")
+	}
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -48,6 +48,7 @@ func init() {
 		newCellsCmd(),
 		newInstancesCmd(),
 		newResumeCmd(),
+		newClearCmd(),
 		newDispatchCmd(),
 		newServiceCmd(),
 		newInitCmd(),


### PR DESCRIPTION
## Summary

Adds `apiary clear`, which resets the project's SQLite database.

- Removes the database (`<config-dir>/.apiary/apiary.db`) and the `-wal`/`-shm`/`-journal` sidecars left by a dirty shutdown. The schema is recreated empty on the next `apiary run`.
- **Confirmation**: prompts `Reset the database? [y/N]` by default; `--yes` skips the prompt (handy in scripts).
- **Safety guard**: refuses to run while the daemon is up — clearing the database under a live process would corrupt the state. Detected by dialing the project's IPC socket (a stale socket with no listener is treated as "not running").
- If there's no database, it reports and exits successfully (idempotent).

## Test plan

- `go test ./...` — green (10 packages). New tests: `resetDatabase` (with and without sidecars) and `daemonIsRunning` (with and without a listener).
- `gofmt`/`go vet` clean.
- Binary smoke test: `clear --yes` (removes db+wal), `clear` with no db ("Nothing to clear"), and the prompt answered `n` (aborts, preserves the db).