### PR TITLE
test(workflow): v2 pipeline e2e tests + example-workflow.yaml in v2 syntax

### DIFF
--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -1,12 +1,15 @@
 version: "1"
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Example: Workflow Mode (experimental)
+# Example: Workflow Mode — v2 authoring syntax
 #
-# This sample shows how to route a task through a multi-step workflow.
-# A matched task runs through `steps` in dependency order, threading a small
-# enrichable "memory" baton between them. Approval steps suspend the instance
-# until a human responds on the task (GitHub issues support this via comments).
+# Steps are written in a nested sequential tree with `if:` guards and
+# `reject_when:`/`on_reject:` loops. The engine lowers this to a DAG IR before
+# execution, so all existing features (memory, approval, foreach, sub-workflows)
+# continue to work unchanged.
+#
+# Low-level primitives (`type: split`, `depends_on`, `goto`) are still available
+# for hand-tuned DAGs; do not mix them with v2 authoring in the same workflow.
 #
 # Inspect and resume instances from the CLI:
 #   apiary instances                 # list workflow instances
@@ -36,21 +39,25 @@ sources:
 
 agents:
   - id: investigator
-    description: "Classifies an issue by complexity"
+    description: "Classifies an issue by complexity and approach"
     soul_file: .apiary/souls/investigator.md
     model: claude-opus-4-8
   - id: engineer
-    description: "Implements the change"
+    description: "Implements the change described in memory"
     soul_file: .apiary/souls/engineer.md
     model: claude-sonnet-4-6
   - id: reviewer
-    description: "Reviews the change"
+    description: "Reviews the implementation and returns a verdict"
     soul_file: .apiary/souls/reviewer.md
+    model: claude-sonnet-4-6
+  - id: qa
+    description: "Runs quality checks and confirms the change is shippable"
+    soul_file: .apiary/souls/qa.md
     model: claude-sonnet-4-6
 
 workflows:
   - id: feature-development
-    description: "Plan → implement → human approval → review"
+    description: "Classify → implement → review (with retry loop) → QA"
     resume: allowed
     trigger:
       priority: 10
@@ -59,50 +66,59 @@ workflows:
         types: [feature, improvement]
 
     steps:
-      # 1) Classify and plan. Persist a couple of fields into workflow memory.
-      - id: plan
+      # ── 1. Classify ─────────────────────────────────────────────────────────
+      # Determine complexity and planned approach; persist both into memory.
+      - id: classify
         agent: investigator
         summary_prompt: "In 3-5 bullets: the approach, risks, and what the implementer needs."
-        output_schema:
+        output:
           type: object
           properties:
             complexity: {type: string, enum: [low, medium, high]}
-            approach: {type: string}
+            approach:   {type: string}
           required: [complexity, approach]
         memory:
           write: [complexity, approach]
 
-      # 2) Route on the planned complexity. High complexity needs sign-off.
-      - id: route
-        type: split
-        depends_on: [plan]
-        branches:
-          - if: 'memory.complexity == "high"'
-            goto: approve
-          - else: true
-            goto: implement
-
-      # 3) Human approval checkpoint (only reached for high-complexity work).
-      #    The engine posts `message` and parks the instance until a maintainer
-      #    comments "approve" (resume) or "reject" (abort), or the timeout fires.
+      # ── 2. High-complexity gate ──────────────────────────────────────────────
+      # An approval step guards high-complexity changes; low/medium skip straight
+      # to implementation. The `if:` condition is evaluated after classify runs.
       - id: approve
         type: approval
-        message: "High-complexity change planned. Comment `approve` to proceed or `reject` to stop."
+        if: ${{ memory.complexity == "high" }}
+        message: |
+          High-complexity change detected (complexity=${{ memory.complexity }}).
+          Comment `approve` to proceed or `reject` to stop.
         resume_on: {comment_contains: "approve"}
-        abort_on: {comment_contains: "reject"}
-        timeout: 24h
-        on_pass: {next: implement}
+        abort_on:  {comment_contains: "reject"}
+        timeout: 48h
 
-      # 4) Implement, then review. Both read the accumulated memory baton.
+      # ── 3. Implement ─────────────────────────────────────────────────────────
       - id: implement
         agent: engineer
-        depends_on: [plan]
-        prompt: "Implement the change following the approach captured in memory."
+        prompt: "Implement the change following the approach in memory."
 
+      # ── 4. Review with automatic retry loop ─────────────────────────────────
+      # The reviewer writes a `verdict` field. If it is "rejected" the engine
+      # loops back to implement and retries up to 2 times.
       - id: review
         agent: reviewer
-        depends_on: [implement]
-        prompt: "Review the implementation for correctness and conventions."
+        prompt: "Review the implementation for correctness, conventions, and the original issue."
+        output:
+          type: object
+          properties:
+            verdict:  {type: string, enum: [approved, rejected]}
+            feedback: {type: string}
+          required: [verdict]
+        reject_when: ${{ memory.verdict == "rejected" }}
+        on_reject:
+          restart_from: implement
+          max: 2
+
+      # ── 5. QA ────────────────────────────────────────────────────────────────
+      - id: qa-check
+        agent: qa
+        prompt: "Run quality checks on the implementation and confirm it is shippable."
 
     on_complete:
       set_state: in_review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4183 symbols, 9272 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4198 symbols, 9312 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4183 symbols, 9272 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4198 symbols, 9312 relationships, 279 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/workflow/dag_e2e_test.go
+++ b/src/internal/workflow/dag_e2e_test.go
@@ -1,0 +1,238 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestE2E_ClassifyImplementReviewQA runs the full pipeline that the v2 authoring
+// spec describes as the canonical example:
+//
+//	classify → implement → review (reject→loop) → qa → done
+//
+// The workflow is authored in v2 (if/reject_when/on_reject) and lowered to DAG
+// IR before execution. The review step rejects once (looping back to implement)
+// then passes, after which qa runs and the workflow completes.
+func TestE2E_ClassifyImplementReviewQA(t *testing.T) {
+	ctx := context.Background()
+	client := realDB(t)
+
+	// seqExec is scripted: review fails on attempt 1, passes on attempt 2.
+	exec := newSeqExecutor()
+	exec.scripts["classify"] = []StepResult{
+		{
+			Success:          true,
+			Output:           "track=implement",
+			StructuredOutput: map[string]any{"track": "implement"},
+			Summary:          "track decided",
+		},
+	}
+	exec.scripts["implement"] = []StepResult{
+		{Success: true, Output: "PR opened", Summary: "impl done"},
+	}
+	exec.scripts["review"] = []StepResult{
+		// First attempt: reject (verdict=rejected)
+		{
+			Success:          true,
+			StructuredOutput: map[string]any{"verdict": "rejected"},
+			Summary:          "needs revision",
+		},
+		// Second attempt: approve
+		{
+			Success:          true,
+			StructuredOutput: map[string]any{"verdict": "approved"},
+			Summary:          "LGTM",
+		},
+	}
+	exec.scripts["qa"] = []StepResult{
+		{Success: true, Output: "tests pass", Summary: "qa ok"},
+	}
+
+	cfg := &config.Config{
+		Agents: []config.AgentConfig{
+			{ID: "investigator", Model: "claude-opus-4-8"},
+			{ID: "engineer", Model: "claude-sonnet-4-6"},
+			{ID: "reviewer", Model: "claude-sonnet-4-6"},
+			{ID: "qa-agent", Model: "claude-sonnet-4-6"},
+		},
+		Settings: config.Settings{Concurrency: 1},
+	}
+	eng := NewEngine(cfg, client, exec)
+
+	// Build a v2-authored workflow, lower it, then run it.
+	rawWF := config.WorkflowConfig{
+		ID: "classify-impl-review-qa",
+		Steps: []config.StepConfig{
+			{
+				ID:    "classify",
+				Agent: "investigator",
+				Output: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"track": {Type: "string"},
+					},
+				},
+			},
+			{
+				ID:    "implement",
+				Agent: "engineer",
+			},
+			{
+				ID:         "review",
+				Agent:      "reviewer",
+				RejectWhen: `${{ memory.verdict == "rejected" }}`,
+				OnReject:   &config.OnRejectConfig{RestartFrom: "implement", Max: 2},
+				Output: &config.OutputSchema{
+					Type: "object",
+					Properties: map[string]config.SchemaField{
+						"verdict": {Type: "string"},
+					},
+				},
+			},
+			{
+				ID:    "qa",
+				Agent: "qa-agent",
+			},
+		},
+	}
+
+	lowered, err := config.LowerV2Workflow(rawWF)
+	if err != nil {
+		t.Fatalf("LowerV2Workflow: %v", err)
+	}
+
+	instID, success, err := eng.RunInstance(ctx, lowered, model.Cell{ID: "issue-42"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatalf("expected workflow to succeed, got failure (instID=%s)", instID)
+	}
+
+	// Verify step runs persisted in DB.
+	runs, err := client.ListStepRuns(ctx, instID)
+	if err != nil {
+		t.Fatalf("ListStepRuns: %v", err)
+	}
+
+	// Expect: classify, implement, review(fail), implement(retry), review(pass), qa
+	// Step IDs in DB depend on seqExecutor scripts: 6 step runs total.
+	if len(runs) < 4 {
+		t.Fatalf("expected at least 4 step runs (classify, implement, review×2, implement×retry, qa), got %d: %v", len(runs), stepIDs(runs))
+	}
+
+	// The last run should be qa.
+	last := runs[len(runs)-1]
+	if last.StepID != "qa" {
+		t.Errorf("expected last step to be qa, got %q", last.StepID)
+	}
+	if last.State != "passed" {
+		t.Errorf("expected qa step state=passed, got %q", last.State)
+	}
+
+	// classify and review must each appear at least once.
+	ran := map[string]int{}
+	for _, r := range runs {
+		ran[r.StepID]++
+	}
+	for _, want := range []string{"classify", "implement", "review", "qa"} {
+		if ran[want] == 0 {
+			t.Errorf("expected step %q to run at least once, got %v", want, ran)
+		}
+	}
+	// implement runs twice (original + retry after review rejection).
+	if ran["implement"] < 2 {
+		t.Errorf("expected implement to run at least 2 times (retry), got %d", ran["implement"])
+	}
+	// review runs twice (rejected + approved).
+	if ran["review"] < 2 {
+		t.Errorf("expected review to run at least 2 times (rejected + approved), got %d", ran["review"])
+	}
+}
+
+// TestE2E_V2ConditionSkipsTrack verifies that the v2 `if:` guard (lowered to
+// `condition`) correctly skips the complex track when the classifier picks
+// "simple". The simple track runs and complex track is skipped.
+func TestE2E_V2ConditionSkipsTrack(t *testing.T) {
+	ctx := context.Background()
+	client := realDB(t)
+
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"classify": {
+			Success:          true,
+			StructuredOutput: map[string]any{"track": "simple"},
+			Summary:          "track=simple",
+		},
+		"simple-impl":  {Success: true, Output: "simple done"},
+		"complex-impl": {Success: true, Output: "complex done"},
+	}}
+
+	cfg := &config.Config{
+		Agents:   []config.AgentConfig{{ID: "ag", Model: "m"}},
+		Settings: config.Settings{Concurrency: 1},
+	}
+	eng := NewEngine(cfg, client, exec)
+
+	// V2 workflow with two mutually exclusive conditional steps after classify.
+	// simple-impl runs (track=simple), complex-impl is skipped.
+	rawWF := config.WorkflowConfig{
+		ID: "track-wf",
+		Steps: []config.StepConfig{
+			{
+				ID:    "classify",
+				Agent: "ag",
+				Output: &config.OutputSchema{
+					Type:       "object",
+					Properties: map[string]config.SchemaField{"track": {Type: "string"}},
+				},
+				Memory: &config.MemoryConfig{Write: []string{"track"}},
+			},
+			{
+				ID:    "simple-impl",
+				Agent: "ag",
+				If:    `${{ memory.track == "simple" }}`,
+			},
+			{
+				ID:    "complex-impl",
+				Agent: "ag",
+				If:    `${{ memory.track == "complex" }}`,
+			},
+		},
+	}
+
+	lowered, err := config.LowerV2Workflow(rawWF)
+	if err != nil {
+		t.Fatalf("LowerV2Workflow: %v", err)
+	}
+
+	_, success, err := eng.RunInstance(ctx, lowered, model.Cell{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success (skipped steps don't fail the workflow)")
+	}
+
+	exec.mu.Lock()
+	ids := executedIDs(exec.seen)
+	exec.mu.Unlock()
+
+	ran := map[string]bool{}
+	for _, id := range ids {
+		ran[id] = true
+	}
+
+	if !ran["classify"] {
+		t.Error("expected classify to run")
+	}
+	if !ran["simple-impl"] {
+		t.Error("expected simple-impl to run (track=simple)")
+	}
+	if ran["complex-impl"] {
+		t.Error("expected complex-impl to be skipped (track=simple)")
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds e2e tests that exercise the full path: LowerV2Workflow → driveDAG → real SQLite
- `TestE2E_ClassifyImplementReviewQA`: classify → implement → review (reject→loop) → qa pipeline; review rejects the first time and accepts the second
- `TestE2E_V2ConditionSkipsTrack`: an `if:` guard skips the wrong track and runs the correct one
- Updates `.apiary/example-workflow.yaml` to v2 syntax with `output:`, `if:`, `reject_when:`, `on_reject:`, documenting `split` as a low-level primitive

## Test plan

- [x] `TestE2E_ClassifyImplementReviewQA` — loop-back works, qa runs after approval
- [x] `TestE2E_V2ConditionSkipsTrack` — the if: guard works correctly
- [x] All existing tests pass unchanged

Closes #46