### PR TITLE
feat(tools): VS Code extension — Apiary Workflow Visualizer

### DIFF
--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Ativas
 
-_(nenhuma change ativa no momento)_
+### internal-task-model
+
+InternalTask como unidade canônica de trabalho: sources viram binders (registram items, recebem output); fan-out de múltiplos workflows por task; write-back por step controlado pelo agente via `APIARY_PUBLISH`.
 
 ## Arquivadas
 

--- a/openspec/changes/internal-task-model/design.md
+++ b/openspec/changes/internal-task-model/design.md
@@ -1,0 +1,482 @@
+# Design: Internal Task Model
+
+## Architecture Overview
+
+The new layered model introduces InternalTask as the central unit. Sources are binders on the left edge; write-back targets on the right. Workflows can spawn new InternalTasks internally, creating a lineage tree independent of source systems.
+
+```mermaid
+flowchart TB
+    subgraph SOURCES["Sources — Binders"]
+        GH[GitHub Issues]
+        JI[Jira Tickets]
+        LM[Log Monitor]
+    end
+
+    subgraph BINDING["Binding Layer"]
+        AD["Adapter — Poll to SourceItem"]
+        SB["SourceBinder<br/>FindOrCreate InternalTask"]
+        BDB[(source_bindings)]
+    end
+
+    subgraph CORE["Core — Internal"]
+        IT[InternalTask]
+        TDB[(internal_tasks)]
+        RO["Router<br/>matches all triggers"]
+        SP["WorkflowSpawner<br/>APIARY_SPAWN handler"]
+    end
+
+    subgraph EXECUTION["Execution Layer"]
+        WF_A[Workflow A]
+        WF_B[Workflow B]
+        ENG["WorkflowEngine<br/>DAG · steps · approvals"]
+    end
+
+    subgraph WRITEBACK["Write-back"]
+        PUB["PublishQueue<br/>APIARY_PUBLISH"]
+        HOOK["TaskCompletionHook<br/>on_complete · on_fail"]
+        TC["Agent Tool Calls<br/>create issue · create task"]
+    end
+
+    GH -->|Poll| AD
+    JI -->|Poll| AD
+    LM -->|Poll| AD
+    AD --> SB
+    SB -->|writes| BDB
+    SB -->|creates or resolves| IT
+    IT -->|persisted in| TDB
+    IT --> RO
+    RO -->|fan-out| WF_A
+    RO -->|fan-out| WF_B
+    WF_A --> ENG
+    WF_B --> ENG
+    ENG -->|APIARY_SPAWN| SP
+    SP -->|creates child InternalTask| IT
+    ENG -->|APIARY_PUBLISH| PUB
+    ENG -->|all workflows done| HOOK
+    ENG -->|source tool calls| TC
+    PUB -->|WriteResult| GH
+    PUB -->|WriteResult| JI
+    HOOK -->|SetState AddLabels| GH
+    HOOK -->|SetState AddLabels| JI
+    TC -->|creates items| GH
+    TC -->|creates items| JI
+```
+
+---
+
+## Task Creation Paths
+
+There are two ways an InternalTask is created. Both enter the same Router → WorkflowEngine pipeline.
+
+```mermaid
+flowchart LR
+    subgraph PATH_A["Path A — Source-bound"]
+        SA["Source Adapter<br/>Poll"] --> SI[SourceItem]
+        SI --> SB2["SourceBinder<br/>FindOrCreate"]
+        SB2 --> IT_A["InternalTask<br/>has SourceBinding"]
+    end
+
+    subgraph PATH_B["Path B — Spawned"]
+        WF["Running Workflow Step"] -->|"APIARY_SPAWN marker"| SP2["WorkflowSpawner"]
+        SP2 --> IT_B["InternalTask<br/>parent_task_id set<br/>no SourceBinding"]
+    end
+
+    IT_A --> RO2[Router]
+    IT_B --> RO2
+    RO2 --> ENG2[WorkflowEngine]
+```
+
+---
+
+## Binding Flow
+
+How a source item becomes an InternalTask (Path A).
+
+```mermaid
+sequenceDiagram
+    participant Src as Source Adapter
+    participant Binder as SourceBinder
+    participant DB as Database
+    participant Router
+    participant Dispatcher
+
+    Src->>Binder: SourceItem from Poll
+    Binder->>DB: lookup source_bindings by source_id and source_item_id
+    alt binding exists
+        DB-->>Binder: existing task_id
+        Binder->>DB: SELECT internal_tasks by id
+        DB-->>Binder: InternalTask
+    else new item
+        Binder->>DB: INSERT internal_tasks
+        DB-->>Binder: new InternalTask state=registered
+        Binder->>DB: INSERT source_bindings
+    end
+    Binder->>Router: RouteAll InternalTask
+    Router-->>Binder: list of WorkflowMatches
+    loop each WorkflowMatch
+        Binder->>Dispatcher: Dispatch task and match
+    end
+```
+
+---
+
+## Spawn Flow
+
+How a workflow step creates a child InternalTask (Path B).
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Engine as WorkflowEngine
+    participant Spawner as WorkflowSpawner
+    participant DB as Database
+    participant Router
+    participant Dispatcher
+
+    Agent->>Engine: step output with APIARY_SPAWN marker
+    Engine->>Spawner: SpawnRequest: workflow + title + input JSON
+    Spawner->>DB: INSERT internal_tasks with parent_task_id and input
+    DB-->>Spawner: child InternalTask state=registered
+    Spawner->>Router: RouteAll child task
+    Router-->>Spawner: WorkflowMatch for named workflow
+    Spawner->>Dispatcher: Dispatch child task and match
+    Spawner-->>Engine: spawn acknowledged
+    Engine->>Engine: step continues — fire and forget by default
+```
+
+---
+
+## Fan-out Dispatch
+
+One InternalTask triggers N workflows. Each runs independently; the task tracks how many are outstanding.
+
+```mermaid
+flowchart LR
+    IT["InternalTask<br/>state: registered"]
+
+    IT --> R{"Router<br/>evaluates ALL triggers"}
+
+    R -->|"p=100 exclusive=false"| WF_A["code-review"]
+    R -->|"p=200 exclusive=false"| WF_B["docs-update"]
+    R -->|"p=300 exclusive=true"| WF_C["security-scan"]
+
+    WF_A --> RUN_A["RunInstance A<br/>running"]
+    WF_B --> RUN_B["RunInstance B<br/>running"]
+    WF_C --> RUN_C["RunInstance C<br/>running"]
+
+    RUN_A -->|done| TRACK{"outstanding = 0?"}
+    RUN_B -->|done| TRACK
+    RUN_C -->|done| TRACK
+
+    TRACK -->|yes| HOOK[TaskCompletionHook]
+    TRACK -->|no| WAIT[wait]
+```
+
+**Exclusive flag semantics:**
+
+```mermaid
+flowchart TD
+    T["Evaluate triggers<br/>ordered by priority"]
+    T --> M{"trigger matches?"}
+    M -->|no| NEXT[next trigger]
+    M -->|yes| DISPATCH[dispatch workflow]
+    DISPATCH --> EX{"exclusive: true?"}
+    EX -->|yes| STOP["stop — no more triggers"]
+    EX -->|no| NEXT
+    NEXT --> M
+```
+
+---
+
+## Per-Step Write-back
+
+Write-back is agent-driven. The agent emits an `APIARY_PUBLISH` block; the engine fans it out to every SourceBinding. If the task has no bindings the marker is silently ignored.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Engine as WorkflowEngine
+    participant PQ as PublishQueue
+    participant DB
+    participant Src as Source Adapters
+
+    Agent->>Engine: step output
+    Engine->>Engine: parse APIARY_PUBLISH marker
+    alt marker found
+        Engine->>DB: SELECT source_bindings by task_id
+        DB-->>Engine: list of SourceBindings
+        alt bindings exist
+            loop each binding
+                Engine->>PQ: enqueue binding and payload
+            end
+            PQ->>Src: WriteResult with payload
+        else no bindings
+            Engine->>Engine: silently ignore
+        end
+    else no marker
+        Engine->>Engine: no write-back
+    end
+```
+
+**Step config — publish control:**
+
+```mermaid
+flowchart LR
+    SC["StepConfig<br/>publish: auto or off"]
+    SC -->|auto| AGT{"Agent emits<br/>APIARY_PUBLISH?"}
+    SC -->|off| SKIP["skip write-back"]
+    AGT -->|yes| WB[write-back fired]
+    AGT -->|no| NOP[no write-back]
+```
+
+---
+
+## Source-mediated Fan-out vs Internal Spawn
+
+```mermaid
+flowchart TB
+    TW["Triage Workflow<br/>running on InternalTask T1"]
+
+    TW -->|"Route A:<br/>add label workflow:engineer<br/>via tool call"| SRC["Source System<br/>GitHub or Jira"]
+    SRC -->|"next Poll cycle"| SB3["SourceBinder<br/>new SourceItem found"]
+    SB3 --> T2["InternalTask T2<br/>SourceBinding to child issue"]
+    T2 --> EW["Engineer Workflow"]
+
+    TW -->|"Route B:<br/>APIARY_SPAWN marker"| SP3["WorkflowSpawner"]
+    SP3 --> T3["InternalTask T3<br/>parent = T1<br/>no SourceBinding"]
+    T3 --> CW["Collect Workflow"]
+```
+
+**When to use each:**
+
+| | Source-mediated | APIARY_SPAWN |
+|---|---|---|
+| Downstream work needs a ticket | yes | no |
+| No source system at the top | no | yes |
+| Incident or log-driven chains | no | yes |
+| Staff creating Jira stories | yes | no |
+| Collect workflow before Staff | no | yes |
+
+---
+
+## Task Lineage
+
+The Incident → Collect → Staff → Fix chain as a lineage tree.
+
+```mermaid
+flowchart TB
+    L["Log event<br/>source: log-monitor"]
+    L --> INC["InternalTask: Incident<br/>source binding: log-monitor"]
+    INC -->|"APIARY_SPAWN"| COL["InternalTask: Collect<br/>parent: Incident<br/>no binding"]
+    COL -->|"APIARY_SPAWN"| STA["InternalTask: Staff<br/>parent: Collect<br/>no binding"]
+    STA -->|"tool call: create issue"| FA["InternalTask: Fix A<br/>source binding: github"]
+    STA -->|"tool call: create task"| FB["InternalTask: Fix B<br/>source binding: jira"]
+    STA -->|"tool call: create task"| FC["InternalTask: Fix C<br/>source binding: jira"]
+    FA --> EW_A["Engineer Workflow"]
+    FB --> EW_B["Engineer Workflow"]
+    FC --> EW_C["Engineer Workflow"]
+```
+
+---
+
+## InternalTask State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> registered: SourceBinder creates or Spawner creates
+
+    registered --> running: first workflow dispatched
+
+    running --> running: fan-out workflow added
+
+    running --> approval_waiting: step parks for approval
+
+    approval_waiting --> running: approval granted or timed out
+
+    running --> done: last outstanding workflow succeeds
+
+    running --> failed: workflow fails with no retry
+
+    done --> [*]
+    failed --> [*]
+```
+
+---
+
+## Data Model
+
+### New Tables
+
+```sql
+-- Canonical internal task registry
+CREATE TABLE internal_tasks (
+    id                    TEXT PRIMARY KEY,     -- ulid
+    parent_task_id        TEXT REFERENCES internal_tasks(id),  -- set for spawned tasks
+    title                 TEXT NOT NULL,
+    description           TEXT,
+    input                 TEXT,                 -- JSON: structured input from spawner
+    state                 TEXT NOT NULL DEFAULT 'registered',
+    -- 'registered' | 'running' | 'approval_waiting' | 'done' | 'failed'
+    metadata              TEXT,                 -- JSON: labels, priority, type, etc.
+    outstanding_workflows INTEGER DEFAULT 0,
+    created_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Links source items to InternalTasks (one-to-many, optional)
+CREATE TABLE source_bindings (
+    id                 TEXT PRIMARY KEY,        -- ulid
+    task_id            TEXT NOT NULL REFERENCES internal_tasks(id),
+    source_id          TEXT NOT NULL,           -- e.g. "github", "jira"
+    source_item_id     TEXT NOT NULL,           -- source-native item ID
+    source_item_url    TEXT,                    -- deep-link for display
+    source_item_number TEXT,                    -- human ref: "#42", "ERP-42"
+    created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_id, source_item_id)
+);
+```
+
+### Modified Tables
+
+```sql
+-- workflow_instances: replace source_item_id+source_id with task_id
+ALTER TABLE workflow_instances
+    ADD COLUMN task_id TEXT REFERENCES internal_tasks(id);
+-- source_item_id and source_id retained for backward compat during migration, then dropped
+
+-- step_runs: add publish and spawn tracking
+ALTER TABLE step_runs
+    ADD COLUMN publish_payload TEXT,            -- extracted APIARY_PUBLISH content, if any
+    ADD COLUMN publish_state   TEXT,            -- null | 'queued' | 'sent' | 'failed'
+    ADD COLUMN spawned_task_id TEXT REFERENCES internal_tasks(id);  -- if step emitted APIARY_SPAWN
+```
+
+### Dropped (after migration)
+
+```sql
+-- workflow_instances.source_item_id  → replaced by task_id
+-- workflow_instances.source_id       → resolved via source_bindings
+```
+
+---
+
+## Go Types
+
+```go
+// internal/model/task.go
+
+type TaskState string
+
+const (
+    TaskStateRegistered   TaskState = "registered"
+    TaskStateRunning      TaskState = "running"
+    TaskStateApprovalWait TaskState = "approval_waiting"
+    TaskStateDone         TaskState = "done"
+    TaskStateFailed       TaskState = "failed"
+)
+
+type InternalTask struct {
+    ID                   string
+    ParentTaskID         string            // empty if root task
+    Title                string
+    Description          string
+    Input                map[string]any    // structured input from spawner, nil for source-bound tasks
+    State                TaskState
+    Metadata             TaskMetadata
+    OutstandingWorkflows int
+    CreatedAt            time.Time
+    UpdatedAt            time.Time
+}
+
+type TaskMetadata struct {
+    Labels   []string
+    Priority string
+    Type     string     // "issue", "work_item", "log_event", "internal", ...
+}
+
+type SourceBinding struct {
+    ID               string
+    TaskID           string
+    SourceID         string
+    SourceItemID     string
+    SourceItemURL    string
+    SourceItemNumber string
+    CreatedAt        time.Time
+}
+```
+
+```go
+// internal/source/binder.go
+
+type SourceBinder interface {
+    // Bind normalizes a SourceItem into an InternalTask, creates a SourceBinding
+    // if one does not exist yet, and returns the task (new or existing).
+    Bind(ctx context.Context, item model.SourceItem) (model.InternalTask, error)
+}
+```
+
+```go
+// internal/workflow/spawner.go
+
+type SpawnRequest struct {
+    ParentTaskID string
+    WorkflowID   string
+    Title        string
+    Input        map[string]any
+}
+
+type WorkflowSpawner interface {
+    Spawn(ctx context.Context, req SpawnRequest) (model.InternalTask, error)
+}
+```
+
+```go
+// internal/config/config.go — additions
+
+type TriggerConfig struct {
+    Priority  int        `yaml:"priority"`
+    Exclusive bool       `yaml:"exclusive"` // stops evaluating further triggers
+    Match     RouteMatch `yaml:"match"`
+}
+
+type StepConfig struct {
+    // ... existing fields ...
+    Publish string `yaml:"publish"` // "auto" (default) | "off"
+    Spawn   string `yaml:"spawn"`   // "auto" (default, fire-and-forget) | "await"
+}
+
+type TasksConfig struct {              // top-level tasks: block
+    OnComplete *OnComplete `yaml:"on_complete"`
+    OnFail     *OnComplete `yaml:"on_fail"`
+}
+```
+
+---
+
+## Affected Components
+
+| Component | Change |
+|---|---|
+| `internal/source/binder.go` | **New.** SourceBinder; replaces inline SourceItem→dispatch in daemon |
+| `internal/workflow/spawner.go` | **New.** WorkflowSpawner; handles APIARY_SPAWN, creates child InternalTasks |
+| `internal/model/task.go` | **New.** InternalTask, SourceBinding, TaskMetadata types |
+| `internal/model/source_item.go` | **Renamed from cell.go.** SourceItem stays within binding layer only |
+| `internal/router/router.go` | **Changed.** `Route(SourceItem)` → `RouteAll(InternalTask) []Match` |
+| `internal/daemon/dispatcher.go` | **Changed.** Calls binder, passes task to RouteAll, fans out dispatches |
+| `internal/workflow/engine.go` | **Changed.** Accepts InternalTask; parses APIARY_SPAWN and APIARY_PUBLISH markers; resolves bindings for write-back |
+| `internal/daemon/workflow.go` | **Changed.** SideEffects resolves adapter via SourceBinding, not SourceItem.SourceID |
+| `internal/db/schema.go` | **Changed.** New tables; migration for workflow_instances |
+| `internal/config/config.go` | **Changed.** TriggerConfig.Exclusive, StepConfig.Publish, StepConfig.Spawn, new TasksConfig |
+| `apps/dashboard` | **Changed.** Task view shows lineage tree, SourceBindings, and WorkflowInstances per task |
+
+---
+
+## Open Questions
+
+1. **Multi-source binding**: today a task has one binding (one source item). The schema supports many. Should the binder ever merge two source items into one InternalTask? Deferred.
+
+2. **Await semantics for spawn**: when `spawn: await`, the spawning step blocks until the child task reaches a terminal state. If the child fails, does the parent step fail too? Proposed default: yes (propagate failure). Deferred to implementation.
+
+3. **Per-binding publish**: currently `APIARY_PUBLISH` fans out to all bindings equally. A future `APIARY_PUBLISH[github]` syntax could target a specific source. Deferred.
+
+4. **Tool-created source items and lineage**: when an agent creates a GitHub issue via tool call, there is no automatic link back to the parent task. The spawned InternalTask only gets its SourceBinding when the new issue is polled and bound. A future `APIARY_BIND` marker or tool return hook could accelerate this. Deferred.

--- a/openspec/changes/internal-task-model/proposal.md
+++ b/openspec/changes/internal-task-model/proposal.md
@@ -1,0 +1,267 @@
+# Proposal: Internal Task Model
+
+## Why
+
+The current architecture treats the **`SourceItem`** — a normalized view of a source item (GitHub Issue, Plane Work-Item) — as the canonical unit of work. The SourceItem flows through routing, workflow execution, side-effects, and approval logic. Every component that touches a task ultimately holds a `SourceItem` with a `SourceID`, making the source system the implicit owner of task identity and state.
+
+This design worked well for simple dispatch (one source item → one workflow) but creates three compounding problems as workflows grow more complex:
+
+1. **One source item can only trigger one workflow.** The router's first-match-wins logic means a GitHub issue labelled `apiary` can dispatch at most one workflow. If you want a code-review *and* a documentation-update to run on the same issue, you need manual workarounds or nested sub-workflows — not a clean fan-out.
+
+2. **Source systems are in the hot path.** Approval polling hits the source API every cycle. Side-effects write back on every step. The workflow engine cannot make any decision without knowing which source adapter to call. This couples execution semantics to source availability.
+
+3. **There is no internal task.** There is no object that represents "this unit of work" independent of its origin. You cannot create a task from an API call, a webhook, a schedule, or a future source type without first manufacturing a fake SourceItem — which is already awkward.
+
+4. **Workflows cannot chain into other workflows.** If a Triage workflow decides that a problem needs an Engineer workflow, there is no first-class way to express that. The only option is sub-workflows, but those are nested and share the same source binding — not independent units of work dispatched to their own execution context.
+
+The fix is to promote **InternalTask** to first-class status, demote sources to **binders** that register work and receive output, and introduce two clean fan-out paths: source-mediated and internal.
+
+---
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Canonical work unit** | `SourceItem` (source-tied) | `InternalTask` (source-independent) |
+| **Source role** | Drives everything: triggers, state, write-back | Registers tasks; receives output log |
+| **Workflow trigger** | One match per SourceItem | N workflows per InternalTask (fan-out) |
+| **Write-back** | Configured globally per workflow | Optional per step; agent decides whether to emit |
+| **Task identity** | `source_item_id + source_id` (compound) | `task_id` (single, internal) |
+| **Workflow chaining** | Sub-workflows only (nested, same binding) | Spawned tasks (independent InternalTasks with lineage) |
+| **Approval polling** | Polls source for comment/label changes | Polls source only when step explicitly requires it |
+
+---
+
+## New Concepts
+
+| Term | Description |
+|---|---|
+| **InternalTask** | The canonical, source-independent unit of work. Has its own ID, title, description, state, input payload, and metadata. May be created from a source binding or spawned by a workflow step. |
+| **SourceBinding** | A link from a source item (`source_id + source_item_id`) to an InternalTask. One task may have many bindings; today, one — but the model is open. Source bindings are optional: spawned tasks may have none. |
+| **Binder** | The role sources play: they register items as InternalTasks via bindings and receive the task's output. They do not own state. |
+| **Task Fan-out** | The ability for one InternalTask to trigger multiple named workflows simultaneously or sequentially. |
+| **Spawned Task** | An InternalTask created by a workflow step rather than a source adapter. It carries a `parent_task_id` linking it to the originating task, and a structured `input` payload passed by the spawning step. It has no source binding at creation time. |
+| **Task Lineage** | The `parent_task_id` chain linking spawned tasks back to their origin. Enables tracing from a targeted fix task all the way back to the original incident or triage item. |
+| **`APIARY_SPAWN` marker** | An agent-emitted marker (analogous to `APIARY_PUBLISH`) that instructs the engine to create a new InternalTask and dispatch a named workflow against it. Used for pure internal chaining when no source item exists at the top. |
+| **Source-mediated fan-out** | A workflow agent creates new source items (GitHub issues, Jira tasks/stories) via tool calls. Those items are picked up naturally by the Poll → Bind → Route cycle and dispatched to their targeted workflows without a triage step. |
+| **Step Publish** | An optional, agent-controlled action within a step that writes a message back to all source bindings of the task. The agent emits a marker to opt in; silence means no write-back. |
+| **Task Completion Hook** | An `on_complete` / `on_fail` hook at the InternalTask level (not per-workflow), applied after all bound workflows reach terminal state. |
+
+---
+
+## What Stays
+
+- **Sources / Adapters** — unchanged interface; they still `Poll`, `Acknowledge`, and `WriteResult`. They just do it on instruction from the task layer, not inline with dispatch.
+- **Router** — matching logic is unchanged; it now matches against InternalTask metadata instead of SourceItem fields.
+- **WorkflowEngine** — DAG execution, split, foreach, approvals, resume — all unchanged. It now operates on InternalTask + SourceBindings instead of SourceItem.
+- **Agents and Runners** — completely unchanged.
+- **Step-level config** — unchanged, plus optional `publish` and `spawn` blocks described below.
+
+---
+
+## Core Behaviors
+
+### 1. Source as Binder
+
+When a source adapter polls and returns a SourceItem, the **SourceBinder** layer translates it into an InternalTask:
+
+- If an InternalTask already exists for this `(source_id, source_item_id)` pair, retrieve it (resume/dedup logic unchanged).
+- If not, create a new InternalTask from the SourceItem's fields (title, description, metadata).
+- Record the SourceBinding linking the SourceItem back to the task.
+- The SourceItem is then discarded — only the InternalTask travels forward into routing and execution.
+
+Sources write back via their SourceBinding when instructed. They are never polled or called unless a step explicitly requests it (approval steps) or a write-back is queued.
+
+### 2. Workflow Fan-out
+
+The router evaluates an InternalTask against **all** registered workflow triggers (not first-match-wins). Every matching trigger produces a workflow dispatch. The dispatcher starts all matched workflows; they run independently against the same InternalTask.
+
+Fan-out ordering is controlled by a new `trigger.priority` semantic:
+- `priority` (existing field) still determines order for conflict-resolution when only one workflow should run.
+- A new `trigger.exclusive: true` flag (default `false`) opts a workflow into first-match-wins, suppressing lower-priority matches.
+
+### 3. Two Fan-out Paths
+
+Once a workflow is running, it can spawn downstream work via two patterns:
+
+**Pattern A — Source-mediated fan-out**
+
+The agent uses tool calls to create new items in a source system (e.g., create a GitHub issue, create a Jira task). Those items are picked up on the next Poll cycle, bound as new InternalTasks, and dispatched to their targeted workflows through the normal route. No engine mechanism needed.
+
+The original source item is handled as the agent (and user config) decides:
+- GitHub: close the original issue, or leave it open with links to child issues.
+- Jira: convert the original ticket to an Epic, create tasks/stories under it.
+
+This is the right pattern when downstream work should be visible and trackable in the source system.
+
+**Pattern B — Internal fan-out via `APIARY_SPAWN`**
+
+The agent emits an `APIARY_SPAWN` marker when there is no source system to go through, or when the downstream task is purely internal:
+
+```
+APIARY_SPAWN_BEGIN
+{
+  "workflow": "collect-workflow",
+  "title": "Collect context for incident #4421",
+  "input": {
+    "log_event": "...",
+    "service": "payments",
+    "severity": "critical"
+  }
+}
+APIARY_SPAWN_END
+```
+
+When the engine detects this marker:
+1. It creates a new InternalTask with `parent_task_id` pointing to the current task.
+2. It populates the new task's `input` field with the provided JSON.
+3. It dispatches the named workflow against the new task.
+4. The spawning step continues; it does not wait for the spawned task (fire-and-forget by default).
+
+Spawned tasks have no source binding initially. If the spawned workflow later creates source items via tool calls, those bindings are added then.
+
+### 4. Per-Step Write-back
+
+Write-back to sources is **agent-driven, not config-driven**. A step agent can emit an `APIARY_PUBLISH` marker in its output — containing the message to post. If no marker is emitted, no write-back occurs for that step.
+
+```
+APIARY_PUBLISH_BEGIN
+Triage complete. Routing to engineer workflow — estimated complexity: medium.
+APIARY_PUBLISH_END
+```
+
+When the engine detects this marker:
+1. It extracts the publish payload.
+2. It queues a write-back against every SourceBinding on the InternalTask.
+3. Each binding's source adapter calls `WriteResult` with the payload.
+
+If a task has no source bindings (purely internal spawned task), `APIARY_PUBLISH` is silently ignored.
+
+### 5. Task Completion Hook
+
+Once **all workflows** bound to an InternalTask reach a terminal state (done or failed), the task-level completion hook fires:
+
+```yaml
+tasks:
+  on_complete:
+    add_labels: ["done"]
+    set_state: "closed"
+  on_fail:
+    add_labels: ["failed"]
+    set_state: "open"
+```
+
+This replaces per-workflow `on_complete` for source write-back. Workflows may still have their own `on_complete` for internal state changes (e.g., setting a workflow-level label without closing the issue).
+
+---
+
+## New Config Schema
+
+### Workflow trigger — fan-out enabled by default
+
+```yaml
+workflows:
+  - id: triage
+    trigger:
+      priority: 100
+      exclusive: true         # first match only — triage owns the issue
+      match:
+        source: github
+        labels: ["apiary"]
+
+  - id: engineer-workflow
+    trigger:
+      priority: 100
+      exclusive: true
+      match:
+        labels: ["workflow:engineer"]  # set by triage agent via tool call or label
+```
+
+### Step publish marker (agent-emitted, no config)
+
+Step config gains an optional `publish` field only to **suppress** write-back for a specific step:
+
+```yaml
+steps:
+  - id: internal-analysis
+    agent: analyzer
+    publish: off          # never write-back even if agent emits marker
+```
+
+Default is `publish: auto` (agent decides).
+
+### Step spawn — suppress or await
+
+By default, spawned tasks are fire-and-forget. A step can optionally wait for a spawned task to complete before continuing:
+
+```yaml
+steps:
+  - id: collect
+    agent: collector
+    spawn: await           # block until spawned task finishes
+```
+
+Default is `spawn: auto` (fire-and-forget).
+
+### Task-level completion hook
+
+```yaml
+# top-level in apiary.yaml
+tasks:
+  on_complete:
+    add_labels: ["done"]
+    set_state: "closed"
+  on_fail:
+    add_labels: ["needs-review"]
+```
+
+---
+
+## Concrete Use Case: ERP Project Workflows
+
+### Triage workflow
+- **Triggered by**: GitHub issue or Jira ticket with label `apiary`
+- **What it does**: Analyzes the issue; decides whether to route to Engineer or Staff workflow
+- **Fan-out pattern**: Source-mediated — agent adds label `workflow:engineer` or `workflow:staff` to the issue, which the router picks up on the next poll. Alternatively, agent emits `APIARY_SPAWN` directly.
+- **Original issue**: Agent decides — may add a triage comment via `APIARY_PUBLISH`, leaves issue open.
+
+### Engineer workflow
+- **Triggered by**: Task with label `workflow:engineer` (set by triage)
+- **What it does**: Engineer step → Code review step → QA step
+- **Write-back**: Each step may post progress comments via `APIARY_PUBLISH`
+- **Completion**: Closes original issue via task completion hook.
+
+### Staff workflow
+- **Triggered by**: Task with label `workflow:staff` (set by triage)
+- **What it does**: Breaks work into smaller deliverables; creates child issues/tasks via tool calls
+  - GitHub: closes or links original issue; creates N targeted child issues with specific labels
+  - Jira: converts original ticket to Epic; creates tasks/stories under it
+- **Fan-out**: Child issues/tasks are picked up on next poll — each routes directly to targeted workflow (engineer, docs, etc.) with no triage needed, because the agent already set the right labels.
+
+### Incident workflow
+- **Triggered by**: Production log event (log monitor source adapter)
+- **What it does**:
+  1. Spawns a Collect task via `APIARY_SPAWN` (internal, no source binding)
+  2. Collect workflow gathers logs, metrics, user session data
+  3. Collect step spawns Staff task via `APIARY_SPAWN` with collected data as input
+  4. Staff workflow runs — at this point it switches to source-mediated fan-out, creating Jira tasks or GitHub issues that become independently tracked items
+
+**Lineage chain**:
+```
+log event
+  → Incident task (source: log-monitor)
+      → Collect task (spawned, parent: incident)
+          → Staff task (spawned, parent: collect)
+              → Fix task A (source: jira, parent: staff)
+              → Fix task B (source: jira, parent: staff)
+              → Fix task C (source: github, parent: staff)
+```
+
+---
+
+## Migration Notes
+
+- Existing `on_complete` / `on_fail` blocks on workflows continue to work and are applied per-workflow (not at task completion). The new task-level hook is additive.
+- `result_comment: per_step` and `result_comment: on_complete` are deprecated in favor of the agent-driven `APIARY_PUBLISH` marker. They remain functional but emit a deprecation warning.
+- The `SourceItem` type is retained internally as the normalized source item within the binding layer; it is no longer the unit passed to the router or engine.
+- Existing single-workflow configs require no changes — the fan-out model is backward compatible (one match = one workflow, same as before).

--- a/openspec/changes/internal-task-model/tasks.md
+++ b/openspec/changes/internal-task-model/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: Internal Task Model
+
+Implementation follows 9 phases. Each phase produces a shippable state and must pass `go test ./...` before the next begins. Read `proposal.md` and `design.md` before starting.
+
+**Key references:**
+- `design.md` — data model, Go types, affected components, all Mermaid diagrams
+- `proposal.md` — behavioral spec, config schema, ERP use case walkthrough
+
+---
+
+## Phase 1 — Foundation: Types & DB Schema
+
+Introduce the new Go types and database tables with no behavioral change. Existing execution paths are untouched.
+
+### 1.1 Go Types
+
+- [ ] 1.1.1 Create `src/internal/model/task.go`: `InternalTask`, `TaskState` constants, `TaskMetadata`, `SourceBinding`, `SpawnRequest` structs (see `design.md` → Go Types)
+- [ ] 1.1.2 Create `src/internal/model/source_item.go` as a copy of `cell.go` with type renamed to `SourceItem` (keep `cell.go` temporarily with a `// Deprecated: use SourceItem` comment — removed in Phase 2)
+- [ ] 1.1.3 Unit tests: zero-value constructors, JSON round-trip on `TaskMetadata.Input`
+
+### 1.2 DB Schema — new tables
+
+- [ ] 1.2.1 Add `internal_tasks` table to `src/internal/db/schema.go` (columns: `id`, `parent_task_id`, `title`, `description`, `input`, `state`, `metadata`, `outstanding_workflows`, `created_at`, `updated_at`)
+- [ ] 1.2.2 Add `source_bindings` table (columns: `id`, `task_id`, `source_id`, `source_item_id`, `source_item_url`, `source_item_number`, `created_at`; unique constraint on `(source_id, source_item_id)`)
+- [ ] 1.2.3 Add migration: `ALTER TABLE workflow_instances ADD COLUMN task_id TEXT REFERENCES internal_tasks(id)` (nullable during migration)
+- [ ] 1.2.4 Add migration: `ALTER TABLE step_runs ADD COLUMN publish_payload TEXT`, `publish_state TEXT`, `spawned_task_id TEXT REFERENCES internal_tasks(id)`
+- [ ] 1.2.5 Implement `InternalTaskStore` in `src/internal/db/task_store.go`: `CreateTask`, `GetTask`, `UpdateTaskState`, `IncrementOutstanding`, `DecrementOutstanding`, `ListTasksByState`
+- [ ] 1.2.6 Implement `SourceBindingStore` in same file or `binding_store.go`: `CreateBinding`, `GetBindingBySourceItem`, `ListBindingsByTask`
+- [ ] 1.2.7 Unit tests: CRUD round-trip for both stores against a real in-memory SQLite
+
+---
+
+## Phase 2 — SourceItem Rename
+
+Complete the `Cell` → `SourceItem` rename across the entire codebase. No behavioral change.
+
+### 2.1 Rename
+
+- [ ] 2.1.1 Delete `src/internal/model/cell.go`; confirm all references now import `SourceItem` from `task.go`
+- [ ] 2.1.2 Update `src/internal/source/source.go`: `Adapter.Poll` returns `[]model.SourceItem`; update `Acknowledge`, `WriteResult`, `TaskPoller.PollTask` signatures
+- [ ] 2.1.3 Update all source adapters (`github/adapter.go`, `plane/adapter.go`): rename `toCell` → `toSourceItem`, update return types
+- [ ] 2.1.4 Update `src/internal/router/router.go`: rename `Route(cell model.Cell)` → `Route(item model.SourceItem)` (single-match, still used internally in Phase 3 transition)
+- [ ] 2.1.5 Update `src/internal/daemon/dispatcher.go` and `workflow.go`: replace all `Cell` references with `SourceItem`
+- [ ] 2.1.6 Update `src/internal/workflow/engine.go` and all workflow files: replace `Cell` with `SourceItem`
+- [ ] 2.1.7 Full grep check: `grep -rn "model\.Cell\b" src/` must return empty
+- [ ] 2.1.8 Run `go test ./...` — must stay green (no behavioral change)
+
+---
+
+## Phase 3 — Binding Layer
+
+Introduce `SourceBinder` between the adapter poll and the dispatcher. The binder creates or retrieves an `InternalTask` for each `SourceItem`. Dispatch still goes to a single workflow (fan-out comes in Phase 4).
+
+### 3.1 SourceBinder
+
+- [ ] 3.1.1 Create `src/internal/source/binder.go`: `SourceBinder` interface (`Bind(ctx, SourceItem) (InternalTask, error)`) and `DefaultSourceBinder` struct
+- [ ] 3.1.2 Implement `Bind`: lookup `source_bindings` by `(source_id, source_item_id)`; if found, fetch and return the existing `InternalTask`; if not, create `InternalTask` + `SourceBinding` in a transaction
+- [ ] 3.1.3 Wire `SourceBinder` into `src/internal/daemon/dispatcher.go`: call `binder.Bind(item)` after each poll item; pass the resulting `InternalTask` forward (still wrapping in a synthetic SourceItem struct for the router for now — cleaned up in Phase 4)
+- [ ] 3.1.4 Unit tests: new item creates task + binding; same item on second poll returns existing task; concurrent bind with same `(source_id, source_item_id)` deduplicates correctly (unique constraint handling)
+
+---
+
+## Phase 4 — Router Fan-out
+
+Replace first-match-wins dispatch with all-matches dispatch. Introduce `trigger.exclusive`.
+
+### 4.1 Router Changes
+
+- [ ] 4.1.1 Add `Exclusive bool` to `TriggerConfig` in `src/internal/config/config.go`
+- [ ] 4.1.2 Add `RouteAll(task model.InternalTask) []Match` to `src/internal/router/router.go`: evaluates all triggers in priority order; stops after first exclusive match; returns all matches
+- [ ] 4.1.3 Unit tests: two non-exclusive triggers both match; exclusive trigger stops evaluation; priority ordering is respected
+
+### 4.2 Dispatcher Fan-out
+
+- [ ] 4.2.1 Update `src/internal/daemon/dispatcher.go`: call `router.RouteAll(task)` instead of `router.Route(item)`; call `dispatchWorkflow` for each match
+- [ ] 4.2.2 Increment `task.outstanding_workflows` by the number of dispatched workflows before any starts
+- [ ] 4.2.3 Unit tests: one task dispatches to two workflows when two triggers match; exclusive trigger dispatches only one
+
+---
+
+## Phase 5 — Engine: InternalTask & SourceBindings
+
+Update the workflow engine to operate on `InternalTask` + `[]SourceBinding` instead of `SourceItem`. Side-effects resolve via bindings.
+
+### 5.1 Engine Signature
+
+- [ ] 5.1.1 Update `WorkflowEngine.RunInstance` signature: `RunInstance(ctx, wf WorkflowConfig, task model.InternalTask) (instanceID, success, err)` — remove `SourceItem` parameter
+- [ ] 5.1.2 Update `workflow_instances` write path: store `task_id` (not `source_item_id + source_id`)
+- [ ] 5.1.3 Update `wfSideEffects`: resolve the source adapter by looking up `source_bindings` for the task instead of reading `SourceItem.SourceID` directly
+- [ ] 5.1.4 Update `StateLock`, `PostComment`, `ApplyHook` to fan-out to all bindings (today: one binding per task — this is a no-op change in behavior but correctness for future multi-binding tasks)
+- [ ] 5.1.5 Update `CheckParkedApprovals`: resolve the `TaskPoller` adapter via `source_bindings` instead of `cell.SourceID`
+- [ ] 5.1.6 Integration test: engine runs a workflow against a task with one binding; side-effects call the correct adapter
+
+---
+
+## Phase 6 — APIARY_PUBLISH
+
+Replace `result_comment` config-driven write-back with the agent-driven `APIARY_PUBLISH` marker. Old config is deprecated with a warning.
+
+### 6.1 Marker Parsing
+
+- [ ] 6.1.1 Add `APIARY_PUBLISH_BEGIN` / `APIARY_PUBLISH_END` block parsing to `src/internal/runner/structured.go` (alongside existing `APIARY_OUTPUT` and `APIARY_SUMMARY` parsers); extract text payload into `RunResult.PublishPayload`
+- [ ] 6.1.2 Respect `StepConfig.Publish`: if `"off"`, clear `PublishPayload` before the engine sees it even if the agent emitted the marker
+
+### 6.2 Write-back Execution
+
+- [ ] 6.2.1 In the engine step completion path: if `RunResult.PublishPayload` is non-empty, call `SideEffects.PostComment` for each `SourceBinding` on the task; if the task has no bindings, silently skip
+- [ ] 6.2.2 Persist `publish_payload` and `publish_state` (`sent`/`failed`/`skipped`) in the `step_runs` row
+- [ ] 6.2.3 Add `Publish string` (`"auto"` | `"off"`) to `StepConfig`; default `"auto"`
+
+### 6.3 Deprecation
+
+- [ ] 6.3.1 Emit a `log.Warn` at config load when `result_comment` is set to any non-default value: `result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead`
+- [ ] 6.3.2 Keep `result_comment: on_complete` and `result_comment: per_step` functional (fallback path) until a future removal change
+
+### 6.4 Tests
+
+- [ ] 6.4.1 Unit test: agent output with `APIARY_PUBLISH` block → `PostComment` called once per binding
+- [ ] 6.4.2 Unit test: `publish: off` suppresses write-back even when marker is present
+- [ ] 6.4.3 Unit test: task with no source bindings — publish silently skipped, no error
+
+---
+
+## Phase 7 — APIARY_SPAWN & WorkflowSpawner
+
+Introduce the internal fan-out path: a workflow step emits `APIARY_SPAWN` and the engine creates a child `InternalTask` and dispatches the named workflow.
+
+### 7.1 WorkflowSpawner
+
+- [ ] 7.1.1 Create `src/internal/workflow/spawner.go`: `WorkflowSpawner` interface and `DefaultSpawner` struct
+- [ ] 7.1.2 Implement `Spawn(ctx, SpawnRequest) (InternalTask, error)`: create `InternalTask` with `parent_task_id` + `input` JSON; call `router.RouteAll` on the new task; dispatch matched workflows via `Dispatcher`
+- [ ] 7.1.3 Wire `WorkflowSpawner` into `WorkflowEngine` via an interface field (keeps engine testable in isolation)
+
+### 7.2 Marker Parsing & Engine Integration
+
+- [ ] 7.2.1 Add `APIARY_SPAWN_BEGIN` / `APIARY_SPAWN_END` block parsing in `structured.go`; parse content as JSON into `RunResult.SpawnRequest` (`workflow`, `title`, `input` fields)
+- [ ] 7.2.2 In the engine step completion path: if `RunResult.SpawnRequest` is set, call `spawner.Spawn`; record the returned `child_task_id` in `step_runs.spawned_task_id`
+- [ ] 7.2.3 Default behavior: fire-and-forget (step does not block on child outcome)
+- [ ] 7.2.4 Add `Spawn string` (`"auto"` | `"await"`) to `StepConfig`; default `"auto"`
+- [ ] 7.2.5 Implement `spawn: await`: step waits until the spawned task reaches a terminal state; if child fails, step fails
+
+### 7.3 Tests
+
+- [ ] 7.3.1 Unit test: step emits `APIARY_SPAWN` → child `InternalTask` created with correct `parent_task_id` and `input`; named workflow dispatched
+- [ ] 7.3.2 Unit test: `spawn: await` — step completes only after child task reaches `done`; child `failed` fails the parent step
+- [ ] 7.3.3 Unit test: invalid JSON in spawn marker → step-level error, workflow fails with descriptive message
+- [ ] 7.3.4 Unit test: `APIARY_SPAWN` on a task with no matching workflow → error, not a silent no-op
+
+---
+
+## Phase 8 — Task Completion Hook & Config
+
+Fire `on_complete` / `on_fail` at the InternalTask level once all outstanding workflows finish. Introduce `tasks:` top-level config block.
+
+### 8.1 Config
+
+- [ ] 8.1.1 Add `TasksConfig` struct (`OnComplete *OnComplete`, `OnFail *OnComplete`) to `src/internal/config/config.go`
+- [ ] 8.1.2 Add `Tasks *TasksConfig` to top-level `Config` struct; parse from `tasks:` YAML key
+- [ ] 8.1.3 Validate: `tasks.on_complete` and `tasks.on_fail` follow the same rules as per-workflow hooks
+
+### 8.2 Outstanding Counter & Hook
+
+- [ ] 8.2.1 On each `WorkflowInstance` reaching a terminal state, call `db.DecrementOutstanding(task_id)`; read back the updated count
+- [ ] 8.2.2 When the count reaches 0 and a `TasksConfig` is set: apply `on_complete` (if all instances succeeded) or `on_fail` (if any failed) to every `SourceBinding` on the task
+- [ ] 8.2.3 Unit test: two workflows on one task — hook fires only after both reach terminal state; correct hook applied (complete vs fail)
+- [ ] 8.2.4 Unit test: task with no source bindings — hook runs without error (nothing to apply)
+
+---
+
+## Phase 9 — Dashboard & Observability
+
+Update the dashboard to surface InternalTask as the primary unit, with lineage and source bindings visible.
+
+### 9.1 Task View
+
+- [ ] 9.1.1 Update the Tasks tab in the TUI/dashboard to show `InternalTask` rows (not raw workflow instances)
+- [ ] 9.1.2 Display `SourceBinding` references per task (source name, item number, URL) alongside the task detail
+- [ ] 9.1.3 Display `parent_task_id` as a lineage link: show parent task title and a breadcrumb path to root
+- [ ] 9.1.4 Show all `workflow_instances` linked to a task (fan-out: multiple instances per task now possible)
+
+### 9.2 Lineage Tree (stretch)
+
+- [ ] 9.2.1 Add a tree view showing parent → child task relationships (Incident → Collect → Staff → Fix A/B/C)
+- [ ] 9.2.2 Each node shows: task title, state badge, source binding if any, workflow instances count
+
+---
+
+## Cross-Cutting
+
+- [ ] X.1 Update `openspec/specs/schema/spec.md`: add `internal_tasks`, `source_bindings` tables; `tasks:` top-level config block; `trigger.exclusive`, `step.publish`, `step.spawn` fields; `APIARY_PUBLISH` and `APIARY_SPAWN` marker spec
+- [ ] X.2 Update `openspec/specs/plugin-api/spec.md`: `Adapter.Poll` returns `[]SourceItem`; new optional `SourceBinder` interface; update `TaskPoller` signature
+- [ ] X.3 Update example config (`apiary.yaml` or `.apiary/example.yaml`) to show fan-out triggers, `tasks:` completion hook, and an `APIARY_SPAWN`-based workflow chain
+- [ ] X.4 Run `gitnexus analyze` after each phase PR to keep the knowledge graph current
+- [ ] X.5 Run `go test ./...` green after every phase before opening the next PR

--- a/tools/vscode-apiary/.gitignore
+++ b/tools/vscode-apiary/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/tools/vscode-apiary/.vscodeignore
+++ b/tools/vscode-apiary/.vscodeignore
@@ -1,0 +1,6 @@
+src/**
+node_modules/**
+.gitignore
+tsconfig.json
+**/*.ts
+**/*.map

--- a/tools/vscode-apiary/package-lock.json
+++ b/tools/vscode-apiary/package-lock.json
@@ -1,0 +1,528 @@
+{
+  "name": "vscode-apiary",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-apiary",
+      "version": "0.1.0",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^18.0.0",
+        "@types/vscode": "^1.85.0",
+        "esbuild": "^0.20.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/vscode-apiary/package.json
+++ b/tools/vscode-apiary/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "vscode-apiary",
+  "displayName": "Apiary Workflow Visualizer",
+  "description": "Live visual preview of apiary.yaml workflow files",
+  "version": "0.1.0",
+  "publisher": "apiary",
+  "engines": { "vscode": "^1.85.0" },
+  "categories": ["Visualization", "Other"],
+  "keywords": ["apiary", "workflow", "yaml", "preview", "diagram"],
+  "activationEvents": ["onLanguage:yaml"],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "apiary.showPreview",
+        "title": "Apiary: Show Workflow Preview",
+        "icon": "$(type-hierarchy-super)"
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "apiary.showPreview",
+          "when": "resourceFilename == apiary.yaml",
+          "group": "navigation"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --platform=node --target=node18 --format=cjs",
+    "watch": "npm run build -- --watch",
+    "package": "vsce package --no-dependencies"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^18.0.0",
+    "@types/vscode": "^1.85.0",
+    "esbuild": "^0.20.0",
+    "typescript": "^5.3.0"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/tools/vscode-apiary/src/extension.ts
+++ b/tools/vscode-apiary/src/extension.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import { ApiaryPreviewPanel, isApiaryYaml } from './previewPanel';
+
+export function activate(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('apiary.showPreview', () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || !isApiaryYaml(editor.document)) {
+        void vscode.window.showInformationMessage(
+          'Open an apiary.yaml file first, then run Apiary: Show Workflow Preview.'
+        );
+        return;
+      }
+      ApiaryPreviewPanel.show(editor.document);
+    })
+  );
+
+  // Auto-open preview when an apiary.yaml becomes the active editor
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(editor => {
+      if (editor && isApiaryYaml(editor.document) && !ApiaryPreviewPanel.isOpen) {
+        ApiaryPreviewPanel.show(editor.document);
+      }
+    })
+  );
+
+  // Handle the file that is already open when the extension activates
+  const activeEditor = vscode.window.activeTextEditor;
+  if (activeEditor && isApiaryYaml(activeEditor.document)) {
+    ApiaryPreviewPanel.show(activeEditor.document);
+  }
+}
+
+export function deactivate(): void {
+  // nothing to clean up — the panel handles its own disposal
+}

--- a/tools/vscode-apiary/src/parser.ts
+++ b/tools/vscode-apiary/src/parser.ts
@@ -1,0 +1,108 @@
+import * as yaml from 'js-yaml';
+
+export interface ApiaryConfig {
+  version?: string;
+  runners?: Runner[];
+  default_runner?: string;
+  sources?: Source[];
+  agents?: Agent[];
+  workflows?: Workflow[];
+  settings?: Settings;
+}
+
+export interface Runner {
+  id: string;
+  type: string;
+  provider?: string;
+  models?: string[];
+}
+
+export interface Source {
+  id: string;
+  type: string;
+  config?: { repo?: string; workspace?: string; project?: string; api_key?: string };
+  poll_interval?: string;
+  filters?: { states?: string[]; labels?: string[] };
+}
+
+export interface Agent {
+  id: string;
+  description?: string;
+  soul_file?: string;
+  model?: string;
+  runner?: string;
+  max_workers?: number;
+  skills?: string[];
+}
+
+export interface Workflow {
+  id: string;
+  description?: string;
+  resume?: string;
+  trigger?: Trigger;
+  steps?: Step[];
+  on_complete?: OnComplete;
+  on_fail?: OnFail;
+}
+
+export interface Trigger {
+  priority?: number;
+  match?: TriggerMatch;
+}
+
+export interface TriggerMatch {
+  source?: string;
+  labels?: string[];
+  exclude_label_prefix?: string;
+  types?: string[];
+  states?: string[];
+}
+
+export interface Step {
+  id: string;
+  type?: string;
+  agent?: string;
+  if?: string;
+  prompt?: string;
+  summary_prompt?: string;
+  output_schema?: unknown;
+  output?: unknown;
+  memory?: { write?: string[]; read?: string[] };
+  branches?: Branch[];
+  reject_when?: string;
+  on_reject?: { restart_from?: string; max?: number };
+  timeout?: string;
+  message?: string;
+  resume_on?: Record<string, string>;
+  abort_on?: Record<string, string>;
+}
+
+export interface Branch {
+  if?: string;
+  else?: boolean;
+  goto: string;
+}
+
+export interface OnComplete {
+  set_state?: string;
+  add_labels?: string[];
+}
+
+export interface OnFail {
+  add_labels?: string[];
+}
+
+export interface Settings {
+  concurrency?: number;
+  log_level?: string;
+  state_lock?: boolean;
+  result_comment?: boolean;
+}
+
+export function parseApiary(content: string): ApiaryConfig {
+  const doc = yaml.load(content) as ApiaryConfig;
+  if (!doc || typeof doc !== 'object') {
+    throw new Error('Invalid apiary YAML: expected an object at the root level');
+  }
+  return doc;
+}

--- a/tools/vscode-apiary/src/previewPanel.ts
+++ b/tools/vscode-apiary/src/previewPanel.ts
@@ -1,0 +1,234 @@
+import * as vscode from 'vscode';
+import { parseApiary } from './parser';
+import { renderApiary } from './renderer';
+
+function getNonce(): string {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
+
+export function isApiaryYaml(document: vscode.TextDocument): boolean {
+  if (document.languageId !== 'yaml') { return false; }
+  const name = document.fileName.split(/[\\/]/).pop() ?? '';
+  return name === 'apiary.yaml' || name.endsWith('.apiary.yaml');
+}
+
+export class ApiaryPreviewPanel {
+  private static current: ApiaryPreviewPanel | undefined;
+
+  private readonly panel: vscode.WebviewPanel;
+  private disposables: vscode.Disposable[] = [];
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  static show(document: vscode.TextDocument): void {
+    if (ApiaryPreviewPanel.current) {
+      ApiaryPreviewPanel.current.panel.reveal(vscode.ViewColumn.Beside, true);
+      ApiaryPreviewPanel.current.update(document.getText());
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      'apiaryPreview',
+      'Apiary Preview',
+      { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+      { enableScripts: true, retainContextWhenHidden: true }
+    );
+    ApiaryPreviewPanel.current = new ApiaryPreviewPanel(panel, document);
+  }
+
+  static get isOpen(): boolean {
+    return ApiaryPreviewPanel.current !== undefined;
+  }
+
+  private constructor(panel: vscode.WebviewPanel, document: vscode.TextDocument) {
+    this.panel = panel;
+    this.panel.webview.html = this.buildHtml();
+
+    // Send initial content once the webview signals it is ready
+    this.panel.webview.onDidReceiveMessage(msg => {
+      if (msg.type === 'ready') {
+        this.update(document.getText());
+      }
+    }, null, this.disposables);
+
+    // Re-render on every keystroke (debounced)
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument(e => {
+        if (isApiaryYaml(e.document)) {
+          this.scheduleUpdate(e.document.getText());
+        }
+      })
+    );
+
+    // Track active editor switches between apiary.yaml files
+    this.disposables.push(
+      vscode.window.onDidChangeActiveTextEditor(editor => {
+        if (editor && isApiaryYaml(editor.document)) {
+          this.update(editor.document.getText());
+          this.panel.title = `Apiary — ${editor.document.fileName.split(/[\\/]/).pop()}`;
+        }
+      })
+    );
+
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+  }
+
+  private scheduleUpdate(text: string): void {
+    if (this.debounceTimer !== undefined) { clearTimeout(this.debounceTimer); }
+    this.debounceTimer = setTimeout(() => this.update(text), 350);
+  }
+
+  private update(text: string): void {
+    try {
+      const config = parseApiary(text);
+      const diagrams = renderApiary(config);
+      void this.panel.webview.postMessage({ type: 'update', diagrams });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      void this.panel.webview.postMessage({ type: 'update', error: message });
+    }
+  }
+
+  private buildHtml(): string {
+    const nonce = getNonce();
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none';
+                 script-src https://cdn.jsdelivr.net 'nonce-${nonce}';
+                 style-src 'unsafe-inline';
+                 img-src data: blob:;">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Apiary Preview</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 14px 18px;
+      background: var(--vscode-editor-background);
+      color: var(--vscode-editor-foreground);
+      font-family: var(--vscode-font-family, sans-serif);
+      font-size: var(--vscode-font-size, 13px);
+    }
+    h2 {
+      margin: 22px 0 10px;
+      padding-bottom: 5px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--vscode-descriptionForeground);
+      border-bottom: 1px solid var(--vscode-widget-border, #444);
+    }
+    h2:first-of-type { margin-top: 0; }
+    .diagram-wrap { overflow-x: auto; }
+    .diagram-wrap svg { display: block; max-width: 100%; }
+    .error {
+      margin: 8px 0;
+      padding: 8px 12px;
+      border-radius: 3px;
+      font-size: 12px;
+      background: var(--vscode-inputValidation-errorBackground, #5a1d1d);
+      border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
+      color: var(--vscode-errorForeground, #f48771);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .empty {
+      padding: 32px 0;
+      text-align: center;
+      font-size: 12px;
+      color: var(--vscode-descriptionForeground);
+    }
+  </style>
+</head>
+<body>
+  <div id="root"><div class="empty">Loading…</div></div>
+
+  <script nonce="${nonce}" src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const root = document.getElementById('root');
+
+    const isDark = document.body.classList.contains('vscode-dark') ||
+                   document.body.classList.contains('vscode-high-contrast');
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: isDark ? 'dark' : 'default',
+      flowchart: { curve: 'basis', useMaxWidth: true, htmlLabels: false },
+      securityLevel: 'loose',
+      logLevel: 'error',
+    });
+
+    async function render(diagrams) {
+      root.innerHTML = '';
+      for (let i = 0; i < diagrams.length; i++) {
+        const d = diagrams[i];
+
+        const h2 = document.createElement('h2');
+        h2.textContent = d.title;
+        root.appendChild(h2);
+
+        const wrap = document.createElement('div');
+        wrap.className = 'diagram-wrap';
+
+        const div = document.createElement('div');
+        div.className = 'mermaid';
+        div.id = 'md-' + i;
+        div.textContent = d.diagram;
+
+        wrap.appendChild(div);
+        root.appendChild(wrap);
+      }
+      try {
+        await mermaid.run({ querySelector: '.mermaid' });
+      } catch (e) {
+        console.error('mermaid render error', e);
+      }
+    }
+
+    window.addEventListener('message', event => {
+      const msg = event.data;
+      if (msg.type !== 'update') { return; }
+
+      root.innerHTML = '';
+
+      if (msg.error) {
+        const div = document.createElement('div');
+        div.className = 'error';
+        div.textContent = msg.error;
+        root.appendChild(div);
+        return;
+      }
+
+      if (!msg.diagrams || msg.diagrams.length === 0) {
+        const div = document.createElement('div');
+        div.className = 'empty';
+        div.textContent = 'No workflows defined in this file.';
+        root.appendChild(div);
+        return;
+      }
+
+      render(msg.diagrams);
+    });
+
+    vscode.postMessage({ type: 'ready' });
+  </script>
+</body>
+</html>`;
+  }
+
+  dispose(): void {
+    ApiaryPreviewPanel.current = undefined;
+    this.panel.dispose();
+    for (const d of this.disposables) { d.dispose(); }
+    this.disposables = [];
+    if (this.debounceTimer !== undefined) { clearTimeout(this.debounceTimer); }
+  }
+}

--- a/tools/vscode-apiary/src/renderer.ts
+++ b/tools/vscode-apiary/src/renderer.ts
@@ -1,0 +1,168 @@
+import { ApiaryConfig, Agent, Source, Workflow, Step, Branch, Trigger } from './parser';
+
+// Produce a valid Mermaid node ID (alphanumeric + underscore)
+function sid(s: string): string {
+  return 'N_' + s.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+// Escape text for Mermaid node labels (no raw quotes)
+function esc(s: string): string {
+  return s.replace(/"/g, '#quot;');
+}
+
+// Shorten Claude model names for compact display
+function shortModel(model: string): string {
+  return model.replace(/^claude-/, '');
+}
+
+function buildTriggerLabel(trigger?: Trigger): string {
+  if (!trigger?.match) { return ''; }
+  const m = trigger.match;
+  const parts: string[] = [];
+  if (m.labels?.length) { parts.push(m.labels.join(', ')); }
+  if (m.exclude_label_prefix) { parts.push(`excl: ${m.exclude_label_prefix}`); }
+  if (m.types?.length) { parts.push(`types: ${m.types.join(', ')}`); }
+  if (m.states?.length) { parts.push(`states: ${m.states.join(', ')}`); }
+  return parts.join(' · ');
+}
+
+function buildBranchLabel(branch: Branch): string {
+  if (branch.else) { return 'else'; }
+  if (!branch.if) { return ''; }
+  // Simplify: memory.agent == "po" → agent = po
+  return branch.if
+    .replace(/memory\./g, '')
+    .replace(/ == /g, ' = ')
+    .replace(/["']/g, '');
+}
+
+function sourceDisplay(source: Source): string {
+  const repo = source.config?.repo ?? source.config?.workspace ?? source.id;
+  return `${esc(source.id)}\\n${esc(repo)}`;
+}
+
+export interface DiagramResult {
+  title: string;
+  diagram: string;
+}
+
+export function renderApiary(config: ApiaryConfig): DiagramResult[] {
+  const agentMap = new Map<string, Agent>(
+    (config.agents ?? []).map(a => [a.id, a])
+  );
+  const sourceMap = new Map<string, Source>(
+    (config.sources ?? []).map(s => [s.id, s])
+  );
+
+  return (config.workflows ?? []).map(wf => ({
+    title: wf.id + (wf.description ? ` — ${wf.description}` : ''),
+    diagram: renderWorkflow(wf, agentMap, sourceMap),
+  }));
+}
+
+function renderWorkflow(
+  wf: Workflow,
+  agentMap: Map<string, Agent>,
+  sourceMap: Map<string, Source>,
+): string {
+  const steps = wf.steps ?? [];
+
+  // Namespace step IDs by workflow to avoid cross-workflow collisions
+  const stepId = (step: Step) => sid(`${wf.id}_${step.id}`);
+  const stepIdByName = (name: string) => sid(`${wf.id}_${name}`);
+
+  const lines: string[] = [
+    'flowchart TD',
+    '  classDef agentNode fill:#1a3a6b,stroke:#5b9bd5,color:#dce8f8,stroke-width:1px',
+    '  classDef splitNode fill:#3a1a6b,stroke:#9b5bd5,color:#e8dcf8,stroke-width:1px',
+    '  classDef approvalNode fill:#5a4a0a,stroke:#c8a83a,color:#f8f0dc,stroke-width:1px',
+    '  classDef sourceNode fill:#0a3a1a,stroke:#3aaa6a,color:#dcf8e8,stroke-width:1px',
+  ];
+
+  // Source node (outside the subgraph)
+  const sourceKey = wf.trigger?.match?.source;
+  const source = sourceKey ? sourceMap.get(sourceKey) : undefined;
+  const srcId = srcNodeId(sourceKey);
+
+  if (srcId && source) {
+    lines.push(`  ${srcId}["📦 ${sourceDisplay(source)}"]:::sourceNode`);
+  } else if (srcId) {
+    lines.push(`  ${srcId}["📦 ${esc(sourceKey!)}"]:::sourceNode`);
+  }
+
+  // Source → first step edge (crosses into the subgraph — valid in Mermaid)
+  if (srcId && steps.length > 0) {
+    const firstId = stepId(steps[0]);
+    const lbl = buildTriggerLabel(wf.trigger);
+    const edge = lbl ? `-->|"${esc(lbl)}"| ` : '--> ';
+    lines.push(`  ${srcId} ${edge}${firstId}`);
+  }
+
+  // Open subgraph
+  const wfLabel = esc(wf.id + (wf.description ? ` — ${wf.description}` : ''));
+  lines.push(`  subgraph ${sid('WF_' + wf.id)}["${wfLabel}"]`);
+
+  // Step node declarations
+  for (const step of steps) {
+    const id = stepId(step);
+    if (step.type === 'split') {
+      lines.push(`    ${id}{"${esc(step.id)}\\nsplit"}:::splitNode`);
+    } else if (step.type === 'approval') {
+      lines.push(`    ${id}[/"⏳ ${esc(step.id)}\\napproval"/]:::approvalNode`);
+    } else {
+      const agent = step.agent ? agentMap.get(step.agent) : undefined;
+      const agentStr = step.agent ? `\\n${esc(step.agent)}` : '';
+      const modelStr = agent?.model ? ` · ${esc(shortModel(agent.model))}` : '';
+      lines.push(`    ${id}["${esc(step.id)}${agentStr}${modelStr}"]:::agentNode`);
+    }
+  }
+
+  // Collect branch target step IDs so we skip the sequential edge into them —
+  // they receive their only incoming edge from the split node itself.
+  const branchTargets = new Set<string>();
+  for (const step of steps) {
+    if (step.type === 'split' && step.branches) {
+      for (const branch of step.branches) { branchTargets.add(branch.goto); }
+    }
+  }
+
+  // Step edges (sequential flow + conditional labels)
+  let prevId: string | null = null;
+
+  for (const step of steps) {
+    const id = stepId(step);
+
+    if (prevId !== null && !branchTargets.has(step.id)) {
+      const ifLabel = step.if ? `|"if: ${esc(step.if)}"| ` : '';
+      lines.push(`    ${prevId} -->${ifLabel}${id}`);
+    }
+
+    if (step.type === 'split' && step.branches?.length) {
+      for (const branch of step.branches) {
+        const targetId = stepIdByName(branch.goto);
+        const lbl = buildBranchLabel(branch);
+        lines.push(`    ${id} -->|"${esc(lbl)}"| ${targetId}`);
+      }
+    }
+
+    prevId = id;
+  }
+
+  // Retry loops (dashed back-edges)
+  for (const step of steps) {
+    if (step.reject_when && step.on_reject?.restart_from) {
+      const fromId = stepId(step);
+      const toId = stepIdByName(step.on_reject.restart_from);
+      const maxStr = step.on_reject.max ? ` max ${step.on_reject.max}x` : '';
+      lines.push(`    ${fromId} -.->|"retry${esc(maxStr)}"| ${toId}`);
+    }
+  }
+
+  lines.push('  end');
+
+  return lines.join('\n');
+}
+
+function srcNodeId(sourceKey?: string): string | null {
+  return sourceKey ? sid('SRC_' + sourceKey) : null;
+}

--- a/tools/vscode-apiary/tsconfig.json
+++ b/tools/vscode-apiary/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Adds `tools/vscode-apiary/` — a Cursor/VS Code extension that renders a live Mermaid diagram alongside any `apiary.yaml`
- Auto-opens a side panel when `apiary.yaml` becomes the active editor; re-renders on every keystroke (350 ms debounce)
- One flowchart per workflow, showing: source node → trigger edge → sequential steps, split diamond with labelled branches, approval parallelogram, dashed retry back-edges
- Dark/light theme aware; only runtime dependency is Mermaid.js from CDN
- Bundle via esbuild (single `dist/extension.js`, ~112 kb)

## Install locally to try it

```bash
cd tools/vscode-apiary
npm install
npm run build
# Then in VS Code/Cursor: Extensions → Install from VSIX, or open the folder
# and press F5 to launch an Extension Development Host
```

## Test plan

- [ ] Open `.apiary/apiary.yaml` → preview panel opens automatically on the side
- [ ] Edit any step or add a workflow → diagram updates within ~350 ms
- [ ] Introduce a YAML syntax error → error message shown in the panel, no crash
- [ ] Open `example-workflow.yaml` → `feature-development` workflow renders with the dashed retry edge from `review` back to `implement`
- [ ] Open `example-apiary-full.yaml` → all 6 workflows render, `triage` shows the split diamond with 5 branches and no spurious edges between branch targets