### PR TITLE
feat(workflow): v2 authoring — structs, lowering pass and validate integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3991 symbols, 8690 relationships, 274 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4095 symbols, 9024 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (3991 symbols, 8690 relationships, 274 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4095 symbols, 9024 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -1,0 +1,465 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LowerV2Workflow converts a WorkflowConfig whose steps may be written in the
+// v2 authored form (nested groups, if:, reject_when:, parallel:, for_each:
+// with a steps body) into an equivalent WorkflowConfig using only the DAG IR
+// (flat steps with depends_on, condition, fail_when, on_fail.goto, foreach,
+// type:workflow). The result is safe to hand directly to the engine.
+//
+// LowerV2Workflow is idempotent: a workflow that already uses only IR fields
+// and contains no v2 authored fields passes through unchanged.
+func LowerV2Workflow(wf WorkflowConfig) (WorkflowConfig, error) {
+	// Quick exit: no step uses v2 fields → nothing to do.
+	if !anyV2Steps(wf.Steps) {
+		return wf, nil
+	}
+
+	lc := &lowerCtx{
+		stepByID: buildStepIndex(wf.Steps),
+	}
+	lowered, err := lc.lowerSteps(wf.Steps, "", "")
+	if err != nil {
+		return wf, fmt.Errorf("workflow %q: %w", wf.ID, err)
+	}
+	out := wf
+	out.Steps = lowered
+	return out, nil
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────────────────────────
+
+// lowerCtx holds the mutable state of one lowering pass.
+type lowerCtx struct {
+	stepByID map[string]StepConfig // original step id → raw v2 node
+}
+
+// buildStepIndex builds a flat map of all step ids in the authored tree
+// (including nested children) so the lowering pass can resolve references.
+func buildStepIndex(steps []StepConfig) map[string]StepConfig {
+	m := map[string]StepConfig{}
+	var walk func([]StepConfig)
+	walk = func(ss []StepConfig) {
+		for _, s := range ss {
+			if s.ID != "" {
+				m[s.ID] = s
+			}
+			walk(s.SubSteps)
+			walk(s.ParallelSteps)
+		}
+	}
+	walk(steps)
+	return m
+}
+
+// anyV2Steps reports whether any step in the list (or its children) uses a v2
+// authored field that requires lowering.
+func anyV2Steps(steps []StepConfig) bool {
+	for _, s := range steps {
+		if s.IsV2Step() {
+			return true
+		}
+		if anyV2Steps(s.SubSteps) || anyV2Steps(s.ParallelSteps) {
+			return true
+		}
+	}
+	return false
+}
+
+// lowerSteps lowers a list of authored steps into flat IR steps, threading
+// implicit depends_on. prevID is the id of the flat step that immediately
+// precedes this list (i.e., the list's first child depends on prevID).
+// inheritedCondition is an AND-composed condition inherited from parent groups.
+func (lc *lowerCtx) lowerSteps(steps []StepConfig, prevID, inheritedCondition string) ([]StepConfig, error) {
+	var out []StepConfig
+	for _, s := range steps {
+		switch {
+		case s.ForEachExpr != "":
+			// v2 for_each: lower to StepTypeForeach (check before SubSteps since
+			// a foreach step also carries SubSteps as its body).
+			flat, err := lc.lowerForeachStep(s, prevID, inheritedCondition)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, flat)
+			prevID = flat.ID
+		case len(s.ParallelSteps) > 0:
+			// Parallel: keep as a StepTypeParallel node with lowered children.
+			flat, err := lc.lowerParallelStep(s, prevID, inheritedCondition)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, flat)
+			prevID = flat.ID
+		case len(s.SubSteps) > 0:
+			// Group: dissolve into children, applying the group's if: to all.
+			groupCond := composeCond(inheritedCondition, lowerExpr(s.If))
+			children, err := lc.lowerSteps(s.SubSteps, prevID, groupCond)
+			if err != nil {
+				return nil, err
+			}
+			if len(children) > 0 {
+				out = append(out, children...)
+				prevID = children[len(children)-1].ID
+			}
+		default:
+			// Leaf agent step (or low-level IR step passed through).
+			flat, err := lc.lowerLeafStep(s, prevID, inheritedCondition)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, flat)
+			prevID = flat.ID
+		}
+	}
+	return out, nil
+}
+
+// lowerLeafStep lowers one agent (leaf) step from v2 authored form to IR.
+func (lc *lowerCtx) lowerLeafStep(s StepConfig, prevID, inheritedCondition string) (StepConfig, error) {
+	out := s
+
+	// Apply implicit sequencing: depend on previous sibling if not overriding.
+	if prevID != "" && len(out.DependsOn) == 0 {
+		out.DependsOn = []string{prevID}
+	}
+
+	// Lower output: alias.
+	if out.Output != nil && out.OutputSchema == nil {
+		out.OutputSchema = out.Output
+	}
+	out.Output = nil
+
+	// Lower if: → condition.
+	ownCond := lowerExpr(out.If)
+	out.Condition = composeCond(inheritedCondition, ownCond)
+	out.If = ""
+
+	// Lower reject_when + on_reject → fail_when + on_fail.
+	if out.RejectWhen != "" {
+		rewritten, err := lc.rewriteExpr(out.RejectWhen, out.ID)
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("step %q reject_when: %w", out.ID, err)
+		}
+		out.FailWhen = rewritten
+		out.RejectWhen = ""
+	}
+	if out.OnReject != nil {
+		if out.OnFail == nil {
+			out.OnFail = &StepOutcome{}
+		}
+		out.OnFail.Goto = out.OnReject.RestartFrom
+		out.OnFail.MaxRetries = out.OnReject.Max
+		out.OnReject = nil
+	}
+
+	// Auto-wire: add output fields referenced in conditions/fail_when to memory.write.
+	lc.autoWireMemory(&out)
+
+	// Lower max: → max_items (for any legacy foreach-style steps that set max).
+	if out.Max > 0 && out.MaxItems == 0 {
+		out.MaxItems = out.Max
+	}
+	out.Max = 0
+
+	return out, nil
+}
+
+// lowerParallelStep lowers a parallel group step into a StepTypeParallel IR node.
+// Children are lowered as a group starting from no prevID (they all depend on
+// the parallel step's own predecessor and are run concurrently by the engine).
+func (lc *lowerCtx) lowerParallelStep(s StepConfig, prevID, inheritedCondition string) (StepConfig, error) {
+	if s.ID == "" {
+		return StepConfig{}, fmt.Errorf("parallel step missing required id")
+	}
+	out := StepConfig{
+		ID:   s.ID,
+		Name: s.Name,
+		Type: StepTypeParallel,
+		Join: s.Join,
+	}
+	if prevID != "" {
+		out.DependsOn = []string{prevID}
+	}
+	ownCond := lowerExpr(s.If)
+	out.Condition = composeCond(inheritedCondition, ownCond)
+
+	// Lower children individually (no implicit chaining — they run concurrently).
+	loweredChildren := make([]StepConfig, 0, len(s.ParallelSteps))
+	for _, child := range s.ParallelSteps {
+		flat, err := lc.lowerLeafStep(child, "", "")
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("parallel step %q child: %w", s.ID, err)
+		}
+		loweredChildren = append(loweredChildren, flat)
+	}
+	out.SubSteps = loweredChildren
+	return out, nil
+}
+
+// lowerForeachStep lowers a v2 for_each step into a StepTypeForeach IR node.
+func (lc *lowerCtx) lowerForeachStep(s StepConfig, prevID, inheritedCondition string) (StepConfig, error) {
+	if s.ID == "" {
+		return StepConfig{}, fmt.Errorf("for_each step missing required id")
+	}
+	out := StepConfig{
+		ID:          s.ID,
+		Name:        s.Name,
+		Type:        StepTypeForeach,
+		As:          s.As,
+		Concurrency: s.Concurrency,
+		FailFast:    s.FailFast,
+	}
+	if prevID != "" {
+		out.DependsOn = []string{prevID}
+	}
+	ownCond := lowerExpr(s.If)
+	out.Condition = composeCond(inheritedCondition, ownCond)
+
+	// Lower max: → max_items.
+	if s.Max > 0 {
+		out.MaxItems = s.Max
+	} else {
+		out.MaxItems = s.MaxItems
+	}
+
+	// Lower for_each expression → dot-path for Items.
+	itemsPath, stepID, field := parseForEachExpr(s.ForEachExpr)
+	out.Items = itemsPath
+	// Auto-add the items array field to the referenced step's memory.write.
+	if stepID != "" && field != "" {
+		lc.ensureMemoryWrite(stepID, field)
+	}
+
+	// Lower body steps.
+	if len(s.SubSteps) == 1 {
+		// Single inner step: use the existing Step pointer.
+		inner, err := lc.lowerLeafStep(s.SubSteps[0], "", "")
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("for_each %q body: %w", s.ID, err)
+		}
+		out.Step = &inner
+	} else if len(s.SubSteps) > 1 {
+		// Multi-step body: wrap in an anonymous sub-workflow.
+		anonID := s.ID + "-body"
+		inner, err := lc.lowerSteps(s.SubSteps, "", "")
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("for_each %q body: %w", s.ID, err)
+		}
+		anon := StepConfig{
+			ID:   anonID,
+			Type: StepTypeWorkflow,
+			// SubSteps holds the anon workflow's steps so the engine can run them.
+			SubSteps: inner,
+		}
+		out.Step = &anon
+	}
+
+	return out, nil
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Expression helpers
+// ──────────────────────────────────────────────────────────────────
+
+// lowerExpr strips optional ${{ }} delimiters from an authored expression.
+func lowerExpr(expr string) string {
+	s := strings.TrimSpace(expr)
+	if strings.HasPrefix(s, "${{") && strings.HasSuffix(s, "}}") {
+		s = strings.TrimSpace(s[3 : len(s)-2])
+	}
+	return s
+}
+
+// composeCond composes two condition expressions with AND, handling empty cases.
+func composeCond(a, b string) string {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+	switch {
+	case a == "" && b == "":
+		return ""
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return "(" + a + ") and (" + b + ")"
+	}
+}
+
+// rewriteExpr rewrites a v2 expression (possibly containing step.field short
+// forms like `review.verdict`) to use memory.* accessors, auto-wiring the
+// referenced fields into the step's memory.write list.
+// currentStepID is the id of the step that owns this expression (for error
+// messages; its own fields are also valid accessors via the transient memory).
+func (lc *lowerCtx) rewriteExpr(expr string, currentStepID string) (string, error) {
+	src := lowerExpr(expr)
+	// Walk through IDENT.IDENT pairs where IDENT1 is a known step id.
+	result, err := rewriteStepRefs(src, lc.stepByID, lc)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+// rewriteStepRefs replaces `<stepid>.<field>` with `memory.<field>` and
+// records the auto-wire in the step index.
+func rewriteStepRefs(src string, stepByID map[string]StepConfig, lc *lowerCtx) (string, error) {
+	// Simple tokenizer: split on whitespace-and-operator boundaries, reconstruct.
+	// We scan for WORD.WORD sequences where WORD1 is a known step id.
+	var buf strings.Builder
+	i := 0
+	runes := []rune(src)
+	for i < len(runes) {
+		// Try to read an identifier.
+		if isIdentRune(runes[i]) {
+			j := i + 1
+			for j < len(runes) && isIdentRune(runes[j]) {
+				j++
+			}
+			word1 := string(runes[i:j])
+			// Check for a following dot + identifier.
+			if j < len(runes) && runes[j] == '.' {
+				k := j + 1
+				for k < len(runes) && isIdentRune(runes[k]) {
+					k++
+				}
+				if k > j+1 {
+					word2 := string(runes[j+1 : k])
+					if _, isStep := stepByID[word1]; isStep {
+						// Rewrite step.field → memory.field.
+						lc.ensureMemoryWrite(word1, word2)
+						buf.WriteString("memory.")
+						buf.WriteString(word2)
+						i = k
+						continue
+					}
+				}
+			}
+			buf.WriteString(word1)
+			i = j
+		} else {
+			buf.WriteRune(runes[i])
+			i++
+		}
+	}
+	return buf.String(), nil
+}
+
+func isIdentRune(r rune) bool {
+	return r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-'
+}
+
+// autoWireMemory scans the step's condition and fail_when expressions for
+// step.field references and adds the fields to the appropriate step's
+// memory.write list.
+func (lc *lowerCtx) autoWireMemory(s *StepConfig) {
+	for _, expr := range []string{s.Condition, s.FailWhen} {
+		if expr == "" {
+			continue
+		}
+		// Scan for memory.field patterns that were already rewritten; confirm
+		// the field came from a known step and auto-wire that step's output.
+		// (Condition/FailWhen at this point already use memory.* from lowerLeafStep.)
+		// The auto-wiring happens in rewriteStepRefs for fail_when; here we only
+		// handle cases where the user wrote memory.* directly with a known field
+		// and the source step must have that field in its output schema.
+		// For conditions, scan for any memory.FIELD and make sure the emitting
+		// step has it in its memory.write.
+		lc.ensureMemoryWriteForExpr(expr)
+	}
+}
+
+// ensureMemoryWriteForExpr scans an expression for `memory.<field>` accessors
+// and attempts to find which step emits that field, adding to its memory.write.
+func (lc *lowerCtx) ensureMemoryWriteForExpr(expr string) {
+	// Look for memory.FIELD patterns and find which step has that field in its output schema.
+	runes := []rune(expr)
+	i := 0
+	for i < len(runes) {
+		if isIdentRune(runes[i]) {
+			j := i + 1
+			for j < len(runes) && isIdentRune(runes[j]) {
+				j++
+			}
+			word1 := string(runes[i:j])
+			if word1 == "memory" && j < len(runes) && runes[j] == '.' {
+				k := j + 1
+				for k < len(runes) && isIdentRune(runes[k]) {
+					k++
+				}
+				if k > j+1 {
+					field := string(runes[j+1 : k])
+					// Find which step declares this field in output_schema / output.
+					for stepID, step := range lc.stepByID {
+						schema := step.OutputSchema
+						if schema == nil {
+							schema = step.Output
+						}
+						if schema != nil {
+							if _, ok := schema.Properties[field]; ok {
+								lc.ensureMemoryWrite(stepID, field)
+							}
+						}
+					}
+				}
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+}
+
+// ensureMemoryWrite adds field to stepID's memory.write if not already present,
+// updating the step index in place.
+func (lc *lowerCtx) ensureMemoryWrite(stepID, field string) {
+	s, ok := lc.stepByID[stepID]
+	if !ok {
+		return
+	}
+	if s.Memory == nil {
+		s.Memory = &MemoryConfig{}
+	}
+	for _, f := range s.Memory.Write {
+		if f == field {
+			lc.stepByID[stepID] = s
+			return
+		}
+	}
+	s.Memory.Write = append(s.Memory.Write, field)
+	lc.stepByID[stepID] = s
+}
+
+// parseForEachExpr parses a for_each expression like `${{ design.tasks }}`
+// and returns the dot-path (for Items), the step id, and the field name.
+// For expressions that are already dot-paths, returns the path as-is.
+func parseForEachExpr(expr string) (dotPath, stepID, field string) {
+	s := lowerExpr(expr)
+	// s is now e.g. "design.tasks" or "steps.design.outputs.tasks"
+	parts := strings.SplitN(s, ".", 2)
+	if len(parts) == 2 && !strings.HasPrefix(s, "steps.") && !strings.HasPrefix(s, "memory.") {
+		return "steps." + parts[0] + ".outputs." + parts[1], parts[0], parts[1]
+	}
+	// Already a full path.
+	return s, "", ""
+}
+
+// LowerV2WorkflowInConfig runs LowerV2Workflow on every workflow in the config,
+// replacing the steps in-place. Called by Config.Validate so that the engine
+// always receives lowered IR.
+func LowerV2WorkflowInConfig(cfg *Config) error {
+	for i, wf := range cfg.Workflows {
+		lowered, err := LowerV2Workflow(wf)
+		if err != nil {
+			return err
+		}
+		cfg.Workflows[i] = lowered
+	}
+	return nil
+}

--- a/src/internal/config/lower_v2_test.go
+++ b/src/internal/config/lower_v2_test.go
@@ -1,0 +1,384 @@
+package config
+
+import (
+	"testing"
+)
+
+func ptr(b bool) *bool { return &b }
+
+func TestLowerV2_NoV2Fields_Passthrough(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "plain",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag", DependsOn: []string{}},
+			{ID: "b", Agent: "ag", DependsOn: []string{"a"}},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Steps) != 2 || out.Steps[0].ID != "a" || out.Steps[1].ID != "b" {
+		t.Errorf("passthrough changed steps: %+v", out.Steps)
+	}
+}
+
+func TestLowerV2_ImplicitSequencing(t *testing.T) {
+	// Steps without depends_on get implicit sequencing from declaration order.
+	wf := WorkflowConfig{
+		ID: "seq",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag"},
+			{ID: "b", Agent: "ag"},
+			{ID: "c", Agent: "ag"},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Without any v2 fields, passthrough — no lowering applied.
+	// Steps without any v2 fields: LowerV2 passes through unchanged.
+	if len(out.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(out.Steps))
+	}
+}
+
+func TestLowerV2_ImplicitSequencing_V2Fields(t *testing.T) {
+	// When any step has v2 fields, lowering runs and adds implicit depends_on.
+	wf := WorkflowConfig{
+		ID: "seq",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag"},
+			{ID: "b", Agent: "ag", If: `${{ cell.priority == "high" }}`},
+			{ID: "c", Agent: "ag"},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(out.Steps))
+	}
+	// a: no prev
+	if len(out.Steps[0].DependsOn) != 0 {
+		t.Errorf("step a should have no depends_on, got %v", out.Steps[0].DependsOn)
+	}
+	// b: depends on a
+	if len(out.Steps[1].DependsOn) != 1 || out.Steps[1].DependsOn[0] != "a" {
+		t.Errorf("step b depends_on = %v, want [a]", out.Steps[1].DependsOn)
+	}
+	// c: depends on b
+	if len(out.Steps[2].DependsOn) != 1 || out.Steps[2].DependsOn[0] != "b" {
+		t.Errorf("step c depends_on = %v, want [b]", out.Steps[2].DependsOn)
+	}
+}
+
+func TestLowerV2_IfLowersToCondition(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "cond",
+		Steps: []StepConfig{
+			{
+				ID: "implement", Agent: "ag",
+				If: `${{ memory.track == "implement" }}`,
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	step := out.Steps[0]
+	if step.Condition != `memory.track == "implement"` {
+		t.Errorf("condition = %q, want stripped expression", step.Condition)
+	}
+	if step.If != "" {
+		t.Errorf("If should be cleared after lowering, got %q", step.If)
+	}
+}
+
+func TestLowerV2_OutputAliasLowersToOutputSchema(t *testing.T) {
+	schema := &OutputSchema{Type: "object", Properties: map[string]SchemaField{
+		"verdict": {Type: "string"},
+	}}
+	wf := WorkflowConfig{
+		ID: "out",
+		Steps: []StepConfig{
+			{ID: "review", Agent: "ag", Output: schema},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	step := out.Steps[0]
+	if step.OutputSchema == nil {
+		t.Error("OutputSchema should be set from Output alias")
+	}
+	if step.Output != nil {
+		t.Error("Output alias should be cleared after lowering")
+	}
+}
+
+func TestLowerV2_RejectWhenLowersToFailWhen(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "rw",
+		Steps: []StepConfig{
+			{
+				ID: "review", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"verdict": {Type: "string"}}},
+				RejectWhen: `${{ review.verdict == "rejected" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "implement", Max: 3},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	step := out.Steps[0]
+	if step.FailWhen == "" {
+		t.Error("FailWhen should be set from RejectWhen")
+	}
+	if step.RejectWhen != "" {
+		t.Errorf("RejectWhen should be cleared, got %q", step.RejectWhen)
+	}
+	if step.OnFail == nil {
+		t.Fatal("OnFail should be set from OnReject")
+	}
+	if step.OnFail.Goto != "implement" {
+		t.Errorf("OnFail.Goto = %q, want implement", step.OnFail.Goto)
+	}
+	if step.OnFail.MaxRetries != 3 {
+		t.Errorf("OnFail.MaxRetries = %d, want 3", step.OnFail.MaxRetries)
+	}
+	if step.OnReject != nil {
+		t.Error("OnReject should be cleared after lowering")
+	}
+}
+
+func TestLowerV2_GroupDissolvedInline(t *testing.T) {
+	// A group step with sub-steps is dissolved; children are inlined.
+	wf := WorkflowConfig{
+		ID: "grp",
+		Steps: []StepConfig{
+			{ID: "classify", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"track": {Type: "string"}}}},
+			{
+				ID: "impl-track",
+				If: `${{ classify.track == "implement" }}`,
+				SubSteps: []StepConfig{
+					{ID: "implement", Agent: "ag"},
+					{ID: "review", Agent: "ag"},
+				},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Group is dissolved: classify + implement + review = 3 flat steps.
+	if len(out.Steps) != 3 {
+		t.Fatalf("expected 3 flat steps (group dissolved), got %d: %v",
+			len(out.Steps), stepIDList(out.Steps))
+	}
+	ids := stepIDList(out.Steps)
+	if ids[0] != "classify" || ids[1] != "implement" || ids[2] != "review" {
+		t.Errorf("expected [classify, implement, review], got %v", ids)
+	}
+	// implement inherits the group's if: condition.
+	if out.Steps[1].Condition == "" {
+		t.Error("implement should inherit the group's condition")
+	}
+	// implement depends on classify (group's predecessor).
+	if len(out.Steps[1].DependsOn) == 0 || out.Steps[1].DependsOn[0] != "classify" {
+		t.Errorf("implement depends_on = %v, want [classify]", out.Steps[1].DependsOn)
+	}
+	// review depends on implement (implicit sequencing within group).
+	if len(out.Steps[2].DependsOn) == 0 || out.Steps[2].DependsOn[0] != "implement" {
+		t.Errorf("review depends_on = %v, want [implement]", out.Steps[2].DependsOn)
+	}
+}
+
+func TestLowerV2_ParallelStepKept(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "par",
+		Steps: []StepConfig{
+			{ID: "setup", Agent: "ag"},
+			{
+				ID:   "checks",
+				Join: "all",
+				ParallelSteps: []StepConfig{
+					{ID: "tests", Agent: "ag"},
+					{ID: "docs", Agent: "ag"},
+				},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// setup + checks = 2 flat steps (parallel node kept, not dissolved).
+	if len(out.Steps) != 2 {
+		t.Fatalf("expected 2 flat steps, got %d: %v", len(out.Steps), stepIDList(out.Steps))
+	}
+	checks := out.Steps[1]
+	if checks.Type != StepTypeParallel {
+		t.Errorf("checks type = %q, want parallel", checks.Type)
+	}
+	if checks.Join != "all" {
+		t.Errorf("checks join = %q, want all", checks.Join)
+	}
+	if len(checks.SubSteps) != 2 {
+		t.Errorf("checks should have 2 children, got %d", len(checks.SubSteps))
+	}
+	if checks.DependsOn[0] != "setup" {
+		t.Errorf("checks depends_on = %v, want [setup]", checks.DependsOn)
+	}
+}
+
+func TestLowerV2_ForEachSingleStepBody(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "fe",
+		Steps: []StepConfig{
+			{
+				ID: "design", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"tasks": {Type: "array"}}},
+			},
+			{
+				ID:          "build",
+				ForEachExpr: "${{ design.tasks }}",
+				As:          "task",
+				Max:         20,
+				SubSteps: []StepConfig{
+					{ID: "impl", Agent: "ag", Prompt: "Implement: ${{ task.title }}"},
+				},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(out.Steps))
+	}
+	build := out.Steps[1]
+	if build.Type != StepTypeForeach {
+		t.Errorf("build type = %q, want foreach", build.Type)
+	}
+	if build.MaxItems != 20 {
+		t.Errorf("build max_items = %d, want 20", build.MaxItems)
+	}
+	if build.As != "task" {
+		t.Errorf("build as = %q, want task", build.As)
+	}
+	if build.Step == nil {
+		t.Fatal("build.Step should be set for single-step body")
+	}
+	if build.Step.ID != "impl" {
+		t.Errorf("inner step id = %q, want impl", build.Step.ID)
+	}
+}
+
+func TestLowerV2_ForEachMultiStepBodyWrapsAnon(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "fe2",
+		Steps: []StepConfig{
+			{
+				ID: "design", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"tasks": {Type: "array"}}},
+			},
+			{
+				ID:          "build",
+				ForEachExpr: "${{ design.tasks }}",
+				As:          "task",
+				SubSteps: []StepConfig{
+					{ID: "impl", Agent: "ag"},
+					{ID: "verify", Agent: "ag"},
+				},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	build := out.Steps[1]
+	if build.Step == nil {
+		t.Fatal("build.Step should be set for multi-step body (anon sub-workflow)")
+	}
+	if build.Step.Type != StepTypeWorkflow {
+		t.Errorf("anon wrapper type = %q, want workflow", build.Step.Type)
+	}
+	if len(build.Step.SubSteps) != 2 {
+		t.Errorf("anon wrapper has %d children, want 2", len(build.Step.SubSteps))
+	}
+}
+
+func TestLowerV2_AutoWireMemoryFromRejectWhen(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "aw",
+		Steps: []StepConfig{
+			{
+				ID: "review", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"verdict": {Type: "string"}}},
+				RejectWhen: `${{ review.verdict == "rejected" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "implement", Max: 2},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The fail_when expression should use memory.verdict (after rewrite).
+	if out.Steps[0].FailWhen != `memory.verdict == "rejected"` {
+		t.Errorf("FailWhen = %q, want memory.verdict == \"rejected\"", out.Steps[0].FailWhen)
+	}
+}
+
+func TestLowerV2_ComposeCond(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"", "", ""},
+		{"A", "", "A"},
+		{"", "B", "B"},
+		{"A", "B", "(A) and (B)"},
+	}
+	for _, c := range cases {
+		got := composeCond(c.a, c.b)
+		if got != c.want {
+			t.Errorf("composeCond(%q,%q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestLowerV2_LowerExpr(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`${{ memory.track == "implement" }}`, `memory.track == "implement"`},
+		{`memory.track == "implement"`, `memory.track == "implement"`},
+		{`${{verdict == "ok"}}`, `verdict == "ok"`},
+	}
+	for _, c := range cases {
+		got := lowerExpr(c.in)
+		if got != c.want {
+			t.Errorf("lowerExpr(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func stepIDList(steps []StepConfig) []string {
+	ids := make([]string, len(steps))
+	for i, s := range steps {
+		ids[i] = s.ID
+	}
+	return ids
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -104,6 +104,11 @@ func (c *Config) Validate() []error {
 		routeIDs[r.ID] = true
 	}
 
+	// Lower v2 authored workflows to DAG IR before validation so the validator
+	// sees only canonical StepConfig fields.
+	if err := LowerV2WorkflowInConfig(c); err != nil {
+		errs = append(errs, err)
+	}
 	errs = append(errs, c.validateWorkflows()...)
 
 	// Removed-directive and unknown-field checks on the raw text (no-op when the

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -9,6 +9,9 @@ const (
 	StepTypeApproval = "approval"
 	StepTypeForeach  = "foreach"
 	StepTypeWorkflow = "workflow"
+	// StepTypeParallel is emitted by the v2 lowering pass for `parallel:` steps.
+	// Children run concurrently (§8e); the step's outcome = the join policy.
+	StepTypeParallel = "parallel"
 )
 
 // Resume policy values for a workflow.
@@ -116,6 +119,34 @@ type StepConfig struct {
 
 	// ── sub-workflow step ─────────────────────────────────────────
 	Workflow string `yaml:"workflow,omitempty"`
+
+	// ── v2 authored fields (present before lowering; absent after) ───
+	// These are written by humans in v2 syntax and lowered to the IR fields
+	// above by LowerV2Workflow. They must not be used directly by the engine.
+
+	// If is the authored guard expression (e.g. `${{ classify.track == 'complex' }}`).
+	// Lowers to Condition.
+	If string `yaml:"if,omitempty"`
+	// RejectWhen is the authored rejection gate expression.
+	// Lowers to FailWhen (with expression rewritten to use memory.* accessors).
+	RejectWhen string `yaml:"reject_when,omitempty"`
+	// OnReject is the authored loop-back spec. Lowers to OnFail.
+	OnReject *OnRejectConfig `yaml:"on_reject,omitempty"`
+	// SubSteps is a sequential group of child steps (v2 `steps:` inside a step).
+	// Dissolved during lowering: children are inlined into the parent flat list.
+	SubSteps []StepConfig `yaml:"steps,omitempty"`
+	// ParallelSteps are concurrent child steps (v2 `parallel:` inside a step).
+	// Lowers to a StepTypeParallel node with embedded children.
+	ParallelSteps []StepConfig `yaml:"parallel,omitempty"`
+	// Join is the parallel step join policy: all (default) | any | ${{ expr }}.
+	Join string `yaml:"join,omitempty"`
+	// ForEachExpr is the v2 `for_each:` expression (e.g. `${{ design.tasks }}`).
+	// Lowers to Items (dot-path) + foreach step type.
+	ForEachExpr string `yaml:"for_each,omitempty"`
+	// Max is the v2 `max:` loop cap. Lowers to MaxItems.
+	Max int `yaml:"max,omitempty"`
+	// Output is the v2 alias for OutputSchema (shorter key in authored YAML).
+	Output *OutputSchema `yaml:"output,omitempty"`
 }
 
 // StepType returns the step's type, defaulting to StepTypeAgent when unset.
@@ -218,4 +249,20 @@ type SchemaField struct {
 	Items      *SchemaField           `yaml:"items,omitempty"`
 	Properties map[string]SchemaField `yaml:"properties,omitempty"`
 	Required   []string               `yaml:"required,omitempty"`
+}
+
+// OnRejectConfig is the v2 authored loop-back spec for reject_when gates.
+// It lowers to StepOutcome (on_fail.goto + max_retries).
+type OnRejectConfig struct {
+	// RestartFrom names the earlier sibling step to restart from when rejected.
+	RestartFrom string `yaml:"restart_from"`
+	// Max is the maximum number of rejection+restart cycles (≥ 1).
+	Max int `yaml:"max,omitempty"`
+}
+
+// IsV2Step reports whether this step was written in v2 authored form (i.e., it
+// uses at least one v2-only field that must be lowered before execution).
+func (s StepConfig) IsV2Step() bool {
+	return s.If != "" || s.RejectWhen != "" || s.OnReject != nil ||
+		len(s.SubSteps) > 0 || len(s.ParallelSteps) > 0 || s.ForEachExpr != "" || s.Output != nil
 }


### PR DESCRIPTION
## Summary

- **`StepTypeParallel`** — a new step type for `parallel:` in v2
- **`OnRejectConfig`** — a struct for the `on_reject:` gate in v2 (lowers to `on_fail`)
- **v2 authored fields** on `StepConfig`: `If`, `RejectWhen`, `OnReject`, `SubSteps`, `ParallelSteps`, `Join`, `ForEachExpr`, `Max`, `Output`
- **Lowering pass** (`config/lower_v2.go`):
  - Implicit sequence → `depends_on` by declaration order
  - Group (nested `steps:`) → dissolved inline with `condition` inheritance
  - Parallel (`parallel:`) → `StepTypeParallel` with embedded children
  - ForEach (`for_each:`) → `StepTypeForeach`; a multi-step body → an anon sub-workflow
  - `if:` → `condition`; `reject_when:` → `fail_when` (rewriting `step.field` → `memory.field`); `on_reject:` → `on_fail.goto + max_retries`
  - `output:` → `output_schema` (alias); `max:` → `max_items`
  - Auto-wire: `step.field` refs in expressions → `memory.write` of the source step
- **`Config.Validate()`** — calls `LowerV2WorkflowInConfig` before validation

## Test plan

- [x] 13 tests in `lower_v2_test.go`: passthrough, implicit sequence, group dissolve, parallel kept, foreach single/multi body, auto-wire, composeCond, lowerExpr
- [x] `go test ./...` — full suite green