### PR TITLE
feat(dashboard): Workflows tab + live workflow monitor with emergency controls

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -663,6 +663,31 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
 	})
+	mux.HandleFunc("/workflows", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(d.WorkflowList())
+	})
+	mux.HandleFunc("/instances/stop/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		instanceID := strings.TrimPrefix(r.URL.Path, "/instances/stop/")
+		if instanceID == "" {
+			http.Error(w, "missing instance id", http.StatusBadRequest)
+			return
+		}
+		if err := d.StopInstance(ctx, instanceID); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"stopped": instanceID})
+	})
 	mux.HandleFunc("/clearlogs/", func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/clearlogs/")
 		if cellID == "" {

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -183,6 +183,9 @@ func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRe
 		aplog.Error("cell %s: create execution record: %v", req.Cell.ID, err)
 		return nil
 	}
+	if req.InstanceID != "" {
+		_ = x.d.db.SetStepLink(ctx, exec.ID, req.InstanceID, req.Step.ID)
+	}
 	return exec
 }
 

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 // InstanceSummary is one row in the `apiary instances` list.
@@ -20,11 +23,21 @@ type InstanceSummary struct {
 
 // StepRunView is one step row in an instance detail.
 type StepRunView struct {
-	StepID   string `json:"step_id"`
-	AgentID  string `json:"agent_id"`
-	State    string `json:"state"`
-	Duration string `json:"duration"`
-	Cached   bool   `json:"cached"`
+	StepID       string     `json:"step_id"`
+	AgentID      string     `json:"agent_id"`
+	State        string     `json:"state"`
+	Duration     string     `json:"duration"`
+	Cached       bool       `json:"cached"`
+	Output       string     `json:"output"`
+	Summary      string     `json:"summary"`
+	InputTokens  int        `json:"input_tokens"`
+	OutputTokens int        `json:"output_tokens"`
+	TotalTokens  int        `json:"total_tokens"`
+	CostUSD      float64    `json:"cost_usd"`
+	NumTurns     int        `json:"num_turns"`
+	NumToolCalls int        `json:"num_tool_calls"`
+	StartedAt    *time.Time `json:"started_at"`
+	FinishedAt   *time.Time `json:"finished_at"`
 }
 
 // InstanceDetail is the payload for `apiary instances <id>`.
@@ -36,6 +49,111 @@ type InstanceDetail struct {
 // InstancesResponse is the JSON payload returned by GET /instances.
 type InstancesResponse struct {
 	Instances []InstanceSummary `json:"instances"`
+}
+
+// WorkflowStepDef is one step in a workflow definition, for the Workflows tab.
+type WorkflowStepDef struct {
+	ID        string   `json:"id"`
+	Type      string   `json:"type"`
+	Agent     string   `json:"agent"`
+	DependsOn []string `json:"depends_on"`
+	Condition string   `json:"condition"`
+	Prompt    string   `json:"prompt"`
+}
+
+// WorkflowSummary is one workflow from the config, for the Workflows tab.
+type WorkflowSummary struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Steps       []WorkflowStepDef `json:"steps"`
+}
+
+// WorkflowListResponse is the payload for GET /workflows.
+type WorkflowListResponse struct {
+	Workflows []WorkflowSummary `json:"workflows"`
+}
+
+// WorkflowList returns all workflows defined in the config.
+func (d *Dispatcher) WorkflowList() WorkflowListResponse {
+	resp := WorkflowListResponse{}
+	for _, wf := range d.cfg.Workflows {
+		ws := WorkflowSummary{
+			ID:          wf.ID,
+			Description: wf.Description,
+		}
+		for _, step := range wf.Steps {
+			sd := WorkflowStepDef{
+				ID:        step.ID,
+				Type:      resolveStepType(step),
+				Agent:     step.Agent,
+				DependsOn: step.DependsOn,
+				Condition: step.Condition,
+				Prompt:    step.Prompt,
+			}
+			ws.Steps = append(ws.Steps, sd)
+		}
+		resp.Workflows = append(resp.Workflows, ws)
+	}
+	return resp
+}
+
+func resolveStepType(s config.StepConfig) string {
+	if s.Type != "" {
+		return s.Type
+	}
+	if len(s.Items) > 0 || s.ForEachExpr != "" {
+		return config.StepTypeForeach
+	}
+	if len(s.ParallelSteps) > 0 {
+		return config.StepTypeParallel
+	}
+	if s.ResumeOn != nil || s.AbortOn != nil {
+		return config.StepTypeApproval
+	}
+	return config.StepTypeAgent
+}
+
+// StopInstance cancels the running execution for a workflow instance without
+// re-dispatching. The instance is marked interrupted; unlike ForceRestart, it
+// does not strip labels or reset the source state.
+func (d *Dispatcher) StopInstance(ctx context.Context, instanceID string) error {
+	if d.db == nil {
+		return nil
+	}
+	inst, err := d.db.GetWorkflowInstance(ctx, instanceID)
+	if err != nil || inst == nil {
+		return err
+	}
+	// Cancel the in-flight run for this cell.
+	if val, ok := d.runCancel.LoadAndDelete(inst.CellID); ok {
+		cancel := val.(context.CancelFunc)
+		cancel()
+	}
+	// Remove from in-flight and active tracking so the slot is freed.
+	d.inFlight.Delete(inst.CellID)
+	d.activeRuns.Range(func(key, val any) bool {
+		run := val.(model.ActiveRun)
+		if run.Cell.ID == inst.CellID {
+			d.activeRuns.Delete(key)
+		}
+		return true
+	})
+
+	// Mark the running task_execution interrupted.
+	if lastExec, err := d.db.GetLastExecution(ctx, inst.CellID); err == nil && lastExec != nil && lastExec.Status == "running" {
+		now := time.Now()
+		lastExec.Status = "interrupted"
+		lastExec.CompletedAt = &now
+		lastExec.ErrorMsg = "stopped by user"
+		_ = d.db.UpdateExecution(ctx, lastExec)
+	}
+
+	// Mark the instance itself interrupted.
+	if err := d.db.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateInterrupted); err != nil {
+		aplog.Error("stop instance %s: update state: %v", instanceID, err)
+	}
+	aplog.Info("stopped instance %s (cell %s)", instanceID, inst.CellID)
+	return nil
 }
 
 // Instances returns workflow instances for the IPC list endpoint, optionally
@@ -76,13 +194,27 @@ func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDe
 		return nil, err
 	}
 	for _, s := range steps {
-		detail.Steps = append(detail.Steps, StepRunView{
-			StepID:   s.StepID,
-			AgentID:  s.AgentID,
-			State:    s.State,
-			Duration: stepDuration(s, now),
-			Cached:   s.SkippedCached,
-		})
+		srv := StepRunView{
+			StepID:     s.StepID,
+			AgentID:    s.AgentID,
+			State:      s.State,
+			Duration:   stepDuration(s, now),
+			Cached:     s.SkippedCached,
+			Output:     s.Output,
+			Summary:    s.Summary,
+			StartedAt:  s.StartedAt,
+			FinishedAt: s.FinishedAt,
+		}
+		// Enrich with token/cost data via the step link columns.
+		if usage, err := d.db.GetStepUsage(ctx, id, s.StepID); err == nil && usage != nil {
+			srv.InputTokens = usage.InputTokens
+			srv.OutputTokens = usage.OutputTokens
+			srv.TotalTokens = usage.TotalTokens
+			srv.CostUSD = usage.CostUSD
+			srv.NumTurns = usage.NumTurns
+			srv.NumToolCalls = usage.NumToolCalls
+		}
+		detail.Steps = append(detail.Steps, srv)
 	}
 	return detail, nil
 }

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -82,6 +82,15 @@ type agentTaskLogsMsg struct {
 }
 type logsDataMsg struct{ logs []LogEntry }
 type usageDataMsg struct{ data UsageTab }
+type workflowsConfigMsg struct{ workflows []WorkflowConfigItem }
+type workflowMonitorMsg struct {
+	taskID   string
+	instance *WorkflowInstanceItem
+}
+type workflowStepLogsMsg struct {
+	stepID string
+	logs   []LogEntry
+}
 
 // ── lifecycle ───────────────────────────────────────────────────────────────
 
@@ -196,6 +205,39 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.model.loading = false
 		a.model.lastRefresh = time.Now()
+
+	case workflowsConfigMsg:
+		if a.model.workflowsTab != nil {
+			a.model.workflowsTab.Workflows = msg.workflows
+		}
+		a.model.loading = false
+		a.model.lastRefresh = time.Now()
+
+	case workflowMonitorMsg:
+		if a.model.tasksTab != nil {
+			a.model.tasksTab.WorkflowInstance = msg.instance
+			a.model.tasksTab.WorkflowStepIdx = 0
+			a.model.tasksTab.WorkflowLogs = nil
+			a.model.tasksTab.WorkflowLogScroll = 0
+			a.model.tasksTab.WorkflowShowLogs = false
+			a.model.tasksTab.View = TaskViewWorkflow
+		}
+		a.model.loading = false
+
+	case workflowStepLogsMsg:
+		if a.model.tasksTab != nil {
+			a.model.tasksTab.WorkflowLogs = msg.logs
+			a.model.tasksTab.WorkflowLogScroll = 0
+			a.model.tasksTab.WorkflowShowLogs = true
+		}
+		a.model.loading = false
+
+	case workflowMonitorRefreshMsg:
+		if a.model.tasksTab != nil && msg.instance != nil {
+			// Update step states without resetting the cursor position.
+			a.model.tasksTab.WorkflowInstance = msg.instance
+		}
+		a.model.loading = false
 	}
 
 	return a, nil
@@ -230,6 +272,8 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return a, a.restartTaskCmd(id)
 			case "clear":
 				return a, a.clearLogsCmd(id)
+			case "stop":
+				return a, a.stopInstanceCmd(id)
 			}
 		default:
 			a.model.confirmAction = ""
@@ -258,9 +302,17 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
-	// While a Tasks sub-view (detail/logs) is open, keys are scoped to it.
+	// While a Tasks sub-view (detail/logs/workflow) is open, keys are scoped to it.
 	if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View != TaskViewList {
 		return a.handleTaskSubViewKey(key)
+	}
+
+	// Workflow config tab: scope navigation keys when the step panel is focused.
+	if a.model.ActiveTab() == "Workflows" && a.model.workflowsTab != nil {
+		switch key {
+		case "up", "down", "k", "j", "enter", "right", "l", "esc", "left", "h", "backspace":
+			return a.handleWorkflowsKey(key)
+		}
 	}
 	// While an Agents sub-view (detail/activity) is open, keys are scoped to it.
 	if a.model.ActiveTab() == "Agents" && a.model.agentsTab != nil && a.model.agentsTab.View != AgentViewList {
@@ -470,7 +522,9 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "Tasks":
 			if id, ok := a.selectedTaskID(); ok {
 				a.model.loading = true
-				return a, a.fetchTaskLogs(id)
+				// Open the workflow monitor if this task has a workflow instance,
+				// otherwise fall back to the task logs view.
+				return a, a.openWorkflowMonitorOrLogs(id)
 			}
 		case "Agents":
 			if id, ok := a.selectedAgentID(); ok {
@@ -703,9 +757,15 @@ func (a *App) selectedActivityTaskID() (string, bool) {
 	return ag.Activity[ag.ActivityIdx].TaskID, true
 }
 
-// handleTaskSubViewKey handles keys while a task detail/logs sub-view is open.
+// handleTaskSubViewKey handles keys while a task detail/logs/workflow sub-view is open.
 func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 	t := a.model.tasksTab
+
+	// Workflow monitor has its own key map.
+	if t.View == TaskViewWorkflow {
+		return a.handleWorkflowMonitorKey(key)
+	}
+
 	switch key {
 	case "esc", "backspace", "h", "left":
 		// Back to the list.
@@ -755,6 +815,149 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		if t.View == TaskViewLogs {
 			t.LogScroll = clampScroll(t.LogScroll+a.pageSize(), len(a.taskLogLines()))
 		}
+	}
+	return a, nil
+}
+
+// handleWorkflowMonitorKey handles keys inside the live workflow monitor.
+func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
+	t := a.model.tasksTab
+	inst := t.WorkflowInstance
+	if inst == nil {
+		t.View = TaskViewList
+		return a, nil
+	}
+
+	switch key {
+	case "esc", "backspace", "h", "left":
+		if t.WorkflowShowLogs {
+			t.WorkflowShowLogs = false
+			t.WorkflowLogs = nil
+		} else {
+			t.View = TaskViewList
+			t.WorkflowInstance = nil
+			t.WorkflowStepIdx = 0
+			t.WorkflowLogs = nil
+		}
+
+	case "up", "k":
+		if t.WorkflowShowLogs {
+			if t.WorkflowLogScroll > 0 {
+				t.WorkflowLogScroll--
+			}
+		} else if t.WorkflowStepIdx > 0 {
+			t.WorkflowStepIdx--
+			t.WorkflowLogs = nil
+			t.WorkflowShowLogs = false
+		}
+
+	case "down", "j":
+		if t.WorkflowShowLogs {
+			lines := a.wfStepLogLines()
+			if t.WorkflowLogScroll < len(lines)-1 {
+				t.WorkflowLogScroll++
+			}
+		} else if t.WorkflowStepIdx < len(inst.Steps)-1 {
+			t.WorkflowStepIdx++
+			t.WorkflowLogs = nil
+			t.WorkflowShowLogs = false
+		}
+
+	case "g", "home":
+		if t.WorkflowShowLogs {
+			t.WorkflowLogScroll = 0
+		} else {
+			t.WorkflowStepIdx = 0
+		}
+
+	case "G", "end":
+		if t.WorkflowShowLogs {
+			t.WorkflowLogScroll = lastIndex(len(a.wfStepLogLines()))
+		} else {
+			t.WorkflowStepIdx = lastIndex(len(inst.Steps))
+		}
+
+	case "pgup", "ctrl+u":
+		if t.WorkflowShowLogs {
+			t.WorkflowLogScroll = clampScroll(t.WorkflowLogScroll-a.pageSize(), len(a.wfStepLogLines()))
+		} else {
+			t.WorkflowStepIdx = clampScroll(t.WorkflowStepIdx-a.pageSize(), len(inst.Steps))
+		}
+
+	case "pgdown", "ctrl+d", " ":
+		if t.WorkflowShowLogs {
+			t.WorkflowLogScroll = clampScroll(t.WorkflowLogScroll+a.pageSize(), len(a.wfStepLogLines()))
+		} else {
+			t.WorkflowStepIdx = clampScroll(t.WorkflowStepIdx+a.pageSize(), len(inst.Steps))
+		}
+
+	case "l", "enter":
+		// Open logs for the selected step.
+		if !t.WorkflowShowLogs && t.WorkflowStepIdx < len(inst.Steps) {
+			step := inst.Steps[t.WorkflowStepIdx]
+			a.model.loading = true
+			return a, a.fetchWorkflowStepLogs(inst.CellID, step.StepID, step.StartedAt, step.FinishedAt)
+		}
+
+	case "r":
+		// Refresh the monitor.
+		if inst != nil {
+			a.model.loading = true
+			return a, a.refreshWorkflowMonitor(inst.ID, inst.CellID)
+		}
+
+	case "X":
+		// Stop the workflow instance (no restart).
+		a.model.confirmAction = "stop"
+		a.model.confirmTaskID = inst.ID
+
+	case "R":
+		// Restart the whole workflow (force-restart the cell).
+		a.model.confirmAction = "restart"
+		a.model.confirmTaskID = inst.CellID
+	}
+	return a, nil
+}
+
+// handleWorkflowsKey handles keys in the static Workflows config tab.
+func (a *App) handleWorkflowsKey(key string) (tea.Model, tea.Cmd) {
+	wt := a.model.workflowsTab
+	if wt == nil {
+		return a, nil
+	}
+	switch key {
+	case "up", "k":
+		if wt.Focus == WorkflowsViewList {
+			if wt.SelectedIdx > 0 {
+				wt.SelectedIdx--
+				wt.StepIdx = 0
+				wt.StepScroll = 0
+			}
+		} else {
+			if wt.StepIdx > 0 {
+				wt.StepIdx--
+			}
+		}
+	case "down", "j":
+		if wt.Focus == WorkflowsViewList {
+			if wt.SelectedIdx < len(wt.Workflows)-1 {
+				wt.SelectedIdx++
+				wt.StepIdx = 0
+				wt.StepScroll = 0
+			}
+		} else {
+			if wt.SelectedIdx < len(wt.Workflows) {
+				steps := wt.Workflows[wt.SelectedIdx].Steps
+				if wt.StepIdx < len(steps)-1 {
+					wt.StepIdx++
+				}
+			}
+		}
+	case "enter", "right", "l":
+		wt.Focus = WorkflowsViewSteps
+		wt.StepIdx = 0
+	case "esc", "left", "h", "backspace":
+		wt.Focus = WorkflowsViewList
 	}
 	return a, nil
 }
@@ -896,6 +1099,199 @@ func (a *App) clearLogsCmd(taskID string) tea.Cmd {
 	}
 }
 
+// stopInstanceCmd sends a POST /instances/stop/{id} request to stop a workflow
+// instance without re-dispatching it.
+func (a *App) stopInstanceCmd(instanceID string) tea.Cmd {
+	return func() tea.Msg {
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", a.socketPath)
+			},
+		}
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		url := fmt.Sprintf("http://apiary/instances/stop/%s", instanceID)
+		resp, err := client.Post(url, "application/json", nil)
+		if err != nil {
+			return nil
+		}
+		resp.Body.Close()
+		return nil
+	}
+}
+
+// openWorkflowMonitorOrLogs opens the workflow monitor if the task has a
+// workflow instance, or the logs view otherwise.
+func (a *App) openWorkflowMonitorOrLogs(taskID string) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		if dbConn != nil {
+			inst, err := dbConn.GetLatestInstanceByCell(ctx, taskID)
+			if err == nil && inst != nil {
+				item := &WorkflowInstanceItem{
+					ID:       inst.ID,
+					Workflow: inst.WorkflowID,
+					State:    inst.State,
+					CellID:   inst.CellID,
+				}
+				if inst.State == "approval_waiting" {
+					item.Message = "Awaiting human approval — reply on the task to resume or abort."
+				}
+				steps, err := dbConn.ListStepRuns(ctx, inst.ID)
+				if err == nil {
+					now := time.Now()
+					for _, s := range steps {
+						si := WorkflowStepItem{
+							StepID:     s.StepID,
+							Agent:      s.AgentID,
+							State:      s.State,
+							Duration:   wfStepDuration(s, now),
+							Cached:     s.SkippedCached,
+							Output:     s.Output,
+							Summary:    s.Summary,
+							StartedAt:  s.StartedAt,
+							FinishedAt: s.FinishedAt,
+						}
+						if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
+							si.InputTokens = usage.InputTokens
+							si.OutputTokens = usage.OutputTokens
+							si.TotalTokens = usage.TotalTokens
+							si.CostUSD = usage.CostUSD
+							si.NumTurns = usage.NumTurns
+							si.NumToolCalls = usage.NumToolCalls
+						}
+						item.Steps = append(item.Steps, si)
+					}
+				}
+				return workflowMonitorMsg{taskID: taskID, instance: item}
+			}
+		}
+		// No workflow instance — fall back to logs view.
+		return taskLogsMsg{taskID: taskID, logs: nil, detail: nil}
+	}
+}
+
+// refreshWorkflowMonitor re-fetches a workflow instance and its steps for the
+// live monitor, updating states in-place (without resetting the step cursor).
+func (a *App) refreshWorkflowMonitor(instanceID, cellID string) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		if dbConn == nil {
+			return nil
+		}
+		inst, err := dbConn.GetWorkflowInstance(ctx, instanceID)
+		if err != nil || inst == nil {
+			return nil
+		}
+		item := &WorkflowInstanceItem{
+			ID:       inst.ID,
+			Workflow: inst.WorkflowID,
+			State:    inst.State,
+			CellID:   inst.CellID,
+		}
+		if inst.State == "approval_waiting" {
+			item.Message = "Awaiting human approval — reply on the task to resume or abort."
+		}
+		steps, err := dbConn.ListStepRuns(ctx, instanceID)
+		if err == nil {
+			now := time.Now()
+			for _, s := range steps {
+				si := WorkflowStepItem{
+					StepID:     s.StepID,
+					Agent:      s.AgentID,
+					State:      s.State,
+					Duration:   wfStepDuration(s, now),
+					Cached:     s.SkippedCached,
+					Output:     s.Output,
+					Summary:    s.Summary,
+					StartedAt:  s.StartedAt,
+					FinishedAt: s.FinishedAt,
+				}
+				if usage, err := dbConn.GetStepUsage(ctx, instanceID, s.StepID); err == nil && usage != nil {
+					si.InputTokens = usage.InputTokens
+					si.OutputTokens = usage.OutputTokens
+					si.TotalTokens = usage.TotalTokens
+					si.CostUSD = usage.CostUSD
+					si.NumTurns = usage.NumTurns
+					si.NumToolCalls = usage.NumToolCalls
+				}
+				item.Steps = append(item.Steps, si)
+			}
+		}
+		// Preserve the step cursor — return a monitor refresh, not a full reset.
+		return workflowMonitorRefreshMsg{instance: item}
+	}
+}
+
+// workflowMonitorRefreshMsg carries a live-refresh of the instance (no cursor reset).
+type workflowMonitorRefreshMsg struct{ instance *WorkflowInstanceItem }
+
+// fetchWorkflowStepLogs fetches task logs scoped to a specific step's time window.
+func (a *App) fetchWorkflowStepLogs(cellID, stepID string, from, to *time.Time) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		var logs []LogEntry
+		if dbConn != nil {
+			if rows, err := dbConn.GetTaskLogsInRange(ctx, cellID, from, to); err == nil {
+				for _, l := range rows {
+					logs = append(logs, LogEntry{
+						Timestamp: l.Timestamp,
+						Level:     l.Level,
+						Message:   l.Message,
+					})
+				}
+			}
+		}
+		return workflowStepLogsMsg{stepID: stepID, logs: logs}
+	}
+}
+
+// fetchWorkflowsConfig fetches workflow definitions from the local config (no IPC needed).
+func (a *App) fetchWorkflowsConfig() tea.Cmd {
+	cfg := a.cfg
+	return func() tea.Msg {
+		var items []WorkflowConfigItem
+		if cfg != nil {
+			for _, wf := range cfg.Workflows {
+				item := WorkflowConfigItem{
+					ID:          wf.ID,
+					Description: wf.Description,
+				}
+				for _, step := range wf.Steps {
+					stype := step.Type
+					if stype == "" {
+						stype = "agent"
+					}
+					item.Steps = append(item.Steps, WorkflowStepDef{
+						ID:        step.ID,
+						Type:      stype,
+						Agent:     step.Agent,
+						DependsOn: step.DependsOn,
+						Condition: step.Condition,
+						Prompt:    step.Prompt,
+					})
+				}
+				items = append(items, item)
+			}
+		}
+		return workflowsConfigMsg{workflows: items}
+	}
+}
+
+// wfStepLogLines returns the log lines for the currently-selected workflow step.
+func (a *App) wfStepLogLines() []string {
+	t := a.model.tasksTab
+	if t == nil {
+		return nil
+	}
+	return a.logEntryLines(t.WorkflowLogs)
+}
+
 // updateAgentConfigCmd sends a PATCH /api/config/agent/{id} request to the
 // daemon via the IPC socket to hot-reload model, runner, or max_workers.
 // Falls back to direct file modification if the socket is unreachable.
@@ -1002,6 +1398,10 @@ func (a *App) fetchActiveTab() tea.Cmd {
 	case "Overview":
 		return a.fetchOverview()
 	case "Tasks":
+		// When the workflow monitor is open, refresh the instance on each tick.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewWorkflow && t.WorkflowInstance != nil {
+			return a.refreshWorkflowMonitor(t.WorkflowInstance.ID, t.WorkflowInstance.CellID)
+		}
 		return a.fetchTasks()
 	case "Agents":
 		return a.fetchAgents()
@@ -1009,6 +1409,8 @@ func (a *App) fetchActiveTab() tea.Cmd {
 		return a.fetchUsage()
 	case "Logs":
 		return a.fetchLogs()
+	case "Workflows":
+		return a.fetchWorkflowsConfig()
 	}
 	return nil
 }
@@ -1452,6 +1854,8 @@ func (a *App) View() string {
 		content = a.renderUsageTab(contentHeight)
 	case "Logs":
 		content = a.renderLogsTab(contentHeight)
+	case "Workflows":
+		content = a.renderWorkflowsTab(contentHeight)
 	default:
 		content = a.box("UNKNOWN", "Unknown tab\n", contentHeight)
 	}
@@ -1466,9 +1870,13 @@ func (a *App) View() string {
 func (a *App) renderConfirmModal(view string) string {
 	label := "Restart task"
 	msg := "Are you sure you want to restart this task?"
-	if a.model.confirmAction == "clear" {
+	switch a.model.confirmAction {
+	case "clear":
 		label = "Clear logs"
 		msg = "Are you sure you want to clear all logs for this task?"
+	case "stop":
+		label = "Stop workflow"
+		msg = "Stop this workflow instance? It will be marked interrupted."
 	}
 
 	dialog := lipgloss.NewStyle().
@@ -1713,6 +2121,8 @@ func (a *App) renderTasksTab(height int) string {
 		return a.renderTaskDetail(t, height)
 	case TaskViewLogs:
 		return a.renderTaskLogs(t, height)
+	case TaskViewWorkflow:
+		return a.renderWorkflowMonitor(t, height)
 	default:
 		return a.renderTaskList(t, height)
 	}
@@ -2560,9 +2970,19 @@ func (a *App) footerKeys() []fkey {
 				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
 				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"C", "clear"}, {"q", "quit"}}
+			case TaskViewWorkflow:
+				if t.WorkflowShowLogs {
+					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
+				}
+				return []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}, {"r", "refresh"}, {"X", "stop"}, {"R", "restart"}, {"esc", "back"}, {"q", "quit"}}
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter/l", "logs"}, {"d", "details"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+	case "Workflows":
+		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
+			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}
+		}
+		return []fkey{{"↑/↓", "workflow"}, {"enter/→", "steps"}, {"tab", "next tab"}, {"q", "quit"}}
 	case "Agents":
 		if ag := a.model.agentsTab; ag != nil {
 			switch ag.View {
@@ -2707,6 +3127,280 @@ func truncate(s string, max int) string {
 		return "…"
 	}
 	return string([]rune(s)[:max-1]) + "…"
+}
+
+// renderWorkflowMonitor renders the live workflow instance monitor.
+// Layout: left panel (step list) | right panel (step detail or logs).
+func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
+	inst := t.WorkflowInstance
+	if inst == nil {
+		return a.box("WORKFLOW MONITOR", StyleMuted.Render("No workflow instance")+"\n", height)
+	}
+
+	totalW := a.model.width - 2
+	leftW := totalW * 2 / 5
+	rightW := totalW - leftW - 1
+	if leftW < 20 {
+		leftW = 20
+	}
+
+	label := "WORKFLOW  " + StyleValueStrong.Render(inst.Workflow) + "  " + wfInstanceBadge(inst.State)
+
+	// ── left panel: step list ───────────────────────────────────────────────
+	var left strings.Builder
+	if inst.Message != "" {
+		left.WriteString(StyleWarning.Render("  ⏸ "+inst.Message) + "\n")
+	}
+	bodyRows := height - 4
+	if bodyRows < 1 {
+		bodyRows = 1
+	}
+
+	// Header row
+	hdr := pad("", 2) + pad("STEP", 18) + " " + pad("AGENT", 14) + " " + pad("STATE", 10) + " " + "DUR"
+	left.WriteString(StyleTableHeader.Render(fitLine(hdr, leftW)) + "\n")
+	bodyRows--
+
+	// Windowed step list
+	start := t.WorkflowStepIdx - bodyRows/2
+	if start > len(inst.Steps)-bodyRows {
+		start = len(inst.Steps) - bodyRows
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := start + bodyRows
+	if end > len(inst.Steps) {
+		end = len(inst.Steps)
+	}
+
+	for i := start; i < end; i++ {
+		s := inst.Steps[i]
+		selected := i == t.WorkflowStepIdx
+		glyph := wfStepGlyph(s.State)
+		stepName := truncate(s.StepID, 17)
+		agent := truncate(valueOr(s.Agent, "—"), 13)
+		state := truncate(s.State, 10)
+		dur := truncate(s.Duration, 8)
+
+		row := glyph + " " + pad(stepName, 17) + " " + pad(agent, 13) + "   " + pad(state, 10) + " " + StyleMuted.Render(dur)
+		if selected {
+			row = StyleSelectedRow.Render(fitLine("  "+stepName+" "+agent+"   "+state+" "+dur, leftW))
+			row = StyleFocusedArrow.Render("▶") + " " + StyleSelectedRow.Render(fitLine(stepName+" "+agent+"   "+state+" "+dur, leftW-2))
+		}
+		left.WriteString(fitLine(row, leftW) + "\n")
+	}
+
+	// ── right panel: step detail or logs ───────────────────────────────────
+	var right strings.Builder
+	if t.WorkflowShowLogs {
+		// Log panel.
+		right.WriteString(StyleTableHeader.Render(fitLine("STEP LOGS", rightW)) + "\n")
+		lines := a.wfStepLogLines()
+		logRows := height - 4
+		ls := t.WorkflowLogScroll
+		if ls > len(lines)-1 {
+			ls = len(lines) - 1
+		}
+		if ls < 0 {
+			ls = 0
+		}
+		le := ls + logRows
+		if le > len(lines) {
+			le = len(lines)
+		}
+		for i := ls; i < le; i++ {
+			right.WriteString(fitLine(lines[i], rightW) + "\n")
+		}
+		if len(lines) == 0 {
+			right.WriteString(StyleMuted.Render("No logs for this step.") + "\n")
+		}
+	} else if t.WorkflowStepIdx < len(inst.Steps) {
+		// Detail panel for selected step.
+		s := inst.Steps[t.WorkflowStepIdx]
+		row2 := func(k, v string) {
+			right.WriteString("  " + StyleLabel.Render(pad(k+":", 12)) + " " + v + "\n")
+		}
+		right.WriteString(StyleTableHeader.Render(fitLine(" "+s.StepID, rightW)) + "\n")
+		row2("State", wfStepGlyph(s.State)+" "+wfStateStyle(s.State).Render(s.State))
+		row2("Agent", valueOr(s.Agent, "—"))
+		row2("Duration", valueOr(s.Duration, "—"))
+		if s.Cached {
+			row2("Cache", StyleMuted.Render("skipped (cached)"))
+		}
+		right.WriteString("\n")
+
+		if s.TotalTokens > 0 {
+			row2("Tokens", fmt.Sprintf("%d in / %d out / %d total", s.InputTokens, s.OutputTokens, s.TotalTokens))
+			row2("Cost", fmt.Sprintf("$%.5f", s.CostUSD))
+			row2("Turns", fmt.Sprintf("%d turns / %d calls", s.NumTurns, s.NumToolCalls))
+			right.WriteString("\n")
+		}
+
+		if s.Summary != "" {
+			right.WriteString("  " + StyleLabel.Render("Summary:") + "\n")
+			for _, line := range wrapPlain(s.Summary, rightW-4) {
+				right.WriteString("    " + StyleMuted.Render(line) + "\n")
+			}
+			right.WriteString("\n")
+		}
+
+		if s.Output != "" {
+			right.WriteString("  " + StyleLabel.Render("Output:") + "\n")
+			outputLines := wrapPlain(s.Output, rightW-4)
+			maxOut := height - lipgloss.Height(right.String()) - 2
+			if maxOut < 1 {
+				maxOut = 1
+			}
+			for i, line := range outputLines {
+				if i >= maxOut {
+					right.WriteString("    " + StyleMuted.Render("…") + "\n")
+					break
+				}
+				right.WriteString("    " + line + "\n")
+			}
+		}
+
+		if s.State == db.StepStateRunning || s.State == db.StepStatePassed || s.State == db.StepStateFailed {
+			right.WriteString("\n  " + StyleMuted.Render("enter/l: logs  X: stop workflow  R: restart workflow") + "\n")
+		}
+	} else {
+		right.WriteString(StyleMuted.Render("  Select a step") + "\n")
+	}
+
+	// Render side-by-side within a single box by stitching lines.
+	leftLines := strings.Split(strings.TrimRight(left.String(), "\n"), "\n")
+	rightLines := strings.Split(strings.TrimRight(right.String(), "\n"), "\n")
+	maxLines := len(leftLines)
+	if len(rightLines) > maxLines {
+		maxLines = len(rightLines)
+	}
+
+	sep := StyleBorder.Render("│")
+	var body strings.Builder
+	for i := 0; i < maxLines; i++ {
+		l := ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		r := ""
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		body.WriteString(fitLine(l, leftW) + sep + fitLine(r, rightW) + "\n")
+	}
+	return a.box(label, body.String(), height)
+}
+
+// renderWorkflowsTab renders the static workflow config navigation tab.
+// Layout: left list of workflows | right step tree for selected workflow.
+func (a *App) renderWorkflowsTab(height int) string {
+	wt := a.model.workflowsTab
+	if wt == nil || len(wt.Workflows) == 0 {
+		return a.box("WORKFLOWS", StyleMuted.Render("No workflows defined in config.")+"\n", height)
+	}
+
+	totalW := a.model.width - 2
+	leftW := 28
+	rightW := totalW - leftW - 1
+
+	// ── left panel: workflow list ───────────────────────────────────────────
+	var left strings.Builder
+	left.WriteString(StyleTableHeader.Render(fitLine("WORKFLOW", leftW)) + "\n")
+
+	for i, wf := range wt.Workflows {
+		selected := i == wt.SelectedIdx
+		label := truncate(wf.ID, leftW-4)
+		steps := fmt.Sprintf("[%d steps]", len(wf.Steps))
+		if selected && wt.Focus == WorkflowsViewList {
+			row := StyleSelectedRow.Render(fitLine(" ▶ "+label, leftW))
+			left.WriteString(row + "\n")
+		} else if selected {
+			row := StyleAccent.Render(fitLine(" ● "+label, leftW-len(steps)-1)) + StyleMuted.Render(steps)
+			left.WriteString(fitLine(row, leftW) + "\n")
+		} else {
+			left.WriteString(fitLine("   "+label, leftW) + "\n")
+		}
+	}
+
+	// ── right panel: step definitions ──────────────────────────────────────
+	var right strings.Builder
+	if wt.SelectedIdx < len(wt.Workflows) {
+		wf := wt.Workflows[wt.SelectedIdx]
+		desc := valueOr(wf.Description, StyleMuted.Render("(no description)"))
+		right.WriteString(StyleValueStrong.Render(wf.ID) + "  " + StyleMuted.Render(desc) + "\n")
+		right.WriteString(StyleMuted.Render(strings.Repeat("─", rightW)) + "\n")
+
+		if len(wf.Steps) == 0 {
+			right.WriteString(StyleMuted.Render("  No steps defined.") + "\n")
+		}
+		for i, step := range wf.Steps {
+			selected := i == wt.StepIdx && wt.Focus == WorkflowsViewSteps
+			typeLabel := styleStepType(step.Type)
+			stepLine := typeLabel + " " + StyleValueStrong.Render(step.ID)
+			if step.Agent != "" {
+				stepLine += "  " + StyleAccent.Render("→ "+step.Agent)
+			}
+			if selected {
+				right.WriteString(StyleSelectedRow.Render(fitLine("  "+ansi.Strip(stepLine), rightW)) + "\n")
+				// Expand detail for selected step.
+				if len(step.DependsOn) > 0 {
+					right.WriteString("    " + StyleMuted.Render("depends: "+strings.Join(step.DependsOn, ", ")) + "\n")
+				}
+				if step.Condition != "" {
+					right.WriteString("    " + StyleMuted.Render("if: "+truncate(step.Condition, rightW-10)) + "\n")
+				}
+				if step.Prompt != "" {
+					right.WriteString("    " + StyleMuted.Render("prompt: "+truncate(step.Prompt, rightW-12)) + "\n")
+				}
+			} else {
+				right.WriteString(fitLine("  "+stepLine, rightW) + "\n")
+				if len(step.DependsOn) > 0 {
+					right.WriteString("    " + StyleMuted.Render("↳ needs: "+strings.Join(step.DependsOn, ", ")) + "\n")
+				}
+			}
+		}
+	}
+
+	// Stitch side-by-side.
+	leftLines := strings.Split(strings.TrimRight(left.String(), "\n"), "\n")
+	rightLines := strings.Split(strings.TrimRight(right.String(), "\n"), "\n")
+	maxLines := len(leftLines)
+	if len(rightLines) > maxLines {
+		maxLines = len(rightLines)
+	}
+
+	sep := StyleBorder.Render("│")
+	var body strings.Builder
+	for i := 0; i < maxLines; i++ {
+		l := ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		r := ""
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		body.WriteString(fitLine(l, leftW) + sep + fitLine(r, rightW) + "\n")
+	}
+	return a.box("WORKFLOWS", body.String(), height)
+}
+
+func styleStepType(t string) string {
+	switch t {
+	case "agent", "":
+		return StyleInfo.Render("[agent]    ")
+	case "approval":
+		return StyleWarning.Render("[approval] ")
+	case "foreach":
+		return StyleAccent.Render("[foreach]  ")
+	case "parallel":
+		return StyleAccent.Render("[parallel] ")
+	case "split":
+		return StyleMuted.Render("[split]    ")
+	default:
+		return StyleMuted.Render("[" + pad(t, 9) + "]")
+	}
 }
 
 // Run starts the dashboard.

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -15,13 +15,14 @@ type Model struct {
 	agentsTab      *AgentsTab
 	usageTab       *UsageTab
 	logsTab        *LogsTab
+	workflowsTab   *WorkflowsTab
 	width          int
 	height         int
 	lastRefresh    time.Time
 	lastTabRefresh map[int]time.Time // Track refresh per tab
 	loading        bool              // Show loading state
 
-	confirmAction string // "restart" or "clear" when awaiting confirmation
+	confirmAction string // "restart" or "clear" or "stop" when awaiting confirmation
 	confirmTaskID string
 }
 
@@ -55,9 +56,10 @@ type OverviewTab struct {
 type TaskView int
 
 const (
-	TaskViewList TaskView = iota
+	TaskViewList     TaskView = iota
 	TaskViewDetail
 	TaskViewLogs
+	TaskViewWorkflow // live workflow instance monitor
 )
 
 // TasksTab shows task history with detail and log sub-views.
@@ -71,6 +73,13 @@ type TasksTab struct {
 	Logs           []LogEntry            // populated when View == TaskViewLogs
 	LogScroll      int
 
+	// Workflow monitor sub-view (View == TaskViewWorkflow).
+	WorkflowInstance *WorkflowInstanceItem // instance being monitored
+	WorkflowStepIdx  int                   // selected step index in monitor
+	WorkflowLogs     []LogEntry            // logs for the selected step
+	WorkflowLogScroll int
+	WorkflowShowLogs bool // true when the log panel is expanded
+
 	// Scroll / filter / sort
 	ScrollOffset int    // first visible row index
 	FilterText   string // current filter query
@@ -80,22 +89,33 @@ type TasksTab struct {
 }
 
 // WorkflowInstanceItem is a workflow instance bound to a task, with its steps,
-// shown in the Task Detail view.
+// shown in the Task Detail and workflow monitor views.
 type WorkflowInstanceItem struct {
 	ID       string
 	Workflow string
 	State    string // pending, running, approval_waiting, interrupted, done, failed
 	Message  string // approval message when State == approval_waiting
+	CellID   string // the task/cell this instance is bound to
 	Steps    []WorkflowStepItem
 }
 
 // WorkflowStepItem is one step row within a WorkflowInstanceItem.
 type WorkflowStepItem struct {
-	StepID   string
-	Agent    string
-	State    string // pending, running, passed, failed, skipped, skipped_cached
-	Duration string
-	Cached   bool
+	StepID       string
+	Agent        string
+	State        string // pending, running, passed, failed, skipped, skipped_cached
+	Duration     string
+	Cached       bool
+	Output       string
+	Summary      string
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	CostUSD      float64
+	NumTurns     int
+	NumToolCalls int
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
 }
 
 // TaskItem is one task row (its latest execution attempt).
@@ -200,11 +220,45 @@ type LogEntry struct {
 	Message   string
 }
 
+// WorkflowStepDef is one step definition shown in the Workflows config tab.
+type WorkflowStepDef struct {
+	ID        string
+	Type      string
+	Agent     string
+	DependsOn []string
+	Condition string
+	Prompt    string
+}
+
+// WorkflowConfigItem is one workflow shown in the Workflows config tab.
+type WorkflowConfigItem struct {
+	ID          string
+	Description string
+	Steps       []WorkflowStepDef
+}
+
+// WorkflowsView is which panel the Workflows tab has focus on.
+type WorkflowsView int
+
+const (
+	WorkflowsViewList WorkflowsView = iota
+	WorkflowsViewSteps
+)
+
+// WorkflowsTab shows the static workflow config definitions (read-only).
+type WorkflowsTab struct {
+	Workflows    []WorkflowConfigItem
+	SelectedIdx  int // selected workflow in the left panel
+	StepIdx      int // selected step in the right panel
+	StepScroll   int // scroll offset in the step list
+	Focus        WorkflowsView
+}
+
 // NewModel creates a new dashboard model.
 func NewModel() *Model {
 	return &Model{
 		activeTab: 0,
-		tabs:      []string{"Overview", "Tasks", "Agents", "Usage", "Logs"},
+		tabs:      []string{"Overview", "Tasks", "Agents", "Usage", "Logs", "Workflows"},
 		overviewTab: &OverviewTab{
 			Status:      "Loading...",
 			Uptime:      "0s",
@@ -217,12 +271,13 @@ func NewModel() *Model {
 		agentsTab: &AgentsTab{
 			Agents: []AgentStatus{},
 		},
-		usageTab: &UsageTab{},
+		usageTab:     &UsageTab{},
 		logsTab: &LogsTab{
 			Logs:        []LogEntry{},
 			FilterLevel: "All",
 			Wrap:        true,
 		},
+		workflowsTab:   &WorkflowsTab{},
 		lastTabRefresh: make(map[int]time.Time),
 		loading:        true,
 	}

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -89,12 +89,14 @@ type Execution struct {
 	CanRetry       bool
 	NextRetryAt    *time.Time
 	CreatedAt      time.Time
-	InputTokens    int
-	OutputTokens   int
-	TotalTokens    int
-	NumTurns       int
-	NumToolCalls   int
-	CostUSD        float64
+	InputTokens        int
+	OutputTokens       int
+	TotalTokens        int
+	NumTurns           int
+	NumToolCalls       int
+	CostUSD            float64
+	WorkflowInstanceID string
+	StepID             string
 }
 
 func (c *Client) CreateExecution(ctx context.Context, taskID, agentID, title, number, taskURL, model, runner string, attempt int) (*Execution, error) {
@@ -157,6 +159,32 @@ func (c *Client) SendHeartbeat(ctx context.Context, execID int64) error {
 		WHERE id = ?
 	`, time.Now(), execID)
 	return err
+}
+
+// SetStepLink associates a task_execution row with its workflow instance and step,
+// enabling per-step usage queries from the dashboard.
+func (c *Client) SetStepLink(ctx context.Context, execID int64, instanceID, stepID string) error {
+	_, err := c.db.ExecContext(ctx, `
+		UPDATE task_executions SET workflow_instance_id = ?, step_id = ? WHERE id = ?
+	`, nullStr(instanceID), nullStr(stepID), execID)
+	return err
+}
+
+// GetStepUsage returns token and cost totals for the most recent execution of a
+// specific step within a workflow instance.
+func (c *Client) GetStepUsage(ctx context.Context, instanceID, stepID string) (*Execution, error) {
+	row := c.db.QueryRowContext(ctx, `
+		SELECT input_tokens, output_tokens, total_tokens, num_turns, num_tool_calls, cost_usd
+		FROM task_executions
+		WHERE workflow_instance_id = ? AND step_id = ?
+		ORDER BY created_at DESC LIMIT 1
+	`, instanceID, stepID)
+	var e Execution
+	err := row.Scan(&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.NumTurns, &e.NumToolCalls, &e.CostUSD)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
 }
 
 // ReconcileOrphanExecutions marks any executions still in the 'running' state

--- a/src/internal/db/dashboard.go
+++ b/src/internal/db/dashboard.go
@@ -489,6 +489,41 @@ func (c *Client) GetTaskLogs(ctx context.Context, taskID string, limit int) ([]T
 	return logs, nil
 }
 
+// GetTaskLogsInRange returns log lines for a task within a time window, used to
+// isolate logs belonging to a specific workflow step run.
+func (c *Client) GetTaskLogsInRange(ctx context.Context, taskID string, from, to *time.Time) ([]TaskLogLine, error) {
+	q := `SELECT timestamp, level, message FROM task_logs WHERE task_id = ?`
+	args := []any{taskID}
+	if from != nil {
+		q += " AND timestamp >= ?"
+		args = append(args, from)
+	}
+	if to != nil {
+		q += " AND timestamp <= ?"
+		args = append(args, to)
+	}
+	q += " ORDER BY id ASC LIMIT 2000"
+
+	rows, err := c.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var logs []TaskLogLine
+	for rows.Next() {
+		var l TaskLogLine
+		var level, msg sql.NullString
+		if err := rows.Scan(&l.Timestamp, &level, &msg); err != nil {
+			continue
+		}
+		l.Level = level.String
+		l.Message = msg.String
+		logs = append(logs, l)
+	}
+	return logs, nil
+}
+
 // LogEntry holds a log record.
 type ServiceLog struct {
 	Timestamp time.Time

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -166,6 +166,8 @@ var migrations = []string{
 	`ALTER TABLE task_executions ADD COLUMN num_turns INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN num_tool_calls INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN cost_usd REAL DEFAULT 0.0`,
+	`ALTER TABLE task_executions ADD COLUMN workflow_instance_id TEXT`,
+	`ALTER TABLE task_executions ADD COLUMN step_id TEXT`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).


### PR DESCRIPTION
## Summary

- **Workflows tab** — browses the workflow definitions from the config (read-only): a list of workflows on the left, steps with type, agent, dependencies and condition on the right; j/k navigation + enter to expand a step.
- **Live monitor in Tasks** — pressing Enter on any task with a workflow instance opens the monitor instead of the raw logs; it refreshes every 2 s via the existing polling.
  - Left panel: all the steps with a state icon (✓ ✗ ● ○ ⊘), duration and agent.
  - Right panel: the selected step with tokens (in/out/total), USD cost, turns, tool calls, summary and output.
  - **Enter/l**: opens the step's logs filtered by the step_run's time range.
- **Emergency controls** — `X` stops the workflow instance without re-dispatching (new endpoint `POST /instances/stop/{id}`); `R` forces a full workflow restart.
- **DB**: `workflow_instance_id` + `step_id` migrations on `task_executions`; `GetStepUsage` and `GetTaskLogsInRange` methods.
- **API**: `GET /workflows` returns the config definitions; `POST /instances/stop/{id}` cancels execution and marks the instance as interrupted.

## Test plan

- [ ] Open the dashboard → the Workflows tab appears and lists the workflows from `apiary.yaml`
- [ ] j/k navigates between workflows; Enter/→ focuses the steps panel and expands the selected step's details
- [ ] Select a task with a workflow instance in the Tasks tab → Enter opens the live monitor
- [ ] The monitor shows steps with colored states; navigate with j/k and watch the right panel update
- [ ] On a completed step: tokens and cost appear; Enter opens logs filtered by the step's range
- [ ] Task with no workflow → Enter opens the logs view (previous behavior)
- [ ] X in the monitor → confirmation → the instance is marked interrupted, the runner cancelled
- [ ] R in the monitor → full workflow restart
- [ ] go test ./... passes with no regressions