### PR TITLE
feat(workflow): engine additions — condition, fail_when, on_missing_output:fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3944 symbols, 8528 relationships, 263 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3991 symbols, 8690 relationships, 274 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3944 symbols, 8528 relationships, 263 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (3991 symbols, 8690 relationships, 274 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -71,6 +71,19 @@ type StepConfig struct {
 	Type      string   `yaml:"type,omitempty"` // agent(default)|split|approval|foreach|workflow
 	DependsOn []string `yaml:"depends_on,omitempty"`
 
+	// ── shared / cross-cutting ────────────────────────────────────
+	// Name is a human-readable label shown in logs and dashboards.
+	Name string `yaml:"name,omitempty"`
+	// Condition is a DAG IR expression (e.g. `memory.track == "implement"`).
+	// When it evaluates to false the step is skipped (and its dependents cascade).
+	// It is the lowered form of the v2 authored `if:` field.
+	Condition string `yaml:"condition,omitempty"`
+	// FailWhen is a DAG IR expression evaluated against the current memory plus
+	// this step's fresh structured output after the agent runs. True → logical
+	// rejection (treated as failure, eligible for on_fail.goto loop-back).
+	// Lowered form of v2 `reject_when:`.
+	FailWhen string `yaml:"fail_when,omitempty"`
+
 	// ── agent step ────────────────────────────────────────────────
 	Agent           string        `yaml:"agent,omitempty"`
 	Model           string        `yaml:"model,omitempty"` // overrides agent's model for this step

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
@@ -97,7 +98,8 @@ func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, cell model.Cel
 
 // driveDAG runs the scheduler until the graph completes, fails, or suspends at
 // an approval step. It honors depends_on ordering, split routing, on_fail.goto
-// loops, and skip propagation, and may be re-entered after an approval resolves.
+// loops, skip propagation, and per-step condition evaluation.
+// It may be re-entered after an approval resolves.
 func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 	for {
 		next := r.pickRunnable()
@@ -108,6 +110,17 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			break // nothing else can run
 		}
 		step := r.byID[next]
+
+		// Per-step condition: evaluate before running; false → skip + cascade.
+		if step.Condition != "" {
+			evalCtx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
+			if e.conditionFalse(step.Condition, evalCtx) {
+				r.markSkipped(next)
+				aplog.Debug("workflow %s: step %q skipped (condition false)", r.wf.ID, next)
+				continue
+			}
+		}
+
 		if step.StepType() == config.StepTypeApproval {
 			e.enterApproval(ctx, r, step)
 			return outcomeWaiting
@@ -319,6 +332,30 @@ func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) bool {
 func (e *Engine) runAgentDAGStep(ctx context.Context, r *dagRun, step config.StepConfig) bool {
 	res := e.runStep(ctx, r.instID, step, r.cell, r.memSteps())
 
+	// on_missing_output: fail — treat as failure when the step declares an output
+	// schema, the policy is "fail", and no structured output was produced.
+	if res.Success && step.OutputSchema != nil &&
+		step.OnMissingOutput == config.OnMissingOutputFail &&
+		len(res.StructuredOutput) == 0 {
+		res.Success = false
+		aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", r.wf.ID, step.ID)
+	}
+
+	// fail_when — evaluate after the agent runs; a true result is a logical
+	// rejection and is treated exactly like a normal failure (eligible for
+	// on_fail.goto loop-back).
+	if res.Success && step.FailWhen != "" {
+		transientMem := r.memoryValues()
+		for field, val := range res.StructuredOutput {
+			transientMem[field] = renderValue(val)
+		}
+		evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates}
+		if e.conditionTrue(step.FailWhen, evalCtx) {
+			res.Success = false
+			aplog.Info("workflow %s: step %q rejected (fail_when matched)", r.wf.ID, step.ID)
+		}
+	}
+
 	r.stepStates[step.ID] = StepState{
 		State:  passFail(res.Success),
 		Output: res.Output,
@@ -426,4 +463,47 @@ func passFail(success bool) string {
 		return stPassed
 	}
 	return stFailed
+}
+
+// conditionFalse reports whether expr evaluates to false (or fails to parse/eval).
+// Used for per-step condition checks: false → skip the step.
+func (e *Engine) conditionFalse(expr string, ctx EvalContext) bool {
+	result, err := e.evalExpr(expr, ctx)
+	if err != nil {
+		aplog.Error("workflow: condition eval error %q: %v (treating as false → skip)", expr, err)
+		return true
+	}
+	return !result
+}
+
+// conditionTrue reports whether expr evaluates to true.
+// Used for fail_when: true → logical rejection.
+func (e *Engine) conditionTrue(expr string, ctx EvalContext) bool {
+	result, err := e.evalExpr(expr, ctx)
+	if err != nil {
+		aplog.Error("workflow: fail_when eval error %q: %v (treating as false → not rejected)", expr, err)
+		return false
+	}
+	return result
+}
+
+// evalExpr parses and evaluates a condition expression. Strips optional ${{ }}
+// wrappers produced by the v2 authoring layer before parsing.
+func (e *Engine) evalExpr(src string, ctx EvalContext) (bool, error) {
+	src = stripExprDelimiters(src)
+	parsed, err := ParseExpr(src)
+	if err != nil {
+		return false, err
+	}
+	return parsed.Eval(ctx)
+}
+
+// stripExprDelimiters removes the optional "${{ … }}" wrapper from a v2
+// expression string, returning the bare expression body.
+func stripExprDelimiters(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "${{") && strings.HasSuffix(s, "}}") {
+		s = strings.TrimSpace(s[3 : len(s)-2])
+	}
+	return s
 }

--- a/src/internal/workflow/dag_engine_additions_test.go
+++ b/src/internal/workflow/dag_engine_additions_test.go
@@ -1,0 +1,256 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestDAG_ConditionSkipsStep verifies that a step whose condition evaluates to
+// false is skipped and its dependents cascade.
+func TestDAG_ConditionSkipsStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"classify": {Success: true, StructuredOutput: map[string]any{"track": "complex"},
+			Summary: "complex issue"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	// classify writes "track" to memory; implement has condition that is false for "complex".
+	wf := config.WorkflowConfig{ID: "cond-wf", Steps: []config.StepConfig{
+		{
+			ID: "classify", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"track": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"track"}},
+		},
+		{
+			ID: "implement", Agent: "backend-dev", DependsOn: []string{"classify"},
+			Condition: `memory.track == "implement"`,
+		},
+		// downstream of implement should also be skipped
+		{ID: "deploy", Agent: "architect", DependsOn: []string{"implement"}},
+	}}
+
+	instID, success, err := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success (skipped steps don't fail the workflow)")
+	}
+	_ = instID
+
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "classify") {
+		t.Errorf("expected classify to run, got %v", ids)
+	}
+	if contains(ids, "implement") {
+		t.Errorf("implement should be skipped (condition false), got %v", ids)
+	}
+	if contains(ids, "deploy") {
+		t.Errorf("deploy should cascade-skip after implement skipped, got %v", ids)
+	}
+}
+
+// TestDAG_ConditionTrueRunsStep verifies that a step whose condition evaluates
+// true runs normally.
+func TestDAG_ConditionTrueRunsStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"classify": {Success: true, StructuredOutput: map[string]any{"track": "implement"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "cond-wf", Steps: []config.StepConfig{
+		{
+			ID: "classify", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"track": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"track"}},
+		},
+		{
+			ID: "implement", Agent: "backend-dev", DependsOn: []string{"classify"},
+			Condition: `memory.track == "implement"`,
+		},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success")
+	}
+	if !contains(executedIDs(exec.seen), "implement") {
+		t.Errorf("implement should run when condition is true, got %v", executedIDs(exec.seen))
+	}
+}
+
+// TestDAG_FailWhenRejectsStep verifies that fail_when = true turns a
+// successful agent run into a rejection (failure eligible for loop-back).
+func TestDAG_FailWhenRejectsStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	// review: first call → agent success but verdict=rejected; second → approved.
+	exec.scripts["review"] = []StepResult{
+		{Success: true, StructuredOutput: map[string]any{"verdict": "rejected"}, Output: "NACK"},
+		{Success: true, StructuredOutput: map[string]any{"verdict": "approved"}, Output: "LGTM"},
+	}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "fw-wf", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{
+			ID: "review", Agent: "architect", DependsOn: []string{"implement"},
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"verdict": {Type: "string"}}},
+			Memory:   &config.MemoryConfig{Write: []string{"verdict"}},
+			FailWhen: `memory.verdict == "rejected"`,
+			OnFail:   &config.StepOutcome{Goto: "implement", MaxRetries: 2},
+		},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success after retry")
+	}
+	if exec.ran("review") != 2 {
+		t.Errorf("expected review to run twice (reject + approve), got %d", exec.ran("review"))
+	}
+	if exec.ran("implement") != 2 {
+		t.Errorf("expected implement to run twice (loop-back), got %d", exec.ran("implement"))
+	}
+}
+
+// TestDAG_FailWhenFalseDoesNotReject verifies that when fail_when evaluates
+// false, a successful agent run passes normally.
+func TestDAG_FailWhenFalseDoesNotReject(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, StructuredOutput: map[string]any{"verdict": "approved"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "fw-wf", Steps: []config.StepConfig{
+		{
+			ID: "review", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"verdict": {Type: "string"}}},
+			FailWhen: `memory.verdict == "rejected"`,
+		},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success when fail_when is false")
+	}
+	if countSeen(exec.seen, "review") != 1 {
+		t.Errorf("expected review to run once, got %d", countSeen(exec.seen, "review"))
+	}
+}
+
+// TestDAG_FailWhenExhaustsRetries verifies that fail_when + retry exhaustion
+// marks the instance as failed after max_retries.
+func TestDAG_FailWhenExhaustsRetries(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, StructuredOutput: map[string]any{"verdict": "rejected"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "fw-wf", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{
+			ID: "review", Agent: "architect", DependsOn: []string{"implement"},
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"verdict": {Type: "string"}}},
+			FailWhen: `memory.verdict == "rejected"`,
+			OnFail:   &config.StepOutcome{Goto: "implement", MaxRetries: 1},
+		},
+	}}
+
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure after exhausted retries")
+	}
+	if store.instances[instID].State != "failed" {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+	// review: attempt 1 (reject, retry) + attempt 2 (reject, exhausted) = 2
+	if countSeen(exec.seen, "review") != 2 {
+		t.Errorf("expected review to run twice, got %d", countSeen(exec.seen, "review"))
+	}
+}
+
+// TestDAG_OnMissingOutputFail verifies that a step with output_schema and
+// on_missing_output=fail fails when no structured output is produced.
+func TestDAG_OnMissingOutputFail(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	// Agent succeeds (exit 0) but produces no structured output.
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"classify": {Success: true, Output: "done but no JSON"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "omf-wf", Steps: []config.StepConfig{
+		{
+			ID: "classify", Agent: "architect",
+			OutputSchema:    &config.OutputSchema{Type: "object"},
+			OnMissingOutput: config.OnMissingOutputFail,
+		},
+	}}
+
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if success {
+		t.Fatal("expected failure when structured output is missing with on_missing_output=fail")
+	}
+	if store.instances[instID].State != "failed" {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+}
+
+// TestDAG_OnMissingOutputWarnDoesNotFail verifies that warn (default) does not
+// fail the step when structured output is absent.
+func TestDAG_OnMissingOutputWarnDoesNotFail(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"classify": {Success: true, Output: "done but no JSON"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "omw-wf", Steps: []config.StepConfig{
+		{
+			ID: "classify", Agent: "architect",
+			OutputSchema:    &config.OutputSchema{Type: "object"},
+			OnMissingOutput: config.OnMissingOutputWarn,
+		},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.Cell{ID: "c1"})
+	if !success {
+		t.Fatal("expected success when on_missing_output=warn and output is absent")
+	}
+}
+
+// TestStripExprDelimiters verifies the ${{ }} wrapper stripping.
+func TestStripExprDelimiters(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`${{ memory.track == "implement" }}`, `memory.track == "implement"`},
+		{`memory.track == "implement"`, `memory.track == "implement"`},
+		{`${{verdict == "rejected"}}`, `verdict == "rejected"`},
+		{`  ${{ cell.priority == "high" }}  `, `cell.priority == "high"`},
+	}
+	for _, c := range cases {
+		got := stripExprDelimiters(c.in)
+		if got != c.want {
+			t.Errorf("stripExprDelimiters(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/src/internal/workflow/dag_test.go
+++ b/src/internal/workflow/dag_test.go
@@ -38,6 +38,16 @@ func (s *seqExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResult
 
 func (s *seqExecutor) ran(stepID string) int { return s.calls[stepID] }
 
+func countSeen(seen []StepRequest, id string) int {
+	n := 0
+	for _, r := range seen {
+		if r.Step.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
 func executedIDs(seen []StepRequest) []string {
 	out := make([]string, 0, len(seen))
 	for _, r := range seen {


### PR DESCRIPTION
## Summary

- **`condition`** on `StepConfig`: an expression evaluated before executing the step — false → the step is marked skipped, dependents cascade. Lowered form of `if:` from authored v2 (design §3.2).
- **`fail_when`** on `StepConfig`: an expression evaluated after the agent runs, with the memory context + this step's fresh structured output — true → a logical rejection treated as a failure (eligible for loop-back via `on_fail.goto`). Lowered form of `reject_when:`.
- **`on_missing_output: fail`**: fails the step when `output_schema` is declared but no structured output is produced.
- **`stripExprDelimiters`**: removes the `${{ }}` wrapper before parsing (accepts both the bare and delimited forms).
- `countSeen` helper added in the tests.

## Test plan

- [x] 7 new tests: condition-skip, condition-true, fail_when-reject, fail_when-false, fail_when-exhaust, on_missing_output-fail, on_missing_output-warn, strip-delimiters
- [x] `go test ./...` — full suite green