### PR TITLE
docs(openspec): InternalTask, tasks: hook and markers; fan-out/spawn example (Cross-Cutting)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -312,6 +312,49 @@ workflows:
     on_fail:
       add_labels: [needs-attention]
 
+  # ── Internal fan-out & agent-driven write-back (internal-task-model) ──────────
+  # `exclusive: true` — when this trigger matches, the router stops evaluating
+  # lower-priority triggers, so an incident does NOT also fan out to the agent:*
+  # workflows above; it is claimed by this workflow alone. (With exclusive: false,
+  # the default, a task fans out to EVERY matching workflow, each as its own
+  # instance, and the top-level `tasks:` hook below fires once all of them finish.)
+  - id: incident-triage
+    description: "Triage an incident, write a summary back to the issue, and spawn a collection task."
+    trigger:
+      priority: 5
+      exclusive: true
+      match:
+        source: project-erp
+        labels: [incident]
+    steps:
+      - id: triage
+        agent: investigator
+        prompt: |
+          Assess the incident. Then write a short human-facing summary back to the
+          issue and spawn a follow-up task to collect diagnostics, by emitting:
+
+          APIARY_PUBLISH_BEGIN
+          <one-paragraph summary posted as a comment on the source item>
+          APIARY_PUBLISH_END
+
+          APIARY_SPAWN_BEGIN
+          {"workflow": "collect-logs", "title": "Collect logs for incident", "input": {"severity": "high"}}
+          APIARY_SPAWN_END
+        publish: auto   # write the APIARY_PUBLISH payload back to the task's source bindings
+        spawn: await    # block until the spawned collect-logs task is terminal; its failure fails this step
+    on_complete:
+      set_state: in review
+
+  # Named child workflow dispatched at runtime by the APIARY_SPAWN marker above. It
+  # has no trigger — it runs against a binding-less InternalTask whose parent is the
+  # spawning task, started BY NAME rather than by routing.
+  - id: collect-logs
+    description: "Collect diagnostic logs for an incident (spawned via APIARY_SPAWN)."
+    steps:
+      - id: collect
+        agent: investigator
+        prompt: "Gather the relevant logs and metrics for the incident described in the task input."
+
 
 # ── Settings ───────────────────────────────────────────────────────────────────
 settings:
@@ -319,3 +362,15 @@ settings:
   log_level: info
   state_lock: true
   result_comment: true
+
+# ── Task completion hook (internal-task-model) ───────────────────────────────────
+# Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a
+# terminal state: on_complete when all succeeded, on_fail when any failed. Applies
+# to every source binding on the task. (Per-workflow on_complete/on_fail above fire
+# once per workflow instance; this fires once per task.)
+tasks:
+  on_complete:
+    add_labels: [ai-complete]
+  on_fail:
+    set_state: blocked
+    add_labels: [ai-failed]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5169 symbols, 11618 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5180 symbols, 11622 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5169 symbols, 11618 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5180 symbols, 11622 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/openspec/specs/plugin-api/spec.md
+++ b/openspec/specs/plugin-api/spec.md
@@ -6,9 +6,15 @@ Apiary is extended through two plugin types: **Source Adapters** and **Runner Ad
 
 A Source Adapter connects Apiary to a task management system.
 
+> **Naming note:** the normalised task unit was renamed from `Cell` to
+> `SourceItem` in the internal-task-model change. A `SourceItem` represents a raw
+> item in the source system; once polled it is bound to a canonical
+> **InternalTask** by the `SourceBinder` (below). Older field/variable names like
+> `RunRequest.Cell` are retained, but their type is now `SourceItem`.
+
 ```go
-// SourceAdapter pulls tasks from an external task system.
-type SourceAdapter interface {
+// Adapter pulls tasks from an external task system.
+type Adapter interface {
     // ID returns the adapter type key (e.g. "plane", "jira", "linear").
     ID() string
 
@@ -17,14 +23,14 @@ type SourceAdapter interface {
 
     // Poll returns tasks matching the source's filter config since the last call.
     // Apiary calls this on the configured poll_interval.
-    Poll(ctx context.Context, since time.Time) ([]Cell, error)
+    Poll(ctx context.Context, since time.Time) ([]SourceItem, error)
 
-    // Acknowledge is called after a Cell has been dispatched to a worker.
+    // Acknowledge is called after a SourceItem has been dispatched to a worker.
     // Adapters use this to transition the task state or add a comment.
-    Acknowledge(ctx context.Context, cell Cell, action AckAction) error
+    Acknowledge(ctx context.Context, item SourceItem, action AckAction) error
 
     // WriteResult posts the agent run output back to the source task.
-    WriteResult(ctx context.Context, cell Cell, result RunResult) error
+    WriteResult(ctx context.Context, item SourceItem, result RunResult) error
 
     // WebhookHandler returns an http.Handler for push-mode sources.
     // Return nil for poll-only adapters.
@@ -32,12 +38,12 @@ type SourceAdapter interface {
 }
 ```
 
-### The `Cell` type
+### The `SourceItem` type
 
-`Cell` is a normalised, source-system-agnostic task unit.
+`SourceItem` is a normalised, source-system-agnostic task unit (formerly `Cell`).
 
 ```go
-type Cell struct {
+type SourceItem struct {
     ID          string            // native task ID in the source system
     SourceID    string            // apiary source id (e.g. "main-plane")
     Title       string
@@ -50,6 +56,49 @@ type Cell struct {
     Metadata    map[string]any    // adapter-specific extra fields
     CreatedAt   time.Time
     UpdatedAt   time.Time
+}
+```
+
+### The `SourceBinder` (binding layer)
+
+A `SourceBinder` normalises a polled `SourceItem` into the canonical
+**InternalTask** the engine runs on, creating a `SourceBinding` row on first sight
+and returning the existing task on every subsequent poll. This is what lets one
+internal task carry many source bindings, and lets spawned (binding-less) tasks
+exist with no source item at all. The default binder is built in; adapters do not
+implement it.
+
+```go
+// SourceBinder maps a SourceItem to its InternalTask (find-or-create).
+type SourceBinder interface {
+    // Bind returns the InternalTask for the given SourceItem, creating it (and
+    // its SourceBinding) on first sight and returning the existing one on every
+    // subsequent poll.
+    Bind(ctx context.Context, item SourceItem) (InternalTask, error)
+}
+
+// InternalTask is the canonical, source-independent unit of work.
+type InternalTask struct {
+    ID                   string         // sortable id
+    ParentTaskID         string         // set for spawned tasks (lineage); empty for roots
+    Title                string
+    Description          string
+    Input                map[string]any // structured input from the spawner; nil for source-bound tasks
+    State                string         // registered | running | approval_waiting | done | failed
+    Metadata             TaskMetadata   // labels, priority, type, source, live source state
+    OutstandingWorkflows int            // workflows still running; completion hook fires at 0
+    CreatedAt, UpdatedAt time.Time
+}
+
+// SourceBinding links a source item to an InternalTask (one task → many bindings).
+type SourceBinding struct {
+    ID               string
+    TaskID           string // references InternalTask.ID
+    SourceID         string // e.g. "github", "plane"
+    SourceItemID     string // source-native id
+    SourceItemURL    string
+    SourceItemNumber string // human ref, e.g. "#42", "ERP-42"
+    CreatedAt        time.Time
 }
 ```
 
@@ -108,11 +157,11 @@ implements `TaskPoller`; otherwise the instance stays parked.
 // TaskPoller fetches a single task's current state, including its comments.
 // Implemented by adapters that can host approval steps.
 type TaskPoller interface {
-    PollTask(ctx context.Context, cellID string) (Cell, error)
+    PollTask(ctx context.Context, sourceItemID string) (SourceItem, error)
 }
 ```
 
-`PollTask` populates `Cell.Comments` so the engine can evaluate approval
+`PollTask` populates `SourceItem.Comments` so the engine can evaluate approval
 conditions (`comment_contains`, `label_added`, `state_changed`):
 
 ```go
@@ -121,7 +170,7 @@ type Comment struct {
     Body      string
     CreatedAt time.Time
 }
-// Cell gains: Comments []Comment  // populated by TaskPoller; empty otherwise
+// SourceItem gains: Comments []Comment  // populated by TaskPoller; empty otherwise
 ```
 
 The built-in **GitHub** adapter implements `TaskPoller` (issue + comments).
@@ -141,7 +190,13 @@ WorkflowInstanceID string  // the owning instance id
 // RunResult, additional fields:
 StructuredOutput map[string]any // parsed APIARY_OUTPUT: JSON (per output_schema)
 Summary          string         // the agent's handoff summary (APIARY_SUMMARY block)
+PublishPayload   string         // APIARY_PUBLISH block; written back per step.publish
+SpawnRequest     *SpawnRequest  // APIARY_SPAWN request {workflow,title,input}; drives internal fan-out
 ```
+
+(`RunRequest.Cell` is a `SourceItem`.) The engine parses the `APIARY_PUBLISH` and
+`APIARY_SPAWN` markers out of the agent's raw output; see the marker reference in
+the config schema spec.
 
 ## Built-in Adapters (v1)
 

--- a/openspec/specs/schema/spec.md
+++ b/openspec/specs/schema/spec.md
@@ -197,15 +197,17 @@ coexist. See the full annotated reference in the `workflow-mode` change specs
 | `id` | string | ✓ | Unique across all workflows and routes |
 | `description` | string | — | Shown in the TUI and logs |
 | `resume` | string | — | `allowed` \| `forbidden` \| `auto` (resume eligibility) |
-| `trigger` | object | ✓ | Same matcher as `routes[].match`, plus `priority` |
+| `trigger` | object | ✓ | Same matcher as `routes[].match`, plus `priority` and `exclusive` |
+| `trigger.priority` | int | — | Evaluation order among matching workflows — lower number first |
+| `trigger.exclusive` | bool | — | When this workflow matches, stop evaluating lower-priority triggers (it claims the task alone). Default `false`: a task **fans out** to every matching workflow (each runs as its own instance) |
 | `steps[]` | object[] | ✓ | Ordered steps forming the DAG |
-| `on_complete` / `on_fail` | object | — | Side-effects on terminal success/failure (`set_state`, `add_labels`) |
+| `on_complete` / `on_fail` | object | — | Per-workflow side-effects on terminal success/failure (`set_state`, `add_labels`) |
 
 **Step types** (`steps[].type`, default `agent`):
 
 | Type | Purpose | Key fields |
 |---|---|---|
-| `agent` | Invoke one agent | `agent`, `model`, `prompt`, `summary_prompt`, `output_schema`, `memory`, `depends_on`, `on_pass.next`, `on_fail.goto`/`max_retries` |
+| `agent` | Invoke one agent | `agent`, `model`, `prompt`, `summary_prompt`, `output_schema`, `memory`, `depends_on`, `on_pass.next`, `on_fail.goto`/`max_retries`, `publish`, `spawn` |
 | `split` | Conditional routing | `branches[].if` (expression) / `else`, `branches[].goto`, `multi` |
 | `approval` | Human checkpoint (suspends the instance) | `message`, `resume_on`, `abort_on`, `timeout` |
 | `foreach` | Fan-out over a prior step's array | `items`, `as`, `agent`, `max_items`, `fail_fast` |
@@ -213,6 +215,83 @@ coexist. See the full annotated reference in the `workflow-mode` change specs
 
 Split/approval conditions use a small expression language over `cell.*`,
 `memory.*`, and `steps.*` with `==`/`!=`/`contains`/`matches` and `and`/`or`/`not`.
+
+**Agent step write-back / fan-out fields:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `publish` | enum | `auto` | `auto`: write the step's `APIARY_PUBLISH` payload back to the task's source bindings as a comment. `off`: never write back, even if a payload is emitted. |
+| `spawn` | enum | `auto` | Controls an `APIARY_SPAWN` request the step emits. `auto`: fire-and-forget — the child task is created and dispatched, the step does not wait. `await`: block until the spawned task is terminal; a child failure fails this step. |
+
+### `tasks` (top-level completion hook)
+
+The optional top-level `tasks:` block fires **once per InternalTask** — when the
+**last** of the task's fanned-out workflows reaches a terminal state — as opposed
+to the per-workflow `on_complete`/`on_fail` hooks which fire once per workflow
+instance. It applies to every `SourceBinding` on the task.
+
+```yaml
+tasks:
+  on_complete:          # applied when ALL of the task's workflows succeeded
+    set_state: done
+    add_labels: [ai-done]
+  on_fail:              # applied when ANY of the task's workflows failed
+    set_state: blocked
+    add_labels: [ai-failed]
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `on_complete` | object | Hook (`set_state`, `add_labels`) applied to every source binding when all workflows succeeded |
+| `on_fail` | object | Hook applied when any workflow failed |
+
+## Internal Task Model
+
+The **InternalTask** is the canonical, source-independent unit of work the engine
+operates on. A source item (a GitHub issue, a Plane work item) is normalised into
+an InternalTask by the **SourceBinder** (see the plugin-api spec), which records a
+**SourceBinding** linking the two. One task may fan out to several workflows and
+may **spawn** child tasks (lineage via `parent_task_id`), forming a tree that is
+independent of any source system. The dashboard surfaces the InternalTask as the
+primary unit, with its bindings, lineage, and workflow instances.
+
+`internal_tasks`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | text (pk) | Sortable id |
+| `parent_task_id` | text | Set for spawned tasks (lineage); empty/NULL for root tasks |
+| `title` / `description` | text | Task content (kept in sync with the live source item for bound tasks) |
+| `input` | text (JSON) | Structured input passed by the spawner; NULL for source-bound tasks |
+| `state` | text | `registered` \| `running` \| `approval_waiting` \| `done` \| `failed` |
+| `metadata` | text (JSON) | Labels, priority, type, source, live source state (for trigger matching) |
+| `outstanding_workflows` | int | Workflows still running for the task; the completion hook fires when it reaches 0 |
+| `created_at` / `updated_at` | timestamp | |
+
+`source_bindings`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | text (pk) | |
+| `task_id` | text | References `internal_tasks(id)` (one task → many bindings) |
+| `source_id` | text | e.g. `github`, `plane` |
+| `source_item_id` | text | Source-native item id |
+| `source_item_url` | text | Deep link for display |
+| `source_item_number` | text | Human reference, e.g. `#42`, `ERP-42` |
+| | | `UNIQUE(source_id, source_item_id)` |
+
+## Agent Output Markers
+
+Agents communicate structured results back to the engine by emitting marker
+blocks in their output. Markers are stripped from the visible output before it is
+displayed or written back.
+
+| Marker | Form | Purpose |
+|---|---|---|
+| `APIARY_OUTPUT:` | single line of JSON | Structured output validated against the step's `output_schema`; the last valid line wins |
+| `APIARY_SUMMARY_START` … `APIARY_SUMMARY_END` | block | The agent's short handoff note (the memory baton between steps) |
+| `APIARY_PUBLISH_BEGIN` … `APIARY_PUBLISH_END` | block | Write-back payload posted as a comment to the task's source bindings (gated by `step.publish`; ignored for binding-less tasks) |
+| `APIARY_SPAWN_BEGIN` … `APIARY_SPAWN_END` | block of JSON `{"workflow","title","input"}` | Requests a child InternalTask running the named workflow (internal fan-out; `parent_task_id` is set by the engine, never by the agent) |
 
 ## Environment Variable Interpolation
 


### PR DESCRIPTION
## Summary

Closes the **Cross-Cutting** items (X.1–X.3) of the `internal-task-model` change — the documentation and example that were missing after the 9 implementation phases.

- **X.1 — `openspec/specs/schema/spec.md`**: `trigger.exclusive` and `step.publish`/`step.spawn` in the workflow tables; a new **`tasks`** section (per-InternalTask completion hook); a new **Internal Task Model** section (the `internal_tasks` + `source_bindings` tables); a new **Agent Output Markers** section (`APIARY_OUTPUT`/`APIARY_SUMMARY`/`APIARY_PUBLISH`/`APIARY_SPAWN`).
- **X.2 — `openspec/specs/plugin-api/spec.md`**: `Adapter.Poll` returns `[]SourceItem` (rename `Cell`→`SourceItem`, with a note); a new **`SourceBinder`** interface + `InternalTask`/`SourceBinding` types; `TaskPoller.PollTask` returns `SourceItem`; `RunResult` gains `PublishPayload`/`SpawnRequest`.
- **X.3 — `.apiary/example-apiary-full.yaml`**: an `incident-triage` workflow with `trigger.exclusive: true` + `publish: auto` + `spawn: await` emitting the `APIARY_PUBLISH`/`APIARY_SPAWN` markers; a `collect-logs` child workflow dispatched by name; a top-level `tasks:` block (`on_complete`/`on_fail`).

All edits are **additive and faithful to the current code** (interfaces/tags/markers verified in the source). The schema's legacy `routes[]` section (the old model, predating workflow-engine-only) was **not rewritten** — that's a separate cleanup.

With this, the `openspec/changes/internal-task-model` change is **complete** (Phases 1–9 + Cross-Cutting).

## Test plan
- [x] `go test ./internal/config/...` — green; `TestLint_ExampleConfigsNoFalsePositives` validates that the edited example lints clean (strict-decode of `exclusive`/`publish`/`spawn`/`tasks`)
- [x] `apiary validate` on the example: the only failures are pre-existing and unrelated (`default_runner: claude-cli` mismatch vs the defined `claude` runner); none of the additions (incident-triage, collect-logs, tasks) produces a new error
- [x] The documented interfaces/markers checked against the code (`source.Adapter`, `SourceBinder`, `TaskPoller`, `StepConfig.Publish/Spawn`, `TriggerConfig.Exclusive`, `TasksConfig`, the marker constants in `runner/execution/structured.go`)

Note: the pre-existing runner mismatch in the example was flagged separately (it's not part of this change).