### PR TITLE
fix(logging): task details in the dashboard show the agent stream

### DIFF
--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -122,8 +122,15 @@ func (l *Logger) TaskError(ctx context.Context, taskID, msg string) {
 }
 
 func (l *Logger) log(ctx context.Context, level Level, msg, component, taskID string) {
-	// Drop messages below the configured threshold (both file and DB).
-	if severity(level) < severity(l.level) {
+	belowThreshold := severity(level) < severity(l.level)
+
+	// Per-task logs are always persisted to the DB so the dashboard's task
+	// detail view shows the full agent stream (which the runner emits at DEBUG)
+	// regardless of the service-wide log level. The console mirror in the
+	// dispatcher prints every entry too, so without this the dashboard would
+	// show nothing while the console showed the whole stream. Service logs and
+	// the shared apiary.log file still respect the threshold.
+	if belowThreshold && taskID == "" {
 		return
 	}
 
@@ -138,12 +145,16 @@ func (l *Logger) log(ctx context.Context, level Level, msg, component, taskID st
 		Timestamp: time.Now(),
 	}
 
-	// Write to file
-	line := fmt.Sprintf("[%s] [%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), level, msg)
-	if component != "" {
-		line = fmt.Sprintf("[%s] [%s] [%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), level, component, msg)
+	// Write to the shared log file only when at/above threshold, to avoid
+	// flooding apiary.log with the verbose per-task stream. The stream is still
+	// captured per task in the DB (and in the per-task log file).
+	if !belowThreshold {
+		line := fmt.Sprintf("[%s] [%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), level, msg)
+		if component != "" {
+			line = fmt.Sprintf("[%s] [%s] [%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), level, component, msg)
+		}
+		l.file.Write([]byte(line))
 	}
-	l.file.Write([]byte(line))
 
 	// Write to database
 	if l.db != nil {

--- a/src/internal/logging/logger_test.go
+++ b/src/internal/logging/logger_test.go
@@ -1,0 +1,57 @@
+package logging
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+// At INFO threshold, DEBUG task logs must still reach the DB so the dashboard's
+// task detail view shows the full agent stream, while DEBUG service logs are
+// dropped as before.
+func TestLog_TaskDebugPersistsBelowThreshold(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	dbClient, err := db.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer dbClient.Close()
+
+	logger, err := New(t.TempDir(), dbClient, LevelInfo)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer logger.Close()
+
+	// DEBUG is below the INFO threshold.
+	logger.TaskDebug(ctx, "task-1", "verbose agent stream line")
+	logger.Debug(ctx, "service debug line", "dispatcher")
+
+	taskLogs, err := dbClient.GetTaskLogs(ctx, "task-1", 100)
+	if err != nil {
+		t.Fatalf("GetTaskLogs: %v", err)
+	}
+	if len(taskLogs) != 1 {
+		t.Fatalf("expected 1 task log persisted below threshold, got %d", len(taskLogs))
+	}
+	if taskLogs[0].Level != string(LevelDebug) {
+		t.Errorf("task log level = %q, want %q", taskLogs[0].Level, LevelDebug)
+	}
+	if taskLogs[0].Message != "verbose agent stream line" {
+		t.Errorf("task log message = %q", taskLogs[0].Message)
+	}
+
+	// Service-level DEBUG logs remain gated by the threshold.
+	svcLogs, err := dbClient.GetRecentLogs(ctx, 100)
+	if err != nil {
+		t.Fatalf("GetRecentLogs: %v", err)
+	}
+	for _, l := range svcLogs {
+		if l.Message == "service debug line" {
+			t.Errorf("service DEBUG log should have been dropped below threshold")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- The workflow executor's `LogSink` mirrors each agent entry to two destinations: the console (`aplog.Info`, always at INFO) and the database (`TaskDebug`/`TaskInfo`/`TaskError`).
- The runner emits **the whole** agent stream (prompt, command, Claude conversation) at `debug` level (`runner/execution/cli.go`).
- Without `--debug`, the structured logger runs at INFO and dropped those DEBUG entries from both the file and the database — so the console showed the full stream, but the task details in the dashboard stayed **empty**.
- Fix: logs with a `taskID` are now always persisted to the database, regardless of the threshold, so the task detail in the dashboard shows the same stream as the console. Service logs and the shared `apiary.log` still respect the configured level (the verbose stream only goes to the file with `--debug`).
- Regression test in `internal/logging/logger_test.go`.

## Test plan
- `make check` (build + full suite) — green.
- New test `TestLog_TaskDebugPersistsBelowThreshold`: confirms a `TaskDebug` at INFO threshold reaches the database (and appears via `GetTaskLogs`), while a service `Debug` is still dropped.