### PR TITLE
docs(vscode-apiary): official site in the homepage and README (v0.1.2)

### DIFF
--- a/tools/vscode-apiary/README.md
+++ b/tools/vscode-apiary/README.md
@@ -1,6 +1,6 @@
 # Apiary Workflow Visualizer
 
-Live visual preview of [apiary](https://github.com/orlandoburli/apiary) workflow YAML files, rendered as a Mermaid flowchart directly inside VS Code or Cursor.
+Live visual preview of [apiary](https://orlandoburli.com.br/apiary/) workflow YAML files, rendered as a Mermaid flowchart directly inside VS Code or Cursor.
 
 ## Features
 
@@ -27,4 +27,7 @@ Cmd+Shift+P → Apiary: Show Workflow Preview
 
 ## About Apiary
 
-[Apiary](https://github.com/orlandoburli/apiary) is an open-source AI agent orchestration system that dispatches work to Claude, OpenCode, and other LLM runners based on GitHub Issues, Plane tasks, and other sources.
+[Apiary](https://orlandoburli.com.br/apiary/) is an open-source AI agent orchestration system that dispatches work to Claude, OpenCode, and other LLM runners based on GitHub Issues, Plane tasks, and other sources.
+
+- 🌐 Website: https://orlandoburli.com.br/apiary/
+- 📦 Source: https://github.com/orlandoburli/apiary

--- a/tools/vscode-apiary/package.json
+++ b/tools/vscode-apiary/package.json
@@ -2,13 +2,17 @@
   "name": "vscode-apiary",
   "displayName": "Apiary Workflow Visualizer",
   "description": "Live visual preview of apiary.yaml workflow files",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "orlandoburli",
   "license": "AGPL-3.0",
   "icon": "icon.png",
+  "homepage": "https://orlandoburli.com.br/apiary/",
   "repository": {
     "type": "git",
     "url": "https://github.com/orlandoburli/apiary"
+  },
+  "bugs": {
+    "url": "https://github.com/orlandoburli/apiary/issues"
   },
   "engines": { "vscode": "^1.85.0" },
   "categories": ["Visualization", "Other"],


### PR DESCRIPTION
## Summary

- Adds `homepage` (https://orlandoburli.com.br/apiary/) and `bugs` to `package.json` — the "Homepage" link now appears on the Marketplace page
- Updates the README to point to the official site
- Bump `0.1.1` → `0.1.2`