### PR TITLE
feat(restart): restart clears control labels to restart the flow

### DIFF
--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -18,8 +18,13 @@ func newRestartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart <cell-id>",
 		Short: "Force-restart a stale task",
-		Long: `Kill the running dispatch for the given cell, reset its state, and 
-re-queue it so the next poll picks it up again.`,
+		Long: `Kill the running dispatch for the given cell, reset its state, and
+re-queue it so the next poll picks it up again.
+
+Also strips the cell's control labels — the lock (e.g. "in-progress") and the
+stage marker (e.g. "agent:engineer") — so the task re-enters the flow from the
+start instead of being shadowed by a stale label. The labels removed are derived
+from the routes' exclude_label_prefix / exclude_labels.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cellID := strings.TrimSpace(args[0])
@@ -46,7 +51,7 @@ re-queue it so the next poll picks it up again.`,
 				return fmt.Errorf("restart failed: HTTP %d", resp.StatusCode)
 			}
 
-			fmt.Printf("✓ Restarted cell %s\n", cellID)
+			fmt.Printf("✓ Restarted cell %s (control labels cleared; re-enters the flow on the next poll)\n", cellID)
 			return nil
 		},
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -506,8 +506,82 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 		}
 	}
 
+	// Strip control labels so the cell re-enters routing from the start instead
+	// of being shadowed by a stale lock (e.g. "in-progress") or a stage marker
+	// (e.g. "agent:engineer"). Needs the source's current labels (TaskPoller) and
+	// label removal (LabelRemover); sources missing either are skipped.
+	for _, sc := range d.cfg.Sources {
+		adapter, ok := d.sources[sc.ID]
+		if !ok {
+			continue
+		}
+		remover, ok := adapter.(source.LabelRemover)
+		if !ok {
+			continue
+		}
+		poller, ok := adapter.(source.TaskPoller)
+		if !ok {
+			continue
+		}
+		cell, err := poller.PollTask(ctx, cellID)
+		if err != nil {
+			aplog.Debug("force-restart %s: cannot fetch labels from %s: %v", cellID, sc.ID, err)
+			continue
+		}
+		if labels := d.controlLabels(cell); len(labels) > 0 {
+			if err := remover.RemoveLabels(ctx, cell, labels); err != nil {
+				aplog.Error("force-restart %s: removing control labels %v: %v", cellID, labels, err)
+			} else {
+				aplog.Info("force-restart %s: removed control labels %v", cellID, labels)
+			}
+		}
+	}
+
 	aplog.Info("force-restarted cell %s", cellID)
 	return nil
+}
+
+// controlLabels returns the labels on the cell that act as routing guards: any
+// label matching a route's exclude_label_prefix (e.g. "agent:") or listed in a
+// route's exclude_labels (e.g. "in-progress"). These are exactly the labels that
+// can keep a cell from matching a route, so force-restart strips them to send the
+// cell back to the start of the flow. Derived from the live config — no
+// hardcoded label names.
+func (d *Dispatcher) controlLabels(cell model.Cell) []string {
+	var prefixes []string
+	excluded := map[string]bool{}
+	collect := func(m config.RouteMatch) {
+		if m.ExcludeLabelPrefix != "" {
+			prefixes = append(prefixes, strings.ToLower(m.ExcludeLabelPrefix))
+		}
+		for _, l := range m.ExcludeLabels {
+			excluded[strings.ToLower(l)] = true
+		}
+	}
+	for _, r := range d.cfg.Routes {
+		collect(r.Match)
+	}
+	for _, wf := range d.cfg.Workflows {
+		if wf.Trigger != nil {
+			collect(wf.Trigger.Match)
+		}
+	}
+
+	var out []string
+	for _, l := range cell.Labels {
+		ll := strings.ToLower(l)
+		if excluded[ll] {
+			out = append(out, l)
+			continue
+		}
+		for _, p := range prefixes {
+			if strings.HasPrefix(ll, p) {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	return out
 }
 
 // StartServer starts an HTTP server on the Unix socket for IPC.

--- a/src/internal/daemon/restart_labels_test.go
+++ b/src/internal/daemon/restart_labels_test.go
@@ -1,0 +1,111 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func restartTestConfig() *config.Config {
+	return &config.Config{
+		Sources: []config.SourceConfig{{ID: "fake"}},
+		Routes: []config.RouteConfig{
+			{ID: "eng", Match: config.RouteMatch{
+				Labels:        []string{"agent:engineer"},
+				ExcludeLabels: []string{"in-progress"},
+			}},
+			{ID: "classify", Match: config.RouteMatch{ExcludeLabelPrefix: "agent:"}},
+		},
+	}
+}
+
+func TestControlLabels_DerivesFromRouteExclusions(t *testing.T) {
+	d := &Dispatcher{cfg: restartTestConfig()}
+	cell := model.Cell{Labels: []string{"agent:engineer", "in-progress", "bug", "area:backend"}}
+
+	got := d.controlLabels(cell)
+
+	want := map[string]bool{"agent:engineer": true, "in-progress": true}
+	if len(got) != len(want) {
+		t.Fatalf("controlLabels = %v, want exactly %v", got, []string{"agent:engineer", "in-progress"})
+	}
+	for _, l := range got {
+		if !want[l] {
+			t.Errorf("unexpected control label %q (non-control labels must be kept)", l)
+		}
+	}
+}
+
+func TestControlLabels_NoneWhenOnlyPlainLabels(t *testing.T) {
+	d := &Dispatcher{cfg: restartTestConfig()}
+	cell := model.Cell{Labels: []string{"bug", "area:backend", "prioridade:alta"}}
+	if got := d.controlLabels(cell); len(got) != 0 {
+		t.Errorf("controlLabels = %v, want none", got)
+	}
+}
+
+// fakeRestartSource implements the Adapter interface plus the optional
+// TaskPoller, LabelRemover, and StateSetter interfaces ForceRestart relies on.
+type fakeRestartSource struct {
+	cell     model.Cell
+	removed  []string
+	stateSet string
+}
+
+func (f *fakeRestartSource) ID() string                                    { return "fake" }
+func (f *fakeRestartSource) Connect(context.Context, map[string]any) error { return nil }
+func (f *fakeRestartSource) Poll(context.Context, time.Time) ([]model.Cell, error) {
+	return nil, nil
+}
+func (f *fakeRestartSource) Acknowledge(context.Context, model.Cell, model.AckAction) error {
+	return nil
+}
+func (f *fakeRestartSource) WriteResult(context.Context, model.Cell, model.RunResult) error {
+	return nil
+}
+func (f *fakeRestartSource) WebhookHandler() http.Handler { return nil }
+func (f *fakeRestartSource) PollTask(context.Context, string) (model.Cell, error) {
+	return f.cell, nil
+}
+func (f *fakeRestartSource) RemoveLabels(_ context.Context, _ model.Cell, labels []string) error {
+	f.removed = append(f.removed, labels...)
+	return nil
+}
+func (f *fakeRestartSource) SetState(_ context.Context, _ model.Cell, state string) error {
+	f.stateSet = state
+	return nil
+}
+
+func TestForceRestart_StripsControlLabels(t *testing.T) {
+	fake := &fakeRestartSource{cell: model.Cell{
+		ID:     "42",
+		Labels: []string{"agent:engineer", "in-progress", "bug"},
+	}}
+	d := &Dispatcher{
+		cfg:     restartTestConfig(),
+		sources: map[string]source.Adapter{"fake": fake},
+	}
+
+	if err := d.ForceRestart(context.Background(), "42"); err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, l := range fake.removed {
+		got[l] = true
+	}
+	if !got["agent:engineer"] || !got["in-progress"] {
+		t.Errorf("removed = %v, want both agent:engineer and in-progress", fake.removed)
+	}
+	if got["bug"] {
+		t.Errorf("removed non-control label 'bug': %v", fake.removed)
+	}
+	if fake.stateSet != "todo" {
+		t.Errorf("stateSet = %q, want todo", fake.stateSet)
+	}
+}

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -243,6 +243,24 @@ func (a *Adapter) AddLabels(ctx context.Context, cell model.Cell, names []string
 	return nil
 }
 
+// RemoveLabels deletes the named labels from an issue, one DELETE per label so
+// the remaining labels are untouched. A label that is already absent (GitHub
+// returns 404) is ignored. Implements source.LabelRemover.
+func (a *Adapter) RemoveLabels(ctx context.Context, cell model.Cell, names []string) error {
+	issueNo := cell.ID
+	for _, name := range names {
+		path := fmt.Sprintf("/repos/%s/%s/issues/%s/labels/%s",
+			a.owner, a.repo, issueNo, url.PathEscape(name))
+		if _, err := a.client.delete(ctx, path); err != nil {
+			if strings.Contains(err.Error(), "status 404") {
+				continue // label already absent — nothing to remove
+			}
+			return fmt.Errorf("github: removing label %q from %s: %w", name, cell.ID, err)
+		}
+	}
+	return nil
+}
+
 func (a *Adapter) ensureLabel(ctx context.Context, name string) error {
 	path := fmt.Sprintf("/repos/%s/%s/labels", a.owner, a.repo)
 	_, err := a.client.post(ctx, path, labelCreateRequest{Name: name})

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -1,7 +1,10 @@
 package github
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -182,5 +185,41 @@ func mustNotContain(t *testing.T, s, sub string) {
 	t.Helper()
 	if strings.Contains(s, sub) {
 		t.Errorf("expected output NOT to contain %q\ngot: %s", sub, s)
+	}
+}
+
+func TestRemoveLabels_DeletesEachLabel(t *testing.T) {
+	var deleted []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			idx := strings.LastIndex(r.URL.Path, "/labels/")
+			deleted = append(deleted, r.URL.Path[idx+len("/labels/"):])
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	cell := model.Cell{ID: "42", Labels: []string{"agent:engineer", "in-progress", "bug"}}
+	if err := a.RemoveLabels(context.Background(), cell, []string{"agent:engineer", "in-progress"}); err != nil {
+		t.Fatalf("RemoveLabels: %v", err)
+	}
+	if len(deleted) != 2 || deleted[0] != "agent:engineer" || deleted[1] != "in-progress" {
+		t.Errorf("deleted = %v, want [agent:engineer in-progress]", deleted)
+	}
+}
+
+func TestRemoveLabels_Ignores404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"Label does not exist"}`, http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	cell := model.Cell{ID: "42", Labels: []string{"in-progress"}}
+	if err := a.RemoveLabels(context.Background(), cell, []string{"in-progress"}); err != nil {
+		t.Errorf("expected 404 to be ignored, got %v", err)
 	}
 }

--- a/src/internal/source/github/client.go
+++ b/src/internal/source/github/client.go
@@ -111,6 +111,14 @@ func (c *client) post(ctx context.Context, path string, payload any) ([]byte, er
 	return c.do(ctx, req)
 }
 
+func (c *client) delete(ctx context.Context, path string) ([]byte, error) {
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
 func (c *client) getAllIssues(ctx context.Context, path string, params url.Values) ([]issue, error) {
 	var all []issue
 	page := 1

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -50,6 +50,14 @@ type LabelAdder interface {
 	AddLabels(ctx context.Context, cell model.Cell, labels []string) error
 }
 
+// LabelRemover is an optional interface that sources may implement to remove
+// labels from a task. The dispatcher uses it on force-restart to strip a cell's
+// control labels — a stale lock (e.g. "in-progress") and the stage marker
+// (e.g. "agent:engineer") — so the task re-enters routing from the start.
+type LabelRemover interface {
+	RemoveLabels(ctx context.Context, cell model.Cell, labels []string) error
+}
+
 // TaskPoller is an optional interface that sources may implement to fetch the
 // current state of a single task by ID, including its comments. The workflow
 // engine uses it to evaluate approval-step resume/abort conditions against the


### PR DESCRIPTION
## Context

Investigating project-erp issues stuck on "no matching route, skipping", the cause is that they carry `in-progress` + `agent:engineer`. Every agent route excludes `in-progress`, and `new-issue-classify`/`triage` excludes the `agent:` prefix — so the cell matches no route and sits in limbo. `in-progress` is a lock (added by the GitHub adapter's `Acknowledge`) that got stuck when the agent was interrupted before doing the label handoff.

`apiary restart` **should** unstick this, but it didn't touch labels — it only cancelled the run and changed internal/DB state and the source *state* (open/closed). Result: restart was a no-op for a cell stuck by a label.

## What changes

`ForceRestart` now, in addition to what it already did, **removes the cell's control labels** to return it to the start of the flow:

- Which labels (derived from the config, **no hardcode**): every label that matches some route `exclude_label_prefix` (e.g. `agent:`) **or** is in `exclude_labels` (e.g. `in-progress`). These are precisely the labels that can block routing. For the project-erp config this gives exactly `{agent:engineer, in-progress}`.
- Ordinary labels (`bug`, `area:backend`, …) are preserved.

### Implementation
- New optional `source.LabelRemover` interface (`RemoveLabels`).
- GitHub adapter: `RemoveLabels` (one `DELETE /issues/:n/labels/:name` per label, ignores 404) + the `client.delete` verb.
- `Dispatcher.ForceRestart`: fetches the current labels via `TaskPoller.PollTask`, computes the control ones (`controlLabels`, derived from routes + workflow triggers) and removes them via `LabelRemover`. Sources without these interfaces are skipped.
- `restart` CLI: help and exit message reflect the cleanup.

## Test plan

- `go test ./...` — green (10 packages). New tests:
  - `RemoveLabels`: delete per label in order; 404 ignored.
  - `controlLabels`: derives `agent:*` + `in-progress` from routes, ignores ordinary labels.
  - `ForceRestart`: removes `agent:engineer` + `in-progress`, preserves `bug`, and sets state `todo`.
- `gofmt`/`go vet` clean on the touched files (the pre-existing churn in dispatcher.go was not altered).

## Note

This applies to the next time a cell gets stuck. For the 6 issues already stuck now, run `apiary restart <n>` (with this binary) or remove the labels manually via `gh`.