### PR TITLE
feat(task-model): InternalTask foundation — types and schema (Phase 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4195 symbols, 9337 relationships, 291 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4542 symbols, 10152 relationships, 299 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4195 symbols, 9337 relationships, 291 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4542 symbols, 10152 relationships, 299 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Ativas
 
-_(nenhuma change ativa no momento)_
+### internal-task-model
+
+InternalTask como unidade canônica de trabalho: sources viram binders (registram items, recebem output); fan-out de múltiplos workflows por task; write-back por step controlado pelo agente via `APIARY_PUBLISH`.
 
 ## Arquivadas
 

--- a/openspec/changes/internal-task-model/design.md
+++ b/openspec/changes/internal-task-model/design.md
@@ -1,0 +1,482 @@
+# Design: Internal Task Model
+
+## Architecture Overview
+
+The new layered model introduces InternalTask as the central unit. Sources are binders on the left edge; write-back targets on the right. Workflows can spawn new InternalTasks internally, creating a lineage tree independent of source systems.
+
+```mermaid
+flowchart TB
+    subgraph SOURCES["Sources — Binders"]
+        GH[GitHub Issues]
+        JI[Jira Tickets]
+        LM[Log Monitor]
+    end
+
+    subgraph BINDING["Binding Layer"]
+        AD["Adapter — Poll to SourceItem"]
+        SB["SourceBinder<br/>FindOrCreate InternalTask"]
+        BDB[(source_bindings)]
+    end
+
+    subgraph CORE["Core — Internal"]
+        IT[InternalTask]
+        TDB[(internal_tasks)]
+        RO["Router<br/>matches all triggers"]
+        SP["WorkflowSpawner<br/>APIARY_SPAWN handler"]
+    end
+
+    subgraph EXECUTION["Execution Layer"]
+        WF_A[Workflow A]
+        WF_B[Workflow B]
+        ENG["WorkflowEngine<br/>DAG · steps · approvals"]
+    end
+
+    subgraph WRITEBACK["Write-back"]
+        PUB["PublishQueue<br/>APIARY_PUBLISH"]
+        HOOK["TaskCompletionHook<br/>on_complete · on_fail"]
+        TC["Agent Tool Calls<br/>create issue · create task"]
+    end
+
+    GH -->|Poll| AD
+    JI -->|Poll| AD
+    LM -->|Poll| AD
+    AD --> SB
+    SB -->|writes| BDB
+    SB -->|creates or resolves| IT
+    IT -->|persisted in| TDB
+    IT --> RO
+    RO -->|fan-out| WF_A
+    RO -->|fan-out| WF_B
+    WF_A --> ENG
+    WF_B --> ENG
+    ENG -->|APIARY_SPAWN| SP
+    SP -->|creates child InternalTask| IT
+    ENG -->|APIARY_PUBLISH| PUB
+    ENG -->|all workflows done| HOOK
+    ENG -->|source tool calls| TC
+    PUB -->|WriteResult| GH
+    PUB -->|WriteResult| JI
+    HOOK -->|SetState AddLabels| GH
+    HOOK -->|SetState AddLabels| JI
+    TC -->|creates items| GH
+    TC -->|creates items| JI
+```
+
+---
+
+## Task Creation Paths
+
+There are two ways an InternalTask is created. Both enter the same Router → WorkflowEngine pipeline.
+
+```mermaid
+flowchart LR
+    subgraph PATH_A["Path A — Source-bound"]
+        SA["Source Adapter<br/>Poll"] --> SI[SourceItem]
+        SI --> SB2["SourceBinder<br/>FindOrCreate"]
+        SB2 --> IT_A["InternalTask<br/>has SourceBinding"]
+    end
+
+    subgraph PATH_B["Path B — Spawned"]
+        WF["Running Workflow Step"] -->|"APIARY_SPAWN marker"| SP2["WorkflowSpawner"]
+        SP2 --> IT_B["InternalTask<br/>parent_task_id set<br/>no SourceBinding"]
+    end
+
+    IT_A --> RO2[Router]
+    IT_B --> RO2
+    RO2 --> ENG2[WorkflowEngine]
+```
+
+---
+
+## Binding Flow
+
+How a source item becomes an InternalTask (Path A).
+
+```mermaid
+sequenceDiagram
+    participant Src as Source Adapter
+    participant Binder as SourceBinder
+    participant DB as Database
+    participant Router
+    participant Dispatcher
+
+    Src->>Binder: SourceItem from Poll
+    Binder->>DB: lookup source_bindings by source_id and source_item_id
+    alt binding exists
+        DB-->>Binder: existing task_id
+        Binder->>DB: SELECT internal_tasks by id
+        DB-->>Binder: InternalTask
+    else new item
+        Binder->>DB: INSERT internal_tasks
+        DB-->>Binder: new InternalTask state=registered
+        Binder->>DB: INSERT source_bindings
+    end
+    Binder->>Router: RouteAll InternalTask
+    Router-->>Binder: list of WorkflowMatches
+    loop each WorkflowMatch
+        Binder->>Dispatcher: Dispatch task and match
+    end
+```
+
+---
+
+## Spawn Flow
+
+How a workflow step creates a child InternalTask (Path B).
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Engine as WorkflowEngine
+    participant Spawner as WorkflowSpawner
+    participant DB as Database
+    participant Router
+    participant Dispatcher
+
+    Agent->>Engine: step output with APIARY_SPAWN marker
+    Engine->>Spawner: SpawnRequest: workflow + title + input JSON
+    Spawner->>DB: INSERT internal_tasks with parent_task_id and input
+    DB-->>Spawner: child InternalTask state=registered
+    Spawner->>Router: RouteAll child task
+    Router-->>Spawner: WorkflowMatch for named workflow
+    Spawner->>Dispatcher: Dispatch child task and match
+    Spawner-->>Engine: spawn acknowledged
+    Engine->>Engine: step continues — fire and forget by default
+```
+
+---
+
+## Fan-out Dispatch
+
+One InternalTask triggers N workflows. Each runs independently; the task tracks how many are outstanding.
+
+```mermaid
+flowchart LR
+    IT["InternalTask<br/>state: registered"]
+
+    IT --> R{"Router<br/>evaluates ALL triggers"}
+
+    R -->|"p=100 exclusive=false"| WF_A["code-review"]
+    R -->|"p=200 exclusive=false"| WF_B["docs-update"]
+    R -->|"p=300 exclusive=true"| WF_C["security-scan"]
+
+    WF_A --> RUN_A["RunInstance A<br/>running"]
+    WF_B --> RUN_B["RunInstance B<br/>running"]
+    WF_C --> RUN_C["RunInstance C<br/>running"]
+
+    RUN_A -->|done| TRACK{"outstanding = 0?"}
+    RUN_B -->|done| TRACK
+    RUN_C -->|done| TRACK
+
+    TRACK -->|yes| HOOK[TaskCompletionHook]
+    TRACK -->|no| WAIT[wait]
+```
+
+**Exclusive flag semantics:**
+
+```mermaid
+flowchart TD
+    T["Evaluate triggers<br/>ordered by priority"]
+    T --> M{"trigger matches?"}
+    M -->|no| NEXT[next trigger]
+    M -->|yes| DISPATCH[dispatch workflow]
+    DISPATCH --> EX{"exclusive: true?"}
+    EX -->|yes| STOP["stop — no more triggers"]
+    EX -->|no| NEXT
+    NEXT --> M
+```
+
+---
+
+## Per-Step Write-back
+
+Write-back is agent-driven. The agent emits an `APIARY_PUBLISH` block; the engine fans it out to every SourceBinding. If the task has no bindings the marker is silently ignored.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Engine as WorkflowEngine
+    participant PQ as PublishQueue
+    participant DB
+    participant Src as Source Adapters
+
+    Agent->>Engine: step output
+    Engine->>Engine: parse APIARY_PUBLISH marker
+    alt marker found
+        Engine->>DB: SELECT source_bindings by task_id
+        DB-->>Engine: list of SourceBindings
+        alt bindings exist
+            loop each binding
+                Engine->>PQ: enqueue binding and payload
+            end
+            PQ->>Src: WriteResult with payload
+        else no bindings
+            Engine->>Engine: silently ignore
+        end
+    else no marker
+        Engine->>Engine: no write-back
+    end
+```
+
+**Step config — publish control:**
+
+```mermaid
+flowchart LR
+    SC["StepConfig<br/>publish: auto or off"]
+    SC -->|auto| AGT{"Agent emits<br/>APIARY_PUBLISH?"}
+    SC -->|off| SKIP["skip write-back"]
+    AGT -->|yes| WB[write-back fired]
+    AGT -->|no| NOP[no write-back]
+```
+
+---
+
+## Source-mediated Fan-out vs Internal Spawn
+
+```mermaid
+flowchart TB
+    TW["Triage Workflow<br/>running on InternalTask T1"]
+
+    TW -->|"Route A:<br/>add label workflow:engineer<br/>via tool call"| SRC["Source System<br/>GitHub or Jira"]
+    SRC -->|"next Poll cycle"| SB3["SourceBinder<br/>new SourceItem found"]
+    SB3 --> T2["InternalTask T2<br/>SourceBinding to child issue"]
+    T2 --> EW["Engineer Workflow"]
+
+    TW -->|"Route B:<br/>APIARY_SPAWN marker"| SP3["WorkflowSpawner"]
+    SP3 --> T3["InternalTask T3<br/>parent = T1<br/>no SourceBinding"]
+    T3 --> CW["Collect Workflow"]
+```
+
+**When to use each:**
+
+| | Source-mediated | APIARY_SPAWN |
+|---|---|---|
+| Downstream work needs a ticket | yes | no |
+| No source system at the top | no | yes |
+| Incident or log-driven chains | no | yes |
+| Staff creating Jira stories | yes | no |
+| Collect workflow before Staff | no | yes |
+
+---
+
+## Task Lineage
+
+The Incident → Collect → Staff → Fix chain as a lineage tree.
+
+```mermaid
+flowchart TB
+    L["Log event<br/>source: log-monitor"]
+    L --> INC["InternalTask: Incident<br/>source binding: log-monitor"]
+    INC -->|"APIARY_SPAWN"| COL["InternalTask: Collect<br/>parent: Incident<br/>no binding"]
+    COL -->|"APIARY_SPAWN"| STA["InternalTask: Staff<br/>parent: Collect<br/>no binding"]
+    STA -->|"tool call: create issue"| FA["InternalTask: Fix A<br/>source binding: github"]
+    STA -->|"tool call: create task"| FB["InternalTask: Fix B<br/>source binding: jira"]
+    STA -->|"tool call: create task"| FC["InternalTask: Fix C<br/>source binding: jira"]
+    FA --> EW_A["Engineer Workflow"]
+    FB --> EW_B["Engineer Workflow"]
+    FC --> EW_C["Engineer Workflow"]
+```
+
+---
+
+## InternalTask State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> registered: SourceBinder creates or Spawner creates
+
+    registered --> running: first workflow dispatched
+
+    running --> running: fan-out workflow added
+
+    running --> approval_waiting: step parks for approval
+
+    approval_waiting --> running: approval granted or timed out
+
+    running --> done: last outstanding workflow succeeds
+
+    running --> failed: workflow fails with no retry
+
+    done --> [*]
+    failed --> [*]
+```
+
+---
+
+## Data Model
+
+### New Tables
+
+```sql
+-- Canonical internal task registry
+CREATE TABLE internal_tasks (
+    id                    TEXT PRIMARY KEY,     -- ulid
+    parent_task_id        TEXT REFERENCES internal_tasks(id),  -- set for spawned tasks
+    title                 TEXT NOT NULL,
+    description           TEXT,
+    input                 TEXT,                 -- JSON: structured input from spawner
+    state                 TEXT NOT NULL DEFAULT 'registered',
+    -- 'registered' | 'running' | 'approval_waiting' | 'done' | 'failed'
+    metadata              TEXT,                 -- JSON: labels, priority, type, etc.
+    outstanding_workflows INTEGER DEFAULT 0,
+    created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Links source items to InternalTasks (one-to-many, optional)
+CREATE TABLE source_bindings (
+    id                 TEXT PRIMARY KEY,        -- ulid
+    task_id            TEXT NOT NULL REFERENCES internal_tasks(id),
+    source_id          TEXT NOT NULL,           -- e.g. "github", "jira"
+    source_item_id     TEXT NOT NULL,           -- source-native item ID
+    source_item_url    TEXT,                    -- deep-link for display
+    source_item_number TEXT,                    -- human ref: "#42", "ERP-42"
+    created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_id, source_item_id)
+);
+```
+
+### Modified Tables
+
+```sql
+-- workflow_instances: replace source_item_id+source_id with task_id
+ALTER TABLE workflow_instances
+    ADD COLUMN task_id TEXT REFERENCES internal_tasks(id);
+-- source_item_id and source_id retained for backward compat during migration, then dropped
+
+-- step_runs: add publish and spawn tracking
+ALTER TABLE step_runs
+    ADD COLUMN publish_payload TEXT,            -- extracted APIARY_PUBLISH content, if any
+    ADD COLUMN publish_state   TEXT,            -- null | 'queued' | 'sent' | 'failed'
+    ADD COLUMN spawned_task_id TEXT REFERENCES internal_tasks(id);  -- if step emitted APIARY_SPAWN
+```
+
+### Dropped (after migration)
+
+```sql
+-- workflow_instances.source_item_id  → replaced by task_id
+-- workflow_instances.source_id       → resolved via source_bindings
+```
+
+---
+
+## Go Types
+
+```go
+// internal/model/task.go
+
+type TaskState string
+
+const (
+    TaskStateRegistered   TaskState = "registered"
+    TaskStateRunning      TaskState = "running"
+    TaskStateApprovalWait TaskState = "approval_waiting"
+    TaskStateDone         TaskState = "done"
+    TaskStateFailed       TaskState = "failed"
+)
+
+type InternalTask struct {
+    ID                   string
+    ParentTaskID         string            // empty if root task
+    Title                string
+    Description          string
+    Input                map[string]any    // structured input from spawner, nil for source-bound tasks
+    State                TaskState
+    Metadata             TaskMetadata
+    OutstandingWorkflows int
+    CreatedAt            time.Time
+    UpdatedAt            time.Time
+}
+
+type TaskMetadata struct {
+    Labels   []string
+    Priority string
+    Type     string     // "issue", "work_item", "log_event", "internal", ...
+}
+
+type SourceBinding struct {
+    ID               string
+    TaskID           string
+    SourceID         string
+    SourceItemID     string
+    SourceItemURL    string
+    SourceItemNumber string
+    CreatedAt        time.Time
+}
+```
+
+```go
+// internal/source/binder.go
+
+type SourceBinder interface {
+    // Bind normalizes a SourceItem into an InternalTask, creates a SourceBinding
+    // if one does not exist yet, and returns the task (new or existing).
+    Bind(ctx context.Context, item model.SourceItem) (model.InternalTask, error)
+}
+```
+
+```go
+// internal/workflow/spawner.go
+
+type SpawnRequest struct {
+    ParentTaskID string
+    WorkflowID   string
+    Title        string
+    Input        map[string]any
+}
+
+type WorkflowSpawner interface {
+    Spawn(ctx context.Context, req SpawnRequest) (model.InternalTask, error)
+}
+```
+
+```go
+// internal/config/config.go — additions
+
+type TriggerConfig struct {
+    Priority  int        `yaml:"priority"`
+    Exclusive bool       `yaml:"exclusive"` // stops evaluating further triggers
+    Match     RouteMatch `yaml:"match"`
+}
+
+type StepConfig struct {
+    // ... existing fields ...
+    Publish string `yaml:"publish"` // "auto" (default) | "off"
+    Spawn   string `yaml:"spawn"`   // "auto" (default, fire-and-forget) | "await"
+}
+
+type TasksConfig struct {              // top-level tasks: block
+    OnComplete *OnComplete `yaml:"on_complete"`
+    OnFail     *OnComplete `yaml:"on_fail"`
+}
+```
+
+---
+
+## Affected Components
+
+| Component | Change |
+|---|---|
+| `internal/source/binder.go` | **New.** SourceBinder; replaces inline SourceItem→dispatch in daemon |
+| `internal/workflow/spawner.go` | **New.** WorkflowSpawner; handles APIARY_SPAWN, creates child InternalTasks |
+| `internal/model/task.go` | **New.** InternalTask, SourceBinding, TaskMetadata types |
+| `internal/model/source_item.go` | **Renamed from cell.go.** SourceItem stays within binding layer only |
+| `internal/router/router.go` | **Changed.** `Route(SourceItem)` → `RouteAll(InternalTask) []Match` |
+| `internal/daemon/dispatcher.go` | **Changed.** Calls binder, passes task to RouteAll, fans out dispatches |
+| `internal/workflow/engine.go` | **Changed.** Accepts InternalTask; parses APIARY_SPAWN and APIARY_PUBLISH markers; resolves bindings for write-back |
+| `internal/daemon/workflow.go` | **Changed.** SideEffects resolves adapter via SourceBinding, not SourceItem.SourceID |
+| `internal/db/schema.go` | **Changed.** New tables; migration for workflow_instances |
+| `internal/config/config.go` | **Changed.** TriggerConfig.Exclusive, StepConfig.Publish, StepConfig.Spawn, new TasksConfig |
+| `apps/dashboard` | **Changed.** Task view shows lineage tree, SourceBindings, and WorkflowInstances per task |
+
+---
+
+## Open Questions
+
+1. **Multi-source binding**: today a task has one binding (one source item). The schema supports many. Should the binder ever merge two source items into one InternalTask? Deferred.
+
+2. **Await semantics for spawn**: when `spawn: await`, the spawning step blocks until the child task reaches a terminal state. If the child fails, does the parent step fail too? Proposed default: yes (propagate failure). Deferred to implementation.
+
+3. **Per-binding publish**: currently `APIARY_PUBLISH` fans out to all bindings equally. A future `APIARY_PUBLISH[github]` syntax could target a specific source. Deferred.
+
+4. **Tool-created source items and lineage**: when an agent creates a GitHub issue via tool call, there is no automatic link back to the parent task. The spawned InternalTask only gets its SourceBinding when the new issue is polled and bound. A future `APIARY_BIND` marker or tool return hook could accelerate this. Deferred.

--- a/openspec/changes/internal-task-model/proposal.md
+++ b/openspec/changes/internal-task-model/proposal.md
@@ -1,0 +1,267 @@
+# Proposal: Internal Task Model
+
+## Why
+
+The current architecture treats the **`SourceItem`** — a normalized view of a source item (GitHub Issue, Plane Work-Item) — as the canonical unit of work. The SourceItem flows through routing, workflow execution, side-effects, and approval logic. Every component that touches a task ultimately holds a `SourceItem` with a `SourceID`, making the source system the implicit owner of task identity and state.
+
+This design worked well for simple dispatch (one source item → one workflow) but creates three compounding problems as workflows grow more complex:
+
+1. **One source item can only trigger one workflow.** The router's first-match-wins logic means a GitHub issue labelled `apiary` can dispatch at most one workflow. If you want a code-review *and* a documentation-update to run on the same issue, you need manual workarounds or nested sub-workflows — not a clean fan-out.
+
+2. **Source systems are in the hot path.** Approval polling hits the source API every cycle. Side-effects write back on every step. The workflow engine cannot make any decision without knowing which source adapter to call. This couples execution semantics to source availability.
+
+3. **There is no internal task.** There is no object that represents "this unit of work" independent of its origin. You cannot create a task from an API call, a webhook, a schedule, or a future source type without first manufacturing a fake SourceItem — which is already awkward.
+
+4. **Workflows cannot chain into other workflows.** If a Triage workflow decides that a problem needs an Engineer workflow, there is no first-class way to express that. The only option is sub-workflows, but those are nested and share the same source binding — not independent units of work dispatched to their own execution context.
+
+The fix is to promote **InternalTask** to first-class status, demote sources to **binders** that register work and receive output, and introduce two clean fan-out paths: source-mediated and internal.
+
+---
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Canonical work unit** | `SourceItem` (source-tied) | `InternalTask` (source-independent) |
+| **Source role** | Drives everything: triggers, state, write-back | Registers tasks; receives output log |
+| **Workflow trigger** | One match per SourceItem | N workflows per InternalTask (fan-out) |
+| **Write-back** | Configured globally per workflow | Optional per step; agent decides whether to emit |
+| **Task identity** | `source_item_id + source_id` (compound) | `task_id` (single, internal) |
+| **Workflow chaining** | Sub-workflows only (nested, same binding) | Spawned tasks (independent InternalTasks with lineage) |
+| **Approval polling** | Polls source for comment/label changes | Polls source only when step explicitly requires it |
+
+---
+
+## New Concepts
+
+| Term | Description |
+|---|---|
+| **InternalTask** | The canonical, source-independent unit of work. Has its own ID, title, description, state, input payload, and metadata. May be created from a source binding or spawned by a workflow step. |
+| **SourceBinding** | A link from a source item (`source_id + source_item_id`) to an InternalTask. One task may have many bindings; today, one — but the model is open. Source bindings are optional: spawned tasks may have none. |
+| **Binder** | The role sources play: they register items as InternalTasks via bindings and receive the task's output. They do not own state. |
+| **Task Fan-out** | The ability for one InternalTask to trigger multiple named workflows simultaneously or sequentially. |
+| **Spawned Task** | An InternalTask created by a workflow step rather than a source adapter. It carries a `parent_task_id` linking it to the originating task, and a structured `input` payload passed by the spawning step. It has no source binding at creation time. |
+| **Task Lineage** | The `parent_task_id` chain linking spawned tasks back to their origin. Enables tracing from a targeted fix task all the way back to the original incident or triage item. |
+| **`APIARY_SPAWN` marker** | An agent-emitted marker (analogous to `APIARY_PUBLISH`) that instructs the engine to create a new InternalTask and dispatch a named workflow against it. Used for pure internal chaining when no source item exists at the top. |
+| **Source-mediated fan-out** | A workflow agent creates new source items (GitHub issues, Jira tasks/stories) via tool calls. Those items are picked up naturally by the Poll → Bind → Route cycle and dispatched to their targeted workflows without a triage step. |
+| **Step Publish** | An optional, agent-controlled action within a step that writes a message back to all source bindings of the task. The agent emits a marker to opt in; silence means no write-back. |
+| **Task Completion Hook** | An `on_complete` / `on_fail` hook at the InternalTask level (not per-workflow), applied after all bound workflows reach terminal state. |
+
+---
+
+## What Stays
+
+- **Sources / Adapters** — unchanged interface; they still `Poll`, `Acknowledge`, and `WriteResult`. They just do it on instruction from the task layer, not inline with dispatch.
+- **Router** — matching logic is unchanged; it now matches against InternalTask metadata instead of SourceItem fields.
+- **WorkflowEngine** — DAG execution, split, foreach, approvals, resume — all unchanged. It now operates on InternalTask + SourceBindings instead of SourceItem.
+- **Agents and Runners** — completely unchanged.
+- **Step-level config** — unchanged, plus optional `publish` and `spawn` blocks described below.
+
+---
+
+## Core Behaviors
+
+### 1. Source as Binder
+
+When a source adapter polls and returns a SourceItem, the **SourceBinder** layer translates it into an InternalTask:
+
+- If an InternalTask already exists for this `(source_id, source_item_id)` pair, retrieve it (resume/dedup logic unchanged).
+- If not, create a new InternalTask from the SourceItem's fields (title, description, metadata).
+- Record the SourceBinding linking the SourceItem back to the task.
+- The SourceItem is then discarded — only the InternalTask travels forward into routing and execution.
+
+Sources write back via their SourceBinding when instructed. They are never polled or called unless a step explicitly requests it (approval steps) or a write-back is queued.
+
+### 2. Workflow Fan-out
+
+The router evaluates an InternalTask against **all** registered workflow triggers (not first-match-wins). Every matching trigger produces a workflow dispatch. The dispatcher starts all matched workflows; they run independently against the same InternalTask.
+
+Fan-out ordering is controlled by a new `trigger.priority` semantic:
+- `priority` (existing field) still determines order for conflict-resolution when only one workflow should run.
+- A new `trigger.exclusive: true` flag (default `false`) opts a workflow into first-match-wins, suppressing lower-priority matches.
+
+### 3. Two Fan-out Paths
+
+Once a workflow is running, it can spawn downstream work via two patterns:
+
+**Pattern A — Source-mediated fan-out**
+
+The agent uses tool calls to create new items in a source system (e.g., create a GitHub issue, create a Jira task). Those items are picked up on the next Poll cycle, bound as new InternalTasks, and dispatched to their targeted workflows through the normal route. No engine mechanism needed.
+
+The original source item is handled as the agent (and user config) decides:
+- GitHub: close the original issue, or leave it open with links to child issues.
+- Jira: convert the original ticket to an Epic, create tasks/stories under it.
+
+This is the right pattern when downstream work should be visible and trackable in the source system.
+
+**Pattern B — Internal fan-out via `APIARY_SPAWN`**
+
+The agent emits an `APIARY_SPAWN` marker when there is no source system to go through, or when the downstream task is purely internal:
+
+```
+APIARY_SPAWN_BEGIN
+{
+  "workflow": "collect-workflow",
+  "title": "Collect context for incident #4421",
+  "input": {
+    "log_event": "...",
+    "service": "payments",
+    "severity": "critical"
+  }
+}
+APIARY_SPAWN_END
+```
+
+When the engine detects this marker:
+1. It creates a new InternalTask with `parent_task_id` pointing to the current task.
+2. It populates the new task's `input` field with the provided JSON.
+3. It dispatches the named workflow against the new task.
+4. The spawning step continues; it does not wait for the spawned task (fire-and-forget by default).
+
+Spawned tasks have no source binding initially. If the spawned workflow later creates source items via tool calls, those bindings are added then.
+
+### 4. Per-Step Write-back
+
+Write-back to sources is **agent-driven, not config-driven**. A step agent can emit an `APIARY_PUBLISH` marker in its output — containing the message to post. If no marker is emitted, no write-back occurs for that step.
+
+```
+APIARY_PUBLISH_BEGIN
+Triage complete. Routing to engineer workflow — estimated complexity: medium.
+APIARY_PUBLISH_END
+```
+
+When the engine detects this marker:
+1. It extracts the publish payload.
+2. It queues a write-back against every SourceBinding on the InternalTask.
+3. Each binding's source adapter calls `WriteResult` with the payload.
+
+If a task has no source bindings (purely internal spawned task), `APIARY_PUBLISH` is silently ignored.
+
+### 5. Task Completion Hook
+
+Once **all workflows** bound to an InternalTask reach a terminal state (done or failed), the task-level completion hook fires:
+
+```yaml
+tasks:
+  on_complete:
+    add_labels: ["done"]
+    set_state: "closed"
+  on_fail:
+    add_labels: ["failed"]
+    set_state: "open"
+```
+
+This replaces per-workflow `on_complete` for source write-back. Workflows may still have their own `on_complete` for internal state changes (e.g., setting a workflow-level label without closing the issue).
+
+---
+
+## New Config Schema
+
+### Workflow trigger — fan-out enabled by default
+
+```yaml
+workflows:
+  - id: triage
+    trigger:
+      priority: 100
+      exclusive: true         # first match only — triage owns the issue
+      match:
+        source: github
+        labels: ["apiary"]
+
+  - id: engineer-workflow
+    trigger:
+      priority: 100
+      exclusive: true
+      match:
+        labels: ["workflow:engineer"]  # set by triage agent via tool call or label
+```
+
+### Step publish marker (agent-emitted, no config)
+
+Step config gains an optional `publish` field only to **suppress** write-back for a specific step:
+
+```yaml
+steps:
+  - id: internal-analysis
+    agent: analyzer
+    publish: off          # never write-back even if agent emits marker
+```
+
+Default is `publish: auto` (agent decides).
+
+### Step spawn — suppress or await
+
+By default, spawned tasks are fire-and-forget. A step can optionally wait for a spawned task to complete before continuing:
+
+```yaml
+steps:
+  - id: collect
+    agent: collector
+    spawn: await           # block until spawned task finishes
+```
+
+Default is `spawn: auto` (fire-and-forget).
+
+### Task-level completion hook
+
+```yaml
+# top-level in apiary.yaml
+tasks:
+  on_complete:
+    add_labels: ["done"]
+    set_state: "closed"
+  on_fail:
+    add_labels: ["needs-review"]
+```
+
+---
+
+## Concrete Use Case: ERP Project Workflows
+
+### Triage workflow
+- **Triggered by**: GitHub issue or Jira ticket with label `apiary`
+- **What it does**: Analyzes the issue; decides whether to route to Engineer or Staff workflow
+- **Fan-out pattern**: Source-mediated — agent adds label `workflow:engineer` or `workflow:staff` to the issue, which the router picks up on the next poll. Alternatively, agent emits `APIARY_SPAWN` directly.
+- **Original issue**: Agent decides — may add a triage comment via `APIARY_PUBLISH`, leaves issue open.
+
+### Engineer workflow
+- **Triggered by**: Task with label `workflow:engineer` (set by triage)
+- **What it does**: Engineer step → Code review step → QA step
+- **Write-back**: Each step may post progress comments via `APIARY_PUBLISH`
+- **Completion**: Closes original issue via task completion hook.
+
+### Staff workflow
+- **Triggered by**: Task with label `workflow:staff` (set by triage)
+- **What it does**: Breaks work into smaller deliverables; creates child issues/tasks via tool calls
+  - GitHub: closes or links original issue; creates N targeted child issues with specific labels
+  - Jira: converts original ticket to Epic; creates tasks/stories under it
+- **Fan-out**: Child issues/tasks are picked up on next poll — each routes directly to targeted workflow (engineer, docs, etc.) with no triage needed, because the agent already set the right labels.
+
+### Incident workflow
+- **Triggered by**: Production log event (log monitor source adapter)
+- **What it does**:
+  1. Spawns a Collect task via `APIARY_SPAWN` (internal, no source binding)
+  2. Collect workflow gathers logs, metrics, user session data
+  3. Collect step spawns Staff task via `APIARY_SPAWN` with collected data as input
+  4. Staff workflow runs — at this point it switches to source-mediated fan-out, creating Jira tasks or GitHub issues that become independently tracked items
+
+**Lineage chain**:
+```
+log event
+  → Incident task (source: log-monitor)
+      → Collect task (spawned, parent: incident)
+          → Staff task (spawned, parent: collect)
+              → Fix task A (source: jira, parent: staff)
+              → Fix task B (source: jira, parent: staff)
+              → Fix task C (source: github, parent: staff)
+```
+
+---
+
+## Migration Notes
+
+- Existing `on_complete` / `on_fail` blocks on workflows continue to work and are applied per-workflow (not at task completion). The new task-level hook is additive.
+- `result_comment: per_step` and `result_comment: on_complete` are deprecated in favor of the agent-driven `APIARY_PUBLISH` marker. They remain functional but emit a deprecation warning.
+- The `SourceItem` type is retained internally as the normalized source item within the binding layer; it is no longer the unit passed to the router or engine.
+- Existing single-workflow configs require no changes — the fan-out model is backward compatible (one match = one workflow, same as before).

--- a/openspec/changes/internal-task-model/tasks.md
+++ b/openspec/changes/internal-task-model/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: Internal Task Model
+
+Implementation follows 9 phases. Each phase produces a shippable state and must pass `go test ./...` before the next begins. Read `proposal.md` and `design.md` before starting.
+
+**Key references:**
+- `design.md` — data model, Go types, affected components, all Mermaid diagrams
+- `proposal.md` — behavioral spec, config schema, ERP use case walkthrough
+
+---
+
+## Phase 1 — Foundation: Types & DB Schema
+
+Introduce the new Go types and database tables with no behavioral change. Existing execution paths are untouched.
+
+### 1.1 Go Types
+
+- [ ] 1.1.1 Create `src/internal/model/task.go`: `InternalTask`, `TaskState` constants, `TaskMetadata`, `SourceBinding`, `SpawnRequest` structs (see `design.md` → Go Types)
+- [ ] 1.1.2 Create `src/internal/model/source_item.go` as a copy of `cell.go` with type renamed to `SourceItem` (keep `cell.go` temporarily with a `// Deprecated: use SourceItem` comment — removed in Phase 2)
+- [ ] 1.1.3 Unit tests: zero-value constructors, JSON round-trip on `TaskMetadata.Input`
+
+### 1.2 DB Schema — new tables
+
+- [ ] 1.2.1 Add `internal_tasks` table to `src/internal/db/schema.go` (columns: `id`, `parent_task_id`, `title`, `description`, `input`, `state`, `metadata`, `outstanding_workflows`, `created_at`, `updated_at`)
+- [ ] 1.2.2 Add `source_bindings` table (columns: `id`, `task_id`, `source_id`, `source_item_id`, `source_item_url`, `source_item_number`, `created_at`; unique constraint on `(source_id, source_item_id)`)
+- [ ] 1.2.3 Add migration: `ALTER TABLE workflow_instances ADD COLUMN task_id TEXT REFERENCES internal_tasks(id)` (nullable during migration)
+- [ ] 1.2.4 Add migration: `ALTER TABLE step_runs ADD COLUMN publish_payload TEXT`, `publish_state TEXT`, `spawned_task_id TEXT REFERENCES internal_tasks(id)`
+- [ ] 1.2.5 Implement `InternalTaskStore` in `src/internal/db/task_store.go`: `CreateTask`, `GetTask`, `UpdateTaskState`, `IncrementOutstanding`, `DecrementOutstanding`, `ListTasksByState`
+- [ ] 1.2.6 Implement `SourceBindingStore` in same file or `binding_store.go`: `CreateBinding`, `GetBindingBySourceItem`, `ListBindingsByTask`
+- [ ] 1.2.7 Unit tests: CRUD round-trip for both stores against a real in-memory SQLite
+
+---
+
+## Phase 2 — SourceItem Rename
+
+Complete the `Cell` → `SourceItem` rename across the entire codebase. No behavioral change.
+
+### 2.1 Rename
+
+- [ ] 2.1.1 Delete `src/internal/model/cell.go`; confirm all references now import `SourceItem` from `task.go`
+- [ ] 2.1.2 Update `src/internal/source/source.go`: `Adapter.Poll` returns `[]model.SourceItem`; update `Acknowledge`, `WriteResult`, `TaskPoller.PollTask` signatures
+- [ ] 2.1.3 Update all source adapters (`github/adapter.go`, `plane/adapter.go`): rename `toCell` → `toSourceItem`, update return types
+- [ ] 2.1.4 Update `src/internal/router/router.go`: rename `Route(cell model.Cell)` → `Route(item model.SourceItem)` (single-match, still used internally in Phase 3 transition)
+- [ ] 2.1.5 Update `src/internal/daemon/dispatcher.go` and `workflow.go`: replace all `Cell` references with `SourceItem`
+- [ ] 2.1.6 Update `src/internal/workflow/engine.go` and all workflow files: replace `Cell` with `SourceItem`
+- [ ] 2.1.7 Full grep check: `grep -rn "model\.Cell\b" src/` must return empty
+- [ ] 2.1.8 Run `go test ./...` — must stay green (no behavioral change)
+
+---
+
+## Phase 3 — Binding Layer
+
+Introduce `SourceBinder` between the adapter poll and the dispatcher. The binder creates or retrieves an `InternalTask` for each `SourceItem`. Dispatch still goes to a single workflow (fan-out comes in Phase 4).
+
+### 3.1 SourceBinder
+
+- [ ] 3.1.1 Create `src/internal/source/binder.go`: `SourceBinder` interface (`Bind(ctx, SourceItem) (InternalTask, error)`) and `DefaultSourceBinder` struct
+- [ ] 3.1.2 Implement `Bind`: lookup `source_bindings` by `(source_id, source_item_id)`; if found, fetch and return the existing `InternalTask`; if not, create `InternalTask` + `SourceBinding` in a transaction
+- [ ] 3.1.3 Wire `SourceBinder` into `src/internal/daemon/dispatcher.go`: call `binder.Bind(item)` after each poll item; pass the resulting `InternalTask` forward (still wrapping in a synthetic SourceItem struct for the router for now — cleaned up in Phase 4)
+- [ ] 3.1.4 Unit tests: new item creates task + binding; same item on second poll returns existing task; concurrent bind with same `(source_id, source_item_id)` deduplicates correctly (unique constraint handling)
+
+---
+
+## Phase 4 — Router Fan-out
+
+Replace first-match-wins dispatch with all-matches dispatch. Introduce `trigger.exclusive`.
+
+### 4.1 Router Changes
+
+- [ ] 4.1.1 Add `Exclusive bool` to `TriggerConfig` in `src/internal/config/config.go`
+- [ ] 4.1.2 Add `RouteAll(task model.InternalTask) []Match` to `src/internal/router/router.go`: evaluates all triggers in priority order; stops after first exclusive match; returns all matches
+- [ ] 4.1.3 Unit tests: two non-exclusive triggers both match; exclusive trigger stops evaluation; priority ordering is respected
+
+### 4.2 Dispatcher Fan-out
+
+- [ ] 4.2.1 Update `src/internal/daemon/dispatcher.go`: call `router.RouteAll(task)` instead of `router.Route(item)`; call `dispatchWorkflow` for each match
+- [ ] 4.2.2 Increment `task.outstanding_workflows` by the number of dispatched workflows before any starts
+- [ ] 4.2.3 Unit tests: one task dispatches to two workflows when two triggers match; exclusive trigger dispatches only one
+
+---
+
+## Phase 5 — Engine: InternalTask & SourceBindings
+
+Update the workflow engine to operate on `InternalTask` + `[]SourceBinding` instead of `SourceItem`. Side-effects resolve via bindings.
+
+### 5.1 Engine Signature
+
+- [ ] 5.1.1 Update `WorkflowEngine.RunInstance` signature: `RunInstance(ctx, wf WorkflowConfig, task model.InternalTask) (instanceID, success, err)` — remove `SourceItem` parameter
+- [ ] 5.1.2 Update `workflow_instances` write path: store `task_id` (not `source_item_id + source_id`)
+- [ ] 5.1.3 Update `wfSideEffects`: resolve the source adapter by looking up `source_bindings` for the task instead of reading `SourceItem.SourceID` directly
+- [ ] 5.1.4 Update `StateLock`, `PostComment`, `ApplyHook` to fan-out to all bindings (today: one binding per task — this is a no-op change in behavior but correctness for future multi-binding tasks)
+- [ ] 5.1.5 Update `CheckParkedApprovals`: resolve the `TaskPoller` adapter via `source_bindings` instead of `cell.SourceID`
+- [ ] 5.1.6 Integration test: engine runs a workflow against a task with one binding; side-effects call the correct adapter
+
+---
+
+## Phase 6 — APIARY_PUBLISH
+
+Replace `result_comment` config-driven write-back with the agent-driven `APIARY_PUBLISH` marker. Old config is deprecated with a warning.
+
+### 6.1 Marker Parsing
+
+- [ ] 6.1.1 Add `APIARY_PUBLISH_BEGIN` / `APIARY_PUBLISH_END` block parsing to `src/internal/runner/structured.go` (alongside existing `APIARY_OUTPUT` and `APIARY_SUMMARY` parsers); extract text payload into `RunResult.PublishPayload`
+- [ ] 6.1.2 Respect `StepConfig.Publish`: if `"off"`, clear `PublishPayload` before the engine sees it even if the agent emitted the marker
+
+### 6.2 Write-back Execution
+
+- [ ] 6.2.1 In the engine step completion path: if `RunResult.PublishPayload` is non-empty, call `SideEffects.PostComment` for each `SourceBinding` on the task; if the task has no bindings, silently skip
+- [ ] 6.2.2 Persist `publish_payload` and `publish_state` (`sent`/`failed`/`skipped`) in the `step_runs` row
+- [ ] 6.2.3 Add `Publish string` (`"auto"` | `"off"`) to `StepConfig`; default `"auto"`
+
+### 6.3 Deprecation
+
+- [ ] 6.3.1 Emit a `log.Warn` at config load when `result_comment` is set to any non-default value: `result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead`
+- [ ] 6.3.2 Keep `result_comment: on_complete` and `result_comment: per_step` functional (fallback path) until a future removal change
+
+### 6.4 Tests
+
+- [ ] 6.4.1 Unit test: agent output with `APIARY_PUBLISH` block → `PostComment` called once per binding
+- [ ] 6.4.2 Unit test: `publish: off` suppresses write-back even when marker is present
+- [ ] 6.4.3 Unit test: task with no source bindings — publish silently skipped, no error
+
+---
+
+## Phase 7 — APIARY_SPAWN & WorkflowSpawner
+
+Introduce the internal fan-out path: a workflow step emits `APIARY_SPAWN` and the engine creates a child `InternalTask` and dispatches the named workflow.
+
+### 7.1 WorkflowSpawner
+
+- [ ] 7.1.1 Create `src/internal/workflow/spawner.go`: `WorkflowSpawner` interface and `DefaultSpawner` struct
+- [ ] 7.1.2 Implement `Spawn(ctx, SpawnRequest) (InternalTask, error)`: create `InternalTask` with `parent_task_id` + `input` JSON; call `router.RouteAll` on the new task; dispatch matched workflows via `Dispatcher`
+- [ ] 7.1.3 Wire `WorkflowSpawner` into `WorkflowEngine` via an interface field (keeps engine testable in isolation)
+
+### 7.2 Marker Parsing & Engine Integration
+
+- [ ] 7.2.1 Add `APIARY_SPAWN_BEGIN` / `APIARY_SPAWN_END` block parsing in `structured.go`; parse content as JSON into `RunResult.SpawnRequest` (`workflow`, `title`, `input` fields)
+- [ ] 7.2.2 In the engine step completion path: if `RunResult.SpawnRequest` is set, call `spawner.Spawn`; record the returned `child_task_id` in `step_runs.spawned_task_id`
+- [ ] 7.2.3 Default behavior: fire-and-forget (step does not block on child outcome)
+- [ ] 7.2.4 Add `Spawn string` (`"auto"` | `"await"`) to `StepConfig`; default `"auto"`
+- [ ] 7.2.5 Implement `spawn: await`: step waits until the spawned task reaches a terminal state; if child fails, step fails
+
+### 7.3 Tests
+
+- [ ] 7.3.1 Unit test: step emits `APIARY_SPAWN` → child `InternalTask` created with correct `parent_task_id` and `input`; named workflow dispatched
+- [ ] 7.3.2 Unit test: `spawn: await` — step completes only after child task reaches `done`; child `failed` fails the parent step
+- [ ] 7.3.3 Unit test: invalid JSON in spawn marker → step-level error, workflow fails with descriptive message
+- [ ] 7.3.4 Unit test: `APIARY_SPAWN` on a task with no matching workflow → error, not a silent no-op
+
+---
+
+## Phase 8 — Task Completion Hook & Config
+
+Fire `on_complete` / `on_fail` at the InternalTask level once all outstanding workflows finish. Introduce `tasks:` top-level config block.
+
+### 8.1 Config
+
+- [ ] 8.1.1 Add `TasksConfig` struct (`OnComplete *OnComplete`, `OnFail *OnComplete`) to `src/internal/config/config.go`
+- [ ] 8.1.2 Add `Tasks *TasksConfig` to top-level `Config` struct; parse from `tasks:` YAML key
+- [ ] 8.1.3 Validate: `tasks.on_complete` and `tasks.on_fail` follow the same rules as per-workflow hooks
+
+### 8.2 Outstanding Counter & Hook
+
+- [ ] 8.2.1 On each `WorkflowInstance` reaching a terminal state, call `db.DecrementOutstanding(task_id)`; read back the updated count
+- [ ] 8.2.2 When the count reaches 0 and a `TasksConfig` is set: apply `on_complete` (if all instances succeeded) or `on_fail` (if any failed) to every `SourceBinding` on the task
+- [ ] 8.2.3 Unit test: two workflows on one task — hook fires only after both reach terminal state; correct hook applied (complete vs fail)
+- [ ] 8.2.4 Unit test: task with no source bindings — hook runs without error (nothing to apply)
+
+---
+
+## Phase 9 — Dashboard & Observability
+
+Update the dashboard to surface InternalTask as the primary unit, with lineage and source bindings visible.
+
+### 9.1 Task View
+
+- [ ] 9.1.1 Update the Tasks tab in the TUI/dashboard to show `InternalTask` rows (not raw workflow instances)
+- [ ] 9.1.2 Display `SourceBinding` references per task (source name, item number, URL) alongside the task detail
+- [ ] 9.1.3 Display `parent_task_id` as a lineage link: show parent task title and a breadcrumb path to root
+- [ ] 9.1.4 Show all `workflow_instances` linked to a task (fan-out: multiple instances per task now possible)
+
+### 9.2 Lineage Tree (stretch)
+
+- [ ] 9.2.1 Add a tree view showing parent → child task relationships (Incident → Collect → Staff → Fix A/B/C)
+- [ ] 9.2.2 Each node shows: task title, state badge, source binding if any, workflow instances count
+
+---
+
+## Cross-Cutting
+
+- [ ] X.1 Update `openspec/specs/schema/spec.md`: add `internal_tasks`, `source_bindings` tables; `tasks:` top-level config block; `trigger.exclusive`, `step.publish`, `step.spawn` fields; `APIARY_PUBLISH` and `APIARY_SPAWN` marker spec
+- [ ] X.2 Update `openspec/specs/plugin-api/spec.md`: `Adapter.Poll` returns `[]SourceItem`; new optional `SourceBinder` interface; update `TaskPoller` signature
+- [ ] X.3 Update example config (`apiary.yaml` or `.apiary/example.yaml`) to show fan-out triggers, `tasks:` completion hook, and an `APIARY_SPAWN`-based workflow chain
+- [ ] X.4 Run `gitnexus analyze` after each phase PR to keep the knowledge graph current
+- [ ] X.5 Run `go test ./...` green after every phase before opening the next PR

--- a/src/internal/db/binding_store.go
+++ b/src/internal/db/binding_store.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// SourceBindingStore persists SourceBinding rows, which link a source item
+// (source_id + source_item_id) to an InternalTask. The (source_id,
+// source_item_id) pair is unique, so the same source item always resolves to
+// the same task.
+type SourceBindingStore struct {
+	db *sql.DB
+}
+
+// SourceBindings returns a store bound to this client's database.
+func (c *Client) SourceBindings() *SourceBindingStore {
+	return &SourceBindingStore{db: c.db}
+}
+
+// NewSourceBindingStore wraps a raw *sql.DB. Used in tests.
+func NewSourceBindingStore(db *sql.DB) *SourceBindingStore {
+	return &SourceBindingStore{db: db}
+}
+
+// CreateBinding inserts a new source binding. If binding.ID is empty a new ID is
+// generated and written back. A duplicate (source_id, source_item_id) violates
+// the unique constraint and surfaces as an error for the caller to handle.
+func (s *SourceBindingStore) CreateBinding(ctx context.Context, binding *model.SourceBinding) error {
+	if binding.ID == "" {
+		binding.ID = newID()
+	}
+	if binding.CreatedAt.IsZero() {
+		binding.CreatedAt = time.Now()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO source_bindings
+		  (id, task_id, source_id, source_item_id, source_item_url, source_item_number, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, binding.ID, binding.TaskID, binding.SourceID, binding.SourceItemID,
+		nullStr(binding.SourceItemURL), nullStr(binding.SourceItemNumber), binding.CreatedAt)
+	return err
+}
+
+// GetBindingBySourceItem returns the binding for a (source_id, source_item_id)
+// pair, or (nil, nil) if none exists.
+func (s *SourceBindingStore) GetBindingBySourceItem(ctx context.Context, sourceID, sourceItemID string) (*model.SourceBinding, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, source_id, source_item_id, COALESCE(source_item_url,''),
+		       COALESCE(source_item_number,''), created_at
+		FROM source_bindings WHERE source_id = ? AND source_item_id = ?
+	`, sourceID, sourceItemID)
+	b, err := scanBinding(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return b, err
+}
+
+// ListBindingsByTask returns all source bindings for a task, oldest first.
+func (s *SourceBindingStore) ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, task_id, source_id, source_item_id, COALESCE(source_item_url,''),
+		       COALESCE(source_item_number,''), created_at
+		FROM source_bindings WHERE task_id = ? ORDER BY created_at ASC
+	`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.SourceBinding
+	for rows.Next() {
+		b, err := scanBinding(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *b)
+	}
+	return out, rows.Err()
+}
+
+func scanBinding(s scanner) (*model.SourceBinding, error) {
+	var b model.SourceBinding
+	if err := s.Scan(&b.ID, &b.TaskID, &b.SourceID, &b.SourceItemID,
+		&b.SourceItemURL, &b.SourceItemNumber, &b.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -133,6 +133,34 @@ CREATE TABLE IF NOT EXISTS step_runs (
   FOREIGN KEY(workflow_instance_id) REFERENCES workflow_instances(id)
 );
 
+-- Canonical internal task registry: the source-independent unit of work.
+CREATE TABLE IF NOT EXISTS internal_tasks (
+  id TEXT PRIMARY KEY,                          -- ulid
+  parent_task_id TEXT,                          -- set for spawned tasks (lineage)
+  title TEXT NOT NULL,
+  description TEXT,
+  input TEXT,                                   -- JSON: structured input from spawner
+  state TEXT NOT NULL DEFAULT 'registered',     -- registered|running|approval_waiting|done|failed
+  metadata TEXT,                                -- JSON: labels, priority, type, etc.
+  outstanding_workflows INTEGER DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(parent_task_id) REFERENCES internal_tasks(id)
+);
+
+-- Links source items to InternalTasks (one-to-many, optional).
+CREATE TABLE IF NOT EXISTS source_bindings (
+  id TEXT PRIMARY KEY,                          -- ulid
+  task_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,                      -- e.g. "github", "plane"
+  source_item_id TEXT NOT NULL,                 -- source-native item ID
+  source_item_url TEXT,                         -- deep-link for display
+  source_item_number TEXT,                      -- human ref: "#42", "ERP-42"
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(task_id) REFERENCES internal_tasks(id),
+  UNIQUE(source_id, source_item_id)
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_executions_task ON task_executions(task_id);
 CREATE INDEX IF NOT EXISTS idx_executions_retry ON task_executions(next_retry_at) WHERE status='failed';
@@ -145,6 +173,10 @@ CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_parent ON workflow_instances(parent_instance_id);
 CREATE INDEX IF NOT EXISTS idx_step_runs_instance ON step_runs(workflow_instance_id);
+CREATE INDEX IF NOT EXISTS idx_internal_tasks_state ON internal_tasks(state);
+CREATE INDEX IF NOT EXISTS idx_internal_tasks_parent ON internal_tasks(parent_task_id);
+CREATE INDEX IF NOT EXISTS idx_source_bindings_task ON source_bindings(task_id);
+CREATE INDEX IF NOT EXISTS idx_source_bindings_item ON source_bindings(source_id, source_item_id);
 `
 
 // migrations are idempotent ALTER statements applied to databases created
@@ -168,6 +200,15 @@ var migrations = []string{
 	`ALTER TABLE task_executions ADD COLUMN cost_usd REAL DEFAULT 0.0`,
 	`ALTER TABLE task_executions ADD COLUMN workflow_instance_id TEXT`,
 	`ALTER TABLE task_executions ADD COLUMN step_id TEXT`,
+	// Internal Task Model: bind workflow instances to an InternalTask. Nullable
+	// during migration; source_item_id (cell_id) + source_id retained until a
+	// later phase drops them.
+	`ALTER TABLE workflow_instances ADD COLUMN task_id TEXT REFERENCES internal_tasks(id)`,
+	// Internal Task Model: per-step write-back (APIARY_PUBLISH) and internal
+	// fan-out (APIARY_SPAWN) tracking.
+	`ALTER TABLE step_runs ADD COLUMN publish_payload TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN publish_state TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN spawned_task_id TEXT REFERENCES internal_tasks(id)`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -1,0 +1,191 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// InternalTaskStore persists InternalTask rows — the canonical, source-independent
+// unit of work. It is a distinct type (not a Client method set) so its
+// UpdateTaskState does not collide with the legacy Client.UpdateTaskState that
+// operates on the old `tasks` table.
+type InternalTaskStore struct {
+	db *sql.DB
+}
+
+// InternalTasks returns a store bound to this client's database.
+func (c *Client) InternalTasks() *InternalTaskStore {
+	return &InternalTaskStore{db: c.db}
+}
+
+// NewInternalTaskStore wraps a raw *sql.DB. Used in tests.
+func NewInternalTaskStore(db *sql.DB) *InternalTaskStore {
+	return &InternalTaskStore{db: db}
+}
+
+// newID returns a lexicographically sortable, dependency-free identifier:
+// a 48-bit millisecond timestamp prefix (sortable) plus 80 bits of randomness.
+// This stands in for a ulid without pulling in an external library.
+func newID() string {
+	ts := uint64(time.Now().UnixMilli())
+	var r [10]byte
+	_, _ = rand.Read(r[:])
+	return fmt.Sprintf("%012x%s", ts&0xFFFFFFFFFFFF, hex.EncodeToString(r[:]))
+}
+
+// CreateTask inserts a new InternalTask. If task.ID is empty a new ID is
+// generated and written back to the struct. Metadata and Input are stored as
+// JSON; a nil Input is stored as SQL NULL.
+func (s *InternalTaskStore) CreateTask(ctx context.Context, task *model.InternalTask) error {
+	if task.ID == "" {
+		task.ID = newID()
+	}
+	now := time.Now()
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = now
+	}
+	task.UpdatedAt = now
+	if task.State == "" {
+		task.State = model.TaskStateRegistered
+	}
+
+	metaJSON, err := json.Marshal(task.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal task metadata: %w", err)
+	}
+	var inputJSON any
+	if task.Input != nil {
+		b, err := json.Marshal(task.Input)
+		if err != nil {
+			return fmt.Errorf("marshal task input: %w", err)
+		}
+		inputJSON = string(b)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO internal_tasks
+		  (id, parent_task_id, title, description, input, state, metadata,
+		   outstanding_workflows, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, task.ID, nullStr(task.ParentTaskID), task.Title, nullStr(task.Description),
+		inputJSON, string(task.State), string(metaJSON), task.OutstandingWorkflows,
+		task.CreatedAt, task.UpdatedAt)
+	return err
+}
+
+// GetTask fetches a task by ID, or (nil, nil) if not found.
+func (s *InternalTaskStore) GetTask(ctx context.Context, id string) (*model.InternalTask, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks WHERE id = ?
+	`, id)
+	task, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return task, err
+}
+
+// UpdateTaskState transitions a task to a new state.
+func (s *InternalTaskStore) UpdateTaskState(ctx context.Context, id string, state model.TaskState) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE internal_tasks SET state = ?, updated_at = ? WHERE id = ?
+	`, string(state), time.Now(), id)
+	return err
+}
+
+// IncrementOutstanding adds delta to a task's outstanding workflow counter and
+// returns the new count. The dispatcher uses this at fan-out time (delta = N).
+func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string, delta int) (int, error) {
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET outstanding_workflows = outstanding_workflows + ?, updated_at = ?
+		WHERE id = ?
+	`, delta, time.Now(), id); err != nil {
+		return 0, err
+	}
+	return s.outstanding(ctx, id)
+}
+
+// DecrementOutstanding subtracts one from a task's outstanding workflow counter
+// (clamped at zero) and returns the new count. Called when a workflow instance
+// reaches a terminal state.
+func (s *InternalTaskStore) DecrementOutstanding(ctx context.Context, id string) (int, error) {
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET outstanding_workflows = MAX(outstanding_workflows - 1, 0), updated_at = ?
+		WHERE id = ?
+	`, time.Now(), id); err != nil {
+		return 0, err
+	}
+	return s.outstanding(ctx, id)
+}
+
+func (s *InternalTaskStore) outstanding(ctx context.Context, id string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(outstanding_workflows,0) FROM internal_tasks WHERE id = ?`, id).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return n, err
+}
+
+// ListTasksByState returns all tasks in the given state, oldest first.
+func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.TaskState) ([]model.InternalTask, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks WHERE state = ? ORDER BY created_at ASC
+	`, string(state))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.InternalTask
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *task)
+	}
+	return out, rows.Err()
+}
+
+func scanTask(s scanner) (*model.InternalTask, error) {
+	var (
+		task      model.InternalTask
+		inputJSON string
+		metaJSON  string
+		state     string
+	)
+	if err := s.Scan(&task.ID, &task.ParentTaskID, &task.Title, &task.Description,
+		&inputJSON, &state, &metaJSON, &task.OutstandingWorkflows,
+		&task.CreatedAt, &task.UpdatedAt); err != nil {
+		return nil, err
+	}
+	task.State = model.TaskState(state)
+	if metaJSON != "" {
+		if err := json.Unmarshal([]byte(metaJSON), &task.Metadata); err != nil {
+			return nil, fmt.Errorf("unmarshal task metadata: %w", err)
+		}
+	}
+	if inputJSON != "" {
+		if err := json.Unmarshal([]byte(inputJSON), &task.Input); err != nil {
+			return nil, fmt.Errorf("unmarshal task input: %w", err)
+		}
+	}
+	return &task, nil
+}

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -1,0 +1,237 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestInternalTask_CRUD(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	task := &model.InternalTask{
+		Title:       "Investigate payments incident",
+		Description: "critical alert from log monitor",
+		Input:       map[string]any{"service": "payments", "severity": "critical"},
+		Metadata: model.TaskMetadata{
+			Labels:   []string{"apiary", "incident"},
+			Priority: "high",
+			Type:     "log_event",
+		},
+	}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if task.ID == "" {
+		t.Fatal("expected generated ID, got empty")
+	}
+	if task.State != model.TaskStateRegistered {
+		t.Errorf("default state = %q, want registered", task.State)
+	}
+
+	got, err := store.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected task, got nil")
+	}
+	if got.Title != task.Title || got.Description != task.Description {
+		t.Errorf("scalar fields wrong: %+v", got)
+	}
+	if got.Input["service"] != "payments" || got.Input["severity"] != "critical" {
+		t.Errorf("input round-trip wrong: %#v", got.Input)
+	}
+	if got.Metadata.Priority != "high" || got.Metadata.Type != "log_event" ||
+		len(got.Metadata.Labels) != 2 {
+		t.Errorf("metadata round-trip wrong: %#v", got.Metadata)
+	}
+}
+
+func TestInternalTask_GetMissing(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	got, err := store.GetTask(ctx, "does-not-exist")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing task, got %+v", got)
+	}
+}
+
+func TestInternalTask_NilInputStoredAsNull(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	task := &model.InternalTask{Title: "no input"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := store.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Input != nil {
+		t.Errorf("expected nil Input, got %#v", got.Input)
+	}
+}
+
+func TestInternalTask_UpdateState(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateRunning); err != nil {
+		t.Fatalf("update state: %v", err)
+	}
+	got, _ := store.GetTask(ctx, task.ID)
+	if got.State != model.TaskStateRunning {
+		t.Errorf("state = %q, want running", got.State)
+	}
+}
+
+func TestInternalTask_OutstandingCounter(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	n, err := store.IncrementOutstanding(ctx, task.ID, 3)
+	if err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("after +3, count = %d, want 3", n)
+	}
+
+	for i, want := range []int{2, 1, 0} {
+		n, err := store.DecrementOutstanding(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("decrement %d: %v", i, err)
+		}
+		if n != want {
+			t.Errorf("decrement %d: count = %d, want %d", i, n, want)
+		}
+	}
+
+	// Clamped at zero — never negative.
+	n, err = store.DecrementOutstanding(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("decrement past zero: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("decrement past zero: count = %d, want 0", n)
+	}
+}
+
+func TestInternalTask_ListByState(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+
+	for i := 0; i < 3; i++ {
+		if err := store.CreateTask(ctx, &model.InternalTask{
+			Title: "running", State: model.TaskStateRunning,
+		}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	if err := store.CreateTask(ctx, &model.InternalTask{
+		Title: "done", State: model.TaskStateDone,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	running, err := store.ListTasksByState(ctx, model.TaskStateRunning)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(running) != 3 {
+		t.Errorf("running count = %d, want 3", len(running))
+	}
+	done, _ := store.ListTasksByState(ctx, model.TaskStateDone)
+	if len(done) != 1 {
+		t.Errorf("done count = %d, want 1", len(done))
+	}
+}
+
+func TestSourceBinding_CRUD(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	tasks := c.InternalTasks()
+	bindings := c.SourceBindings()
+
+	task := &model.InternalTask{Title: "bound task"}
+	if err := tasks.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	b := &model.SourceBinding{
+		TaskID:           task.ID,
+		SourceID:         "github",
+		SourceItemID:     "12345",
+		SourceItemURL:    "https://github.com/o/r/issues/42",
+		SourceItemNumber: "#42",
+	}
+	if err := bindings.CreateBinding(ctx, b); err != nil {
+		t.Fatalf("create binding: %v", err)
+	}
+	if b.ID == "" {
+		t.Fatal("expected generated binding ID")
+	}
+
+	got, err := bindings.GetBindingBySourceItem(ctx, "github", "12345")
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected binding, got nil")
+	}
+	if got.TaskID != task.ID || got.SourceItemNumber != "#42" {
+		t.Errorf("binding fields wrong: %+v", got)
+	}
+
+	list, err := bindings.ListBindingsByTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("bindings count = %d, want 1", len(list))
+	}
+}
+
+func TestSourceBinding_GetMissing(t *testing.T) {
+	ctx := context.Background()
+	bindings := newTestClient(t).SourceBindings()
+	got, err := bindings.GetBindingBySourceItem(ctx, "github", "nope")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing binding, got %+v", got)
+	}
+}
+
+func TestSourceBinding_UniqueConstraint(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	task := &model.InternalTask{Title: "t"}
+	if err := c.InternalTasks().CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	bindings := c.SourceBindings()
+	first := &model.SourceBinding{TaskID: task.ID, SourceID: "github", SourceItemID: "1"}
+	if err := bindings.CreateBinding(ctx, first); err != nil {
+		t.Fatalf("first binding: %v", err)
+	}
+	dup := &model.SourceBinding{TaskID: task.ID, SourceID: "github", SourceItemID: "1"}
+	if err := bindings.CreateBinding(ctx, dup); err == nil {
+		t.Error("expected unique-constraint error on duplicate (source_id, source_item_id)")
+	}
+}

--- a/src/internal/model/source_item.go
+++ b/src/internal/model/source_item.go
@@ -2,12 +2,14 @@ package model
 
 import "time"
 
-// Cell is a normalized, source-system-agnostic task unit.
+// SourceItem is a normalized, source-system-agnostic view of a single item
+// returned by a source adapter's Poll. It lives only within the binding layer:
+// the SourceBinder translates a SourceItem into an InternalTask, after which the
+// task — not the SourceItem — travels forward into routing and execution.
 //
-// Deprecated: use SourceItem (source_item.go). Cell is retained only to keep
-// existing call sites compiling during the Internal Task Model migration and is
+// This is the canonical name; the legacy alias Cell (cell.go) is deprecated and
 // removed in Phase 2.
-type Cell struct {
+type SourceItem struct {
 	ID          string
 	SourceID    string
 	Number      string // human-facing reference, e.g. "ERP-42" or "#42"
@@ -26,18 +28,3 @@ type Cell struct {
 	// approval condition.
 	Comments []Comment
 }
-
-// Comment is a single comment on a source task, used to evaluate approval-step
-// resume/abort conditions (comment_contains).
-type Comment struct {
-	ID        string
-	Body      string
-	CreatedAt time.Time
-}
-
-type AckAction string
-
-const (
-	AckActionInProgress AckAction = "in_progress"
-	AckActionSkip       AckAction = "skip"
-)

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -1,0 +1,60 @@
+package model
+
+import "time"
+
+// TaskState is the lifecycle state of an InternalTask.
+type TaskState string
+
+const (
+	TaskStateRegistered   TaskState = "registered"
+	TaskStateRunning      TaskState = "running"
+	TaskStateApprovalWait TaskState = "approval_waiting"
+	TaskStateDone         TaskState = "done"
+	TaskStateFailed       TaskState = "failed"
+)
+
+// InternalTask is the canonical, source-independent unit of work. It may be
+// created from a source binding (see SourceBinding) or spawned by a workflow
+// step (see SpawnRequest), in which case ParentTaskID and Input are populated.
+type InternalTask struct {
+	ID                   string
+	ParentTaskID         string // empty if root task
+	Title                string
+	Description          string
+	Input                map[string]any // structured input from spawner, nil for source-bound tasks
+	State                TaskState
+	Metadata             TaskMetadata
+	OutstandingWorkflows int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// TaskMetadata carries routing-relevant attributes of an InternalTask. It is
+// persisted as JSON in internal_tasks.metadata.
+type TaskMetadata struct {
+	Labels   []string
+	Priority string
+	Type     string // "issue", "work_item", "log_event", "internal", ...
+}
+
+// SourceBinding links a source item to an InternalTask. One task may have many
+// bindings; spawned tasks may have none.
+type SourceBinding struct {
+	ID               string
+	TaskID           string
+	SourceID         string
+	SourceItemID     string
+	SourceItemURL    string
+	SourceItemNumber string
+	CreatedAt        time.Time
+}
+
+// SpawnRequest describes a new InternalTask requested by a workflow step via the
+// APIARY_SPAWN marker. WorkflowSpawner (internal/workflow) consumes it to create
+// the child task and dispatch the named workflow.
+type SpawnRequest struct {
+	ParentTaskID string
+	WorkflowID   string
+	Title        string
+	Input        map[string]any
+}

--- a/src/internal/model/task_test.go
+++ b/src/internal/model/task_test.go
@@ -1,0 +1,112 @@
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestInternalTaskZeroValue(t *testing.T) {
+	var task InternalTask
+	if task.ID != "" {
+		t.Errorf("zero-value ID = %q, want empty", task.ID)
+	}
+	if task.ParentTaskID != "" {
+		t.Errorf("zero-value ParentTaskID = %q, want empty", task.ParentTaskID)
+	}
+	if task.State != "" {
+		t.Errorf("zero-value State = %q, want empty", task.State)
+	}
+	if task.Input != nil {
+		t.Errorf("zero-value Input = %v, want nil", task.Input)
+	}
+	if task.OutstandingWorkflows != 0 {
+		t.Errorf("zero-value OutstandingWorkflows = %d, want 0", task.OutstandingWorkflows)
+	}
+	if len(task.Metadata.Labels) != 0 {
+		t.Errorf("zero-value Metadata.Labels = %v, want empty", task.Metadata.Labels)
+	}
+}
+
+func TestSourceBindingZeroValue(t *testing.T) {
+	var b SourceBinding
+	if b.ID != "" || b.TaskID != "" || b.SourceID != "" || b.SourceItemID != "" {
+		t.Errorf("zero-value SourceBinding has non-empty fields: %+v", b)
+	}
+}
+
+func TestSpawnRequestZeroValue(t *testing.T) {
+	var r SpawnRequest
+	if r.ParentTaskID != "" || r.WorkflowID != "" || r.Title != "" {
+		t.Errorf("zero-value SpawnRequest has non-empty fields: %+v", r)
+	}
+	if r.Input != nil {
+		t.Errorf("zero-value SpawnRequest.Input = %v, want nil", r.Input)
+	}
+}
+
+func TestTaskStateConstants(t *testing.T) {
+	cases := map[TaskState]string{
+		TaskStateRegistered:   "registered",
+		TaskStateRunning:      "running",
+		TaskStateApprovalWait: "approval_waiting",
+		TaskStateDone:         "done",
+		TaskStateFailed:       "failed",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("TaskState = %q, want %q", got, want)
+		}
+	}
+}
+
+// TestTaskInputJSONRoundTrip verifies the structured Input payload survives a
+// marshal/unmarshal cycle, which is how it is persisted in internal_tasks.input.
+func TestTaskInputJSONRoundTrip(t *testing.T) {
+	in := map[string]any{
+		"service":  "payments",
+		"severity": "critical",
+		"attempt":  float64(3), // JSON numbers decode to float64
+		"nested": map[string]any{
+			"region": "us-east-1",
+		},
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch:\n got = %#v\nwant = %#v", out, in)
+	}
+}
+
+// TestTaskMetadataJSONRoundTrip verifies TaskMetadata serializes as stored in
+// internal_tasks.metadata.
+func TestTaskMetadataJSONRoundTrip(t *testing.T) {
+	meta := TaskMetadata{
+		Labels:   []string{"apiary", "workflow:engineer"},
+		Priority: "high",
+		Type:     "issue",
+	}
+
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out TaskMetadata
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !reflect.DeepEqual(meta, out) {
+		t.Errorf("round-trip mismatch:\n got = %#v\nwant = %#v", out, meta)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the `internal-task-model` change: introduces the canonical **InternalTask** unit and the binding layer, **with no behavior change** on the existing execution paths (the foundation for the following phases).

- **model**: `InternalTask`, `TaskState` (+ constants), `TaskMetadata`, `SourceBinding`, `SpawnRequest` in `task.go`
- **model**: `SourceItem` (copy of `Cell`); `Cell` marked `// Deprecated` (removed in Phase 2)
- **db/schema**: new `internal_tasks` and `source_bindings` tables (+ indexes)
- **db/schema**: **additive** migrations — `workflow_instances.task_id` and `step_runs.publish_payload`/`publish_state`/`spawned_task_id`
- **db**: `InternalTaskStore` and `SourceBindingStore` as their own types (avoids a collision with the legacy `Client.UpdateTaskState` of the `tasks` table); accessed via `client.InternalTasks()` / `client.SourceBindings()`
- **tests**: CRUD round-trip on in-memory SQLite, `outstanding` counter, `(source_id, source_item_id)` unique constraint, JSON round-trip of `Input`/`Metadata`

## Notes

- `InternalTaskStore`/`SourceBindingStore` are distinct types (not `Client` methods) because of a name collision with the legacy `Client.UpdateTaskState` — aligned with tasks.md 1.2.5/1.2.6.
- `gitnexus impact InitSchema` returned HIGH risk (the daemon's startup path); the change is purely additive/backward-compatible, per Phase 1's "no behavioral change" mandate.

## Test plan

- [x] `go build ./...` (worktree) — OK
- [x] `go test ./...` (worktree) — exit 0, all packages green
- [x] `go vet ./internal/db/ ./internal/model/` — clean
- [x] `gofmt -l` on the new/changed files — clean