### PR TITLE
docs: remove references to the removed assign_from_output/APIARY-ASSIGN directive

### DIFF
--- a/docs/apiary-guide.md
+++ b/docs/apiary-guide.md
@@ -302,15 +302,6 @@ routes:
 | `agent` | Target agent ID |
 | `on_complete.set_state` | State to set on source when done |
 | `on_complete.add_labels` | Labels to add on source when done |
-| `on_complete.assign_from_output` | Parse `APIARY-ASSIGN: <agent>` from agent output and add label |
-
-#### `on_complete` directives
-
-Agents can output directives that Apiary parses from their final response:
-
-| Directive | Action |
-|---|---|
-| `APIARY-ASSIGN: <agent-id>` | Adds `agent:<agent-id>` label to source, reassigns task |
 
 ### `settings`
 

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -43,7 +43,7 @@ sources:
 | **Acknowledge** | `POST /repos/{owner}/{repo}/issues/{number}/labels` (adds `in-progress`) | When `settings.state_lock: true` |
 | **WriteResult** | `POST /repos/{owner}/{repo}/issues/{number}/comments` | When `settings.result_comment: true` |
 | **SetState** | `PATCH /repos/{owner}/{repo}/issues/{number}` (sets `state`) | Via `route.on_complete.set_state` |
-| **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `route.on_complete.add_labels` or `assign_from_output` |
+| **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `route.on_complete.add_labels` |
 
 GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
 them out during polling — only plain issues become cells (always
@@ -93,7 +93,7 @@ source-level `api_key`:
 - **Acknowledge** — adds `in-progress` label
 - **WriteResult** — posts comment with run output
 - **SetState** — closes/re-opens issue via `on_complete.set_state`
-- **AddLabels** — adds labels via `on_complete.add_labels` or `assign_from_output`
+- **AddLabels** — adds labels via `on_complete.add_labels`
 
 **Poll** always uses the source-level `api_key` — one account reads all issues.
 
@@ -151,14 +151,11 @@ Routes are evaluated in `priority` ascending order. The first match wins.
 |---|---|---|
 | `set_state` | `string` | Transition the cell to this state after a successful run |
 | `add_labels` | `[string]` | Add these labels to the cell after a successful run |
-| `assign_from_output` | `bool` | Parse `APIARY-ASSIGN: <agent>` from output and add label `agent:<agent>` |
-| `assign_label_prefix` | `string` | Label prefix for assign_from_output (default: `"agent:"`) |
 
-### Example: issue classification flow
+### Example: route by label
 
 ```yaml
 routes:
-  # Specific agent routes — evaluated first (lower priority wins)
   - id: engineer-implement
     priority: 20
     match:
@@ -167,21 +164,10 @@ routes:
     agent: engineer
     on_complete:
       set_state: closed
-
-  # Fallback: classify unassigned issues
-  - id: new-issue-classify
-    priority: 100
-    match:
-      source: my-repo
-      exclude_label_prefix: "agent:"
-    agent: investigator
-    on_complete:
-      assign_from_output: true
 ```
 
-The fallback catches any cell without an `agent:*` label. The investigator
-classifies it and outputs `APIARY-ASSIGN: engineer`, which Apiary converts
-to the label `agent:engineer`. On the next poll, the matching route fires.
+The route matches any cell carrying the `agent:engineer` label and dispatches
+it to the engineer agent, closing the issue when the run succeeds.
 
 ## Environment variables
 
@@ -210,14 +196,6 @@ No manual sourcing needed — `Config.Load()` handles it.
 | `GIT_AUTHOR_EMAIL` | Runner — set from `agent.source_email` |
 | `GIT_COMMITTER_NAME` | Runner — same as `GIT_AUTHOR_NAME` |
 | `GIT_COMMITTER_EMAIL` | Runner — same as `GIT_AUTHOR_EMAIL` |
-
-## `on_complete` directives
-
-Agents can output directives in their final output to trigger side effects:
-
-| Directive | Example | Effect |
-|---|---|---|
-| `APIARY-ASSIGN` | `APIARY-ASSIGN: engineer` | Adds label `agent:engineer` (via `assign_from_output`) |
 
 ## Setting up locally
 


### PR DESCRIPTION
## Summary

Follows the cleanup noted in PR #86. `on_complete.assign_from_output`, `on_complete.assign_label_prefix` and the `APIARY-ASSIGN` directive were already **removed from the engine** — `config/lint.go` hard-errors if they appear in the config. But the docs still documented them as active features.

- `docs/github-source.md`: removes the two `on_complete` table rows (`assign_from_output`, `assign_label_prefix`), the mentions in "What the adapter does" / `source_token`, and the `## on_complete directives` section (whose only line was `APIARY-ASSIGN`). The "issue classification flow" example (which existed only to demonstrate the removed directive) becomes a simple route-by-label example.
- `docs/apiary-guide.md`: removes the `on_complete.assign_from_output` line and the `on_complete directives` subsection.

**Out of scope (user's decision):** the `routes:` model itself — which was also replaced by `workflows[].trigger` — remains documented. Left for a separate cleanup.

## Test plan

- Docs-only, no code change.
- `grep -rn 'assign_from_output|assign_label_prefix|APIARY-ASSIGN' docs/` returns empty.