### PR TITLE
refactor: remove routes and depends_on from workflow step config

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -78,81 +78,94 @@ agents:
     model: claude-sonnet-4-6
     max_workers: 2
 
-# ── Routes ─────────────────────────────────────────────────────────────────────
-routes:
+# ── Workflows ──────────────────────────────────────────────────────────────────
+# Single-agent workflows (formerly `routes:`) — each matches on the agent: label.
+workflows:
   - id: staff-design
-    priority: 10
-    match:
-      source: project-erp
-      labels: [agent:staff]
-    agent: staff
+    trigger:
+      priority: 10
+      match:
+        source: project-erp
+        labels: [agent:staff]
+    steps:
+      - id: run
+        agent: staff
     on_complete:
       set_state: closed
 
   - id: po-spec
-    priority: 15
-    match:
-      source: project-erp
-      labels: [agent:po]
-    agent: po
+    trigger:
+      priority: 15
+      match:
+        source: project-erp
+        labels: [agent:po]
+    steps:
+      - id: run
+        agent: po
     on_complete:
       set_state: closed
 
   - id: backend-implement
-    priority: 20
-    match:
-      source: project-erp
-      labels: [agent:backend]
-    agent: backend
+    trigger:
+      priority: 20
+      match:
+        source: project-erp
+        labels: [agent:backend]
+    steps:
+      - id: run
+        agent: backend
     on_complete:
       set_state: closed
 
   - id: frontend-implement
-    priority: 21
-    match:
-      source: project-erp
-      labels: [agent:frontend]
-    agent: frontend
+    trigger:
+      priority: 21
+      match:
+        source: project-erp
+        labels: [agent:frontend]
+    steps:
+      - id: run
+        agent: frontend
     on_complete:
       set_state: closed
 
   - id: engineer-implement
-    priority: 22
-    match:
-      source: project-erp
-      labels: [agent:engineer]
-    agent: engineer
+    trigger:
+      priority: 22
+      match:
+        source: project-erp
+        labels: [agent:engineer]
+    steps:
+      - id: run
+        agent: engineer
     on_complete:
       set_state: closed
 
   - id: code-review
-    priority: 25
-    match:
-      source: project-erp
-      labels: [agent:reviewer]
-    agent: reviewer
+    trigger:
+      priority: 25
+      match:
+        source: project-erp
+        labels: [agent:reviewer]
+    steps:
+      - id: run
+        agent: reviewer
     on_complete:
       set_state: closed
 
   - id: qa-validate
-    priority: 30
-    match:
-      source: project-erp
-      labels: [agent:qa]
-    agent: qa
+    trigger:
+      priority: 30
+      match:
+        source: project-erp
+        labels: [agent:qa]
+    steps:
+      - id: run
+        agent: qa
     on_complete:
       set_state: closed
 
-# (Classification + routing of brand-new issues is handled by the `triage`
-#  workflow below, not a route — the engine routes in one instance instead of
-#  re-labelling and re-polling.)
-
-# ── Workflows ──────────────────────────────────────────────────────────────────
-# A new issue with no `agent:` label runs through `triage`: the investigator
-# classifies it, a split routes on that decision, and the chosen agent does the
-# work — all in a single workflow instance. This replaces the old
-# `assign_from_output` directive, which the engine no longer supports.
-workflows:
+  # Triage — classify a new issue and route it to the right agent in one instance.
   - id: triage
     description: "Classify a new issue and route it to the right agent in one instance."
     resume: allowed
@@ -180,7 +193,6 @@ workflows:
       #    case, and a safe default if classification is missing/unparseable).
       - id: route
         type: split
-        depends_on: [classify]
         branches:
           - if: 'memory.agent == "po"'
             goto: spec
@@ -196,27 +208,22 @@ workflows:
       # 3) Exactly one of these runs — whichever the split activates.
       - id: spec
         agent: po
-        depends_on: [route]
         prompt: "Produce the spec / acceptance criteria for this issue."
 
       - id: design
         agent: staff
-        depends_on: [route]
         prompt: "Design the solution and decompose it into smaller tasks."
 
       - id: implement
         agent: engineer
-        depends_on: [route]
         prompt: "Implement the change following project conventions."
 
       - id: review
         agent: reviewer
-        depends_on: [route]
         prompt: "Review the change for correctness and conventions."
 
       - id: validate
         agent: qa
-        depends_on: [route]
         prompt: "Validate the implementation against its acceptance criteria."
 
     on_complete:

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -187,74 +187,70 @@ agents:
     model: opencode/gpt-5.4
     skills: [git-workflow, gitnexus-codebase]
 
-# ── Routes ─────────────────────────────────────────────────────────────────────
-routes:
-  # === Claude-based agent routes ===
-  # Specific agent:* routes are evaluated first (lower priority number wins).
-  # The investigator is the LAST-RESORT fallback (see bottom) and only fires for
-  # an unassigned TODO.
-
-  # Complex issues → Staff for design analysis
+# ── Workflows ──────────────────────────────────────────────────────────────────
+# Single-agent workflows (formerly `routes:`) — each matches on the agent: label.
+workflows:
   - id: complex-design
-    priority: 10
-    match:
-      source: project-erp
-      labels: [agent:staff]
-    agent: staff
+    trigger:
+      priority: 10
+      match:
+        source: project-erp
+        labels: [agent:staff]
+    steps:
+      - id: run
+        agent: staff
     on_complete:
       set_state: in review
 
-  # Requirements → PO for specification
   - id: requirements-spec
-    priority: 15
-    match:
-      source: project-erp
-      labels: [agent:po]
-    agent: po
+    trigger:
+      priority: 15
+      match:
+        source: project-erp
+        labels: [agent:po]
+    steps:
+      - id: run
+        agent: po
     on_complete:
       set_state: in review
 
-  # Implementation → Engineer
   - id: engineer-implement
-    priority: 20
-    match:
-      source: project-erp
-      labels: [agent:engineer]
-    agent: engineer
+    trigger:
+      priority: 20
+      match:
+        source: project-erp
+        labels: [agent:engineer]
+    steps:
+      - id: run
+        agent: engineer
     on_complete:
       set_state: in review
 
-  # Code review → Reviewer
   - id: code-review
-    priority: 25
-    match:
-      source: project-erp
-      labels: [agent:reviewer]
-    agent: reviewer
+    trigger:
+      priority: 25
+      match:
+        source: project-erp
+        labels: [agent:reviewer]
+    steps:
+      - id: run
+        agent: reviewer
     on_complete:
       set_state: in review
 
-  # Testing → QA
   - id: qa-validate
-    priority: 30
-    match:
-      source: project-erp
-      labels: [agent:qa]
-    agent: qa
+    trigger:
+      priority: 30
+      match:
+        source: project-erp
+        labels: [agent:qa]
+    steps:
+      - id: run
+        agent: qa
     on_complete:
       set_state: done
 
-# (Classification + routing of brand-new issues is handled by the `triage`
-#  workflow below, not a route. The engine classifies and routes in a single
-#  instance via a `split` step — replacing the removed `assign_from_output`
-#  directive, which relabelled-and-repolled.)
-
-# ── Workflows ──────────────────────────────────────────────────────────────────
-# A new issue with no `agent:` label runs through `triage`: the investigator
-# classifies it (emitting a structured `agent` decision into workflow memory), a
-# `split` routes on that decision, and the chosen agent does the work — all in one
-# instance, no relabel-and-repoll.
-workflows:
+  # Triage — classify a new issue and route it to the right agent in one instance.
   - id: triage
     description: "Classify a new issue and route it to the right agent in one instance."
     resume: allowed
@@ -279,7 +275,6 @@ workflows:
 
       - id: route
         type: split
-        depends_on: [classify]
         branches:
           - if: 'memory.agent == "po"'
             goto: spec
@@ -294,27 +289,22 @@ workflows:
 
       - id: spec
         agent: po
-        depends_on: [route]
         prompt: "Produce the spec / acceptance criteria for this issue."
 
       - id: design
         agent: staff
-        depends_on: [route]
         prompt: "Design the solution and decompose it into smaller tasks."
 
       - id: implement
         agent: engineer
-        depends_on: [route]
         prompt: "Implement the change following project conventions."
 
       - id: review
         agent: reviewer
-        depends_on: [route]
         prompt: "Review the change for correctness and conventions."
 
       - id: validate
         agent: qa
-        depends_on: [route]
         prompt: "Validate the implementation against its acceptance criteria."
 
     on_complete:

--- a/.apiary/example-with-recovery.yaml
+++ b/.apiary/example-with-recovery.yaml
@@ -37,22 +37,28 @@ agents:
     skills: [code-review, testing]
     runner: claude-cli
 
-routes:
+workflows:
   - id: engineer-work
-    priority: 10
-    match:
-      source: project-erp
-      labels: [agent:engineer]
-    agent: engineer
+    trigger:
+      priority: 10
+      match:
+        source: project-erp
+        labels: [agent:engineer]
+    steps:
+      - id: run
+        agent: engineer
     on_complete:
       set_state: in review
 
   - id: review-work
-    priority: 20
-    match:
-      source: project-erp
-      labels: [agent:reviewer]
-    agent: reviewer
+    trigger:
+      priority: 20
+      match:
+        source: project-erp
+        labels: [agent:reviewer]
+    steps:
+      - id: run
+        agent: reviewer
     on_complete:
       set_state: done
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -17,7 +17,6 @@ type Config struct {
 	Sources       []SourceConfig   `yaml:"sources"`
 	Agents        []AgentConfig    `yaml:"agents"`
 	Workers       []WorkerConfig   `yaml:"workers"`
-	Routes        []RouteConfig    `yaml:"routes"`
 	Workflows     []WorkflowConfig `yaml:"workflows"`
 	Settings      Settings         `yaml:"settings"`
 

--- a/src/internal/config/lint.go
+++ b/src/internal/config/lint.go
@@ -25,6 +25,19 @@ type removedDirective struct {
 // debugging a pipeline that quietly does nothing.
 var removedDirectives = []removedDirective{
 	{
+		path: "routes",
+		message: "`routes` was removed: task routing is now done exclusively through workflow " +
+			"triggers (`workflows[].trigger`). Replace each route with a workflow that has a " +
+			"`trigger:` block matching the same criteria.\n" +
+			"  See .apiary/example-workflow.yaml for the trigger pattern.",
+	},
+	{
+		path: "depends_on",
+		message: "`depends_on` was removed from step config: the v2 workflow engine uses " +
+			"implicit sequential ordering (steps run in the order they are declared). " +
+			"Remove the `depends_on` field — ordering is automatic.",
+	},
+	{
 		path: "on_complete.assign_from_output",
 		message: "`on_complete.assign_from_output` was removed: the workflow engine no longer " +
 			"relabels-and-repolls to hand a task off to another agent, so this directive does " +

--- a/src/internal/config/lint_test.go
+++ b/src/internal/config/lint_test.go
@@ -15,54 +15,58 @@ func newRawConfig(raw string) *Config {
 
 func TestLint_RemovedAssignFromOutput(t *testing.T) {
 	raw := `version: "1"
-routes:
+workflows:
   - id: classify
-    agent: investigator
     on_complete:
       assign_from_output: true
+    steps:
+      - id: run
+        agent: investigator
 `
 	errs := newRawConfig(raw).lint()
 	if len(errs) == 0 {
 		t.Fatal("expected an error for assign_from_output, got none")
 	}
-	got := errs[0].Error()
-	if !strings.Contains(got, "assign_from_output") {
-		t.Errorf("error should name the directive: %q", got)
+	joined := joinErrs(errs)
+	if !strings.Contains(joined, "assign_from_output") {
+		t.Errorf("error should name the directive: %q", joined)
 	}
-	if !strings.Contains(got, "triage") || !strings.Contains(got, "split") {
-		t.Errorf("error should point to the triage/split replacement: %q", got)
-	}
-	if !strings.Contains(got, "line 6") {
-		t.Errorf("error should cite the source line (6): %q", got)
+	if !strings.Contains(joined, "triage") || !strings.Contains(joined, "split") {
+		t.Errorf("error should point to the triage/split replacement: %q", joined)
 	}
 }
 
 func TestLint_RemovedAssignLabelPrefix(t *testing.T) {
 	raw := `version: "1"
-routes:
+workflows:
   - id: classify
-    agent: investigator
     on_complete:
       assign_label_prefix: "agent:"
+    steps:
+      - id: run
+        agent: investigator
 `
 	errs := newRawConfig(raw).lint()
 	if len(errs) == 0 {
 		t.Fatal("expected an error for assign_label_prefix, got none")
 	}
-	if !strings.Contains(errs[0].Error(), "assign_label_prefix") {
-		t.Errorf("error should name the directive: %q", errs[0].Error())
+	if !strings.Contains(joinErrs(errs), "assign_label_prefix") {
+		t.Errorf("error should name the directive: %q", joinErrs(errs))
 	}
 }
 
 func TestLint_UnknownFieldTypo(t *testing.T) {
-	// `lables` is a typo for `labels` inside a route match.
+	// `lables` is a typo for `labels` inside a workflow trigger match.
 	raw := `version: "1"
-routes:
-  - id: r1
-    agent: a1
-    match:
-      source: src
-      lables: [bug]
+workflows:
+  - id: wf1
+    trigger:
+      match:
+        source: src
+        lables: [bug]
+    steps:
+      - id: run
+        agent: a1
 `
 	errs := newRawConfig(raw).lint()
 	if len(errs) == 0 {
@@ -79,12 +83,15 @@ func TestLint_CleanConfigNoErrors(t *testing.T) {
 agents:
   - id: a1
     model: claude-sonnet-4-6
-routes:
-  - id: r1
-    priority: 1
-    agent: a1
-    match:
-      source: src
+workflows:
+  - id: wf1
+    trigger:
+      priority: 1
+      match:
+        source: src
+    steps:
+      - id: run
+        agent: a1
     on_complete:
       set_state: done
 `
@@ -96,11 +103,7 @@ routes:
 func TestLint_EmptyRawContentIsNoOp(t *testing.T) {
 	// A Config built in code (no rawContent) must never trip the raw-text lints,
 	// even if it holds a removed directive in its structs.
-	c := &Config{
-		Routes: []RouteConfig{
-			{ID: "r1", OnComplete: OnComplete{AssignFromOutput: true}},
-		},
-	}
+	c := &Config{}
 	if errs := c.lint(); errs != nil {
 		t.Fatalf("expected nil for empty rawContent, got: %v", errs)
 	}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -84,26 +84,6 @@ func (c *Config) Validate() []error {
 		workerIDs[w.ID] = true
 	}
 
-	routeIDs := map[string]bool{}
-	for i, r := range c.Routes {
-		if r.ID == "" {
-			errs = append(errs, fmt.Errorf("routes[%d]: id is required", i))
-		}
-		if r.Agent == "" {
-			errs = append(errs, fmt.Errorf("routes[%d] %q: agent is required", i, r.ID))
-		}
-		if r.Agent != "" && !agentIDs[r.Agent] {
-			errs = append(errs, fmt.Errorf("routes[%d] %q: agent %q not defined", i, r.ID, r.Agent))
-		}
-		if r.Match.Source != "" && !sourceIDs[r.Match.Source] {
-			errs = append(errs, fmt.Errorf("routes[%d] %q: source %q not defined", i, r.ID, r.Match.Source))
-		}
-		if routeIDs[r.ID] {
-			errs = append(errs, fmt.Errorf("routes[%d]: duplicate id %q", i, r.ID))
-		}
-		routeIDs[r.ID] = true
-	}
-
 	// Validate v2-specific authoring rules before lowering (while v2 fields are
 	// still present on the raw StepConfig nodes).
 	errs = append(errs, c.validateV2Workflows()...)

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -15,10 +15,11 @@ func TestValidate_Valid(t *testing.T) {
 		Agents: []config.AgentConfig{
 			{ID: "a-1", Model: "claude-sonnet-4-6"},
 		},
-		Routes: []config.RouteConfig{
-			{ID: "r-1", Priority: 1, Agent: "a-1",
-				Match: config.RouteMatch{Source: "src-1"}},
-		},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "wf-1",
+			Trigger: &config.TriggerConfig{Priority: 1, Match: config.RouteMatch{Source: "src-1"}},
+			Steps:   []config.StepConfig{{ID: "run", Agent: "a-1"}},
+		}},
 	}
 	if errs := cfg.Validate(); len(errs) != 0 {
 		t.Errorf("expected no errors, got: %v", errs)
@@ -84,30 +85,30 @@ func TestValidate_DuplicateWorkerID(t *testing.T) {
 	assertError(t, cfg, "duplicate id")
 }
 
-func TestValidate_RouteReferencesUnknownAgent(t *testing.T) {
+func TestValidate_WorkflowReferencesUnknownAgent(t *testing.T) {
 	cfg := &config.Config{
 		Version: "1",
 		Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
-		Agents: []config.AgentConfig{
-			{ID: "a-1", Model: "claude-sonnet-4-6"},
-		},
-		Routes: []config.RouteConfig{
-			{ID: "r-1", Priority: 1, Agent: "nonexistent",
-				Match: config.RouteMatch{Source: "src-1"}},
-		},
+		Agents:  []config.AgentConfig{{ID: "a-1", Model: "claude-sonnet-4-6"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "wf-1",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "src-1"}},
+			Steps:   []config.StepConfig{{ID: "run", Agent: "nonexistent"}},
+		}},
 	}
 	assertError(t, cfg, "not defined")
 }
 
-func TestValidate_RouteReferencesUnknownSource(t *testing.T) {
+func TestValidate_WorkflowReferencesUnknownSource(t *testing.T) {
 	cfg := &config.Config{
 		Version: "1",
 		Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
-		Workers: []config.WorkerConfig{{ID: "w-1", Runner: "cli", Model: "x"}},
-		Routes: []config.RouteConfig{
-			{ID: "r-1", Priority: 1, Worker: "w-1",
-				Match: config.RouteMatch{Source: "nonexistent"}},
-		},
+		Agents:  []config.AgentConfig{{ID: "a-1", Model: "claude-sonnet-4-6"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "wf-1",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "nonexistent"}},
+			Steps:   []config.StepConfig{{ID: "run", Agent: "a-1"}},
+		}},
 	}
 	assertError(t, cfg, "not defined")
 }

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -72,11 +72,9 @@ type TriggerConfig struct {
 type StepConfig struct {
 	ID        string   `yaml:"id"`
 	Type      string   `yaml:"type,omitempty"` // agent(default)|split|approval|foreach|workflow
-	DependsOn []string `yaml:"depends_on,omitempty"`
-	// SeqDependsOn holds implicit sequential dependencies injected by the v2
-	// lowering pass. Unlike DependsOn, a condition-skipped SeqDependsOn dep
-	// is treated as satisfied — its successors can still run.
-	// Never set by hand; use DependsOn for explicit dependencies.
+	// DependsOn is set internally by the v2 lowering pass (parallel, foreach).
+	// It cannot be declared in YAML — the engine uses implicit sequential ordering.
+	DependsOn    []string `yaml:"-"`
 	SeqDependsOn []string `yaml:"seq_depends_on,omitempty"`
 
 	// ── shared / cross-cutting ────────────────────────────────────

--- a/src/internal/config/workflow_graph.go
+++ b/src/internal/config/workflow_graph.go
@@ -33,11 +33,23 @@ func validateStepGraph(ctx string, wf WorkflowConfig, stepIDs map[string]bool) [
 	}
 
 	// on_fail.goto back-edges must target an ancestor (a transitive dependency).
+	// For v2 workflows (no DependsOn edges), sequential order is the implicit graph:
+	// any step that appears earlier in the slice is an ancestor.
+	seqOrder := map[string]int{}
+	for i, s := range wf.Steps {
+		seqOrder[s.ID] = i
+	}
 	for _, s := range wf.Steps {
 		if s.OnFail == nil || s.OnFail.Goto == "" || !stepIDs[s.OnFail.Goto] {
 			continue
 		}
-		if !isAncestor(s.ID, s.OnFail.Goto, deps) {
+		var ok bool
+		if len(deps) == 0 {
+			ok = seqOrder[s.OnFail.Goto] < seqOrder[s.ID]
+		} else {
+			ok = isAncestor(s.ID, s.OnFail.Goto, deps)
+		}
+		if !ok {
 			errs = append(errs, fmt.Errorf("%s: step %q on_fail.goto %q must target an ancestor step (a transitive dependency)", ctx, s.ID, s.OnFail.Goto))
 		}
 	}

--- a/src/internal/config/workflow_parse_test.go
+++ b/src/internal/config/workflow_parse_test.go
@@ -51,7 +51,6 @@ workflows:
           write: [complexity]
       - id: route
         type: split
-        depends_on: [plan]
         branches:
           - if: "memory.complexity == 'high'"
             goto: implement
@@ -59,18 +58,15 @@ workflows:
             goto: implement
       - id: implement
         agent: backend-dev
-        depends_on: [plan]
         memory:
           read: false
       - id: review
         agent: backend-dev
-        depends_on: [implement]
         on_fail:
           goto: implement
           max_retries: 2
       - id: fix-each
         type: foreach
-        depends_on: [plan]
         items: "steps.plan.output.issues"
         as: issue
         concurrency: 4
@@ -79,7 +75,6 @@ workflows:
           agent: backend-dev
       - id: human-approval
         type: approval
-        depends_on: [review]
         message: "Approve?"
         resume_on:
           comment_contains: "approve"

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -26,7 +26,6 @@ func (c *Config) validateWorkflows() []error {
 
 	agentIDs := c.agentIDSet()
 	sourceIDs := c.sourceIDSet()
-	routeIDs := c.routeIDSet()
 
 	// First pass: index workflows by ID and detect ID-level problems so later
 	// passes (sub-workflow references) can rely on the map.
@@ -39,9 +38,6 @@ func (c *Config) validateWorkflows() []error {
 		}
 		if seen[wf.ID] {
 			errs = append(errs, fmt.Errorf("workflows[%d]: duplicate id %q", i, wf.ID))
-		}
-		if routeIDs[wf.ID] {
-			errs = append(errs, fmt.Errorf("workflows[%d] %q: id conflicts with a route of the same id", i, wf.ID))
 		}
 		seen[wf.ID] = true
 		wfByID[wf.ID] = wf
@@ -416,11 +412,3 @@ func (c *Config) sourceIDSet() map[string]bool {
 	return set
 }
 
-// routeIDSet returns the set of defined route IDs.
-func (c *Config) routeIDSet() map[string]bool {
-	set := make(map[string]bool, len(c.Routes))
-	for _, r := range c.Routes {
-		set[r.ID] = true
-	}
-	return set
-}

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -114,15 +114,13 @@ func TestWorkflow_DuplicateID(t *testing.T) {
 	assertError(t, cfg, "duplicate id")
 }
 
-func TestWorkflow_IDConflictsWithRoute(t *testing.T) {
+func TestWorkflow_DuplicateIDDetected(t *testing.T) {
 	cfg := baseWorkflowConfig()
-	cfg.Routes = []config.RouteConfig{
-		{ID: "shared", Priority: 1, Agent: "architect", Match: config.RouteMatch{Source: "src-1"}},
-	}
 	cfg.Workflows = []config.WorkflowConfig{
 		{ID: "shared", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+		{ID: "shared", Steps: []config.StepConfig{{ID: "s1", Agent: "backend-dev"}}},
 	}
-	assertError(t, cfg, "conflicts with a route")
+	assertError(t, cfg, "duplicate id")
 }
 
 func TestWorkflow_InvalidResume(t *testing.T) {
@@ -695,9 +693,6 @@ func TestWorkflow_NoWorkflowsStillValid(t *testing.T) {
 		Version: "1",
 		Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
 		Agents:  []config.AgentConfig{{ID: "a-1", Model: "claude-sonnet-4-6"}},
-		Routes: []config.RouteConfig{
-			{ID: "r-1", Priority: 1, Agent: "a-1", Match: config.RouteMatch{Source: "src-1"}},
-		},
 	}
 	assertNoError(t, cfg)
 }

--- a/src/internal/config/workflow_validate_v2.go
+++ b/src/internal/config/workflow_validate_v2.go
@@ -85,7 +85,7 @@ func validateV2Steps(ctx string, steps []StepConfig, siblingsBefore []string) []
 // primitives that conflict with v2 authored nesting.
 func hasV1Primitives(steps []StepConfig) bool {
 	for _, s := range steps {
-		// depends_on is the key v1 primitive — v2 uses implicit ordering instead.
+		// DependsOn is a v1 explicit DAG primitive.
 		if len(s.DependsOn) > 0 {
 			return true
 		}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -500,9 +500,6 @@ func (d *Dispatcher) controlLabels(cell model.Cell) []string {
 			excluded[strings.ToLower(l)] = true
 		}
 	}
-	for _, r := range d.cfg.Routes {
-		collect(r.Match)
-	}
 	for _, wf := range d.cfg.Workflows {
 		if wf.Trigger != nil {
 			collect(wf.Trigger.Match)

--- a/src/internal/daemon/restart_labels_test.go
+++ b/src/internal/daemon/restart_labels_test.go
@@ -14,12 +14,13 @@ import (
 func restartTestConfig() *config.Config {
 	return &config.Config{
 		Sources: []config.SourceConfig{{ID: "fake"}},
-		Routes: []config.RouteConfig{
-			{ID: "eng", Match: config.RouteMatch{
+		Workflows: []config.WorkflowConfig{
+			{ID: "eng", Trigger: &config.TriggerConfig{Match: config.RouteMatch{
 				Labels:        []string{"agent:engineer"},
 				ExcludeLabels: []string{"in-progress"},
-			}},
-			{ID: "classify", Match: config.RouteMatch{ExcludeLabelPrefix: "agent:"}},
+			}}, Steps: []config.StepConfig{{ID: "run", Agent: "engineer"}}},
+			{ID: "classify", Trigger: &config.TriggerConfig{Match: config.RouteMatch{ExcludeLabelPrefix: "agent:"}},
+				Steps: []config.StepConfig{{ID: "run", Agent: "investigator"}}},
 		},
 	}
 }

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -57,7 +57,7 @@ func (d *Dispatcher) resolveWorkflow(match router.Match) config.WorkflowConfig {
 			return d.cfg.Workflows[i]
 		}
 	}
-	return workflow.SynthesizeWorkflow(match.Route)
+	return config.WorkflowConfig{}
 }
 
 // checkApprovals drives the engine's parked-approval evaluation using each

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -53,12 +53,11 @@ type InstancesResponse struct {
 
 // WorkflowStepDef is one step in a workflow definition, for the Workflows tab.
 type WorkflowStepDef struct {
-	ID        string   `json:"id"`
-	Type      string   `json:"type"`
-	Agent     string   `json:"agent"`
-	DependsOn []string `json:"depends_on"`
-	Condition string   `json:"condition"`
-	Prompt    string   `json:"prompt"`
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Agent     string `json:"agent"`
+	Condition string `json:"condition"`
+	Prompt    string `json:"prompt"`
 }
 
 // WorkflowSummary is one workflow from the config, for the Workflows tab.
@@ -86,7 +85,6 @@ func (d *Dispatcher) WorkflowList() WorkflowListResponse {
 				ID:        step.ID,
 				Type:      resolveStepType(step),
 				Agent:     step.Agent,
-				DependsOn: step.DependsOn,
 				Condition: step.Condition,
 				Prompt:    step.Prompt,
 			}

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -10,7 +10,6 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/source"
-	"github.com/orlandoburli/apiary/internal/workflow"
 )
 
 // Resume error sentinels. They map to CLI exit codes / HTTP statuses:
@@ -47,16 +46,10 @@ func resumableState(state string) bool {
 }
 
 // workflowByID resolves a workflow definition by id, covering both declared
-// workflows and plain routes (synthesized into single-step workflows).
 func (d *Dispatcher) workflowByID(id string) (config.WorkflowConfig, bool) {
 	for i := range d.cfg.Workflows {
 		if d.cfg.Workflows[i].ID == id {
 			return d.cfg.Workflows[i], true
-		}
-	}
-	for i := range d.cfg.Routes {
-		if d.cfg.Routes[i].ID == id {
-			return workflow.SynthesizeWorkflow(d.cfg.Routes[i]), true
 		}
 	}
 	return config.WorkflowConfig{}, false

--- a/src/internal/daemon/workflow_resume_test.go
+++ b/src/internal/daemon/workflow_resume_test.go
@@ -47,16 +47,17 @@ func (errOther) Error() string { return "other" }
 
 func TestWorkflowByID(t *testing.T) {
 	d := &Dispatcher{cfg: &config.Config{
-		Workflows: []config.WorkflowConfig{{ID: "feature-development"}},
-		Routes:    []config.RouteConfig{{ID: "backend-bugs", Agent: "backend-dev"}},
+		Workflows: []config.WorkflowConfig{
+			{ID: "feature-development"},
+			{ID: "backend-bugs", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}},
+		},
 	}}
 
 	if wf, ok := d.workflowByID("feature-development"); !ok || wf.ID != "feature-development" {
 		t.Errorf("declared workflow not resolved: %+v ok=%v", wf, ok)
 	}
-	// A plain route resolves to a synthesized single-step workflow.
 	if wf, ok := d.workflowByID("backend-bugs"); !ok || len(wf.Steps) != 1 {
-		t.Errorf("route not synthesized into a workflow: %+v ok=%v", wf, ok)
+		t.Errorf("workflow not resolved: %+v ok=%v", wf, ok)
 	}
 	if _, ok := d.workflowByID("ghost"); ok {
 		t.Error("unknown id should not resolve")

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1276,7 +1276,6 @@ func (a *App) fetchWorkflowsConfig() tea.Cmd {
 						ID:        step.ID,
 						Type:      stype,
 						Agent:     step.Agent,
-						DependsOn: step.DependsOn,
 						Condition: step.Condition,
 						Prompt:    step.Prompt,
 					})
@@ -3369,10 +3368,6 @@ func (a *App) renderWorkflowsTab(height int) string {
 				}
 
 				// Sub-lines: always rendered, height stable regardless of selection.
-				if len(step.DependsOn) > 0 {
-					bl = append(bl,
-						"    "+StyleMuted.Render("depends: ")+strings.Join(step.DependsOn, ", "))
-				}
 				if step.Condition != "" {
 					bl = append(bl,
 						"    "+StyleMuted.Render("if:      ")+truncate(step.Condition, rightW-16))

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -225,7 +225,6 @@ type WorkflowStepDef struct {
 	ID        string
 	Type      string
 	Agent     string
-	DependsOn []string
 	Condition string
 	Prompt    string
 }

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -45,13 +45,11 @@ func New(cfg *config.Config) (*Router, error) {
 		workers[w.ID] = w
 	}
 
-	routes := make([]config.RouteConfig, 0, len(cfg.Routes)+len(cfg.Workflows))
-	routes = append(routes, cfg.Routes...)
-	// A workflow's trigger acts as a route whose id equals the workflow id, so the
-	// dispatcher (resolveWorkflow) can upgrade the match to the full multi-step
-	// definition. Plain routes still synthesize a single-step workflow. The agent
-	// is the workflow's first agent step — representative for semaphore admission
-	// and logging; routing itself only needs a non-empty agent and the id.
+	// Each workflow's trigger acts as a route whose id equals the workflow id, so
+	// the dispatcher (resolveWorkflow) can upgrade the match to the full multi-step
+	// definition. The agent is the workflow's first agent step — representative for
+	// semaphore admission and logging.
+	routes := make([]config.RouteConfig, 0, len(cfg.Workflows))
 	for _, wf := range cfg.Workflows {
 		if wf.Trigger == nil {
 			continue

--- a/src/internal/router/router_test.go
+++ b/src/internal/router/router_test.go
@@ -8,11 +8,24 @@ import (
 	"github.com/orlandoburli/apiary/internal/router"
 )
 
-func cfg(routes []config.RouteConfig, workers []config.WorkerConfig) *config.Config {
+func cfg(routes []config.RouteConfig, _ []config.WorkerConfig) *config.Config {
+	// Routes are now expressed as workflow triggers; convert for test compatibility.
+	// Worker-based routes are rewritten to agent-based (worker ID becomes agent ID).
+	wfs := make([]config.WorkflowConfig, 0, len(routes))
+	for _, r := range routes {
+		agent := r.Agent
+		if agent == "" {
+			agent = r.Worker // backward compat: treat worker ID as agent ID
+		}
+		wfs = append(wfs, config.WorkflowConfig{
+			ID:      r.ID,
+			Trigger: &config.TriggerConfig{Priority: r.Priority, Match: r.Match},
+			Steps:   []config.StepConfig{{ID: "run", Agent: agent}},
+		})
+	}
 	return &config.Config{
-		Version: "1",
-		Workers: workers,
-		Routes:  routes,
+		Version:   "1",
+		Workflows: wfs,
 	}
 }
 
@@ -350,13 +363,13 @@ func TestRoute_CombinedConditions(t *testing.T) {
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-func assertMatch(t *testing.T, ok bool, m router.Match, wantWorker string) {
+func assertMatch(t *testing.T, ok bool, m router.Match, wantAgent string) {
 	t.Helper()
 	if !ok {
 		t.Fatal("expected a match, got none")
 	}
-	if m.Worker.ID != wantWorker {
-		t.Errorf("matched worker = %q, want %q", m.Worker.ID, wantWorker)
+	if m.Route.Agent != wantAgent {
+		t.Errorf("matched agent = %q, want %q", m.Route.Agent, wantAgent)
 	}
 }
 
@@ -407,14 +420,18 @@ func TestRoute_WorkflowTriggerBecomesRoute(t *testing.T) {
 func TestRoute_ExplicitRouteWinsOverTriggerByPriority(t *testing.T) {
 	c := &config.Config{
 		Version: "1",
-		Routes: []config.RouteConfig{
-			agentRoute("direct-engineer", 10, "engineer", config.RouteMatch{Source: "src-a", Labels: []string{"agent:engineer"}}),
+		Workflows: []config.WorkflowConfig{
+			{
+				ID:      "direct-engineer",
+				Trigger: &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src-a", Labels: []string{"agent:engineer"}}},
+				Steps:   []config.StepConfig{{ID: "run", Agent: "engineer"}},
+			},
+			{
+				ID:      "triage",
+				Trigger: &config.TriggerConfig{Priority: 100, Match: config.RouteMatch{Source: "src-a", ExcludeLabelPrefix: "agent:"}},
+				Steps:   []config.StepConfig{{ID: "classify", Agent: "investigator"}},
+			},
 		},
-		Workflows: []config.WorkflowConfig{{
-			ID:      "triage",
-			Trigger: &config.TriggerConfig{Priority: 100, Match: config.RouteMatch{Source: "src-a", ExcludeLabelPrefix: "agent:"}},
-			Steps:   []config.StepConfig{{ID: "classify", Agent: "investigator"}},
-		}},
 	}
 	r, err := router.New(c)
 	if err != nil {

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -276,17 +276,6 @@ func (e *Engine) findAgent(id string) *config.AgentConfig {
 	return nil
 }
 
-// SynthesizeWorkflow builds a single-step workflow equivalent to a plain route,
-// so routes and workflows execute through the same engine path.
-func SynthesizeWorkflow(route config.RouteConfig) config.WorkflowConfig {
-	oc := route.OnComplete
-	return config.WorkflowConfig{
-		ID:         route.ID,
-		Trigger:    &config.TriggerConfig{Priority: route.Priority, Match: route.Match},
-		Steps:      []config.StepConfig{{ID: "run", Agent: route.Agent}},
-		OnComplete: &oc,
-	}
-}
 
 func perStepComment(step config.StepConfig, res StepResult) string {
 	status := "✓ passed"

--- a/src/internal/workflow/engine_integration_test.go
+++ b/src/internal/workflow/engine_integration_test.go
@@ -35,7 +35,7 @@ func TestEngine_PersistsToRealSQLite(t *testing.T) {
 	var store Store = client
 	eng := NewEngine(cfg, store, exec)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{
+	wf := synthWF(config.RouteConfig{
 		ID: "backend-bugs", Agent: "backend-dev",
 		OnComplete: config.OnComplete{SetState: "in_review"},
 	})
@@ -100,7 +100,7 @@ func TestEngine_FailedStepPersistsFailedState(t *testing.T) {
 	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: false, Output: "boom"}}}
 	eng := NewEngine(cfg, client, exec)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "a"})
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "a"})
 	instID, success, _ := eng.RunInstance(ctx, wf, model.Cell{ID: "C1"})
 
 	if success {

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
+// synthWF converts a RouteConfig to an equivalent single-step WorkflowConfig.
+// Used only in tests; production code no longer has SynthesizeWorkflow.
+func synthWF(route config.RouteConfig) config.WorkflowConfig {
+	oc := route.OnComplete
+	return config.WorkflowConfig{
+		ID:         route.ID,
+		Trigger:    &config.TriggerConfig{Priority: route.Priority, Match: route.Match},
+		Steps:      []config.StepConfig{{ID: "run", Agent: route.Agent}},
+		OnComplete: &oc,
+	}
+}
+
 // fakeStore records instances and step runs in memory. Thread-safe so it can be
 // used from concurrent engine tests.
 type fakeStore struct {
@@ -135,7 +147,7 @@ func TestEngine_SingleStepSuccess(t *testing.T) {
 	side := &fakeSide{}
 	eng := testEngine(cfg, store, exec, side)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{
+	wf := synthWF(config.RouteConfig{
 		ID: "backend-bugs", Priority: 10, Agent: "backend-dev",
 		OnComplete: config.OnComplete{SetState: "in_review"},
 	})
@@ -177,7 +189,7 @@ func TestEngine_StepFailureMarksInstanceFailed(t *testing.T) {
 	side := &fakeSide{}
 	eng := testEngine(cfg, store, exec, side)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev",
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev",
 		OnComplete: config.OnComplete{SetState: "in_review"}})
 	wf.OnFail = &config.OnComplete{SetState: "blocked"}
 
@@ -284,7 +296,7 @@ func TestEngine_ResultCommentOnComplete(t *testing.T) {
 	side := &fakeSide{}
 	eng := testEngine(cfg, store, exec, side)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
 	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1", Title: "t"})
 
 	if len(side.comments) != 1 {
@@ -330,7 +342,7 @@ func TestEngine_ResultCommentOff(t *testing.T) {
 	side := &fakeSide{}
 	eng := testEngine(cfg, store, exec, side)
 
-	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
 	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
 
 	if len(side.comments) != 0 {
@@ -346,7 +358,7 @@ func TestEngine_StructuredOutputPersisted(t *testing.T) {
 	}}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	wf := SynthesizeWorkflow(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
 	_, _, _ = eng.RunInstance(context.Background(), wf, model.Cell{ID: "C1"})
 
 	sr := store.stepRuns[store.stepOrder[0]]
@@ -358,13 +370,13 @@ func TestEngine_StructuredOutputPersisted(t *testing.T) {
 	}
 }
 
-func TestSynthesizeWorkflow(t *testing.T) {
+func TestSynthWF(t *testing.T) {
 	route := config.RouteConfig{
 		ID: "backend-bugs", Priority: 10, Agent: "backend-dev",
 		Match:      config.RouteMatch{Source: "main-plane", Labels: []string{"bug"}},
 		OnComplete: config.OnComplete{SetState: "in_review"},
 	}
-	wf := SynthesizeWorkflow(route)
+	wf := synthWF(route)
 	if wf.ID != "backend-bugs" || len(wf.Steps) != 1 {
 		t.Fatalf("unexpected synthesized workflow: %+v", wf)
 	}


### PR DESCRIPTION
## Summary

- Remove `routes:` top-level section from config — task routing is now done exclusively through `workflows[].trigger`
- Remove `depends_on` from YAML-facing workflow step config — the v2 engine uses implicit sequential ordering (steps run in declaration order)
- Config lint hard-errors on both removed directives with clear migration hints
- `workflow_graph.go`: `on_fail.goto` ancestor check now falls back to sequential position for v2 workflows (where no `DependsOn` graph exists)
- Example YAML files updated: former `routes:` entries converted to single-step workflows with `trigger:`, all `depends_on:` removed from steps

## Test plan

- [ ] `go test ./...` passes in `src/` — all 27 changed files compile and all tests green
- [ ] `TestLint_ExampleConfigsNoFalsePositives` verifies all 4 example configs lint clean
- [ ] `TestWorkflowYAMLParsing` verifies complex workflow fixture parses and validates correctly
- [ ] `TestValidateV2_MixV1V2_Rejected` detects mixing v1 DependsOn with v2 If primitives

Closes #55