### PR TITLE
fix(config): make LowerV2Workflow idempotent for parallel steps

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -11,8 +11,11 @@ import (
 // (flat steps with depends_on, condition, fail_when, on_fail.goto, foreach,
 // type:workflow). The result is safe to hand directly to the engine.
 //
-// LowerV2Workflow is idempotent: a workflow that already uses only IR fields
-// and contains no v2 authored fields passes through unchanged.
+// LowerV2Workflow is idempotent: lowering its own output is a no-op. A workflow
+// that uses only IR fields passes through unchanged, and a lowered parallel node
+// (Type==parallel, children in SubSteps) is recognized as already-lowered rather
+// than re-dissolved into a sequential group — so re-validating an in-place-lowered
+// Config (Config.Validate mutates) preserves concurrency and the join policy.
 func LowerV2Workflow(wf WorkflowConfig) (WorkflowConfig, error) {
 	// Quick exit: no step uses v2 fields → nothing to do.
 	if !anyV2Steps(wf.Steps) {
@@ -92,10 +95,28 @@ func (lc *lowerCtx) lowerSteps(steps []StepConfig, prevID, inheritedCondition st
 		switch {
 		case s.ForEachExpr != "":
 			// v2 for_each: lower to StepTypeForeach (check before SubSteps since
-			// a foreach step also carries SubSteps as its body).
+			// a foreach step also carries SubSteps as its body). Checked before the
+			// already-lowered guard below so a node that (mistakenly) carries both
+			// type:foreach and for_each: is still lowered rather than passed through.
 			flat, err := lc.lowerForeachStep(s, prevID, inheritedCondition)
 			if err != nil {
 				return nil, err
+			}
+			out = append(out, flat)
+			prevID = flat.ID
+		case s.Type == StepTypeParallel || s.Type == StepTypeForeach:
+			// Already-lowered IR node (idempotent re-entry). Only the lowering pass
+			// sets these types; an authored parallel/foreach uses ParallelSteps /
+			// for_each: with Type unset. A lowered parallel keeps its children in
+			// SubSteps and a lowered foreach keeps its body in Step, so without this
+			// guard the parallel would fall through to the len(SubSteps)>0 group
+			// branch and be dissolved into a sequential chain — silently dropping
+			// concurrency and the join policy. Pass it through verbatim. (In the
+			// common case the early exit in LowerV2Workflow already short-circuits
+			// re-lowering; this covers a mixed config validated alongside raw v2.)
+			flat := s
+			if prevID != "" && len(flat.DependsOn) == 0 && len(flat.SeqDependsOn) == 0 {
+				flat.SeqDependsOn = []string{prevID}
 			}
 			out = append(out, flat)
 			prevID = flat.ID

--- a/src/internal/config/lower_v2_test.go
+++ b/src/internal/config/lower_v2_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -246,6 +247,60 @@ func TestLowerV2_ParallelStepKept(t *testing.T) {
 	}
 	if checks.DependsOn[0] != "setup" {
 		t.Errorf("checks depends_on = %v, want [setup]", checks.DependsOn)
+	}
+}
+
+// TestLowerV2_ParallelDoubleLowerIdempotent guards the documented invariant that
+// LowerV2Workflow is idempotent: lowering an already-lowered workflow is a no-op.
+// A lowered parallel node has Type==parallel with its children in SubSteps; before
+// the fix, IsV2Step re-flagged it (len(SubSteps)>0) and lowerSteps dissolved it via
+// the group branch — silently dropping the concurrency and the join policy.
+func TestLowerV2_ParallelDoubleLowerIdempotent(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "par",
+		Steps: []StepConfig{
+			{ID: "setup", Agent: "ag"},
+			{
+				ID:   "checks",
+				Join: "all",
+				ParallelSteps: []StepConfig{
+					{ID: "tests", Agent: "ag"},
+					{ID: "docs", Agent: "ag"},
+				},
+			},
+		},
+	}
+	once, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("first lower: %v", err)
+	}
+	// Lower the output of the first pass again — this is the idempotence check.
+	twice, err := LowerV2Workflow(once)
+	if err != nil {
+		t.Fatalf("second lower: %v", err)
+	}
+
+	if len(twice.Steps) != 2 {
+		t.Fatalf("double-lower changed step count: got %d %v, want 2 (parallel dissolved?)",
+			len(twice.Steps), stepIDList(twice.Steps))
+	}
+	checks := twice.Steps[1]
+	if checks.Type != StepTypeParallel {
+		t.Errorf("checks type after double-lower = %q, want parallel (parallel was dissolved into a group)", checks.Type)
+	}
+	if checks.Join != "all" {
+		t.Errorf("checks join after double-lower = %q, want all (join policy lost)", checks.Join)
+	}
+	if len(checks.SubSteps) != 2 {
+		t.Errorf("checks children after double-lower = %d, want 2", len(checks.SubSteps))
+	}
+	if len(checks.DependsOn) != 1 || checks.DependsOn[0] != "setup" {
+		t.Errorf("checks depends_on after double-lower = %v, want [setup]", checks.DependsOn)
+	}
+
+	// Strongest assertion: the second pass must reproduce the first pass exactly.
+	if !reflect.DeepEqual(once, twice) {
+		t.Errorf("double-lower not idempotent:\n once = %+v\ntwice = %+v", once.Steps, twice.Steps)
 	}
 }
 

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -292,6 +292,16 @@ type OnRejectConfig struct {
 // IsV2Step reports whether this step was written in v2 authored form (i.e., it
 // uses at least one v2-only field that must be lowered before execution).
 func (s StepConfig) IsV2Step() bool {
+	// A lowered parallel node carries its children in SubSteps but is already IR:
+	// only the lowering pass sets Type=parallel, never the author. Treat it as
+	// already-lowered so a second lowering pass exits early (LowerV2Workflow is
+	// documented idempotent). Without this, len(SubSteps)>0 below would re-flag it
+	// and lowerSteps would dissolve the parallel into a sequential group, losing
+	// the concurrency and the join policy. (Lowered foreach already returns false:
+	// it uses Items+Step, leaving SubSteps/ParallelSteps/ForEachExpr empty.)
+	if s.Type == StepTypeParallel {
+		return false
+	}
 	return s.If != "" || s.RejectWhen != "" || s.OnReject != nil ||
 		len(s.SubSteps) > 0 || len(s.ParallelSteps) > 0 || s.ForEachExpr != "" || s.Output != nil
 }


### PR DESCRIPTION
## Summary

- `LowerV2Workflow` is documented as idempotent, but the invariant was violated for `parallel:` steps.
- An already-lowered `parallel` node has `Type==parallel` with its children in `SubSteps`. Since `StepConfig.IsV2Step()` returned `true` whenever `len(SubSteps)>0`, a second lowering pass re-flagged the node and `lowerSteps` fell into the group branch (`len(SubSteps)>0`), **dissolving the parallel into a sequential chain** — silently losing the concurrency and the `join` policy. (foreach wasn't affected: it lowers to `Items`+`Step`, leaving `SubSteps`/`ParallelSteps`/`ForEachExpr` empty.)
- Relevant because `Config.Validate` lowers **in-place** (`LowerV2WorkflowInConfig`); the only thing preventing the regression today was the incidental coupling of "nobody validates the same `*Config` twice".

### Fix
- **`IsV2Step`**: treats `Type==StepTypeParallel` as already-lowered (`return false`), so a re-pass exits early in `LowerV2Workflow`.
- **`lowerSteps`**: passes already-typed `parallel`/`foreach` nodes through intact (covers the mixed case — raw v2 alongside an already-lowered node — where `anyV2Steps` returns true and the lowering runs anyway).
- `LowerV2Workflow`'s doc adjusted to describe the invariant precisely (idempotent over its own output).

## Test plan

- A new regression test `TestLowerV2_ParallelDoubleLowerIdempotent`: lowers a workflow with `parallel:`, lowers the output again, and requires the parallel node to survive (`Type==parallel`, same `SubSteps`, same `Join`, same `DependsOn`) + `reflect.DeepEqual(once, twice)`. **Confirmed it fails without the fix** (the parallel is dissolved into `[setup, tests, docs]`).
- `cd src && go test ./internal/config/ ./internal/workflow/` → both **ok** (the existing suite, including `TestLowerV2_ParallelStepKept`, stays green).
- `go build ./...` and `go vet ./internal/config/` clean.