### PR TITLE
docs(openspec): mark tasks done — workflow-sequential-authoring and workflow-mode

### DIFF
--- a/openspec/changes/workflow-mode/tasks.md
+++ b/openspec/changes/workflow-mode/tasks.md
@@ -147,11 +147,11 @@ classifier `assign_from_output`) were intentionally dropped.
 
 ### 3.7 Tests
 
-- [ ] 3.7.1 Integration test: 3-step sequential workflow completes, memory populated correctly
-- [ ] 3.7.2 Integration test: parallel steps run concurrently, fan-in step waits for both
-- [ ] 3.7.3 Integration test: split routes to correct branch based on memory field
-- [ ] 3.7.4 Integration test: `on_fail.goto` loops back, respects `max_retries`
-- [ ] 3.7.5 Run full test suite: `go test ./...`
+- [x] 3.7.1 Integration test: 3-step sequential workflow completes, memory populated correctly
+- [x] 3.7.2 Integration test: parallel steps run concurrently, fan-in step waits for both
+- [x] 3.7.3 Integration test: split routes to correct branch based on memory field
+- [x] 3.7.4 Integration test: `on_fail.goto` loops back, respects `max_retries`
+- [x] 3.7.5 Run full test suite: `go test ./...`
 
 ---
 

--- a/openspec/changes/workflow-sequential-authoring/tasks.md
+++ b/openspec/changes/workflow-sequential-authoring/tasks.md
@@ -1,63 +1,65 @@
 # Tasks — workflow-sequential-authoring
 
-> Design only. Nothing implemented yet; this is the proposed build order.
+> Implementation complete (PRs #46–#50).
 
 ## Engine (two small additions)
-- [ ] `fail_when` on the agent step: in `workflow/dag.go` `runAgentDAGStep`, derive
+- [x] `fail_when` on the agent step: in `workflow/dag.go` `runAgentDAGStep`, derive
       `failed` from `!res.Success || eval(fail_when over this step's output)`.
-- [ ] Step-level `condition` (per-step `if:`): mark a step skipped when false in
+- [x] Step-level `condition` (per-step `if:`): mark a step skipped when false in
       scheduling (`pickRunnable`/`markSkipped`).
-- [ ] Eval context helper exposing the current step's fresh structured output
+- [x] Eval context helper exposing the current step's fresh structured output
       (transient memory view) — reuse `EvalContext`/`ParseExpr` (`workflow/expr.go`).
-- [ ] Honor `on_missing_output: fail` together with `reject_when`.
+- [x] Honor `on_missing_output: fail` together with `reject_when`.
 
 ## Authoring layer (nested tree + lowering)
-- [ ] v2 parse: **nested step tree** — leaf (`agent:`), group (`steps:`), parallel
+- [x] v2 parse: **nested step tree** — leaf (`agent:`), group (`steps:`), parallel
       (`parallel:` + `join`), loop (`for_each:`+`as:`+`steps:`); per-step/group
       `if:`, `name:`, `output:`, `${{ … }}` expressions (`config` package).
-- [ ] Lowering pass tree → `[]StepConfig`: nesting/order→`depends_on`,
+- [x] Lowering pass tree → `[]StepConfig`: nesting/order→`depends_on`,
       group→sub-chain (or anon `type: workflow`), `parallel`+`join`→concurrent
       children + computed outcome, `for_each`→`type: foreach` (anon sub-workflow
       body if >1 step), `if`→`condition`, `on_reject`→`on_fail.goto`,
       `reject_when`→`fail_when`, auto-wire `steps.x.outputs.y` refs into `memory.write`.
 
 ## Validation
-- [ ] Parse-check `if`/`reject_when`/`join` expressions; `restart_from` must be an
+- [x] Parse-check `if`/`reject_when`/`join` expressions; `restart_from` must be an
       earlier sibling; `step.field` must be declared in that step's `output`.
-- [ ] Reject ambiguous mix of authored nesting and hand-written `goto` in one flow.
-- [ ] Warn on `reject_when` without `on_reject`.
+- [x] Reject ambiguous mix of authored nesting and hand-written `goto` in one flow.
+- [x] Warn on `reject_when` without `on_reject`.
 
 ## Examples, souls, docs
-- [ ] Rewrite project-erp `triage` in v2 (implement + complex tracks).
+- [ ] Rewrite project-erp `triage` in v2 (implement + complex tracks). _(follow-up)_
 - [ ] Souls: engineer (implement + open PR; read PR comments on retry), reviewer
-      (verdict + PR review comments), qa (verdict + findings), staff (doc + sub-issues).
-- [ ] Update `.apiary/example-workflow.yaml` to v2; document `split` as low-level.
+      (verdict + PR review comments), qa (verdict + findings), staff (doc + sub-issues). _(follow-up)_
+- [x] Update `.apiary/example-workflow.yaml` to v2; document `split` as low-level.
 
 ## Tests
-- [ ] Lowering tests: v2 tree → expected `[]StepConfig` (golden).
-- [ ] Engine tests for `fail_when` pass/reject/loop-back/retry-exhaustion.
-- [ ] End-to-end: classify→implement→review(reject→loop)→qa→done.
+- [x] Lowering tests: v2 tree → expected `[]StepConfig` (golden).
+- [x] Engine tests for `fail_when` pass/reject/loop-back/retry-exhaustion.
+- [x] End-to-end: classify→implement→review(reject→loop)→qa→done.
 
 ## Composition (nested sub-steps / loops / parallel)
-- [ ] Nested `steps:` group (inline sub-workflow) — sub-chain or anon `type: workflow`.
-- [ ] `for_each:`+`as:`+nested `steps:` body → `type: foreach`; multi-step body via
+- [x] Nested `steps:` group (inline sub-workflow) — sub-chain or anon `type: workflow`.
+- [x] `for_each:`+`as:`+nested `steps:` body → `type: foreach`; multi-step body via
       anon sub-workflow (or widen `foreach.step` to a list — decide at impl).
-- [ ] `parallel:` step with `join` policy (`all`/`any`/`${{ expr }}`); the parallel
+- [x] `parallel:` step with `join` policy (`all`/`any`/`${{ expr }}`); the parallel
       step's outcome = the join; successor depends on the parallel step.
 
 ## Concurrency (in scope — §8e)
-- [ ] Concurrent scheduler: `pickAllRunnable()`; single scheduler goroutine owns
+- [x] Concurrent scheduler: `pickAllRunnable()`; single scheduler goroutine owns
       `dagRun` state; worker goroutines run agents and return results on a channel;
       re-dispatch newly-unblocked steps until quiescent.
-- [ ] Global agent semaphore sized by `settings.concurrency` around every runner
+- [x] Global agent semaphore sized by `settings.concurrency` around every runner
       invocation (plus per-agent `max_workers` as secondary cap).
-- [ ] Deterministic memory ordering: `passedOrder` by declaration order, not
+- [x] Deterministic memory ordering: `passedOrder` by declaration order, not
       completion order.
-- [ ] Loop-back with in-flight siblings: drain then `resetLoop`; approval steps
+- [x] Loop-back with in-flight siblings: drain then `resetLoop`; approval steps
       quiesce before parking.
-- [ ] Honor `for_each.concurrency` via the same semaphore.
-- [ ] Verify `concurrency: 1` reproduces today's sequential behaviour (regression
+- [ ] Honor `for_each.concurrency` via the same semaphore. _(follow-up: foreach still sequential per item)_
+- [x] Verify `concurrency: 1` reproduces today's sequential behaviour (regression
       guard — all existing engine tests pass unchanged).
 
 ## Follow-up (separate change)
 - [ ] Decide fate of `settings.retry_policy` (inert today).
+- [ ] Implement `for_each.concurrency` cap via the global semaphore.
+- [ ] Conditional step skip should not block implicit successor steps (v2 seq edge case).


### PR DESCRIPTION
## Summary

- Marks all implemented tasks with `[x]` in `workflow-sequential-authoring/tasks.md` (PRs #46–#50: concurrent engine, v2 authoring, lowering, validation, tests).
- Updates `workflow-mode/tasks.md` with explicit follow-up items.
- No code changes — only state documentation.

## Test plan

- [ ] Verify the items marked `[x]` correspond to what was delivered in PRs #46–#50.