### PR TITLE
feat(tasks): InternalTask completion hook + outstanding counter (Phase 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4985 symbols, 11146 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5054 symbols, 11316 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (4985 symbols, 11146 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5054 symbols, 11316 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Workers       []WorkerConfig   `yaml:"workers"`
 	Workflows     []WorkflowConfig `yaml:"workflows"`
 	Settings      Settings         `yaml:"settings"`
+	Tasks         *TasksConfig     `yaml:"tasks"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 }
@@ -148,6 +149,18 @@ type OnComplete struct {
 	// AssignLabelPrefix is the label prefix used for AssignFromOutput. Defaults
 	// to "agent:" so the assigned label matches the agent:* route convention.
 	AssignLabelPrefix string `yaml:"assign_label_prefix"`
+}
+
+// TasksConfig is the top-level `tasks:` block. Its hooks fire once per
+// InternalTask — when the LAST of the task's fanned-out workflows reaches a
+// terminal state — as opposed to the per-workflow on_complete/on_fail hooks
+// which fire once per workflow instance. OnComplete applies when every instance
+// succeeded; OnFail applies when any instance failed. Both follow the same rules
+// as per-workflow hooks (set_state, add_labels; the removed assign_* directives
+// are rejected by lint).
+type TasksConfig struct {
+	OnComplete *OnComplete `yaml:"on_complete"`
+	OnFail     *OnComplete `yaml:"on_fail"`
 }
 
 type Settings struct {

--- a/src/internal/config/lint_test.go
+++ b/src/internal/config/lint_test.go
@@ -133,6 +133,66 @@ func TestLint_ExampleConfigsNoFalsePositives(t *testing.T) {
 	}
 }
 
+// TestLoad_ParsesTasksBlock verifies 8.1.1/8.1.2: the top-level tasks: block
+// parses into Config.Tasks with its on_complete/on_fail hooks, and the strict
+// unknown-field lint accepts the new keys (a clean load).
+func TestLoad_ParsesTasksBlock(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `version: "1"
+tasks:
+  on_complete:
+    set_state: done
+    add_labels: [resolved]
+  on_fail:
+    set_state: blocked
+`
+	path := filepath.Join(dir, "apiary.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Tasks == nil {
+		t.Fatal("expected Config.Tasks to be parsed, got nil")
+	}
+	if cfg.Tasks.OnComplete == nil || cfg.Tasks.OnComplete.SetState != "done" {
+		t.Errorf("tasks.on_complete parsed incorrectly: %+v", cfg.Tasks.OnComplete)
+	}
+	if cfg.Tasks.OnComplete == nil || len(cfg.Tasks.OnComplete.AddLabels) != 1 || cfg.Tasks.OnComplete.AddLabels[0] != "resolved" {
+		t.Errorf("tasks.on_complete.add_labels parsed incorrectly: %+v", cfg.Tasks.OnComplete)
+	}
+	if cfg.Tasks.OnFail == nil || cfg.Tasks.OnFail.SetState != "blocked" {
+		t.Errorf("tasks.on_fail parsed incorrectly: %+v", cfg.Tasks.OnFail)
+	}
+	// The new keys must not trip the strict unknown-field lint.
+	if errs := cfg.lint(); len(errs) != 0 {
+		t.Errorf("valid tasks: block should lint clean, got: %v", errs)
+	}
+}
+
+// TestLint_RemovedAssignUnderTasksHook verifies 8.1.3: the top-level tasks:
+// on_complete/on_fail hooks follow the same rules as per-workflow hooks, so the
+// removed assign_* directives are rejected there too. The removed-directive lint
+// matches on the leaf+parent key (assign_from_output under on_complete), so it
+// catches the directive regardless of whether on_complete sits under a workflow
+// or under the tasks: block.
+func TestLint_RemovedAssignUnderTasksHook(t *testing.T) {
+	raw := `version: "1"
+tasks:
+  on_complete:
+    assign_from_output: true
+`
+	errs := newRawConfig(raw).lint()
+	if len(errs) == 0 {
+		t.Fatal("expected an error for assign_from_output under tasks.on_complete, got none")
+	}
+	if !strings.Contains(joinErrs(errs), "assign_from_output") {
+		t.Errorf("error should name the directive: %q", joinErrs(errs))
+	}
+}
+
 func joinErrs(errs []error) string {
 	var b strings.Builder
 	for _, e := range errs {

--- a/src/internal/daemon/engine_binding_test.go
+++ b/src/internal/daemon/engine_binding_test.go
@@ -295,20 +295,31 @@ func TestRunOnce_SpawnCreatesChildTask(t *testing.T) {
 	}
 
 	// The spawned child task must exist with the parent task as its parent and the
-	// input carried through. The parent is the source-bound task for INC-1.
-	tasks, err := dbc.InternalTasks().ListTasksByState(ctx, model.TaskStateRegistered)
-	if err != nil {
-		t.Fatalf("list tasks: %v", err)
-	}
+	// input carried through. The parent is the source-bound task for INC-1. The
+	// child is created synchronously at spawn but its lifecycle state is advanced
+	// asynchronously by the fire-and-forget run (Phase 8), so we search across all
+	// states rather than assuming it is still registered.
 	var child *model.InternalTask
-	for i := range tasks {
-		if tasks[i].ParentTaskID != "" {
-			child = &tasks[i]
+	for _, st := range []model.TaskState{
+		model.TaskStateRegistered, model.TaskStateRunning,
+		model.TaskStateApprovalWait, model.TaskStateDone, model.TaskStateFailed,
+	} {
+		tasks, err := dbc.InternalTasks().ListTasksByState(ctx, st)
+		if err != nil {
+			t.Fatalf("list tasks (%s): %v", st, err)
+		}
+		for i := range tasks {
+			if tasks[i].ParentTaskID != "" {
+				child = &tasks[i]
+				break
+			}
+		}
+		if child != nil {
 			break
 		}
 	}
 	if child == nil {
-		t.Fatalf("no spawned child task found among %d tasks", len(tasks))
+		t.Fatalf("no spawned child task found in any state")
 	}
 	if child.Title != "Collect logs" {
 		t.Errorf("child Title = %q, want Collect logs", child.Title)
@@ -321,5 +332,77 @@ func TestRunOnce_SpawnCreatesChildTask(t *testing.T) {
 	parent, err := dbc.InternalTasks().GetTask(ctx, child.ParentTaskID)
 	if err != nil || parent == nil {
 		t.Fatalf("parent task %q not found: %v", child.ParentTaskID, err)
+	}
+}
+
+// TestTaskCompletion_NoBindingsAppliesHookWithoutError covers 8.2.4: a task with
+// no source bindings (e.g. a spawned task) runs its workflow to completion and the
+// top-level tasks: on_complete hook is applied through the real wfSideEffects —
+// fanning out over zero bindings is a clean no-op, so there is nothing to apply
+// and no error. The outstanding counter drains to 0 and the task reaches done.
+func TestTaskCompletion_NoBindingsAppliesHookWithoutError(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "nobind.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version:  "1",
+		Agents:   []config.AgentConfig{{ID: "collector", Model: "test/model"}},
+		Settings: config.Settings{StateLock: false, ResultComment: false},
+		Tasks: &config.TasksConfig{
+			OnComplete: &config.OnComplete{SetState: "closed", AddLabels: []string{"resolved"}},
+			OnFail:     &config.OnComplete{SetState: "blocked"},
+		},
+		Workflows: []config.WorkflowConfig{{
+			ID:    "collect",
+			Steps: []config.StepConfig{{ID: "collect", Agent: "collector"}},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{}, // no sources: nothing to fan a hook out to
+		runners:     map[string]runnerpkg.Runner{"agent-collector": &countingRunner{}},
+		agentRunner: map[string]string{"collector": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{},
+	}
+
+	// A binding-less task with one outstanding workflow, as the spawner would leave it.
+	task := model.InternalTask{ID: "T-spawned", Title: "Collect", State: model.TaskStateRegistered, Input: map[string]any{}}
+	if err := dbc.InternalTasks().CreateTask(ctx, &task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := dbc.InternalTasks().IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment outstanding: %v", err)
+	}
+
+	_, success, err := d.workflowEngine().RunInstance(ctx, cfg.Workflows[0], task)
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatalf("expected the workflow to succeed")
+	}
+
+	got, err := dbc.InternalTasks().GetTask(ctx, task.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.OutstandingWorkflows != 0 {
+		t.Errorf("outstanding_workflows = %d, want 0", got.OutstandingWorkflows)
+	}
+	if got.State != model.TaskStateDone {
+		t.Errorf("task state = %q, want done", got.State)
 	}
 }

--- a/src/internal/daemon/fanout_test.go
+++ b/src/internal/daemon/fanout_test.go
@@ -93,7 +93,7 @@ func newFanoutDispatcher(t *testing.T, workflows []config.WorkflowConfig) (*Disp
 	return d, runner, dbc
 }
 
-func outstandingForCell(t *testing.T, dbc *db.Client, sourceID, itemID string) int {
+func taskForCell(t *testing.T, dbc *db.Client, sourceID, itemID string) *model.InternalTask {
 	t.Helper()
 	ctx := context.Background()
 	binding, err := dbc.SourceBindings().GetBindingBySourceItem(ctx, sourceID, itemID)
@@ -110,7 +110,7 @@ func outstandingForCell(t *testing.T, dbc *db.Client, sourceID, itemID string) i
 	if task == nil {
 		t.Fatal("expected the bound task to exist")
 	}
-	return task.OutstandingWorkflows
+	return task
 }
 
 func TestRunOnce_FanOutTwoWorkflows(t *testing.T) {
@@ -126,8 +126,15 @@ func TestRunOnce_FanOutTwoWorkflows(t *testing.T) {
 	if got := runner.n.Load(); got != 2 {
 		t.Errorf("expected 2 workflow dispatches, runner ran %d time(s)", got)
 	}
-	if got := outstandingForCell(t, dbc, "src", "c1"); got != 2 {
-		t.Errorf("outstanding_workflows = %d, want 2", got)
+	// Both fanned-out workflows reached a terminal state, so the outstanding
+	// counter (bumped to 2 at fan-out) has drained back to 0 and the task has
+	// transitioned to done.
+	task := taskForCell(t, dbc, "src", "c1")
+	if task.OutstandingWorkflows != 0 {
+		t.Errorf("outstanding_workflows = %d, want 0 after both completed", task.OutstandingWorkflows)
+	}
+	if task.State != model.TaskStateDone {
+		t.Errorf("task state = %q, want done", task.State)
 	}
 }
 
@@ -144,7 +151,13 @@ func TestRunOnce_ExclusiveDispatchesOne(t *testing.T) {
 	if got := runner.n.Load(); got != 1 {
 		t.Errorf("exclusive trigger should dispatch once, runner ran %d time(s)", got)
 	}
-	if got := outstandingForCell(t, dbc, "src", "c1"); got != 1 {
-		t.Errorf("outstanding_workflows = %d, want 1", got)
+	// The single (exclusive) workflow completed, so the counter drained from 1
+	// back to 0 and the task is done.
+	task := taskForCell(t, dbc, "src", "c1")
+	if task.OutstandingWorkflows != 0 {
+		t.Errorf("outstanding_workflows = %d, want 0 after completion", task.OutstandingWorkflows)
+	}
+	if task.State != model.TaskStateDone {
+		t.Errorf("task state = %q, want done", task.State)
 	}
 }

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -22,7 +22,10 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 	d.engineOnce.Do(func() {
 		opts := []workflow.Option{workflow.WithSideEffects(&wfSideEffects{d: d})}
 		if d.db != nil {
-			opts = append(opts, workflow.WithSpawner(d.newSpawner()))
+			opts = append(opts,
+				workflow.WithSpawner(d.newSpawner()),
+				workflow.WithTaskTracker(dbTaskTracker{db: d.db}),
+			)
 		}
 		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d}, opts...)
 	})
@@ -47,6 +50,23 @@ func (d *Dispatcher) newSpawner() workflow.WorkflowSpawner {
 		return success, err
 	}
 	return workflow.NewDefaultSpawner(resolve, d.db.InternalTasks(), run, nil, nil)
+}
+
+// dbTaskTracker adapts *db.Client to workflow.TaskTracker, backing the top-level
+// tasks: completion hook. The outstanding-counter and task-state methods live on
+// the InternalTaskStore; HasFailedInstance queries the workflow_instances table.
+type dbTaskTracker struct{ db *db.Client }
+
+func (t dbTaskTracker) DecrementOutstanding(ctx context.Context, taskID string) (int, error) {
+	return t.db.InternalTasks().DecrementOutstanding(ctx, taskID)
+}
+
+func (t dbTaskTracker) HasFailedInstance(ctx context.Context, taskID string) (bool, error) {
+	return t.db.HasFailedInstance(ctx, taskID)
+}
+
+func (t dbTaskTracker) SetTaskState(ctx context.Context, taskID string, state model.TaskState) error {
+	return t.db.InternalTasks().UpdateTaskState(ctx, taskID, state)
 }
 
 // dispatchWorkflow runs a matched task through the workflow engine. The route is

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -144,16 +144,22 @@ func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string,
 
 // DecrementOutstanding subtracts one from a task's outstanding workflow counter
 // (clamped at zero) and returns the new count. Called when a workflow instance
-// reaches a terminal state.
+// reaches a terminal state. The UPDATE ... RETURNING runs as a single atomic
+// statement so two sibling instances of the same task settling concurrently each
+// observe a distinct post-decrement count — exactly one of them sees zero — which
+// the engine relies on to fire the task completion hook exactly once.
 func (s *InternalTaskStore) DecrementOutstanding(ctx context.Context, id string) (int, error) {
-	if _, err := s.db.ExecContext(ctx, `
+	var n int
+	err := s.db.QueryRowContext(ctx, `
 		UPDATE internal_tasks
 		SET outstanding_workflows = MAX(outstanding_workflows - 1, 0), updated_at = ?
 		WHERE id = ?
-	`, time.Now(), id); err != nil {
-		return 0, err
+		RETURNING outstanding_workflows
+	`, time.Now(), id).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
 	}
-	return s.outstanding(ctx, id)
+	return n, err
 }
 
 func (s *InternalTaskStore) outstanding(ctx context.Context, id string) (int, error) {

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -92,6 +93,52 @@ func TestInternalTask_UpdateState(t *testing.T) {
 	got, _ := store.GetTask(ctx, task.ID)
 	if got.State != model.TaskStateRunning {
 		t.Errorf("state = %q, want running", got.State)
+	}
+}
+
+// TestInternalTask_DecrementOutstandingConcurrent locks in the race-free
+// guarantee the engine's completion hook relies on: when N sibling instances of
+// one task settle concurrently, the N atomic UPDATE ... RETURNING decrements each
+// return a distinct post-decrement count (the full 0..N-1 set), so exactly one
+// caller observes zero and fires the hook once. A non-atomic update-then-select
+// would let two callers both read zero.
+func TestInternalTask_DecrementOutstandingConcurrent(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const n = 16
+	if _, err := store.IncrementOutstanding(ctx, task.ID, n); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+
+	results := make([]int, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			got, err := store.DecrementOutstanding(ctx, task.ID)
+			if err != nil {
+				t.Errorf("decrement: %v", err)
+				return
+			}
+			results[i] = got
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[int]int)
+	for _, r := range results {
+		seen[r]++
+	}
+	for v := 0; v < n; v++ {
+		if seen[v] != 1 {
+			t.Fatalf("count %d returned %d time(s), want exactly 1 — results=%v", v, seen[v], results)
+		}
 	}
 }
 

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -112,6 +112,20 @@ func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowI
 	return inst, err
 }
 
+// HasFailedInstance reports whether any workflow instance bound to the given task
+// is in the failed state. The engine calls it when a task's last outstanding
+// workflow settles, to choose between the tasks: on_complete and on_fail hooks.
+func (c *Client) HasFailedInstance(ctx context.Context, taskID string) (bool, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_instances WHERE task_id = ? AND state = ?
+	`, taskID, InstanceStateFailed).Scan(&n)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return n > 0, err
+}
+
 // ListWorkflowInstancesByState returns all instances in the given state, oldest first.
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -27,6 +28,25 @@ type Store interface {
 // satisfies it; fake stores in tests that omit it simply yield no bindings.
 type bindingLister interface {
 	ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error)
+}
+
+// TaskTracker is the optional capability the engine uses to apply the top-level
+// tasks: completion hook. When an instance reaches a terminal state the engine
+// decrements the task's outstanding-workflow counter; when it hits zero it flips
+// the task's lifecycle state and (if a tasks: block is configured) applies the
+// aggregate on_complete/on_fail hook. A nil tracker disables all of this — the
+// counter is left untouched and the task keeps its running state, matching the
+// pre-Phase-8 behaviour. The daemon's *db.Client-backed wiring satisfies it.
+type TaskTracker interface {
+	// DecrementOutstanding subtracts one from the task's outstanding-workflow
+	// counter and returns the new count. Must be atomic so concurrent sibling
+	// instances each see a distinct post-decrement value (exactly one sees zero).
+	DecrementOutstanding(ctx context.Context, taskID string) (int, error)
+	// HasFailedInstance reports whether any of the task's workflow instances
+	// failed, used to pick on_complete vs on_fail once the last one settles.
+	HasFailedInstance(ctx context.Context, taskID string) (bool, error)
+	// SetTaskState transitions the InternalTask to a terminal lifecycle state.
+	SetTaskState(ctx context.Context, taskID string, state model.TaskState) error
 }
 
 // StepRequest is the input to executing one agent step.
@@ -89,6 +109,7 @@ type Engine struct {
 	side    SideEffects
 	mem     MemoryBuilder
 	spawner WorkflowSpawner
+	tracker TaskTracker
 
 	now   func() time.Time
 	newID func(prefix string) string
@@ -114,6 +135,10 @@ func WithMemoryBuilder(b MemoryBuilder) Option { return func(e *Engine) { e.mem 
 
 // WithSpawner sets the APIARY_SPAWN handler used to create child tasks.
 func WithSpawner(s WorkflowSpawner) Option { return func(e *Engine) { e.spawner = s } }
+
+// WithTaskTracker sets the task completion tracker used to decrement the
+// outstanding-workflow counter and apply the top-level tasks: hook.
+func WithTaskTracker(t TaskTracker) Option { return func(e *Engine) { e.tracker = t } }
 
 // NewEngine builds an Engine. cfg, store, and exec are required.
 func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {
@@ -234,7 +259,58 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 	delete(e.parked, r.instID)
 	e.mu.Unlock()
 	e.applyCompletion(ctx, r, failed)
+	e.completeTask(ctx, r, failed)
 	return !failed
+}
+
+// completeTask decrements the task's outstanding-workflow counter now that this
+// instance has reached a terminal state and, when it was the last outstanding
+// workflow, transitions the task's lifecycle state and applies the top-level
+// tasks: on_complete/on_fail hook to every source binding. It is a no-op when no
+// TaskTracker is wired (the pre-Phase-8 default) or for a binding-less transient
+// task with no id. The aggregate outcome is failed if THIS instance failed or any
+// sibling instance of the task did (HasFailedInstance also covers this instance,
+// whose terminal state was just persisted above).
+func (e *Engine) completeTask(ctx context.Context, r *dagRun, failed bool) {
+	if e.tracker == nil || r.task.ID == "" {
+		return
+	}
+	remaining, err := e.tracker.DecrementOutstanding(ctx, r.task.ID)
+	if err != nil {
+		aplog.Error("task %s: decrement outstanding: %v", r.task.ID, err)
+		return
+	}
+	if remaining > 0 {
+		return
+	}
+
+	anyFailed := failed
+	if !anyFailed {
+		if hf, err := e.tracker.HasFailedInstance(ctx, r.task.ID); err != nil {
+			aplog.Error("task %s: check failed instances: %v", r.task.ID, err)
+		} else {
+			anyFailed = hf
+		}
+	}
+
+	finalState := model.TaskStateDone
+	if anyFailed {
+		finalState = model.TaskStateFailed
+	}
+	if err := e.tracker.SetTaskState(ctx, r.task.ID, finalState); err != nil {
+		aplog.Error("task %s: set state %s: %v", r.task.ID, finalState, err)
+	}
+
+	if e.cfg.Tasks == nil || e.side == nil {
+		return
+	}
+	hook := e.cfg.Tasks.OnComplete
+	if anyFailed {
+		hook = e.cfg.Tasks.OnFail
+	}
+	if hook != nil {
+		_ = e.side.ApplyHook(ctx, r.task, r.bindings, *hook)
+	}
 }
 
 // runStep executes one agent step, persisting its step run, and returns the

--- a/src/internal/workflow/task_completion_test.go
+++ b/src/internal/workflow/task_completion_test.go
@@ -1,0 +1,184 @@
+package workflow
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// fakeTracker is an in-memory TaskTracker: it tracks a per-task outstanding
+// counter (decremented on each terminal instance), a settable "a sibling
+// instance failed" flag, and the lifecycle state the engine flips the task to.
+type fakeTracker struct {
+	mu          sync.Mutex
+	outstanding map[string]int
+	failed      map[string]bool
+	states      map[string]model.TaskState
+}
+
+func newFakeTracker() *fakeTracker {
+	return &fakeTracker{
+		outstanding: map[string]int{},
+		failed:      map[string]bool{},
+		states:      map[string]model.TaskState{},
+	}
+}
+
+func (f *fakeTracker) DecrementOutstanding(_ context.Context, id string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := f.outstanding[id] - 1
+	if n < 0 {
+		n = 0
+	}
+	f.outstanding[id] = n
+	return n, nil
+}
+
+func (f *fakeTracker) HasFailedInstance(_ context.Context, id string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.failed[id], nil
+}
+
+func (f *fakeTracker) SetTaskState(_ context.Context, id string, s model.TaskState) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.states[id] = s
+	return nil
+}
+
+func (f *fakeTracker) state(id string) (model.TaskState, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.states[id]
+	return s, ok
+}
+
+// taskHookCfg returns a config with no per-workflow hooks (so the only thing
+// reaching fakeSide.hooks is the top-level tasks: completion hook) and a tasks:
+// block with distinguishable on_complete/on_fail states.
+func taskHookCfg() *config.Config {
+	cfg := baseCfg()
+	cfg.Settings.StateLock = false
+	cfg.Settings.ResultComment = false
+	cfg.Tasks = &config.TasksConfig{
+		OnComplete: &config.OnComplete{SetState: "all_done"},
+		OnFail:     &config.OnComplete{SetState: "all_failed"},
+	}
+	return cfg
+}
+
+func trackerEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects, tr TaskTracker) *Engine {
+	var seq atomic.Int64
+	return NewEngine(cfg, store, exec,
+		WithSideEffects(side),
+		WithTaskTracker(tr),
+		WithClock(func() time.Time { return time.Unix(1000, 0) }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+	)
+}
+
+func oneStepWF(id, stepID string) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: id, Steps: []config.StepConfig{{ID: stepID, Agent: "backend-dev"}}}
+}
+
+// TestEngine_TaskHookFiresAfterLastWorkflowSucceeds covers 8.2.3 (success path):
+// with two workflows fanned out on one task, the tasks: on_complete hook fires
+// only once the second (last) instance settles — not after the first — and the
+// task transitions to done.
+func TestEngine_TaskHookFiresAfterLastWorkflowSucceeds(t *testing.T) {
+	cfg := taskHookCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	side := &fakeSide{}
+	tr := newFakeTracker()
+	tr.outstanding["T1"] = 2
+	eng := trackerEngine(cfg, store, exec, side, tr)
+	task := model.InternalTask{ID: "T1", Title: "x"}
+
+	if _, _, err := eng.RunInstance(context.Background(), oneStepWF("wf-a", "a"), task); err != nil {
+		t.Fatalf("RunInstance wf-a: %v", err)
+	}
+	if len(side.hooks) != 0 {
+		t.Fatalf("task hook fired after first of two workflows: %+v", side.hooks)
+	}
+	if _, ok := tr.state("T1"); ok {
+		t.Fatalf("task state set before the last workflow settled")
+	}
+
+	if _, _, err := eng.RunInstance(context.Background(), oneStepWF("wf-b", "b"), task); err != nil {
+		t.Fatalf("RunInstance wf-b: %v", err)
+	}
+	if len(side.hooks) != 1 || side.hooks[0].SetState != "all_done" {
+		t.Fatalf("expected one on_complete task hook, got %+v", side.hooks)
+	}
+	if s, _ := tr.state("T1"); s != model.TaskStateDone {
+		t.Errorf("task state = %q, want done", s)
+	}
+}
+
+// TestEngine_TaskHookFiresOnFailWhenAnyWorkflowFailed covers 8.2.3 (failure
+// path): when one of the task's instances failed (recorded earlier, surfaced via
+// HasFailedInstance), the aggregate outcome is failure — so once the last
+// instance settles the tasks: on_fail hook fires even though that final instance
+// itself succeeded, and the task transitions to failed.
+func TestEngine_TaskHookFiresOnFailWhenAnyWorkflowFailed(t *testing.T) {
+	cfg := taskHookCfg()
+	store := newFakeStore()
+	// wf-a's step fails; wf-b's step succeeds (default).
+	exec := &fakeExecutor{results: map[string]StepResult{"a": {Success: false, Output: "boom"}}}
+	side := &fakeSide{}
+	tr := newFakeTracker()
+	tr.outstanding["T1"] = 2
+	tr.failed["T1"] = true // a sibling instance failed and was persisted
+	eng := trackerEngine(cfg, store, exec, side, tr)
+	task := model.InternalTask{ID: "T1", Title: "x"}
+
+	// First (failing) instance settles: counter 2→1, no hook yet.
+	if _, _, err := eng.RunInstance(context.Background(), oneStepWF("wf-a", "a"), task); err != nil {
+		t.Fatalf("RunInstance wf-a: %v", err)
+	}
+	if len(side.hooks) != 0 {
+		t.Fatalf("task hook fired before the last workflow settled: %+v", side.hooks)
+	}
+
+	// Last (succeeding) instance settles: counter 1→0; aggregate is failed.
+	if _, _, err := eng.RunInstance(context.Background(), oneStepWF("wf-b", "b"), task); err != nil {
+		t.Fatalf("RunInstance wf-b: %v", err)
+	}
+	if len(side.hooks) != 1 || side.hooks[0].SetState != "all_failed" {
+		t.Fatalf("expected one on_fail task hook, got %+v", side.hooks)
+	}
+	if s, _ := tr.state("T1"); s != model.TaskStateFailed {
+		t.Errorf("task state = %q, want failed", s)
+	}
+}
+
+// TestEngine_TaskHookNoTrackerIsNoOp asserts the pre-Phase-8 default: with no
+// TaskTracker wired the engine neither decrements nor applies the tasks: hook,
+// even when a tasks: block is configured.
+func TestEngine_TaskHookNoTrackerIsNoOp(t *testing.T) {
+	cfg := taskHookCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	side := &fakeSide{}
+	// No WithTaskTracker.
+	var seq atomic.Int64
+	eng := NewEngine(cfg, store, exec,
+		WithSideEffects(side),
+		WithClock(func() time.Time { return time.Unix(1000, 0) }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+	)
+	if _, _, err := eng.RunInstance(context.Background(), oneStepWF("wf-a", "a"), model.InternalTask{ID: "T1"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if len(side.hooks) != 0 {
+		t.Errorf("tasks: hook applied without a tracker: %+v", side.hooks)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 8 of the `internal-task-model` change — **Task Completion Hook & Config**. Closes the `InternalTask` lifecycle: when the **last** fanned-out workflow of a task reaches a terminal state, the task transitions to `done`/`failed` and the new top-level `tasks:` block (`on_complete`/`on_fail`) is applied to each `SourceBinding`. This wires up the `outstanding_workflows` counter, which had been **incremented since Phase 4 but never decremented**.

### Config (8.1)
- A new `TasksConfig` (`on_complete`/`on_fail`) and a `Tasks *TasksConfig` field at the top of `Config`, parsed from the `tasks:` key.
- `tasks.on_complete`/`tasks.on_fail` follow the **same rules** as the per-workflow hooks: the removed-directives lint (`assign_from_output`/`assign_label_prefix`) already matches by leaf+parent, covering the `tasks:` block with no new code.

### Counter & hook (8.2)
- `engine`: a new optional `TaskTracker` capability (injected via `WithTaskTracker`) + a `completeTask` method, called in `settle` — the one point where an instance reaches a terminal state (covers `RunInstance`, `ResolveApproval` and `ResumeInstance`; instances parked on an approval do **not** decrement).
- On each terminal instance: decrements the counter; on reaching **zero**, sets the task state and applies the aggregate hook — `on_complete` if all passed, `on_fail` if any failed (`HasFailedInstance`, which also covers the just-persisted instance).
- `db`: `DecrementOutstanding` now uses `UPDATE ... RETURNING` (atomic) so that concurrent sibling instances see distinct counts and **exactly one** observes zero → the hook fires exactly once; a new `HasFailedInstance`.
- `daemon`: a `dbTaskTracker` adapter wires the engine to the `*db.Client`.

### Design notes
- The `TaskTracker` is optional: without it (the default pre-Phase-8) the engine neither decrements nor applies the hook — behavior unchanged.
- Spawned tasks (no bindings) also advance state on completion; the hook fanned out over zero bindings is a clean no-op (this was the "child state NOT advanced until Phase 8" limitation).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — green
- [x] `go test -race ./internal/{workflow,daemon,db,config}/...` — green
- [x] **8.2.3** — two workflows on a task: the hook fires only after the last instance; complete vs fail correct (engine, `task_completion_test.go`)
- [x] **8.2.4** — a task with no source bindings applies the hook without error, via the real `wfSideEffects` (daemon, `TestTaskCompletion_NoBindingsAppliesHookWithoutError`)
- [x] The concurrent counter (16 goroutines) guarantees a single zero (`TestInternalTask_DecrementOutstandingConcurrent`)
- [x] **8.1** — parsing of the `tasks:` block and the lint rejecting `tasks.on_complete.assign_from_output`
- [x] The Phase 4/7 fan-out/spawn tests updated to the Phase 8 reality (the counter drains to 0, the task → done)

Part of the `openspec/changes/internal-task-model` change (Phase 8 of 9).