### PR TITLE
feat(release): Phase 4 — Homebrew cask + Scoop bucket

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -41,3 +41,7 @@ jobs:
         with:
           version: "~> v2"
           args: release --snapshot --clean
+        env:
+          # snapshot skips upload, but the brews/scoops token template is still
+          # resolved — give it a dummy so the build doesn't fail on a missing env.
+          TAP_GITHUB_TOKEN: dummy-snapshot-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with contents:write on homebrew-tap + scoop-bucket. Empty until
+          # the secret is created — fine, because brews/scoops skip_upload: auto
+          # skips prereleases, and stable releases run only after it's set.
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,3 +117,49 @@ release:
     name: apiary
   draft: false
   prerelease: auto # tags like v0.1.0-rc1 are marked pre-release automatically
+
+# Homebrew (macOS + Linux). Pushes a cask to orlandoburli/homebrew-tap →
+#   brew install --cask orlandoburli/tap/apiary
+# (homebrew_casks replaces the deprecated `brews`/formula path for prebuilt
+# binaries.) Needs TAP_GITHUB_TOKEN (a PAT with contents:write on the tap repo);
+# the default GITHUB_TOKEN can't push to other repos.
+homebrew_casks:
+  - name: apiary
+    ids: [apiary]
+    repository:
+      owner: orlandoburli
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/orlandoburli/apiary"
+    description: "Task-driven agent orchestration harness (GitHub Issues, Plane, and other sources)."
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser-bot@users.noreply.github.com
+    skip_upload: auto # don't publish casks for prereleases / snapshots
+    # Unsigned binary: strip the Gatekeeper quarantine flag on install so macOS
+    # doesn't block it. (Proper notarization is a deferred follow-up.)
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/apiary"]
+          end
+
+# Scoop (Windows). Pushes a manifest to orlandoburli/scoop-bucket →
+#   scoop bucket add orlandoburli https://github.com/orlandoburli/scoop-bucket
+#   scoop install apiary
+scoops:
+  - name: apiary
+    ids: [apiary]
+    repository:
+      owner: orlandoburli
+      name: scoop-bucket
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/orlandoburli/apiary"
+    description: "Task-driven agent orchestration harness (GitHub Issues, Plane, and other sources)."
+    license: "AGPL-3.0"
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser-bot@users.noreply.github.com
+    skip_upload: auto # don't publish manifests for prereleases / snapshots

--- a/openspec/changes/binary-distribution/tasks.md
+++ b/openspec/changes/binary-distribution/tasks.md
@@ -22,7 +22,7 @@ Minimum shippable: tag → cross-platform archives + checksums on the GitHub Rel
 - [x] 1.1 Add `.goreleaser.yaml` with `builds`, `archives`, `checksums`, `release` blocks; ldflags set `internal/version.Version` to match the Makefile
 - [x] 1.2 Add `.github/workflows/release.yml` (`on: push tags 'v*'`, `contents:write`), running `goreleaser release --clean`
 - [x] 1.3 Add a PR check job (`release-check.yml`): `goreleaser check` + `goreleaser release --snapshot --clean` (no publish) so config breakage is caught pre-tag
-- [ ] 1.4 Dry-run: cut a `v0.x.0-rc` pre-release; download each archive, run `apiary version`, confirm it prints the tag *(local snapshot verified: 6 archives + checksums build, binary reports injected version; real tag still pending)*
+- [x] 1.4 Dry-run done: **`v0.1.0-rc.1`** released live — GitHub prerelease with 11 assets (6 archives + 4 deb/rpm + checksums); binary reports the injected version
 
 ## Phase 2 — Linux native packages
 
@@ -33,13 +33,14 @@ Minimum shippable: tag → cross-platform archives + checksums on the GitHub Rel
 
 - [x] 3.1 Add `Dockerfile` (distroless/static, nonroot) and `dockers` + `docker_manifests` blocks (linux/amd64 + arm64). **Note:** `dockers`/`docker_manifests` are deprecated in favor of `dockers_v2` — migrate later (Phase 7-ish).
 - [x] 3.2 Add ghcr.io login + QEMU + buildx + `packages:write` to `release.yml`; multi-arch manifest (`:latest` stable-only via `skip_push: auto`)
-- [ ] 3.3 Make the ghcr package public after first push; smoke `docker run ghcr.io/orlandoburli/apiary:<tag> version` *(local snapshot image runs + reports version; real push pending the RC tag)*
+- [~] 3.3 Images + manifest pushed live by `v0.1.0-rc.1` (tag is `0.1.0-rc.1`, no `v`). **(user)** still must flip the ghcr package visibility to **public** (access-control change); then `docker pull ghcr.io/orlandoburli/apiary:0.1.0-rc.1` works anonymously
 
 ## Phase 4 — Homebrew + Scoop
 
-- [ ] 4.1 Create `orlandoburli/homebrew-tap` and `orlandoburli/scoop-bucket` repos
-- [ ] 4.2 Create fine-grained PAT `TAP_GITHUB_TOKEN` (contents:write on the tap/bucket repos); add as Actions secret
-- [ ] 4.3 Add `brews` + `scoops` blocks; tag a release; verify `brew install orlandoburli/tap/apiary` (macOS + Linux) and `scoop install apiary`
+- [ ] 4.1 **(user)** Create `orlandoburli/homebrew-tap` and `orlandoburli/scoop-bucket` repos (public)
+- [ ] 4.2 **(user)** Create fine-grained PAT `TAP_GITHUB_TOKEN` (contents:write on the tap/bucket repos); add as Actions secret
+- [x] 4.3 Add `homebrew_casks` + `scoops` blocks (config landed ahead of the repos/token); wire `TAP_GITHUB_TOKEN` into `release.yml` (+ dummy in `release-check.yml`). `skip_upload: auto` → only stable tags publish. **Note:** `brews` (formula) is deprecated → used `homebrew_casks`, so install is `brew install --cask orlandoburli/tap/apiary`. Cask includes an `xattr` postflight to strip Gatekeeper quarantine (unsigned binary). Validated: snapshot writes `Casks/apiary.rb` (per-arch URLs+sha) and `scoop/apiary.json`.
+- [ ] 4.4 After 4.1+4.2: cut a **stable** tag (`v0.1.0`), then verify `brew install --cask orlandoburli/tap/apiary` (macOS + Linux) and `scoop install apiary`
 
 ## Phase 5 — winget + AUR (fast-follow if deferred in 0.3)
 


### PR DESCRIPTION
## Summary

Adds the Homebrew (macOS+Linux) and Scoop (Windows) channels to the GoReleaser pipeline. The config landed **ahead of** the external infra (created by the user in parallel) — `skip_upload: auto` ensures nothing is published to the taps until a **stable** tag.

- **Homebrew** via `homebrew_casks` (the old `brews`/formula is deprecated and makes `goreleaser check` fail). Push to `orlandoburli/homebrew-tap` → `brew install --cask orlandoburli/tap/apiary`. The cask generates URLs+sha per arch (darwin/linux × intel/arm) and a `postflight` with `xattr -dr com.apple.quarantine` (unsigned binary — works around Gatekeeper until notarization).
- **Scoop** via `scoops`. Push to `orlandoburli/scoop-bucket` → `scoop install apiary`.
- `TAP_GITHUB_TOKEN` wired in `release.yml` (empty until the secret exists — fine because `skip_upload: auto`); a dummy in `release-check.yml` so the snapshot can resolve the template.

## User prerequisites (to enable publication)

1. Create the public repos `orlandoburli/homebrew-tap` and `orlandoburli/scoop-bucket` (task 4.1).
2. Create a fine-grained PAT `TAP_GITHUB_TOKEN` (contents:write on those repos) and add it as an Actions secret (task 4.2).
3. Then cut a **stable** tag `v0.1.0` (task 4.4) — at which point the cask/manifest are published.

## Test plan

- [x] `goreleaser check` — valid (no more deprecated-`brews` error; only the `dockers` warning)
- [x] `goreleaser release --snapshot` (dummy token) — generates `dist/homebrew/Casks/apiary.rb` (URLs+sha per arch, `binary` stanza, `postflight` xattr) and `dist/scoop/apiary.json`
- [ ] Real cask/manifest publication — validated on the first stable tag after 4.1+4.2

Also updates the spec: marks 1.4 (RC live) and 3.3 (images published, still need to make the ghcr package public) done.