### PR TITLE
feat(config): validate removed directives and unknown fields

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -244,23 +244,83 @@ routes:
     on_complete:
       set_state: done
 
-  # New issues → Investigator for classification.
-  # Fallback: only UNASSIGNED issues still in TODO.
-  # - exclude_label_prefix: "agent:" → skip anything already routed to an agent
-  # - states: [todo]                 → only brand-new work
-  # Highest priority number → evaluated last, after every agent:* route.
-  - id: new-issue-classify
-    priority: 100
-    match:
-      source: project-erp
-      states: [todo]
-      exclude_label_prefix: "agent:"
-    agent: investigator
+# (Classification + routing of brand-new issues is handled by the `triage`
+#  workflow below, not a route. The engine classifies and routes in a single
+#  instance via a `split` step — replacing the removed `assign_from_output`
+#  directive, which relabelled-and-repolled.)
+
+# ── Workflows ──────────────────────────────────────────────────────────────────
+# A new issue with no `agent:` label runs through `triage`: the investigator
+# classifies it (emitting a structured `agent` decision into workflow memory), a
+# `split` routes on that decision, and the chosen agent does the work — all in one
+# instance, no relabel-and-repoll.
+workflows:
+  - id: triage
+    description: "Classify a new issue and route it to the right agent in one instance."
+    resume: allowed
+    trigger:
+      priority: 100
+      match:
+        source: project-erp
+        states: [todo]
+        exclude_label_prefix: "agent:"
+
+    steps:
+      - id: classify
+        agent: investigator
+        summary_prompt: "One line: which agent you chose and the key reason."
+        output_schema:
+          type: object
+          properties:
+            agent: {type: string, enum: [po, staff, engineer, reviewer, qa]}
+          required: [agent]
+        memory:
+          write: [agent]
+
+      - id: route
+        type: split
+        depends_on: [classify]
+        branches:
+          - if: 'memory.agent == "po"'
+            goto: spec
+          - if: 'memory.agent == "staff"'
+            goto: design
+          - if: 'memory.agent == "reviewer"'
+            goto: review
+          - if: 'memory.agent == "qa"'
+            goto: validate
+          - else: true
+            goto: implement
+
+      - id: spec
+        agent: po
+        depends_on: [route]
+        prompt: "Produce the spec / acceptance criteria for this issue."
+
+      - id: design
+        agent: staff
+        depends_on: [route]
+        prompt: "Design the solution and decompose it into smaller tasks."
+
+      - id: implement
+        agent: engineer
+        depends_on: [route]
+        prompt: "Implement the change following project conventions."
+
+      - id: review
+        agent: reviewer
+        depends_on: [route]
+        prompt: "Review the change for correctness and conventions."
+
+      - id: validate
+        agent: qa
+        depends_on: [route]
+        prompt: "Validate the implementation against its acceptance criteria."
+
     on_complete:
-      # Apiary parses `APIARY-ASSIGN: <agent>` from the investigator's output and
-      # adds the `agent:<agent>` label. The task stays in Todo (no set_state), so
-      # the chosen agent's route matches it on the next poll.
-      assign_from_output: true
+      set_state: done
+    on_fail:
+      add_labels: [needs-attention]
 
 
 # ── Settings ───────────────────────────────────────────────────────────────────

--- a/.apiary/example-with-recovery.yaml
+++ b/.apiary/example-with-recovery.yaml
@@ -26,14 +26,14 @@ agents:
   - id: engineer
     description: Senior software engineer — backend and API design
     soul_file: .apiary/souls/engineer.md
-    preferred_models: [claude-sonnet-4-6, claude-haiku-4-5]
+    model: claude-sonnet-4-6
     skills: [backend-api, error-handling, database]
     runner: claude-cli
 
   - id: reviewer
     description: Code reviewer — quality assurance and best practices
     soul_file: .apiary/souls/reviewer.md
-    preferred_models: [claude-sonnet-4-6]
+    model: claude-sonnet-4-6
     skills: [code-review, testing]
     runner: claude-cli
 

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -6,6 +6,7 @@
 |---|---|---|
 | [foundation](changes/foundation/) | Especificação inicial do projeto | in-progress |
 | [workflow-mode](changes/workflow-mode/) | Substituir pool/router flat por pipelines multi-step declarativos | proposed |
+| [config-lint-removed-directives](changes/config-lint-removed-directives/) | `validate`/`run` rejeitam diretivas removidas (ex.: `assign_from_output`) e campos desconhecidos, com mensagem de migração | proposed |
 
 ## Arquivadas
 

--- a/openspec/changes/config-lint-removed-directives/proposal.md
+++ b/openspec/changes/config-lint-removed-directives/proposal.md
@@ -1,0 +1,49 @@
+# Config lint — detectar diretivas removidas e campos desconhecidos
+
+## Motivação
+
+Um pipeline real (project-erp) quebrou silenciosamente: só o primeiro agente
+(investigator) rodava. A causa foi `on_complete.assign_from_output: true` — uma
+diretiva **removida** quando o workflow engine virou o único caminho de dispatch.
+O campo ainda existe na struct e faz parse, mas nada o consome, então o engine
+nunca roteava a issue adiante (e ela re-triava em loop). `apiary validate` dizia
+`✓ config is valid`.
+
+A raiz foi misconfiguração, mas o problema mais profundo é que o apiary **aceita
+diretivas removidas e campos desconhecidos em silêncio**. Quem edita o config não
+tem como saber que uma diretiva está morta.
+
+## O que muda
+
+- **Registry de diretivas removidas** (`removedDirectives`): hoje cobre
+  `on_complete.assign_from_output` e `on_complete.assign_label_prefix`. Cada
+  entrada vira um **erro de validação** com a linha do YAML e uma mensagem que
+  aponta o substituto (workflow `triage` com passo `split`).
+- **Modo estrito (KnownFields)**: qualquer chave sem campo correspondente na struct
+  (typo como `lables`, diretiva inexistente) vira erro, em vez de ser ignorada.
+- Ambos rodam dentro de `(*Config).Validate()`, que `apiary validate` e `apiary run`
+  já tratam como erro fatal — logo a diretiva morta passa a **bloquear o start**
+  até o config ser migrado.
+- `apiary run` passa a imprimir também os `WorkflowWarnings()` no startup (antes só
+  apareciam no `validate`).
+- Exemplos migrados: `example-apiary-full.yaml` deixa de usar `assign_from_output`
+  (passa a usar `triage`/`split`); `example-with-recovery.yaml` troca o campo
+  inexistente `preferred_models` pelo `model` correto.
+
+## Fora de escopo
+
+- `settings.retry_policy`: a máquina de retry está inerte (a fila nunca é
+  populada; `ShouldRetry`/`IsRetriable` sem callers), mas há um exemplo dedicado
+  (`example-with-recovery.yaml`). Decidir entre remover ou religar o retry é uma
+  change à parte.
+- Comando `apiary migrate` que reescreve o config legado automaticamente
+  (possível follow-up).
+
+## Impacto
+
+- Mudança de comportamento **intencional**: configs com diretiva removida passam a
+  falhar no `validate`/`run` até serem migrados. É exatamente o "forcing function"
+  pedido.
+- Blast radius pequeno: `Validate()` tem dois callers, ambos já falham nos seus
+  erros. Risco principal são falsos positivos do modo estrito — coberto por teste
+  que faz lint de todos os exemplos versionados.

--- a/openspec/changes/config-lint-removed-directives/tasks.md
+++ b/openspec/changes/config-lint-removed-directives/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — config-lint-removed-directives
+
+- [x] `src/internal/config/lint.go`: registry `removedDirectives` +
+      `lintRemovedDirectives` (walk de `yaml.Node` p/ número de linha) +
+      `lintUnknownFields` (decode estrito `KnownFields(true)`) + combinador `lint()`
+      (no-op quando `rawContent` vazio).
+- [x] `src/internal/config/validate.go`: chamar `c.lint()` em `Validate()`.
+- [x] `src/internal/cli/run.go`: imprimir `WorkflowWarnings()` no startup.
+- [x] Migrar `.apiary/example-apiary-full.yaml` para `triage`/`split`.
+- [x] Corrigir `.apiary/example-with-recovery.yaml` (`preferred_models` → `model`).
+- [x] `src/internal/config/lint_test.go`: assign_from_output → erro+linha+mensagem;
+      typo → erro de campo desconhecido; todos os exemplos → lint limpo;
+      `rawContent` vazio → nil.
+- [x] `go build ./...`, `go vet`, `go test ./...` — tudo verde.
+- [ ] Follow-up (change à parte): decidir destino de `settings.retry_policy`.

--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -42,6 +42,9 @@ func newRunCmd() *cobra.Command {
 				}
 				return fmt.Errorf("config validation failed")
 			}
+			for _, w := range cfg.WorkflowWarnings() {
+				fmt.Fprintf(os.Stderr, "  ⚠ %s\n", w)
+			}
 
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()

--- a/src/internal/config/lint.go
+++ b/src/internal/config/lint.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// removedDirective describes a config key that older versions accepted but the
+// current engine no longer honors. Detecting these is what turns a silent no-op
+// (the directive is parsed but ignored) into a clear, actionable error.
+type removedDirective struct {
+	// path is the dotted YAML key path, e.g. "on_complete.assign_from_output".
+	// Only the last two segments are matched: the leaf key and (when present) its
+	// immediate parent key, which is enough to disambiguate without a full schema.
+	path string
+	// message explains what was removed and how to achieve the same result now.
+	message string
+}
+
+// removedDirectives is the registry of directives that were removed but still
+// parse into the structs (so a plain YAML decode accepts them silently). Add an
+// entry here whenever a directive is dropped so users get told instead of
+// debugging a pipeline that quietly does nothing.
+var removedDirectives = []removedDirective{
+	{
+		path: "on_complete.assign_from_output",
+		message: "`on_complete.assign_from_output` was removed: the workflow engine no longer " +
+			"relabels-and-repolls to hand a task off to another agent, so this directive does " +
+			"nothing — the classifier runs and the task is never routed onward.\n" +
+			"  Fix: route new work with a `triage` workflow that classifies and routes in ONE " +
+			"instance using a `split` step (classify → split → agent).\n" +
+			"  See .apiary/example-workflow.yaml for the pattern.",
+	},
+	{
+		path: "on_complete.assign_label_prefix",
+		message: "`on_complete.assign_label_prefix` was removed: it only configured the removed " +
+			"`assign_from_output` directive and now does nothing.\n" +
+			"  Fix: drop it and route via a `triage` workflow with a `split` step " +
+			"(see .apiary/example-workflow.yaml).",
+	},
+}
+
+// lint runs the post-parse config checks that a plain YAML decode cannot express:
+// removed directives that still parse silently, and unknown/typo'd keys. It
+// operates on the raw config text captured at load time, so it is a no-op for
+// configs constructed directly in code or via LoadDefaults (no rawContent).
+func (c *Config) lint() []error {
+	if c.rawContent == "" {
+		return nil
+	}
+	var errs []error
+	errs = append(errs, c.lintRemovedDirectives()...)
+	errs = append(errs, c.lintUnknownFields()...)
+	return errs
+}
+
+// lintRemovedDirectives walks the raw YAML and reports any removed directive from
+// the registry, with the source line so the user can jump straight to it.
+func (c *Config) lintRemovedDirectives() []error {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(c.rawContent), &root); err != nil {
+		// A YAML syntax error is reported by the real decode in Load; skip here.
+		return nil
+	}
+
+	var errs []error
+	walkYAMLKeys(&root, "", func(key, parentKey string, line int) {
+		for _, d := range removedDirectives {
+			leaf, parent := splitLeaf(d.path)
+			if key != leaf {
+				continue
+			}
+			if parent != "" && parentKey != parent {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("line %d: %s", line, d.message))
+		}
+	})
+	return errs
+}
+
+// lintUnknownFields strict-decodes the raw config and surfaces any key that has no
+// matching struct field — typically a typo (e.g. `lables:`) or a stray directive.
+// Free-form blocks (source/runner `config:` are map[string]any) accept any key, so
+// they never trip this. Removed directives that still exist as struct fields are
+// "known" to the decoder and are reported by lintRemovedDirectives instead, so
+// there is no double-reporting.
+func (c *Config) lintUnknownFields() []error {
+	dec := yaml.NewDecoder(strings.NewReader(expandEnv(c.rawContent)))
+	dec.KnownFields(true)
+
+	var probe Config
+	err := dec.Decode(&probe)
+	if err == nil {
+		return nil
+	}
+
+	var typeErr *yaml.TypeError
+	if !asTypeError(err, &typeErr) {
+		// Non-strictness parse errors are surfaced by the real decode in Load.
+		return nil
+	}
+
+	var errs []error
+	for _, msg := range typeErr.Errors {
+		errs = append(errs, fmt.Errorf("unknown config field — %s (typo, or a directive that does not exist)", msg))
+	}
+	return errs
+}
+
+// walkYAMLKeys visits every mapping key in the tree, passing the key name, its
+// immediate parent key (""for the root), and the key's source line.
+func walkYAMLKeys(n *yaml.Node, parentKey string, visit func(key, parentKey string, line int)) {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			walkYAMLKeys(c, parentKey, visit)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k, v := n.Content[i], n.Content[i+1]
+			visit(k.Value, parentKey, k.Line)
+			walkYAMLKeys(v, k.Value, visit)
+		}
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			walkYAMLKeys(c, parentKey, visit)
+		}
+	}
+}
+
+// splitLeaf returns the last path segment (the leaf key) and the segment before it
+// (its expected parent key, or "" when the path has a single segment).
+func splitLeaf(path string) (leaf, parent string) {
+	parts := strings.Split(path, ".")
+	leaf = parts[len(parts)-1]
+	if len(parts) >= 2 {
+		parent = parts[len(parts)-2]
+	}
+	return leaf, parent
+}
+
+// asTypeError reports whether err is a *yaml.TypeError, assigning it to target.
+// (errors.As avoids importing the errors package elsewhere in this file.)
+func asTypeError(err error, target **yaml.TypeError) bool {
+	te, ok := err.(*yaml.TypeError)
+	if ok {
+		*target = te
+	}
+	return ok
+}

--- a/src/internal/config/lint_test.go
+++ b/src/internal/config/lint_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newRawConfig builds a Config carrying raw YAML so the lint checks (which key off
+// rawContent) run, without going through file I/O or the rest of Validate.
+func newRawConfig(raw string) *Config {
+	return &Config{rawContent: raw}
+}
+
+func TestLint_RemovedAssignFromOutput(t *testing.T) {
+	raw := `version: "1"
+routes:
+  - id: classify
+    agent: investigator
+    on_complete:
+      assign_from_output: true
+`
+	errs := newRawConfig(raw).lint()
+	if len(errs) == 0 {
+		t.Fatal("expected an error for assign_from_output, got none")
+	}
+	got := errs[0].Error()
+	if !strings.Contains(got, "assign_from_output") {
+		t.Errorf("error should name the directive: %q", got)
+	}
+	if !strings.Contains(got, "triage") || !strings.Contains(got, "split") {
+		t.Errorf("error should point to the triage/split replacement: %q", got)
+	}
+	if !strings.Contains(got, "line 6") {
+		t.Errorf("error should cite the source line (6): %q", got)
+	}
+}
+
+func TestLint_RemovedAssignLabelPrefix(t *testing.T) {
+	raw := `version: "1"
+routes:
+  - id: classify
+    agent: investigator
+    on_complete:
+      assign_label_prefix: "agent:"
+`
+	errs := newRawConfig(raw).lint()
+	if len(errs) == 0 {
+		t.Fatal("expected an error for assign_label_prefix, got none")
+	}
+	if !strings.Contains(errs[0].Error(), "assign_label_prefix") {
+		t.Errorf("error should name the directive: %q", errs[0].Error())
+	}
+}
+
+func TestLint_UnknownFieldTypo(t *testing.T) {
+	// `lables` is a typo for `labels` inside a route match.
+	raw := `version: "1"
+routes:
+  - id: r1
+    agent: a1
+    match:
+      source: src
+      lables: [bug]
+`
+	errs := newRawConfig(raw).lint()
+	if len(errs) == 0 {
+		t.Fatal("expected an unknown-field error for the `lables` typo, got none")
+	}
+	joined := joinErrs(errs)
+	if !strings.Contains(joined, "lables") || !strings.Contains(joined, "unknown config field") {
+		t.Errorf("expected an unknown-field error mentioning `lables`, got: %q", joined)
+	}
+}
+
+func TestLint_CleanConfigNoErrors(t *testing.T) {
+	raw := `version: "1"
+agents:
+  - id: a1
+    model: claude-sonnet-4-6
+routes:
+  - id: r1
+    priority: 1
+    agent: a1
+    match:
+      source: src
+    on_complete:
+      set_state: done
+`
+	if errs := newRawConfig(raw).lint(); len(errs) != 0 {
+		t.Fatalf("expected no lint errors, got: %v", errs)
+	}
+}
+
+func TestLint_EmptyRawContentIsNoOp(t *testing.T) {
+	// A Config built in code (no rawContent) must never trip the raw-text lints,
+	// even if it holds a removed directive in its structs.
+	c := &Config{
+		Routes: []RouteConfig{
+			{ID: "r1", OnComplete: OnComplete{AssignFromOutput: true}},
+		},
+	}
+	if errs := c.lint(); errs != nil {
+		t.Fatalf("expected nil for empty rawContent, got: %v", errs)
+	}
+}
+
+// TestLint_ExampleConfigsNoFalsePositives strict-decodes and removed-checks every
+// shipped example so a stricter validator never rejects a config we ship.
+func TestLint_ExampleConfigsNoFalsePositives(t *testing.T) {
+	root := repoRoot(t)
+	examples := []string{
+		".apiary/example-apiary-full.yaml",
+		".apiary/example-workflow.yaml",
+		".apiary/example-with-recovery.yaml",
+		".apiary/apiary.yaml",
+	}
+	for _, rel := range examples {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(root, rel))
+			if err != nil {
+				t.Skipf("example not found: %v", err)
+			}
+			if errs := newRawConfig(string(data)).lint(); len(errs) != 0 {
+				t.Errorf("%s should lint clean, got: %v", rel, errs)
+			}
+		})
+	}
+}
+
+func joinErrs(errs []error) string {
+	var b strings.Builder
+	for _, e := range errs {
+		b.WriteString(e.Error())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// repoRoot walks up from the test's working directory to the repository root (the
+// dir holding the .apiary/ example configs), which sits above the Go module root
+// (go.mod lives in src/), so example paths resolve regardless of package location.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if fi, err := os.Stat(filepath.Join(dir, ".apiary")); err == nil && fi.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("could not locate repository root (.apiary/)")
+	return ""
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -106,5 +106,9 @@ func (c *Config) Validate() []error {
 
 	errs = append(errs, c.validateWorkflows()...)
 
+	// Removed-directive and unknown-field checks on the raw text (no-op when the
+	// config was built in code rather than loaded from a file).
+	errs = append(errs, c.lint()...)
+
 	return errs
 }


### PR DESCRIPTION
## Summary

Configs that use **removed** directives (e.g. `on_complete.assign_from_output`) passed silently: the field parses into the struct but the engine doesn't consume it, so the pipeline broke without warning and `apiary validate` still said `✓ config is valid`. That's exactly what stalled a real pipeline (only the investigator ran; the issues re-triaged in a loop).

This PR makes the config layer **detect and guide** that kind of error:

- **Removed-directives registry** (`src/internal/config/lint.go`): `on_complete.assign_from_output` and `assign_label_prefix` become an **error** with the YAML line number and a message pointing to the replacement (a `triage` workflow with a `split` step).
- **Strict mode (`KnownFields`)**: keys with no matching field (typos like `lables`, non-existent directives) become an error instead of being ignored.
- Both run inside `(*Config).Validate()`, which `apiary validate` and `apiary run` already treat as a fatal error → a dead directive now **blocks startup** until the config is migrated.
- `apiary run` now prints `WorkflowWarnings()` at startup (previously they only appeared in `validate`).
- Examples fixed: `example-apiary-full.yaml` migrates `assign_from_output` → `triage`/`split`; `example-with-recovery.yaml` swaps the non-existent field `preferred_models` → `model`.
- OpenSpec: the `config-lint-removed-directives` change + a `CHANGELOG` entry.

### Behavior change (intentional)
Configs with a removed directive now **fail** in `validate`/`run` until migrated — the desired forcing function.

### Out of scope
- `settings.retry_policy`: the retry machinery is inert (the queue is never populated; `ShouldRetry`/`IsRetriable` have no callers), but it has a dedicated example — remove vs. re-wire is a separate change.
- `example-apiary-full.yaml` has a pre-existing `default_runner`/`runner` mismatch (unrelated), left out of this PR.

## Test plan

- `go build ./...`, `go vet`, `go test ./...` — all green.
- `lint_test.go`: `assign_from_output` → error + line + migration message; a typo → unknown-field error; **all versioned examples** pass the lint (no false positives); empty `rawContent` → no-op.
- Manual smoke: `apiary validate` on a config with `assign_from_output` → exit 1 with the migration message pointing at line 165.