### PR TITLE
feat(binding/router): trigger fan-out — RouteAll(InternalTask) (Phase 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4666 symbols, 10318 relationships, 292 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4755 symbols, 10610 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4666 symbols, 10318 relationships, 292 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4755 symbols, 10610 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -112,6 +112,10 @@ type RouteConfig struct {
 	Agent      string     `yaml:"agent"`
 	Worker     string     `yaml:"worker"`
 	OnComplete OnComplete `yaml:"on_complete"`
+	// Exclusive mirrors TriggerConfig.Exclusive: a matched exclusive route stops
+	// RouteAll from considering any lower-priority route. Set by the Router when it
+	// synthesizes routes from workflow triggers.
+	Exclusive bool `yaml:"-"`
 }
 
 type RouteMatch struct {

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -64,8 +64,12 @@ func (w WorkflowConfig) ResumePolicy() string {
 // TriggerConfig selects which tasks start a workflow. It mirrors route matching:
 // priority ordering plus a RouteMatch condition.
 type TriggerConfig struct {
-	Priority int        `yaml:"priority"`
-	Match    RouteMatch `yaml:"match"`
+	Priority int `yaml:"priority"`
+	// Exclusive, when true, stops trigger evaluation after this trigger matches:
+	// no lower-priority trigger is considered. Use it for a terminal classifier or
+	// catch-all that must own a task alone rather than fan out alongside others.
+	Exclusive bool       `yaml:"exclusive"`
+	Match     RouteMatch `yaml:"match"`
 }
 
 // StepConfig is one node in a workflow graph. The active fields depend on Type.

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -56,10 +56,10 @@ type Dispatcher struct {
 	// nil when no DB is configured (tests / dry-run without persistence).
 	binder source.SourceBinder
 
-	sem       chan struct{}            // poll concurrency (size 1)
-	agentSem  map[string]chan struct{} // per-agent dispatch concurrency
-	active    atomic.Int32
-	inFlight  sync.Map
+	sem        chan struct{}            // poll concurrency (size 1)
+	agentSem   map[string]chan struct{} // per-agent dispatch concurrency
+	active     atomic.Int32
+	inFlight   sync.Map
 	activeRuns sync.Map
 	runCancel  sync.Map
 
@@ -309,38 +309,18 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 			if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
 				continue
 			}
-			d.bindItem(ctx, cell)
-			match, ok := d.router.Route(cell)
-			if !ok {
+			task, persisted := d.bindItem(ctx, cell)
+			matches := d.router.RouteAll(task)
+			if len(matches) == 0 {
 				aplog.Debug("  %q: no route matched (source=%q labels=%v)", cell.Title, cell.SourceID, cell.Labels)
 				d.inFlight.Delete(cell.ID)
 				continue
 			}
-
-			agentID := match.Route.Agent
-			sem := d.agentSem[agentID]
-			if sem != nil {
-				sem <- struct{}{}
-			}
-			d.active.Add(1)
-			wg.Add(1)
-
-			go func(id string, sem chan struct{}) {
-				defer func() {
-					if sem != nil {
-						<-sem
-					}
-					d.active.Add(-1)
-					d.inFlight.Delete(id)
-					wg.Done()
-				}()
-				result := d.dispatch(ctx, cell, adapter, match)
-				if !result.Success {
-					mu.Lock()
-					failedIDs = append(failedIDs, id)
-					mu.Unlock()
-				}
-			}(cell.ID, sem)
+			d.fanOut(ctx, cell, adapter, task, persisted, matches, &wg, func(id string) {
+				mu.Lock()
+				failedIDs = append(failedIDs, id)
+				mu.Unlock()
+			})
 		}
 	}
 
@@ -784,23 +764,51 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			aplog.Debug("cell %s: already in-flight, skipping", cell.ID)
 			continue
 		}
-		d.bindItem(ctx, cell)
-		match, ok := d.router.Route(cell)
-		if !ok {
+		task, persisted := d.bindItem(ctx, cell)
+		matches := d.router.RouteAll(task)
+		if len(matches) == 0 {
 			aplog.Debug("cell %s (%q): no matching route, skipping", cell.ID, cell.Title)
 			d.inFlight.Delete(cell.ID)
 			continue
 		}
+		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+	}
+}
 
-		aplog.Info("dispatching cell %s (%q) → worker %s [%s]",
-			cell.ID, cell.Title, match.Worker.ID, match.Worker.Model)
+// fanOut dispatches every workflow matched for a polled cell. One InternalTask
+// may match several triggers, so the cell fans out to N workflows. The task's
+// outstanding-workflow counter is bumped by len(matches) before any workflow
+// starts (so a completion hook can tell when all have finished); then one
+// dispatch goroutine is launched per match, each admitted through its agent's
+// semaphore and tracked as an active run. The cell's in-flight marker is cleared
+// only after every dispatch finishes. When wg is non-nil each dispatch joins it
+// (so RunOnce can wait); onFail, if set, is called with the cell ID per failure.
+func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, persisted bool, matches []router.Match, wg *sync.WaitGroup, onFail func(cellID string)) {
+	if len(matches) == 0 {
+		d.inFlight.Delete(cell.ID)
+		return
+	}
 
+	// Track outstanding workflows on the task up front, before any can complete.
+	if persisted && d.db != nil {
+		if _, err := d.db.InternalTasks().IncrementOutstanding(ctx, task.ID, len(matches)); err != nil {
+			aplog.Error("task %s: increment outstanding by %d: %v", task.ID, len(matches), err)
+		}
+	}
+
+	var inner sync.WaitGroup
+	for _, match := range matches {
+		match := match
 		agentID := match.Route.Agent
 		agentCh := d.agentSem[agentID]
 		if agentCh != nil {
 			agentCh <- struct{}{}
 		}
 		d.active.Add(1)
+		inner.Add(1)
+		if wg != nil {
+			wg.Add(1)
+		}
 
 		runID := d.nextRunID()
 		d.activeRuns.Store(runID, model.ActiveRun{
@@ -812,36 +820,73 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			StartedAt: time.Now(),
 		})
 
-		go func() {
+		aplog.Info("dispatching cell %s (%q) → workflow %s [agent %s]",
+			cell.ID, cell.Title, match.Route.ID, agentID)
+
+		go func(runID string, match router.Match, agentCh chan struct{}) {
 			defer func() {
 				if agentCh != nil {
 					<-agentCh
 				}
 				d.active.Add(-1)
-				d.inFlight.Delete(cell.ID)
 				d.activeRuns.Delete(runID)
+				inner.Done()
+				if wg != nil {
+					wg.Done()
+				}
 			}()
-			d.dispatch(ctx, cell, adapter, match)
-		}()
+			result := d.dispatch(ctx, cell, adapter, match)
+			if !result.Success && onFail != nil {
+				onFail(cell.ID)
+			}
+		}(runID, match, agentCh)
+	}
+
+	// Release the in-flight marker once all of this cell's dispatches finish, so
+	// the cell can be re-polled (and re-routed against its refreshed task).
+	go func() {
+		inner.Wait()
+		d.inFlight.Delete(cell.ID)
+	}()
+}
+
+// transientTask builds an unpersisted InternalTask from a source item, mapping
+// the same routing-relevant attributes the SourceBinder would. It is the routing
+// target when no binder is configured (no DB) — routing still works, but there is
+// no task ID to track outstanding workflows against.
+func transientTask(cell model.SourceItem) model.InternalTask {
+	return model.InternalTask{
+		Title:       cell.Title,
+		Description: cell.Description,
+		State:       model.TaskStateRegistered,
+		Metadata: model.TaskMetadata{
+			Labels:   cell.Labels,
+			Priority: cell.Priority,
+			Type:     cell.Type,
+			Source:   cell.SourceID,
+			State:    cell.State,
+		},
 	}
 }
 
-// bindItem records a polled source item as an InternalTask + SourceBinding via
-// the binder. It is idempotent: re-polling the same item resolves to the same
-// task. Binding is independent of routing — an item with no matching route still
-// gets a registered task. A bind failure is logged, not fatal: Phase 3 still
-// dispatches off the SourceItem, so a missing task only affects the new task
-// registry, not the existing execution path. No-op when the binder is unset.
-func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) {
+// bindItem records a polled source item as an InternalTask + SourceBinding via the
+// binder and returns the task to route on. It is idempotent: re-polling the same
+// item resolves to the same task, refreshed from the live item. With no binder (no
+// DB) it returns a transient, unpersisted task built from the item so routing
+// still works. persisted reports whether the task is DB-backed — only then can
+// outstanding_workflows be tracked. A bind failure is logged, not fatal: routing
+// falls back to a transient task.
+func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task model.InternalTask, persisted bool) {
 	if d.binder == nil {
-		return
+		return transientTask(cell), false
 	}
 	task, err := d.binder.Bind(ctx, cell)
 	if err != nil {
 		aplog.Error("bind source item %s (%q): %v", cell.ID, cell.Title, err)
-		return
+		return transientTask(cell), false
 	}
 	aplog.Debug("bound source item %s → task %s [%s]", cell.ID, task.ID, task.State)
+	return task, true
 }
 
 // dispatch acknowledges, runs, and writes the result for a single cell.
@@ -980,12 +1025,12 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		"prompt":      "{file:./agents/" + ac.ID + ".md}",
 		"skills":      ac.Skills,
 		"permission": map[string]any{
-			"edit":  "allow",
-			"bash":  "allow",
-			"read":  "allow",
-			"glob":  "allow",
-			"grep":  "allow",
-			"task":  "allow",
+			"edit": "allow",
+			"bash": "allow",
+			"read": "allow",
+			"glob": "allow",
+			"grep": "allow",
+			"task": "allow",
 		},
 	}
 

--- a/src/internal/daemon/fanout_test.go
+++ b/src/internal/daemon/fanout_test.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// fanoutAdapter is a poll-only source returning a fixed set of items.
+type fanoutAdapter struct{ items []model.SourceItem }
+
+func (a *fanoutAdapter) ID() string                                    { return "fake" }
+func (a *fanoutAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *fanoutAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *fanoutAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *fanoutAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *fanoutAdapter) WebhookHandler() http.Handler { return nil }
+
+// countingRunner records how many times it ran; all steps succeed.
+type countingRunner struct{ n atomic.Int32 }
+
+func (r *countingRunner) ID() string                     { return "counting" }
+func (r *countingRunner) Configure(map[string]any) error { return nil }
+func (r *countingRunner) Run(context.Context, model.RunRequest) (model.RunResult, error) {
+	r.n.Add(1)
+	return model.RunResult{Success: true}, nil
+}
+
+func fanoutWorkflow(id, agent string, prio int, exclusive bool) config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: id,
+		Trigger: &config.TriggerConfig{
+			Priority:  prio,
+			Exclusive: exclusive,
+			Match:     config.RouteMatch{Source: "src"},
+		},
+		Steps: []config.StepConfig{{ID: "run", Agent: agent}},
+	}
+}
+
+func newFanoutDispatcher(t *testing.T, workflows []config.WorkflowConfig) (*Dispatcher, *countingRunner, *db.Client) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "fanout.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents: []config.AgentConfig{
+			{ID: "a", Model: "test/model"},
+			{ID: "b", Model: "test/model"},
+		},
+		Workflows: workflows,
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	runner := &countingRunner{}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": &fanoutAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it"}}}},
+		runners:     map[string]runnerpkg.Runner{"agent-a": runner, "agent-b": runner},
+		agentRunner: map[string]string{"a": "claude", "b": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, runner, dbc
+}
+
+func outstandingForCell(t *testing.T, dbc *db.Client, sourceID, itemID string) int {
+	t.Helper()
+	ctx := context.Background()
+	binding, err := dbc.SourceBindings().GetBindingBySourceItem(ctx, sourceID, itemID)
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if binding == nil {
+		t.Fatal("expected a binding for the polled item")
+	}
+	task, err := dbc.InternalTasks().GetTask(ctx, binding.TaskID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if task == nil {
+		t.Fatal("expected the bound task to exist")
+	}
+	return task.OutstandingWorkflows
+}
+
+func TestRunOnce_FanOutTwoWorkflows(t *testing.T) {
+	d, runner, dbc := newFanoutDispatcher(t, []config.WorkflowConfig{
+		fanoutWorkflow("wf-a", "a", 10, false),
+		fanoutWorkflow("wf-b", "b", 20, false),
+	})
+
+	if err := d.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if got := runner.n.Load(); got != 2 {
+		t.Errorf("expected 2 workflow dispatches, runner ran %d time(s)", got)
+	}
+	if got := outstandingForCell(t, dbc, "src", "c1"); got != 2 {
+		t.Errorf("outstanding_workflows = %d, want 2", got)
+	}
+}
+
+func TestRunOnce_ExclusiveDispatchesOne(t *testing.T) {
+	d, runner, dbc := newFanoutDispatcher(t, []config.WorkflowConfig{
+		fanoutWorkflow("wf-a", "a", 10, true), // exclusive: claims the task alone
+		fanoutWorkflow("wf-b", "b", 20, false),
+	})
+
+	if err := d.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if got := runner.n.Load(); got != 1 {
+		t.Errorf("exclusive trigger should dispatch once, runner ran %d time(s)", got)
+	}
+	if got := outstandingForCell(t, dbc, "src", "c1"); got != 1 {
+		t.Errorf("outstanding_workflows = %d, want 1", got)
+	}
+}

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -110,6 +110,25 @@ func (s *InternalTaskStore) UpdateTaskState(ctx context.Context, id string, stat
 	return err
 }
 
+// UpdateTaskMetadata refreshes a source-bound task's title, description, and
+// routing metadata (labels, state, source, type, priority) from the live source
+// item. The SourceBinder calls it on every poll so Router.RouteAll matches the
+// current source state — the apiary handoff flow advances a task by mutating its
+// source item's labels, and routing must observe those changes. It does not touch
+// state, input, or the outstanding-workflow counter.
+func (s *InternalTaskStore) UpdateTaskMetadata(ctx context.Context, id, title, description string, meta model.TaskMetadata) error {
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal task metadata: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET title = ?, description = ?, metadata = ?, updated_at = ?
+		WHERE id = ?
+	`, title, nullStr(description), string(metaJSON), time.Now(), id)
+	return err
+}
+
 // IncrementOutstanding adds delta to a task's outstanding workflow counter and
 // returns the new count. The dispatcher uses this at fan-out time (delta = N).
 func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string, delta int) (int, error) {

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -31,10 +31,22 @@ type InternalTask struct {
 
 // TaskMetadata carries routing-relevant attributes of an InternalTask. It is
 // persisted as JSON in internal_tasks.metadata.
+//
+// For source-bound tasks the SourceBinder keeps these fields in sync with the
+// live source item on every poll, so trigger matching (Router.RouteAll) sees the
+// current labels/state — the apiary handoff flow mutates a source item's labels
+// to advance it from one workflow to the next, and routing must observe that.
 type TaskMetadata struct {
 	Labels   []string
 	Priority string
 	Type     string // "issue", "work_item", "log_event", "internal", ...
+	// Source is the originating source id for a source-bound task (empty for
+	// spawned tasks). It mirrors the source item's SourceID so triggers gated on
+	// match.source still resolve once routing is on the task, not the SourceItem.
+	Source string
+	// State mirrors the live source item's state (e.g. "todo", "in_progress")
+	// so triggers gated on match.states resolve. Empty for spawned tasks.
+	State string
 }
 
 // SourceBinding links a source item to an InternalTask. One task may have many

--- a/src/internal/router/routeall_test.go
+++ b/src/internal/router/routeall_test.go
@@ -1,0 +1,146 @@
+package router_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// task builds an InternalTask whose routing attributes mirror a SourceItem, so
+// the cell(...) option builders can be reused to describe what RouteAll sees.
+func task(opts ...func(*model.SourceItem)) model.InternalTask {
+	c := cell(opts...)
+	return model.InternalTask{
+		Title: c.Title,
+		Metadata: model.TaskMetadata{
+			Labels:   c.Labels,
+			Priority: c.Priority,
+			Type:     c.Type,
+			Source:   c.SourceID,
+			State:    c.State,
+		},
+	}
+}
+
+func ids(matches []router.Match) []string {
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.Route.ID
+	}
+	return out
+}
+
+// exclusiveRoute is agentRoute with the exclusive flag set.
+func exclusiveRoute(id string, prio int, agent string, m config.RouteMatch) config.RouteConfig {
+	r := agentRoute(id, prio, agent, m)
+	r.Exclusive = true
+	return r
+}
+
+func TestRouteAll_TwoNonExclusiveBothMatch(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("review", 10, "reviewer", config.RouteMatch{Source: "src-a", Labels: []string{"ai-ready"}}),
+		agentRoute("docs", 20, "scribe", config.RouteMatch{Source: "src-a", Labels: []string{"ai-ready"}}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches := r.RouteAll(task(withLabels("ai-ready")))
+	if got := ids(matches); len(got) != 2 || got[0] != "review" || got[1] != "docs" {
+		t.Fatalf("expected fan-out to [review docs], got %v", got)
+	}
+}
+
+func TestRouteAll_ExclusiveStopsEvaluation(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		exclusiveRoute("classify", 10, "investigator", config.RouteMatch{Source: "src-a"}),
+		agentRoute("review", 20, "reviewer", config.RouteMatch{Source: "src-a"}),
+		agentRoute("docs", 30, "scribe", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches := r.RouteAll(task())
+	if got := ids(matches); len(got) != 1 || got[0] != "classify" {
+		t.Fatalf("exclusive trigger should claim the task alone, got %v", got)
+	}
+}
+
+func TestRouteAll_PriorityOrderingRespected(t *testing.T) {
+	// Declared out of priority order; New sorts by priority ascending, and
+	// RouteAll must return matches in that order.
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("third", 30, "c", config.RouteMatch{Source: "src-a"}),
+		agentRoute("first", 10, "a", config.RouteMatch{Source: "src-a"}),
+		agentRoute("second", 20, "b", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches := r.RouteAll(task())
+	want := []string{"first", "second", "third"}
+	got := ids(matches)
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("priority order wrong: expected %v, got %v", want, got)
+		}
+	}
+}
+
+// A non-exclusive trigger before an exclusive one still fans out, then the
+// exclusive one caps evaluation — matches before it are kept.
+func TestRouteAll_NonExclusiveThenExclusive(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("review", 10, "reviewer", config.RouteMatch{Source: "src-a"}),
+		exclusiveRoute("owner", 20, "owner", config.RouteMatch{Source: "src-a"}),
+		agentRoute("never", 30, "ghost", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches := r.RouteAll(task())
+	if got := ids(matches); len(got) != 2 || got[0] != "review" || got[1] != "owner" {
+		t.Fatalf("expected [review owner] (stop after exclusive owner), got %v", got)
+	}
+}
+
+func TestRouteAll_NoMatchReturnsNil(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("review", 10, "reviewer", config.RouteMatch{Source: "other-src"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if matches := r.RouteAll(task()); matches != nil {
+		t.Fatalf("expected nil for no match, got %v", ids(matches))
+	}
+}
+
+// RouteAll honours match conditions beyond source: a task missing a required
+// label is excluded from the fan-out while others still match.
+func TestRouteAll_PartialMatchFiltersByConditions(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("always", 10, "a", config.RouteMatch{Source: "src-a"}),
+		agentRoute("labelled", 20, "b", config.RouteMatch{Source: "src-a", Labels: []string{"ai-ready"}}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := ids(r.RouteAll(task())); len(got) != 1 || got[0] != "always" {
+		t.Fatalf("expected only [always] without the label, got %v", got)
+	}
+	if got := ids(r.RouteAll(task(withLabels("ai-ready")))); len(got) != 2 {
+		t.Fatalf("expected both routes with the label, got %v", got)
+	}
+}

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -55,10 +55,11 @@ func New(cfg *config.Config) (*Router, error) {
 			continue
 		}
 		routes = append(routes, config.RouteConfig{
-			ID:       wf.ID,
-			Priority: wf.Trigger.Priority,
-			Match:    wf.Trigger.Match,
-			Agent:    firstAgentStep(wf),
+			ID:        wf.ID,
+			Priority:  wf.Trigger.Priority,
+			Match:     wf.Trigger.Match,
+			Agent:     firstAgentStep(wf),
+			Exclusive: wf.Trigger.Exclusive,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {
@@ -102,21 +103,91 @@ func firstAgentStep(wf config.WorkflowConfig) string {
 // Route evaluates all rules against the SourceItem and returns the first match.
 // Returns (zero, false) if no rule matches.
 func (r *Router) Route(item model.SourceItem) (Match, bool) {
+	t := targetFromItem(item)
 	for _, route := range r.routes {
-		if r.matches(route, item) {
-			// Agent-based routing: route.Agent is required; worker is for backward compat
-			if route.Agent != "" {
-				return Match{Route: route}, true
+		if ok, _ := r.evaluateTarget(route, t); ok {
+			if m, ok := r.resolveMatch(route); ok {
+				return m, true
 			}
-			// Backward compat: fall back to worker if agent not specified
-			worker, ok := r.workers[route.Worker]
-			if !ok {
-				continue
-			}
-			return Match{Worker: worker, Route: route}, true
 		}
 	}
 	return Match{}, false
+}
+
+// RouteAll evaluates every trigger against the task in priority order and returns
+// all matches — one InternalTask may fan out to several workflows. Evaluation
+// stops after the first matched route that is Exclusive, so a terminal trigger
+// (e.g. a classifier or catch-all) can claim the task alone instead of fanning
+// out alongside lower-priority triggers. Returns nil if nothing matches.
+//
+// Routing is on the task, not the SourceItem: a source-bound task's routing
+// attributes (labels, state, source, type, priority) are kept live by the
+// SourceBinder on each poll, so RouteAll observes the same data Route would.
+func (r *Router) RouteAll(task model.InternalTask) []Match {
+	t := targetFromTask(task)
+	var matches []Match
+	for _, route := range r.routes {
+		ok, _ := r.evaluateTarget(route, t)
+		if !ok {
+			continue
+		}
+		m, ok := r.resolveMatch(route)
+		if !ok {
+			continue
+		}
+		matches = append(matches, m)
+		if route.Exclusive {
+			break
+		}
+	}
+	return matches
+}
+
+// resolveMatch turns a matched route into a Match: agent-based routing is
+// preferred (route.Agent), falling back to a defined worker for backward compat.
+// Returns false if the route resolves to neither — the caller skips it.
+func (r *Router) resolveMatch(route config.RouteConfig) (Match, bool) {
+	if route.Agent != "" {
+		return Match{Route: route}, true
+	}
+	if worker, ok := r.workers[route.Worker]; ok {
+		return Match{Worker: worker, Route: route}, true
+	}
+	return Match{}, false
+}
+
+// target is the set of attributes a route is evaluated against. Both a SourceItem
+// and an InternalTask map onto it (see targetFromItem / targetFromTask), so the
+// same matching logic serves Route (SourceItem) and RouteAll (InternalTask).
+type target struct {
+	sourceID string
+	state    string
+	labels   []string
+	typ      string
+	priority string
+	title    string
+}
+
+func targetFromItem(cell model.SourceItem) target {
+	return target{
+		sourceID: cell.SourceID,
+		state:    cell.State,
+		labels:   cell.Labels,
+		typ:      cell.Type,
+		priority: cell.Priority,
+		title:    cell.Title,
+	}
+}
+
+func targetFromTask(task model.InternalTask) target {
+	return target{
+		sourceID: task.Metadata.Source,
+		state:    task.Metadata.State,
+		labels:   task.Metadata.Labels,
+		typ:      task.Metadata.Type,
+		priority: task.Metadata.Priority,
+		title:    task.Title,
+	}
 }
 
 func (r *Router) matches(route config.RouteConfig, cell model.SourceItem) bool {
@@ -128,29 +199,36 @@ func (r *Router) matches(route config.RouteConfig, cell model.SourceItem) bool {
 // On a miss the reason names the first condition that rejected the cell; on a
 // hit it summarises which conditions were satisfied.
 func (r *Router) evaluate(route config.RouteConfig, cell model.SourceItem) (bool, string) {
+	return r.evaluateTarget(route, targetFromItem(cell))
+}
+
+// evaluateTarget is the shared matching core. It reports whether a route matches
+// the given target and a human-readable reason — on a miss, the first condition
+// that rejected it; on a hit, a summary of the satisfied conditions.
+func (r *Router) evaluateTarget(route config.RouteConfig, t target) (bool, string) {
 	m := route.Match
 
-	if m.Source != "" && cell.SourceID != m.Source {
-		return false, fmt.Sprintf("source %q != required %q", cell.SourceID, m.Source)
+	if m.Source != "" && t.sourceID != m.Source {
+		return false, fmt.Sprintf("source %q != required %q", t.sourceID, m.Source)
 	}
 
-	if len(m.States) > 0 && !containsInsensitive(m.States, cell.State) {
-		return false, fmt.Sprintf("state %q not in %v", cell.State, m.States)
+	if len(m.States) > 0 && !containsInsensitive(m.States, t.state) {
+		return false, fmt.Sprintf("state %q not in %v", t.state, m.States)
 	}
 
 	if len(m.Labels) > 0 {
-		cellLabels := toLowerSet(cell.Labels)
+		labels := toLowerSet(t.labels)
 		for _, required := range m.Labels {
-			if !cellLabels[strings.ToLower(required)] {
-				return false, fmt.Sprintf("missing required label %q (cell has %v)", required, cell.Labels)
+			if !labels[strings.ToLower(required)] {
+				return false, fmt.Sprintf("missing required label %q (cell has %v)", required, t.labels)
 			}
 		}
 	}
 
 	if len(m.ExcludeLabels) > 0 {
-		cellLabels := toLowerSet(cell.Labels)
+		labels := toLowerSet(t.labels)
 		for _, excluded := range m.ExcludeLabels {
-			if cellLabels[strings.ToLower(excluded)] {
+			if labels[strings.ToLower(excluded)] {
 				return false, fmt.Sprintf("has excluded label %q", excluded)
 			}
 		}
@@ -158,24 +236,24 @@ func (r *Router) evaluate(route config.RouteConfig, cell model.SourceItem) (bool
 
 	if m.ExcludeLabelPrefix != "" {
 		prefix := strings.ToLower(m.ExcludeLabelPrefix)
-		for _, l := range cell.Labels {
+		for _, l := range t.labels {
 			if strings.HasPrefix(strings.ToLower(l), prefix) {
 				return false, fmt.Sprintf("has label %q matching excluded prefix %q", l, m.ExcludeLabelPrefix)
 			}
 		}
 	}
 
-	if len(m.Types) > 0 && !containsInsensitive(m.Types, cell.Type) {
-		return false, fmt.Sprintf("type %q not in %v", cell.Type, m.Types)
+	if len(m.Types) > 0 && !containsInsensitive(m.Types, t.typ) {
+		return false, fmt.Sprintf("type %q not in %v", t.typ, m.Types)
 	}
 
-	if len(m.Priority) > 0 && !containsInsensitive(m.Priority, cell.Priority) {
-		return false, fmt.Sprintf("priority %q not in %v", cell.Priority, m.Priority)
+	if len(m.Priority) > 0 && !containsInsensitive(m.Priority, t.priority) {
+		return false, fmt.Sprintf("priority %q not in %v", t.priority, m.Priority)
 	}
 
 	if re, ok := r.regexes[route.ID]; ok {
-		if !re.MatchString(cell.Title) {
-			return false, fmt.Sprintf("title %q does not match /%s/", cell.Title, m.TitleRegex)
+		if !re.MatchString(t.title) {
+			return false, fmt.Sprintf("title %q does not match /%s/", t.title, m.TitleRegex)
 		}
 	}
 

--- a/src/internal/router/router_test.go
+++ b/src/internal/router/router_test.go
@@ -19,7 +19,7 @@ func cfg(routes []config.RouteConfig, _ []config.WorkerConfig) *config.Config {
 		}
 		wfs = append(wfs, config.WorkflowConfig{
 			ID:      r.ID,
-			Trigger: &config.TriggerConfig{Priority: r.Priority, Match: r.Match},
+			Trigger: &config.TriggerConfig{Priority: r.Priority, Exclusive: r.Exclusive, Match: r.Match},
 			Steps:   []config.StepConfig{{ID: "run", Agent: agent}},
 		})
 	}

--- a/src/internal/source/binder.go
+++ b/src/internal/source/binder.go
@@ -44,7 +44,7 @@ func (b *DefaultSourceBinder) Bind(ctx context.Context, item model.SourceItem) (
 	if existing, err := b.resolveExisting(ctx, item); err != nil {
 		return model.InternalTask{}, err
 	} else if existing != nil {
-		return *existing, nil
+		return b.refresh(ctx, *existing, item)
 	}
 
 	task := taskFromItem(item)
@@ -87,6 +87,53 @@ func (b *DefaultSourceBinder) resolveExisting(ctx context.Context, item model.So
 	return task, nil
 }
 
+// refresh keeps a source-bound task's routing attributes in step with the live
+// source item on every poll. The apiary handoff flow advances a task by mutating
+// its source item's labels (and state), so Router.RouteAll must observe the
+// current values, not those frozen at first bind. It only rewrites title,
+// description, and metadata when they actually changed; task lifecycle state,
+// input, and the outstanding-workflow counter are left untouched.
+func (b *DefaultSourceBinder) refresh(ctx context.Context, task model.InternalTask, item model.SourceItem) (model.InternalTask, error) {
+	fresh := metaFromItem(item)
+	if task.Title == item.Title && task.Description == item.Description && metaEqual(task.Metadata, fresh) {
+		return task, nil
+	}
+	if err := b.tasks.UpdateTaskMetadata(ctx, task.ID, item.Title, item.Description, fresh); err != nil {
+		return model.InternalTask{}, fmt.Errorf("refresh task %s from %s/%s: %w", task.ID, item.SourceID, item.ID, err)
+	}
+	task.Title = item.Title
+	task.Description = item.Description
+	task.Metadata = fresh
+	return task, nil
+}
+
+// metaFromItem maps a source item's routing-relevant attributes into TaskMetadata.
+func metaFromItem(item model.SourceItem) model.TaskMetadata {
+	return model.TaskMetadata{
+		Labels:   item.Labels,
+		Priority: item.Priority,
+		Type:     item.Type,
+		Source:   item.SourceID,
+		State:    item.State,
+	}
+}
+
+// metaEqual reports whether two TaskMetadata carry the same routing attributes.
+func metaEqual(a, b model.TaskMetadata) bool {
+	if a.Priority != b.Priority || a.Type != b.Type || a.Source != b.Source || a.State != b.State {
+		return false
+	}
+	if len(a.Labels) != len(b.Labels) {
+		return false
+	}
+	for i := range a.Labels {
+		if a.Labels[i] != b.Labels[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // taskFromItem builds a registered InternalTask from a source item. Input is left
 // nil: structured input is only set for spawned tasks, never source-bound ones.
 func taskFromItem(item model.SourceItem) model.InternalTask {
@@ -94,11 +141,7 @@ func taskFromItem(item model.SourceItem) model.InternalTask {
 		Title:       item.Title,
 		Description: item.Description,
 		State:       model.TaskStateRegistered,
-		Metadata: model.TaskMetadata{
-			Labels:   item.Labels,
-			Priority: item.Priority,
-			Type:     item.Type,
-		},
+		Metadata:    metaFromItem(item),
 	}
 }
 

--- a/src/internal/source/binder_test.go
+++ b/src/internal/source/binder_test.go
@@ -58,6 +58,9 @@ func TestBind_NewItemCreatesTaskAndBinding(t *testing.T) {
 	if task.Metadata.Priority != "high" || task.Metadata.Type != "issue" || len(task.Metadata.Labels) != 2 {
 		t.Errorf("metadata not mapped: %#v", task.Metadata)
 	}
+	if task.Metadata.Source != item.SourceID {
+		t.Errorf("metadata.Source = %q, want %q", task.Metadata.Source, item.SourceID)
+	}
 	if task.Input != nil {
 		t.Errorf("source-bound task should have nil Input, got %#v", task.Input)
 	}
@@ -163,6 +166,103 @@ func TestBind_ConcurrentSameItemDeduplicates(t *testing.T) {
 	}
 	if len(registered) != 1 {
 		t.Errorf("expected exactly 1 task, got %d (orphan task created on race)", len(registered))
+	}
+}
+
+func TestBind_RefreshUpdatesRoutingMetadataOnRepoll(t *testing.T) {
+	ctx := context.Background()
+	c := newBinderTestDB(t)
+	binder := NewSourceBinder(c)
+
+	item := sampleItem()
+	item.State = "todo"
+	first, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+	if first.Metadata.State != "todo" {
+		t.Fatalf("metadata.State = %q, want todo", first.Metadata.State)
+	}
+
+	// The handoff flow mutates the source item: a new label and a state change.
+	// Re-polling must refresh the task's routing metadata so RouteAll re-routes.
+	item.Labels = []string{"bug", "apiary", "agent:engineer"}
+	item.State = "in_progress"
+	item.Title = "Fix the widget (updated)"
+	second, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("second bind: %v", err)
+	}
+
+	if second.ID != first.ID {
+		t.Fatalf("refresh created a new task %q, want %q", second.ID, first.ID)
+	}
+	if second.Metadata.State != "in_progress" {
+		t.Errorf("returned task State = %q, want in_progress", second.Metadata.State)
+	}
+	if len(second.Metadata.Labels) != 3 {
+		t.Errorf("returned task labels not refreshed: %v", second.Metadata.Labels)
+	}
+	if second.Title != "Fix the widget (updated)" {
+		t.Errorf("returned task Title not refreshed: %q", second.Title)
+	}
+
+	// The refresh must be persisted, not just reflected in the return value.
+	stored, err := c.InternalTasks().GetTask(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if stored.Metadata.State != "in_progress" || len(stored.Metadata.Labels) != 3 || stored.Title != "Fix the widget (updated)" {
+		t.Errorf("refresh not persisted: %+v", stored)
+	}
+
+	// Still exactly one task and one binding — refresh updates in place.
+	bindings, err := c.SourceBindings().ListBindingsByTask(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Errorf("expected exactly 1 binding, got %d", len(bindings))
+	}
+}
+
+func TestBind_RefreshPreservesStateAndCounter(t *testing.T) {
+	ctx := context.Background()
+	c := newBinderTestDB(t)
+	binder := NewSourceBinder(c)
+	item := sampleItem()
+
+	first, err := binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("first bind: %v", err)
+	}
+
+	// Simulate the dispatcher advancing the task: lifecycle state + outstanding
+	// counter. A subsequent refresh (label change) must not clobber either.
+	if err := c.InternalTasks().UpdateTaskState(ctx, first.ID, model.TaskStateRunning); err != nil {
+		t.Fatalf("update state: %v", err)
+	}
+	if _, err := c.InternalTasks().IncrementOutstanding(ctx, first.ID, 2); err != nil {
+		t.Fatalf("increment outstanding: %v", err)
+	}
+
+	item.Labels = []string{"bug", "apiary", "agent:engineer"}
+	if _, err := binder.Bind(ctx, item); err != nil {
+		t.Fatalf("refresh bind: %v", err)
+	}
+
+	stored, err := c.InternalTasks().GetTask(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if stored.State != model.TaskStateRunning {
+		t.Errorf("refresh clobbered lifecycle state: %q", stored.State)
+	}
+	if stored.OutstandingWorkflows != 2 {
+		t.Errorf("refresh clobbered outstanding counter: %d", stored.OutstandingWorkflows)
+	}
+	if len(stored.Metadata.Labels) != 3 {
+		t.Errorf("labels not refreshed: %v", stored.Metadata.Labels)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 4 of the `internal-task-model` change: routing now operates over the **InternalTask** and an item can dispatch **multiple workflows** (fan-out), with the dispatcher tracking how many are outstanding.

- **config**: `TriggerConfig.Exclusive` (stops the evaluation after the first exclusive match) and `RouteConfig.Exclusive` (propagated by the Router from the trigger).
- **router**: `RouteAll(model.InternalTask) []Match` — evaluates all triggers by priority, returns **all** matches and **stops after the first exclusive one**. `evaluate` was refactored over a common target (`target`), preserving `Route`/`Explain` over `SourceItem`.
- **model**: `TaskMetadata.Source`/`State` — routing attributes of the source item, since routing is now over the task (not the `SourceItem`).
- **source**: `SourceBinder.refresh` — keeps the task's title/description/metadata in sync with the live item **on each poll**. The handoff flow mutates labels/state on the source item, so `RouteAll` needs to see the current value. It doesn't touch the lifecycle `state`, `input` or the outstanding counter.
- **db**: `InternalTaskStore.UpdateTaskMetadata` for the refresh.
- **daemon**: `poll` and `RunOnce` call `RouteAll` and fan out via `fanOut` — increments `outstanding_workflows` by N **before** starting, dispatches one workflow per match, and releases the in-flight marker only when **all** finish. Without a DB, falls back to a transient task (routing works, no counter).

### Scope decision
`RouteAll` receives only the task, which carries no source identity or live state. Since the real flow is **label-driven** (an `on_complete` swaps `agent:staff`→`agent:po` and the next poll re-routes), the task must reflect the live item. We chose a **per-poll refresh** (`TaskMetadata.Source/State` + `SourceBinder.refresh`), making `RouteAll(task)` equivalent to the old `Route(cell)`. Without it, a task with frozen metadata would re-match the first trigger forever.

## Test plan

- `go build ./...`, `go vet ./...` — OK
- `go test ./...` — OK (full suite)
- `go test -race ./internal/daemon/... ./internal/source/... ./internal/router/...` — OK
- New tests:
  - router `RouteAll`: two non-exclusive matches; an exclusive stops the evaluation; priority order respected; filter by conditions; no match → nil.
  - binder `refresh`: metadata (labels/state/title) updated and **persisted** on re-poll; preserves the lifecycle `state` and `outstanding_workflows`.
  - dispatcher fan-out (`RunOnce`): one item → two workflows (`outstanding_workflows == 2`); an exclusive trigger dispatches only one (`== 1`).

Phase 4 of 9. The engine over `InternalTask` + bindings is Phase 5.