### PR TITLE
feat(dashboard): InternalTask as the primary unit — bindings, lineage, instances (Phase 9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5054 symbols, 11316 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5169 symbols, 11618 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5054 symbols, 11316 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5169 symbols, 11618 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 // refreshInterval controls how often the active tab re-queries the database.
@@ -537,9 +538,9 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		switch a.model.ActiveTab() {
 		case "Tasks":
-			if id, ok := a.selectedTaskID(); ok {
+			if row, ok := a.selectedTask(); ok {
 				a.model.loading = true
-				return a, a.fetchTaskDetail(id)
+				return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 			}
 		case "Agents":
 			// Detail uses the already-loaded stats — no DB round-trip needed.
@@ -776,9 +777,9 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		t.Logs = nil
 		t.LogScroll = 0
 	case "d":
-		if id, ok := a.selectedTaskID(); ok {
+		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
-			return a, a.fetchTaskDetail(id)
+			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 		}
 	case "l", "enter":
 		if id, ok := a.selectedTaskID(); ok {
@@ -786,12 +787,12 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			return a, a.fetchTaskLogs(id)
 		}
 	case "r":
-		if id, ok := a.selectedTaskID(); ok {
+		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
 			if t.View == TaskViewLogs {
-				return a, a.fetchTaskLogs(id)
+				return a, a.fetchTaskLogs(row.TaskID)
 			}
-			return a, a.fetchTaskDetail(id)
+			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 		}
 	case "up":
 		if t.View == TaskViewLogs && t.LogScroll > 0 {
@@ -996,13 +997,29 @@ func lastIndex(total int) int {
 	return total - 1
 }
 
-// selectedTaskID returns the task id under the cursor in the Tasks list.
-func (a *App) selectedTaskID() (string, bool) {
+// selectedTask returns the TaskItem under the cursor in the Tasks list. It
+// indexes the filtered/sorted view (what the user actually sees), not the raw
+// History — SelectedIdx tracks the filtered list.
+func (a *App) selectedTask() (*TaskItem, bool) {
 	t := a.model.tasksTab
-	if t == nil || t.SelectedIdx < 0 || t.SelectedIdx >= len(t.History) {
+	if t == nil {
+		return nil, false
+	}
+	rows := a.filteredTasks(t)
+	if t.SelectedIdx < 0 || t.SelectedIdx >= len(rows) {
+		return nil, false
+	}
+	return &rows[t.SelectedIdx], true
+}
+
+// selectedTaskID returns the drill key (legacy cell id) of the task under the
+// cursor in the Tasks list — what the execution/logs/workflow machinery keys on.
+func (a *App) selectedTaskID() (string, bool) {
+	row, ok := a.selectedTask()
+	if !ok {
 		return "", false
 	}
-	return t.History[t.SelectedIdx].TaskID, true
+	return row.TaskID, true
 }
 
 // focusedTaskURL returns the source URL of the task the user is currently
@@ -1018,8 +1035,8 @@ func (a *App) focusedTaskURL() (string, bool) {
 		if t.View == TaskViewDetail && t.Detail != nil {
 			return t.Detail.URL, t.Detail.URL != ""
 		}
-		if t.SelectedIdx >= 0 && t.SelectedIdx < len(t.History) {
-			u := t.History[t.SelectedIdx].URL
+		if rows := a.filteredTasks(t); t.SelectedIdx >= 0 && t.SelectedIdx < len(rows) {
+			u := rows[t.SelectedIdx].URL
 			return u, u != ""
 		}
 	case "Agents":
@@ -1048,8 +1065,8 @@ func (a *App) focusedTaskID() (string, bool) {
 		if t.View == TaskViewDetail && t.Detail != nil {
 			return t.Detail.TaskID, true
 		}
-		if t.SelectedIdx >= 0 && t.SelectedIdx < len(t.History) {
-			return t.History[t.SelectedIdx].TaskID, true
+		if rows := a.filteredTasks(t); t.SelectedIdx >= 0 && t.SelectedIdx < len(rows) {
+			return rows[t.SelectedIdx].TaskID, true
 		}
 	case "Agents":
 		ag := a.model.agentsTab
@@ -1406,6 +1423,14 @@ func (a *App) fetchActiveTab() tea.Cmd {
 		if t := a.model.tasksTab; t != nil && t.View == TaskViewWorkflow && t.WorkflowInstance != nil {
 			return a.refreshWorkflowMonitor(t.WorkflowInstance.ID, t.WorkflowInstance.CellID)
 		}
+		// Only refresh the list while the list itself is showing. While a detail
+		// or logs sub-view is open we must not refetch — re-sorting History under
+		// the cursor would make the SelectedIdx-keyed reload (r/d/l) target a
+		// different task than the one on screen. The sub-view content is static
+		// until the user reloads it; returning to the list resumes auto-refresh.
+		if t := a.model.tasksTab; t != nil && t.View != TaskViewList {
+			return nil
+		}
 		return a.fetchTasks()
 	case "Agents":
 		return a.fetchAgents()
@@ -1481,14 +1506,76 @@ func (a *App) fetchTasks() tea.Cmd {
 
 		items := make([]TaskItem, 0)
 		if dbConn != nil {
-			if rows, err := dbConn.GetTaskHistory(ctx, 100); err == nil {
-				for _, r := range rows {
-					items = append(items, taskItemFromHistory(r))
+			// Phase 9: the Tasks tab is keyed on the canonical InternalTask, not
+			// per-execution rows. Each row carries the internal id (for lineage /
+			// bindings / instances) plus a drill key (the primary binding's source
+			// item id, or the task id when binding-less) that the legacy
+			// detail/logs/monitor machinery resolves.
+			if tasks, err := dbConn.InternalTasks().ListTasks(ctx, 100); err == nil {
+				for _, tk := range tasks {
+					bindings, _ := dbConn.ListBindingsByTask(ctx, tk.ID)
+					items = append(items, taskItemFromInternal(tk, bindings))
 				}
 			}
 		}
 		return tasksDataMsg{items: items}
 	}
+}
+
+// taskItemFromInternal converts an InternalTask (plus its source bindings) into a
+// dashboard Tasks-tab row. Execution-scoped fields (Agent/Model/tokens/duration)
+// are left zero here and hydrated on drill-down; StartedAt/CompletedAt mirror the
+// task timestamps so the list's "when" column and time sort stay meaningful.
+func taskItemFromInternal(t model.InternalTask, bindings []model.SourceBinding) TaskItem {
+	created := t.CreatedAt
+	item := TaskItem{
+		TaskID:               drillKeyFor(t, bindings), // legacy machinery key (== DrillKey)
+		Title:                t.Title,
+		Status:               string(t.State),
+		StartedAt:            &created,
+		InternalTaskID:       t.ID,
+		DrillKey:             drillKeyFor(t, bindings),
+		ParentTaskID:         t.ParentTaskID,
+		OutstandingWorkflows: t.OutstandingWorkflows,
+		Bindings:             mapBindings(bindings),
+	}
+	if t.State == model.TaskStateDone || t.State == model.TaskStateFailed {
+		updated := t.UpdatedAt
+		item.CompletedAt = &updated
+	}
+	if len(bindings) > 0 {
+		item.Number = bindings[0].SourceItemNumber
+		item.URL = bindings[0].SourceItemURL
+	}
+	return item
+}
+
+// drillKeyFor returns the key the legacy task_executions/task_logs/workflow_instances
+// (by cell_id) machinery uses for a task: the primary binding's source item id when
+// bound, otherwise the task's own id (which the engine uses as the cell id for
+// binding-less spawned tasks).
+func drillKeyFor(t model.InternalTask, bindings []model.SourceBinding) string {
+	if len(bindings) > 0 {
+		return bindings[0].SourceItemID
+	}
+	return t.ID
+}
+
+// mapBindings converts model.SourceBinding rows into dashboard view-models.
+func mapBindings(bindings []model.SourceBinding) []SourceBindingItem {
+	if len(bindings) == 0 {
+		return nil
+	}
+	out := make([]SourceBindingItem, 0, len(bindings))
+	for _, b := range bindings {
+		out = append(out, SourceBindingItem{
+			SourceID:   b.SourceID,
+			ItemNumber: b.SourceItemNumber,
+			ItemURL:    b.SourceItemURL,
+			ItemID:     b.SourceItemID,
+		})
+	}
+	return out
 }
 
 // taskItemFromHistory converts a DB history row into a dashboard TaskItem.
@@ -1583,7 +1670,12 @@ func (a *App) fetchAgentTaskLogs(taskID string) tea.Cmd {
 	}
 }
 
-func (a *App) fetchTaskDetail(taskID string) tea.Cmd {
+// fetchTaskDetail loads the detail panel for a task. drillKey is the legacy
+// cell id used by the execution/logs/workflow-instance machinery; internalTaskID
+// is the canonical InternalTask id used to augment the panel with source
+// bindings, lineage (ancestors + children), and the full list of workflow
+// instances. internalTaskID may be empty for legacy/agent-drilled rows.
+func (a *App) fetchTaskDetail(drillKey, internalTaskID string) tea.Cmd {
 	dbConn := a.dbConn
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
@@ -1591,7 +1683,7 @@ func (a *App) fetchTaskDetail(taskID string) tea.Cmd {
 
 		var detail *TaskItem
 		if dbConn != nil {
-			if r, err := dbConn.GetTaskDetail(ctx, taskID); err == nil && r != nil {
+			if r, err := dbConn.GetTaskDetail(ctx, drillKey); err == nil && r != nil {
 				detail = &TaskItem{
 					TaskID:       r.TaskID,
 					Number:       r.Number,
@@ -1614,11 +1706,97 @@ func (a *App) fetchTaskDetail(taskID string) tea.Cmd {
 					CostUSD:      r.CostUSD,
 				}
 			}
+			if internalTaskID != "" {
+				detail = a.augmentTaskDetail(ctx, dbConn, detail, drillKey, internalTaskID)
+			}
 		}
 
-		instance := a.fetchWorkflowInstance(ctx, dbConn, taskID)
-		return taskDetailMsg{taskID: taskID, detail: detail, instance: instance}
+		instance := a.fetchWorkflowInstance(ctx, dbConn, drillKey)
+		return taskDetailMsg{taskID: drillKey, detail: detail, instance: instance}
 	}
+}
+
+// augmentTaskDetail enriches a task detail with InternalTask data: parent/
+// outstanding counters, source bindings, the lineage breadcrumb (ancestors,
+// root-first), spawned children, and every workflow instance bound to the task.
+// When the task has no execution row yet (e.g. a registered task that never ran)
+// it synthesizes a minimal detail from the InternalTask so the panel still
+// renders. Returns the (possibly newly-created) detail, or the input unchanged
+// when the InternalTask is gone.
+func (a *App) augmentTaskDetail(ctx context.Context, dbConn *db.Client, detail *TaskItem, drillKey, internalTaskID string) *TaskItem {
+	tk, err := dbConn.InternalTasks().GetTask(ctx, internalTaskID)
+	if err != nil || tk == nil {
+		return detail
+	}
+	if detail == nil {
+		created := tk.CreatedAt
+		detail = &TaskItem{
+			TaskID:    drillKey,
+			Title:     tk.Title,
+			Status:    string(tk.State),
+			StartedAt: &created,
+		}
+	}
+	detail.InternalTaskID = tk.ID
+	detail.DrillKey = drillKey
+	detail.ParentTaskID = tk.ParentTaskID
+	detail.OutstandingWorkflows = tk.OutstandingWorkflows
+	// Show the InternalTask lifecycle state so the detail Status matches the list
+	// (Phase 9's primary unit). Per-execution/instance outcomes remain visible in
+	// the Workflow Instances section below.
+	detail.Status = string(tk.State)
+
+	if b, _ := dbConn.ListBindingsByTask(ctx, internalTaskID); len(b) > 0 {
+		detail.Bindings = mapBindings(b)
+	}
+	if anc, _ := dbConn.InternalTasks().GetTaskAncestors(ctx, internalTaskID); len(anc) > 0 {
+		detail.Lineage = mapLineage(ctx, dbConn, anc)
+		if len(anc) >= 2 { // the node just before self (self is last) is the parent
+			detail.ParentTitle = anc[len(anc)-2].Title
+		}
+	}
+	if kids, _ := dbConn.InternalTasks().ListChildTasks(ctx, internalTaskID); len(kids) > 0 {
+		detail.Children = mapLineage(ctx, dbConn, kids)
+	}
+	if insts, _ := dbConn.ListWorkflowInstancesByTask(ctx, internalTaskID); len(insts) > 0 {
+		detail.Instances = mapInstances(insts)
+	}
+	return detail
+}
+
+// mapLineage converts InternalTask rows into lineage nodes, enriching each with
+// whether it has a source binding and how many workflow instances it has (bounded
+// fan-out per node, run in the background fetch command).
+func mapLineage(ctx context.Context, dbConn *db.Client, tasks []model.InternalTask) []TaskLineageItem {
+	out := make([]TaskLineageItem, 0, len(tasks))
+	for _, t := range tasks {
+		node := TaskLineageItem{TaskID: t.ID, Title: t.Title, State: string(t.State)}
+		if b, _ := dbConn.ListBindingsByTask(ctx, t.ID); len(b) > 0 {
+			node.HasBinding = true
+		}
+		if insts, _ := dbConn.ListWorkflowInstancesByTask(ctx, t.ID); len(insts) > 0 {
+			node.InstanceCount = len(insts)
+		}
+		out = append(out, node)
+	}
+	return out
+}
+
+// mapInstances converts db workflow-instance rows into dashboard view-models.
+func mapInstances(insts []db.WorkflowInstance) []WorkflowInstanceItem {
+	out := make([]WorkflowInstanceItem, 0, len(insts))
+	for _, in := range insts {
+		out = append(out, WorkflowInstanceItem{
+			ID:               in.ID,
+			Workflow:         in.WorkflowID,
+			State:            in.State,
+			CellID:           in.CellID,
+			ParentInstanceID: in.ParentInstanceID,
+			ResumedFrom:      in.ResumedFrom,
+			CreatedAt:        in.CreatedAt,
+		})
+	}
+	return out
 }
 
 // fetchWorkflowInstance loads the workflow instance (and its steps) bound to a
@@ -2320,6 +2498,12 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	row("Task ID", StyleValueStrong.Render(d.TaskID))
 	row("Title", valueOr(d.Title, "—"))
 	row("Status", taskStatusBadge(d.Status))
+	if d.OutstandingWorkflows > 0 {
+		row("Outstanding", fmt.Sprintf("%d workflow(s) running", d.OutstandingWorkflows))
+	}
+	if d.ParentTitle != "" {
+		row("Parent", StyleMuted.Render(d.ParentTitle))
+	}
 	row("Agent", valueOr(d.Agent, "—"))
 	row("Model", valueOr(d.Model, "—"))
 	row("Runner", valueOr(d.Runner, "—"))
@@ -2341,8 +2525,103 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	if t.DetailInstance != nil {
 		b.WriteString(renderWorkflowSteps(t.DetailInstance))
 	}
+	b.WriteString(renderSourceBindings(d))
+	b.WriteString(renderTaskLineage(d))
+	b.WriteString(renderTaskInstances(d))
 	label := taskDetailLabel(d)
 	return a.box(label, b.String(), height)
+}
+
+// renderSourceBindings renders a task's source bindings (9.1.2): one row per
+// bound source item showing its number, source id, and deep link. Empty when the
+// task has no bindings (e.g. a spawned task).
+func renderSourceBindings(d *TaskItem) string {
+	if len(d.Bindings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n  " + StyleLabel.Render("Source Bindings") + "\n")
+	for _, sb := range d.Bindings {
+		b.WriteString(fmt.Sprintf("    %s  %s  %s\n",
+			StyleAccent.Render(pad(valueOr(sb.ItemNumber, "—"), 10)),
+			StyleMuted.Render(pad(sb.SourceID, 10)),
+			StyleInfo.Render(sb.ItemURL),
+		))
+	}
+	return b.String()
+}
+
+// renderTaskLineage renders a task's lineage (9.1.3 + 9.2): a root→self
+// breadcrumb of ancestors and a tree of direct children. Each child node shows a
+// state badge, a binding indicator, its title, and its workflow-instance count
+// (9.2.2). Empty when the task is a root with no children.
+func renderTaskLineage(d *TaskItem) string {
+	var b strings.Builder
+	if len(d.Lineage) > 1 { // a single-element lineage is just the task itself
+		parts := make([]string, 0, len(d.Lineage))
+		for i, n := range d.Lineage {
+			title := valueOr(n.Title, n.TaskID)
+			if i == len(d.Lineage)-1 {
+				parts = append(parts, StyleValueStrong.Render(title)) // self, last
+			} else {
+				parts = append(parts, StyleMuted.Render(title))
+			}
+		}
+		b.WriteString("\n  " + StyleLabel.Render("Lineage") + "  " + strings.Join(parts, StyleMuted.Render(" > ")) + "\n")
+	}
+	if len(d.Children) > 0 {
+		b.WriteString("\n  " + StyleLabel.Render(fmt.Sprintf("Children (%d)", len(d.Children))) + "\n")
+		for _, c := range d.Children {
+			b.WriteString("    " + lineageNodeRow(c) + "\n")
+		}
+	}
+	return b.String()
+}
+
+// lineageNodeRow renders one lineage tree node: state badge, binding indicator
+// (● when the task has a source binding), title, and instance count.
+func lineageNodeRow(n TaskLineageItem) string {
+	bind := StyleFooterDim.Render("·")
+	if n.HasBinding {
+		bind = StyleAccent.Render("●")
+	}
+	return fmt.Sprintf("%s %s %s  %s",
+		taskStatusBadge(n.State),
+		bind,
+		valueOr(n.Title, n.TaskID),
+		StyleMuted.Render(fmt.Sprintf("(%d inst)", n.InstanceCount)),
+	)
+}
+
+// renderTaskInstances renders every workflow instance bound to a task (9.1.4):
+// a task may fan out to several workflows, so all instances are listed with their
+// state, workflow id, creation time, and a resumed/sub-workflow marker.
+func renderTaskInstances(d *TaskItem) string {
+	if len(d.Instances) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n  " + StyleLabel.Render(fmt.Sprintf("Workflow Instances (%d)", len(d.Instances))) + "\n")
+	for _, in := range d.Instances {
+		when := "—"
+		if !in.CreatedAt.IsZero() {
+			when = in.CreatedAt.Format("01-02 15:04")
+		}
+		marker := ""
+		switch {
+		case in.ResumedFrom != "":
+			marker = StyleMuted.Render(" (resumed)")
+		case in.ParentInstanceID != "":
+			marker = StyleMuted.Render(" (sub)")
+		}
+		b.WriteString(fmt.Sprintf("    %s  %s  %s%s\n",
+			wfInstanceBadge(in.State),
+			pad(truncate(in.Workflow, 18), 18),
+			StyleMuted.Render(when),
+			marker,
+		))
+	}
+	return b.String()
 }
 
 // renderWorkflowSteps renders the step-progress panel for a task that ran
@@ -3082,19 +3361,26 @@ func padLeft(s string, width int) string {
 	return s
 }
 
-// taskStatusBadge renders a colored, fixed-width status label.
+// taskStatusBadge renders a colored, fixed-width status label. It handles both
+// legacy execution statuses (success/failed/running, used by the Agents tab) and
+// InternalTask lifecycle states (registered/running/approval_waiting/done/failed,
+// used by the Tasks tab since Phase 9). The longer internal states are shown with
+// short synonyms so the badge stays within its 8-char column.
 func taskStatusBadge(status string) string {
-	label := pad(valueOr(status, "—"), 8)
+	label, style := status, StyleMuted
 	switch status {
-	case "success":
-		return StyleSuccess.Render(label)
+	case "success", "done":
+		style = StyleSuccess
 	case "failed":
-		return StyleError.Render(label)
+		style = StyleError
 	case "running":
-		return StyleWarning.Render(label)
-	default:
-		return StyleMuted.Render(label)
+		style = StyleWarning
+	case "approval_waiting":
+		label, style = "approval", StyleWarning
+	case "registered":
+		label, style = "queued", StyleMuted
 	}
+	return style.Render(pad(valueOr(label, "—"), 8))
 }
 
 // taskWhen returns a short "when" description for a task list row.

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -91,12 +91,36 @@ type TasksTab struct {
 // WorkflowInstanceItem is a workflow instance bound to a task, with its steps,
 // shown in the Task Detail and workflow monitor views.
 type WorkflowInstanceItem struct {
-	ID       string
-	Workflow string
-	State    string // pending, running, approval_waiting, interrupted, done, failed
-	Message  string // approval message when State == approval_waiting
-	CellID   string // the task/cell this instance is bound to
-	Steps    []WorkflowStepItem
+	ID               string
+	Workflow         string
+	State            string // pending, running, approval_waiting, interrupted, done, failed
+	Message          string // approval message when State == approval_waiting
+	CellID           string // the task/cell this instance is bound to
+	ParentInstanceID string // set for sub-workflow instances
+	ResumedFrom      string // set when this instance resumed a prior one
+	CreatedAt        time.Time
+	Steps            []WorkflowStepItem
+}
+
+// SourceBindingItem is a task's link to one source item (e.g. a GitHub issue or
+// a Plane work item), shown in the Task Detail. A task may have several bindings;
+// spawned tasks have none.
+type SourceBindingItem struct {
+	SourceID   string // "github", "plane"
+	ItemNumber string // human ref, e.g. "#42", "ERP-42"
+	ItemURL    string // deep link to the item in its source UI
+	ItemID     string // source-native id
+}
+
+// TaskLineageItem is one node in a task's lineage: an ancestor on the breadcrumb
+// to root, or a direct child (spawned task). It carries enough to render a tree
+// node (title, state badge, whether it has a source binding, instance count).
+type TaskLineageItem struct {
+	TaskID        string
+	Title         string
+	State         string // InternalTask state: registered|running|approval_waiting|done|failed
+	HasBinding    bool
+	InstanceCount int
 }
 
 // WorkflowStepItem is one step row within a WorkflowInstanceItem.
@@ -118,7 +142,12 @@ type WorkflowStepItem struct {
 	FinishedAt   *time.Time
 }
 
-// TaskItem is one task row (its latest execution attempt).
+// TaskItem is one row in the Tasks tab. Since Phase 9 the list is keyed on the
+// canonical InternalTask (InternalTaskID), with the legacy execution fields
+// (Agent/Model/tokens/duration) hydrated on drill-down via DrillKey, which keys
+// the legacy task_executions/task_logs/workflow_instances-by-cell machinery.
+// It is also reused by the Agents tab, where it is built from a TaskHistoryItem
+// (taskItemFromHistory) and the InternalTask fields are left zero.
 type TaskItem struct {
 	TaskID       string
 	Number       string // human reference, e.g. "ERP-42"
@@ -127,7 +156,7 @@ type TaskItem struct {
 	Agent        string
 	Model        string
 	Runner       string
-	Status       string // running, success, failed
+	Status       string // execution status (running/success/failed) or InternalTask state
 	Attempt      int
 	Duration     time.Duration
 	StartedAt    *time.Time
@@ -139,6 +168,18 @@ type TaskItem struct {
 	NumTurns     int
 	NumToolCalls int
 	CostUSD      float64
+
+	// Internal task model (Phase 9). Populated when the row/detail comes from an
+	// InternalTask; zero-valued for legacy/Agents-tab rows.
+	InternalTaskID       string                 // canonical internal_tasks.id (primary identity)
+	DrillKey             string                 // legacy cell_id for executions/logs/monitor
+	ParentTaskID         string                 // empty for root tasks
+	ParentTitle          string                 // resolved parent title, for the breadcrumb
+	OutstandingWorkflows int                    // workflows still running for this task
+	Bindings             []SourceBindingItem    // source items bound to this task
+	Lineage              []TaskLineageItem      // ancestors root-first incl. self (detail only)
+	Children             []TaskLineageItem      // direct children / spawned tasks (detail only)
+	Instances            []WorkflowInstanceItem // all workflow instances for this task (detail only)
 }
 
 // AgentView is which sub-screen the Agents tab is showing.

--- a/src/internal/dashboard/task_fetch_test.go
+++ b/src/internal/dashboard/task_fetch_test.go
@@ -1,0 +1,136 @@
+package dashboard
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestDrillKeyFor(t *testing.T) {
+	task := model.InternalTask{ID: "tk_1"}
+	if got := drillKeyFor(task, nil); got != "tk_1" {
+		t.Errorf("drillKeyFor(no bindings) = %q, want the task id tk_1", got)
+	}
+	bound := []model.SourceBinding{{SourceID: "github", SourceItemID: "ISSUE-9"}}
+	if got := drillKeyFor(task, bound); got != "ISSUE-9" {
+		t.Errorf("drillKeyFor(bound) = %q, want the primary binding's source item id ISSUE-9", got)
+	}
+}
+
+func TestTaskItemFromInternal(t *testing.T) {
+	created := time.Date(2026, 6, 6, 9, 0, 0, 0, time.UTC)
+	updated := created.Add(5 * time.Minute)
+
+	// Bound, done task: number/url from binding, drill key = source item id, completed set.
+	done := model.InternalTask{
+		ID: "tk_done", Title: "Fix login", State: model.TaskStateDone,
+		CreatedAt: created, UpdatedAt: updated, OutstandingWorkflows: 0,
+	}
+	bindings := []model.SourceBinding{{SourceID: "github", SourceItemID: "ISSUE-9", SourceItemNumber: "#9", SourceItemURL: "https://x/9"}}
+	it := taskItemFromInternal(done, bindings)
+	if it.InternalTaskID != "tk_done" || it.DrillKey != "ISSUE-9" || it.TaskID != "ISSUE-9" {
+		t.Errorf("ids wrong: InternalTaskID=%q DrillKey=%q TaskID=%q", it.InternalTaskID, it.DrillKey, it.TaskID)
+	}
+	if it.Status != "done" || it.Number != "#9" || it.URL != "https://x/9" {
+		t.Errorf("mapping wrong: Status=%q Number=%q URL=%q", it.Status, it.Number, it.URL)
+	}
+	if it.StartedAt == nil || !it.StartedAt.Equal(created) {
+		t.Errorf("StartedAt should mirror CreatedAt")
+	}
+	if it.CompletedAt == nil || !it.CompletedAt.Equal(updated) {
+		t.Errorf("CompletedAt should mirror UpdatedAt for a done task")
+	}
+	if len(it.Bindings) != 1 || it.Bindings[0].ItemNumber != "#9" {
+		t.Errorf("Bindings not mapped: %+v", it.Bindings)
+	}
+
+	// Binding-less running task: drill key = task id, no CompletedAt.
+	running := model.InternalTask{ID: "tk_run", Title: "spawned", State: model.TaskStateRunning, CreatedAt: created}
+	r := taskItemFromInternal(running, nil)
+	if r.DrillKey != "tk_run" || r.TaskID != "tk_run" {
+		t.Errorf("binding-less drill key should be the task id, got %q", r.DrillKey)
+	}
+	if r.CompletedAt != nil {
+		t.Errorf("a running task should have no CompletedAt")
+	}
+	if len(r.Bindings) != 0 {
+		t.Errorf("binding-less task should have no bindings, got %+v", r.Bindings)
+	}
+}
+
+// TestFetchTaskDetailAugments exercises the full fetch glue end-to-end against a
+// real DB: a spawned child task (bound, with a workflow instance and a parent)
+// must come back with its bindings, root-first lineage, parent title, instances,
+// and a Status that reflects the InternalTask lifecycle state.
+func TestFetchTaskDetailAugments(t *testing.T) {
+	ctx := context.Background()
+	c, err := db.New(ctx, filepath.Join(t.TempDir(), "detail.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	ts := c.InternalTasks()
+	base := time.Date(2026, 6, 6, 9, 0, 0, 0, time.UTC)
+
+	parent := &model.InternalTask{Title: "Payments incident", State: model.TaskStateRunning, CreatedAt: base}
+	if err := ts.CreateTask(ctx, parent); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child := &model.InternalTask{
+		Title: "Collect logs", State: model.TaskStateRunning, ParentTaskID: parent.ID,
+		OutstandingWorkflows: 1, CreatedAt: base.Add(time.Minute),
+	}
+	if err := ts.CreateTask(ctx, child); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	binding := &model.SourceBinding{TaskID: child.ID, SourceID: "github", SourceItemID: "ISSUE-9", SourceItemNumber: "#9", SourceItemURL: "https://x/9"}
+	if err := c.SourceBindings().CreateBinding(ctx, binding); err != nil {
+		t.Fatalf("create binding: %v", err)
+	}
+	// Two workflow instances for the child (fan-out).
+	_ = c.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "collect-logs", CellID: "ISSUE-9", TaskID: child.ID, State: db.InstanceStateRunning, CreatedAt: base.Add(2 * time.Minute)})
+	_ = c.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "notify", CellID: "ISSUE-9", TaskID: child.ID, State: db.InstanceStateDone, CreatedAt: base.Add(3 * time.Minute)})
+
+	a := &App{model: NewModel(), dbConn: c}
+	msg := a.fetchTaskDetail("ISSUE-9", child.ID)()
+	dm, ok := msg.(taskDetailMsg)
+	if !ok {
+		t.Fatalf("expected taskDetailMsg, got %T", msg)
+	}
+	d := dm.detail
+	if d == nil {
+		t.Fatal("expected a synthesized detail for a task with no execution row")
+	}
+	if d.InternalTaskID != child.ID || d.DrillKey != "ISSUE-9" {
+		t.Errorf("ids wrong: InternalTaskID=%q DrillKey=%q", d.InternalTaskID, d.DrillKey)
+	}
+	if d.Status != "running" {
+		t.Errorf("detail Status = %q, want the InternalTask state 'running'", d.Status)
+	}
+	if d.OutstandingWorkflows != 1 {
+		t.Errorf("OutstandingWorkflows = %d, want 1", d.OutstandingWorkflows)
+	}
+	if len(d.Bindings) != 1 || d.Bindings[0].ItemNumber != "#9" {
+		t.Errorf("bindings not augmented: %+v", d.Bindings)
+	}
+	// Lineage root-first incl. self: [parent, child]; parent title resolved.
+	if len(d.Lineage) != 2 || d.Lineage[0].Title != "Payments incident" || d.Lineage[1].Title != "Collect logs" {
+		t.Fatalf("lineage = %+v, want [Payments incident, Collect logs]", d.Lineage)
+	}
+	if d.ParentTitle != "Payments incident" {
+		t.Errorf("ParentTitle = %q, want Payments incident", d.ParentTitle)
+	}
+	// All instances surfaced, newest first.
+	if len(d.Instances) != 2 || d.Instances[0].ID != "i2" {
+		t.Fatalf("instances = %+v, want 2 newest-first (i2,i1)", d.Instances)
+	}
+	// The single-latest instance still drives the step-progress panel.
+	if dm.instance == nil || dm.instance.ID != "i2" {
+		t.Errorf("DetailInstance should be the latest instance i2, got %+v", dm.instance)
+	}
+}

--- a/src/internal/dashboard/task_lineage_render_test.go
+++ b/src/internal/dashboard/task_lineage_render_test.go
@@ -1,0 +1,161 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderSourceBindings(t *testing.T) {
+	d := &TaskItem{
+		Bindings: []SourceBindingItem{
+			{SourceID: "github", ItemNumber: "#42", ItemURL: "https://github.com/o/r/issues/42", ItemID: "42"},
+			{SourceID: "plane", ItemNumber: "ERP-7", ItemURL: "https://plane.example/erp-7", ItemID: "erp7"},
+		},
+	}
+	out := stripANSI(renderSourceBindings(d))
+	for _, want := range []string{"Source Bindings", "#42", "github", "https://github.com/o/r/issues/42", "ERP-7", "plane"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderSourceBindings missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderSourceBindings_Empty(t *testing.T) {
+	if out := renderSourceBindings(&TaskItem{}); out != "" {
+		t.Errorf("expected no output for a task with no bindings, got: %q", out)
+	}
+}
+
+func TestRenderTaskLineage_Breadcrumb(t *testing.T) {
+	d := &TaskItem{
+		Lineage: []TaskLineageItem{
+			{TaskID: "r", Title: "Incident", State: "done"},
+			{TaskID: "m", Title: "Collect", State: "done"},
+			{TaskID: "s", Title: "Staff", State: "running"},
+		},
+	}
+	out := stripANSI(renderTaskLineage(d))
+	for _, want := range []string{"Lineage", "Incident", "Collect", "Staff", " > "} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderTaskLineage breadcrumb missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTaskLineage_ChildrenTree(t *testing.T) {
+	d := &TaskItem{
+		Children: []TaskLineageItem{
+			{TaskID: "a", Title: "Fix A", State: "done", HasBinding: true, InstanceCount: 2},
+			{TaskID: "b", Title: "Fix B", State: "registered", HasBinding: false, InstanceCount: 0},
+		},
+	}
+	out := stripANSI(renderTaskLineage(d))
+	for _, want := range []string{"Children (2)", "Fix A", "Fix B", "(2 inst)", "(0 inst)", "●"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderTaskLineage children missing %q:\n%s", want, out)
+		}
+	}
+	// The registered child's badge uses the short "queued" label.
+	if !strings.Contains(out, "queued") {
+		t.Errorf("expected registered state to render as 'queued':\n%s", out)
+	}
+}
+
+func TestRenderTaskLineage_RootNoChildren(t *testing.T) {
+	// A root task (single-element lineage) with no children renders nothing.
+	d := &TaskItem{Lineage: []TaskLineageItem{{TaskID: "r", Title: "Root", State: "running"}}}
+	if out := renderTaskLineage(d); out != "" {
+		t.Errorf("expected no lineage output for a childless root, got: %q", out)
+	}
+}
+
+func TestRenderTaskInstances(t *testing.T) {
+	base := time.Date(2026, 6, 6, 10, 30, 0, 0, time.UTC)
+	d := &TaskItem{
+		Instances: []WorkflowInstanceItem{
+			{ID: "i1", Workflow: "code-review", State: "done", CreatedAt: base},
+			{ID: "i2", Workflow: "docs-update", State: "running", CreatedAt: base.Add(time.Minute), ResumedFrom: "i0"},
+			{ID: "i3", Workflow: "sub-collect", State: "done", CreatedAt: base.Add(2 * time.Minute), ParentInstanceID: "i1"},
+		},
+	}
+	out := stripANSI(renderTaskInstances(d))
+	for _, want := range []string{"Workflow Instances (3)", "code-review", "docs-update", "sub-collect", "(resumed)", "(sub)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("renderTaskInstances missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderTaskInstances_Empty(t *testing.T) {
+	if out := renderTaskInstances(&TaskItem{}); out != "" {
+		t.Errorf("expected no output for a task with no instances, got: %q", out)
+	}
+}
+
+// TestTaskDetailShowsTaskModelSections wires bindings, lineage, children, and
+// instances into the full detail view and asserts they render inside a correctly
+// framed box (9.1.2-9.1.4 + 9.2 in the Detail panel).
+func TestTaskDetailShowsTaskModelSections(t *testing.T) {
+	now := time.Now()
+	a := newTestApp(90, 44)
+	a.model.tasksTab.View = TaskViewDetail
+	a.model.tasksTab.Detail = &TaskItem{
+		TaskID:               "ISSUE-9",
+		InternalTaskID:       "tk_child",
+		Title:                "Collect incident logs",
+		Status:               "running",
+		OutstandingWorkflows: 2,
+		ParentTitle:          "Payments incident",
+		StartedAt:            &now,
+		Bindings: []SourceBindingItem{
+			{SourceID: "github", ItemNumber: "#9", ItemURL: "https://github.com/o/r/issues/9", ItemID: "9"},
+		},
+		Lineage: []TaskLineageItem{
+			{TaskID: "tk_root", Title: "Payments incident", State: "running"},
+			{TaskID: "tk_child", Title: "Collect incident logs", State: "running"},
+		},
+		Children: []TaskLineageItem{
+			{TaskID: "tk_g", Title: "Staff", State: "registered", InstanceCount: 1},
+		},
+		Instances: []WorkflowInstanceItem{
+			{ID: "i1", Workflow: "collect-logs", State: "running", CreatedAt: now},
+		},
+	}
+
+	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 40))
+	for _, want := range []string{
+		"Outstanding", "Parent", "Payments incident",
+		"Source Bindings", "#9", "github",
+		"Lineage", "Children (1)", "Staff",
+		"Workflow Instances (1)", "collect-logs",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("task detail missing %q:\n%s", want, out)
+		}
+	}
+	assertFramed(t, a.renderTaskDetail(a.model.tasksTab, 40), 90)
+}
+
+// TestTaskStatusBadge_InternalStates verifies the badge handles the InternalTask
+// lifecycle states (Phase 9) in addition to the legacy execution statuses, and
+// stays within its 8-char column.
+func TestTaskStatusBadge_InternalStates(t *testing.T) {
+	cases := map[string]string{
+		"registered":       "queued",
+		"approval_waiting": "approval",
+		"done":             "done",
+		"running":          "running",
+		"failed":           "failed",
+		"success":          "success", // legacy, still supported
+	}
+	for state, want := range cases {
+		out := stripANSI(taskStatusBadge(state))
+		if !strings.Contains(out, want) {
+			t.Errorf("taskStatusBadge(%q) = %q, want it to contain %q", state, out, want)
+		}
+		if w := len([]rune(strings.TrimRight(out, " "))); w > 8 {
+			t.Errorf("taskStatusBadge(%q) label %q exceeds 8 chars", state, out)
+		}
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -204,6 +204,10 @@ var migrations = []string{
 	// during migration; source_item_id (cell_id) + source_id retained until a
 	// later phase drops them.
 	`ALTER TABLE workflow_instances ADD COLUMN task_id TEXT REFERENCES internal_tasks(id)`,
+	// Index on the migration-added task_id column. Must live here (after the
+	// ALTER) rather than in the CREATE INDEX block, which runs before migrations.
+	// Backs the dashboard's "instances for a task" query (ListWorkflowInstancesByTask).
+	`CREATE INDEX IF NOT EXISTS idx_wf_instances_task ON workflow_instances(task_id)`,
 	// Internal Task Model: per-step write-back (APIARY_PUBLISH) and internal
 	// fan-out (APIARY_SPAWN) tracking.
 	`ALTER TABLE step_runs ADD COLUMN publish_payload TEXT`,

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -196,6 +196,99 @@ func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.Ta
 	return out, rows.Err()
 }
 
+// ListTasks returns the most recent internal tasks across all states, newest
+// first. limit <= 0 defaults to 100. It backs the dashboard Tasks tab, which
+// surfaces the InternalTask as the primary unit (not per-execution rows).
+func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.InternalTask, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks ORDER BY created_at DESC LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.InternalTask
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *task)
+	}
+	return out, rows.Err()
+}
+
+// ListChildTasks returns a task's direct children (spawned tasks), oldest first.
+// Backed by idx_internal_tasks_parent.
+func (s *InternalTaskStore) ListChildTasks(ctx context.Context, parentTaskID string) ([]model.InternalTask, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks WHERE parent_task_id = ? ORDER BY created_at ASC
+	`, parentTaskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.InternalTask
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *task)
+	}
+	return out, rows.Err()
+}
+
+// GetTaskAncestors returns the task's lineage from root to the task itself
+// (root first, the task last), walking parent_task_id via a recursive CTE. The
+// depth cap (32) is cheap insurance against an accidental cycle. For a root task
+// the slice has a single element (the task). Empty if the id is unknown.
+func (s *InternalTaskStore) GetTaskAncestors(ctx context.Context, id string) ([]model.InternalTask, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		WITH RECURSIVE anc(id, parent_task_id, title, description, input, state,
+		                    metadata, outstanding_workflows, created_at, updated_at, depth) AS (
+			SELECT id, parent_task_id, title, description, input, state,
+			       metadata, outstanding_workflows, created_at, updated_at, 0
+			FROM internal_tasks WHERE id = ?
+			UNION ALL
+			SELECT t.id, t.parent_task_id, t.title, t.description, t.input, t.state,
+			       t.metadata, t.outstanding_workflows, t.created_at, t.updated_at, anc.depth + 1
+			FROM internal_tasks t
+			JOIN anc ON t.id = anc.parent_task_id
+			WHERE anc.depth < 32
+		)
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM anc ORDER BY depth DESC
+	`, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.InternalTask
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *task)
+	}
+	return out, rows.Err()
+}
+
 func scanTask(s scanner) (*model.InternalTask, error) {
 	var (
 		task      model.InternalTask

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -281,4 +282,136 @@ func TestSourceBinding_UniqueConstraint(t *testing.T) {
 	if err := bindings.CreateBinding(ctx, dup); err == nil {
 		t.Error("expected unique-constraint error on duplicate (source_id, source_item_id)")
 	}
+}
+
+func TestInternalTask_ListTasks(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Three tasks in different states, inserted with increasing created_at.
+	for i, st := range []model.TaskState{model.TaskStateRegistered, model.TaskStateRunning, model.TaskStateDone} {
+		task := &model.InternalTask{
+			Title:     "t" + string(rune('A'+i)),
+			State:     st,
+			CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	got, err := store.ListTasks(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("ListTasks returned %d tasks, want 3 (across all states)", len(got))
+	}
+	// Newest first: tC (done) before tB (running) before tA (registered).
+	if got[0].Title != "tC" || got[1].Title != "tB" || got[2].Title != "tA" {
+		t.Errorf("ListTasks order = [%s %s %s], want newest-first [tC tB tA]", got[0].Title, got[1].Title, got[2].Title)
+	}
+
+	// limit is honored.
+	lim, err := store.ListTasks(ctx, 2)
+	if err != nil {
+		t.Fatalf("ListTasks(2): %v", err)
+	}
+	if len(lim) != 2 || lim[0].Title != "tC" {
+		t.Errorf("ListTasks(2) = %d rows starting %q, want 2 starting tC", len(lim), titleAt(lim, 0))
+	}
+}
+
+func TestInternalTask_ListChildTasks(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	parent := &model.InternalTask{Title: "parent", CreatedAt: base}
+	if err := store.CreateTask(ctx, parent); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	other := &model.InternalTask{Title: "other", CreatedAt: base}
+	if err := store.CreateTask(ctx, other); err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	// Two children of parent (oldest-first expected), one child of other.
+	c1 := &model.InternalTask{Title: "child1", ParentTaskID: parent.ID, CreatedAt: base.Add(1 * time.Minute)}
+	c2 := &model.InternalTask{Title: "child2", ParentTaskID: parent.ID, CreatedAt: base.Add(2 * time.Minute)}
+	c3 := &model.InternalTask{Title: "child3", ParentTaskID: other.ID, CreatedAt: base.Add(3 * time.Minute)}
+	for _, c := range []*model.InternalTask{c1, c2, c3} {
+		if err := store.CreateTask(ctx, c); err != nil {
+			t.Fatalf("create child: %v", err)
+		}
+	}
+
+	kids, err := store.ListChildTasks(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("ListChildTasks: %v", err)
+	}
+	if len(kids) != 2 || kids[0].Title != "child1" || kids[1].Title != "child2" {
+		t.Fatalf("ListChildTasks(parent) = %d %v, want [child1 child2] oldest-first", len(kids), titles(kids))
+	}
+	if none, _ := store.ListChildTasks(ctx, parent.ID+"-missing"); len(none) != 0 {
+		t.Errorf("ListChildTasks(unknown) = %d, want 0", len(none))
+	}
+}
+
+func TestInternalTask_GetTaskAncestors(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Chain: root -> mid -> leaf
+	root := &model.InternalTask{Title: "root", CreatedAt: base}
+	if err := store.CreateTask(ctx, root); err != nil {
+		t.Fatalf("create root: %v", err)
+	}
+	mid := &model.InternalTask{Title: "mid", ParentTaskID: root.ID, CreatedAt: base.Add(time.Minute)}
+	if err := store.CreateTask(ctx, mid); err != nil {
+		t.Fatalf("create mid: %v", err)
+	}
+	leaf := &model.InternalTask{Title: "leaf", ParentTaskID: mid.ID, CreatedAt: base.Add(2 * time.Minute)}
+	if err := store.CreateTask(ctx, leaf); err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+
+	anc, err := store.GetTaskAncestors(ctx, leaf.ID)
+	if err != nil {
+		t.Fatalf("GetTaskAncestors: %v", err)
+	}
+	// Root first, leaf last.
+	if len(anc) != 3 || anc[0].Title != "root" || anc[1].Title != "mid" || anc[2].Title != "leaf" {
+		t.Fatalf("GetTaskAncestors(leaf) = %v, want root-first [root mid leaf]", titles(anc))
+	}
+
+	// A root task is its own only ancestor.
+	rootAnc, err := store.GetTaskAncestors(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("GetTaskAncestors(root): %v", err)
+	}
+	if len(rootAnc) != 1 || rootAnc[0].Title != "root" {
+		t.Errorf("GetTaskAncestors(root) = %v, want [root]", titles(rootAnc))
+	}
+
+	// Unknown id yields no rows.
+	if none, _ := store.GetTaskAncestors(ctx, "nope"); len(none) != 0 {
+		t.Errorf("GetTaskAncestors(unknown) = %d, want 0", len(none))
+	}
+}
+
+func titles(ts []model.InternalTask) []string {
+	out := make([]string, len(ts))
+	for i := range ts {
+		out[i] = ts[i].Title
+	}
+	return out
+}
+
+func titleAt(ts []model.InternalTask, i int) string {
+	if i < len(ts) {
+		return ts[i].Title
+	}
+	return ""
 }

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -172,6 +172,22 @@ func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*W
 	return inst, err
 }
 
+// ListWorkflowInstancesByTask returns every workflow instance bound to an
+// InternalTask, newest first. A task may fan out to several workflows (Phase 4),
+// so the dashboard lists all of them per task. Backed by idx_wf_instances_task.
+func (c *Client) ListWorkflowInstancesByTask(ctx context.Context, taskID string) ([]WorkflowInstance, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		FROM workflow_instances WHERE task_id = ? ORDER BY created_at DESC
+	`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
 // LatestResumableInstance returns the most recent failed or interrupted
 // instance of a workflow, or (nil, nil) when none exists.
 func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -124,6 +124,35 @@ func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
 	}
 }
 
+func TestWorkflowInstance_ListByTask(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Two instances for task T1 (fan-out), one for T2.
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "i1", WorkflowID: "wf-a", CellID: "c1", TaskID: "T1", State: InstanceStateDone, CreatedAt: base})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "i2", WorkflowID: "wf-b", CellID: "c1", TaskID: "T1", State: InstanceStateRunning, CreatedAt: base.Add(time.Minute)})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "i3", WorkflowID: "wf-c", CellID: "c2", TaskID: "T2", State: InstanceStateDone, CreatedAt: base.Add(2 * time.Minute)})
+
+	got, err := c.ListWorkflowInstancesByTask(ctx, "T1")
+	if err != nil {
+		t.Fatalf("ListWorkflowInstancesByTask: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d instances for T1, want 2", len(got))
+	}
+	// Newest first: i2 before i1.
+	if got[0].ID != "i2" || got[1].ID != "i1" {
+		t.Errorf("order = [%s %s], want newest-first [i2 i1]", got[0].ID, got[1].ID)
+	}
+	if got[0].TaskID != "T1" {
+		t.Errorf("TaskID = %q, want T1", got[0].TaskID)
+	}
+	if none, _ := c.ListWorkflowInstancesByTask(ctx, "missing"); len(none) != 0 {
+		t.Errorf("ListWorkflowInstancesByTask(unknown) = %d, want 0", len(none))
+	}
+}
+
 func TestStepRun_CRUD(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)


### PR DESCRIPTION
## Summary

Phase 9 (final) of the `internal-task-model` change — **Dashboard & Observability**. Reorients the dashboard (TUI) **Tasks** tab around the canonical `InternalTask`, instead of per-execution rows from the legacy `task_executions` table, and exposes bindings, lineage and multiple workflow instances per task.

### Architectural discovery (resolved in code)
`workflow_instances` is the bridge between the two worlds: `task_id` = `internal_tasks.id` (canonical), `cell_id` = the legacy key (`source_item_id` of the primary binding, or the task id when there's no binding) under which `task_executions`/`task_logs` were written. That's why each list row carries **two ids**: `InternalTaskID` (lineage/bindings/instances) and `DrillKey` (legacy detail/logs/monitor) — the existing drill-down machinery stays intact.

### DB (new, additive queries)
- `InternalTaskStore.ListTasks` (all states, most recent first), `ListChildTasks` (direct children), `GetTaskAncestors` (recursive CTE, root→self, depth cap).
- `Client.ListWorkflowInstancesByTask` (all instances of a task — fan-out).
- The `idx_wf_instances_task` index added in the **migrations** (after the ALTER that creates `task_id`; the `CREATE INDEX` block runs before the migrations).

### Dashboard
- **9.1.1** — the Tasks list comes from `internal_tasks` via `taskItemFromInternal`; `taskStatusBadge` gains the internal states (`registered`→queued, `approval_waiting`→approval, `done`) **additively** (the legacy success/failed/running statuses, used by the Agents tab, intact).
- **9.1.2** — a **Source Bindings** section in the detail (source, number, URL).
- **9.1.3** — a **Lineage** breadcrumb (root→self) + parent title.
- **9.1.4** — a **Workflow Instances** section with ALL of the task's instances (resumed/sub markers).
- **9.2** (stretch) — a rendered children tree, each node with a state badge, a binding indicator and an instance count.
- Selection fix: `selectedTaskID`/`focusedTaskID`/`focusedTaskURL` index the **filtered** list (not `History`); while a sub-view is open the list is **not refetched** (avoids reordering `History` under the cursor and reloading the wrong task — an adversarial-review finding).

### Notes
- `taskStatusBadge` (**CRITICAL** impact) and `fetchTasks` (**HIGH**) were edited additively / preserving the behavior of the other consumers (Agents/Overview tabs). The detail's Status aligned to the InternalTask state to match the list.
- The legacy readers of the `tasks` table (`GetRecentTasks`, `GetActiveRuns`, `GetTaskTitle`, `ListWorkflowInstanceViews`) were **left intact** (no dashboard consumer / used by the CLI) — out of scope for Phase 9.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — green
- [x] `go test -race ./internal/db/... ./internal/dashboard/...` — green
- [x] DB: `ListTasks` (newest-first, limit), `ListChildTasks` (direct children, oldest-first), `GetTaskAncestors` (root→self, root alone, unknown id), `ListWorkflowInstancesByTask` (newest-first, per task)
- [x] Render: bindings, breadcrumb, children tree (badge/binding/count), instances (resumed/sub), full framed detail (`assertFramed`), the internal-states badge
- [x] Glue: `fetchTaskDetail`/`augmentTaskDetail` end-to-end against a real DB (bindings + lineage + instances + parent title + Status = InternalTask state) and dual-id mapping (`taskItemFromInternal`/`drillKeyFor`)
- [x] Multi-agent adversarial review (3 dimensions → per-finding verification): 1 confirmed finding (sub-view refetch) fixed; the rest rejected as intentional/hypothetical design

Completes the `openspec/changes/internal-task-model` change (Phase 9 of 9). The Cross-Cutting items (specs/examples) follow in a separate PR.