### PR TITLE
feat(engine): engine over InternalTask + SourceBindings (Phase 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4755 symbols, 10610 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4810 symbols, 10735 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4755 symbols, 10610 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4810 symbols, 10735 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -835,7 +835,7 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 					wg.Done()
 				}
 			}()
-			result := d.dispatch(ctx, cell, adapter, match)
+			result := d.dispatch(ctx, cell, adapter, task, match)
 			if !result.Success && onFail != nil {
 				onFail(cell.ID)
 			}
@@ -856,6 +856,10 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 // no task ID to track outstanding workflows against.
 func transientTask(cell model.SourceItem) model.InternalTask {
 	return model.InternalTask{
+		// No DB row exists, so this id is never persisted; it stands in as the
+		// engine's execution-view id (sourceItemView falls back to it when the
+		// task has no binding) so the runner still keys on the source item id.
+		ID:          cell.ID,
 		Title:       cell.Title,
 		Description: cell.Description,
 		State:       model.TaskStateRegistered,
@@ -889,12 +893,12 @@ func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task 
 	return task, true
 }
 
-// dispatch acknowledges, runs, and writes the result for a single cell.
-func (d *Dispatcher) dispatch(ctx context.Context, cell model.SourceItem, adapter source.Adapter, match router.Match) model.RunResult {
-	// Workflow mode is the only dispatch path: every matched cell runs
+// dispatch acknowledges, runs, and writes the result for a single task.
+func (d *Dispatcher) dispatch(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, match router.Match) model.RunResult {
+	// Workflow mode is the only dispatch path: every matched task runs
 	// through the workflow engine (instances + step runs + memory). A plain
 	// route is synthesized into a single-step workflow by dispatchWorkflow.
-	return d.dispatchWorkflow(ctx, cell, adapter, match)
+	return d.dispatchWorkflow(ctx, cell, task, match)
 }
 
 func (d *Dispatcher) recordPoll(sourceID string, count int) {

--- a/src/internal/daemon/engine_binding_test.go
+++ b/src/internal/daemon/engine_binding_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// recordingAdapter is a poll-once source that captures every side-effect call so
+// a test can assert the engine resolved the adapter (and the SourceItem) through
+// the task's source binding. It implements LabelAdder and StateSetter.
+type recordingAdapter struct {
+	items []model.SourceItem
+
+	mu      sync.Mutex
+	acked   []model.SourceItem
+	wrote   []model.SourceItem
+	labeled [][]string
+	states  []string
+}
+
+func (a *recordingAdapter) ID() string                                    { return "fake" }
+func (a *recordingAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *recordingAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *recordingAdapter) Acknowledge(_ context.Context, item model.SourceItem, _ model.AckAction) error {
+	a.mu.Lock()
+	a.acked = append(a.acked, item)
+	a.mu.Unlock()
+	return nil
+}
+func (a *recordingAdapter) WriteResult(_ context.Context, item model.SourceItem, _ model.RunResult) error {
+	a.mu.Lock()
+	a.wrote = append(a.wrote, item)
+	a.mu.Unlock()
+	return nil
+}
+func (a *recordingAdapter) AddLabels(_ context.Context, item model.SourceItem, labels []string) error {
+	a.mu.Lock()
+	a.labeled = append(a.labeled, labels)
+	a.mu.Unlock()
+	return nil
+}
+func (a *recordingAdapter) SetState(_ context.Context, item model.SourceItem, state string) error {
+	a.mu.Lock()
+	a.states = append(a.states, state)
+	a.mu.Unlock()
+	return nil
+}
+func (a *recordingAdapter) WebhookHandler() http.Handler { return nil }
+
+var (
+	_ source.Adapter     = (*recordingAdapter)(nil)
+	_ source.LabelAdder  = (*recordingAdapter)(nil)
+	_ source.StateSetter = (*recordingAdapter)(nil)
+)
+
+// TestRunOnce_SideEffectsResolveViaBinding runs a single workflow against a
+// source-bound task and asserts every side effect (state_lock, result comment,
+// on_complete hook) reaches the adapter through the task's binding, carrying the
+// binding's source item identity rather than a frozen SourceItem (Phase 5).
+func TestRunOnce_SideEffectsResolveViaBinding(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "binding.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	adapter := &recordingAdapter{items: []model.SourceItem{
+		{ID: "ISSUE-7", SourceID: "src", Number: "#7", Title: "Fix login", State: "todo"},
+	}}
+
+	cfg := &config.Config{
+		Version:  "1",
+		Sources:  []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:   []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Settings: config.Settings{StateLock: true, ResultComment: true},
+		Workflows: []config.WorkflowConfig{{
+			ID:         "wf-a",
+			Trigger:    &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src"}},
+			Steps:      []config.StepConfig{{ID: "run", Agent: "a"}},
+			OnComplete: &config.OnComplete{SetState: "in_review", AddLabels: []string{"reviewed"}},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": &countingRunner{}},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	if err := d.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+
+	// state_lock → Acknowledge against the bound source item.
+	if len(adapter.acked) != 1 {
+		t.Fatalf("expected 1 state_lock Acknowledge, got %d", len(adapter.acked))
+	}
+	if adapter.acked[0].ID != "ISSUE-7" || adapter.acked[0].SourceID != "src" {
+		t.Errorf("state_lock item = %+v, want source item ISSUE-7 from binding", adapter.acked[0])
+	}
+	if adapter.acked[0].Number != "#7" {
+		t.Errorf("state_lock item Number = %q, want #7 (from binding)", adapter.acked[0].Number)
+	}
+
+	// result_comment (on_complete) → WriteResult.
+	if len(adapter.wrote) != 1 {
+		t.Fatalf("expected 1 result-comment WriteResult, got %d", len(adapter.wrote))
+	}
+	if adapter.wrote[0].ID != "ISSUE-7" {
+		t.Errorf("result-comment item id = %q, want ISSUE-7", adapter.wrote[0].ID)
+	}
+
+	// on_complete hook → AddLabels + SetState.
+	if len(adapter.labeled) != 1 || len(adapter.labeled[0]) != 1 || adapter.labeled[0][0] != "reviewed" {
+		t.Errorf("on_complete add_labels = %v, want [[reviewed]]", adapter.labeled)
+	}
+	if len(adapter.states) != 1 || adapter.states[0] != "in_review" {
+		t.Errorf("on_complete set_state = %v, want [in_review]", adapter.states)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -26,20 +26,21 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 	return d.engine
 }
 
-// dispatchWorkflow runs a matched cell through the workflow engine. The route is
+// dispatchWorkflow runs a matched task through the workflow engine. The route is
 // matched to a defined workflow when one shares the route's id; otherwise the
-// route is synthesized into a single-step workflow.
+// route is synthesized into a single-step workflow. cell is retained for logging
+// (the engine derives its own execution view from the task + its bindings).
 //
 // This is the dispatch path; it requires a run-history DB (the engine persists
 // instances and step runs).
-func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem, adapter source.Adapter, match router.Match) model.RunResult {
+func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem, task model.InternalTask, match router.Match) model.RunResult {
 	if d.db == nil {
 		aplog.Error("cell %s: workflow dispatch requires a run-history database", cell.ID)
 		return model.RunResult{Success: false}
 	}
 
 	wf := d.resolveWorkflow(match)
-	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, cell)
+	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
 	if err != nil {
 		aplog.Error("cell %s: workflow run failed: %v", cell.ID, err)
 		return model.RunResult{Success: false, WorkerID: match.Route.Agent}
@@ -218,50 +219,81 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 	}
 }
 
-// wfSideEffects applies source-facing actions for a workflow instance. It
-// resolves the adapter per cell (via the cell's SourceID) so a single long-lived
-// engine can serve cells from any configured source.
+// wfSideEffects applies source-facing actions for a workflow instance. It fans
+// each action out across the task's source bindings, resolving the adapter per
+// binding (via binding.SourceID) so a single long-lived engine can serve tasks
+// bound to any configured source. A task with no bindings (spawned) is a no-op.
 type wfSideEffects struct {
 	d *Dispatcher
 }
 
-// adapterFor returns the source adapter that produced the cell, or nil.
-func (s *wfSideEffects) adapterFor(cell model.SourceItem) source.Adapter {
-	return s.d.sources[cell.SourceID]
+// sourceItemFromBinding reconstructs the SourceItem an adapter call needs from a
+// binding (source identity) plus the live task (content + routing attributes).
+func sourceItemFromBinding(task model.InternalTask, b model.SourceBinding) model.SourceItem {
+	return model.SourceItem{
+		ID:          b.SourceItemID,
+		SourceID:    b.SourceID,
+		Number:      b.SourceItemNumber,
+		URL:         b.SourceItemURL,
+		Title:       task.Title,
+		Description: task.Description,
+		Labels:      task.Metadata.Labels,
+		Type:        task.Metadata.Type,
+		Priority:    task.Metadata.Priority,
+		State:       task.Metadata.State,
+	}
 }
 
-func (s *wfSideEffects) StateLock(ctx context.Context, cell model.SourceItem) error {
-	adapter := s.adapterFor(cell)
-	if adapter == nil {
-		return fmt.Errorf("no adapter for source %q", cell.SourceID)
-	}
-	return adapter.Acknowledge(ctx, cell, model.AckActionInProgress)
-}
-
-func (s *wfSideEffects) PostComment(ctx context.Context, cell model.SourceItem, comment string) error {
-	adapter := s.adapterFor(cell)
-	if adapter == nil {
-		return fmt.Errorf("no adapter for source %q", cell.SourceID)
-	}
-	return adapter.WriteResult(ctx, cell, model.RunResult{Success: true, Output: comment})
-}
-
-func (s *wfSideEffects) ApplyHook(ctx context.Context, cell model.SourceItem, hook config.OnComplete) error {
-	adapter := s.adapterFor(cell)
-	if adapter == nil {
-		return fmt.Errorf("no adapter for source %q", cell.SourceID)
-	}
-	if len(hook.AddLabels) > 0 {
-		if la, ok := adapter.(source.LabelAdder); ok {
-			if err := la.AddLabels(ctx, cell, hook.AddLabels); err != nil {
-				aplog.Error("cell %s: add labels %v: %v", cell.ID, hook.AddLabels, err)
-			}
+func (s *wfSideEffects) StateLock(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding) error {
+	for _, b := range bindings {
+		adapter := s.d.sources[b.SourceID]
+		if adapter == nil {
+			aplog.Error("task %s: no adapter for source %q (state_lock)", task.ID, b.SourceID)
+			continue
+		}
+		item := sourceItemFromBinding(task, b)
+		if err := adapter.Acknowledge(ctx, item, model.AckActionInProgress); err != nil {
+			aplog.Error("item %s: state_lock: %v", item.ID, err)
 		}
 	}
-	if hook.SetState != "" {
-		if ss, ok := adapter.(source.StateSetter); ok {
-			if err := ss.SetState(ctx, cell, hook.SetState); err != nil {
-				aplog.Error("cell %s: set_state %q: %v", cell.ID, hook.SetState, err)
+	return nil
+}
+
+func (s *wfSideEffects) PostComment(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, comment string) error {
+	for _, b := range bindings {
+		adapter := s.d.sources[b.SourceID]
+		if adapter == nil {
+			aplog.Error("task %s: no adapter for source %q (post_comment)", task.ID, b.SourceID)
+			continue
+		}
+		item := sourceItemFromBinding(task, b)
+		if err := adapter.WriteResult(ctx, item, model.RunResult{Success: true, Output: comment}); err != nil {
+			aplog.Error("item %s: post_comment: %v", item.ID, err)
+		}
+	}
+	return nil
+}
+
+func (s *wfSideEffects) ApplyHook(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, hook config.OnComplete) error {
+	for _, b := range bindings {
+		adapter := s.d.sources[b.SourceID]
+		if adapter == nil {
+			aplog.Error("task %s: no adapter for source %q (apply_hook)", task.ID, b.SourceID)
+			continue
+		}
+		item := sourceItemFromBinding(task, b)
+		if len(hook.AddLabels) > 0 {
+			if la, ok := adapter.(source.LabelAdder); ok {
+				if err := la.AddLabels(ctx, item, hook.AddLabels); err != nil {
+					aplog.Error("item %s: add labels %v: %v", item.ID, hook.AddLabels, err)
+				}
+			}
+		}
+		if hook.SetState != "" {
+			if ss, ok := adapter.(source.StateSetter); ok {
+				if err := ss.SetState(ctx, item, hook.SetState); err != nil {
+					aplog.Error("item %s: set_state %q: %v", item.ID, hook.SetState, err)
+				}
 			}
 		}
 	}

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -132,10 +132,10 @@ func (d *Dispatcher) StartResume(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	cell := d.cellForInstance(ctx, inst)
+	task := d.taskForInstance(ctx, inst)
 
 	go func() {
-		success, rerr := d.workflowEngine().ResumeInstance(ctx, id, wf, cell, steps)
+		success, rerr := d.workflowEngine().ResumeInstance(ctx, id, wf, task, steps)
 		if rerr != nil {
 			aplog.Error("resume %s: %v", id, rerr)
 			return
@@ -173,6 +173,20 @@ func resumeHTTPStatus(err error) int {
 	default:
 		return http.StatusInternalServerError
 	}
+}
+
+// taskForInstance resolves the InternalTask a resume runs against. When the
+// instance carries a task id (the post-Phase-5 path) the persisted task is
+// loaded so the engine can resolve its source bindings for side effects. A
+// legacy instance with no task id falls back to a transient task synthesized
+// from the live/stored cell (no bindings → side effects are skipped on resume).
+func (d *Dispatcher) taskForInstance(ctx context.Context, inst *db.WorkflowInstance) model.InternalTask {
+	if inst.TaskID != "" {
+		if t, err := d.db.InternalTasks().GetTask(ctx, inst.TaskID); err == nil && t != nil {
+			return *t
+		}
+	}
+	return transientTask(d.cellForInstance(ctx, inst))
 }
 
 // cellForInstance rebuilds the cell to resume against: a fresh poll when the

--- a/src/internal/db/binding_store.go
+++ b/src/internal/db/binding_store.go
@@ -66,6 +66,13 @@ func (s *SourceBindingStore) GetBindingBySourceItem(ctx context.Context, sourceI
 	return b, err
 }
 
+// ListBindingsByTask returns all source bindings for a task, oldest first. It is
+// a Client-level convenience so the workflow engine can resolve a task's bindings
+// (for side-effect fan-out) through the same Store it already holds.
+func (c *Client) ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error) {
+	return c.SourceBindings().ListBindingsByTask(ctx, taskID)
+}
+
 // ListBindingsByTask returns all source bindings for a task, oldest first.
 func (s *SourceBindingStore) ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -26,10 +26,13 @@ const (
 	StepStateSkippedCached = "skipped_cached"
 )
 
-// WorkflowInstance is a single execution of a workflow bound to a Cell.
+// WorkflowInstance is a single execution of a workflow bound to an InternalTask.
+// TaskID is the canonical link; CellID/SourceID are retained (and still populated
+// from the task's primary source binding) for the dashboard until a future change.
 type WorkflowInstance struct {
 	ID               string
 	WorkflowID       string
+	TaskID           string
 	CellID           string
 	SourceID         string
 	State            string
@@ -65,9 +68,9 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 	inst.UpdatedAt = now
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO workflow_instances
-		  (id, workflow_id, cell_id, source_id, state, parent_instance_id, resumed_from, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, inst.ID, inst.WorkflowID, inst.CellID, nullStr(inst.SourceID), inst.State,
+		  (id, workflow_id, task_id, cell_id, source_id, state, parent_instance_id, resumed_from, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, inst.ID, inst.WorkflowID, nullStr(inst.TaskID), inst.CellID, nullStr(inst.SourceID), inst.State,
 		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.CreatedAt, inst.UpdatedAt)
 	return err
 }
@@ -84,7 +87,7 @@ func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state stri
 func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE id = ?
 	`, id)
 	inst, err := scanInstance(row)
@@ -98,7 +101,7 @@ func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowI
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE state = ? ORDER BY created_at ASC
 	`, state)
 	if err != nil {
@@ -115,7 +118,7 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 	}
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances ORDER BY created_at DESC LIMIT ?
 	`, limit)
 	if err != nil {
@@ -130,7 +133,7 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC LIMIT 1
 	`, cellID)
 	inst, err := scanInstance(row)
@@ -145,7 +148,7 @@ func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*W
 func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances
 		WHERE workflow_id = ? AND state IN ('failed','interrupted')
 		ORDER BY created_at DESC LIMIT 1
@@ -173,7 +176,7 @@ func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowI
 	q := `
 		SELECT wi.id, wi.workflow_id, wi.cell_id, COALESCE(wi.source_id,''), wi.state,
 		       COALESCE(wi.parent_instance_id,''), COALESCE(wi.resumed_from,''),
-		       wi.created_at, wi.updated_at, COALESCE(t.title,'')
+		       wi.created_at, wi.updated_at, COALESCE(wi.task_id,''), COALESCE(t.title,'')
 		FROM workflow_instances wi
 		LEFT JOIN tasks t ON t.id = wi.cell_id
 		WHERE 1=1`
@@ -199,7 +202,7 @@ func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowI
 	for rows.Next() {
 		var v WorkflowInstanceView
 		if err := rows.Scan(&v.ID, &v.WorkflowID, &v.CellID, &v.SourceID, &v.State,
-			&v.ParentInstanceID, &v.ResumedFrom, &v.CreatedAt, &v.UpdatedAt, &v.Title); err != nil {
+			&v.ParentInstanceID, &v.ResumedFrom, &v.CreatedAt, &v.UpdatedAt, &v.TaskID, &v.Title); err != nil {
 			return nil, err
 		}
 		out = append(out, v)
@@ -294,7 +297,7 @@ type scanner interface {
 func scanInstance(s scanner) (*WorkflowInstance, error) {
 	var inst WorkflowInstance
 	err := s.Scan(&inst.ID, &inst.WorkflowID, &inst.CellID, &inst.SourceID, &inst.State,
-		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt)
+		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt, &inst.TaskID)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -78,7 +78,8 @@ func labelPresent(cell model.SourceItem, label string) bool {
 // ParkedApproval describes an instance suspended at an approval step.
 type ParkedApproval struct {
 	InstanceID string
-	Cell       model.SourceItem
+	Task       model.InternalTask
+	Bindings   []model.SourceBinding
 	Step       config.StepConfig // the waiting approval step (resume_on/abort_on/timeout)
 	ParkedAt   time.Time
 }
@@ -91,7 +92,8 @@ func (e *Engine) ParkedApprovals() []ParkedApproval {
 	for id, r := range e.parked {
 		out = append(out, ParkedApproval{
 			InstanceID: id,
-			Cell:       r.cell,
+			Task:       r.task,
+			Bindings:   r.bindings,
 			Step:       r.byID[r.waitingStep],
 			ParkedAt:   r.parkedAt,
 		})
@@ -119,29 +121,38 @@ func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decisio
 	return e.settle(ctx, r, outcome), nil
 }
 
-// CheckParkedApprovals evaluates every parked instance against its live task
-// (fetched via poll) and resumes, aborts, or times it out as conditions dictate.
-// poll returns the current Cell for a (sourceID, cellID); when poll errors the
-// instance is left parked for the next cycle.
-func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, cellID string) (model.SourceItem, error)) {
+// CheckParkedApprovals evaluates every parked instance against its live source
+// item(s) and resumes, aborts, or times it out as conditions dictate. The live
+// item is fetched per source binding (poll is keyed by source id + source item
+// id), so the TaskPoller adapter is resolved from the task's bindings rather than
+// a frozen SourceItem. The first binding whose live item satisfies a resume/abort
+// condition decides the instance; when poll errors for a binding it is skipped.
+// A binding-less (spawned) task cannot be resolved via a source and stays parked
+// until it times out.
+func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, sourceItemID string) (model.SourceItem, error)) {
 	for _, p := range e.ParkedApprovals() {
 		if to := p.Step.ParsedTimeout(); to > 0 && e.now().Sub(p.ParkedAt) >= to {
 			aplog.Info("workflow: approval on instance %s timed out after %s — aborting", p.InstanceID, to)
 			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
 			continue
 		}
-		cell, err := poll(p.Cell.SourceID, p.Cell.ID)
-		if err != nil {
-			aplog.Debug("workflow: poll task %s for approval check failed: %v", p.Cell.ID, err)
-			continue
-		}
-		switch EvaluateApproval(p.Step, cell) {
-		case ApprovalResume:
-			aplog.Info("workflow: approval on instance %s resumed", p.InstanceID)
-			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalResume)
-		case ApprovalAbort:
-			aplog.Info("workflow: approval on instance %s aborted by condition", p.InstanceID)
-			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
+		for _, b := range p.Bindings {
+			item, err := poll(b.SourceID, b.SourceItemID)
+			if err != nil {
+				aplog.Debug("workflow: poll item %s/%s for approval check failed: %v", b.SourceID, b.SourceItemID, err)
+				continue
+			}
+			decision := EvaluateApproval(p.Step, item)
+			if decision == ApprovalResume {
+				aplog.Info("workflow: approval on instance %s resumed", p.InstanceID)
+				_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalResume)
+				break
+			}
+			if decision == ApprovalAbort {
+				aplog.Info("workflow: approval on instance %s aborted by condition", p.InstanceID)
+				_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
+				break
+			}
 		}
 	}
 }

--- a/src/internal/workflow/approval_test.go
+++ b/src/internal/workflow/approval_test.go
@@ -57,7 +57,7 @@ func TestApproval_SuspendsAtApprovalStep(t *testing.T) {
 	side := &fakeSide{}
 	eng := testEngine(cfg, store, exec, side)
 
-	instID, success, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1"})
+	instID, success, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("a parked instance should not report success")
 	}
@@ -87,7 +87,7 @@ func TestApproval_ResumeContinuesWorkflow(t *testing.T) {
 	exec := &fakeExecutor{}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1"})
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 
 	success, err := eng.ResolveApproval(context.Background(), instID, ApprovalResume)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestApproval_AbortFailsWorkflow(t *testing.T) {
 	exec := &fakeExecutor{}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1"})
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 
 	success, _ := eng.ResolveApproval(context.Background(), instID, ApprovalAbort)
 	if success {
@@ -141,7 +141,8 @@ func TestApproval_CheckResumesOnComment(t *testing.T) {
 	exec := &fakeExecutor{}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1", SourceID: "s1"})
+	store.bindings["c1"] = []model.SourceBinding{{TaskID: "c1", SourceID: "s1", SourceItemID: "c1"}}
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 
 	// Poll returns a cell with an approving comment.
 	poll := func(sourceID, cellID string) (model.SourceItem, error) {
@@ -171,7 +172,7 @@ func TestApproval_CheckTimesOut(t *testing.T) {
 		WithIDGen(func(p string) string { return p + "-1" }),
 	)
 
-	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1", SourceID: "s1"})
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 
 	// Advance clock past 48h; poll returns nothing actionable.
 	clock = time.Unix(0, 0).Add(49 * time.Hour)
@@ -190,7 +191,8 @@ func TestApproval_CheckWaitsWhenNoSignal(t *testing.T) {
 	store := newFakeStore()
 	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
 
-	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.SourceItem{ID: "c1", SourceID: "s1"})
+	store.bindings["c1"] = []model.SourceBinding{{TaskID: "c1", SourceID: "s1", SourceItemID: "c1"}}
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
 
 	poll := func(sourceID, cellID string) (model.SourceItem, error) {
 		return model.SourceItem{ID: cellID, Comments: []model.Comment{{Body: "still thinking"}}}, nil

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -34,11 +34,13 @@ const (
 // dagRun holds the mutable state of one workflow instance's step graph as the
 // scheduler walks it.
 type dagRun struct {
-	instID string
-	wf     config.WorkflowConfig
-	cell   model.SourceItem
-	depth  int          // nesting depth (0 = top-level; >0 = sub-workflow child)
-	seed   []MemoryStep // inherited memory (sub-workflow snapshot from the parent)
+	instID   string
+	wf       config.WorkflowConfig
+	task     model.InternalTask    // the unit of work this instance runs against
+	bindings []model.SourceBinding // task's source bindings (side-effect targets)
+	cell     model.SourceItem      // execution view derived from task + primary binding
+	depth    int                   // nesting depth (0 = top-level; >0 = sub-workflow child)
+	seed     []MemoryStep          // inherited memory (sub-workflow snapshot from the parent)
 
 	byID  map[string]config.StepConfig
 	order []string // step ids in declaration order (deterministic scheduling)
@@ -56,13 +58,16 @@ type dagRun struct {
 	parkedAt    time.Time // when the current approval parked (for timeout)
 }
 
-// initDAG builds the in-memory state for a workflow instance's step graph. seed
+// initDAG builds the in-memory state for a workflow instance's step graph. The
+// execution view (cell) is projected from the task + its primary binding. seed
 // is inherited memory for a sub-workflow child; depth tracks nesting.
-func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, cell model.SourceItem, seed []MemoryStep, depth int) *dagRun {
+func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) *dagRun {
 	r := &dagRun{
 		instID:      instID,
 		wf:          wf,
-		cell:        cell,
+		task:        task,
+		bindings:    bindings,
+		cell:        sourceItemView(task, bindings),
 		depth:       depth,
 		seed:        seed,
 		byID:        map[string]config.StepConfig{},
@@ -194,7 +199,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 					}
 					foreachExitCode = fr.failed
 				case config.StepTypeWorkflow:
-					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.cell, memSnap, r.depth, r.wf.ID)
+					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
 				default: // StepTypeAgent
 					res = e.runStep(ctx, r.instID, step, r.cell, memSnap)
 				}
@@ -284,7 +289,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		r.stepStates[step.ID] = ss
 
 		if e.resultCommentMode(r.wf) == config.ResultCommentPerStep && e.side != nil {
-			_ = e.side.PostComment(ctx, r.cell, perStepComment(step, res))
+			_ = e.side.PostComment(ctx, r.task, r.bindings, perStepComment(step, res))
 		}
 
 		if res.Success {
@@ -350,7 +355,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 // aborts it via the engine's approval handling.
 func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepConfig) {
 	if e.side != nil && step.Message != "" {
-		_ = e.side.PostComment(ctx, r.cell, step.Message)
+		_ = e.side.PostComment(ctx, r.task, r.bindings, step.Message)
 	}
 	r.state[step.ID] = stWaiting
 	r.waitingStep = step.ID

--- a/src/internal/workflow/dag_concurrent_test.go
+++ b/src/internal/workflow/dag_concurrent_test.go
@@ -66,7 +66,7 @@ func TestConcurrentScheduler_IndependentStepsRunParallel(t *testing.T) {
 		{ID: "b", Agent: "architect"}, // no depends_on: independent from a
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestConcurrentScheduler_Concurrency1IsSequential(t *testing.T) {
 		{ID: "c", Agent: "architect"},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestConcurrentScheduler_DepsPreventEarlyDispatch(t *testing.T) {
 		{ID: "b", Agent: "architect", DependsOn: []string{"a"}},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestParallelStep_AllJoin(t *testing.T) {
 		{ID: "after", Agent: "architect", DependsOn: []string{"par"}},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestParallelStep_AllJoinFailsIfAnyChildFails(t *testing.T) {
 		},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure (child-b failed, join=all)")
 	}
@@ -231,7 +231,7 @@ func TestParallelStep_AnyJoinPassesIfOneChildPasses(t *testing.T) {
 		{ID: "after", Agent: "architect", DependsOn: []string{"par"}},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -285,7 +285,7 @@ func TestConcurrentScheduler_MemoryOrderDeterministic(t *testing.T) {
 		{ID: "c", Agent: "architect", DependsOn: []string{"a", "b"}},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}

--- a/src/internal/workflow/dag_e2e_test.go
+++ b/src/internal/workflow/dag_e2e_test.go
@@ -104,7 +104,7 @@ func TestE2E_ClassifyImplementReviewQA(t *testing.T) {
 		t.Fatalf("LowerV2Workflow: %v", err)
 	}
 
-	instID, success, err := eng.RunInstance(ctx, lowered, model.SourceItem{ID: "issue-42"})
+	instID, success, err := eng.RunInstance(ctx, lowered, model.InternalTask{ID: "issue-42"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestE2E_V2ConditionSkipsTrack(t *testing.T) {
 		t.Fatalf("LowerV2Workflow: %v", err)
 	}
 
-	_, success, err := eng.RunInstance(ctx, lowered, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(ctx, lowered, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}

--- a/src/internal/workflow/dag_engine_additions_test.go
+++ b/src/internal/workflow/dag_engine_additions_test.go
@@ -35,7 +35,7 @@ func TestDAG_ConditionSkipsStep(t *testing.T) {
 		{ID: "deploy", Agent: "architect", DependsOn: []string{"implement"}},
 	}}
 
-	instID, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	instID, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestDAG_CondSkip_SeqSuccessorStillRuns(t *testing.T) {
 		},
 	}}
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestDAG_ConditionTrueRunsStep(t *testing.T) {
 		},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -157,7 +157,7 @@ func TestDAG_FailWhenRejectsStep(t *testing.T) {
 		},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success after retry")
 	}
@@ -188,7 +188,7 @@ func TestDAG_FailWhenFalseDoesNotReject(t *testing.T) {
 		},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success when fail_when is false")
 	}
@@ -218,7 +218,7 @@ func TestDAG_FailWhenExhaustsRetries(t *testing.T) {
 		},
 	}}
 
-	instID, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure after exhausted retries")
 	}
@@ -250,7 +250,7 @@ func TestDAG_OnMissingOutputFail(t *testing.T) {
 		},
 	}}
 
-	instID, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure when structured output is missing with on_missing_output=fail")
 	}
@@ -277,7 +277,7 @@ func TestDAG_OnMissingOutputWarnDoesNotFail(t *testing.T) {
 		},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success when on_missing_output=warn and output is absent")
 	}

--- a/src/internal/workflow/dag_integration_test.go
+++ b/src/internal/workflow/dag_integration_test.go
@@ -81,7 +81,7 @@ func TestDAGIntegration_SequentialMemory(t *testing.T) {
 		},
 	}
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "T-1", Title: "Add feature"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-1", Title: "Add feature"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestDAGIntegration_DiamondFanIn(t *testing.T) {
 		},
 	}
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "T-2"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-2"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestDAGIntegration_SplitByMemoryField(t *testing.T) {
 		},
 	}
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "T-3"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-3"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestDAGIntegration_OnFailLoopBackAndRetry(t *testing.T) {
 		},
 	}
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "T-4"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-4"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestDAGIntegration_OnFailMaxRetriesExhausted(t *testing.T) {
 		},
 	}
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "T-5"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-5"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}

--- a/src/internal/workflow/dag_test.go
+++ b/src/internal/workflow/dag_test.go
@@ -79,7 +79,7 @@ func TestDAG_DiamondParallelJoin(t *testing.T) {
 		{ID: "D", Agent: "architect", DependsOn: []string{"B", "C"}},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -116,7 +116,7 @@ func TestDAG_SplitFirstMatch(t *testing.T) {
 		{ID: "junior", Agent: "backend-dev"},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -150,7 +150,7 @@ func TestDAG_SplitFallback(t *testing.T) {
 		{ID: "junior", Agent: "backend-dev"},
 	}}
 
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	ids := executedIDs(exec.seen)
 	if !contains(ids, "junior") || contains(ids, "senior") {
 		t.Errorf("expected fallback junior only, got %v", ids)
@@ -172,7 +172,7 @@ func TestDAG_SplitMultiFanOut(t *testing.T) {
 		{ID: "fe", Agent: "architect"},
 	}}
 
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1", Labels: []string{"backend", "frontend"}})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1", Metadata: model.TaskMetadata{Labels: []string{"backend", "frontend"}}})
 	ids := executedIDs(exec.seen)
 	if !contains(ids, "be") || !contains(ids, "fe") {
 		t.Errorf("expected both branches via multi, got %v", ids)
@@ -196,7 +196,7 @@ func TestDAG_SplitSkipCascadesDownstream(t *testing.T) {
 		{ID: "b2", Agent: "architect", DependsOn: []string{"b"}},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1", Priority: "high"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1", Metadata: model.TaskMetadata{Priority: "high"}})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -225,7 +225,7 @@ func TestDAG_OnFailLoopSucceedsOnRetry(t *testing.T) {
 			OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 2}},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success after retry")
 	}
@@ -250,7 +250,7 @@ func TestDAG_OnFailLoopExhaustsRetries(t *testing.T) {
 			OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 1}},
 	}}
 
-	instID, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure after exhausting retries")
 	}
@@ -279,7 +279,7 @@ func TestDAG_FailureWithoutLoopStopsGraph(t *testing.T) {
 		{ID: "deploy", Agent: "architect", DependsOn: []string{"build"}},
 	}}
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure")
 	}
@@ -300,7 +300,7 @@ func TestDAG_LinearChainOrder(t *testing.T) {
 		{ID: "b", Agent: "backend-dev", DependsOn: []string{"a"}},
 		{ID: "c", Agent: "architect", DependsOn: []string{"b"}},
 	}}
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -22,6 +22,13 @@ type Store interface {
 	UpdateStepRun(ctx context.Context, sr *db.StepRun) error
 }
 
+// bindingLister is the optional capability the engine uses to resolve a task's
+// source bindings (for side-effect fan-out and the execution view). *db.Client
+// satisfies it; fake stores in tests that omit it simply yield no bindings.
+type bindingLister interface {
+	ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error)
+}
+
 // StepRequest is the input to executing one agent step.
 type StepRequest struct {
 	InstanceID string
@@ -50,14 +57,18 @@ type StepExecutor interface {
 	ExecuteStep(ctx context.Context, req StepRequest) StepResult
 }
 
-// SideEffects applies source-facing actions. A nil SideEffects disables them.
+// SideEffects applies source-facing actions for an InternalTask. Each action
+// fans out to the task's source bindings (today a task has at most one binding;
+// spawned tasks have none, in which case the action is a no-op). A nil
+// SideEffects disables them.
 type SideEffects interface {
-	// StateLock marks the task in-progress at workflow start.
-	StateLock(ctx context.Context, cell model.SourceItem) error
-	// PostComment posts a comment (result_comment) on the task.
-	PostComment(ctx context.Context, cell model.SourceItem, comment string) error
-	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels).
-	ApplyHook(ctx context.Context, cell model.SourceItem, hook config.OnComplete) error
+	// StateLock marks each bound source item in-progress at workflow start.
+	StateLock(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding) error
+	// PostComment posts a comment (result_comment) on each bound source item.
+	PostComment(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, comment string) error
+	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels) to
+	// each bound source item.
+	ApplyHook(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, hook config.OnComplete) error
 }
 
 // Engine orchestrates a workflow instance: it persists the instance and its step
@@ -111,17 +122,22 @@ func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Optio
 	return e
 }
 
-// RunInstance executes a workflow for a cell. It returns the created instance ID
-// and whether the instance completed successfully. An instance that suspends at
-// an approval step returns success=false with no error — it is parked in state
-// approval_waiting until ResolveApproval (driven by the polling loop) resumes it.
-// Errors creating the instance are returned; per-step failures are recorded and
-// reflected in the final instance state and the success flag, not returned.
-func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell model.SourceItem) (instanceID string, success bool, err error) {
+// RunInstance executes a workflow for an InternalTask. It returns the created
+// instance ID and whether the instance completed successfully. An instance that
+// suspends at an approval step returns success=false with no error — it is parked
+// in state approval_waiting until ResolveApproval (driven by the polling loop)
+// resumes it. Errors creating the instance are returned; per-step failures are
+// recorded and reflected in the final instance state and the success flag, not
+// returned.
+func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task model.InternalTask) (instanceID string, success bool, err error) {
+	bindings := e.bindingsFor(ctx, task.ID)
+	cell := sourceItemView(task, bindings)
+
 	instID := e.newID("wf")
 	inst := &db.WorkflowInstance{
 		ID:         instID,
 		WorkflowID: wf.ID,
+		TaskID:     task.ID,
 		CellID:     cell.ID,
 		SourceID:   cell.SourceID,
 		State:      db.InstanceStateRunning,
@@ -133,12 +149,56 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, cell
 
 	// state_lock fires once at workflow start (not per step).
 	if e.cfg.Settings.StateLock && e.side != nil {
-		_ = e.side.StateLock(ctx, cell)
+		_ = e.side.StateLock(ctx, task, bindings)
 	}
 
-	r := e.initDAG(instID, wf, cell, nil, 0)
+	r := e.initDAG(instID, wf, task, bindings, nil, 0)
 	outcome := e.driveDAG(ctx, r)
 	return instID, e.settle(ctx, r, outcome), nil
+}
+
+// bindingsFor resolves a task's source bindings via the Store when it supports
+// it (the production *db.Client). Returns nil for fake stores, spawned tasks
+// (no bindings), or on error — all of which leave side effects as no-ops.
+func (e *Engine) bindingsFor(ctx context.Context, taskID string) []model.SourceBinding {
+	if taskID == "" {
+		return nil
+	}
+	bl, ok := e.store.(bindingLister)
+	if !ok {
+		return nil
+	}
+	bindings, err := bl.ListBindingsByTask(ctx, taskID)
+	if err != nil {
+		return nil
+	}
+	return bindings
+}
+
+// sourceItemView projects an InternalTask (plus its primary source binding, if
+// any) into the SourceItem shape the executor, memory builder, and expression
+// engine consume. The primary binding supplies source identity (id, number, url);
+// the task supplies the live content and routing attributes. For a binding-less
+// task (spawned, or no-DB transient) the task's own ID and metadata stand in.
+func sourceItemView(task model.InternalTask, bindings []model.SourceBinding) model.SourceItem {
+	item := model.SourceItem{
+		ID:          task.ID,
+		SourceID:    task.Metadata.Source,
+		Title:       task.Title,
+		Description: task.Description,
+		Labels:      task.Metadata.Labels,
+		Type:        task.Metadata.Type,
+		Priority:    task.Metadata.Priority,
+		State:       task.Metadata.State,
+	}
+	if len(bindings) > 0 {
+		b := bindings[0]
+		item.ID = b.SourceItemID
+		item.SourceID = b.SourceID
+		item.Number = b.SourceItemNumber
+		item.URL = b.SourceItemURL
+	}
+	return item
 }
 
 // settle persists the terminal state of a run and applies completion hooks, or
@@ -162,7 +222,7 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 	e.mu.Lock()
 	delete(e.parked, r.instID)
 	e.mu.Unlock()
-	e.applyCompletion(ctx, r.wf, r.cell, failed, r.memSteps())
+	e.applyCompletion(ctx, r, failed)
 	return !failed
 }
 
@@ -223,15 +283,16 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 }
 
 // applyCompletion applies the on_complete/on_fail hook and posts the on_complete
-// result comment (the final memory document).
-func (e *Engine) applyCompletion(ctx context.Context, wf config.WorkflowConfig, cell model.SourceItem, failed bool, memSteps []MemoryStep) {
+// result comment (the final memory document) to the task's source bindings.
+func (e *Engine) applyCompletion(ctx context.Context, r *dagRun, failed bool) {
 	if e.side == nil {
 		return
 	}
+	wf := r.wf
 
 	if !failed && e.resultCommentMode(wf) == config.ResultCommentOnComplete {
-		doc := e.mem.Build(cell, memSteps)
-		_ = e.side.PostComment(ctx, cell, finalComment(wf, false, doc))
+		doc := e.mem.Build(r.cell, r.memSteps())
+		_ = e.side.PostComment(ctx, r.task, r.bindings, finalComment(wf, false, doc))
 	}
 
 	var hook *config.OnComplete
@@ -241,7 +302,7 @@ func (e *Engine) applyCompletion(ctx context.Context, wf config.WorkflowConfig, 
 		hook = wf.OnComplete
 	}
 	if hook != nil {
-		_ = e.side.ApplyHook(ctx, cell, *hook)
+		_ = e.side.ApplyHook(ctx, r.task, r.bindings, *hook)
 	}
 }
 

--- a/src/internal/workflow/engine_integration_test.go
+++ b/src/internal/workflow/engine_integration_test.go
@@ -40,7 +40,7 @@ func TestEngine_PersistsToRealSQLite(t *testing.T) {
 		OnComplete: config.OnComplete{SetState: "in_review"},
 	})
 
-	instID, success, err := eng.RunInstance(ctx, wf, model.SourceItem{ID: "PLANE-1", Title: "Fix it", SourceID: "main-plane"})
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "PLANE-1", Title: "Fix it", Metadata: model.TaskMetadata{Source: "main-plane"}})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -58,6 +58,9 @@ func TestEngine_PersistsToRealSQLite(t *testing.T) {
 	}
 	if inst.WorkflowID != "backend-bugs" || inst.CellID != "PLANE-1" || inst.SourceID != "main-plane" {
 		t.Errorf("instance fields wrong: %+v", inst)
+	}
+	if inst.TaskID != "PLANE-1" {
+		t.Errorf("instance task_id = %q, want PLANE-1", inst.TaskID)
 	}
 
 	// Step run persisted with structured output + summary.
@@ -101,7 +104,7 @@ func TestEngine_FailedStepPersistsFailedState(t *testing.T) {
 	eng := NewEngine(cfg, client, exec)
 
 	wf := synthWF(config.RouteConfig{ID: "r", Agent: "a"})
-	instID, success, _ := eng.RunInstance(ctx, wf, model.SourceItem{ID: "C1"})
+	instID, success, _ := eng.RunInstance(ctx, wf, model.InternalTask{ID: "C1"})
 
 	if success {
 		t.Error("expected failure")

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -32,10 +32,23 @@ type fakeStore struct {
 	instances map[string]*db.WorkflowInstance
 	stepRuns  map[string]*db.StepRun
 	stepOrder []string
+	bindings  map[string][]model.SourceBinding // task id → bindings (for bindingLister)
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{instances: map[string]*db.WorkflowInstance{}, stepRuns: map[string]*db.StepRun{}}
+	return &fakeStore{
+		instances: map[string]*db.WorkflowInstance{},
+		stepRuns:  map[string]*db.StepRun{},
+		bindings:  map[string][]model.SourceBinding{},
+	}
+}
+
+// ListBindingsByTask satisfies bindingLister so the engine resolves a task's
+// bindings the same way the production *db.Client does.
+func (f *fakeStore) ListBindingsByTask(_ context.Context, taskID string) ([]model.SourceBinding, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.bindings[taskID], nil
 }
 
 func (f *fakeStore) CreateWorkflowInstance(_ context.Context, inst *db.WorkflowInstance) error {
@@ -95,15 +108,15 @@ type fakeSide struct {
 	hooks       []config.OnComplete
 }
 
-func (f *fakeSide) StateLock(_ context.Context, _ model.SourceItem) error {
+func (f *fakeSide) StateLock(_ context.Context, _ model.InternalTask, _ []model.SourceBinding) error {
 	f.stateLocked = true
 	return nil
 }
-func (f *fakeSide) PostComment(_ context.Context, _ model.SourceItem, c string) error {
+func (f *fakeSide) PostComment(_ context.Context, _ model.InternalTask, _ []model.SourceBinding, c string) error {
 	f.comments = append(f.comments, c)
 	return nil
 }
-func (f *fakeSide) ApplyHook(_ context.Context, _ model.SourceItem, h config.OnComplete) error {
+func (f *fakeSide) ApplyHook(_ context.Context, _ model.InternalTask, _ []model.SourceBinding, h config.OnComplete) error {
 	f.hooks = append(f.hooks, h)
 	return nil
 }
@@ -155,7 +168,7 @@ func TestEngine_SingleStepSuccess(t *testing.T) {
 		OnComplete: config.OnComplete{SetState: "in_review"},
 	})
 
-	instID, _, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1", Title: "Fix bug"})
+	instID, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "Fix bug"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -196,7 +209,7 @@ func TestEngine_StepFailureMarksInstanceFailed(t *testing.T) {
 		OnComplete: config.OnComplete{SetState: "in_review"}})
 	wf.OnFail = &config.OnComplete{SetState: "blocked"}
 
-	instID, _, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1"})
+	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
 
 	if store.instances[instID].State != db.InstanceStateFailed {
 		t.Errorf("expected failed instance, got %s", store.instances[instID].State)
@@ -236,7 +249,7 @@ func TestEngine_SequentialMemoryThreading(t *testing.T) {
 		},
 	}
 
-	_, _, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1", Title: "Add auth"})
+	_, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "Add auth"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -269,7 +282,7 @@ func TestEngine_MemoryReadFalseSkipsInjection(t *testing.T) {
 	wf := config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{
 		{ID: "s", Agent: "architect", Memory: &config.MemoryConfig{Read: &rd}},
 	}}
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1", Title: "t"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
 
 	if exec.seen[0].MemoryDoc != "" {
 		t.Errorf("expected empty memory doc when memory.read is false, got:\n%s", exec.seen[0].MemoryDoc)
@@ -285,7 +298,7 @@ func TestEngine_PerStepModelOverride(t *testing.T) {
 	wf := config.WorkflowConfig{ID: "w", Steps: []config.StepConfig{
 		{ID: "s", Agent: "backend-dev", Model: "claude-haiku-4-5"},
 	}}
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
 
 	if exec.seen[0].Model != "claude-haiku-4-5" {
 		t.Errorf("expected step model override, got %q", exec.seen[0].Model)
@@ -300,7 +313,7 @@ func TestEngine_ResultCommentOnComplete(t *testing.T) {
 	eng := testEngine(cfg, store, exec, side)
 
 	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1", Title: "t"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
 
 	if len(side.comments) != 1 {
 		t.Fatalf("expected 1 on_complete comment, got %d", len(side.comments))
@@ -327,7 +340,7 @@ func TestEngine_ResultCommentPerStep(t *testing.T) {
 			{ID: "implement", Agent: "backend-dev", DependsOn: []string{"plan"}},
 		},
 	}
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
 
 	if len(side.comments) != 2 {
 		t.Fatalf("expected 2 per-step comments, got %d: %v", len(side.comments), side.comments)
@@ -346,7 +359,7 @@ func TestEngine_ResultCommentOff(t *testing.T) {
 	eng := testEngine(cfg, store, exec, side)
 
 	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
 
 	if len(side.comments) != 0 {
 		t.Errorf("expected no comments when result_comment off, got: %v", side.comments)
@@ -362,7 +375,7 @@ func TestEngine_StructuredOutputPersisted(t *testing.T) {
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
 	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "C1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
 
 	sr := store.stepRuns[store.stepOrder[0]]
 	if !strings.Contains(sr.StructuredOutput, `"k":"v"`) {

--- a/src/internal/workflow/foreach_test.go
+++ b/src/internal/workflow/foreach_test.go
@@ -67,7 +67,7 @@ func TestForeach_RunsOnePerItem(t *testing.T) {
 		Step: &config.StepConfig{Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
 	})
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -95,7 +95,7 @@ func TestForeach_RenderedPromptReachesExecutor(t *testing.T) {
 		As:   "issue",
 		Step: &config.StepConfig{Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
 	})
-	_, _, _ = eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 
 	var prompts []string
 	for _, req := range exec.seen {
@@ -122,7 +122,7 @@ func TestForeach_MaxItemsGuard(t *testing.T) {
 		MaxItems: 5,
 		Step:     &config.StepConfig{Agent: "backend-dev"},
 	})
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure when items exceed max_items")
 	}
@@ -149,7 +149,7 @@ func TestForeach_FailFast(t *testing.T) {
 		FailFast: true,
 		Step:     &config.StepConfig{Agent: "backend-dev"},
 	})
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure")
 	}
@@ -180,7 +180,7 @@ func TestForeach_AllPassDownstreamRuns(t *testing.T) {
 		ID: "summarize", Agent: "architect", DependsOn: []string{"fix-each"},
 	})
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -209,7 +209,7 @@ func TestForeach_ConcurrentItems(t *testing.T) {
 		Step:        &config.StepConfig{Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
 	})
 
-	_, success, err := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if err != nil {
 		t.Fatalf("RunInstance: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestForeach_ConcurrentFailFast(t *testing.T) {
 		Step:        &config.StepConfig{Agent: "backend-dev"},
 	})
 
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure (item 0 failed with fail_fast)")
 	}
@@ -263,7 +263,7 @@ func TestForeach_InvalidItemsPathFails(t *testing.T) {
 
 	wf := foreachWorkflow(config.StepConfig{As: "i", Step: &config.StepConfig{Agent: "backend-dev"}})
 	wf.Steps[1].Items = "steps.plan.output.notarray" // not an array
-	_, success, _ := eng.RunInstance(context.Background(), wf, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure when items path is not an array")
 	}

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -21,10 +21,11 @@ import (
 // steps are intentionally re-evaluated (they are side-effect-free and their
 // branch routing must re-activate the chosen target), while agent, foreach,
 // sub-workflow, and approval steps that passed are carried over untouched.
-func (e *Engine) ResumeInstance(ctx context.Context, instID string, wf config.WorkflowConfig, cell model.SourceItem, priorSteps []db.StepRun) (success bool, err error) {
+func (e *Engine) ResumeInstance(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun) (success bool, err error) {
 	_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateRunning)
 
-	r := e.initDAG(instID, wf, cell, nil, 0)
+	bindings := e.bindingsFor(ctx, task.ID)
+	r := e.initDAG(instID, wf, task, bindings, nil, 0)
 	e.seedResume(ctx, r, priorSteps)
 
 	aplog.Info("workflow %s: resuming instance %s (%d cached step(s))", wf.ID, instID, len(r.passedOrder))

--- a/src/internal/workflow/resume_test.go
+++ b/src/internal/workflow/resume_test.go
@@ -39,7 +39,7 @@ func TestResume_SkipsCachedAndContinues(t *testing.T) {
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
 
-	success, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.SourceItem{ID: "c1"}, prior)
+	success, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior)
 	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestResume_CachedMemoryAvailableDownstream(t *testing.T) {
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
 
-	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.SourceItem{ID: "c1"}, prior); err != nil {
+	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior); err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
 
@@ -105,7 +105,7 @@ func TestResume_MarksPriorStepCached(t *testing.T) {
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
 
-	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.SourceItem{ID: "c1"}, prior); err != nil {
+	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior); err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
 	if sr := store.stepRuns["sr-plan"]; sr == nil || !sr.SkippedCached {
@@ -144,7 +144,7 @@ func TestResume_ReevaluatesSplit(t *testing.T) {
 		{ID: "sr-senior", WorkflowInstanceID: instID, StepID: "senior", State: db.StepStateFailed},
 	}
 
-	success, err := eng.ResumeInstance(context.Background(), instID, wf, model.SourceItem{ID: "c1"}, prior)
+	success, err := eng.ResumeInstance(context.Background(), instID, wf, model.InternalTask{ID: "c1"}, prior)
 	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -20,7 +20,7 @@ const maxSubWorkflowDepth = 1
 // memory taken on the scheduler goroutine before dispatch.
 func (e *Engine) executeSubWorkflowStep(
 	ctx context.Context, parentInstID string,
-	step config.StepConfig, cell model.SourceItem,
+	step config.StepConfig, task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, depth int, wfID string,
 ) StepResult {
 	if depth >= maxSubWorkflowDepth {
@@ -35,7 +35,7 @@ func (e *Engine) executeSubWorkflowStep(
 		return StepResult{Success: false, Output: fmt.Sprintf("workflow %q not found", step.Workflow)}
 	}
 
-	_, success := e.runChildInstance(ctx, parentInstID, *child, cell, memSnap, depth+1)
+	_, success := e.runChildInstance(ctx, parentInstID, *child, task, bindings, memSnap, depth+1)
 	summary := ""
 	if success {
 		summary = fmt.Sprintf("sub-workflow %q completed", child.ID)
@@ -48,11 +48,13 @@ func (e *Engine) executeSubWorkflowStep(
 // instance) and does not apply the child's on_complete/on_fail hooks against the
 // shared cell — the child is an isolated pipeline whose only outward signal is
 // success/failure.
-func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, child config.WorkflowConfig, cell model.SourceItem, seed []MemoryStep, depth int) (string, bool) {
+func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, child config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) (string, bool) {
 	childID := e.newID("wf")
+	cell := sourceItemView(task, bindings)
 	inst := &db.WorkflowInstance{
 		ID:               childID,
 		WorkflowID:       child.ID,
+		TaskID:           task.ID,
 		CellID:           cell.ID,
 		SourceID:         cell.SourceID,
 		State:            db.InstanceStateRunning,
@@ -64,7 +66,7 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 		return "", false
 	}
 
-	r := e.initDAG(childID, child, cell, seed, depth)
+	r := e.initDAG(childID, child, task, bindings, seed, depth)
 	outcome := e.driveDAG(ctx, r)
 	// A sub-workflow cannot park independently in Phase 4: an approval step inside
 	// a child is treated as a failure (unsupported). Top-level approvals are the

--- a/src/internal/workflow/subworkflow_test.go
+++ b/src/internal/workflow/subworkflow_test.go
@@ -33,7 +33,7 @@ func TestSubWorkflow_ChildRunsAndLinks(t *testing.T) {
 	exec := &fakeExecutor{}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	parentID, success, _ := eng.RunInstance(context.Background(), parent, model.SourceItem{ID: "c1"})
+	parentID, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -78,7 +78,7 @@ func TestSubWorkflow_ChildFailureFailsParentStep(t *testing.T) {
 	exec := &fakeExecutor{results: map[string]StepResult{"check": {Success: false}}}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	_, success, _ := eng.RunInstance(context.Background(), parent, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected parent to fail when child fails")
 	}
@@ -96,7 +96,7 @@ func TestSubWorkflow_UnknownReferenceFails(t *testing.T) {
 	store := newFakeStore()
 	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
 
-	_, success, _ := eng.RunInstance(context.Background(), parent, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure for unknown sub-workflow reference")
 	}
@@ -123,7 +123,7 @@ func TestSubWorkflow_ParentMemorySeedsChild(t *testing.T) {
 	}}
 	eng := testEngine(cfg, store, exec, &fakeSide{})
 
-	_, success, _ := eng.RunInstance(context.Background(), parent, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
 	if !success {
 		t.Fatal("expected success")
 	}
@@ -155,7 +155,7 @@ func TestSubWorkflow_NoNestingBeyondDepth(t *testing.T) {
 	store := newFakeStore()
 	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
 
-	_, success, _ := eng.RunInstance(context.Background(), parent, model.SourceItem{ID: "c1"})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("expected failure: nesting beyond one level must be refused")
 	}


### PR DESCRIPTION
## Summary

Phase 5 of the `internal-task-model` change: the **WorkflowEngine now operates over `model.InternalTask` + `[]SourceBinding`** instead of `SourceItem`. Side effects resolve the adapter via bindings.

- **`RunInstance`/`ResumeInstance` take a `model.InternalTask`** (removing the `SourceItem` parameter) — 5.1.1. The *execution view* (`cell`) is projected from the task + primary binding (`sourceItemView`), keeping `dag.go`/expr/memory/foreach/parallel/subworkflow structurally intact.
- **`workflow_instances` writes `task_id`** as the canonical link — 5.1.2. `cell_id`/`source_id` stay populated (from the primary binding) for the dashboard until a future removal; `cell_id` is `NOT NULL`.
- **`SideEffects` (`StateLock`/`PostComment`/`ApplyHook`) take `task + bindings`** — 5.1.3/5.1.4. `wfSideEffects` resolves the adapter by `binding.SourceID` and **fans out** over all bindings, reconstructing each binding's `SourceItem` + task content. A task with no binding (spawned) = no-op.
- **`CheckParkedApprovals` resolves the `TaskPoller` via `source_bindings`** — 5.1.5: it polls per binding (`SourceID` + `SourceItemID`) instead of a frozen `SourceItem`.
- The engine resolves bindings via an optional `bindingLister` capability on the `Store` (the `*db.Client` satisfies it; fakes without it yield zero bindings).

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — green.
- `go test -race ./internal/workflow/... ./internal/daemon/... ./internal/db/...` — clean.
- **New integration test (5.1.6)** `TestRunOnce_SideEffectsResolveViaBinding`: a workflow against a task with one binding; `state_lock`/result-comment/`on_complete` reach the adapter carrying the source item's identity **from the binding** (`ID`/`Number`), with task content.
- A `task_id` persisted assert in `TestEngine_PersistsToRealSQLite`.
- ~60 test call sites migrated from `SourceItem` to `InternalTask`; the approval tests register a binding for the `CheckParkedApprovals` path.

Part of the OpenSpec `internal-task-model` change (one PR per phase). `gofmt`: only files already flagged at HEAD by go1.26.3 remain (untouched regions).