### PR TITLE
docs(openspec): workflow authoring v2 — sequence + if/else + gates (design)

### DIFF
--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -7,6 +7,7 @@
 | [foundation](changes/foundation/) | Especificação inicial do projeto | in-progress |
 | [workflow-mode](changes/workflow-mode/) | Substituir pool/router flat por pipelines multi-step declarativos | proposed |
 | [config-lint-removed-directives](changes/config-lint-removed-directives/) | `validate`/`run` rejeitam diretivas removidas (ex.: `assign_from_output`) e campos desconhecidos, com mensagem de migração | proposed |
+| [workflow-sequential-authoring](changes/workflow-sequential-authoring/) | Autoria v2: sequência implícita + `if/else` + gates de aprovação (`reject_when`/`on_reject`), compilando para o DAG atual (design only) | proposed |
 
 ## Arquivadas
 

--- a/openspec/changes/workflow-sequential-authoring/design.md
+++ b/openspec/changes/workflow-sequential-authoring/design.md
@@ -151,7 +151,71 @@ Remaining (decide at implementation):
 - Field-name collisions when two steps emit the same output field — qualify by step
   id in the lowered `memory` namespace if it ever happens.
 
-## 8. Worked example — the two target flows (authored form)
+## 8. Composition: loops, parallel, sub-workflows (GHA-inspired)
+
+All three were in the original `workflow-mode` spec. Status and v2 surface:
+
+### a) Loop over child items — `for_each` (GHA `strategy.matrix`)
+**Engine: built, but serial.** `StepTypeForeach` exists (`workflow/foreach.go`); it
+iterates `items` and binds each to `as`, but the loop is a plain `for range` — the
+`concurrency` field is parsed and **ignored** today.
+
+```yaml
+- id: implement-tasks
+  for_each: ${{ steps.design.outputs.tasks }}   # array from a prior step's output
+  as: task
+  agent: engineer
+  prompt: "Implement: ${{ task.title }}"
+  max: 20            # cap (lowers to foreach max_items)
+  concurrency: 4     # run N items at once  ← needs engine to honor it
+```
+Lowers to the existing `type: foreach` (`items`/`as`/`max_items`/`step`). Use case:
+Staff emits a `tasks` array → fan out an engineer run per task. **Work to do:**
+honor `concurrency` (bounded goroutines over items) — depends on §8d.
+
+### b) Sub-workflows / sub-steps — `uses` (GHA reusable workflows)
+**Engine: built.** `StepTypeWorkflow` (`workflow/subworkflow.go`) runs another named
+workflow as a step (one level of nesting), inheriting memory.
+
+```yaml
+- id: ship
+  uses: implement-pipeline        # call another workflow by id
+  if: ${{ classify.track == 'implement' }}
+```
+This is how a track becomes a reusable building block: define `implement-pipeline`
+(engineer→review→qa) once, `uses:` it from `triage` and elsewhere. Lowers to
+`type: workflow, workflow: implement-pipeline`. v2 work is just the `uses:` alias +
+parse.
+
+### c) Parallel steps — `parallel:` block (GHA parallel jobs)
+**Engine: NOT built.** `driveDAG`/`pickRunnable` runs one step at a time, so
+independent steps currently execute sequentially. True concurrency needs a
+concurrent scheduler bounded by a global agent semaphore (the unbuilt
+`concurrency-model` spec).
+
+```yaml
+- parallel:                       # run these concurrently, join when all pass
+    - { id: tests, agent: qa,       prompt: "Run the test suite." }
+    - { id: docs,  agent: engineer, prompt: "Update the docs." }
+# steps after the block run once BOTH finished (selective join)
+```
+Lowers to: block members share the upstream dep and have no order between them; the
+next step joins on all. **Biggest lift** — requires making the executor run ready
+steps on bounded goroutines and a global `settings.concurrency` semaphore around
+every agent invocation. Until built, `parallel:` could be accepted but executed
+sequentially (correct, not yet concurrent) — flagged so it's not a silent no-op.
+
+### d) Concurrency model (prerequisite for true a + c)
+Adopt the original `concurrency-model` decision: `settings.concurrency` is one
+global cap on simultaneous agent invocations across all instances, parallel steps,
+and foreach items. Every runner call acquires/releases one slot. This is what makes
+`for_each.concurrency` and `parallel:` safe (no 24-agents-on-one-workdir blowups).
+
+**Honest scope:** (b) is essentially free (alias). (a) needs concurrency honored.
+(c)+(d) are the real engineering — a concurrent scheduler + global semaphore — and
+should likely be their own change after the sequential v2 + gates land.
+
+## 9. Worked example — the two target flows (authored form)
 
 ```yaml
 workflows:

--- a/openspec/changes/workflow-sequential-authoring/design.md
+++ b/openspec/changes/workflow-sequential-authoring/design.md
@@ -1,106 +1,116 @@
-# Design — Workflow authoring v2
+# Design — Workflow authoring v2 (GitHub Actions–inspired)
 
 > Design only. Describes the authoring surface, how it lowers to the current DAG
-> engine, and the one new engine capability (`fail_when`).
+> engine, and the small engine capabilities it needs.
+
+## 0. Inspiration: GitHub Actions
+
+The authored surface follows the GitHub Actions `steps:` model, which already
+matches the requested feel: a flat, ordered list that runs top-to-bottom, each
+step optionally guarded by `if:`, with outputs referenced across steps.
+
+| GitHub Actions            | Apiary v2                              |
+|---------------------------|---------------------------------------|
+| `steps:` (ordered)        | `steps:` (ordered, implicit sequence) |
+| `uses:` / `run:`          | `agent:`                              |
+| `with:`                   | `prompt:` (per-step instruction)      |
+| `id:`, `name:`            | `id:`, `name:`                        |
+| `if: ${{ … }}`            | `if: ${{ … }}` (skip when false)      |
+| step outputs (`$GITHUB_OUTPUT`) | `output:` schema, filled from `APIARY_OUTPUT` |
+| `${{ steps.x.outputs.y }}`| `${{ steps.x.outputs.y }}` (short: `x.y`) |
+| `github`, `env` contexts  | `cell`, `workflow` contexts           |
+| `continue-on-error`       | `reject_when` + `on_reject` (richer: loop-back) |
+
+Where Actions stops (it has no "reject → redo an earlier step"), we add the gate
+primitives in §2.
 
 ## 1. Authoring model
 
-A workflow's `steps` is an **ordered list**. Two kinds of entries:
+`steps:` is a flat **ordered list**. Each step:
 
-### a) Agent step
 ```yaml
-- id: review                # optional; auto-generated if omitted, required if referenced
+- id: review                 # optional; required only if referenced
+  name: Review the PR        # optional, human label
   agent: reviewer
-  prompt: "..."             # optional per-step instruction
-  output: { verdict: { enum: [approved, rejected] } }   # structured-output schema
-  reject_when: 'review.verdict == "rejected"'           # optional gate
-  on_reject: { restart_from: implement, max: 3 }        # optional loop-back
+  prompt: "..."              # optional per-step instruction
+  if: ${{ steps.classify.outputs.track == 'implement' }}   # optional guard
+  output:                    # structured-output schema; fields become outputs
+    verdict: { enum: [approved, rejected] }
+  reject_when: ${{ steps.review.outputs.verdict == 'rejected' }}
+  on_reject: { restart_from: implement, max: 3 }
 ```
 
-### b) Conditional block
-```yaml
-- if: '<expr>'
-  then: [ <steps...> ]      # ordered list of steps
-  else: [ <steps...> ]      # optional
-```
+Rules:
+- **Implicit sequencing.** Step *N* runs after step *N-1*. Declaration order =
+  execution order. No `depends_on` in the authored form.
+- **Per-step `if:`** (GHA-style). Evaluated before the step runs; false → the step
+  is **skipped** and the sequence continues. Branching is expressed by giving steps
+  complementary conditions (the "implement" steps carry
+  `if: …track == 'implement'`; the "complex" step carries `if: …track ==
+  'complex'`). No `then/else` blocks, no `goto`, and **no explicit join** — a step
+  after a branch simply omits `if:` and runs next.
+- **Outputs & references.** Declaring `output:` makes a step's fields addressable
+  as `${{ steps.<id>.outputs.<field> }}`, with `<id>.<field>` as a short alias.
+  No manual `memory.write`.
+- **Expressions** use `${{ … }}` over contexts `steps`, `cell`, `workflow`.
+- A step with an unmet `if:` and everything depending on its output skips too
+  (handled by the engine skip-cascade).
 
-`if` blocks nest arbitrarily. No `goto`, no labels.
-
-### Rules
-- **Implicit sequencing:** within any list, step *N* runs only after step *N-1*
-  completes (passed). Declaration order = execution order.
-- **No `depends_on` in v2.** (Kept only as the lowered form / advanced escape
-  hatch — see §6 compatibility.)
-- **Output references:** `&lt;step_id&gt;.&lt;field&gt;` resolves to that step's structured
-  output. Available to any later step's `if` / `reject_when`. No manual
-  `memory.write` — declaring `output:` makes the fields addressable.
-- A branch with no further steps just ends (e.g. the `complex` track is
-  `staff` then End).
-
-## 2. Approval / reject gates
+## 2. Approval / reject gates (beyond Actions)
 
 ```yaml
 - id: review
   agent: reviewer
   output: { verdict: { enum: [approved, rejected] } }
-  reject_when: 'review.verdict == "rejected"'
+  reject_when: ${{ steps.review.outputs.verdict == 'rejected' }}
   on_reject: { restart_from: implement, max: 3 }
 ```
 
-Semantics:
 - After the agent runs, evaluate `reject_when` against the step's **own** fresh
-  structured output. True → the step is **rejected** (a logical failure, distinct
-  from a crash).
-- `on_reject.restart_from: <earlier step id>` → re-run from that step (and
-  everything after it), up to `max` times.
-- No `on_reject` + rejected → the workflow fails → `on_fail` (e.g.
-  `add_labels: [needs-attention]`).
-- Retries exhausted → workflow fails → `on_fail`. (If the engineer can't satisfy
-  the reviewer in `max` rounds, escalate to a human.)
-- A genuine crash (agent exits non-zero) is still a failure independent of
+  output → true means **rejected** (a logical failure, distinct from a crash).
+- `on_reject.restart_from: <earlier step id>` re-runs from that step (and
+  everything after), up to `max` times.
+- No `on_reject` + rejected, or retries exhausted → the workflow fails →
+  `on_fail` (e.g. `add_labels: [needs-attention]`) — escalate to a human.
+- A real crash (agent exits non-zero) is still a failure independent of
   `reject_when`.
 
-## 3. New engine capability: `fail_when` (the only executor change)
+## 3. Engine capabilities needed (two small additions)
 
-Today `Success = (cli exit == 0)` (`runner/execution/cli.go:197`); structured
-output does not affect it. We add a way to derive a step's outcome from its output:
+Everything else is authoring-time lowering. The engine needs:
 
-- New optional field on the lowered agent step: `fail_when string` (expression).
-- In `runAgentDAGStep` (`workflow/dag.go`), after `runStep` returns `res`:
-  - Build a **transient** eval context = current memory (`r.memoryValues()`) plus
-    *this* step's just-produced structured output (it isn't "passed" yet, so it
-    isn't in memory). Reuse `EvalContext` + `ParseExpr`/`Eval` (`workflow/expr.go`).
-  - `rejected := step.FailWhen != "" && eval(step.FailWhen)`.
-  - `failed := !res.Success || rejected`.
-  - Then take the existing pass/fail branches unchanged — on fail, the current
-    `on_fail.goto` + `max_retries` + `resetLoop` machinery handles the loop-back.
-- Reuse existing `on_missing_output: fail` so a reviewer that forgets to emit
-  `verdict` escalates instead of silently passing (missing key → `reject_when`
-  would be false → would otherwise proceed).
+1. **`fail_when`** on the agent step. Today `Success = (cli exit == 0)`
+   (`runner/execution/cli.go:197`). In `workflow/dag.go` `runAgentDAGStep`, after
+   `runStep` returns `res`, build a transient eval context = current memory +
+   *this* step's fresh structured output, then
+   `failed := !res.Success || eval(fail_when)`. Reuse `EvalContext` /
+   `ParseExpr` / `Eval` (`workflow/expr.go`). Existing `on_fail.goto` +
+   `max_retries` + `resetLoop` handle the loop-back unchanged.
 
-That is the entire engine delta. Everything else is authoring-time lowering.
+2. **Step-level `condition`** (the lowered form of per-step `if:`). In
+   `pickRunnable`/scheduling, a step whose `condition` evaluates false is marked
+   **skipped** (cascading to dependents via existing `markSkipped`). This is the
+   GHA `if:` semantics and is simpler than synthesizing a `split` per condition.
+
+Both are small and localized; the DAG executor is otherwise untouched.
 
 ## 4. Lowering v2 → current DAG `StepConfig`
 
-The parser compiles the v2 tree into today's flat `[]StepConfig` that the engine
-already runs:
+The parser compiles the authored list into today's `[]StepConfig`:
 
-| v2 construct                  | Lowered form |
+| v2 (authored)                 | Lowered form |
 |-------------------------------|--------------|
-| step *N* after step *N-1*     | `depends_on: [<id of N-1>]` |
-| `if/then/else`                | a `split` step (`type: split`) whose `branches` are `{if: <expr>, goto: <first step of then>}` and `{else: true, goto: <first step of else>}`; the last step before the block depends on nothing extra; block steps chain internally; steps **after** the block depend on the block's join |
-| `reject_when`                 | `fail_when` on the lowered agent step |
-| `on_reject: {restart_from, max}` | `on_fail: {goto: <restart_from>, max_retries: max}` |
-| `step.field` reference        | `memory.field` is auto-wired: the parser adds the referenced fields to that step's `memory.write`, so the existing eval context resolves them |
+| order (implicit sequence)     | `depends_on: [<previous step id>]` |
+| per-step `if: ${{ … }}`       | step-level `condition` (§3.2) |
+| `${{ steps.x.outputs.y }}` / `x.y` | rewritten to the flat `memory.y` lookup; parser adds `y` to step *x*'s `memory.write` (field names unique per workflow; else qualify) |
+| `output: {…}`                 | `output_schema: {…}` (alias) |
+| `reject_when`                 | `fail_when` (§3.1) |
+| `on_reject: {restart_from, max}` | `on_fail: {goto: restart_from, max_retries: max}` |
 
-Join handling after an `if` block: steps following the block depend on whichever
-branch ran. The current engine already models this — unchosen branches are skipped
-and skip-cascades downstream (`skipUnreachable`/`markSkipped`), so a post-block
-step `depends_on` the branch tips with "any passed" join semantics. (Open question
-§7 — confirm the join rule or insert a synthetic no-op join step.)
-
-Because lowering targets the existing structures, **all current engine tests keep
-passing**; v2 is validated by asserting the lowered DAG equals a hand-written one.
+`split`/`goto` are **not** emitted by the lowering — branching is per-step
+`condition`. (`split` remains a valid hand-authored low-level primitive; see §6.)
+Because lowering targets existing structures, current engine tests keep passing and
+v2 is verified by asserting the lowered DAG matches a golden `[]StepConfig`.
 
 ## 5. Reject feedback survives the loop (via the PR, not memory)
 
@@ -109,36 +119,79 @@ passing**; v2 is validated by asserting the lowered DAG equals a hand-written on
 `implement`, the reviewer's contribution is wiped — the engineer would not see the
 feedback through workflow memory.
 
-Resolution: rejection feedback lives on the **PR itself** (the reviewer posts a
-real GitHub review / comments; QA posts findings). On restart, the engineer re-reads
-the PR thread. Workflow memory only carries the gate verdict. This matches how human
-teams work and sidesteps the memory-reset entirely. Souls are written accordingly
-(reviewer/QA comment on the PR; engineer reads PR comments before redoing).
+Resolution: rejection feedback lives on the **PR** (reviewer posts a real GitHub
+review/comments; QA posts findings). On restart, the engineer re-reads the PR
+thread. Workflow memory only carries the gate verdict. This matches how human teams
+work and sidesteps the memory reset. Souls are written accordingly.
 
 ## 6. Backward compatibility
 
-- `depends_on`, `split`/`branches`/`goto` remain valid — they are exactly the
-  lowered form. Existing configs run unchanged.
-- v2 is additive sugar. A workflow may not mix `if:` blocks and manual `goto` for
-  the same flow (validation rejects the ambiguous mix).
-- Docs/examples move to v2 as the recommended style; `split` documented as the
-  low-level form.
+- `depends_on`, `split`/`branches`/`goto` remain valid — the low-level form the v2
+  surface lowers to. Existing configs run unchanged.
+- `depends_on` is **kept as an advanced escape hatch** for non-linear/diamond flows
+  (decision r1); the default authored surface is sequence + per-step `if:`.
+- v2 is additive. A flow may not mix authored `if:`/sequence with hand-written
+  `goto` (validation rejects the ambiguous mix).
+- Docs/examples move to v2; `split`/`depends_on` documented as low-level.
 
-## 7. Validation & open questions
+## 7. Decisions (review round 1) & remaining questions
 
-Validation (extends `config/workflow_validate.go`):
-- `reject_when`/`if` expressions must parse (`ParseExpr`).
-- `on_reject.restart_from` must reference an earlier step in the same sequence.
-- referenced `&lt;step&gt;.&lt;field&gt;` must be declared in that step's `output:`.
-- `reject_when` without `on_reject` → warning (a reject will fail the whole flow).
+Resolved:
+1. **Branching = per-step `if:`** (GHA-style); no `then/else` blocks. This also
+   resolves the earlier "join after a block" question — there are no blocks, so a
+   post-branch step just omits `if:` (implicit any-passed continuation).
+2. **`depends_on` kept as advanced** escape hatch.
+3. **Step-scoped references** `${{ steps.<id>.outputs.<field> }}` (short `<id>.<field>`).
+4. **`output:`** adopted as the authored key (alias of `output_schema:`).
 
-Open questions for review:
-1. **Join semantics** after an `if` block: rely on skip-cascade "any-passed" join,
-   or always insert a synthetic join step? (Affects steps placed after a block.)
-2. **Keep or drop `depends_on`** in the authored surface (parallel/diamond flows
-   are the only thing pure sequencing can't express). Keep as advanced, or add an
-   explicit `parallel:` block later?
-3. **Reference syntax:** `review.verdict` (step-scoped, proposed) vs keep
-   `memory.verdict`. Step-scoped is clearer but needs the auto-wiring in §4.
-4. **`output` shorthand** vs current `output_schema`: adopt the short `output:` key
-   or keep `output_schema:`?
+Remaining (decide at implementation):
+- Whether to support the `${{ … }}` delimiter literally or accept bare expressions
+  (e.g. `if: "classify.track == 'complex'"`). Leaning: accept both; `${{ }}` for
+  GHA familiarity, bare for brevity.
+- Field-name collisions when two steps emit the same output field — qualify by step
+  id in the lowered `memory` namespace if it ever happens.
+
+## 8. Worked example — the two target flows (authored form)
+
+```yaml
+workflows:
+  - id: triage
+    trigger:
+      match: { source: project-erp, exclude_label_prefix: "agent:" }
+    steps:
+      - id: classify
+        name: Classify the issue
+        agent: investigator
+        output: { track: { enum: [implement, complex] } }
+
+      # Complex track → Staff documents + splits into sub-issues, then End.
+      - id: design
+        name: Design & decompose
+        agent: staff
+        if: ${{ classify.track == 'complex' }}
+
+      # Implementation track → Engineer → Reviewer → QA, reject loops back.
+      - id: implement
+        name: Implement & open PR
+        agent: engineer
+        if: ${{ classify.track == 'implement' }}
+
+      - id: review
+        name: Review the PR
+        agent: reviewer
+        if: ${{ classify.track == 'implement' }}
+        output: { verdict: { enum: [approved, rejected] } }
+        reject_when: ${{ review.verdict == 'rejected' }}
+        on_reject: { restart_from: implement, max: 3 }
+
+      - id: qa
+        name: QA validation
+        agent: qa
+        if: ${{ classify.track == 'implement' }}
+        output: { verdict: { enum: [approved, rejected] } }
+        reject_when: ${{ qa.verdict == 'rejected' }}
+        on_reject: { restart_from: implement, max: 3 }
+
+    on_complete: { set_state: closed }
+    on_fail:     { add_labels: [needs-attention] }
+```

--- a/openspec/changes/workflow-sequential-authoring/design.md
+++ b/openspec/changes/workflow-sequential-authoring/design.md
@@ -1,0 +1,144 @@
+# Design — Workflow authoring v2
+
+> Design only. Describes the authoring surface, how it lowers to the current DAG
+> engine, and the one new engine capability (`fail_when`).
+
+## 1. Authoring model
+
+A workflow's `steps` is an **ordered list**. Two kinds of entries:
+
+### a) Agent step
+```yaml
+- id: review                # optional; auto-generated if omitted, required if referenced
+  agent: reviewer
+  prompt: "..."             # optional per-step instruction
+  output: { verdict: { enum: [approved, rejected] } }   # structured-output schema
+  reject_when: 'review.verdict == "rejected"'           # optional gate
+  on_reject: { restart_from: implement, max: 3 }        # optional loop-back
+```
+
+### b) Conditional block
+```yaml
+- if: '<expr>'
+  then: [ <steps...> ]      # ordered list of steps
+  else: [ <steps...> ]      # optional
+```
+
+`if` blocks nest arbitrarily. No `goto`, no labels.
+
+### Rules
+- **Implicit sequencing:** within any list, step *N* runs only after step *N-1*
+  completes (passed). Declaration order = execution order.
+- **No `depends_on` in v2.** (Kept only as the lowered form / advanced escape
+  hatch — see §6 compatibility.)
+- **Output references:** `&lt;step_id&gt;.&lt;field&gt;` resolves to that step's structured
+  output. Available to any later step's `if` / `reject_when`. No manual
+  `memory.write` — declaring `output:` makes the fields addressable.
+- A branch with no further steps just ends (e.g. the `complex` track is
+  `staff` then End).
+
+## 2. Approval / reject gates
+
+```yaml
+- id: review
+  agent: reviewer
+  output: { verdict: { enum: [approved, rejected] } }
+  reject_when: 'review.verdict == "rejected"'
+  on_reject: { restart_from: implement, max: 3 }
+```
+
+Semantics:
+- After the agent runs, evaluate `reject_when` against the step's **own** fresh
+  structured output. True → the step is **rejected** (a logical failure, distinct
+  from a crash).
+- `on_reject.restart_from: <earlier step id>` → re-run from that step (and
+  everything after it), up to `max` times.
+- No `on_reject` + rejected → the workflow fails → `on_fail` (e.g.
+  `add_labels: [needs-attention]`).
+- Retries exhausted → workflow fails → `on_fail`. (If the engineer can't satisfy
+  the reviewer in `max` rounds, escalate to a human.)
+- A genuine crash (agent exits non-zero) is still a failure independent of
+  `reject_when`.
+
+## 3. New engine capability: `fail_when` (the only executor change)
+
+Today `Success = (cli exit == 0)` (`runner/execution/cli.go:197`); structured
+output does not affect it. We add a way to derive a step's outcome from its output:
+
+- New optional field on the lowered agent step: `fail_when string` (expression).
+- In `runAgentDAGStep` (`workflow/dag.go`), after `runStep` returns `res`:
+  - Build a **transient** eval context = current memory (`r.memoryValues()`) plus
+    *this* step's just-produced structured output (it isn't "passed" yet, so it
+    isn't in memory). Reuse `EvalContext` + `ParseExpr`/`Eval` (`workflow/expr.go`).
+  - `rejected := step.FailWhen != "" && eval(step.FailWhen)`.
+  - `failed := !res.Success || rejected`.
+  - Then take the existing pass/fail branches unchanged — on fail, the current
+    `on_fail.goto` + `max_retries` + `resetLoop` machinery handles the loop-back.
+- Reuse existing `on_missing_output: fail` so a reviewer that forgets to emit
+  `verdict` escalates instead of silently passing (missing key → `reject_when`
+  would be false → would otherwise proceed).
+
+That is the entire engine delta. Everything else is authoring-time lowering.
+
+## 4. Lowering v2 → current DAG `StepConfig`
+
+The parser compiles the v2 tree into today's flat `[]StepConfig` that the engine
+already runs:
+
+| v2 construct                  | Lowered form |
+|-------------------------------|--------------|
+| step *N* after step *N-1*     | `depends_on: [<id of N-1>]` |
+| `if/then/else`                | a `split` step (`type: split`) whose `branches` are `{if: <expr>, goto: <first step of then>}` and `{else: true, goto: <first step of else>}`; the last step before the block depends on nothing extra; block steps chain internally; steps **after** the block depend on the block's join |
+| `reject_when`                 | `fail_when` on the lowered agent step |
+| `on_reject: {restart_from, max}` | `on_fail: {goto: <restart_from>, max_retries: max}` |
+| `step.field` reference        | `memory.field` is auto-wired: the parser adds the referenced fields to that step's `memory.write`, so the existing eval context resolves them |
+
+Join handling after an `if` block: steps following the block depend on whichever
+branch ran. The current engine already models this — unchosen branches are skipped
+and skip-cascades downstream (`skipUnreachable`/`markSkipped`), so a post-block
+step `depends_on` the branch tips with "any passed" join semantics. (Open question
+§7 — confirm the join rule or insert a synthetic no-op join step.)
+
+Because lowering targets the existing structures, **all current engine tests keep
+passing**; v2 is validated by asserting the lowered DAG equals a hand-written one.
+
+## 5. Reject feedback survives the loop (via the PR, not memory)
+
+`resetLoop(target)` resets the target and its transitive dependents to pending and
+**deletes their memory contributions**. So when `review` rejects and restarts from
+`implement`, the reviewer's contribution is wiped — the engineer would not see the
+feedback through workflow memory.
+
+Resolution: rejection feedback lives on the **PR itself** (the reviewer posts a
+real GitHub review / comments; QA posts findings). On restart, the engineer re-reads
+the PR thread. Workflow memory only carries the gate verdict. This matches how human
+teams work and sidesteps the memory-reset entirely. Souls are written accordingly
+(reviewer/QA comment on the PR; engineer reads PR comments before redoing).
+
+## 6. Backward compatibility
+
+- `depends_on`, `split`/`branches`/`goto` remain valid — they are exactly the
+  lowered form. Existing configs run unchanged.
+- v2 is additive sugar. A workflow may not mix `if:` blocks and manual `goto` for
+  the same flow (validation rejects the ambiguous mix).
+- Docs/examples move to v2 as the recommended style; `split` documented as the
+  low-level form.
+
+## 7. Validation & open questions
+
+Validation (extends `config/workflow_validate.go`):
+- `reject_when`/`if` expressions must parse (`ParseExpr`).
+- `on_reject.restart_from` must reference an earlier step in the same sequence.
+- referenced `&lt;step&gt;.&lt;field&gt;` must be declared in that step's `output:`.
+- `reject_when` without `on_reject` → warning (a reject will fail the whole flow).
+
+Open questions for review:
+1. **Join semantics** after an `if` block: rely on skip-cascade "any-passed" join,
+   or always insert a synthetic join step? (Affects steps placed after a block.)
+2. **Keep or drop `depends_on`** in the authored surface (parallel/diamond flows
+   are the only thing pure sequencing can't express). Keep as advanced, or add an
+   explicit `parallel:` block later?
+3. **Reference syntax:** `review.verdict` (step-scoped, proposed) vs keep
+   `memory.verdict`. Step-scoped is clearer but needs the auto-wiring in §4.
+4. **`output` shorthand** vs current `output_schema`: adopt the short `output:` key
+   or keep `output_schema:`?

--- a/openspec/changes/workflow-sequential-authoring/design.md
+++ b/openspec/changes/workflow-sequential-authoring/design.md
@@ -75,9 +75,11 @@ Rules:
 - A real crash (agent exits non-zero) is still a failure independent of
   `reject_when`.
 
-## 3. Engine capabilities needed (two small additions)
+## 3. Engine capabilities needed
 
-Everything else is authoring-time lowering. The engine needs:
+Everything else is authoring-time lowering. The engine needs three additions; the
+first two are small and localized, the third (concurrency) is the substantial one
+and is now **in scope** (§8e).
 
 1. **`fail_when`** on the agent step. Today `Success = (cli exit == 0)`
    (`runner/execution/cli.go:197`). In `workflow/dag.go` `runAgentDAGStep`, after
@@ -92,9 +94,23 @@ Everything else is authoring-time lowering. The engine needs:
    **skipped** (cascading to dependents via existing `markSkipped`). This is the
    GHA `if:` semantics and is simpler than synthesizing a `split` per condition.
 
-Both are small and localized; the DAG executor is otherwise untouched.
+3. **Concurrent scheduler + global agent semaphore** (§8e) — runs all
+   currently-runnable steps at once and bounds total simultaneous agent invocations
+   by `settings.concurrency`. This is what makes `parallel:` and
+   `for_each.concurrency` real.
 
 ## 4. Lowering v2 → current DAG `StepConfig`
+
+```mermaid
+flowchart LR
+  yaml["authored v2 YAML<br/>steps + if + gates + for_each/uses/parallel"]
+  yaml --> parse[parse]
+  parse --> lower["lowering pass"]
+  lower --> ir["[]StepConfig (existing IR)<br/>depends_on · condition · split · fail_when · on_fail.goto · foreach · workflow"]
+  ir --> eng["DAG engine<br/>concurrent scheduler (§8e)"]
+  eng --> sem["global semaphore<br/>settings.concurrency"]
+  sem --> run["runner adapters → agents"]
+```
 
 The parser compiles the authored list into today's `[]StepConfig`:
 
@@ -171,7 +187,18 @@ iterates `items` and binds each to `as`, but the loop is a plain `for range` —
 ```
 Lowers to the existing `type: foreach` (`items`/`as`/`max_items`/`step`). Use case:
 Staff emits a `tasks` array → fan out an engineer run per task. **Work to do:**
-honor `concurrency` (bounded goroutines over items) — depends on §8d.
+honor `concurrency` (bounded goroutines over items) — depends on §8e.
+
+```mermaid
+flowchart TD
+  design["design · staff<br/>output: tasks[]"] --> fe[/"for_each task<br/>concurrency 4"/]
+  fe --> t1["engineer · task 1"]
+  fe --> t2["engineer · task 2"]
+  fe --> tn["engineer · task N"]
+  t1 --> j([join])
+  t2 --> j
+  tn --> j
+```
 
 ### b) Sub-workflows / sub-steps — `uses` (GHA reusable workflows)
 **Engine: built.** `StepTypeWorkflow` (`workflow/subworkflow.go`) runs another named
@@ -188,10 +215,9 @@ This is how a track becomes a reusable building block: define `implement-pipelin
 parse.
 
 ### c) Parallel steps — `parallel:` block (GHA parallel jobs)
-**Engine: NOT built.** `driveDAG`/`pickRunnable` runs one step at a time, so
-independent steps currently execute sequentially. True concurrency needs a
-concurrent scheduler bounded by a global agent semaphore (the unbuilt
-`concurrency-model` spec).
+**Engine: in scope** (scheduler design in §8e). `driveDAG`/`pickRunnable` runs one
+step at a time today; this change makes the executor run all ready steps
+concurrently, bounded by the global semaphore.
 
 ```yaml
 - parallel:                       # run these concurrently, join when all pass
@@ -200,22 +226,77 @@ concurrent scheduler bounded by a global agent semaphore (the unbuilt
 # steps after the block run once BOTH finished (selective join)
 ```
 Lowers to: block members share the upstream dep and have no order between them; the
-next step joins on all. **Biggest lift** — requires making the executor run ready
-steps on bounded goroutines and a global `settings.concurrency` semaphore around
-every agent invocation. Until built, `parallel:` could be accepted but executed
-sequentially (correct, not yet concurrent) — flagged so it's not a silent no-op.
+next step `depends_on` all of them (selective join — proceed only when all pass).
 
-### d) Concurrency model (prerequisite for true a + c)
+```mermaid
+flowchart TD
+  impl["implement · engineer"] --> fork{{parallel}}
+  fork --> tests["tests · qa"]
+  fork --> docs["docs · engineer"]
+  tests --> join{{join · all passed}}
+  docs --> join
+  join --> ship["ship · engineer"]
+```
+
+### d) Concurrency model
 Adopt the original `concurrency-model` decision: `settings.concurrency` is one
 global cap on simultaneous agent invocations across all instances, parallel steps,
 and foreach items. Every runner call acquires/releases one slot. This is what makes
 `for_each.concurrency` and `parallel:` safe (no 24-agents-on-one-workdir blowups).
+Per-agent `max_workers` remains as a secondary cap (acquire both).
 
-**Honest scope:** (b) is essentially free (alias). (a) needs concurrency honored.
-(c)+(d) are the real engineering — a concurrent scheduler + global semaphore — and
-should likely be their own change after the sequential v2 + gates land.
+### e) Concurrent scheduler design (the substantial piece)
+
+Turn the sequential loop into a concurrent one:
+
+- **`pickAllRunnable()`** replaces `pickRunnable()` — returns *every* step that is
+  activated, pending, condition-true, and deps-passed.
+- The driver launches each on a goroutine that acquires a **global semaphore**
+  (`settings.concurrency`) and its per-agent slot before invoking the runner, and
+  releases on completion. Results return on a channel.
+- A single **scheduler goroutine owns `dagRun` state**; worker goroutines only run
+  agents and send results back. The scheduler applies each result (set
+  passed/failed, split activation, `on_fail.goto` reset), then re-computes the
+  runnable set and dispatches newly-unblocked steps. No shared-state mutation off
+  the scheduler goroutine → no lock sprawl. (`dagRun` stays single-writer.)
+- **Termination:** done when nothing is running and nothing is runnable; then the
+  existing failed/skip logic decides the outcome.
+
+Concurrency-specific decisions:
+- **Deterministic memory ordering.** `passedOrder` must order by **declaration
+  order**, not completion order, so the memory document and last-write-wins are
+  reproducible regardless of who finishes first.
+- **Loop-back while siblings run.** If a step triggers `on_fail.goto`, the
+  scheduler stops dispatching new work, lets in-flight siblings finish (or cancels
+  them — decision below), applies `resetLoop`, then resumes. Default: **let
+  in-flight finish, then reset** (simpler, no cancellation races).
+- **Approval steps** force a quiesce: when an approval becomes runnable the
+  scheduler drains in-flight steps, then parks (`outcomeWaiting`) as today.
+- **`for_each.concurrency`** uses the same global semaphore for its item runs.
+
+Risk/cost: this is the largest part. It is additive — when `settings.concurrency`
+is 1, behaviour is identical to today's sequential executor, so existing tests and
+flows are unchanged; concurrency is opt-in by raising the cap and using `parallel:`.
+
+**Scope summary:** (b) ~free (alias); (a) easy (alias, real once §8e lands);
+(c)+(d)+(e) are the real engineering, now included in this change.
 
 ## 9. Worked example — the two target flows (authored form)
+
+```mermaid
+flowchart TD
+  classify["classify · investigator<br/>output: track"] --> dec{track?}
+  dec -->|complex| design["design · staff<br/>doc + split into sub-issues"] --> done([End])
+  dec -->|implement| implement["implement · engineer<br/>opens PR"]
+  implement --> review["review · reviewer<br/>verdict"]
+  review -->|approved| qa["qa · verdict"]
+  review -->|rejected| implement
+  qa -->|approved| done
+  qa -->|rejected| implement
+```
+
+The authored YAML (per-step `if:` + gates) that produces the flow above:
+
 
 ```yaml
 workflows:

--- a/openspec/changes/workflow-sequential-authoring/design.md
+++ b/openspec/changes/workflow-sequential-authoring/design.md
@@ -6,55 +6,94 @@
 ## 0. Inspiration: GitHub Actions
 
 The authored surface follows the GitHub Actions `steps:` model, which already
-matches the requested feel: a flat, ordered list that runs top-to-bottom, each
-step optionally guarded by `if:`, with outputs referenced across steps.
+matches the requested feel: an ordered `steps:` list that runs top-to-bottom, each
+step optionally guarded by `if:`, with outputs referenced across steps. We borrow
+that feel but **diverge on composition**: Actions is flat, whereas here sub-steps,
+parallel, and loops are **nested inside a parent step** (§1) — more readable, no
+references.
 
 | GitHub Actions            | Apiary v2                              |
 |---------------------------|---------------------------------------|
-| `steps:` (ordered)        | `steps:` (ordered, implicit sequence) |
-| `uses:` / `run:`          | `agent:`                              |
+| `steps:` (ordered, flat)  | `steps:` (ordered, **nestable** tree) |
+| `uses:` / `run:`          | `agent:` (leaf); composition is nesting, not `uses:` |
 | `with:`                   | `prompt:` (per-step instruction)      |
 | `id:`, `name:`            | `id:`, `name:`                        |
-| `if: ${{ … }}`            | `if: ${{ … }}` (skip when false)      |
+| `if: ${{ … }}`            | `if: ${{ … }}` on a step **or a whole group** |
 | step outputs (`$GITHUB_OUTPUT`) | `output:` schema, filled from `APIARY_OUTPUT` |
 | `${{ steps.x.outputs.y }}`| `${{ steps.x.outputs.y }}` (short: `x.y`) |
 | `github`, `env` contexts  | `cell`, `workflow` contexts           |
+| `strategy.matrix`         | nested `for_each:` + `as:` + `steps:` |
+| parallel jobs             | explicit `parallel:` step with a `join` outcome |
 | `continue-on-error`       | `reject_when` + `on_reject` (richer: loop-back) |
 
-Where Actions stops (it has no "reject → redo an earlier step"), we add the gate
-primitives in §2.
+Where Actions stops (no "reject → redo an earlier step", flat steps only), we add
+nested composition (§1, §8) and the gate primitives (§2).
 
-## 1. Authoring model
+## 1. Authoring model — a nested step tree
 
-`steps:` is a flat **ordered list**. Each step:
+`steps:` is an **ordered tree**. Composition is **visual nesting**, never
+references or `depends_on`: if a step has sub-steps, runs things in parallel, or
+loops, those steps live **inside** it. The indentation *is* the control flow — you
+read the whole pipeline top-to-bottom without chasing ids.
 
+A step is one of four kinds:
+
+**Leaf — an agent step**
 ```yaml
-- id: review                 # optional; required only if referenced
+- id: review                 # optional; required only if referenced by an expr
   name: Review the PR        # optional, human label
   agent: reviewer
   prompt: "..."              # optional per-step instruction
-  if: ${{ steps.classify.outputs.track == 'implement' }}   # optional guard
-  output:                    # structured-output schema; fields become outputs
-    verdict: { enum: [approved, rejected] }
-  reject_when: ${{ steps.review.outputs.verdict == 'rejected' }}
+  if: ${{ classify.track == 'implement' }}   # optional guard
+  output: { verdict: { enum: [approved, rejected] } }   # structured output
+  reject_when: ${{ review.verdict == 'rejected' }}
   on_reject: { restart_from: implement, max: 3 }
 ```
 
+**Group — sequential sub-steps** (this is "sub-workflow", inline)
+```yaml
+- id: implement-track
+  if: ${{ classify.track == 'implement' }}   # guard the whole group
+  steps:                                      # run in order, nested
+    - { id: implement, agent: engineer }
+    - { id: review,    agent: reviewer, reject_when: ..., on_reject: { restart_from: implement } }
+    - { id: qa,        agent: qa }
+```
+
+**Parallel — concurrent sub-steps**
+```yaml
+- id: checks
+  parallel:                                   # run nested steps at once; join after
+    - { id: tests, agent: qa }
+    - { id: docs,  agent: engineer }
+```
+
+**Loop — sub-steps per child item**
+```yaml
+- id: build-tasks
+  for_each: ${{ design.tasks }}               # array from a prior step's output
+  as: task
+  concurrency: 4                              # optional; items at once
+  steps:                                      # nested body runs per item
+    - { id: impl,   agent: engineer, prompt: "Implement: ${{ task.title }}" }
+    - { id: verify, agent: qa }
+```
+
 Rules:
-- **Implicit sequencing.** Step *N* runs after step *N-1*. Declaration order =
-  execution order. No `depends_on` in the authored form.
-- **Per-step `if:`** (GHA-style). Evaluated before the step runs; false → the step
-  is **skipped** and the sequence continues. Branching is expressed by giving steps
-  complementary conditions (the "implement" steps carry
-  `if: …track == 'implement'`; the "complex" step carries `if: …track ==
-  'complex'`). No `then/else` blocks, no `goto`, and **no explicit join** — a step
-  after a branch simply omits `if:` and runs next.
-- **Outputs & references.** Declaring `output:` makes a step's fields addressable
-  as `${{ steps.<id>.outputs.<field> }}`, with `<id>.<field>` as a short alias.
-  No manual `memory.write`.
+- **Implicit sequencing.** Within any `steps:` list, step *N* runs after step *N-1*.
+  Declaration order = execution order. No `depends_on` in the authored form.
+- **Nesting = composition.** A group/parallel/loop step *contains* its children;
+  there is no `uses:`/reference and no cross-step `depends_on`. Reuse, if needed,
+  is by copying a group or (future) a top-level template — not by reference, to keep
+  the YAML self-contained and readable.
+- **`if:` guards any step**, including a whole group — so branching is "a guarded
+  group" (the complex track vs the implement track), not a condition repeated on
+  every line. A skipped group skips all its children.
+- **Outputs & references.** Declaring `output:` makes a step's fields addressable as
+  `${{ steps.<id>.outputs.<field> }}` (short `<id>.<field>`). No manual `memory.write`.
 - **Expressions** use `${{ … }}` over contexts `steps`, `cell`, `workflow`.
-- A step with an unmet `if:` and everything depending on its output skips too
-  (handled by the engine skip-cascade).
+- **Gates** (`reject_when`/`on_reject`) work on any leaf step; `restart_from`
+  targets an earlier sibling in the same `steps:` list (§2).
 
 ## 2. Approval / reject gates (beyond Actions)
 
@@ -103,30 +142,41 @@ and is now **in scope** (§8e).
 
 ```mermaid
 flowchart LR
-  yaml["authored v2 YAML<br/>steps + if + gates + for_each/uses/parallel"]
-  yaml --> parse[parse]
-  parse --> lower["lowering pass"]
-  lower --> ir["[]StepConfig (existing IR)<br/>depends_on · condition · split · fail_when · on_fail.goto · foreach · workflow"]
+  yaml["authored v2 YAML<br/>nested step tree: steps / parallel / for_each + if + gates"]
+  yaml --> parse[parse → step tree]
+  parse --> lower["lowering pass<br/>flatten tree"]
+  lower --> ir["[]StepConfig (existing IR)<br/>depends_on · condition · fail_when · on_fail.goto · foreach · workflow"]
   ir --> eng["DAG engine<br/>concurrent scheduler (§8e)"]
   eng --> sem["global semaphore<br/>settings.concurrency"]
   sem --> run["runner adapters → agents"]
 ```
 
-The parser compiles the authored list into today's `[]StepConfig`:
+The parser builds a **step tree** and a lowering pass flattens it to today's
+`[]StepConfig`. The author never sees `depends_on`/`goto`/`split`; nesting and order
+carry all the structure.
 
-| v2 (authored)                 | Lowered form |
+| v2 (authored, nested)         | Lowered form |
 |-------------------------------|--------------|
-| order (implicit sequence)     | `depends_on: [<previous step id>]` |
-| per-step `if: ${{ … }}`       | step-level `condition` (§3.2) |
-| `${{ steps.x.outputs.y }}` / `x.y` | rewritten to the flat `memory.y` lookup; parser adds `y` to step *x*'s `memory.write` (field names unique per workflow; else qualify) |
+| order within a `steps:` list  | `depends_on: [<previous sibling id>]` |
+| **group** (`steps:` nested)   | inline as a sub-chain: first child `depends_on` the group's predecessor, the group's successor `depends_on` the last child (or → an anonymous `type: workflow` sub-run when isolation is wanted) |
+| **parallel** (`parallel:` + `join`) | children all `depends_on` the predecessor and run concurrently (§8e); the parallel step's outcome = the `join` policy (`all`/`any`/`${{ expr }}`) evaluated over child results; successor `depends_on` the parallel step |
+| **loop** (`for_each:` + `steps:`) | `type: foreach` whose per-item body is the nested steps (anonymous sub-workflow when the body has >1 step; today's `foreach.step` is single → extend to a step list or wrap) |
+| `if: ${{ … }}` on any step    | step-level `condition` (§3.2); on a group/parallel/loop it guards the whole subtree (children skip-cascade) |
+| `${{ steps.x.outputs.y }}` / `x.y` | flat `memory.y` lookup; parser adds `y` to step *x*'s `memory.write` (field names unique per workflow; else qualify) |
 | `output: {…}`                 | `output_schema: {…}` (alias) |
-| `reject_when`                 | `fail_when` (§3.1) |
-| `on_reject: {restart_from, max}` | `on_fail: {goto: restart_from, max_retries: max}` |
+| `reject_when` / `on_reject`   | `fail_when` (§3.1) / `on_fail: {goto: restart_from, max_retries: max}` |
 
-`split`/`goto` are **not** emitted by the lowering — branching is per-step
-`condition`. (`split` remains a valid hand-authored low-level primitive; see §6.)
-Because lowering targets existing structures, current engine tests keep passing and
-v2 is verified by asserting the lowered DAG matches a golden `[]StepConfig`.
+`split`/`goto`/`depends_on` are **not** authored — branching is a guarded group,
+sequence is nesting order. They remain valid hand-written low-level primitives
+(§6). Because lowering targets existing structures, current engine tests keep
+passing and v2 is verified by asserting the lowered DAG matches a golden
+`[]StepConfig`.
+
+**Engine note:** the one place the existing IR is thin is multi-step `foreach`
+bodies — `config.StepConfig.Step` is a single `*StepConfig`. The loop lowering
+either (a) wraps a multi-step body in an anonymous sub-workflow (reuses
+`type: workflow`), or (b) `foreach.step` is widened to a step list. Decide at
+implementation; (a) reuses more existing machinery.
 
 ## 5. Reject feedback survives the loop (via the PR, not memory)
 
@@ -142,23 +192,31 @@ work and sidesteps the memory reset. Souls are written accordingly.
 
 ## 6. Backward compatibility
 
-- `depends_on`, `split`/`branches`/`goto` remain valid — the low-level form the v2
+- `depends_on`, `split`/`branches`/`goto` remain valid — the low-level IR the v2
   surface lowers to. Existing configs run unchanged.
-- `depends_on` is **kept as an advanced escape hatch** for non-linear/diamond flows
-  (decision r1); the default authored surface is sequence + per-step `if:`.
-- v2 is additive. A flow may not mix authored `if:`/sequence with hand-written
-  `goto` (validation rejects the ambiguous mix).
+- The authored surface is **nesting + order + `if:`**; `depends_on`/`split`/`goto`
+  are not authored (only emitted by lowering, or hand-written as an advanced escape
+  hatch).
+- v2 is additive. A flow may not mix authored nesting with hand-written `goto`
+  (validation rejects the ambiguous mix).
 - Docs/examples move to v2; `split`/`depends_on` documented as low-level.
 
 ## 7. Decisions (review round 1) & remaining questions
 
 Resolved:
-1. **Branching = per-step `if:`** (GHA-style); no `then/else` blocks. This also
-   resolves the earlier "join after a block" question — there are no blocks, so a
-   post-branch step just omits `if:` (implicit any-passed continuation).
-2. **`depends_on` kept as advanced** escape hatch.
-3. **Step-scoped references** `${{ steps.<id>.outputs.<field> }}` (short `<id>.<field>`).
-4. **`output:`** adopted as the authored key (alias of `output_schema:`).
+1. **Composition = visual nesting** (round 2). A step that has sub-steps, parallels,
+   or loops *contains* them; no `uses:`/reference, no authored `depends_on`. Nesting
+   and order carry all structure.
+2. **Branching = a guarded nested group** — `if:` on a group runs/skips the whole
+   subtree (the complex track vs the implement track). `if:` on a single step still
+   works for one-off guards. (Supersedes the round-1 "per-step `if:` only" idea.)
+3. **Parallelism is explicit** — only steps nested under a `parallel:` step run
+   concurrently, and that step owns its **join outcome** (`all` default / `any` /
+   `${{ expr }}`); its success = the join, feeding the next step and `on_reject`.
+4. **`depends_on`/`split`/`goto` are not authored** — they remain only as the
+   lowered IR and as advanced hand-written escape hatches.
+5. **Step-scoped references** `${{ steps.<id>.outputs.<field> }}` (short `<id>.<field>`).
+6. **`output:`** adopted as the authored key (alias of `output_schema:`).
 
 Remaining (decide at implementation):
 - Whether to support the `${{ … }}` delimiter literally or accept bare expressions
@@ -167,66 +225,83 @@ Remaining (decide at implementation):
 - Field-name collisions when two steps emit the same output field — qualify by step
   id in the lowered `memory` namespace if it ever happens.
 
-## 8. Composition: loops, parallel, sub-workflows (GHA-inspired)
+## 8. Composition: nested sub-steps, loops, parallel
 
-All three were in the original `workflow-mode` spec. Status and v2 surface:
+Composition is **visual nesting** — a composite step contains its children; no
+`uses:`/reference, no `depends_on`. All three lower onto existing engine structures.
 
-### a) Loop over child items — `for_each` (GHA `strategy.matrix`)
-**Engine: built, but serial.** `StepTypeForeach` exists (`workflow/foreach.go`); it
-iterates `items` and binds each to `as`, but the loop is a plain `for range` — the
-`concurrency` field is parsed and **ignored** today.
+### a) Sub-steps — a nested `steps:` group (inline "sub-workflow")
+**Engine: built** (`StepTypeWorkflow`/sub-chain). A group step holds an ordered
+`steps:` list that runs as a unit. This replaces the reference-based `uses:` — the
+sub-pipeline lives where it's used.
 
 ```yaml
-- id: implement-tasks
-  for_each: ${{ steps.design.outputs.tasks }}   # array from a prior step's output
-  as: task
-  agent: engineer
-  prompt: "Implement: ${{ task.title }}"
-  max: 20            # cap (lowers to foreach max_items)
-  concurrency: 4     # run N items at once  ← needs engine to honor it
+- id: implement-track
+  if: ${{ classify.track == 'implement' }}    # guard the whole group
+  steps:
+    - { id: implement, agent: engineer }
+    - { id: review,    agent: reviewer, reject_when: ..., on_reject: { restart_from: implement } }
+    - { id: qa,        agent: qa }
 ```
-Lowers to the existing `type: foreach` (`items`/`as`/`max_items`/`step`). Use case:
-Staff emits a `tasks` array → fan out an engineer run per task. **Work to do:**
-honor `concurrency` (bounded goroutines over items) — depends on §8e.
+Lowers to the children chained by `depends_on` (or an anonymous `type: workflow`
+sub-run for isolation). A guarded group skips all its children when `if:` is false.
+
+### b) Loop over child items — nested `for_each` (GHA `strategy.matrix`)
+**Engine: built, but serial.** `StepTypeForeach` exists (`workflow/foreach.go`); it
+iterates `items` bound to `as`, but the loop is a plain `for range` — `concurrency`
+is parsed and **ignored** today. The loop body is a **nested `steps:` list**, not a
+single step.
+
+```yaml
+- id: build-tasks
+  for_each: ${{ design.tasks }}   # array from a prior step's output
+  as: task
+  max: 20            # cap (lowers to foreach max_items)
+  concurrency: 4     # run N items at once  ← needs engine to honor it (§8e)
+  steps:             # nested body runs per item
+    - { id: impl,   agent: engineer, prompt: "Implement: ${{ task.title }}" }
+    - { id: verify, agent: qa }
+```
+Use case: Staff emits a `tasks` array → fan out the nested body per task. Multi-step
+body lowers via an anonymous sub-workflow (§4 engine note); `concurrency` needs §8e.
 
 ```mermaid
 flowchart TD
-  design["design · staff<br/>output: tasks[]"] --> fe[/"for_each task<br/>concurrency 4"/]
-  fe --> t1["engineer · task 1"]
-  fe --> t2["engineer · task 2"]
-  fe --> tn["engineer · task N"]
-  t1 --> j([join])
-  t2 --> j
-  tn --> j
+  design["design · staff<br/>output: tasks[]"] --> fe[/"for_each task · concurrency 4"/]
+  subgraph body["nested body (per item)"]
+    impl["engineer · impl"] --> verify["qa · verify"]
+  end
+  fe --> impl
+  verify --> j([join])
 ```
 
-### b) Sub-workflows / sub-steps — `uses` (GHA reusable workflows)
-**Engine: built.** `StepTypeWorkflow` (`workflow/subworkflow.go`) runs another named
-workflow as a step (one level of nesting), inheriting memory.
+### c) Parallel steps — an explicit `parallel:` step with a join outcome
+**Engine: in scope** (scheduler design in §8e). Parallelism is never implicit: you
+**declare** a step whose children run concurrently, and that step decides its own
+**outcome** from the children's results. Nothing runs in parallel unless you nest it
+under a `parallel:` step.
 
 ```yaml
-- id: ship
-  uses: implement-pipeline        # call another workflow by id
-  if: ${{ classify.track == 'implement' }}
+- id: checks
+  parallel:                         # children run concurrently
+    - { id: tests, agent: qa,       output: { ok: { type: boolean } } }
+    - { id: docs,  agent: engineer, output: { ok: { type: boolean } } }
+  join: all                         # outcome policy (default: all)
+  # join options:
+  #   all                  → step passes iff every child passed   (default)
+  #   any                  → passes iff at least one child passed
+  #   ${{ expr }}          → custom: passes iff the expr is true
+  #                          e.g. join: ${{ tests.ok && docs.ok }}
+  on_reject: { restart_from: implement, max: 3 }   # react to a failed join
 ```
-This is how a track becomes a reusable building block: define `implement-pipeline`
-(engineer→review→qa) once, `uses:` it from `triage` and elsewhere. Lowers to
-`type: workflow, workflow: implement-pipeline`. v2 work is just the `uses:` alias +
-parse.
 
-### c) Parallel steps — `parallel:` block (GHA parallel jobs)
-**Engine: in scope** (scheduler design in §8e). `driveDAG`/`pickRunnable` runs one
-step at a time today; this change makes the executor run all ready steps
-concurrently, bounded by the global semaphore.
-
-```yaml
-- parallel:                       # run these concurrently, join when all pass
-    - { id: tests, agent: qa,       prompt: "Run the test suite." }
-    - { id: docs,  agent: engineer, prompt: "Update the docs." }
-# steps after the block run once BOTH finished (selective join)
-```
-Lowers to: block members share the upstream dep and have no order between them; the
-next step `depends_on` all of them (selective join — proceed only when all pass).
+The `parallel:` step is itself a normal step: its **success/fail is the `join`
+result**, so the next step runs only when the join passed, and `reject_when`/
+`on_reject` work on it like any gate. Lowering: children all `depends_on` the
+parallel step's predecessor and run concurrently (§8e); the parallel step's outcome
+is computed from the children per `join`; the successor `depends_on` the parallel
+step. So the join is **explicit and owned by the step**, not an implicit
+"next step depends on all".
 
 ```mermaid
 flowchart TD
@@ -286,17 +361,26 @@ flows are unchanged; concurrency is opt-in by raising the cap and using `paralle
 ```mermaid
 flowchart TD
   classify["classify · investigator<br/>output: track"] --> dec{track?}
-  dec -->|complex| design["design · staff<br/>doc + split into sub-issues"] --> done([End])
-  dec -->|implement| implement["implement · engineer<br/>opens PR"]
-  implement --> review["review · reviewer<br/>verdict"]
-  review -->|approved| qa["qa · verdict"]
-  review -->|rejected| implement
+  dec -->|complex| complexg
+  dec -->|implement| implg
+  subgraph complexg["complex-track (guarded group)"]
+    design["design · staff<br/>doc + split into sub-issues"]
+  end
+  subgraph implg["implement-track (guarded group)"]
+    implement["implement · engineer<br/>opens PR"]
+    review["review · reviewer<br/>verdict"]
+    qa["qa · verdict"]
+    implement --> review
+    review -->|approved| qa
+    review -->|rejected| implement
+    qa -->|rejected| implement
+  end
+  design --> done([End])
   qa -->|approved| done
-  qa -->|rejected| implement
 ```
 
-The authored YAML (per-step `if:` + gates) that produces the flow above:
-
+The authored YAML — two **guarded nested groups**, one per track (the `if:` guards
+the whole group; gates loop back to a sibling inside the group):
 
 ```yaml
 workflows:
@@ -310,33 +394,33 @@ workflows:
         output: { track: { enum: [implement, complex] } }
 
       # Complex track → Staff documents + splits into sub-issues, then End.
-      - id: design
-        name: Design & decompose
-        agent: staff
+      - id: complex-track
         if: ${{ classify.track == 'complex' }}
+        steps:
+          - { id: design, name: Design & decompose, agent: staff }
 
       # Implementation track → Engineer → Reviewer → QA, reject loops back.
-      - id: implement
-        name: Implement & open PR
-        agent: engineer
+      - id: implement-track
         if: ${{ classify.track == 'implement' }}
+        steps:
+          - { id: implement, name: Implement & open PR, agent: engineer }
 
-      - id: review
-        name: Review the PR
-        agent: reviewer
-        if: ${{ classify.track == 'implement' }}
-        output: { verdict: { enum: [approved, rejected] } }
-        reject_when: ${{ review.verdict == 'rejected' }}
-        on_reject: { restart_from: implement, max: 3 }
+          - id: review
+            name: Review the PR
+            agent: reviewer
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: ${{ review.verdict == 'rejected' }}
+            on_reject: { restart_from: implement, max: 3 }
 
-      - id: qa
-        name: QA validation
-        agent: qa
-        if: ${{ classify.track == 'implement' }}
-        output: { verdict: { enum: [approved, rejected] } }
-        reject_when: ${{ qa.verdict == 'rejected' }}
-        on_reject: { restart_from: implement, max: 3 }
+          - id: qa
+            name: QA validation
+            agent: qa
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: ${{ qa.verdict == 'rejected' }}
+            on_reject: { restart_from: implement, max: 3 }
 
     on_complete: { set_state: closed }
     on_fail:     { add_labels: [needs-attention] }
 ```
+
+Notice the condition appears **once per track** (on the group), not on every step.

--- a/openspec/changes/workflow-sequential-authoring/proposal.md
+++ b/openspec/changes/workflow-sequential-authoring/proposal.md
@@ -1,0 +1,115 @@
+# Workflow authoring v2 — sequência + if/else + gates de aprovação
+
+> Status: **proposed (design only)** — sem implementação. Documento para revisão.
+
+## Motivação
+
+O modelo atual de definição de workflow ainda "cheira a router": na prática um
+`triage` classifica e manda a issue para **um** agente, e acabou. Além disso, a
+forma de *escrever* o workflow é de baixo nível demais:
+
+- **`depends_on` é verboso e indireto.** O autor tem que declarar arestas de um
+  grafo para expressar algo que quase sempre é uma sequência simples. Se eu listo
+  vários steps, a ordem em que escrevi **já deveria ser** a ordem de execução.
+- **`split` + `branches` + `goto` é mecânica de labels/jump.** Para ramificar eu
+  pulo para steps soltos por id; o fluxo fica difícil de ler e fácil de errar.
+- **Não existe gate de aprovação/rejeição limpo.** Hoje um step só "falha" se o
+  processo do agente sai com código ≠ 0 — o que confunde *rejeição deliberada* (o
+  reviewer reprovou) com *erro* (o agente quebrou). Sem isso, não dá para modelar
+  "reviewer reprova → engenheiro refaz".
+
+O resultado é que pipelines reais — Investigator → Engineer → Reviewer → QA, com
+loop-back em reprovação — não são expressáveis de forma natural.
+
+## O que muda (superfície de autoria)
+
+Uma camada de autoria **sequencial e estruturada**, que **compila para o engine de
+DAG já existente** (sem reescrever o executor — ele já faz sequência via ordem,
+ramificação via split e loop via `on_fail.goto`):
+
+1. **Sequência implícita.** Steps numa lista rodam **na ordem declarada**. Sem
+   `depends_on` para o caso comum.
+2. **`if` / `then` / `else`** com blocos aninhados de steps, no lugar de
+   `split`/`goto`.
+3. **Referência a saída por id de step:** `classify.track`, `review.verdict` —
+   sem `memory.write` manual.
+4. **Gates de aprovação:** `reject_when: <expr>` + `on_reject: { restart_from: <step>, max: N }`.
+   O agente emite um veredito estruturado; o step "reprova" logicamente e o fluxo
+   volta para um step anterior (loop-back), reaproveitando o mecanismo de retry do
+   engine.
+
+### Os dois fluxos-alvo, na sintaxe nova
+
+```yaml
+workflows:
+  - id: triage
+    trigger:
+      match: { source: project-erp, exclude_label_prefix: "agent:" }
+    steps:
+      - id: classify
+        agent: investigator
+        output: { track: { enum: [implement, complex] } }   # decisão estruturada
+
+      - if: 'classify.track == "complex"'
+        then:
+          # Complexo: Staff documenta a solução e quebra em sub-issues → Fim.
+          # (as sub-issues são issues novas e voltam pelo `triage`.)
+          - agent: staff
+
+        else:
+          # Implementação: sequência real, não um único agente.
+          - id: implement
+            agent: engineer                      # implementa + abre PR
+
+          - id: review
+            agent: reviewer                      # aprova / reprova o PR
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: 'review.verdict == "rejected"'
+            on_reject: { restart_from: implement, max: 3 }
+
+          - id: qa
+            agent: qa                            # testa, aprova / reprova
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: 'qa.verdict == "rejected"'
+            on_reject: { restart_from: implement, max: 3 }
+
+    on_complete: { set_state: closed }
+    on_fail:     { add_labels: [needs-attention] }   # esgotou os retries → humano
+```
+
+Compare com a sintaxe atual (split + goto + depends_on + memory.write): o fluxo
+acima é lido de cima para baixo, a ramificação é um `if/else`, e o loop de
+reprovação é uma linha.
+
+## Compila para o engine atual (sem reescrita)
+
+| Superfície nova            | Lowering no DAG atual                                  |
+|----------------------------|-------------------------------------------------------|
+| ordem dos steps (sequência)| `depends_on` = step anterior                           |
+| `if/then/else`             | `split` com `branches` + `goto`; `else` = fallback     |
+| `step.field`               | contexto de avaliação (`memory`/`steps`) já existente   |
+| `reject_when`              | `fail_when` (Success derivado de expressão sobre a saída)|
+| `on_reject.restart_from`   | `on_fail.goto` + `max_retries` (já reseta e re-roda)   |
+
+A **única** capacidade nova de engine é `fail_when`: hoje `Success = (exit == 0)`
+(cli.go:197); precisamos derivar o resultado do step de uma expressão sobre a
+saída estruturada. Todo o resto é açúcar de autoria que baixa para primitivas
+existentes (`depends_on`, `split`, `on_fail.goto`).
+
+## Escopo / decisões em aberto
+
+- **Compatibilidade:** manter `depends_on`/`split` funcionando (são a forma
+  "baixa" para a qual a v2 compila) ou deprecá-los? Proposta: manter, documentar a
+  v2 como recomendada.
+- **Feedback de reprovação no loop:** `on_fail.goto` reseta o step alvo e seus
+  dependentes e **apaga** a contribuição de memória deles — então o feedback do
+  reviewer não chega ao engenheiro via memória no retry. Proposta: o feedback vive
+  no **PR** (review real do GitHub); o engenheiro relê o PR no retry. Memória só
+  carrega o veredito do gate. (Ver design.md.)
+- `settings.retry_policy` continua fora (inerte; decisão à parte).
+
+## Não-objetivos
+
+- Reescrever o executor de DAG.
+- Loops gerais / `while` arbitrário além do loop-back de gate.
+- Comando de migração automática da sintaxe antiga → v2.

--- a/openspec/changes/workflow-sequential-authoring/proposal.md
+++ b/openspec/changes/workflow-sequential-authoring/proposal.md
@@ -23,20 +23,22 @@ loop-back em reprovação — não são expressáveis de forma natural.
 
 ## O que muda (superfície de autoria)
 
-Uma camada de autoria **sequencial e estruturada**, que **compila para o engine de
-DAG já existente** (sem reescrever o executor — ele já faz sequência via ordem,
-ramificação via split e loop via `on_fail.goto`):
+Uma camada de autoria **inspirada no GitHub Actions** (`steps:` plano e ordenado,
+`if:` por step, expressões `${{ … }}`, `steps.<id>.outputs.<field>`), que **compila
+para o engine de DAG já existente** (ele já faz sequência via ordem e loop via
+`on_fail.goto`):
 
 1. **Sequência implícita.** Steps numa lista rodam **na ordem declarada**. Sem
    `depends_on` para o caso comum.
-2. **`if` / `then` / `else`** com blocos aninhados de steps, no lugar de
-   `split`/`goto`.
-3. **Referência a saída por id de step:** `classify.track`, `review.verdict` —
-   sem `memory.write` manual.
+2. **`if:` por step (estilo GitHub Actions)**, no lugar de `split`/`goto`. Step com
+   `if:` falso é pulado; ramificação = steps com condições complementares. Sem
+   `then/else`, sem join explícito (o step seguinte sem `if:` simplesmente roda).
+3. **Referência a saída por id de step:** `${{ steps.review.outputs.verdict }}`
+   (abreviado `review.verdict`) — sem `memory.write` manual.
 4. **Gates de aprovação:** `reject_when: <expr>` + `on_reject: { restart_from: <step>, max: N }`.
    O agente emite um veredito estruturado; o step "reprova" logicamente e o fluxo
    volta para um step anterior (loop-back), reaproveitando o mecanismo de retry do
-   engine.
+   engine. (É o que falta no Actions: "reprovou → refaz um step anterior".)
 
 ### Os dois fluxos-alvo, na sintaxe nova
 
@@ -50,51 +52,54 @@ workflows:
         agent: investigator
         output: { track: { enum: [implement, complex] } }   # decisão estruturada
 
-      - if: 'classify.track == "complex"'
-        then:
-          # Complexo: Staff documenta a solução e quebra em sub-issues → Fim.
-          # (as sub-issues são issues novas e voltam pelo `triage`.)
-          - agent: staff
+      # Complexo: Staff documenta a solução e quebra em sub-issues → Fim.
+      # (as sub-issues são issues novas e voltam pelo `triage`.)
+      - id: design
+        agent: staff
+        if: ${{ classify.track == 'complex' }}
 
-        else:
-          # Implementação: sequência real, não um único agente.
-          - id: implement
-            agent: engineer                      # implementa + abre PR
+      # Implementação: sequência real, não um único agente.
+      - id: implement
+        agent: engineer                          # implementa + abre PR
+        if: ${{ classify.track == 'implement' }}
 
-          - id: review
-            agent: reviewer                      # aprova / reprova o PR
-            output: { verdict: { enum: [approved, rejected] } }
-            reject_when: 'review.verdict == "rejected"'
-            on_reject: { restart_from: implement, max: 3 }
+      - id: review
+        agent: reviewer                          # aprova / reprova o PR
+        if: ${{ classify.track == 'implement' }}
+        output: { verdict: { enum: [approved, rejected] } }
+        reject_when: ${{ review.verdict == 'rejected' }}
+        on_reject: { restart_from: implement, max: 3 }
 
-          - id: qa
-            agent: qa                            # testa, aprova / reprova
-            output: { verdict: { enum: [approved, rejected] } }
-            reject_when: 'qa.verdict == "rejected"'
-            on_reject: { restart_from: implement, max: 3 }
+      - id: qa
+        agent: qa                                # testa, aprova / reprova
+        if: ${{ classify.track == 'implement' }}
+        output: { verdict: { enum: [approved, rejected] } }
+        reject_when: ${{ qa.verdict == 'rejected' }}
+        on_reject: { restart_from: implement, max: 3 }
 
     on_complete: { set_state: closed }
     on_fail:     { add_labels: [needs-attention] }   # esgotou os retries → humano
 ```
 
 Compare com a sintaxe atual (split + goto + depends_on + memory.write): o fluxo
-acima é lido de cima para baixo, a ramificação é um `if/else`, e o loop de
-reprovação é uma linha.
+acima é lido de cima para baixo como um job do GitHub Actions, a ramificação é
+`if:` por step, e o loop de reprovação é uma linha.
 
 ## Compila para o engine atual (sem reescrita)
 
 | Superfície nova            | Lowering no DAG atual                                  |
 |----------------------------|-------------------------------------------------------|
 | ordem dos steps (sequência)| `depends_on` = step anterior                           |
-| `if/then/else`             | `split` com `branches` + `goto`; `else` = fallback     |
-| `step.field`               | contexto de avaliação (`memory`/`steps`) já existente   |
+| `if:` por step             | `condition` no step (pulado quando falso)              |
+| `steps.x.outputs.y` / `x.y`| reescrito p/ `memory.y` (parser auto-adiciona ao `memory.write` do step x) |
 | `reject_when`              | `fail_when` (Success derivado de expressão sobre a saída)|
 | `on_reject.restart_from`   | `on_fail.goto` + `max_retries` (já reseta e re-roda)   |
 
-A **única** capacidade nova de engine é `fail_when`: hoje `Success = (exit == 0)`
-(cli.go:197); precisamos derivar o resultado do step de uma expressão sobre a
-saída estruturada. Todo o resto é açúcar de autoria que baixa para primitivas
-existentes (`depends_on`, `split`, `on_fail.goto`).
+São **duas** capacidades novas de engine, ambas pequenas: `fail_when` (hoje
+`Success = (exit == 0)`, cli.go:197 — derivar o resultado da saída estruturada) e
+`condition` por step (pular quando o `if:` é falso, estilo GitHub Actions). Todo o
+resto é açúcar de autoria que baixa para primitivas existentes (`depends_on`,
+`on_fail.goto`).
 
 ## Escopo / decisões em aberto
 

--- a/openspec/changes/workflow-sequential-authoring/proposal.md
+++ b/openspec/changes/workflow-sequential-authoring/proposal.md
@@ -41,9 +41,13 @@ para o engine de DAG já existente** (ele já faz sequência via ordem e loop vi
    engine. (É o que falta no Actions: "reprovou → refaz um step anterior".)
 5. **Composição (já no spec original):** `for_each:` (loop sobre itens-filho — GHA
    `strategy.matrix`), `uses:` (sub-workflow reutilizável — GHA reusable workflows)
-   e `parallel:` (fan-out + join — GHA jobs paralelos). Status honesto: foreach e
-   sub-workflow já existem no engine (foreach roda **serial**); **parallel não
-   existe** (o executor roda um step por vez). Ver design.md §8.
+   e `parallel:` (fan-out + join — GHA jobs paralelos). foreach e sub-workflow já
+   existem no engine; **parallel** é incluído nesta change. Ver design.md §8.
+6. **Execução concorrente (em escopo):** scheduler concorrente + semáforo global de
+   `settings.concurrency` — roda todos os steps prontos ao mesmo tempo, com teto
+   global de invocações de agente. É o `concurrency-model` original; torna
+   `parallel:` e `for_each.concurrency` reais. Aditivo: com `concurrency: 1` o
+   comportamento é idêntico ao executor sequencial de hoje. Ver design.md §8e.
 
 ### Os dois fluxos-alvo, na sintaxe nova
 
@@ -120,10 +124,8 @@ resto é açúcar de autoria que baixa para primitivas existentes (`depends_on`,
 
 ## Não-objetivos (desta change)
 
-- Reescrever o executor de DAG.
-- **Execução paralela real** (`parallel:` concorrente + semáforo global de
-  `concurrency`) e `for_each.concurrency` honrado — é o `concurrency-model` original,
-  o maior esforço; vira change própria **depois** da v2 sequencial + gates. Nesta
-  change `parallel:` é aceito mas roda serial (sinalizado, não é no-op silencioso).
+- Reescrever o executor de DAG **do zero** — o scheduler concorrente é evolução do
+  atual (mesmas estruturas/IR), não reescrita.
 - Loops gerais / `while` arbitrário além de `for_each` e do loop-back de gate.
 - Comando de migração automática da sintaxe antiga → v2.
+- Cancelamento de steps in-flight no loop-back (default: drenar e então resetar).

--- a/openspec/changes/workflow-sequential-authoring/proposal.md
+++ b/openspec/changes/workflow-sequential-authoring/proposal.md
@@ -23,31 +23,32 @@ loop-back em reprovação — não são expressáveis de forma natural.
 
 ## O que muda (superfície de autoria)
 
-Uma camada de autoria **inspirada no GitHub Actions** (`steps:` plano e ordenado,
-`if:` por step, expressões `${{ … }}`, `steps.<id>.outputs.<field>`), que **compila
-para o engine de DAG já existente** (ele já faz sequência via ordem e loop via
-`on_fail.goto`):
+Uma **árvore de steps aninhada** (inspirada no GitHub Actions para steps/`if:`/
+`${{ … }}`, mas com **composição por aninhamento visual**, não por referência), que
+**compila para o engine de DAG já existente**:
 
-1. **Sequência implícita.** Steps numa lista rodam **na ordem declarada**. Sem
-   `depends_on` para o caso comum.
-2. **`if:` por step (estilo GitHub Actions)**, no lugar de `split`/`goto`. Step com
-   `if:` falso é pulado; ramificação = steps com condições complementares. Sem
-   `then/else`, sem join explícito (o step seguinte sem `if:` simplesmente roda).
-3. **Referência a saída por id de step:** `${{ steps.review.outputs.verdict }}`
-   (abreviado `review.verdict`) — sem `memory.write` manual.
-4. **Gates de aprovação:** `reject_when: <expr>` + `on_reject: { restart_from: <step>, max: N }`.
+1. **Sequência implícita.** Steps numa lista `steps:` rodam **na ordem declarada**.
+   Sem `depends_on` na autoria.
+2. **Composição = aninhamento visual.** Se um step tem sub-steps, paralelo ou loop,
+   esses steps ficam **dentro** dele. Sem `uses:`/referência e sem `depends_on`
+   entre steps — a indentação *é* o fluxo. Mais fácil de ler.
+3. **Ramificação = grupo guardado.** `if:` num grupo roda/pula a subárvore inteira
+   (track complexo vs track de implementação) — a condição aparece **uma vez por
+   track**, não repetida em cada step.
+4. **Paralelo é explícito.** Só roda concorrente o que estiver aninhado num step
+   `parallel:`, e **esse step decide o desfecho (join)**: `all` (default) / `any` /
+   `${{ expr }}`. O sucesso do step paralelo = o join, alimentando o próximo step e
+   `on_reject`.
+5. **Loop sobre itens-filho:** `for_each:` + `as:` com **corpo aninhado** (`steps:`)
+   rodando por item (GHA `strategy.matrix`).
+6. **Gates de aprovação:** `reject_when: <expr>` + `on_reject: { restart_from: <step>, max: N }`.
    O agente emite um veredito estruturado; o step "reprova" logicamente e o fluxo
-   volta para um step anterior (loop-back), reaproveitando o mecanismo de retry do
-   engine. (É o que falta no Actions: "reprovou → refaz um step anterior".)
-5. **Composição (já no spec original):** `for_each:` (loop sobre itens-filho — GHA
-   `strategy.matrix`), `uses:` (sub-workflow reutilizável — GHA reusable workflows)
-   e `parallel:` (fan-out + join — GHA jobs paralelos). foreach e sub-workflow já
-   existem no engine; **parallel** é incluído nesta change. Ver design.md §8.
-6. **Execução concorrente (em escopo):** scheduler concorrente + semáforo global de
-   `settings.concurrency` — roda todos os steps prontos ao mesmo tempo, com teto
-   global de invocações de agente. É o `concurrency-model` original; torna
-   `parallel:` e `for_each.concurrency` reais. Aditivo: com `concurrency: 1` o
-   comportamento é idêntico ao executor sequencial de hoje. Ver design.md §8e.
+   volta para um step-irmão anterior (loop-back). (É o que falta no Actions.)
+7. **Referência a saída por id:** `${{ steps.review.outputs.verdict }}` (abreviado
+   `review.verdict`) — sem `memory.write` manual.
+8. **Execução concorrente (em escopo):** scheduler concorrente + semáforo global de
+   `settings.concurrency`. Aditivo: com `concurrency: 1` o comportamento é idêntico
+   ao executor sequencial de hoje. Ver design.md §8e.
 
 ### Os dois fluxos-alvo, na sintaxe nova
 
@@ -61,54 +62,55 @@ workflows:
         agent: investigator
         output: { track: { enum: [implement, complex] } }   # decisão estruturada
 
-      # Complexo: Staff documenta a solução e quebra em sub-issues → Fim.
-      # (as sub-issues são issues novas e voltam pelo `triage`.)
-      - id: design
-        agent: staff
+      # Track complexo: Staff documenta + quebra em sub-issues → Fim. (Grupo
+      # guardado: o if: cobre a subárvore toda.)
+      - id: complex-track
         if: ${{ classify.track == 'complex' }}
+        steps:
+          - { id: design, agent: staff }
 
-      # Implementação: sequência real, não um único agente.
-      - id: implement
-        agent: engineer                          # implementa + abre PR
+      # Track de implementação: grupo aninhado, sequência real.
+      - id: implement-track
         if: ${{ classify.track == 'implement' }}
+        steps:
+          - { id: implement, agent: engineer }     # implementa + abre PR
 
-      - id: review
-        agent: reviewer                          # aprova / reprova o PR
-        if: ${{ classify.track == 'implement' }}
-        output: { verdict: { enum: [approved, rejected] } }
-        reject_when: ${{ review.verdict == 'rejected' }}
-        on_reject: { restart_from: implement, max: 3 }
+          - id: review
+            agent: reviewer                        # aprova / reprova o PR
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: ${{ review.verdict == 'rejected' }}
+            on_reject: { restart_from: implement, max: 3 }
 
-      - id: qa
-        agent: qa                                # testa, aprova / reprova
-        if: ${{ classify.track == 'implement' }}
-        output: { verdict: { enum: [approved, rejected] } }
-        reject_when: ${{ qa.verdict == 'rejected' }}
-        on_reject: { restart_from: implement, max: 3 }
+          - id: qa
+            agent: qa                              # testa, aprova / reprova
+            output: { verdict: { enum: [approved, rejected] } }
+            reject_when: ${{ qa.verdict == 'rejected' }}
+            on_reject: { restart_from: implement, max: 3 }
 
     on_complete: { set_state: closed }
     on_fail:     { add_labels: [needs-attention] }   # esgotou os retries → humano
 ```
 
 Compare com a sintaxe atual (split + goto + depends_on + memory.write): o fluxo
-acima é lido de cima para baixo como um job do GitHub Actions, a ramificação é
-`if:` por step, e o loop de reprovação é uma linha.
+acima é lido de cima para baixo, a ramificação é um **grupo guardado** por `if:`, e
+o loop de reprovação é uma linha.
 
 ## Compila para o engine atual (sem reescrita)
 
-| Superfície nova            | Lowering no DAG atual                                  |
-|----------------------------|-------------------------------------------------------|
-| ordem dos steps (sequência)| `depends_on` = step anterior                           |
-| `if:` por step             | `condition` no step (pulado quando falso)              |
-| `steps.x.outputs.y` / `x.y`| reescrito p/ `memory.y` (parser auto-adiciona ao `memory.write` do step x) |
-| `reject_when`              | `fail_when` (Success derivado de expressão sobre a saída)|
-| `on_reject.restart_from`   | `on_fail.goto` + `max_retries` (já reseta e re-roda)   |
+| Superfície nova (aninhada)  | Lowering no DAG atual                                  |
+|-----------------------------|-------------------------------------------------------|
+| ordem dentro de `steps:`    | `depends_on` = step-irmão anterior                     |
+| grupo (`steps:` aninhado)   | sub-cadeia inline (ou sub-workflow anônimo p/ isolar)  |
+| `parallel:` + `join`        | filhos concorrentes; desfecho do step = `join` (`all`/`any`/`${{ }}`) |
+| `for_each:` + `steps:`      | `type: foreach` com corpo aninhado (sub-workflow anônimo se >1 step) |
+| `if:` em qualquer step/grupo| `condition` no step (pula a subárvore quando falso)    |
+| `steps.x.outputs.y` / `x.y` | reescrito p/ `memory.y` (parser auto-adiciona ao `memory.write` do step x) |
+| `reject_when` / `on_reject` | `fail_when` / `on_fail.goto` + `max_retries`           |
 
-São **duas** capacidades novas de engine, ambas pequenas: `fail_when` (hoje
-`Success = (exit == 0)`, cli.go:197 — derivar o resultado da saída estruturada) e
-`condition` por step (pular quando o `if:` é falso, estilo GitHub Actions). Todo o
-resto é açúcar de autoria que baixa para primitivas existentes (`depends_on`,
-`on_fail.goto`).
+São **três** capacidades novas de engine: `fail_when` e `condition` (ambas pequenas)
+e o **scheduler concorrente + semáforo global** (o esforço maior, §8e). Todo o resto
+é açúcar de autoria que baixa para primitivas existentes (`depends_on`, `foreach`,
+`type: workflow`, `on_fail.goto`).
 
 ## Escopo / decisões em aberto
 

--- a/openspec/changes/workflow-sequential-authoring/proposal.md
+++ b/openspec/changes/workflow-sequential-authoring/proposal.md
@@ -39,6 +39,11 @@ para o engine de DAG já existente** (ele já faz sequência via ordem e loop vi
    O agente emite um veredito estruturado; o step "reprova" logicamente e o fluxo
    volta para um step anterior (loop-back), reaproveitando o mecanismo de retry do
    engine. (É o que falta no Actions: "reprovou → refaz um step anterior".)
+5. **Composição (já no spec original):** `for_each:` (loop sobre itens-filho — GHA
+   `strategy.matrix`), `uses:` (sub-workflow reutilizável — GHA reusable workflows)
+   e `parallel:` (fan-out + join — GHA jobs paralelos). Status honesto: foreach e
+   sub-workflow já existem no engine (foreach roda **serial**); **parallel não
+   existe** (o executor roda um step por vez). Ver design.md §8.
 
 ### Os dois fluxos-alvo, na sintaxe nova
 
@@ -113,8 +118,12 @@ resto é açúcar de autoria que baixa para primitivas existentes (`depends_on`,
   carrega o veredito do gate. (Ver design.md.)
 - `settings.retry_policy` continua fora (inerte; decisão à parte).
 
-## Não-objetivos
+## Não-objetivos (desta change)
 
 - Reescrever o executor de DAG.
-- Loops gerais / `while` arbitrário além do loop-back de gate.
+- **Execução paralela real** (`parallel:` concorrente + semáforo global de
+  `concurrency`) e `for_each.concurrency` honrado — é o `concurrency-model` original,
+  o maior esforço; vira change própria **depois** da v2 sequencial + gates. Nesta
+  change `parallel:` é aceito mas roda serial (sinalizado, não é no-op silencioso).
+- Loops gerais / `while` arbitrário além de `for_each` e do loop-back de gate.
 - Comando de migração automática da sintaxe antiga → v2.

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -2,19 +2,21 @@
 
 > Design only. Nothing implemented yet; this is the proposed build order.
 
-## Engine (minimal)
+## Engine (two small additions)
 - [ ] `fail_when` on the agent step: in `workflow/dag.go` `runAgentDAGStep`, derive
       `failed` from `!res.Success || eval(fail_when over this step's output)`.
+- [ ] Step-level `condition` (per-step `if:`): mark a step skipped when false in
+      scheduling (`pickRunnable`/`markSkipped`).
 - [ ] Eval context helper exposing the current step's fresh structured output
       (transient memory view) — reuse `EvalContext`/`ParseExpr` (`workflow/expr.go`).
 - [ ] Honor `on_missing_output: fail` together with `reject_when`.
 
 ## Authoring layer (lowering)
-- [ ] v2 parse: `if/then/else` blocks + implicit sequencing in `config` package.
-- [ ] Lowering pass v2 tree → `[]StepConfig` (sequence→`depends_on`,
-      `if`→`split`+`goto`, `on_reject`→`on_fail.goto`, `reject_when`→`fail_when`,
-      auto-wire `step.field` refs into `memory.write`).
-- [ ] Resolve join semantics after an `if` block (open question §7).
+- [ ] v2 parse: flat `steps:` with per-step `if:`, `name:`, `output:`,
+      `${{ … }}` expressions, implicit sequencing (`config` package).
+- [ ] Lowering pass v2 → `[]StepConfig` (sequence→`depends_on`, `if`→`condition`,
+      `on_reject`→`on_fail.goto`, `reject_when`→`fail_when`, auto-wire
+      `steps.x.outputs.y` refs into `memory.write`).
 
 ## Validation
 - [ ] Parse-check `if`/`reject_when` expressions; `restart_from` must be an earlier

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -35,5 +35,16 @@
 - [ ] Engine tests for `fail_when` pass/reject/loop-back/retry-exhaustion.
 - [ ] End-to-end: classify→implement→review(reject→loop)→qa→done.
 
-## Follow-up (separate change)
+## Composition (loops / sub-workflows / parallel)
+- [ ] `uses:` alias for sub-workflow steps (engine already supports `type: workflow`).
+- [ ] `for_each:`/`as:`/`max:` authored aliases → existing `type: foreach`
+      (`items`/`as`/`max_items`/`step`); loop already runs (serial).
+- [ ] Accept `parallel:` block in the parser (lowers to independent steps + join);
+      execute sequentially for now, clearly flagged as not-yet-concurrent.
+
+## Follow-up (separate changes)
+- [ ] **Concurrent scheduler + global `settings.concurrency` semaphore** — makes
+      `parallel:` truly parallel and `for_each.concurrency` real (the original
+      `concurrency-model` spec). Biggest lift; its own change after v2 + gates land.
+- [ ] Honor `for_each.concurrency` (bounded goroutines over items) on top of it.
 - [ ] Decide fate of `settings.retry_policy` (inert today).

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — workflow-sequential-authoring
+
+> Design only. Nothing implemented yet; this is the proposed build order.
+
+## Engine (minimal)
+- [ ] `fail_when` on the agent step: in `workflow/dag.go` `runAgentDAGStep`, derive
+      `failed` from `!res.Success || eval(fail_when over this step's output)`.
+- [ ] Eval context helper exposing the current step's fresh structured output
+      (transient memory view) — reuse `EvalContext`/`ParseExpr` (`workflow/expr.go`).
+- [ ] Honor `on_missing_output: fail` together with `reject_when`.
+
+## Authoring layer (lowering)
+- [ ] v2 parse: `if/then/else` blocks + implicit sequencing in `config` package.
+- [ ] Lowering pass v2 tree → `[]StepConfig` (sequence→`depends_on`,
+      `if`→`split`+`goto`, `on_reject`→`on_fail.goto`, `reject_when`→`fail_when`,
+      auto-wire `step.field` refs into `memory.write`).
+- [ ] Resolve join semantics after an `if` block (open question §7).
+
+## Validation
+- [ ] Parse-check `if`/`reject_when` expressions; `restart_from` must be an earlier
+      step; `step.field` must be declared in that step's `output`.
+- [ ] Reject ambiguous mix of `if:` blocks and manual `goto` in one flow.
+- [ ] Warn on `reject_when` without `on_reject`.
+
+## Examples, souls, docs
+- [ ] Rewrite project-erp `triage` in v2 (implement + complex tracks).
+- [ ] Souls: engineer (implement + open PR; read PR comments on retry), reviewer
+      (verdict + PR review comments), qa (verdict + findings), staff (doc + sub-issues).
+- [ ] Update `.apiary/example-workflow.yaml` to v2; document `split` as low-level.
+
+## Tests
+- [ ] Lowering tests: v2 tree → expected `[]StepConfig` (golden).
+- [ ] Engine tests for `fail_when` pass/reject/loop-back/retry-exhaustion.
+- [ ] End-to-end: classify→implement→review(reject→loop)→qa→done.
+
+## Follow-up (separate change)
+- [ ] Decide fate of `settings.retry_policy` (inert today).

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -38,13 +38,23 @@
 ## Composition (loops / sub-workflows / parallel)
 - [ ] `uses:` alias for sub-workflow steps (engine already supports `type: workflow`).
 - [ ] `for_each:`/`as:`/`max:` authored aliases → existing `type: foreach`
-      (`items`/`as`/`max_items`/`step`); loop already runs (serial).
-- [ ] Accept `parallel:` block in the parser (lowers to independent steps + join);
-      execute sequentially for now, clearly flagged as not-yet-concurrent.
+      (`items`/`as`/`max_items`/`step`).
+- [ ] `parallel:` block in the parser → independent steps + selective join
+      (next step `depends_on` all members).
 
-## Follow-up (separate changes)
-- [ ] **Concurrent scheduler + global `settings.concurrency` semaphore** — makes
-      `parallel:` truly parallel and `for_each.concurrency` real (the original
-      `concurrency-model` spec). Biggest lift; its own change after v2 + gates land.
-- [ ] Honor `for_each.concurrency` (bounded goroutines over items) on top of it.
+## Concurrency (in scope — §8e)
+- [ ] Concurrent scheduler: `pickAllRunnable()`; single scheduler goroutine owns
+      `dagRun` state; worker goroutines run agents and return results on a channel;
+      re-dispatch newly-unblocked steps until quiescent.
+- [ ] Global agent semaphore sized by `settings.concurrency` around every runner
+      invocation (plus per-agent `max_workers` as secondary cap).
+- [ ] Deterministic memory ordering: `passedOrder` by declaration order, not
+      completion order.
+- [ ] Loop-back with in-flight siblings: drain then `resetLoop`; approval steps
+      quiesce before parking.
+- [ ] Honor `for_each.concurrency` via the same semaphore.
+- [ ] Verify `concurrency: 1` reproduces today's sequential behaviour (regression
+      guard — all existing engine tests pass unchanged).
+
+## Follow-up (separate change)
 - [ ] Decide fate of `settings.retry_policy` (inert today).

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -11,17 +11,20 @@
       (transient memory view) — reuse `EvalContext`/`ParseExpr` (`workflow/expr.go`).
 - [ ] Honor `on_missing_output: fail` together with `reject_when`.
 
-## Authoring layer (lowering)
-- [ ] v2 parse: flat `steps:` with per-step `if:`, `name:`, `output:`,
-      `${{ … }}` expressions, implicit sequencing (`config` package).
-- [ ] Lowering pass v2 → `[]StepConfig` (sequence→`depends_on`, `if`→`condition`,
-      `on_reject`→`on_fail.goto`, `reject_when`→`fail_when`, auto-wire
-      `steps.x.outputs.y` refs into `memory.write`).
+## Authoring layer (nested tree + lowering)
+- [ ] v2 parse: **nested step tree** — leaf (`agent:`), group (`steps:`), parallel
+      (`parallel:` + `join`), loop (`for_each:`+`as:`+`steps:`); per-step/group
+      `if:`, `name:`, `output:`, `${{ … }}` expressions (`config` package).
+- [ ] Lowering pass tree → `[]StepConfig`: nesting/order→`depends_on`,
+      group→sub-chain (or anon `type: workflow`), `parallel`+`join`→concurrent
+      children + computed outcome, `for_each`→`type: foreach` (anon sub-workflow
+      body if >1 step), `if`→`condition`, `on_reject`→`on_fail.goto`,
+      `reject_when`→`fail_when`, auto-wire `steps.x.outputs.y` refs into `memory.write`.
 
 ## Validation
-- [ ] Parse-check `if`/`reject_when` expressions; `restart_from` must be an earlier
-      step; `step.field` must be declared in that step's `output`.
-- [ ] Reject ambiguous mix of `if:` blocks and manual `goto` in one flow.
+- [ ] Parse-check `if`/`reject_when`/`join` expressions; `restart_from` must be an
+      earlier sibling; `step.field` must be declared in that step's `output`.
+- [ ] Reject ambiguous mix of authored nesting and hand-written `goto` in one flow.
 - [ ] Warn on `reject_when` without `on_reject`.
 
 ## Examples, souls, docs
@@ -35,12 +38,12 @@
 - [ ] Engine tests for `fail_when` pass/reject/loop-back/retry-exhaustion.
 - [ ] End-to-end: classify→implement→review(reject→loop)→qa→done.
 
-## Composition (loops / sub-workflows / parallel)
-- [ ] `uses:` alias for sub-workflow steps (engine already supports `type: workflow`).
-- [ ] `for_each:`/`as:`/`max:` authored aliases → existing `type: foreach`
-      (`items`/`as`/`max_items`/`step`).
-- [ ] `parallel:` block in the parser → independent steps + selective join
-      (next step `depends_on` all members).
+## Composition (nested sub-steps / loops / parallel)
+- [ ] Nested `steps:` group (inline sub-workflow) — sub-chain or anon `type: workflow`.
+- [ ] `for_each:`+`as:`+nested `steps:` body → `type: foreach`; multi-step body via
+      anon sub-workflow (or widen `foreach.step` to a list — decide at impl).
+- [ ] `parallel:` step with `join` policy (`all`/`any`/`${{ expr }}`); the parallel
+      step's outcome = the join; successor depends on the parallel step.
 
 ## Concurrency (in scope — §8e)
 - [ ] Concurrent scheduler: `pickAllRunnable()`; single scheduler goroutine owns


### PR DESCRIPTION
## Summary

**Design only — no implementation.** An OpenSpec proposal (`workflow-sequential-authoring`) to redesign the workflow *authoring surface*, based on feedback that the current model still feels like a "router" and is too low-level.

Proposed changes to how workflows are written:
- **Implicit sequence** — steps run in declaration order; no `depends_on`.
- **`if/then/else`** with nested blocks, in place of `split`/`goto`.
- **Approval gates** — `reject_when` + `on_reject: {restart_from, max}` for "reviewer rejects → engineer redoes".
- **Output reference by id** — `review.verdict` instead of manual `memory.write`.

All of this **compiles to the existing DAG engine** (sequence→`depends_on`, `if`→`split`, `on_reject`→`on_fail.goto`). The **only** new engine capability is `fail_when`: deriving the step's result from an expression over the structured output (today `Success = exit==0`).

Includes the two target flows written in the new syntax (implement: Investigator→Engineer→Reviewer→QA with loop-back; complex: Investigator→Staff→End).

## Files
- `openspec/changes/workflow-sequential-authoring/{proposal,design,tasks}.md`
- an entry in `openspec/CHANGELOG.md` (status: proposed)

## Test plan
N/A — design document. For review and iteration; see "Open questions" in design.md (join after `if`, keep/remove `depends_on`, reference syntax, `output` vs `output_schema`).

> ⚠️ Don't merge yet — awaiting design review.