### PR TITLE
fix(github): do not ingest pull requests as tasks

### DIFF
--- a/docs/apiary-guide.md
+++ b/docs/apiary-guide.md
@@ -214,8 +214,7 @@ sources:
 **Key behavior:**
 
 - Poll returns **ALL** matching issues every cycle. `inFlight` map prevents re-dispatch of already-running tasks.
-- PRs are NOT filtered out — they become Cells with `Type: "pull_request"`.
-- To route only PRs: `match.types: ["pull_request"]` in the route.
+- Pull requests are filtered out during polling (GitHub's `/issues` endpoint returns PRs too, but they are not work items). GitHub Cells are always `Type: "issue"`.
 
 #### Plane source
 
@@ -297,7 +296,7 @@ routes:
 | `priority` | Lower number = evaluated first |
 | `match.source` | Source ID to match |
 | `match.labels` | Cell must have ALL these labels |
-| `match.types` | Cell types to match (e.g. `[pull_request]`) |
+| `match.types` | Cell types to match (GitHub Cells are always `issue`) |
 | `match.states` | Cell states to match |
 | `match.exclude_label_prefix` | Exclude cells with labels starting with prefix (e.g. `agent:`) |
 | `agent` | Target agent ID |
@@ -312,9 +311,6 @@ Agents can output directives that Apiary parses from their final response:
 | Directive | Action |
 |---|---|
 | `APIARY-ASSIGN: <agent-id>` | Adds `agent:<agent-id>` label to source, reassigns task |
-| `APIARY-REVIEW: approve \| request-changes \| comment` | Submits a PR review (GitHub only) |
-
-PR review is standalone in the dispatcher (not via source adapter) — sources are for issue tracking, PRs are code review.
 
 ### `settings`
 
@@ -369,15 +365,6 @@ In detail view: `m` cycles model, `r` cycles runner, `w` cycles max_workers. Cha
 |---|---|
 | `w` | Toggle word wrap |
 | `←` / `→` | Horizontal scroll (when wrap is off) |
-
-## PR Review
-
-When an agent returns a response containing `APIARY-REVIEW: approve | request-changes | comment`, Apiary calls the GitHub API to submit a PR review on the pull request associated with the Cell.
-
-- Parsed from agent output via regex
-- Calls `POST /repos/{owner}/{repo}/pulls/{number}/reviews`
-- Uses agent's `source_token` if set
-- Independent of source adapter — works with any issue tracker via GitHub source
 
 ## Key Concepts
 

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -1,8 +1,9 @@
 # GitHub Source
 
 The `github` source adapter polls issues from a GitHub repository and maps them
-to Apiary Cells for routing and dispatch. Pull requests are also included as
-cells with `Type: "pull_request"`.
+to Apiary Cells for routing and dispatch. Pull requests are **not** ingested:
+GitHub's issues endpoint also returns PRs (every PR is an issue in the API), but
+the adapter skips them — PRs are implementation artifacts, not work items.
 
 ## Configuration
 
@@ -44,9 +45,9 @@ sources:
 | **SetState** | `PATCH /repos/{owner}/{repo}/issues/{number}` (sets `state`) | Via `route.on_complete.set_state` |
 | **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `route.on_complete.add_labels` or `assign_from_output` |
 
-Both issues and pull requests are returned by the poll. PRs are not filtered
-out — they get `Type: "pull_request"` and can be routed independently via
-`match.types: ["pull_request"]`.
+GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
+them out during polling — only plain issues become cells (always
+`Type: "issue"`).
 
 ## Token permissions
 
@@ -140,7 +141,7 @@ Routes are evaluated in `priority` ascending order. The first match wins.
 | `exclude_labels` | `[string]` | Cell must NOT have any of these labels |
 | `exclude_label_prefix` | `string` | Cell must not have a label starting with this prefix |
 | `states` | `[string]` | Only match cells whose state is in this list |
-| `types` | `[string]` | Only match cells whose type is in this list (e.g. `["pull_request"]`) |
+| `types` | `[string]` | Only match cells whose type is in this list (GitHub cells are always `"issue"`) |
 | `title_regex` | `string` | Cell title must match this Go regexp |
 | `priority` | `[string]` | Only match cells whose priority is in this list |
 
@@ -182,50 +183,6 @@ The fallback catches any cell without an `agent:*` label. The investigator
 classifies it and outputs `APIARY-ASSIGN: engineer`, which Apiary converts
 to the label `agent:engineer`. On the next poll, the matching route fires.
 
-## PR Review
-
-When a cell has `Type: "pull_request"` and the agent's output contains an
-`APIARY-REVIEW` directive, the dispatcher submits a formal GitHub PR review.
-
-### Directive
-
-The agent outputs one of these (last directive wins):
-
-```
-APIARY-REVIEW: approve
-APIARY-REVIEW: request-changes
-APIARY-REVIEW: comment
-```
-
-### Route
-
-```yaml
-routes:
-  - id: review-pr
-    priority: 12
-    match:
-      source: my-repo
-      types: [pull_request]
-    agent: reviewer
-    on_complete:
-      set_state: closed
-```
-
-### How it works
-
-1. Poll returns the PR as a cell with `Type: "pull_request"`
-2. Route matches by `types: [pull_request]` → dispatches to reviewer agent
-3. Reviewer agent gets the PR number (`cell.ID`), description, labels
-4. Agent reviews the code (e.g. via `gh pr diff {number}`)
-5. Agent outputs `APIARY-REVIEW: approve`
-6. Dispatcher calls `POST /repos/{owner}/{repo}/pulls/{number}/reviews`
-   using the agent's `source_token` — the review comes from the agent's
-   GitHub identity
-
-PR review is independent of the source adapter. The repo is parsed from the
-cell's URL, and the token comes from `agent.source_token` (with fallback to
-the source-level `api_key`).
-
 ## Environment variables
 
 ### `.env` auto-load
@@ -261,7 +218,6 @@ Agents can output directives in their final output to trigger side effects:
 | Directive | Example | Effect |
 |---|---|---|
 | `APIARY-ASSIGN` | `APIARY-ASSIGN: engineer` | Adds label `agent:engineer` (via `assign_from_output`) |
-| `APIARY-REVIEW` | `APIARY-REVIEW: approve` | Submits PR review (approve/request-changes/comment) |
 
 ## Setting up locally
 

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -103,6 +103,13 @@ func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, er
 
 	var cells []model.SourceItem
 	for _, item := range issues {
+		// GitHub's /issues endpoint also returns pull requests (every PR is an
+		// issue in the API). PRs are implementation artifacts, not work items,
+		// so we never ingest them as tasks.
+		if item.PullRequest != nil {
+			aplog.Debug("  #%d (%q): pull request, skipping", item.Number, item.Title)
+			continue
+		}
 		if !a.matchesFilters(item) {
 			continue
 		}
@@ -278,12 +285,7 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 	createdAt, _ := time.Parse(time.RFC3339, item.CreatedAt)
 	updatedAt, _ := time.Parse(time.RFC3339, item.UpdatedAt)
 
-	cellType := "issue"
-	if item.PullRequest != nil {
-		cellType = "pull_request"
-	}
-
-	url := strings.Replace(item.HTMLURL, "/pull/", "/issues/", 1)
+	// Poll skips pull requests, so every ingested item is a plain issue.
 	return model.SourceItem{
 		ID:          fmt.Sprintf("%d", item.Number),
 		SourceID:    a.ID(),
@@ -291,9 +293,9 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		Title:       item.Title,
 		Description: item.Body,
 		Labels:      labels,
-		Type:        cellType,
+		Type:        "issue",
 		State:       item.State,
-		URL:         url,
+		URL:         item.HTMLURL,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 	}

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -223,3 +223,31 @@ func TestRemoveLabels_Ignores404(t *testing.T) {
 		t.Errorf("expected 404 to be ignored, got %v", err)
 	}
 }
+
+// TestPoll_SkipsPullRequests verifies that pull requests returned by GitHub's
+// /issues endpoint (every PR is also an issue in the API) are not ingested as
+// tasks — only plain issues become SourceItems.
+func TestPoll_SkipsPullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"number": 1, "title": "A real issue", "state": "open"},
+			{"number": 2, "title": "A pull request", "state": "open", "pull_request": {}}
+		]`))
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 (PR should be skipped): %+v", len(items), items)
+	}
+	if items[0].ID != "1" {
+		t.Errorf("ingested item ID = %q, want %q (the issue, not the PR)", items[0].ID, "1")
+	}
+	if items[0].Type != "issue" {
+		t.Errorf("Type = %q, want %q", items[0].Type, "issue")
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -45,8 +45,3 @@ type labelListRequest struct {
 type labelCreateRequest struct {
 	Name string `json:"name"`
 }
-
-type reviewRequest struct {
-	Event string `json:"event"`
-	Body  string `json:"body"`
-}


### PR DESCRIPTION
## Summary

- The GitHub adapter now **ignores pull requests** during the poll. GitHub's `/issues` endpoint also returns PRs (every PR is an issue in the API); since PRs are implementation artifacts and not work items, they no longer become tasks. Only issues become a `SourceItem` (always `Type: "issue"`).
- Removes dead code that became unreachable: the `pull_request` type detection and the `/pull/` → `/issues/` URL rewrite in `toSourceItem`.
- Removes the `reviewRequest` type — a vestige of the PR-review flow that had already been removed (no call site remained).
- Updates `docs/github-source.md` and `docs/apiary-guide.md`: removes the PR-ingestion documentation and the `APIARY-REVIEW` / PR Review section (they described already-removed features).

## Test plan

- A new test `TestPoll_SkipsPullRequests`: a payload with 1 issue + 1 PR results in only 1 `SourceItem` (the issue).
- `go build ./...`, `go vet ./internal/source/...` clean.
- `go test ./...` passes (full suite).