### PR TITLE
feat(spawn): APIARY_SPAWN & WorkflowSpawner — internal fan-out (Phase 7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4832 symbols, 10824 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4985 symbols, 11146 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4832 symbols, 10824 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (4985 symbols, 11146 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -35,6 +35,13 @@ const (
 	PublishOff  = "off"  // never write back, even if a payload is present
 )
 
+// Spawn modes for an agent step: how the engine treats an APIARY_SPAWN request
+// emitted by the agent.
+const (
+	SpawnAuto  = "auto"  // default: fire-and-forget — do not block on the child
+	SpawnAwait = "await" // block until the spawned task is terminal; child failure fails the step
+)
+
 // on_missing_output policy values for an agent step that declares output_schema.
 const (
 	OnMissingOutputWarn   = "warn"
@@ -116,6 +123,10 @@ type StepConfig struct {
 	// agent is written back to the task's source bindings: auto (default) | off.
 	// Empty inherits the auto default.
 	Publish string `yaml:"publish,omitempty"`
+	// Spawn controls how an APIARY_SPAWN request emitted by this step's agent is
+	// handled: auto (default, fire-and-forget) | await (block on the child).
+	// Empty inherits the auto default.
+	Spawn string `yaml:"spawn,omitempty"`
 
 	// ── split step ────────────────────────────────────────────────
 	Multi    bool          `yaml:"multi,omitempty"`

--- a/src/internal/daemon/engine_binding_test.go
+++ b/src/internal/daemon/engine_binding_test.go
@@ -76,6 +76,24 @@ func (r *publishingRunner) Run(context.Context, model.RunRequest) (model.RunResu
 	return model.RunResult{Success: true, PublishPayload: r.payload}, nil
 }
 
+// spawningRunner emits an APIARY_SPAWN request once (for the first call), then
+// returns plain successes — so the parent step spawns a child while the child
+// workflow's own step does not recurse.
+type spawningRunner struct {
+	mu  sync.Mutex
+	req *model.SpawnRequest
+}
+
+func (r *spawningRunner) ID() string                     { return "spawning" }
+func (r *spawningRunner) Configure(map[string]any) error { return nil }
+func (r *spawningRunner) Run(context.Context, model.RunRequest) (model.RunResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	req := r.req
+	r.req = nil
+	return model.RunResult{Success: true, SpawnRequest: req}, nil
+}
+
 // TestRunOnce_PublishWritesBackToBinding runs a workflow whose agent emits an
 // APIARY_PUBLISH payload and asserts the engine writes it back to the task's
 // source binding via the adapter (WriteResult), end-to-end (6.2.1, 6.4.1).
@@ -215,5 +233,93 @@ func TestRunOnce_SideEffectsResolveViaBinding(t *testing.T) {
 	}
 	if len(adapter.states) != 1 || adapter.states[0] != "in_review" {
 		t.Errorf("on_complete set_state = %v, want [in_review]", adapter.states)
+	}
+}
+
+// TestRunOnce_SpawnCreatesChildTask runs a parent workflow whose agent emits an
+// APIARY_SPAWN request and asserts a child InternalTask is persisted with the
+// parent's id, end-to-end through the dispatcher's wired spawner (7.3.1).
+func TestRunOnce_SpawnCreatesChildTask(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "spawn.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	adapter := &recordingAdapter{items: []model.SourceItem{
+		{ID: "INC-1", SourceID: "src", Number: "#1", Title: "Incident", State: "todo"},
+	}}
+
+	cfg := &config.Config{
+		Version:  "1",
+		Sources:  []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:   []config.AgentConfig{{ID: "triage", Model: "test/model"}, {ID: "collector", Model: "test/model"}},
+		Settings: config.Settings{StateLock: false, ResultComment: false},
+		Workflows: []config.WorkflowConfig{
+			{
+				ID:      "wf-parent",
+				Trigger: &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src"}},
+				Steps:   []config.StepConfig{{ID: "triage", Agent: "triage", Spawn: config.SpawnAwait}},
+			},
+			{
+				// Named child workflow; no trigger (it is dispatched by name, not routing).
+				ID:    "collect-logs",
+				Steps: []config.StepConfig{{ID: "collect", Agent: "collector"}},
+			},
+		},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	d := &Dispatcher{
+		cfg:     cfg,
+		db:      dbc,
+		router:  r,
+		sources: map[string]source.Adapter{"src": adapter},
+		runners: map[string]runnerpkg.Runner{
+			"agent-triage":    &spawningRunner{req: &model.SpawnRequest{WorkflowID: "collect-logs", Title: "Collect logs", Input: map[string]any{"severity": "high"}}},
+			"agent-collector": &countingRunner{},
+		},
+		agentRunner: map[string]string{"triage": "claude", "collector": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	if err := d.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// The spawned child task must exist with the parent task as its parent and the
+	// input carried through. The parent is the source-bound task for INC-1.
+	tasks, err := dbc.InternalTasks().ListTasksByState(ctx, model.TaskStateRegistered)
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	var child *model.InternalTask
+	for i := range tasks {
+		if tasks[i].ParentTaskID != "" {
+			child = &tasks[i]
+			break
+		}
+	}
+	if child == nil {
+		t.Fatalf("no spawned child task found among %d tasks", len(tasks))
+	}
+	if child.Title != "Collect logs" {
+		t.Errorf("child Title = %q, want Collect logs", child.Title)
+	}
+	if child.Input["severity"] != "high" {
+		t.Errorf("child Input = %#v, want severity=high", child.Input)
+	}
+
+	// The child's parent is the bound task for the polled source item.
+	parent, err := dbc.InternalTasks().GetTask(ctx, child.ParentTaskID)
+	if err != nil || parent == nil {
+		t.Fatalf("parent task %q not found: %v", child.ParentTaskID, err)
 	}
 }

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -20,10 +20,33 @@ import (
 // approval steps survive across dispatch and poll cycles.
 func (d *Dispatcher) workflowEngine() *workflow.Engine {
 	d.engineOnce.Do(func() {
-		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d},
-			workflow.WithSideEffects(&wfSideEffects{d: d}))
+		opts := []workflow.Option{workflow.WithSideEffects(&wfSideEffects{d: d})}
+		if d.db != nil {
+			opts = append(opts, workflow.WithSpawner(d.newSpawner()))
+		}
+		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d}, opts...)
 	})
 	return d.engine
+}
+
+// newSpawner builds the WorkflowSpawner backing the APIARY_SPAWN marker: it
+// resolves a named workflow from config, persists the child InternalTask, and
+// runs the workflow through this dispatcher's engine. A nil DB disables spawning
+// (handled by the engine as a step error if a marker is emitted).
+func (d *Dispatcher) newSpawner() workflow.WorkflowSpawner {
+	resolve := func(id string) (config.WorkflowConfig, bool) {
+		for i := range d.cfg.Workflows {
+			if d.cfg.Workflows[i].ID == id {
+				return d.cfg.Workflows[i], true
+			}
+		}
+		return config.WorkflowConfig{}, false
+	}
+	run := func(ctx context.Context, wf config.WorkflowConfig, task model.InternalTask) (bool, error) {
+		_, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
+		return success, err
+	}
+	return workflow.NewDefaultSpawner(resolve, d.db.InternalTasks(), run, nil, nil)
 }
 
 // dispatchWorkflow runs a matched task through the workflow engine. The route is
@@ -164,12 +187,19 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		publishPayload = ""
 	}
 
+	// A malformed APIARY_SPAWN block is a step-level error so the workflow fails
+	// with a descriptive message rather than silently dropping the request.
+	if res.SpawnError != nil {
+		return workflow.StepResult{Success: false, Output: res.Output, Err: res.SpawnError}
+	}
+
 	return workflow.StepResult{
 		Success:          res.Success,
 		Output:           res.Output,
 		StructuredOutput: res.StructuredOutput,
 		Summary:          res.Summary,
 		PublishPayload:   publishPayload,
+		SpawnRequest:     res.SpawnRequest,
 		Err:              res.Error,
 	}
 }

--- a/src/internal/daemon/workflow_executor_test.go
+++ b/src/internal/daemon/workflow_executor_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -128,5 +129,51 @@ func TestWfStepExecutor_PublishPropagation(t *testing.T) {
 	})
 	if off.PublishPayload != "" {
 		t.Errorf("publish off: payload = %q, want cleared", off.PublishPayload)
+	}
+}
+
+// TestWfStepExecutor_SpawnPropagationAndError verifies the executor forwards a
+// parsed APIARY_SPAWN request to the engine, and turns a malformed block
+// (RunResult.SpawnError) into a failed step (7.2.1, 7.3.3).
+func TestWfStepExecutor_SpawnPropagationAndError(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	newExec := func(res model.RunResult) *wfStepExecutor {
+		d := &Dispatcher{
+			cfg:         &config.Config{},
+			db:          dbc,
+			runners:     map[string]runnerpkg.Runner{"agent-architect": &fakeRunner{result: res}},
+			agentRunner: map[string]string{"architect": "claude"},
+		}
+		return &wfStepExecutor{d: d}
+	}
+	step := config.StepConfig{ID: "plan", Agent: "architect"}
+
+	// Valid spawn request propagates to the engine.
+	okRes := newExec(model.RunResult{Success: true, SpawnRequest: &model.SpawnRequest{WorkflowID: "collect"}}).
+		ExecuteStep(ctx, workflow.StepRequest{InstanceID: "wf_1", Cell: model.SourceItem{ID: "c1"}, Step: step})
+	if !okRes.Success {
+		t.Fatalf("expected success, got %+v", okRes)
+	}
+	if okRes.SpawnRequest == nil || okRes.SpawnRequest.WorkflowID != "collect" {
+		t.Errorf("spawn request not propagated: %+v", okRes.SpawnRequest)
+	}
+
+	// Malformed spawn block → failed step with the error surfaced.
+	badRes := newExec(model.RunResult{Success: true, SpawnError: errors.New("invalid JSON")}).
+		ExecuteStep(ctx, workflow.StepRequest{InstanceID: "wf_2", Cell: model.SourceItem{ID: "c1"}, Step: step})
+	if badRes.Success {
+		t.Error("expected failed step for malformed spawn block")
+	}
+	if badRes.Err == nil {
+		t.Error("expected spawn error surfaced on the step result")
+	}
+	if badRes.SpawnRequest != nil {
+		t.Errorf("malformed spawn should yield no request, got %+v", badRes.SpawnRequest)
 	}
 }

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -66,8 +66,11 @@ type StepRun struct {
 	// PublishState records the write-back outcome: sent | failed | skipped.
 	// Empty when the step emitted no publish payload.
 	PublishState string
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
+	// SpawnedTaskID is the child InternalTask id created when the step emitted an
+	// APIARY_SPAWN request. Empty when the step spawned nothing.
+	SpawnedTaskID string
+	StartedAt     *time.Time
+	FinishedAt    *time.Time
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
@@ -254,12 +257,13 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO step_runs
 		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
-		   summary, exit_code, skipped_cached, publish_payload, publish_state, started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		   summary, exit_code, skipped_cached, publish_payload, publish_state, spawned_task_id,
+		   started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
-		sr.StartedAt, sr.FinishedAt)
+		nullStr(sr.SpawnedTaskID), sr.StartedAt, sr.FinishedAt)
 	return err
 }
 
@@ -270,11 +274,11 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		UPDATE step_runs
 		SET state = ?, output = ?, structured_output = ?, summary = ?,
 		    exit_code = ?, skipped_cached = ?, publish_payload = ?, publish_state = ?,
-		    started_at = ?, finished_at = ?
+		    spawned_task_id = ?, started_at = ?, finished_at = ?
 		WHERE id = ?
 	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
-		sr.StartedAt, sr.FinishedAt, sr.ID)
+		nullStr(sr.SpawnedTaskID), sr.StartedAt, sr.FinishedAt, sr.ID)
 	return err
 }
 
@@ -284,7 +288,8 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		SELECT id, workflow_instance_id, step_id, COALESCE(agent_id,''), state,
 		       COALESCE(output,''), COALESCE(structured_output,''), COALESCE(summary,''),
 		       COALESCE(exit_code,0), COALESCE(skipped_cached,0),
-		       COALESCE(publish_payload,''), COALESCE(publish_state,''), started_at, finished_at
+		       COALESCE(publish_payload,''), COALESCE(publish_state,''),
+		       COALESCE(spawned_task_id,''), started_at, finished_at
 		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
 	`, instanceID)
 	if err != nil {
@@ -297,7 +302,7 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		var sr StepRun
 		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
 			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
-			&sr.PublishPayload, &sr.PublishState, &sr.StartedAt, &sr.FinishedAt); err != nil {
+			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.StartedAt, &sr.FinishedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, sr)

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -70,6 +70,14 @@ type RunResult struct {
 	// Output. The workflow engine writes this back to the task's source
 	// bindings as a comment (the agent-driven replacement for result_comment).
 	PublishPayload string
+	// SpawnRequest is the parsed APIARY_SPAWN_BEGIN/END block, when present and
+	// valid JSON. Nil otherwise. The markers are stripped from Output. The
+	// workflow engine creates a child InternalTask and dispatches the named
+	// workflow against it.
+	SpawnRequest *SpawnRequest
+	// SpawnError is set when an APIARY_SPAWN block was present but its body was
+	// not valid JSON. The workflow executor turns this into a failed step.
+	SpawnError error
 }
 
 type LogEntry struct {

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -63,10 +63,12 @@ type SourceBinding struct {
 
 // SpawnRequest describes a new InternalTask requested by a workflow step via the
 // APIARY_SPAWN marker. WorkflowSpawner (internal/workflow) consumes it to create
-// the child task and dispatch the named workflow.
+// the child task and dispatch the named workflow. The JSON tags map the marker's
+// payload ({"workflow","title","input"}) onto this struct; ParentTaskID is never
+// taken from agent output — the engine sets it to the spawning task's id.
 type SpawnRequest struct {
-	ParentTaskID string
-	WorkflowID   string
-	Title        string
-	Input        map[string]any
+	ParentTaskID string         `json:"-"`
+	WorkflowID   string         `json:"workflow"`
+	Title        string         `json:"title"`
+	Input        map[string]any `json:"input"`
 }

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -16,21 +17,26 @@ const (
 	summaryEndMarker   = "APIARY_SUMMARY_END"
 	publishStartMarker = "APIARY_PUBLISH_BEGIN"
 	publishEndMarker   = "APIARY_PUBLISH_END"
+	spawnStartMarker   = "APIARY_SPAWN_BEGIN"
+	spawnEndMarker     = "APIARY_SPAWN_END"
 )
 
 // extractStructured scans an agent's raw output for the APIARY_OUTPUT: sentinel,
-// the APIARY_SUMMARY_START/END block, and the APIARY_PUBLISH_BEGIN/END block. It
-// returns the cleaned output (with those lines removed), the parsed structured
-// object (nil when absent or unparseable), the summary text (empty when absent),
-// and the publish payload (empty when absent). The last valid APIARY_OUTPUT line
-// wins; the publish block is taken verbatim between its markers.
-func extractStructured(output string) (cleaned string, structured map[string]any, summary, publish string) {
+// the APIARY_SUMMARY_START/END block, the APIARY_PUBLISH_BEGIN/END block, and the
+// APIARY_SPAWN_BEGIN/END block. It returns the cleaned output (with those lines
+// removed), the parsed structured object (nil when absent or unparseable), the
+// summary text, the publish payload, and the raw spawn payload (all empty when
+// absent). The last valid APIARY_OUTPUT line wins; block payloads are taken
+// verbatim between their markers.
+func extractStructured(output string) (cleaned string, structured map[string]any, summary, publish, spawn string) {
 	lines := strings.Split(output, "\n")
 	kept := make([]string, 0, len(lines))
 	var summaryLines []string
 	var publishLines []string
+	var spawnLines []string
 	inSummary := false
 	inPublish := false
+	inSpawn := false
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -43,10 +49,16 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 			inPublish = true
 		case trimmed == publishEndMarker:
 			inPublish = false
+		case trimmed == spawnStartMarker:
+			inSpawn = true
+		case trimmed == spawnEndMarker:
+			inSpawn = false
 		case inSummary:
 			summaryLines = append(summaryLines, line)
 		case inPublish:
 			publishLines = append(publishLines, line)
+		case inSpawn:
+			spawnLines = append(spawnLines, line)
 		case strings.HasPrefix(trimmed, apiaryOutputPrefix):
 			jsonPart := strings.TrimSpace(strings.TrimPrefix(trimmed, apiaryOutputPrefix))
 			var obj map[string]any
@@ -62,19 +74,29 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 	cleaned = strings.TrimSpace(strings.Join(kept, "\n"))
 	summary = strings.TrimSpace(strings.Join(summaryLines, "\n"))
 	publish = strings.TrimSpace(strings.Join(publishLines, "\n"))
-	return cleaned, structured, summary, publish
+	spawn = strings.TrimSpace(strings.Join(spawnLines, "\n"))
+	return cleaned, structured, summary, publish, spawn
 }
 
 // applyStructured post-processes a RunResult's Output, moving any structured
-// output, summary, and publish payload into their dedicated fields. Safe to call
-// for plain runs: when no sentinels are present, Output is unchanged and the new
-// fields stay nil/empty.
+// output, summary, publish payload, and spawn request into their dedicated
+// fields. Safe to call for plain runs: when no sentinels are present, Output is
+// unchanged and the new fields stay nil/empty. A malformed APIARY_SPAWN block
+// (invalid JSON) is surfaced via RunResult.SpawnError so the engine fails the step.
 func applyStructured(result *model.RunResult) {
-	cleaned, structured, summary, publish := extractStructured(result.Output)
+	cleaned, structured, summary, publish, spawn := extractStructured(result.Output)
 	result.Output = cleaned
 	result.StructuredOutput = structured
 	result.Summary = summary
 	result.PublishPayload = publish
+	if spawn != "" {
+		var req model.SpawnRequest
+		if err := json.Unmarshal([]byte(spawn), &req); err != nil {
+			result.SpawnError = fmt.Errorf("APIARY_SPAWN: invalid JSON: %w", err)
+		} else {
+			result.SpawnRequest = &req
+		}
+	}
 }
 
 // summaryInstruction returns the text appended to a prompt instructing the agent

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -18,7 +18,7 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 		`APIARY_OUTPUT: {"complexity":"high","action":"implement"}`,
 	}, "\n")
 
-	cleaned, structured, summary, _ := extractStructured(raw)
+	cleaned, structured, summary, _, _ := extractStructured(raw)
 
 	if strings.Contains(cleaned, "APIARY_OUTPUT") || strings.Contains(cleaned, "APIARY_SUMMARY") {
 		t.Errorf("cleaned output still contains sentinels:\n%s", cleaned)
@@ -39,7 +39,7 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 
 func TestExtractStructured_NoSentinels(t *testing.T) {
 	raw := "Just a normal agent response.\nNothing structured here."
-	cleaned, structured, summary, publish := extractStructured(raw)
+	cleaned, structured, summary, publish, _ := extractStructured(raw)
 	if publish != "" {
 		t.Errorf("expected empty publish, got: %q", publish)
 	}
@@ -60,7 +60,7 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 		"some text",
 		`APIARY_OUTPUT: {"v":2}`,
 	}, "\n")
-	_, structured, _, _ := extractStructured(raw)
+	_, structured, _, _, _ := extractStructured(raw)
 	if structured == nil || structured["v"] != float64(2) {
 		t.Errorf("expected last APIARY_OUTPUT to win, got: %#v", structured)
 	}
@@ -68,7 +68,7 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 
 func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
 	raw := "real output\nAPIARY_OUTPUT: {not valid json}"
-	cleaned, structured, _, _ := extractStructured(raw)
+	cleaned, structured, _, _, _ := extractStructured(raw)
 	if structured != nil {
 		t.Errorf("expected nil structured for invalid JSON, got: %#v", structured)
 	}
@@ -90,7 +90,7 @@ func TestExtractStructured_PublishBlock(t *testing.T) {
 		"Trailing line.",
 	}, "\n")
 
-	cleaned, structured, summary, publish := extractStructured(raw)
+	cleaned, structured, summary, publish, _ := extractStructured(raw)
 
 	if structured != nil || summary != "" {
 		t.Errorf("expected no structured/summary, got %#v / %q", structured, summary)
@@ -103,6 +103,52 @@ func TestExtractStructured_PublishBlock(t *testing.T) {
 	}
 	if publish != "## Result\nDone. See the diff." {
 		t.Errorf("publish payload parsed incorrectly: %q", publish)
+	}
+}
+
+func TestApplyStructured_SpawnBlock(t *testing.T) {
+	result := model.RunResult{
+		Output: strings.Join([]string{
+			"Decided to delegate.",
+			"APIARY_SPAWN_BEGIN",
+			`{"workflow":"collect-logs","title":"Collect logs","input":{"severity":"high"}}`,
+			"APIARY_SPAWN_END",
+		}, "\n"),
+	}
+	applyStructured(&result)
+
+	if result.Output != "Decided to delegate." {
+		t.Errorf("spawn block not stripped from output: %q", result.Output)
+	}
+	if result.SpawnError != nil {
+		t.Fatalf("unexpected spawn error: %v", result.SpawnError)
+	}
+	if result.SpawnRequest == nil {
+		t.Fatal("expected spawn request, got nil")
+	}
+	if result.SpawnRequest.WorkflowID != "collect-logs" || result.SpawnRequest.Title != "Collect logs" {
+		t.Errorf("spawn request parsed incorrectly: %#v", result.SpawnRequest)
+	}
+	if result.SpawnRequest.Input["severity"] != "high" {
+		t.Errorf("spawn input parsed incorrectly: %#v", result.SpawnRequest.Input)
+	}
+	// ParentTaskID is never taken from agent output (json:"-").
+	if result.SpawnRequest.ParentTaskID != "" {
+		t.Errorf("ParentTaskID should not be set from agent output, got %q", result.SpawnRequest.ParentTaskID)
+	}
+}
+
+func TestApplyStructured_SpawnInvalidJSON(t *testing.T) {
+	result := model.RunResult{
+		Output: "APIARY_SPAWN_BEGIN\n{not valid json}\nAPIARY_SPAWN_END",
+	}
+	applyStructured(&result)
+
+	if result.SpawnRequest != nil {
+		t.Errorf("expected nil spawn request for invalid JSON, got %#v", result.SpawnRequest)
+	}
+	if result.SpawnError == nil {
+		t.Fatal("expected spawn error for invalid JSON, got nil")
 	}
 }
 

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -52,7 +52,10 @@ type StepResult struct {
 	// engine writes it back to the task's source bindings as a comment. The
 	// executor clears it when the step sets publish: off.
 	PublishPayload string
-	Err            error
+	// SpawnRequest is the parsed APIARY_SPAWN request the agent emitted, if any.
+	// The engine creates a child task and dispatches the named workflow.
+	SpawnRequest *model.SpawnRequest
+	Err          error
 }
 
 // StepExecutor performs the actual runner invocation for a single agent step.
@@ -80,11 +83,12 @@ type SideEffects interface {
 // Phase 2 it executes agent steps sequentially in declaration order (single-step
 // and linear chains); the DAG executor with splits/foreach arrives in Phase 3.
 type Engine struct {
-	cfg   *config.Config
-	store Store
-	exec  StepExecutor
-	side  SideEffects
-	mem   MemoryBuilder
+	cfg     *config.Config
+	store   Store
+	exec    StepExecutor
+	side    SideEffects
+	mem     MemoryBuilder
+	spawner WorkflowSpawner
 
 	now   func() time.Time
 	newID func(prefix string) string
@@ -107,6 +111,9 @@ func WithIDGen(gen func(prefix string) string) Option { return func(e *Engine) {
 
 // WithMemoryBuilder overrides the memory builder.
 func WithMemoryBuilder(b MemoryBuilder) Option { return func(e *Engine) { e.mem = b } }
+
+// WithSpawner sets the APIARY_SPAWN handler used to create child tasks.
+func WithSpawner(s WorkflowSpawner) Option { return func(e *Engine) { e.spawner = s } }
 
 // NewEngine builds an Engine. cfg, store, and exec are required.
 func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {
@@ -281,6 +288,9 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 			sr.StructuredOutput = string(data)
 		}
 	}
+	// Spawn handling runs before the pass/fail decision so a spawn failure (or an
+	// await on a failed child) fails the step.
+	e.spawnStep(ctx, task, step, &res, sr)
 	if res.Success {
 		sr.State = db.StepStatePassed
 	} else {
@@ -289,6 +299,47 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	e.publishStep(ctx, task, bindings, res, sr)
 	_ = e.store.UpdateStepRun(ctx, sr)
 	return res
+}
+
+// spawnStep handles an agent-emitted APIARY_SPAWN request: it creates a child
+// InternalTask via the spawner, dispatches the named workflow, and records the
+// child id on the step run. By default (spawn: auto) it is fire-and-forget; with
+// spawn: await it blocks until the child reaches a terminal state and fails the
+// step if the child failed. A spawn request is only honored when the agent step
+// itself succeeded; a missing spawner, an unknown workflow, or a create failure
+// fails the step (never a silent no-op).
+func (e *Engine) spawnStep(ctx context.Context, task model.InternalTask, step config.StepConfig, res *StepResult, sr *db.StepRun) {
+	if res.SpawnRequest == nil || !res.Success {
+		return
+	}
+	if e.spawner == nil {
+		res.Success = false
+		res.Err = fmt.Errorf("step %q requested APIARY_SPAWN but no spawner is configured", step.ID)
+		return
+	}
+
+	req := *res.SpawnRequest
+	req.ParentTaskID = task.ID
+	child, err := e.spawner.Spawn(ctx, req)
+	if err != nil {
+		res.Success = false
+		res.Err = fmt.Errorf("spawn workflow %q: %w", req.WorkflowID, err)
+		return
+	}
+	sr.SpawnedTaskID = child.ID
+
+	if step.Spawn == config.SpawnAwait {
+		ok, werr := e.spawner.Await(ctx, child.ID)
+		if werr != nil {
+			res.Success = false
+			res.Err = fmt.Errorf("spawn await child %s: %w", child.ID, werr)
+			return
+		}
+		if !ok {
+			res.Success = false
+			res.Err = fmt.Errorf("spawned task %s failed", child.ID)
+		}
+	}
 }
 
 // publishStep writes an agent-emitted APIARY_PUBLISH payload back to the task's

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,9 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 )
+
+// errTest is a sentinel error for tests that script a failure.
+var errTest = errors.New("test error")
 
 // synthWF converts a RouteConfig to an equivalent single-step WorkflowConfig.
 // Used only in tests; production code no longer has SynthesizeWorkflow.
@@ -121,6 +125,39 @@ func (f *fakeSide) ApplyHook(_ context.Context, _ model.InternalTask, _ []model.
 	return nil
 }
 
+// fakeSpawner records spawn requests and returns scripted outcomes.
+type fakeSpawner struct {
+	mu       sync.Mutex
+	requests []model.SpawnRequest
+	child    model.InternalTask
+	spawnErr error
+	awaitOK  bool
+	awaitErr error
+}
+
+func (f *fakeSpawner) Spawn(_ context.Context, req model.SpawnRequest) (model.InternalTask, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, req)
+	f.mu.Unlock()
+	if f.spawnErr != nil {
+		return model.InternalTask{}, f.spawnErr
+	}
+	return f.child, nil
+}
+
+func (f *fakeSpawner) Await(_ context.Context, _ string) (bool, error) {
+	return f.awaitOK, f.awaitErr
+}
+
+func (f *fakeSpawner) lastRequest() (model.SpawnRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.requests) == 0 {
+		return model.SpawnRequest{}, false
+	}
+	return f.requests[len(f.requests)-1], true
+}
+
 func testEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects) *Engine {
 	var seq atomic.Int64
 	return NewEngine(cfg, store, exec,
@@ -130,6 +167,27 @@ func testEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEff
 			return prefix + "-" + itoa(int(seq.Add(1)))
 		}),
 	)
+}
+
+// testEngineWithSpawner builds a test engine wired with a spawner.
+func testEngineWithSpawner(cfg *config.Config, store Store, exec StepExecutor, side SideEffects, sp WorkflowSpawner) *Engine {
+	var seq atomic.Int64
+	return NewEngine(cfg, store, exec,
+		WithSideEffects(side),
+		WithSpawner(sp),
+		WithClock(func() time.Time { return time.Unix(1000, 0) }),
+		WithIDGen(func(prefix string) string {
+			return prefix + "-" + itoa(int(seq.Add(1)))
+		}),
+	)
+}
+
+// spawnWF builds a single-step workflow whose agent step uses the given spawn mode.
+func spawnWF(spawnMode string) config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID:    "r",
+		Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev", Spawn: spawnMode}},
+	}
 }
 
 func itoa(n int) string {
@@ -284,6 +342,107 @@ func TestEngine_PublishSkippedWhenNoBindings(t *testing.T) {
 	}
 	if sr.PublishPayload != "should not post" {
 		t.Errorf("expected publish_payload persisted even when skipped, got %q", sr.PublishPayload)
+	}
+}
+
+// TestEngine_SpawnAutoFireAndForget covers 7.2.2/7.2.3 + 7.3.1 at the engine
+// level: a step emitting APIARY_SPAWN creates a child (parent set to the running
+// task) and records spawned_task_id; in auto mode the step's own success stands.
+func TestEngine_SpawnAutoFireAndForget(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", SpawnRequest: &model.SpawnRequest{
+			WorkflowID: "collect", Title: "Collect", Input: map[string]any{"k": "v"},
+		}},
+	}}
+	sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}}
+	eng := testEngineWithSpawner(cfg, store, exec, &fakeSide{}, sp)
+
+	instID, _, err := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto),
+		model.InternalTask{ID: "C1", Title: "Parent"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected instance done, got %s", store.instances[instID].State)
+	}
+
+	req, ok := sp.lastRequest()
+	if !ok {
+		t.Fatal("spawner was not called")
+	}
+	if req.ParentTaskID != "C1" {
+		t.Errorf("spawn ParentTaskID = %q, want C1 (the running task)", req.ParentTaskID)
+	}
+	if req.WorkflowID != "collect" || req.Input["k"] != "v" {
+		t.Errorf("spawn request not forwarded: %+v", req)
+	}
+	sr := store.stepRuns[store.stepOrder[0]]
+	if sr.SpawnedTaskID != "task-child" {
+		t.Errorf("spawned_task_id = %q, want task-child", sr.SpawnedTaskID)
+	}
+}
+
+// TestEngine_SpawnAwait covers 7.2.5 + 7.3.2: spawn: await fails the step when
+// the child fails and passes it when the child succeeds.
+func TestEngine_SpawnAwait(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		awaitOK bool
+		want    string
+	}{
+		{"child done", true, db.InstanceStateDone},
+		{"child failed", false, db.InstanceStateFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeStore()
+			exec := &fakeExecutor{results: map[string]StepResult{
+				"run": {Success: true, Output: "ok", SpawnRequest: &model.SpawnRequest{WorkflowID: "collect"}},
+			}}
+			sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}, awaitOK: tc.awaitOK}
+			eng := testEngineWithSpawner(baseCfg(), store, exec, &fakeSide{}, sp)
+
+			instID, _, err := eng.RunInstance(context.Background(), spawnWF(config.SpawnAwait),
+				model.InternalTask{ID: "C1"})
+			if err != nil {
+				t.Fatalf("RunInstance: %v", err)
+			}
+			if store.instances[instID].State != tc.want {
+				t.Errorf("instance state = %s, want %s", store.instances[instID].State, tc.want)
+			}
+		})
+	}
+}
+
+// TestEngine_SpawnErrorFailsStep covers 7.3.4 at the engine level: a spawner
+// error (e.g. unknown workflow) fails the step rather than passing silently.
+func TestEngine_SpawnErrorFailsStep(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, SpawnRequest: &model.SpawnRequest{WorkflowID: "nope"}},
+	}}
+	sp := &fakeSpawner{spawnErr: errTest}
+	eng := testEngineWithSpawner(baseCfg(), store, exec, &fakeSide{}, sp)
+
+	instID, _, _ := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto), model.InternalTask{ID: "C1"})
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed instance on spawn error, got %s", store.instances[instID].State)
+	}
+}
+
+// TestEngine_SpawnWithoutSpawnerFailsStep: a spawn marker with no spawner wired
+// is a step error, never a silent no-op (7.3.4 spirit).
+func TestEngine_SpawnWithoutSpawnerFailsStep(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, SpawnRequest: &model.SpawnRequest{WorkflowID: "collect"}},
+	}}
+	eng := testEngine(baseCfg(), store, exec, &fakeSide{}) // no spawner
+
+	instID, _, _ := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto), model.InternalTask{ID: "C1"})
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed instance when no spawner configured, got %s", store.instances[instID].State)
 	}
 }
 

--- a/src/internal/workflow/spawner.go
+++ b/src/internal/workflow/spawner.go
@@ -1,0 +1,140 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// WorkflowSpawner creates a child InternalTask for an APIARY_SPAWN request and
+// runs the named workflow against it. The engine holds one via an interface field
+// so it stays testable in isolation (see Engine.spawner / WithSpawner).
+type WorkflowSpawner interface {
+	// Spawn creates and persists the child task, then launches the named workflow
+	// against it. The run proceeds asynchronously; Spawn returns the freshly
+	// created (registered) child immediately. It errors synchronously only when
+	// the named workflow is unknown or persisting the task fails.
+	Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error)
+	// Await blocks until the workflow launched for the spawned task reaches a
+	// terminal state, reporting whether it succeeded. It errors if taskID was not
+	// spawned by this spawner (or the wait context is cancelled).
+	Await(ctx context.Context, taskID string) (bool, error)
+}
+
+// taskCreator persists a new InternalTask, filling in any unset id/timestamps.
+// *db.InternalTaskStore satisfies it.
+type taskCreator interface {
+	CreateTask(ctx context.Context, task *model.InternalTask) error
+}
+
+// DefaultSpawner is the production WorkflowSpawner. It resolves the named
+// workflow from config, persists the child task, and runs the workflow via an
+// injected runner (the engine's RunInstance), tracking completion so spawn:await
+// steps can block on the outcome.
+type DefaultSpawner struct {
+	resolve func(workflowID string) (config.WorkflowConfig, bool)
+	creator taskCreator
+	run     func(ctx context.Context, wf config.WorkflowConfig, task model.InternalTask) (bool, error)
+	newID   func(prefix string) string
+	now     func() time.Time
+
+	mu      sync.Mutex
+	running map[string]*spawnHandle // child task id → completion handle
+}
+
+// spawnHandle tracks an in-flight spawned workflow so Await can block on it.
+type spawnHandle struct {
+	done    chan struct{}
+	success bool // valid once done is closed
+}
+
+// NewDefaultSpawner builds a DefaultSpawner. resolve maps a workflow id to its
+// config (ok=false when unknown); creator persists the child task; run executes a
+// workflow against a task and reports success. newID/now may be nil (defaults are
+// used) — pass them in tests for determinism.
+func NewDefaultSpawner(
+	resolve func(string) (config.WorkflowConfig, bool),
+	creator taskCreator,
+	run func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error),
+	newID func(string) string,
+	now func() time.Time,
+) *DefaultSpawner {
+	if now == nil {
+		now = time.Now
+	}
+	if newID == nil {
+		newID = defaultIDGen(now)
+	}
+	return &DefaultSpawner{
+		resolve: resolve,
+		creator: creator,
+		run:     run,
+		newID:   newID,
+		now:     now,
+		running: map[string]*spawnHandle{},
+	}
+}
+
+// Spawn resolves the named workflow, persists a child InternalTask carrying the
+// parent id and input, and launches the workflow on its own goroutine. The child
+// is returned immediately in the registered state; spawn:await callers block via
+// Await. A missing workflow or a persistence failure is returned synchronously.
+func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error) {
+	wf, ok := s.resolve(req.WorkflowID)
+	if !ok {
+		return model.InternalTask{}, fmt.Errorf("workflow %q not found", req.WorkflowID)
+	}
+
+	now := s.now()
+	child := model.InternalTask{
+		ID:           s.newID("task"),
+		ParentTaskID: req.ParentTaskID,
+		Title:        req.Title,
+		Input:        req.Input,
+		State:        model.TaskStateRegistered,
+		Metadata:     model.TaskMetadata{Type: "internal"},
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := s.creator.CreateTask(ctx, &child); err != nil {
+		return model.InternalTask{}, fmt.Errorf("create spawned task: %w", err)
+	}
+
+	h := &spawnHandle{done: make(chan struct{})}
+	s.mu.Lock()
+	s.running[child.ID] = h
+	s.mu.Unlock()
+
+	// Fire-and-forget: the child workflow runs on its own goroutine with a context
+	// detached from the parent step, so cancelling the step does not abort the
+	// spawned work. spawn:await callers observe completion through Await.
+	go func() {
+		success, err := s.run(context.WithoutCancel(ctx), wf, child)
+		h.success = success && err == nil
+		close(h.done)
+	}()
+
+	return child, nil
+}
+
+// Await blocks until the workflow launched for taskID reaches a terminal state,
+// returning whether it succeeded. It errors if the task was not spawned here or
+// the wait context is cancelled first.
+func (s *DefaultSpawner) Await(ctx context.Context, taskID string) (bool, error) {
+	s.mu.Lock()
+	h, ok := s.running[taskID]
+	s.mu.Unlock()
+	if !ok {
+		return false, fmt.Errorf("spawned task %q not tracked", taskID)
+	}
+	select {
+	case <-h.done:
+		return h.success, nil
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+}

--- a/src/internal/workflow/spawner_test.go
+++ b/src/internal/workflow/spawner_test.go
@@ -1,0 +1,169 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// fakeCreator records created tasks. CreateTask mimics the store's behaviour of
+// leaving a caller-supplied id in place.
+type fakeCreator struct {
+	mu    sync.Mutex
+	tasks []model.InternalTask
+}
+
+func (f *fakeCreator) CreateTask(_ context.Context, t *model.InternalTask) error {
+	f.mu.Lock()
+	f.tasks = append(f.tasks, *t)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeCreator) created() []model.InternalTask {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]model.InternalTask(nil), f.tasks...)
+}
+
+type ranWorkflow struct {
+	wf   config.WorkflowConfig
+	task model.InternalTask
+}
+
+func testIDGen() func(string) string {
+	var seq int
+	return func(p string) string { seq++; return fmt.Sprintf("%s-%d", p, seq) }
+}
+
+// TestDefaultSpawner_CreatesChildAndRuns covers 7.3.1: a spawn request creates a
+// child task carrying parent_task_id + input, and the named workflow is run
+// against that child.
+func TestDefaultSpawner_CreatesChildAndRuns(t *testing.T) {
+	creator := &fakeCreator{}
+	ran := make(chan ranWorkflow, 1)
+	resolve := func(id string) (config.WorkflowConfig, bool) {
+		if id == "collect" {
+			return config.WorkflowConfig{ID: "collect"}, true
+		}
+		return config.WorkflowConfig{}, false
+	}
+	run := func(_ context.Context, wf config.WorkflowConfig, task model.InternalTask) (bool, error) {
+		ran <- ranWorkflow{wf: wf, task: task}
+		return true, nil
+	}
+	s := NewDefaultSpawner(resolve, creator, run, testIDGen(), func() time.Time { return time.Unix(1000, 0) })
+
+	child, err := s.Spawn(context.Background(), model.SpawnRequest{
+		ParentTaskID: "parent-1",
+		WorkflowID:   "collect",
+		Title:        "Collect logs",
+		Input:        map[string]any{"severity": "high"},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	if child.ParentTaskID != "parent-1" {
+		t.Errorf("child ParentTaskID = %q, want parent-1", child.ParentTaskID)
+	}
+	if child.Title != "Collect logs" || child.Input["severity"] != "high" {
+		t.Errorf("child not populated from request: %+v", child)
+	}
+	if child.State != model.TaskStateRegistered {
+		t.Errorf("child State = %q, want registered", child.State)
+	}
+
+	created := creator.created()
+	if len(created) != 1 || created[0].ID != child.ID || created[0].ParentTaskID != "parent-1" {
+		t.Fatalf("child not persisted with parent: %+v", created)
+	}
+
+	select {
+	case got := <-ran:
+		if got.wf.ID != "collect" {
+			t.Errorf("ran workflow %q, want collect", got.wf.ID)
+		}
+		if got.task.ID != child.ID {
+			t.Errorf("ran against task %q, want child %q", got.task.ID, child.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("named workflow was not dispatched")
+	}
+}
+
+// TestDefaultSpawner_UnknownWorkflowErrors covers 7.3.4: a spawn naming an
+// unknown workflow returns an error rather than silently doing nothing.
+func TestDefaultSpawner_UnknownWorkflowErrors(t *testing.T) {
+	creator := &fakeCreator{}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{}, false },
+		creator,
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+
+	_, err := s.Spawn(context.Background(), model.SpawnRequest{WorkflowID: "nope"})
+	if err == nil {
+		t.Fatal("expected error for unknown workflow, got nil")
+	}
+	if len(creator.created()) != 0 {
+		t.Errorf("no task should be created for an unknown workflow, got %d", len(creator.created()))
+	}
+}
+
+// TestDefaultSpawner_AwaitReportsOutcome verifies Await blocks until the spawned
+// workflow finishes and reports the child's success (the basis for spawn: await).
+func TestDefaultSpawner_AwaitReportsOutcome(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		success bool
+		runErr  error
+		want    bool
+	}{
+		{"child succeeds", true, nil, true},
+		{"child fails", false, nil, false},
+		{"run errors", true, fmt.Errorf("boom"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			release := make(chan struct{})
+			run := func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) {
+				<-release
+				return tc.success, tc.runErr
+			}
+			s := NewDefaultSpawner(
+				func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+				&fakeCreator{}, run, testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+			)
+			child, err := s.Spawn(context.Background(), model.SpawnRequest{WorkflowID: "w"})
+			if err != nil {
+				t.Fatalf("Spawn: %v", err)
+			}
+			close(release)
+			ok, err := s.Await(context.Background(), child.ID)
+			if err != nil {
+				t.Fatalf("Await: %v", err)
+			}
+			if ok != tc.want {
+				t.Errorf("Await success = %v, want %v", ok, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSpawner_AwaitUnknownTask(t *testing.T) {
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{}, true },
+		&fakeCreator{},
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+	if _, err := s.Await(context.Background(), "never-spawned"); err == nil {
+		t.Fatal("expected error awaiting an untracked task")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 7 of the `internal-task-model` change: the **internal fan-out path**. A workflow step emits `APIARY_SPAWN` and the engine creates a child `InternalTask` (with no source binding) and dispatches a named workflow against it, with lineage via `parent_task_id` + `input`.

- **Marker parsing** (`runner/execution/structured.go`): the `APIARY_SPAWN_BEGIN`/`END` block → JSON into `model.SpawnRequest` (`workflow`/`title`/`input`; `ParentTaskID` is `json:"-"`, set by the engine). Invalid JSON becomes `RunResult.SpawnError` → the step fails with a descriptive message (never a silent no-op).
- **`WorkflowSpawner`** (`workflow/spawner.go`, new): the `{Spawn, Await}` interface + `DefaultSpawner`. `Spawn` resolves the named workflow (error if unknown), persists the child task (`registered`, parent+input) and dispatches the run **asynchronously** (fire-and-forget), returning the child immediately. `Await` blocks until the run finishes — the basis for `spawn: await`.
- **Engine** (`workflow/engine.go`): a `spawner` field (via `WithSpawner`); `StepResult.SpawnRequest`; `runStep` → `spawnStep` after the agent runs (only when the step passed): creates the child, writes `step_runs.spawned_task_id`; `spawn: await` fails the step if the child fails. A marker present with no spawner configured = step error.
- **`StepConfig.Spawn`** `"auto"` (default, fire-and-forget) | `"await"`.
- **Persistence**: `step_runs.spawned_task_id` (Phase 1 column) in Create/Update/List.
- **Wiring** (`daemon/workflow.go`): the executor maps `SpawnRequest`/`SpawnError`; `workflowEngine()` injects the `DefaultSpawner` (resolves by config, `CreateTask`, run via `RunInstance`).

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all green. `-race` on workflow/daemon/db/runner/config — clean.
- New tests:
  - parsing: `TestApplyStructured_SpawnBlock`, `TestApplyStructured_SpawnInvalidJSON` (7.2.1, 7.3.3).
  - spawner: `TestDefaultSpawner_CreatesChildAndRuns` (7.3.1), `…_UnknownWorkflowErrors` (7.3.4), `…_AwaitReportsOutcome`, `…_AwaitUnknownTask`.
  - engine: `TestEngine_SpawnAutoFireAndForget` (7.2.2/7.2.3 + writes `spawned_task_id`), `TestEngine_SpawnAwait` (done/failed → 7.2.5/7.3.2), `…_SpawnErrorFailsStep`, `…_SpawnWithoutSpawnerFailsStep` (7.3.4).
  - executor: `TestWfStepExecutor_SpawnPropagationAndError` (7.2.1, 7.3.3).
  - e2e daemon: `TestRunOnce_SpawnCreatesChildTask` — the child persisted with `parent_task_id` + input (7.3.1).

Part of the phased change `openspec/changes/internal-task-model` (one phase per PR).