### PR TITLE
feat(config): validate v2 authoring rules before lowering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4095 symbols, 9024 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4122 symbols, 9128 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4095 symbols, 9024 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4122 symbols, 9128 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -104,6 +104,10 @@ func (c *Config) Validate() []error {
 		routeIDs[r.ID] = true
 	}
 
+	// Validate v2-specific authoring rules before lowering (while v2 fields are
+	// still present on the raw StepConfig nodes).
+	errs = append(errs, c.validateV2Workflows()...)
+
 	// Lower v2 authored workflows to DAG IR before validation so the validator
 	// sees only canonical StepConfig fields.
 	if err := LowerV2WorkflowInConfig(c); err != nil {

--- a/src/internal/config/workflow_validate_v2.go
+++ b/src/internal/config/workflow_validate_v2.go
@@ -1,0 +1,113 @@
+package config
+
+import "fmt"
+
+// validateV2Workflows checks v2-specific authoring rules on all workflows
+// BEFORE the lowering pass strips the v2 fields. Called from Config.Validate().
+func (c *Config) validateV2Workflows() []error {
+	var errs []error
+	for i, wf := range c.Workflows {
+		ctx := fmt.Sprintf("workflows[%d] %q", i, wf.ID)
+		errs = append(errs, validateV2Workflow(ctx, wf)...)
+	}
+	return errs
+}
+
+func validateV2Workflow(ctx string, wf WorkflowConfig) []error {
+	var errs []error
+	if !anyV2Steps(wf.Steps) {
+		return errs // pure v1 workflow — nothing to check
+	}
+
+	// Rule: no mixing of v2 authored nesting with hand-written v1 primitives in
+	// the same workflow. A workflow is either fully v2 or fully v1.
+	if hasV1Primitives(wf.Steps) {
+		errs = append(errs, fmt.Errorf(
+			"%s: mixes v2 authoring (if:/steps:/parallel:/for_each:) with v1 primitives "+
+				"(depends_on/branches/goto) in the same workflow — use one or the other",
+			ctx))
+	}
+
+	errs = append(errs, validateV2Steps(ctx, wf.Steps, nil)...)
+	return errs
+}
+
+// validateV2Steps recursively validates a list of authored steps.
+// siblingsBefore holds the ids of earlier siblings in the same steps: list.
+func validateV2Steps(ctx string, steps []StepConfig, siblingsBefore []string) []error {
+	var errs []error
+	var seen []string // ids in this steps list, in order
+
+	for _, s := range steps {
+		stepCtx := fmt.Sprintf("%s: step %q", ctx, s.ID)
+
+		// reject_when without on_reject.
+		if s.RejectWhen != "" && s.OnReject == nil {
+			errs = append(errs, fmt.Errorf(
+				"%s: has reject_when but no on_reject — add on_reject.restart_from and max, or remove reject_when",
+				stepCtx))
+		}
+
+		// on_reject.restart_from must name an earlier sibling.
+		if s.OnReject != nil && s.OnReject.RestartFrom != "" {
+			if !containsStr(seen, s.OnReject.RestartFrom) {
+				errs = append(errs, fmt.Errorf(
+					"%s: on_reject.restart_from %q is not an earlier sibling in the same steps list",
+					stepCtx, s.OnReject.RestartFrom))
+			}
+			if s.OnReject.Max < 1 {
+				errs = append(errs, fmt.Errorf(
+					"%s: on_reject.max must be ≥ 1, got %d", stepCtx, s.OnReject.Max))
+			}
+		}
+
+		// Recursively validate group children.
+		if len(s.SubSteps) > 0 {
+			errs = append(errs, validateV2Steps(stepCtx, s.SubSteps, nil)...)
+		}
+
+		// Recursively validate parallel children.
+		if len(s.ParallelSteps) > 0 {
+			errs = append(errs, validateV2Steps(stepCtx+" (parallel)", s.ParallelSteps, nil)...)
+		}
+
+		// Recursively validate foreach body.
+		if s.ForEachExpr != "" && len(s.SubSteps) > 0 {
+			errs = append(errs, validateV2Steps(stepCtx+" (for_each body)", s.SubSteps, nil)...)
+		}
+
+		seen = append(seen, s.ID)
+	}
+	return errs
+}
+
+// hasV1Primitives reports whether any step in the list uses v1-only hand-written
+// primitives that conflict with v2 authored nesting.
+func hasV1Primitives(steps []StepConfig) bool {
+	for _, s := range steps {
+		// depends_on is the key v1 primitive — v2 uses implicit ordering instead.
+		if len(s.DependsOn) > 0 {
+			return true
+		}
+		// Split branches + goto are v1 split routing.
+		if len(s.Branches) > 0 {
+			return true
+		}
+		if len(s.SubSteps) > 0 && hasV1Primitives(s.SubSteps) {
+			return true
+		}
+		if len(s.ParallelSteps) > 0 && hasV1Primitives(s.ParallelSteps) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/config/workflow_validate_v2_test.go
+++ b/src/internal/config/workflow_validate_v2_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateV2_RejectWhenWithoutOnReject(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "review", Agent: "a", RejectWhen: `${{ memory.verdict == "rejected" }}`},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if !anyError(errs, "on_reject") {
+		t.Errorf("expected on_reject error, got: %v", errs)
+	}
+}
+
+func TestValidateV2_RejectWhenWithOnReject_OK(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "impl", Agent: "a"},
+			{ID: "review", Agent: "a",
+				RejectWhen: `${{ memory.verdict == "rejected" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "impl", Max: 2}},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateV2_RestartFromEarlierSibling(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "impl", Agent: "a"},
+			{ID: "review", Agent: "a",
+				RejectWhen: `${{ memory.v == "no" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "impl", Max: 2}},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidateV2_RestartFromNotEarlierSibling(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "review", Agent: "a",
+				RejectWhen: `${{ memory.v == "no" }}`,
+				// "qa" doesn't exist yet as an earlier sibling
+				OnReject: &OnRejectConfig{RestartFrom: "qa", Max: 2}},
+			{ID: "qa", Agent: "a"},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if !anyError(errs, "earlier sibling") {
+		t.Errorf("expected earlier-sibling error, got: %v", errs)
+	}
+}
+
+func TestValidateV2_OnRejectMaxZero(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "impl", Agent: "a"},
+			{ID: "review", Agent: "a",
+				RejectWhen: `${{ memory.v == "no" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "impl", Max: 0}},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if !anyError(errs, "max") {
+		t.Errorf("expected max error, got: %v", errs)
+	}
+}
+
+func TestValidateV2_MixV1V2_Rejected(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag", If: `${{ cell.priority == "high" }}`},
+			{ID: "b", Agent: "ag", DependsOn: []string{"a"}}, // v1 depends_on mixed in
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if !anyError(errs, "mixes v2") {
+		t.Errorf("expected v2+v1 mix error, got: %v", errs)
+	}
+}
+
+func TestValidateV2_PureV1_NoErrors(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag"},
+			{ID: "b", Agent: "ag", DependsOn: []string{"a"}},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if len(errs) != 0 {
+		t.Errorf("pure v1 workflow should produce no v2 validation errors, got: %v", errs)
+	}
+}
+
+func TestValidateV2_PureV2_NoErrors(t *testing.T) {
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "a", Agent: "ag"},
+			{ID: "b", Agent: "ag", If: `${{ cell.priority == "high" }}`},
+		},
+	}}
+	errs := c.validateV2Workflows()
+	if len(errs) != 0 {
+		t.Errorf("pure v2 workflow should produce no v2 validation errors, got: %v", errs)
+	}
+}
+
+// minimalConfig returns a minimal valid config for testing validation helpers.
+func minimalConfig() *Config {
+	return &Config{
+		Version: "1",
+		Agents:  []AgentConfig{{ID: "a", Model: "m"}},
+	}
+}
+
+func anyError(errs []error, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Error(), substr) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Adds `validateV2Workflows()` called in `Config.Validate()` BEFORE the lowering pass, while the v2 fields are still present on the `StepConfig` nodes
- Validates: `reject_when` without `on_reject`, `on_reject.restart_from` must reference a previous sibling in the same list, `on_reject.max >= 1`
- Forbids mixing v2 authoring (`if:/steps:/parallel:/for_each:`) with v1 primitives (`depends_on/branches`) in the same workflow

## Test plan

- [x] `TestValidateV2_RejectWhenWithoutOnReject` — error when reject_when without on_reject
- [x] `TestValidateV2_RejectWhenWithOnReject_OK` — no error when correct
- [x] `TestValidateV2_RestartFromEarlierSibling` — restart_from to a previous sibling OK
- [x] `TestValidateV2_RestartFromNotEarlierSibling` — error when restart_from is not a previous sibling
- [x] `TestValidateV2_OnRejectMaxZero` — error when max = 0
- [x] `TestValidateV2_MixV1V2_Rejected` — error when mixing v1 and v2
- [x] `TestValidateV2_PureV1_NoErrors` and `TestValidateV2_PureV2_NoErrors` — pure workflows produce no errors

Closes #46