### PR TITLE
fix(config): v2 lowering rewrites if: and persists memory auto-wire

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -26,6 +26,10 @@ func LowerV2Workflow(wf WorkflowConfig) (WorkflowConfig, error) {
 	if err != nil {
 		return wf, fmt.Errorf("workflow %q: %w", wf.ID, err)
 	}
+	// Apply auto-wired memory.write fields to the steps that are actually emitted
+	// (lowerSteps built `lowered` as fresh copies, so wiring recorded during the
+	// pass must be replayed here rather than on the discarded stepByID copies).
+	lc.applyPendingWrites(lowered)
 	out := wf
 	out.Steps = lowered
 	return out, nil
@@ -38,6 +42,12 @@ func LowerV2Workflow(wf WorkflowConfig) (WorkflowConfig, error) {
 // lowerCtx holds the mutable state of one lowering pass.
 type lowerCtx struct {
 	stepByID map[string]StepConfig // original step id → raw v2 node
+	// pendingWrites accumulates memory.write fields that must be persisted by the
+	// emitting step, keyed by step id, in first-referenced order. They are applied
+	// to the lowered OUTPUT steps by applyPendingWrites — not to stepByID, whose
+	// StepConfig copies are discarded — so cross-step auto-wiring (step B's
+	// condition referencing step A's output) actually reaches the emitted config.
+	pendingWrites map[string][]string
 }
 
 // buildStepIndex builds a flat map of all step ids in the authored tree
@@ -99,7 +109,13 @@ func (lc *lowerCtx) lowerSteps(steps []StepConfig, prevID, inheritedCondition st
 			prevID = flat.ID
 		case len(s.SubSteps) > 0:
 			// Group: dissolve into children, applying the group's if: to all.
-			groupCond := composeCond(inheritedCondition, lowerExpr(s.If))
+			// Rewrite step-output shorthand so the guard the children inherit is a
+			// runtime-valid memory.* expression and the source field is auto-wired.
+			ownCond, err := lc.rewriteExpr(s.If, s.ID)
+			if err != nil {
+				return nil, fmt.Errorf("group %q if: %w", s.ID, err)
+			}
+			groupCond := composeCond(inheritedCondition, ownCond)
 			children, err := lc.lowerSteps(s.SubSteps, prevID, groupCond)
 			if err != nil {
 				return nil, err
@@ -137,8 +153,14 @@ func (lc *lowerCtx) lowerLeafStep(s StepConfig, prevID, inheritedCondition strin
 	}
 	out.Output = nil
 
-	// Lower if: → condition.
-	ownCond := lowerExpr(out.If)
+	// Lower if: → condition. Run it through rewriteExpr (not just lowerExpr) so
+	// step-output shorthand like `classify.track` becomes `memory.track` — the
+	// only accessor form the runtime expr engine accepts — and the referenced
+	// field is auto-wired into the emitting step's memory.write.
+	ownCond, err := lc.rewriteExpr(out.If, out.ID)
+	if err != nil {
+		return StepConfig{}, fmt.Errorf("step %q if: %w", out.ID, err)
+	}
 	out.Condition = composeCond(inheritedCondition, ownCond)
 	out.If = ""
 
@@ -188,7 +210,10 @@ func (lc *lowerCtx) lowerParallelStep(s StepConfig, prevID, inheritedCondition s
 	if prevID != "" {
 		out.DependsOn = []string{prevID}
 	}
-	ownCond := lowerExpr(s.If)
+	ownCond, err := lc.rewriteExpr(s.If, s.ID)
+	if err != nil {
+		return StepConfig{}, fmt.Errorf("parallel step %q if: %w", s.ID, err)
+	}
 	out.Condition = composeCond(inheritedCondition, ownCond)
 
 	// Lower children individually (no implicit chaining — they run concurrently).
@@ -220,7 +245,10 @@ func (lc *lowerCtx) lowerForeachStep(s StepConfig, prevID, inheritedCondition st
 	if prevID != "" {
 		out.DependsOn = []string{prevID}
 	}
-	ownCond := lowerExpr(s.If)
+	ownCond, err := lc.rewriteExpr(s.If, s.ID)
+	if err != nil {
+		return StepConfig{}, fmt.Errorf("for_each %q if: %w", s.ID, err)
+	}
 	out.Condition = composeCond(inheritedCondition, ownCond)
 
 	// Lower max: → max_items.
@@ -417,24 +445,62 @@ func (lc *lowerCtx) ensureMemoryWriteForExpr(expr string) {
 	}
 }
 
-// ensureMemoryWrite adds field to stepID's memory.write if not already present,
-// updating the step index in place.
+// ensureMemoryWrite records that stepID must persist field to workflow memory.
+// The write is staged in pendingWrites (deduplicated, first-referenced order) and
+// applied to the emitted steps by applyPendingWrites. Mutating stepByID here would
+// be lost: lowerSteps builds the output as separate StepConfig copies.
 func (lc *lowerCtx) ensureMemoryWrite(stepID, field string) {
-	s, ok := lc.stepByID[stepID]
-	if !ok {
+	if _, ok := lc.stepByID[stepID]; !ok {
 		return
 	}
-	if s.Memory == nil {
-		s.Memory = &MemoryConfig{}
+	if lc.pendingWrites == nil {
+		lc.pendingWrites = map[string][]string{}
 	}
-	for _, f := range s.Memory.Write {
+	for _, f := range lc.pendingWrites[stepID] {
 		if f == field {
-			lc.stepByID[stepID] = s
 			return
 		}
 	}
-	s.Memory.Write = append(s.Memory.Write, field)
-	lc.stepByID[stepID] = s
+	lc.pendingWrites[stepID] = append(lc.pendingWrites[stepID], field)
+}
+
+// applyPendingWrites walks the lowered output tree and merges each step's staged
+// memory.write fields (recorded by ensureMemoryWrite) into the step that is
+// actually emitted, creating a MemoryConfig when the step declared none.
+func (lc *lowerCtx) applyPendingWrites(steps []StepConfig) {
+	for i := range steps {
+		lc.applyPendingWritesToStep(&steps[i])
+	}
+}
+
+func (lc *lowerCtx) applyPendingWritesToStep(s *StepConfig) {
+	if fields := lc.pendingWrites[s.ID]; len(fields) > 0 {
+		if s.Memory == nil {
+			s.Memory = &MemoryConfig{}
+		}
+		for _, f := range fields {
+			if !memoryWrites(s.Memory, f) {
+				s.Memory.Write = append(s.Memory.Write, f)
+			}
+		}
+	}
+	// Recurse into every position a lowered step can hold children: dissolved
+	// groups land in SubSteps, parallel children too, and foreach bodies in Step.
+	lc.applyPendingWrites(s.SubSteps)
+	lc.applyPendingWrites(s.ParallelSteps)
+	if s.Step != nil {
+		lc.applyPendingWritesToStep(s.Step)
+	}
+}
+
+// memoryWrites reports whether m already persists field.
+func memoryWrites(m *MemoryConfig, field string) bool {
+	for _, f := range m.Write {
+		if f == field {
+			return true
+		}
+	}
+	return false
 }
 
 // parseForEachExpr parses a for_each expression like `${{ design.tasks }}`

--- a/src/internal/config/lower_v2_engine_test.go
+++ b/src/internal/config/lower_v2_engine_test.go
@@ -1,0 +1,100 @@
+package config_test
+
+// This file lives in the external test package so it can import the runtime
+// workflow expr engine (which itself imports config) without an import cycle.
+// It is the end-to-end proof for the v2 if:-shorthand lowering fix: the lowered
+// condition must be something the engine's expr parser/evaluator actually
+// accepts, and the field it reads must be one the emitting step persists.
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// TestLowerV2_IfShorthandIsRuntimeValid lowers the documented v2 example and then
+// feeds the result through the real expr engine. It guards both bugs against
+// regression at the layer that actually matters: the runtime.
+func TestLowerV2_IfShorthandIsRuntimeValid(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "triage",
+		Steps: []config.StepConfig{
+			{ID: "classify", Agent: "investigator",
+				Output: &config.OutputSchema{Type: "object",
+					Properties: map[string]config.SchemaField{"track": {Type: "string"}}}},
+			{
+				ID: "complex-track",
+				If: `${{ classify.track == 'complex' }}`,
+				SubSteps: []config.StepConfig{
+					{ID: "design", Agent: "staff"},
+				},
+			},
+		},
+	}
+
+	lowered, err := config.LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("LowerV2Workflow: %v", err)
+	}
+
+	// Locate the lowered child step and its emitting predecessor.
+	var classify, design config.StepConfig
+	for _, s := range lowered.Steps {
+		switch s.ID {
+		case "classify":
+			classify = s
+		case "design":
+			design = s
+		}
+	}
+	if design.ID == "" || classify.ID == "" {
+		t.Fatalf("expected classify+design in lowered steps, got %v", lowered.Steps)
+	}
+
+	// The emitting step must persist the field the condition reads — otherwise the
+	// memory accessor resolves to empty at runtime and the guard never matches.
+	if got := classify.MemoryWriteFields(); !contains(got, "track") {
+		t.Fatalf("classify.memory.write = %v, want it to contain \"track\"", got)
+	}
+
+	// The lowered condition must parse and evaluate under the runtime expr engine.
+	expr, err := workflow.ParseExpr(design.Condition)
+	if err != nil {
+		t.Fatalf("engine rejected lowered condition %q: %v", design.Condition, err)
+	}
+	gotTrue, err := expr.Eval(workflow.EvalContext{Memory: map[string]string{"track": "complex"}})
+	if err != nil {
+		t.Fatalf("eval(track=complex) errored: %v", err)
+	}
+	if !gotTrue {
+		t.Errorf("condition %q with track=complex = false, want true", design.Condition)
+	}
+	gotFalse, err := expr.Eval(workflow.EvalContext{Memory: map[string]string{"track": "implement"}})
+	if err != nil {
+		t.Fatalf("eval(track=implement) errored: %v", err)
+	}
+	if gotFalse {
+		t.Errorf("condition %q with track=implement = true, want false", design.Condition)
+	}
+
+	// Negative control: the un-rewritten shorthand parses syntactically but the
+	// engine rejects `classify.*` at eval time (unknown accessor root). That eval
+	// error is exactly what the engine swallows into a silent skip — i.e. the bug.
+	bad, err := workflow.ParseExpr(`classify.track == 'complex'`)
+	if err != nil {
+		t.Fatalf("setup: bare step-ref should still parse, got %v", err)
+	}
+	if _, err := bad.Eval(workflow.EvalContext{Memory: map[string]string{"track": "complex"}}); err == nil {
+		t.Error("expected eval error for bare step-ref `classify.track`, got nil (the lowering must rewrite it)")
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/config/lower_v2_test.go
+++ b/src/internal/config/lower_v2_test.go
@@ -389,3 +389,94 @@ func stepIDList(steps []StepConfig) []string {
 	}
 	return ids
 }
+
+// memHasWrite reports whether a step's memory.write list contains field.
+func memHasWrite(m *MemoryConfig, field string) bool {
+	if m == nil {
+		return false
+	}
+	for _, f := range m.Write {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLowerV2_GroupIfStepRefRewritesAndAutoWires covers the documented v2 example
+// (proposal §"Os dois fluxos-alvo"): a group guarded by `if: ${{ classify.track
+// == 'complex' }}`. The step-output shorthand must be rewritten to memory.* (so
+// the runtime expr engine accepts it) AND the referenced field must be auto-wired
+// into the emitting step's memory.write (so it is actually persisted at runtime).
+func TestLowerV2_GroupIfStepRefRewritesAndAutoWires(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "triage",
+		Steps: []StepConfig{
+			{ID: "classify", Agent: "investigator",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"track": {Type: "string"}}}},
+			{
+				ID: "complex-track",
+				If: `${{ classify.track == 'complex' }}`,
+				SubSteps: []StepConfig{
+					{ID: "design", Agent: "staff"},
+				},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Group dissolved: classify + design.
+	if len(out.Steps) != 2 {
+		t.Fatalf("expected 2 flat steps, got %d: %v", len(out.Steps), stepIDList(out.Steps))
+	}
+	classify, design := out.Steps[0], out.Steps[1]
+
+	// Bug 1: the group's if: must lower to a runtime-valid condition (memory.*),
+	// not the bare step-ref shorthand the expr engine would reject.
+	if design.Condition != `memory.track == 'complex'` {
+		t.Errorf("design.Condition = %q, want %q", design.Condition, `memory.track == 'complex'`)
+	}
+
+	// Bug 2: the referenced field must be auto-wired into classify's memory.write
+	// on the EMITTED step, not a discarded copy.
+	if !memHasWrite(classify.Memory, "track") {
+		t.Errorf("classify.Memory.Write = %v, want it to contain %q", classify.MemoryWriteFields(), "track")
+	}
+}
+
+// TestLowerV2_LeafIfStepRefRewritesAndAutoWires is the leaf-step counterpart of
+// the group case: a leaf `if:` referencing an earlier step's output must rewrite
+// the same way and auto-wire the emitting step.
+func TestLowerV2_LeafIfStepRefRewritesAndAutoWires(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "triage",
+		Steps: []StepConfig{
+			{ID: "classify", Agent: "investigator",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"track": {Type: "string"}}}},
+			{ID: "design", Agent: "staff",
+				If: `${{ classify.track == 'complex' }}`},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out.Steps) != 2 {
+		t.Fatalf("expected 2 flat steps, got %d: %v", len(out.Steps), stepIDList(out.Steps))
+	}
+	classify, design := out.Steps[0], out.Steps[1]
+
+	if design.Condition != `memory.track == 'complex'` {
+		t.Errorf("design.Condition = %q, want %q", design.Condition, `memory.track == 'complex'`)
+	}
+	if design.If != "" {
+		t.Errorf("design.If should be cleared after lowering, got %q", design.If)
+	}
+	if !memHasWrite(classify.Memory, "track") {
+		t.Errorf("classify.Memory.Write = %v, want it to contain %q", classify.MemoryWriteFields(), "track")
+	}
+}


### PR DESCRIPTION
## Problem

The v2 authoring lowering (`src/internal/config/lower_v2.go`) had **two bugs** that made the documented nested example (`openspec/changes/archive/2026-06-06-workflow-sequential-authoring/proposal.md`, used by the project-erp use case) produce **silently broken** workflows.

### Bug 1 — `if:` was not rewritten
`lowerLeafStep` and the group case lowered the `if:` via `lowerExpr` (which only strips `${{ }}`), not via `rewriteExpr`. An `if: ${{ classify.track == 'complex' }}` became the condition `classify.track == 'complex'` — but the expr engine (`internal/workflow/expr.go`, `resolveAccessor`) only accepts `cell.*`, `memory.*`, `steps.<id>.<field>`; a raw `classify.track` errors on eval, which the engine swallows by treating it as `false` → **the step is silently skipped**. Only `reject_when` went through `rewriteExpr`.

**Fix:** the `if:` now goes through `rewriteExpr` in **leaf, group, parallel and foreach** → `classify.track` becomes `memory.track` and the field is auto-wired into the emitting step's `memory.write`.

### Bug 2 — the memory auto-wire wrote into a discarded copy
`ensureMemoryWrite` mutated the steps in `lc.stepByID` (copies of the authored ones), but the lowered output is the list built separately by `lowerSteps`. When step B's condition referenced step A's output, A was wired in `stepByID` but the **emitted** A ended up without `memory.write` — the field was never persisted at runtime and the downstream condition read empty.

**Fix:** the pending writes are accumulated in `lc.pendingWrites` and applied in a **final pass** (`applyPendingWrites`) over the actually-emitted step tree.

## Tests
- `lower_v2_test.go`: the group `if: ${{ classify.track == 'complex' }}` lowers to `memory.track == 'complex'` **and** `classify` ends with a `memory.write` containing `track`; same for the leaf case. (Both fail on the old code, pass on the new.)
- `lower_v2_engine_test.go` (external package `config_test`): the lowered condition is evaluated by the **real expr engine** — `memory.track == 'complex'` matches `track=complex` and doesn't match `track=implement`; a negative control confirms the un-rewritten shorthand (`classify.track`) errors on eval (the cause of the silent skip).

## Verification
- `go vet` clean; `go test ./...` green.
- `apiary validate` accepts the documented v2 example (`✓ config is valid`).

Reported while authoring the project-erp `.apiary/apiary.yaml` (worked around there by writing explicit `memory.*` + `memory.write`); the v2 sugar now works as documented.