### PR TITLE
feat(publish): APIARY_PUBLISH — agent-driven write-back (Phase 6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4810 symbols, 10735 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4832 symbols, 10824 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4810 symbols, 10735 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4832 symbols, 10824 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
 )
 
 type Config struct {
@@ -415,7 +417,24 @@ func Load(path string) (*Config, error) {
 	if cfg.Settings.LogLevel == "" {
 		cfg.Settings.LogLevel = "info"
 	}
+	warnDeprecatedResultComment(&cfg)
 	return &cfg, nil
+}
+
+// warnDeprecatedResultComment logs a deprecation warning when result_comment is
+// set to any non-default value, at the global settings level or on any workflow.
+// The feature still works (see Engine.resultCommentMode); the APIARY_PUBLISH
+// marker in agent output is the supported replacement.
+func warnDeprecatedResultComment(cfg *Config) {
+	const msg = "result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead"
+	if cfg.Settings.ResultComment {
+		aplog.Warn("settings.result_comment: %s", msg)
+	}
+	for _, wf := range cfg.Workflows {
+		if wf.ResultComment != "" {
+			aplog.Warn("workflow %q: %s", wf.ID, msg)
+		}
+	}
 }
 
 func expandEnv(s string) string {

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -28,6 +28,13 @@ const (
 	ResultCommentOff        = "off"
 )
 
+// Publish modes for an agent step: whether the engine writes an APIARY_PUBLISH
+// payload emitted by the agent back to the task's source bindings.
+const (
+	PublishAuto = "auto" // default: write back when the agent emits a payload
+	PublishOff  = "off"  // never write back, even if a payload is present
+)
+
 // on_missing_output policy values for an agent step that declares output_schema.
 const (
 	OnMissingOutputWarn   = "warn"
@@ -105,6 +112,10 @@ type StepConfig struct {
 	Memory          *MemoryConfig `yaml:"memory,omitempty"`
 	OnPass          *StepNext     `yaml:"on_pass,omitempty"`
 	OnFail          *StepOutcome  `yaml:"on_fail,omitempty"`
+	// Publish controls whether an APIARY_PUBLISH payload emitted by this step's
+	// agent is written back to the task's source bindings: auto (default) | off.
+	// Empty inherits the auto default.
+	Publish string `yaml:"publish,omitempty"`
 
 	// ── split step ────────────────────────────────────────────────
 	Multi    bool          `yaml:"multi,omitempty"`

--- a/src/internal/daemon/engine_binding_test.go
+++ b/src/internal/daemon/engine_binding_test.go
@@ -66,6 +66,77 @@ var (
 	_ source.StateSetter = (*recordingAdapter)(nil)
 )
 
+// publishingRunner is a runner whose every step emits a fixed APIARY_PUBLISH
+// payload, so a test can assert the engine writes it back to the source binding.
+type publishingRunner struct{ payload string }
+
+func (r *publishingRunner) ID() string                     { return "publishing" }
+func (r *publishingRunner) Configure(map[string]any) error { return nil }
+func (r *publishingRunner) Run(context.Context, model.RunRequest) (model.RunResult, error) {
+	return model.RunResult{Success: true, PublishPayload: r.payload}, nil
+}
+
+// TestRunOnce_PublishWritesBackToBinding runs a workflow whose agent emits an
+// APIARY_PUBLISH payload and asserts the engine writes it back to the task's
+// source binding via the adapter (WriteResult), end-to-end (6.2.1, 6.4.1).
+func TestRunOnce_PublishWritesBackToBinding(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "publish.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	adapter := &recordingAdapter{items: []model.SourceItem{
+		{ID: "ISSUE-9", SourceID: "src", Number: "#9", Title: "Ship it", State: "todo"},
+	}}
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		// result_comment OFF so the only WriteResult comes from the publish payload.
+		Settings: config.Settings{StateLock: false, ResultComment: false},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "wf-pub",
+			Trigger: &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src"}},
+			Steps:   []config.StepConfig{{ID: "run", Agent: "a"}},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": &publishingRunner{payload: "## Result\nshipped"}},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	if err := d.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+
+	// The publish payload is written back to the bound source item exactly once.
+	if len(adapter.wrote) != 1 {
+		t.Fatalf("expected 1 publish WriteResult, got %d", len(adapter.wrote))
+	}
+	if adapter.wrote[0].ID != "ISSUE-9" || adapter.wrote[0].Number != "#9" {
+		t.Errorf("publish item = %+v, want source item ISSUE-9/#9 from binding", adapter.wrote[0])
+	}
+}
+
 // TestRunOnce_SideEffectsResolveViaBinding runs a single workflow against a
 // source-bound task and asserts every side effect (state_lock, result comment,
 // on_complete hook) reaches the adapter through the task's binding, carrying the

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -157,11 +157,19 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 
 	x.finishExecution(ctx, exec, res)
 
+	// publish: off suppresses write-back before the engine ever sees the payload,
+	// even when the agent emitted an APIARY_PUBLISH block.
+	publishPayload := res.PublishPayload
+	if req.Step.Publish == config.PublishOff {
+		publishPayload = ""
+	}
+
 	return workflow.StepResult{
 		Success:          res.Success,
 		Output:           res.Output,
 		StructuredOutput: res.StructuredOutput,
 		Summary:          res.Summary,
+		PublishPayload:   publishPayload,
 		Err:              res.Error,
 	}
 }

--- a/src/internal/daemon/workflow_executor_test.go
+++ b/src/internal/daemon/workflow_executor_test.go
@@ -84,3 +84,49 @@ func TestWfStepExecutor_RecordsExecution(t *testing.T) {
 		t.Errorf("duration = %dms, want 1200", exec.DurationMs)
 	}
 }
+
+// TestWfStepExecutor_PublishPropagation verifies the executor forwards the
+// runner's APIARY_PUBLISH payload to the engine by default (publish: auto) and
+// clears it when the step sets publish: off, before the engine ever sees it
+// (6.1.2, 6.4.2).
+func TestWfStepExecutor_PublishPropagation(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	runner := &fakeRunner{result: model.RunResult{
+		Success:        true,
+		Output:         "done",
+		PublishPayload: "## Result\nshipped",
+	}}
+	d := &Dispatcher{
+		cfg:         &config.Config{},
+		db:          dbc,
+		runners:     map[string]runnerpkg.Runner{"agent-architect": runner},
+		agentRunner: map[string]string{"architect": "claude"},
+	}
+	x := &wfStepExecutor{d: d}
+
+	// Default (publish unset == auto): payload propagates.
+	auto := x.ExecuteStep(ctx, workflow.StepRequest{
+		InstanceID: "wf_1",
+		Cell:       model.SourceItem{ID: "c1"},
+		Step:       config.StepConfig{ID: "plan", Agent: "architect"},
+	})
+	if auto.PublishPayload != "## Result\nshipped" {
+		t.Errorf("auto: payload = %q, want it propagated", auto.PublishPayload)
+	}
+
+	// publish: off clears the payload before the engine sees it.
+	off := x.ExecuteStep(ctx, workflow.StepRequest{
+		InstanceID: "wf_2",
+		Cell:       model.SourceItem{ID: "c1"},
+		Step:       config.StepConfig{ID: "plan", Agent: "architect", Publish: config.PublishOff},
+	})
+	if off.PublishPayload != "" {
+		t.Errorf("publish off: payload = %q, want cleared", off.PublishPayload)
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -26,6 +26,13 @@ const (
 	StepStateSkippedCached = "skipped_cached"
 )
 
+// Publish states for a step run's APIARY_PUBLISH write-back.
+const (
+	PublishStateSent    = "sent"    // payload posted to all source bindings
+	PublishStateFailed  = "failed"  // a binding's PostComment returned an error
+	PublishStateSkipped = "skipped" // payload present but task has no bindings
+)
+
 // WorkflowInstance is a single execution of a workflow bound to an InternalTask.
 // TaskID is the canonical link; CellID/SourceID are retained (and still populated
 // from the task's primary source binding) for the dashboard until a future change.
@@ -54,8 +61,13 @@ type StepRun struct {
 	Summary            string
 	ExitCode           int
 	SkippedCached      bool
-	StartedAt          *time.Time
-	FinishedAt         *time.Time
+	// PublishPayload is the APIARY_PUBLISH text the step's agent emitted, if any.
+	PublishPayload string
+	// PublishState records the write-back outcome: sent | failed | skipped.
+	// Empty when the step emitted no publish payload.
+	PublishState string
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
@@ -242,11 +254,12 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO step_runs
 		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
-		   summary, exit_code, skipped_cached, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		   summary, exit_code, skipped_cached, publish_payload, publish_state, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
-		sr.ExitCode, sr.SkippedCached, sr.StartedAt, sr.FinishedAt)
+		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
+		sr.StartedAt, sr.FinishedAt)
 	return err
 }
 
@@ -256,10 +269,12 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE step_runs
 		SET state = ?, output = ?, structured_output = ?, summary = ?,
-		    exit_code = ?, skipped_cached = ?, started_at = ?, finished_at = ?
+		    exit_code = ?, skipped_cached = ?, publish_payload = ?, publish_state = ?,
+		    started_at = ?, finished_at = ?
 		WHERE id = ?
 	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
-		sr.ExitCode, sr.SkippedCached, sr.StartedAt, sr.FinishedAt, sr.ID)
+		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
+		sr.StartedAt, sr.FinishedAt, sr.ID)
 	return err
 }
 
@@ -268,7 +283,8 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_instance_id, step_id, COALESCE(agent_id,''), state,
 		       COALESCE(output,''), COALESCE(structured_output,''), COALESCE(summary,''),
-		       COALESCE(exit_code,0), COALESCE(skipped_cached,0), started_at, finished_at
+		       COALESCE(exit_code,0), COALESCE(skipped_cached,0),
+		       COALESCE(publish_payload,''), COALESCE(publish_state,''), started_at, finished_at
 		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
 	`, instanceID)
 	if err != nil {
@@ -281,7 +297,7 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		var sr StepRun
 		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
 			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
-			&sr.StartedAt, &sr.FinishedAt); err != nil {
+			&sr.PublishPayload, &sr.PublishState, &sr.StartedAt, &sr.FinishedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, sr)

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -65,6 +65,11 @@ type RunResult struct {
 	// Summary is the text extracted from the APIARY_SUMMARY_START/END markers,
 	// when present. Empty otherwise. The markers are stripped from Output.
 	Summary string
+	// PublishPayload is the text extracted from the APIARY_PUBLISH_BEGIN/END
+	// block, when present. Empty otherwise. The markers are stripped from
+	// Output. The workflow engine writes this back to the task's source
+	// bindings as a comment (the agent-driven replacement for result_comment).
+	PublishPayload string
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -14,18 +14,23 @@ const (
 	apiaryOutputPrefix = "APIARY_OUTPUT:"
 	summaryStartMarker = "APIARY_SUMMARY_START"
 	summaryEndMarker   = "APIARY_SUMMARY_END"
+	publishStartMarker = "APIARY_PUBLISH_BEGIN"
+	publishEndMarker   = "APIARY_PUBLISH_END"
 )
 
-// extractStructured scans an agent's raw output for the APIARY_OUTPUT: sentinel
-// and the APIARY_SUMMARY_START/END block. It returns the cleaned output (with
-// those lines removed), the parsed structured object (nil when absent or
-// unparseable), and the summary text (empty when absent). The last valid
-// APIARY_OUTPUT line wins.
-func extractStructured(output string) (cleaned string, structured map[string]any, summary string) {
+// extractStructured scans an agent's raw output for the APIARY_OUTPUT: sentinel,
+// the APIARY_SUMMARY_START/END block, and the APIARY_PUBLISH_BEGIN/END block. It
+// returns the cleaned output (with those lines removed), the parsed structured
+// object (nil when absent or unparseable), the summary text (empty when absent),
+// and the publish payload (empty when absent). The last valid APIARY_OUTPUT line
+// wins; the publish block is taken verbatim between its markers.
+func extractStructured(output string) (cleaned string, structured map[string]any, summary, publish string) {
 	lines := strings.Split(output, "\n")
 	kept := make([]string, 0, len(lines))
 	var summaryLines []string
+	var publishLines []string
 	inSummary := false
+	inPublish := false
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -34,8 +39,14 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 			inSummary = true
 		case trimmed == summaryEndMarker:
 			inSummary = false
+		case trimmed == publishStartMarker:
+			inPublish = true
+		case trimmed == publishEndMarker:
+			inPublish = false
 		case inSummary:
 			summaryLines = append(summaryLines, line)
+		case inPublish:
+			publishLines = append(publishLines, line)
 		case strings.HasPrefix(trimmed, apiaryOutputPrefix):
 			jsonPart := strings.TrimSpace(strings.TrimPrefix(trimmed, apiaryOutputPrefix))
 			var obj map[string]any
@@ -50,18 +61,20 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 
 	cleaned = strings.TrimSpace(strings.Join(kept, "\n"))
 	summary = strings.TrimSpace(strings.Join(summaryLines, "\n"))
-	return cleaned, structured, summary
+	publish = strings.TrimSpace(strings.Join(publishLines, "\n"))
+	return cleaned, structured, summary, publish
 }
 
 // applyStructured post-processes a RunResult's Output, moving any structured
-// output and summary into their dedicated fields. Safe to call for plain runs:
-// when no sentinels are present, Output is unchanged and the new fields stay
-// nil/empty.
+// output, summary, and publish payload into their dedicated fields. Safe to call
+// for plain runs: when no sentinels are present, Output is unchanged and the new
+// fields stay nil/empty.
 func applyStructured(result *model.RunResult) {
-	cleaned, structured, summary := extractStructured(result.Output)
+	cleaned, structured, summary, publish := extractStructured(result.Output)
 	result.Output = cleaned
 	result.StructuredOutput = structured
 	result.Summary = summary
+	result.PublishPayload = publish
 }
 
 // summaryInstruction returns the text appended to a prompt instructing the agent

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -18,7 +18,7 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 		`APIARY_OUTPUT: {"complexity":"high","action":"implement"}`,
 	}, "\n")
 
-	cleaned, structured, summary := extractStructured(raw)
+	cleaned, structured, summary, _ := extractStructured(raw)
 
 	if strings.Contains(cleaned, "APIARY_OUTPUT") || strings.Contains(cleaned, "APIARY_SUMMARY") {
 		t.Errorf("cleaned output still contains sentinels:\n%s", cleaned)
@@ -39,7 +39,10 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 
 func TestExtractStructured_NoSentinels(t *testing.T) {
 	raw := "Just a normal agent response.\nNothing structured here."
-	cleaned, structured, summary := extractStructured(raw)
+	cleaned, structured, summary, publish := extractStructured(raw)
+	if publish != "" {
+		t.Errorf("expected empty publish, got: %q", publish)
+	}
 	if cleaned != raw {
 		t.Errorf("cleaned should be unchanged, got: %q", cleaned)
 	}
@@ -57,7 +60,7 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 		"some text",
 		`APIARY_OUTPUT: {"v":2}`,
 	}, "\n")
-	_, structured, _ := extractStructured(raw)
+	_, structured, _, _ := extractStructured(raw)
 	if structured == nil || structured["v"] != float64(2) {
 		t.Errorf("expected last APIARY_OUTPUT to win, got: %#v", structured)
 	}
@@ -65,7 +68,7 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 
 func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
 	raw := "real output\nAPIARY_OUTPUT: {not valid json}"
-	cleaned, structured, _ := extractStructured(raw)
+	cleaned, structured, _, _ := extractStructured(raw)
 	if structured != nil {
 		t.Errorf("expected nil structured for invalid JSON, got: %#v", structured)
 	}
@@ -77,9 +80,35 @@ func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
 	}
 }
 
+func TestExtractStructured_PublishBlock(t *testing.T) {
+	raw := strings.Join([]string{
+		"Working on it.",
+		"APIARY_PUBLISH_BEGIN",
+		"## Result",
+		"Done. See the diff.",
+		"APIARY_PUBLISH_END",
+		"Trailing line.",
+	}, "\n")
+
+	cleaned, structured, summary, publish := extractStructured(raw)
+
+	if structured != nil || summary != "" {
+		t.Errorf("expected no structured/summary, got %#v / %q", structured, summary)
+	}
+	if strings.Contains(cleaned, "APIARY_PUBLISH") || strings.Contains(cleaned, "## Result") {
+		t.Errorf("publish block not stripped from cleaned output:\n%s", cleaned)
+	}
+	if !strings.Contains(cleaned, "Working on it.") || !strings.Contains(cleaned, "Trailing line.") {
+		t.Errorf("cleaned output dropped human text:\n%s", cleaned)
+	}
+	if publish != "## Result\nDone. See the diff." {
+		t.Errorf("publish payload parsed incorrectly: %q", publish)
+	}
+}
+
 func TestApplyStructured_MutatesResult(t *testing.T) {
 	result := model.RunResult{
-		Output: "done\nAPIARY_OUTPUT: {\"ok\":true}",
+		Output: "done\nAPIARY_OUTPUT: {\"ok\":true}\nAPIARY_PUBLISH_BEGIN\nposted\nAPIARY_PUBLISH_END",
 	}
 	applyStructured(&result)
 	if result.Output != "done" {
@@ -87,6 +116,9 @@ func TestApplyStructured_MutatesResult(t *testing.T) {
 	}
 	if result.StructuredOutput == nil || result.StructuredOutput["ok"] != true {
 		t.Errorf("structured not populated: %#v", result.StructuredOutput)
+	}
+	if result.PublishPayload != "posted" {
+		t.Errorf("publish payload not populated: %q", result.PublishPayload)
 	}
 }
 

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -185,23 +185,23 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				var foreachExitCode int
 				switch step.StepType() {
 				case config.StepTypeParallel:
-					res, parallelContribs = e.runParallelStep(ctx, r.instID, step, r.cell, memSnap)
+					res, parallelContribs = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap)
 				case config.StepTypeForeach:
 					var fr foreachResult
 					if step.Concurrency > 1 {
 						// Release our global slot so item goroutines can use all
 						// available slots. Re-acquire before the deferred release fires.
 						<-sem
-						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, memSnap, contribSnap, r.wf.ID, sem)
+						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, sem)
 						sem <- struct{}{}
 					} else {
-						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, memSnap, contribSnap, r.wf.ID, nil)
+						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, nil)
 					}
 					foreachExitCode = fr.failed
 				case config.StepTypeWorkflow:
 					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
 				default: // StepTypeAgent
-					res = e.runStep(ctx, r.instID, step, r.cell, memSnap)
+					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap)
 				}
 				resultCh <- workerResult{
 					stepID:           step.ID,

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -25,6 +25,7 @@ type parallelChildResult struct {
 func (e *Engine) runParallelStep(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
+	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep,
 ) (StepResult, []MemoryStep) {
 	children := step.SubSteps
@@ -36,7 +37,7 @@ func (e *Engine) runParallelStep(
 
 	for i, child := range children {
 		go func(i int, child config.StepConfig) {
-			res := e.runStep(ctx, instID, child, cell, memSnap)
+			res := e.runStep(ctx, instID, child, cell, task, bindings, memSnap)
 			resultCh <- parallelChildResult{idx: i, step: child, res: res}
 		}(i, child)
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -48,7 +48,11 @@ type StepResult struct {
 	Output           string
 	StructuredOutput map[string]any
 	Summary          string
-	Err              error
+	// PublishPayload is the APIARY_PUBLISH text the agent emitted, if any. The
+	// engine writes it back to the task's source bindings as a comment. The
+	// executor clears it when the step sets publish: off.
+	PublishPayload string
+	Err            error
 }
 
 // StepExecutor performs the actual runner invocation for a single agent step.
@@ -226,8 +230,12 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 	return !failed
 }
 
-// runStep executes one agent step, persisting its step run, and returns the result.
-func (e *Engine) runStep(ctx context.Context, instID string, step config.StepConfig, cell model.SourceItem, memSteps []MemoryStep) StepResult {
+// runStep executes one agent step, persisting its step run, and returns the
+// result. task and bindings are immutable snapshots threaded through so the
+// publish write-back can reach the task's source bindings; they are passed by
+// value (not via dagRun) so the function stays safe to call from the parallel
+// and foreach worker goroutines.
+func (e *Engine) runStep(ctx context.Context, instID string, step config.StepConfig, cell model.SourceItem, task model.InternalTask, bindings []model.SourceBinding, memSteps []MemoryStep) StepResult {
 	started := e.now()
 	sr := &db.StepRun{
 		ID:                 e.newID("sr"),
@@ -278,8 +286,30 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	} else {
 		sr.State = db.StepStateFailed
 	}
+	e.publishStep(ctx, task, bindings, res, sr)
 	_ = e.store.UpdateStepRun(ctx, sr)
 	return res
+}
+
+// publishStep writes an agent-emitted APIARY_PUBLISH payload back to the task's
+// source bindings and records the outcome on the step run. The executor has
+// already cleared the payload when the step set publish: off, so a non-empty
+// payload here means write-back was requested. A task with no bindings (e.g. a
+// spawned task) is silently skipped.
+func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, res StepResult, sr *db.StepRun) {
+	if res.PublishPayload == "" {
+		return
+	}
+	sr.PublishPayload = res.PublishPayload
+	if e.side == nil || len(bindings) == 0 {
+		sr.PublishState = db.PublishStateSkipped
+		return
+	}
+	if err := e.side.PostComment(ctx, task, bindings, res.PublishPayload); err != nil {
+		sr.PublishState = db.PublishStateFailed
+		return
+	}
+	sr.PublishState = db.PublishStateSent
 }
 
 // applyCompletion applies the on_complete/on_fail hook and posts the on_complete

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -224,6 +224,69 @@ func TestEngine_StepFailureMarksInstanceFailed(t *testing.T) {
 	}
 }
 
+// TestEngine_PublishWritesBackToBindings asserts that a step whose agent emits
+// an APIARY_PUBLISH payload writes it back via PostComment and records the step
+// run's publish_payload/publish_state (6.2.1, 6.2.2, 6.4.1).
+func TestEngine_PublishWritesBackToBindings(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false // isolate the publish comment from result_comment
+	store := newFakeStore()
+	store.bindings["C1"] = []model.SourceBinding{{TaskID: "C1", SourceID: "s1", SourceItemID: "ISSUE-1"}}
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done", PublishPayload: "## Result\nshipped"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	_, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "Fix"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	if len(side.comments) != 1 || side.comments[0] != "## Result\nshipped" {
+		t.Fatalf("expected one publish comment %q, got %#v", "## Result\nshipped", side.comments)
+	}
+	sr := store.stepRuns[store.stepOrder[0]]
+	if sr.PublishState != db.PublishStateSent {
+		t.Errorf("expected publish_state %q, got %q", db.PublishStateSent, sr.PublishState)
+	}
+	if sr.PublishPayload != "## Result\nshipped" {
+		t.Errorf("expected publish_payload persisted, got %q", sr.PublishPayload)
+	}
+}
+
+// TestEngine_PublishSkippedWhenNoBindings asserts that a publish payload on a
+// task with no source bindings (e.g. a spawned task) is silently skipped: no
+// PostComment, no error, and publish_state recorded as skipped (6.2.1, 6.4.3).
+func TestEngine_PublishSkippedWhenNoBindings(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false
+	store := newFakeStore() // no bindings registered for C1
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done", PublishPayload: "should not post"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	_, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	if len(side.comments) != 0 {
+		t.Errorf("expected no publish comment when task has no bindings, got %#v", side.comments)
+	}
+	sr := store.stepRuns[store.stepOrder[0]]
+	if sr.PublishState != db.PublishStateSkipped {
+		t.Errorf("expected publish_state %q, got %q", db.PublishStateSkipped, sr.PublishState)
+	}
+	if sr.PublishPayload != "should not post" {
+		t.Errorf("expected publish_payload persisted even when skipped, got %q", sr.PublishPayload)
+	}
+}
+
 func TestEngine_SequentialMemoryThreading(t *testing.T) {
 	cfg := baseCfg()
 	store := newFakeStore()

--- a/src/internal/workflow/foreach.go
+++ b/src/internal/workflow/foreach.go
@@ -33,6 +33,7 @@ type foreachResult struct {
 func (e *Engine) executeForeachStep(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
+	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, contribSnap map[string]MemoryStep,
 	wfID string, sem chan struct{},
 ) (StepResult, foreachResult) {
@@ -66,15 +67,16 @@ func (e *Engine) executeForeachStep(
 	}
 
 	if sem != nil && step.Concurrency > 1 {
-		return e.executeForeachConcurrent(ctx, instID, step, cell, memSnap, wfID, sem, items, as)
+		return e.executeForeachConcurrent(ctx, instID, step, cell, task, bindings, memSnap, wfID, sem, items, as)
 	}
-	return e.executeForeachSequential(ctx, instID, step, cell, memSnap, wfID, items, as)
+	return e.executeForeachSequential(ctx, instID, step, cell, task, bindings, memSnap, wfID, items, as)
 }
 
 // executeForeachSequential runs foreach items one at a time (original behaviour).
 func (e *Engine) executeForeachSequential(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
+	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, wfID string,
 	items []any, as string,
 ) (StepResult, foreachResult) {
@@ -86,7 +88,7 @@ func (e *Engine) executeForeachSequential(
 		sub.DependsOn = nil
 		sub.Prompt = renderItemTemplate(step.Step.Prompt, as, item)
 
-		res := e.runStep(ctx, instID, sub, cell, memSnap)
+		res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap)
 		if res.Success {
 			fr.passed++
 		} else {
@@ -106,6 +108,7 @@ func (e *Engine) executeForeachSequential(
 func (e *Engine) executeForeachConcurrent(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
+	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, wfID string,
 	sem chan struct{}, items []any, as string,
 ) (StepResult, foreachResult) {
@@ -146,7 +149,7 @@ func (e *Engine) executeForeachConcurrent(
 			sem <- struct{}{} // acquire global slot
 			defer func() { <-sem }()
 
-			res := e.runStep(ctx, instID, sub, cell, memSnap)
+			res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap)
 
 			mu.Lock()
 			if res.Success {


### PR DESCRIPTION
## Summary

Phase 6 of the `internal-task-model` change: replaces the static `result_comment` with an **`APIARY_PUBLISH` marker emitted by the agent itself**, written back to the task's `source_bindings`.

- **Marker parsing** (`runner/execution/structured.go`): the `APIARY_PUBLISH_BEGIN`/`END` block is extracted from stdout (alongside `APIARY_OUTPUT`/`APIARY_SUMMARY`) → `model.RunResult.PublishPayload`; the markers are removed from the visible output.
- **`StepConfig.Publish`** (`"auto"` default | `"off"`): with `publish: off` the executor clears the payload **before the engine sees it**.
- **Write-back in the engine** (`workflow/engine.go`): `runStep` receives `task`+`bindings` (by-value snapshots, safe for the `parallel`/`foreach` goroutines) and calls `publishStep`, which posts the payload via `SideEffects.PostComment` (the existing per-binding fan-out). A task **with no bindings** (e.g. a spawned task) is silently skipped.
- **Persistence** (`db`): `step_runs.publish_payload` + `publish_state` (`sent`/`failed`/`skipped`) written in Create/Update/List (columns created in Phase 1).
- **Deprecation** (`config.Load`): `log.Warn` when `result_comment` is set (settings or workflow). The `result_comment` path (`on_complete`/`per_step`) **stays functional** until a future removal.

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green.
- `go test -race ./internal/{workflow,daemon,db,config,runner}/...` — clean.
- New tests:
  - `TestExtractStructured_PublishBlock` / `TestApplyStructured_MutatesResult` — block parsing (6.1.1).
  - `TestWfStepExecutor_PublishPropagation` — `publish: auto` propagates, `publish: off` clears (6.1.2, 6.4.2).
  - `TestEngine_PublishWritesBackToBindings` — write-back + `publish_state=sent` (6.2.1, 6.2.2, 6.4.1).
  - `TestEngine_PublishSkippedWhenNoBindings` — a task with no bindings skips without error, `publish_state=skipped` (6.4.3).
  - `TestRunOnce_PublishWritesBackToBinding` — e2e in the daemon: the payload reaches the binding's adapter (6.4.1).

Part of the phased change `openspec/changes/internal-task-model` (one phase per PR).