### PR TITLE
feat(binding): SourceBinder — InternalTask per SourceItem (Phase 3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4621 symbols, 10226 relationships, 299 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4666 symbols, 10318 relationships, 292 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4621 symbols, 10226 relationships, 299 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4666 symbols, 10318 relationships, 292 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -52,6 +52,10 @@ type Dispatcher struct {
 	db     *db.Client
 	logger *logging.Logger
 
+	// binder records each polled SourceItem as an InternalTask + SourceBinding.
+	// nil when no DB is configured (tests / dry-run without persistence).
+	binder source.SourceBinder
+
 	sem       chan struct{}            // poll concurrency (size 1)
 	agentSem  map[string]chan struct{} // per-agent dispatch concurrency
 	active    atomic.Int32
@@ -92,6 +96,11 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		sem:         make(chan struct{}, 1), // poll: one at a time
 		agentSem:    make(map[string]chan struct{}),
 		stats:       make(map[string]*sourceStat),
+	}
+
+	// The binder persists InternalTasks + SourceBindings; it needs the DB.
+	if dbClient != nil {
+		d.binder = source.NewSourceBinder(dbClient)
 	}
 
 	// Per-agent concurrency: each agent gets its own semaphore so that
@@ -300,6 +309,7 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 			if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
 				continue
 			}
+			d.bindItem(ctx, cell)
 			match, ok := d.router.Route(cell)
 			if !ok {
 				aplog.Debug("  %q: no route matched (source=%q labels=%v)", cell.Title, cell.SourceID, cell.Labels)
@@ -774,6 +784,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			aplog.Debug("cell %s: already in-flight, skipping", cell.ID)
 			continue
 		}
+		d.bindItem(ctx, cell)
 		match, ok := d.router.Route(cell)
 		if !ok {
 			aplog.Debug("cell %s (%q): no matching route, skipping", cell.ID, cell.Title)
@@ -813,6 +824,24 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			d.dispatch(ctx, cell, adapter, match)
 		}()
 	}
+}
+
+// bindItem records a polled source item as an InternalTask + SourceBinding via
+// the binder. It is idempotent: re-polling the same item resolves to the same
+// task. Binding is independent of routing — an item with no matching route still
+// gets a registered task. A bind failure is logged, not fatal: Phase 3 still
+// dispatches off the SourceItem, so a missing task only affects the new task
+// registry, not the existing execution path. No-op when the binder is unset.
+func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) {
+	if d.binder == nil {
+		return
+	}
+	task, err := d.binder.Bind(ctx, cell)
+	if err != nil {
+		aplog.Error("bind source item %s (%q): %v", cell.ID, cell.Title, err)
+		return
+	}
+	aplog.Debug("bound source item %s → task %s [%s]", cell.ID, task.ID, task.State)
 }
 
 // dispatch acknowledges, runs, and writes the result for a single cell.

--- a/src/internal/db/binding_store.go
+++ b/src/internal/db/binding_store.go
@@ -30,13 +30,19 @@ func NewSourceBindingStore(db *sql.DB) *SourceBindingStore {
 // generated and written back. A duplicate (source_id, source_item_id) violates
 // the unique constraint and surfaces as an error for the caller to handle.
 func (s *SourceBindingStore) CreateBinding(ctx context.Context, binding *model.SourceBinding) error {
+	return insertBinding(ctx, s.db, binding)
+}
+
+// insertBinding writes a binding row using the given executor (a *sql.DB or a
+// *sql.Tx), so it can participate in CreateTaskWithBinding's transaction.
+func insertBinding(ctx context.Context, ex execer, binding *model.SourceBinding) error {
 	if binding.ID == "" {
 		binding.ID = newID()
 	}
 	if binding.CreatedAt.IsZero() {
 		binding.CreatedAt = time.Now()
 	}
-	_, err := s.db.ExecContext(ctx, `
+	_, err := ex.ExecContext(ctx, `
 		INSERT INTO source_bindings
 		  (id, task_id, source_id, source_item_id, source_item_url, source_item_number, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -3,19 +3,35 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 type Client struct {
 	db *sql.DB
 }
 
+// execer is the subset of *sql.DB / *sql.Tx used by the insert helpers, so the
+// same INSERT logic can run either directly or inside a transaction.
+type execer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
 // New opens a SQLite database and initializes schema.
 func New(ctx context.Context, dbPath string) (*Client, error) {
-	db, err := sql.Open("sqlite3", dbPath)
+	// _busy_timeout lets a writer wait for a held lock instead of failing
+	// immediately with SQLITE_BUSY — required for the concurrent SourceBinder
+	// path, where two pollers may bind the same item at once.
+	dsn := dbPath
+	if !strings.Contains(dsn, "?") {
+		dsn += "?_busy_timeout=5000"
+	}
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
@@ -38,6 +54,47 @@ func New(ctx context.Context, dbPath string) (*Client, error) {
 
 func (c *Client) Close() error {
 	return c.db.Close()
+}
+
+// ErrBindingExists is returned by CreateTaskWithBinding when a binding for the
+// (source_id, source_item_id) pair already exists. The transaction is rolled
+// back (so no orphan task remains) and the caller should re-fetch the winning
+// task via SourceBindingStore.GetBindingBySourceItem.
+var ErrBindingExists = errors.New("source binding already exists")
+
+// CreateTaskWithBinding atomically inserts an InternalTask and a SourceBinding
+// referencing it, in a single transaction. The binding's TaskID is set to the
+// (possibly generated) task ID before insertion. If the binding violates the
+// UNIQUE(source_id, source_item_id) constraint — i.e. a concurrent bind won the
+// race — the transaction rolls back and ErrBindingExists is returned, leaving no
+// orphan task behind.
+func (c *Client) CreateTaskWithBinding(ctx context.Context, task *model.InternalTask, binding *model.SourceBinding) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := insertTask(ctx, tx, task); err != nil {
+		return fmt.Errorf("insert task: %w", err)
+	}
+	binding.TaskID = task.ID
+	if err := insertBinding(ctx, tx, binding); err != nil {
+		if isUniqueViolation(err) {
+			return ErrBindingExists
+		}
+		return fmt.Errorf("insert binding: %w", err)
+	}
+	return tx.Commit()
+}
+
+// isUniqueViolation reports whether err is a SQLite UNIQUE-constraint failure.
+func isUniqueViolation(err error) bool {
+	var se sqlite3.Error
+	if errors.As(err, &se) {
+		return se.Code == sqlite3.ErrConstraint && se.ExtendedCode == sqlite3.ErrConstraintUnique
+	}
+	return false
 }
 
 // Task operations

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -44,6 +44,13 @@ func newID() string {
 // generated and written back to the struct. Metadata and Input are stored as
 // JSON; a nil Input is stored as SQL NULL.
 func (s *InternalTaskStore) CreateTask(ctx context.Context, task *model.InternalTask) error {
+	return insertTask(ctx, s.db, task)
+}
+
+// insertTask writes a task row using the given executor (a *sql.DB or a *sql.Tx).
+// It fills in a generated ID, timestamps, and the default state on the struct so
+// the caller can read them back — notably to set SourceBinding.TaskID.
+func insertTask(ctx context.Context, ex execer, task *model.InternalTask) error {
 	if task.ID == "" {
 		task.ID = newID()
 	}
@@ -69,7 +76,7 @@ func (s *InternalTaskStore) CreateTask(ctx context.Context, task *model.Internal
 		inputJSON = string(b)
 	}
 
-	_, err = s.db.ExecContext(ctx, `
+	_, err = ex.ExecContext(ctx, `
 		INSERT INTO internal_tasks
 		  (id, parent_task_id, title, description, input, state, metadata,
 		   outstanding_workflows, created_at, updated_at)

--- a/src/internal/source/binder.go
+++ b/src/internal/source/binder.go
@@ -1,0 +1,114 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// SourceBinder turns a SourceItem (the binding-layer view of a polled source
+// item) into an InternalTask — the canonical, source-independent unit of work.
+// It is idempotent per (source_id, source_item_id): the same source item always
+// resolves to the same InternalTask, so re-polling never creates duplicates.
+type SourceBinder interface {
+	// Bind returns the InternalTask for the given SourceItem, creating it (and
+	// its SourceBinding) on first sight and returning the existing one on every
+	// subsequent poll.
+	Bind(ctx context.Context, item model.SourceItem) (model.InternalTask, error)
+}
+
+// DefaultSourceBinder is the database-backed SourceBinder. It records the
+// source→task link in source_bindings and the task itself in internal_tasks.
+type DefaultSourceBinder struct {
+	client   *db.Client
+	tasks    *db.InternalTaskStore
+	bindings *db.SourceBindingStore
+}
+
+// NewSourceBinder builds a DefaultSourceBinder backed by the given client.
+func NewSourceBinder(client *db.Client) *DefaultSourceBinder {
+	return &DefaultSourceBinder{
+		client:   client,
+		tasks:    client.InternalTasks(),
+		bindings: client.SourceBindings(),
+	}
+}
+
+// Bind looks up an existing binding for the item; if found it returns the bound
+// task. Otherwise it creates the task and binding atomically. A concurrent bind
+// of the same item is resolved by re-fetching the winning task.
+func (b *DefaultSourceBinder) Bind(ctx context.Context, item model.SourceItem) (model.InternalTask, error) {
+	if existing, err := b.resolveExisting(ctx, item); err != nil {
+		return model.InternalTask{}, err
+	} else if existing != nil {
+		return *existing, nil
+	}
+
+	task := taskFromItem(item)
+	binding := bindingFromItem(item)
+	err := b.client.CreateTaskWithBinding(ctx, &task, &binding)
+	switch {
+	case errors.Is(err, db.ErrBindingExists):
+		// Lost a race with a concurrent bind of the same item — the other
+		// caller's task is the winner; return it.
+		existing, err := b.resolveExisting(ctx, item)
+		if err != nil {
+			return model.InternalTask{}, err
+		}
+		if existing == nil {
+			return model.InternalTask{}, fmt.Errorf("bind %s/%s: binding vanished after conflict", item.SourceID, item.ID)
+		}
+		return *existing, nil
+	case err != nil:
+		return model.InternalTask{}, fmt.Errorf("bind %s/%s: %w", item.SourceID, item.ID, err)
+	}
+	return task, nil
+}
+
+// resolveExisting returns the task already bound to the item, or nil if none.
+func (b *DefaultSourceBinder) resolveExisting(ctx context.Context, item model.SourceItem) (*model.InternalTask, error) {
+	binding, err := b.bindings.GetBindingBySourceItem(ctx, item.SourceID, item.ID)
+	if err != nil {
+		return nil, fmt.Errorf("lookup binding %s/%s: %w", item.SourceID, item.ID, err)
+	}
+	if binding == nil {
+		return nil, nil
+	}
+	task, err := b.tasks.GetTask(ctx, binding.TaskID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch task %s: %w", binding.TaskID, err)
+	}
+	if task == nil {
+		return nil, fmt.Errorf("binding %s references missing task %s", binding.ID, binding.TaskID)
+	}
+	return task, nil
+}
+
+// taskFromItem builds a registered InternalTask from a source item. Input is left
+// nil: structured input is only set for spawned tasks, never source-bound ones.
+func taskFromItem(item model.SourceItem) model.InternalTask {
+	return model.InternalTask{
+		Title:       item.Title,
+		Description: item.Description,
+		State:       model.TaskStateRegistered,
+		Metadata: model.TaskMetadata{
+			Labels:   item.Labels,
+			Priority: item.Priority,
+			Type:     item.Type,
+		},
+	}
+}
+
+// bindingFromItem builds a SourceBinding for an item. TaskID is filled in by
+// CreateTaskWithBinding once the task ID is known.
+func bindingFromItem(item model.SourceItem) model.SourceBinding {
+	return model.SourceBinding{
+		SourceID:         item.SourceID,
+		SourceItemID:     item.ID,
+		SourceItemURL:    item.URL,
+		SourceItemNumber: item.Number,
+	}
+}

--- a/src/internal/source/binder_test.go
+++ b/src/internal/source/binder_test.go
@@ -1,0 +1,170 @@
+package source
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func newBinderTestDB(t *testing.T) *db.Client {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "binder.db")
+	c, err := db.New(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func sampleItem() model.SourceItem {
+	return model.SourceItem{
+		ID:          "42",
+		SourceID:    "github",
+		Number:      "#42",
+		Title:       "Fix the widget",
+		Description: "the widget is broken",
+		Labels:      []string{"bug", "apiary"},
+		Type:        "issue",
+		Priority:    "high",
+		URL:         "https://github.com/acme/repo/issues/42",
+	}
+}
+
+func TestBind_NewItemCreatesTaskAndBinding(t *testing.T) {
+	ctx := context.Background()
+	c := newBinderTestDB(t)
+	binder := NewSourceBinder(c)
+	item := sampleItem()
+
+	task, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+
+	if task.ID == "" {
+		t.Fatal("expected generated task ID")
+	}
+	if task.State != model.TaskStateRegistered {
+		t.Errorf("state = %q, want registered", task.State)
+	}
+	if task.Title != item.Title || task.Description != item.Description {
+		t.Errorf("scalar fields not copied: %+v", task)
+	}
+	if task.Metadata.Priority != "high" || task.Metadata.Type != "issue" || len(task.Metadata.Labels) != 2 {
+		t.Errorf("metadata not mapped: %#v", task.Metadata)
+	}
+	if task.Input != nil {
+		t.Errorf("source-bound task should have nil Input, got %#v", task.Input)
+	}
+
+	// The binding must exist and point at the task.
+	binding, err := c.SourceBindings().GetBindingBySourceItem(ctx, item.SourceID, item.ID)
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if binding == nil {
+		t.Fatal("expected a binding to be created")
+	}
+	if binding.TaskID != task.ID {
+		t.Errorf("binding.TaskID = %q, want %q", binding.TaskID, task.ID)
+	}
+	if binding.SourceItemNumber != item.Number || binding.SourceItemURL != item.URL {
+		t.Errorf("binding ref fields wrong: %+v", binding)
+	}
+}
+
+func TestBind_SecondPollReturnsExistingTask(t *testing.T) {
+	ctx := context.Background()
+	c := newBinderTestDB(t)
+	binder := NewSourceBinder(c)
+	item := sampleItem()
+
+	first, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+
+	// Re-poll: same source item must resolve to the same task, with no duplicate.
+	second, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("second bind: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("second bind created a new task %q, want %q", second.ID, first.ID)
+	}
+
+	bindings, err := c.SourceBindings().ListBindingsByTask(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Errorf("expected exactly 1 binding, got %d", len(bindings))
+	}
+}
+
+func TestBind_ConcurrentSameItemDeduplicates(t *testing.T) {
+	ctx := context.Background()
+	c := newBinderTestDB(t)
+	binder := NewSourceBinder(c)
+	item := sampleItem()
+
+	const n = 8
+	var wg sync.WaitGroup
+	ids := make([]string, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // line everyone up to maximize contention
+			task, err := binder.Bind(ctx, item)
+			ids[i] = task.ID
+			errs[i] = err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: bind error: %v", i, err)
+		}
+	}
+
+	// Every concurrent bind must resolve to the same single task ID.
+	first := ids[0]
+	if first == "" {
+		t.Fatal("empty task ID")
+	}
+	for i, id := range ids {
+		if id != first {
+			t.Errorf("goroutine %d got task %q, want %q", i, id, first)
+		}
+	}
+
+	// And there must be exactly one binding and one task overall.
+	bindings, err := c.SourceBindings().ListBindingsByTask(ctx, first)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Errorf("expected exactly 1 binding after concurrent bind, got %d", len(bindings))
+	}
+	registered, err := c.InternalTasks().ListTasksByState(ctx, model.TaskStateRegistered)
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(registered) != 1 {
+		t.Errorf("expected exactly 1 task, got %d (orphan task created on race)", len(registered))
+	}
+}
+
+// DefaultSourceBinder must satisfy the SourceBinder interface.
+var _ SourceBinder = (*DefaultSourceBinder)(nil)


### PR DESCRIPTION
## Summary

Phase 3 of the `internal-task-model` change: introduces the **binding layer** between the adapter poll and the dispatcher. Each polled `SourceItem` is now registered as an `InternalTask` + `SourceBinding`. Dispatch still happens via `SourceItem` (the fan-out comes in Phase 4) — so there's no change to the existing execution path.

- **`internal/source/binder.go`** (new): the `SourceBinder` interface + `DefaultSourceBinder`. `Bind` does an idempotent find-or-create by `(source_id, source_item_id)` — re-polls always resolve to the same task.
- **`internal/db`**: `CreateTaskWithBinding` inserts task + binding in a single transaction. On a concurrent race (the same item polled by two cycles), the binding insert violates the UNIQUE constraint → returns `ErrBindingExists`, the transaction is rolled back (no orphan task) and the binder re-resolves the winning task. `insertTask`/`insertBinding` helpers share the SQL via an `execer` interface (`*sql.DB` or `*sql.Tx`).
- **`internal/db/client.go`**: `_busy_timeout=5000` in the SQLite DSN, needed for the binder's concurrent path (the second writer waits for the lock instead of failing with `SQLITE_BUSY`).
- **`internal/daemon/dispatcher.go`**: wires the binder into the `Dispatcher` (nil when there's no DB). `bindItem` registers each polled item in `poll` and `RunOnce`, independent of routing — an item with no route still gets a `registered` task. A bind failure is logged, not fatal.

## Test plan

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all packages green)
- `go test -race ./internal/source/` ✅ (concurrent bind test race-clean)
- New tests in `binder_test.go`:
  - a new item creates task + binding with the fields mapped correctly
  - a second poll of the same item returns the existing task (no duplicate)
  - 8 concurrent binds of the same item deduplicate to 1 task + 1 binding (no orphan)

Part of the OpenSpec `internal-task-model` change (Phase 3 of 9). No behavior change in the current dispatch path.