### PR TITLE
fix(config): preserve ${{ }} in env expansion and validate shipped examples

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -4,7 +4,7 @@ version: "1"
 # Define how agents will execute (CLI, API, custom gateway, etc.)
 runners:
   # Claude CLI runner (local development, no API keys needed)
-  - id: claude
+  - id: claude-cli
     type: cli
     provider: claude
     config:

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -452,6 +452,13 @@ func warnDeprecatedResultComment(cfg *Config) {
 
 func expandEnv(s string) string {
 	return os.Expand(s, func(key string) string {
+		// Leave workflow expression delimiters `${{ … }}` untouched — they are a
+		// supported authoring syntax (see lower_v2.lowerExpr), not env references.
+		// os.Expand splits `${{ expr }}` into key=`{ expr ` with the trailing `}`
+		// left in the stream, so returning `${`+key+`}` reconstitutes the literal.
+		if strings.HasPrefix(key, "{") {
+			return "${" + key + "}"
+		}
 		return os.Getenv(strings.TrimSpace(key))
 	})
 }

--- a/src/internal/config/expand_env_test.go
+++ b/src/internal/config/expand_env_test.go
@@ -1,0 +1,45 @@
+package config
+
+import "testing"
+
+// TestExpandEnv covers the env-var expansion done before YAML parsing. The key
+// invariant — beyond expanding genuine ${VAR}/$VAR references — is that workflow
+// expression delimiters `${{ … }}` survive untouched, since os.Expand would
+// otherwise mangle them into invalid YAML before the parser ever sees them.
+func TestExpandEnv(t *testing.T) {
+	t.Setenv("APIARY_TEST_TOKEN", "secret123")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"braced ref", "key: ${APIARY_TEST_TOKEN}", "key: secret123"},
+		{"bare ref", "key: $APIARY_TEST_TOKEN", "key: secret123"},
+		{"spaced braced ref", "key: ${ APIARY_TEST_TOKEN }", "key: secret123"},
+		{"unset ref expands empty", "key: ${APIARY_TEST_UNSET}", "key: "},
+		{
+			"expression delimiter preserved",
+			`if: ${{ memory.complexity == "high" }}`,
+			`if: ${{ memory.complexity == "high" }}`,
+		},
+		{
+			"expression with simple ident preserved",
+			`if: ${{ cell.priority == "high" }}`,
+			`if: ${{ cell.priority == "high" }}`,
+		},
+		{
+			"env ref and expression coexist in one string",
+			`api_key: ${APIARY_TEST_TOKEN}` + "\n" + `if: ${{ memory.x == "y" }}`,
+			`api_key: secret123` + "\n" + `if: ${{ memory.x == "y" }}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := expandEnv(tc.in); got != tc.want {
+				t.Errorf("expandEnv(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/src/internal/config/lint_test.go
+++ b/src/internal/config/lint_test.go
@@ -109,10 +109,17 @@ func TestLint_EmptyRawContentIsNoOp(t *testing.T) {
 	}
 }
 
-// TestLint_ExampleConfigsNoFalsePositives strict-decodes and removed-checks every
-// shipped example so a stricter validator never rejects a config we ship.
+// TestLint_ExampleConfigsNoFalsePositives strict-decodes, removed-checks, AND
+// fully validates every shipped example so neither a stricter linter nor the
+// structural validator ever rejects a config we ship. lint() alone is not
+// enough: it never runs Validate(), which is how a runner-id mismatch
+// (default_runner / agent runner not defined in runners) once slipped through a
+// shipped example. Validate() resolves soul_file paths against the process
+// working directory, so the test runs from the repo root where the examples'
+// relative soul_file paths live.
 func TestLint_ExampleConfigsNoFalsePositives(t *testing.T) {
 	root := repoRoot(t)
+	t.Chdir(root)
 	examples := []string{
 		".apiary/example-apiary-full.yaml",
 		".apiary/example-workflow.yaml",
@@ -120,14 +127,23 @@ func TestLint_ExampleConfigsNoFalsePositives(t *testing.T) {
 		".apiary/apiary.yaml",
 	}
 	for _, rel := range examples {
-		rel := rel
 		t.Run(rel, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join(root, rel))
+			data, err := os.ReadFile(rel)
 			if err != nil {
 				t.Skipf("example not found: %v", err)
 			}
 			if errs := newRawConfig(string(data)).lint(); len(errs) != 0 {
 				t.Errorf("%s should lint clean, got: %v", rel, errs)
+			}
+			// Full structural validation must also be clean: Load() parses and
+			// expands env vars, Validate() checks runner/source/agent references
+			// and soul_file existence.
+			cfg, err := Load(rel)
+			if err != nil {
+				t.Fatalf("%s should load, got: %v", rel, err)
+			}
+			if errs := cfg.Validate(); len(errs) != 0 {
+				t.Errorf("%s should Validate clean, got: %v", rel, errs)
 			}
 		})
 	}

--- a/tools/vscode-apiary/package-lock.json
+++ b/tools/vscode-apiary/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "vscode-apiary",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-apiary",
-      "version": "0.1.0",
+      "version": "0.1.2",
+      "license": "AGPL-3.0",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },


### PR DESCRIPTION
## Summary

Recovers already-implemented and tested work that was uncommitted in the working tree. Two fronts:

**Config — env expansion + example validation**
- `expandEnv` now preserves the workflow expression delimiters `${{ … }}`. Without this, `os.Expand` breaks `${{ expr }}` into invalid YAML **before** the parser sees the file (the expansion runs pre-parse). A new `expand_env_test.go` covers the invariant: `${VAR}`/`$VAR`/`${ VAR }` still expand, but `${{ … }}` survives intact.
- `TestLint_ExampleConfigsNoFalsePositives` now runs **`Load()` + `Validate()`** on each shipped example, not just `lint()`. `lint()` alone never called `Validate()`, which is how a runner-id mismatch (default_runner / agent runner not defined in `runners`) slipped through in one example. Uses `t.Chdir(root)` to resolve the relative `soul_file`s.
- `example-apiary-full.yaml`: renames the runner `id: claude` → `claude-cli`, aligning with `default_runner: claude-cli` and the 6 agents that **already** referenced `claude-cli`. Without the rename the example fails the new validation.

**VS Code extension**
- `package-lock.json` synced with the `0.1.2` version + `license: AGPL-3.0` that were already in the committed `package.json` (only the lockfile was stale).

## Test plan

- `cd src && go test ./...` → all **ok** (includes `TestExpandEnv` and the reinforced `TestLint_ExampleConfigsNoFalsePositives` validating `example-apiary-full.yaml`).
- `go build ./...` and `go vet ./internal/config/` clean.

> Note: these changes were already compiled into the locally installed binary (`v0.1.0-2-...-dirty`); this PR makes them part of `main` so the build stops being `-dirty`.