### PR TITLE
feat(dispatch): internal in-flight guard per (task, workflow)

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -766,6 +766,13 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		}
 		task, persisted := d.bindItem(ctx, cell)
 		matches := d.router.RouteAll(task)
+		// Source-agnostic in-flight guard: drop any matched workflow that already
+		// has a non-terminal instance for this task, so a re-poll does not dispatch
+		// a duplicate while it runs or waits at an approval step. Replaces the
+		// label-based lock (state_lock / "in-progress"), which is source-specific.
+		if persisted && d.db != nil {
+			matches = d.dropActiveMatches(ctx, task.ID, matches)
+		}
 		if len(matches) == 0 {
 			aplog.Debug("cell %s (%q): no matching route, skipping", cell.ID, cell.Title)
 			d.inFlight.Delete(cell.ID)
@@ -891,6 +898,31 @@ func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task 
 	}
 	aplog.Debug("bound source item %s → task %s [%s]", cell.ID, task.ID, task.State)
 	return task, true
+}
+
+// dropActiveMatches removes matches whose workflow already has a non-terminal
+// instance for this task (running or approval_waiting). It is the source-agnostic
+// in-flight guard: the in-memory inFlight marker is released when a workflow parks
+// at an approval step, so without this a later poll would dispatch a duplicate
+// while the instance is still waiting. Keyed on (task, workflow) so a completed
+// earlier workflow (e.g. triage) does not block the one a hand-off routes to.
+// Fail-closed: on a query error the match is dropped (skip this poll, retry next)
+// rather than risk a duplicate dispatch.
+func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, matches []router.Match) []router.Match {
+	out := make([]router.Match, 0, len(matches))
+	for _, m := range matches {
+		active, err := d.db.HasActiveInstanceForRoute(ctx, taskID, m.Route.ID)
+		if err != nil {
+			aplog.Error("in-flight check task %s workflow %s: %v — skipping this poll", taskID, m.Route.ID, err)
+			continue
+		}
+		if active {
+			aplog.Debug("task %s: workflow %s already active (running/approval_waiting), skipping re-dispatch", taskID, m.Route.ID)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // dispatch acknowledges, runs, and writes the result for a single task.

--- a/src/internal/daemon/inflight_guard_test.go
+++ b/src/internal/daemon/inflight_guard_test.go
@@ -1,0 +1,52 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// TestDropActiveMatches verifies the source-agnostic in-flight guard: a workflow
+// with a non-terminal instance for the task is dropped (no re-dispatch), while a
+// completed earlier workflow and a not-yet-run workflow are kept — so the
+// triage→implementation hand-off still flows and a parked instance isn't doubled.
+func TestDropActiveMatches(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "inflight.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	// task T1: implementation parked at an approval step (the gap inFlight misses);
+	// triage already done.
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "implementation", CellID: "1948", TaskID: "T1", State: db.InstanceStateApprovalWaiting})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "triage", CellID: "1948", TaskID: "T1", State: db.InstanceStateDone})
+
+	d := &Dispatcher{db: dbc}
+
+	matches := []router.Match{
+		{Route: config.RouteConfig{ID: "implementation"}}, // active → dropped
+		{Route: config.RouteConfig{ID: "triage"}},         // done → kept
+		{Route: config.RouteConfig{ID: "po-spec"}},        // never ran → kept
+	}
+	got := d.dropActiveMatches(ctx, "T1", matches)
+
+	kept := map[string]bool{}
+	for _, m := range got {
+		kept[m.Route.ID] = true
+	}
+	if kept["implementation"] {
+		t.Error("implementation is parked (approval_waiting) and must be dropped")
+	}
+	if !kept["triage"] || !kept["po-spec"] {
+		t.Errorf("triage(done)/po-spec(absent) must be kept; got %v", kept)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 kept matches, got %d", len(got))
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -126,6 +126,26 @@ func (c *Client) HasFailedInstance(ctx context.Context, taskID string) (bool, er
 	return n > 0, err
 }
 
+// HasActiveInstanceForRoute reports whether the task already has a non-terminal
+// instance for the given workflow — running or approval_waiting. The dispatcher
+// uses it as a source-agnostic in-flight guard: it stops a later poll from
+// dispatching a duplicate while the workflow runs or, crucially, waits at an
+// approval step (where the in-memory inFlight marker has already been released).
+// Keyed on (task, workflow) so a completed earlier workflow (e.g. triage) does not
+// block the next one a hand-off routes to. terminal/interrupted states do not
+// block — they remain eligible for retry or manual resume.
+func (c *Client) HasActiveInstanceForRoute(ctx context.Context, taskID, workflowID string) (bool, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_instances
+		WHERE task_id = ? AND workflow_id = ? AND state IN (?, ?)
+	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting).Scan(&n)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return n > 0, err
+}
+
 // ListWorkflowInstancesByState returns all instances in the given state, oldest first.
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -124,6 +124,44 @@ func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
 	}
 }
 
+func TestHasActiveInstanceForRoute(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// task T1: triage already done; implementation running.
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-triage", WorkflowID: "triage", CellID: "1948", TaskID: "T1", State: InstanceStateDone})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-impl", WorkflowID: "implementation", CellID: "1948", TaskID: "T1", State: InstanceStateRunning})
+	// task T2: implementation parked at an approval step.
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-impl", WorkflowID: "implementation", CellID: "2000", TaskID: "T2", State: InstanceStateApprovalWaiting})
+	// task T3: implementation failed (terminal — eligible for retry, must NOT block).
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-impl", WorkflowID: "implementation", CellID: "3000", TaskID: "T3", State: InstanceStateFailed})
+
+	cases := []struct {
+		name       string
+		taskID     string
+		workflowID string
+		want       bool
+	}{
+		{"running blocks", "T1", "implementation", true},
+		{"approval_waiting blocks (the park gap)", "T2", "implementation", true},
+		{"done earlier workflow does not block hand-off", "T1", "triage", false},
+		{"different task not blocked", "T2", "triage", false},
+		{"failed is terminal, retry allowed", "T3", "implementation", false},
+		{"unknown task", "T9", "implementation", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := c.HasActiveInstanceForRoute(ctx, tc.taskID, tc.workflowID)
+			if err != nil {
+				t.Fatalf("HasActiveInstanceForRoute: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("HasActiveInstanceForRoute(%q,%q) = %v, want %v", tc.taskID, tc.workflowID, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWorkflowInstance_ListByTask(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)


### PR DESCRIPTION
## Summary
Replaces the source label (`state_lock`/`in-progress`) as the **duplicate-dispatch** guard with an internal, **source-agnostic** (GitHub/Jira/Plane) control in the DB.

**Motivation:** the guard today is two mechanisms — `inFlight` (in-memory, per poll) + the `in-progress` label. `inFlight` is released when a workflow **parks on an `approval`** (`RunInstance` returns); during that wait, only the label prevented the 60s poll from dispatching a 2nd instance. That tied the pipeline to the source's label mechanics.

**Changes:**
- `db.HasActiveInstanceForRoute(taskID, workflowID)` — is there a non-terminal instance (`running`/`approval_waiting`) for the `(task, workflow)` pair?
- `dispatcher.dropActiveMatches` — filters out already-active matches during the poll. Keyed by `(task, workflow)` so it doesn't block the hand-off (a `done` triage doesn't bar `implementation`). Fail-closed on a query error. Covers exactly the `inFlight` gap during the park.
- Tests: `HasActiveInstanceForRoute` (running/approval_waiting block; done/failed/different task don't) and `dropActiveMatches`.

Allows turning `state_lock` off in the consumer (project-erp) and removing the `in-progress` dependency.

## Test plan
- [x] `make test` green (includes the new tests).
- [x] `make vet` clean.
- [x] `make install` and smoke (`apiary validate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)