### PR TITLE
feat(dashboard): per-task workflow history (instances + steps + logs)

### DIFF
--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -47,6 +47,7 @@ func init() {
 		newValidateCmd(),
 		newCellsCmd(),
 		newInstancesCmd(),
+		newTaskCmd(),
 		newResumeCmd(),
 		newClearCmd(),
 		newDispatchCmd(),

--- a/src/internal/cli/task.go
+++ b/src/internal/cli/task.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+// newTaskCmd renders the full workflow history of a single InternalTask: every
+// workflow instance it ran (e.g. investigator → implementation), each as a labeled
+// section with its steps and the log lines scoped to that instance's time window.
+func newTaskCmd() *cobra.Command {
+	var (
+		source string
+		item   string
+		asJSON bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "task [internal-task-id]",
+		Short: "Show a task's full workflow history (all instances, steps, scoped logs)",
+		Long: "Show a task's full workflow history. Pass the InternalTask id, or locate it\n" +
+			"from a source item with --source and --item (e.g. --source github --item 1948).",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			q := url.Values{}
+			switch {
+			case len(args) == 1:
+				q.Set("task", args[0])
+			case source != "" && item != "":
+				q.Set("source", source)
+				q.Set("item", item)
+			default:
+				return fmt.Errorf("provide a task id, or both --source and --item")
+			}
+
+			var resp daemon.TaskHistoryResponse
+			if err := ipcGetJSON("/tasks/history?"+q.Encode(), &resp); err != nil {
+				if strings.Contains(err.Error(), "not found") {
+					fmt.Println(instErr.Render("No task history found."))
+					os.Exit(2)
+				}
+				return daemonDownHint()
+			}
+
+			if asJSON {
+				line, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Println(string(line))
+				return nil
+			}
+			renderTaskHistory(resp)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&source, "source", "", "resolve the task by source id (with --item), e.g. github")
+	cmd.Flags().StringVar(&item, "item", "", "resolve the task by source item id/number (with --source), e.g. 1948")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+// renderTaskHistory prints the per-instance history top-to-bottom (oldest first):
+// for each workflow instance, a section header, its steps, then its scoped logs.
+func renderTaskHistory(resp daemon.TaskHistoryResponse) {
+	head := resp.TaskID
+	if resp.Title != "" {
+		head += " — " + resp.Title
+	}
+	fmt.Printf("%s  %s\n", instMuted.Render("Task:"), head)
+
+	if len(resp.Segments) == 0 {
+		fmt.Println(instMuted.Render("No workflow instances yet."))
+		return
+	}
+
+	for _, seg := range resp.Segments {
+		in := seg.Instance
+		fmt.Println()
+		// ── <glyph> <workflow> · <state> · <started> (<duration>) ──
+		header := fmt.Sprintf("%s %s · %s · %s (%s)",
+			stateGlyph(in.State), instHeader.Render(in.Workflow), in.State, in.Started, in.Duration)
+		fmt.Println(instMuted.Render("── ") + header + instMuted.Render(" ──"))
+
+		for _, s := range seg.Steps {
+			state := s.State
+			if s.Cached {
+				state += " (cached)"
+			}
+			fmt.Printf("  %s %-16s %-14s %-8s %s\n",
+				stepGlyph(s.State), truncate(s.StepID, 16), truncate(s.AgentID, 14),
+				s.Duration, stateColor(s.State).Render(state))
+			if s.Summary != "" {
+				fmt.Println(instMuted.Render("      " + truncate(s.Summary, 100)))
+			}
+		}
+
+		for _, l := range seg.Logs {
+			fmt.Printf("  %s %s %s\n",
+				instMuted.Render(l.Timestamp.Format("15:04:05")), logLevelTag(l.Level), l.Message)
+		}
+	}
+}
+
+// logLevelTag renders a fixed-width, color-coded log level.
+func logLevelTag(level string) string {
+	switch strings.ToUpper(level) {
+	case "ERROR":
+		return instErr.Render("ERROR")
+	case "WARN":
+		return instWarn.Render("WARN ")
+	default:
+		return instMuted.Render(fmt.Sprintf("%-5s", strings.ToUpper(level)))
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -610,6 +610,47 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(detail)
 	})
+	mux.HandleFunc("/tasks/history", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// Either ?task=<internal-task-id> directly, or ?source=<id>&item=<num>
+		// (e.g. github + 1948) which is resolved to the bound task.
+		taskID := r.URL.Query().Get("task")
+		if taskID == "" {
+			source, item := r.URL.Query().Get("source"), r.URL.Query().Get("item")
+			if source == "" || item == "" {
+				http.Error(w, "provide ?task=<id> or ?source=<id>&item=<num>", http.StatusBadRequest)
+				return
+			}
+			if d.db == nil {
+				http.Error(w, "no database", http.StatusServiceUnavailable)
+				return
+			}
+			binding, err := d.db.SourceBindings().GetBindingBySourceItem(r.Context(), source, item)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if binding == nil {
+				http.Error(w, "no task bound to "+source+"/"+item, http.StatusNotFound)
+				return
+			}
+			taskID = binding.TaskID
+		}
+		hist, err := d.TaskHistory(r.Context(), taskID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if hist == nil {
+			http.Error(w, "task history not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(hist)
+	})
 	mux.HandleFunc("/resume/", func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimPrefix(r.URL.Path, "/resume/")
 		if id == "" {

--- a/src/internal/daemon/task_history_test.go
+++ b/src/internal/daemon/task_history_test.go
@@ -1,0 +1,87 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func mustCreateInstance(t *testing.T, dbc *db.Client, inst *db.WorkflowInstance) {
+	t.Helper()
+	if err := dbc.CreateWorkflowInstance(context.Background(), inst); err != nil {
+		t.Fatalf("create instance %s: %v", inst.ID, err)
+	}
+}
+
+// TestTaskHistory_OrdersInstancesAndMapsStepsAndLogs verifies the IPC mapping:
+// segments are oldest-first and each instance's summary/steps/logs are carried
+// into the view. (Precise per-instance log windowing is covered at the db layer
+// in TestGetTaskWorkflowHistory_*.)
+func TestTaskHistory_OrdersInstancesAndMapsStepsAndLogs(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "history.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	const task, cell = "task-1", "issue-1948"
+	// Past dates so the WriteTaskLog line (timestamped now) lands in the latest,
+	// open-ended instance window regardless of when the test runs.
+	t0 := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * time.Minute)
+
+	mustCreateInstance(t, dbc, &db.WorkflowInstance{ID: "wi_inv", WorkflowID: "investigator", TaskID: task, CellID: cell, State: db.InstanceStateDone, CreatedAt: t0})
+	mustCreateInstance(t, dbc, &db.WorkflowInstance{ID: "wi_impl", WorkflowID: "implementation", TaskID: task, CellID: cell, State: db.InstanceStateRunning, CreatedAt: t1})
+
+	for _, s := range []struct{ inst, step string }{{"wi_inv", "classify"}, {"wi_inv", "triage"}, {"wi_impl", "implement"}} {
+		if err := dbc.CreateStepRun(ctx, &db.StepRun{ID: s.inst + "-" + s.step, WorkflowInstanceID: s.inst, StepID: s.step, AgentID: "ag", State: db.StepStatePassed}); err != nil {
+			t.Fatalf("create step %s/%s: %v", s.inst, s.step, err)
+		}
+	}
+	_ = dbc.WriteTaskLog(ctx, cell, "INFO", "started implementation workflow")
+
+	resp, err := (&Dispatcher{db: dbc}).TaskHistory(ctx, task)
+	if err != nil {
+		t.Fatalf("TaskHistory: %v", err)
+	}
+	if resp == nil || len(resp.Segments) != 2 {
+		t.Fatalf("expected 2 segments, got %+v", resp)
+	}
+	if resp.Segments[0].Instance.Workflow != "investigator" || resp.Segments[1].Instance.Workflow != "implementation" {
+		t.Fatalf("segments out of order: %q then %q (want investigator then implementation)",
+			resp.Segments[0].Instance.Workflow, resp.Segments[1].Instance.Workflow)
+	}
+	if len(resp.Segments[0].Steps) != 2 {
+		t.Errorf("investigator step views = %d, want 2", len(resp.Segments[0].Steps))
+	}
+	if len(resp.Segments[1].Steps) != 1 || resp.Segments[1].Steps[0].StepID != "implement" {
+		t.Errorf("implementation steps = %+v, want [implement]", resp.Segments[1].Steps)
+	}
+	if resp.Segments[1].Instance.State != db.InstanceStateRunning {
+		t.Errorf("implementation state = %q, want running", resp.Segments[1].Instance.State)
+	}
+	if len(resp.Segments[1].Logs) != 1 || resp.Segments[1].Logs[0].Message != "started implementation workflow" {
+		t.Errorf("implementation logs = %+v, want one mapped line", resp.Segments[1].Logs)
+	}
+}
+
+func TestTaskHistory_NoInstancesReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	resp, err := (&Dispatcher{db: dbc}).TaskHistory(ctx, "nobody")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("expected nil for a task with no instances, got %+v", resp)
+	}
+}

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -192,29 +192,88 @@ func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDe
 		return nil, err
 	}
 	for _, s := range steps {
-		srv := StepRunView{
-			StepID:     s.StepID,
-			AgentID:    s.AgentID,
-			State:      s.State,
-			Duration:   stepDuration(s, now),
-			Cached:     s.SkippedCached,
-			Output:     s.Output,
-			Summary:    s.Summary,
-			StartedAt:  s.StartedAt,
-			FinishedAt: s.FinishedAt,
-		}
-		// Enrich with token/cost data via the step link columns.
-		if usage, err := d.db.GetStepUsage(ctx, id, s.StepID); err == nil && usage != nil {
-			srv.InputTokens = usage.InputTokens
-			srv.OutputTokens = usage.OutputTokens
-			srv.TotalTokens = usage.TotalTokens
-			srv.CostUSD = usage.CostUSD
-			srv.NumTurns = usage.NumTurns
-			srv.NumToolCalls = usage.NumToolCalls
-		}
-		detail.Steps = append(detail.Steps, srv)
+		detail.Steps = append(detail.Steps, d.stepRunView(ctx, id, s, now))
 	}
 	return detail, nil
+}
+
+// stepRunView maps a stored step run to its IPC view, enriching token/cost usage
+// via the step link columns. Shared by InstanceDetail and TaskHistory.
+func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.StepRun, now time.Time) StepRunView {
+	srv := StepRunView{
+		StepID:     s.StepID,
+		AgentID:    s.AgentID,
+		State:      s.State,
+		Duration:   stepDuration(s, now),
+		Cached:     s.SkippedCached,
+		Output:     s.Output,
+		Summary:    s.Summary,
+		StartedAt:  s.StartedAt,
+		FinishedAt: s.FinishedAt,
+	}
+	if usage, err := d.db.GetStepUsage(ctx, instanceID, s.StepID); err == nil && usage != nil {
+		srv.InputTokens = usage.InputTokens
+		srv.OutputTokens = usage.OutputTokens
+		srv.TotalTokens = usage.TotalTokens
+		srv.CostUSD = usage.CostUSD
+		srv.NumTurns = usage.NumTurns
+		srv.NumToolCalls = usage.NumToolCalls
+	}
+	return srv
+}
+
+// TaskLogLineView is one log line scoped to a task-history segment's instance.
+type TaskLogLineView struct {
+	Timestamp time.Time `json:"timestamp"`
+	Level     string    `json:"level"`
+	Message   string    `json:"message"`
+}
+
+// TaskHistorySegmentView is one workflow instance's slice of a task's history:
+// the instance summary, its steps, and the logs scoped to its time window.
+type TaskHistorySegmentView struct {
+	Instance InstanceSummary   `json:"instance"`
+	Steps    []StepRunView     `json:"steps"`
+	Logs     []TaskLogLineView `json:"logs"`
+}
+
+// TaskHistoryResponse is the payload for GET /tasks/{id}/history.
+type TaskHistoryResponse struct {
+	TaskID   string                   `json:"task_id"`
+	Title    string                   `json:"title"`
+	Segments []TaskHistorySegmentView `json:"segments"`
+}
+
+// TaskHistory returns the full per-instance history for an InternalTask, oldest
+// instance first (each instance with its steps and time-windowed logs). Returns
+// (nil, nil) when the task has no workflow instances.
+func (d *Dispatcher) TaskHistory(ctx context.Context, internalTaskID string) (*TaskHistoryResponse, error) {
+	if d.db == nil {
+		return nil, nil
+	}
+	segs, err := d.db.GetTaskWorkflowHistory(ctx, internalTaskID)
+	if err != nil {
+		return nil, err
+	}
+	if len(segs) == 0 {
+		return nil, nil
+	}
+	now := time.Now()
+	// All instances of a task share one cell, so one title lookup covers them all.
+	title, _ := d.db.GetTaskTitle(ctx, segs[0].Instance.CellID)
+	resp := &TaskHistoryResponse{TaskID: internalTaskID, Title: title}
+	for _, seg := range segs {
+		view := db.WorkflowInstanceView{WorkflowInstance: seg.Instance, Title: title}
+		sv := TaskHistorySegmentView{Instance: instanceSummary(view, now)}
+		for _, s := range seg.Steps {
+			sv.Steps = append(sv.Steps, d.stepRunView(ctx, seg.Instance.ID, s, now))
+		}
+		for _, l := range seg.Logs {
+			sv.Logs = append(sv.Logs, TaskLogLineView{Timestamp: l.Timestamp, Level: l.Level, Message: l.Message})
+		}
+		resp.Segments = append(resp.Segments, sv)
+	}
+	return resp, nil
 }
 
 func instanceSummary(v db.WorkflowInstanceView, now time.Time) InstanceSummary {

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -71,6 +71,11 @@ type taskLogsMsg struct {
 	logs   []LogEntry
 	detail *TaskItem
 }
+type taskHistoryMsg struct {
+	taskID   string
+	segments []TaskHistorySegmentItem
+	detail   *TaskItem
+}
 type agentsDataMsg struct{ agents []AgentStatus }
 type agentActivityMsg struct {
 	agentID string
@@ -152,6 +157,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case taskLogsMsg:
 		if a.model.tasksTab != nil {
 			a.model.tasksTab.Logs = msg.logs
+			a.model.tasksTab.InstanceHistory = nil
+			a.model.tasksTab.Detail = msg.detail
+			a.model.tasksTab.LogScroll = 0
+			a.model.tasksTab.View = TaskViewLogs
+		}
+		a.model.loading = false
+
+	case taskHistoryMsg:
+		if a.model.tasksTab != nil {
+			a.model.tasksTab.InstanceHistory = msg.segments
+			a.model.tasksTab.Logs = nil
 			a.model.tasksTab.Detail = msg.detail
 			a.model.tasksTab.LogScroll = 0
 			a.model.tasksTab.View = TaskViewLogs
@@ -775,6 +791,7 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		t.View = TaskViewList
 		t.Detail = nil
 		t.Logs = nil
+		t.InstanceHistory = nil
 		t.LogScroll = 0
 	case "d":
 		if row, ok := a.selectedTask(); ok {
@@ -782,15 +799,15 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 		}
 	case "l", "enter":
-		if id, ok := a.selectedTaskID(); ok {
+		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
-			return a, a.fetchTaskLogs(id)
+			return a, a.fetchTaskHistory(row.InternalTaskID, row.TaskID)
 		}
 	case "r":
 		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
 			if t.View == TaskViewLogs {
-				return a, a.fetchTaskLogs(row.TaskID)
+				return a, a.fetchTaskHistory(row.InternalTaskID, row.TaskID)
 			}
 			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 		}
@@ -1857,41 +1874,107 @@ func (a *App) fetchTaskLogs(taskID string) tea.Cmd {
 		var detail *TaskItem
 		logs := make([]LogEntry, 0)
 		if dbConn != nil {
-			if r, err := dbConn.GetTaskDetail(ctx, taskID); err == nil && r != nil {
-				detail = &TaskItem{
-					TaskID:       r.TaskID,
-					Number:       r.Number,
-					URL:          r.URL,
-					Title:        r.Title,
-					Agent:        r.AgentID,
-					Model:        r.Model,
-					Runner:       r.Runner,
-					Status:       r.Status,
-					Attempt:      r.Attempt,
-					Duration:     time.Duration(r.DurationMs) * time.Millisecond,
-					StartedAt:    r.StartedAt,
-					CompletedAt:  r.CompletedAt,
-					Error:        r.Error,
-					InputTokens:  r.InputTokens,
-					OutputTokens: r.OutputTokens,
-					TotalTokens:  r.TotalTokens,
-					NumTurns:     r.NumTurns,
-					NumToolCalls: r.NumToolCalls,
-					CostUSD:      r.CostUSD,
-				}
-			}
+			detail = taskDetailItem(ctx, dbConn, taskID)
 			if rows, err := dbConn.GetTaskLogs(ctx, taskID, 5000); err == nil {
-				for _, l := range rows {
-					logs = append(logs, LogEntry{
-						Timestamp: l.Timestamp,
-						Level:     l.Level,
-						Message:   l.Message,
-					})
-				}
+				logs = mapLogLines(rows)
 			}
 		}
 		return taskLogsMsg{taskID: taskID, logs: logs, detail: detail}
 	}
+}
+
+// fetchTaskHistory loads the full per-instance history for the repurposed logs
+// view: every workflow instance bound to the InternalTask (e.g. investigator →
+// implementation), each with its steps and the logs scoped to its time window.
+// internalTaskID keys the history; drillKey hydrates the detail header. Falls back
+// to the flat log stream when there is no InternalTask id (legacy/pre-Phase-9 rows
+// or the Agents-tab drill-down).
+func (a *App) fetchTaskHistory(internalTaskID, drillKey string) tea.Cmd {
+	if internalTaskID == "" {
+		return a.fetchTaskLogs(drillKey)
+	}
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+
+		var detail *TaskItem
+		segments := make([]TaskHistorySegmentItem, 0)
+		if dbConn != nil {
+			detail = taskDetailItem(ctx, dbConn, drillKey)
+			if segs, err := dbConn.GetTaskWorkflowHistory(ctx, internalTaskID); err == nil {
+				now := time.Now()
+				for _, seg := range segs {
+					item := mapInstances([]db.WorkflowInstance{seg.Instance})[0]
+					item.Steps = mapStepRuns(seg.Steps, now)
+					if item.State == db.InstanceStateApprovalWaiting {
+						item.Message = "Awaiting human approval — reply on the task to resume or abort."
+					}
+					segments = append(segments, TaskHistorySegmentItem{
+						Instance: item,
+						Logs:     mapLogLines(seg.Logs),
+					})
+				}
+			}
+		}
+		return taskHistoryMsg{taskID: internalTaskID, segments: segments, detail: detail}
+	}
+}
+
+// taskDetailItem builds the detail-header TaskItem from the latest execution for a
+// (drill) cell id, or nil when none exists. Shared by the logs and history fetches.
+func taskDetailItem(ctx context.Context, dbConn *db.Client, taskID string) *TaskItem {
+	r, err := dbConn.GetTaskDetail(ctx, taskID)
+	if err != nil || r == nil {
+		return nil
+	}
+	return &TaskItem{
+		TaskID:       r.TaskID,
+		Number:       r.Number,
+		URL:          r.URL,
+		Title:        r.Title,
+		Agent:        r.AgentID,
+		Model:        r.Model,
+		Runner:       r.Runner,
+		Status:       r.Status,
+		Attempt:      r.Attempt,
+		Duration:     time.Duration(r.DurationMs) * time.Millisecond,
+		StartedAt:    r.StartedAt,
+		CompletedAt:  r.CompletedAt,
+		Error:        r.Error,
+		InputTokens:  r.InputTokens,
+		OutputTokens: r.OutputTokens,
+		TotalTokens:  r.TotalTokens,
+		NumTurns:     r.NumTurns,
+		NumToolCalls: r.NumToolCalls,
+		CostUSD:      r.CostUSD,
+	}
+}
+
+// mapLogLines converts db log rows into dashboard log entries.
+func mapLogLines(rows []db.TaskLogLine) []LogEntry {
+	out := make([]LogEntry, 0, len(rows))
+	for _, l := range rows {
+		out = append(out, LogEntry{Timestamp: l.Timestamp, Level: l.Level, Message: l.Message})
+	}
+	return out
+}
+
+// mapStepRuns converts db step-run rows into dashboard step items.
+func mapStepRuns(steps []db.StepRun, now time.Time) []WorkflowStepItem {
+	out := make([]WorkflowStepItem, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, WorkflowStepItem{
+			StepID:   s.StepID,
+			Agent:    s.AgentID,
+			State:    s.State,
+			Duration: wfStepDuration(s, now),
+			Cached:   s.SkippedCached,
+			Output:   s.Output,
+			Summary:  s.Summary,
+		})
+	}
+	return out
 }
 
 func (a *App) fetchAgents() tea.Cmd {
@@ -2642,18 +2725,25 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 	}
 	b.WriteString("\n  " + StyleLabel.Render("Steps") + "\n")
 	for _, s := range inst.Steps {
-		state := s.State
-		if s.Cached {
-			state += " (cached)"
-		}
-		b.WriteString(fmt.Sprintf("    %s  %s  %s  %s\n",
-			wfStepGlyph(s.State),
-			pad(truncate(s.StepID, 16), 16),
-			pad(truncate(s.Agent, 16), 16),
-			StyleMuted.Render(pad(s.Duration, 8))+"  "+wfStateStyle(s.State).Render(state),
-		))
+		b.WriteString("    " + wfStepRow(s) + "\n")
 	}
 	return b.String()
+}
+
+// wfStepRow formats a single workflow step as one display row (glyph, step id,
+// agent, duration, state) without indentation or trailing newline, so callers can
+// place it in a panel or a flattened log-line list.
+func wfStepRow(s WorkflowStepItem) string {
+	state := s.State
+	if s.Cached {
+		state += " (cached)"
+	}
+	return fmt.Sprintf("%s  %s  %s  %s",
+		wfStepGlyph(s.State),
+		pad(truncate(s.StepID, 16), 16),
+		pad(truncate(s.Agent, 16), 16),
+		StyleMuted.Render(pad(s.Duration, 8))+"  "+wfStateStyle(s.State).Render(state),
+	)
 }
 
 func wfInstanceBadge(state string) string {
@@ -2718,7 +2808,7 @@ func taskDetailLabel(d *TaskItem) string {
 }
 
 func (a *App) renderTaskLogs(t *TasksTab, height int) string {
-	if len(t.Logs) == 0 {
+	if len(t.Logs) == 0 && len(t.InstanceHistory) == 0 {
 		label := "TASK LOGS"
 		if t.Detail != nil {
 			label = taskDetailLabel(t.Detail)
@@ -2764,7 +2854,54 @@ func (a *App) taskLogLines() []string {
 	if t == nil {
 		return nil
 	}
+	if len(t.InstanceHistory) > 0 {
+		return a.taskHistoryLines()
+	}
 	return a.logEntryLines(t.Logs)
+}
+
+// taskHistoryLines flattens the per-instance history into styled visual lines for
+// the repurposed logs view: each workflow instance becomes a labeled header, then
+// its step rows, then its time-scoped log lines — oldest instance first, so a
+// multi-workflow task reads top-to-bottom as a chronological story.
+func (a *App) taskHistoryLines() []string {
+	t := a.model.tasksTab
+	if t == nil {
+		return nil
+	}
+	sw := a.model.width - 8
+	if sw < 20 {
+		sw = 20
+	}
+	var out []string
+	for i, seg := range t.InstanceHistory {
+		if i > 0 {
+			out = append(out, "") // blank separator between instances
+		}
+		out = append(out, historySegmentHeader(seg.Instance))
+		if seg.Instance.State == db.InstanceStateApprovalWaiting && seg.Instance.Message != "" {
+			out = append(out, "  "+StyleWarning.Render("⏸ "+seg.Instance.Message))
+		}
+		for _, s := range seg.Instance.Steps {
+			out = append(out, "  "+wfStepRow(s))
+			if s.Summary != "" {
+				out = append(out, "      "+StyleMuted.Render(truncate(s.Summary, sw)))
+			}
+		}
+		out = append(out, a.logEntryLines(seg.Logs)...)
+	}
+	return out
+}
+
+// historySegmentHeader renders the section header for one workflow instance: a
+// state badge, the workflow id, and when it started.
+func historySegmentHeader(in WorkflowInstanceItem) string {
+	when := ""
+	if !in.CreatedAt.IsZero() {
+		when = StyleMuted.Render(" · " + in.CreatedAt.Format("01-02 15:04"))
+	}
+	return StyleMuted.Render("── ") + wfInstanceBadge(in.State) + " " +
+		StyleValueStrong.Render(valueOr(in.Workflow, "—")) + when + StyleMuted.Render(" ──")
 }
 
 // agentTaskLogLines renders the drill-down logs of the task selected in an
@@ -3269,8 +3406,8 @@ func (a *App) footerKeys() []fkey {
 	case "Agents":
 		if ag := a.model.agentsTab; ag != nil {
 			switch ag.View {
-		case AgentViewDetail:
-			return []fkey{{"esc", "back"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
+			case AgentViewDetail:
+				return []fkey{{"esc", "back"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
 			case AgentViewActivity:
 				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"pgup/dn", "page"}, {"q", "quit"}}
 			case AgentViewTaskLogs:

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -67,11 +67,12 @@ type TasksTab struct {
 	History     []TaskItem // running + past tasks, newest first
 	SelectedIdx int
 
-	View           TaskView
-	Detail         *TaskItem             // populated when View == TaskViewDetail
-	DetailInstance *WorkflowInstanceItem // workflow instance for Detail, if any
-	Logs           []LogEntry            // populated when View == TaskViewLogs
-	LogScroll      int
+	View            TaskView
+	Detail          *TaskItem                // populated when View == TaskViewDetail
+	DetailInstance  *WorkflowInstanceItem    // workflow instance for Detail, if any
+	Logs            []LogEntry               // legacy flat stream (TaskViewLogs, legacy rows)
+	InstanceHistory []TaskHistorySegmentItem // per-instance history (TaskViewLogs, InternalTask rows)
+	LogScroll       int
 
 	// Workflow monitor sub-view (View == TaskViewWorkflow).
 	WorkflowInstance *WorkflowInstanceItem // instance being monitored
@@ -100,6 +101,16 @@ type WorkflowInstanceItem struct {
 	ResumedFrom      string // set when this instance resumed a prior one
 	CreatedAt        time.Time
 	Steps            []WorkflowStepItem
+}
+
+// TaskHistorySegmentItem is one workflow instance's slice of a task's history in
+// the Tasks tab: the instance (with its steps) plus the log lines scoped to that
+// instance's time window. Rendered as a labeled section in the repurposed logs
+// view so a multi-workflow task (e.g. investigator → implementation) reads
+// top-to-bottom as a chronological story.
+type TaskHistorySegmentItem struct {
+	Instance WorkflowInstanceItem
+	Logs     []LogEntry
 }
 
 // SourceBindingItem is a task's link to one source item (e.g. a GitHub issue or

--- a/src/internal/db/task_history.go
+++ b/src/internal/db/task_history.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"time"
+)
+
+// TaskHistorySegment is one workflow instance's slice of an InternalTask's life:
+// the instance, its step runs, and the raw task logs scoped to that instance's
+// time window. Segments are returned oldest-first so a task that handed off from
+// one workflow to another (e.g. investigator → implementation) reads top-to-bottom
+// as a chronological story.
+type TaskHistorySegment struct {
+	Instance WorkflowInstance
+	Steps    []StepRun
+	Logs     []TaskLogLine
+}
+
+// GetTaskWorkflowHistory returns the full per-instance history for an InternalTask,
+// oldest instance first.
+//
+// task_logs are keyed by cell id — shared by every instance of a task, since they
+// all bind to the same source item — and carry no instance id, so each instance's
+// logs are isolated by time-windowing the shared stream: instance i owns
+// [created_at(i), created_at(i+1)), and the most recent instance is open-ended so
+// its still-arriving live logs keep flowing in. This is accurate while hand-offs are
+// sequential (HasActiveInstanceForRoute blocks a duplicate (task, workflow) while one
+// runs/waits); concurrent fan-out instances on one task would interleave and
+// mis-attribute — revisit with a task_logs.instance_id column if that becomes common.
+// A log written exactly at the next instance's created_at lands in both adjacent
+// windows, but timestamps come from time.Now() so an exact tie is vanishingly rare.
+func (c *Client) GetTaskWorkflowHistory(ctx context.Context, internalTaskID string) ([]TaskHistorySegment, error) {
+	insts, err := c.ListWorkflowInstancesByTask(ctx, internalTaskID)
+	if err != nil {
+		return nil, err
+	}
+	// ListWorkflowInstancesByTask is newest-first; reverse to oldest-first.
+	for i, j := 0, len(insts)-1; i < j; i, j = i+1, j-1 {
+		insts[i], insts[j] = insts[j], insts[i]
+	}
+
+	segments := make([]TaskHistorySegment, 0, len(insts))
+	for i := range insts {
+		inst := insts[i]
+		steps, err := c.ListStepRuns(ctx, inst.ID)
+		if err != nil {
+			return nil, err
+		}
+		// Window: [this.created_at, next.created_at). The last (most recent)
+		// instance is open-ended (to == nil) so live logs are still captured.
+		from := inst.CreatedAt
+		var to *time.Time
+		if i+1 < len(insts) {
+			next := insts[i+1].CreatedAt
+			to = &next
+		}
+		logs, err := c.GetTaskLogsInRange(ctx, inst.CellID, &from, to)
+		if err != nil {
+			return nil, err
+		}
+		segments = append(segments, TaskHistorySegment{
+			Instance: inst,
+			Steps:    steps,
+			Logs:     logs,
+		})
+	}
+	return segments, nil
+}

--- a/src/internal/db/task_history_test.go
+++ b/src/internal/db/task_history_test.go
@@ -1,0 +1,152 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// seedHistory creates one instance bound to (taskID, cellID) at createdAt with the
+// given workflow id/state, plus one step run per step id (state "passed").
+func seedHistory(t *testing.T, c *Client, instID, workflowID, taskID, cellID, state string, createdAt time.Time, stepIDs ...string) {
+	t.Helper()
+	ctx := context.Background()
+	inst := &WorkflowInstance{
+		ID:         instID,
+		WorkflowID: workflowID,
+		TaskID:     taskID,
+		CellID:     cellID,
+		State:      state,
+		CreatedAt:  createdAt, // CreateWorkflowInstance honours a preset CreatedAt
+	}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("seed instance %s: %v", instID, err)
+	}
+	for i, sid := range stepIDs {
+		_, err := c.db.ExecContext(ctx,
+			`INSERT INTO step_runs (id, workflow_instance_id, step_id, agent_id, state) VALUES (?, ?, ?, ?, ?)`,
+			instID+"-s"+itoa(i), instID, sid, "ag", StepStatePassed)
+		if err != nil {
+			t.Fatalf("seed step %s/%s: %v", instID, sid, err)
+		}
+	}
+}
+
+// writeLogAt inserts a task_logs row at an explicit timestamp (WriteTaskLog uses
+// time.Now(), so the test inserts directly for deterministic windowing).
+func writeLogAt(t *testing.T, c *Client, cellID, msg string, at time.Time) {
+	t.Helper()
+	_, err := c.db.ExecContext(context.Background(),
+		`INSERT INTO task_logs (task_id, level, message, timestamp) VALUES (?, ?, ?, ?)`,
+		cellID, "INFO", msg, at)
+	if err != nil {
+		t.Fatalf("seed log %q: %v", msg, err)
+	}
+}
+
+func itoa(i int) string { return string(rune('0' + i)) }
+
+func logMessages(segs []TaskHistorySegment, i int) []string {
+	var out []string
+	for _, l := range segs[i].Logs {
+		out = append(out, l.Message)
+	}
+	return out
+}
+
+func TestGetTaskWorkflowHistory_HandoffSplitsLogsByInstance(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	const task, cell = "task-1", "issue-1948"
+	t0 := time.Date(2026, 6, 6, 14, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * time.Minute) // implementation starts later
+
+	// investigator ran first, then handed off to implementation (same cell).
+	seedHistory(t, c, "wi_inv", "investigator", task, cell, InstanceStateDone, t0, "classify", "triage")
+	seedHistory(t, c, "wi_impl", "implementation", task, cell, InstanceStateRunning, t1, "implement")
+
+	writeLogAt(t, c, cell, "picked up issue #1948", t0.Add(1*time.Minute)) // → investigator window
+	writeLogAt(t, c, cell, "APIARY_PUBLISH → implementation", t0.Add(2*time.Minute))
+	writeLogAt(t, c, cell, "started implementation workflow", t1.Add(1*time.Minute)) // → implementation window
+
+	segs, err := c.GetTaskWorkflowHistory(ctx, task)
+	if err != nil {
+		t.Fatalf("GetTaskWorkflowHistory: %v", err)
+	}
+	if len(segs) != 2 {
+		t.Fatalf("expected 2 segments, got %d", len(segs))
+	}
+
+	// Oldest-first: investigator, then implementation.
+	if segs[0].Instance.WorkflowID != "investigator" {
+		t.Errorf("segment 0 workflow = %q, want investigator (oldest first)", segs[0].Instance.WorkflowID)
+	}
+	if segs[1].Instance.WorkflowID != "implementation" {
+		t.Errorf("segment 1 workflow = %q, want implementation", segs[1].Instance.WorkflowID)
+	}
+
+	// Steps preserved per instance.
+	if len(segs[0].Steps) != 2 || segs[0].Steps[0].StepID != "classify" || segs[0].Steps[1].StepID != "triage" {
+		t.Errorf("investigator steps = %+v, want [classify triage]", stepIDsOf(segs[0].Steps))
+	}
+	if len(segs[1].Steps) != 1 || segs[1].Steps[0].StepID != "implement" {
+		t.Errorf("implementation steps = %+v, want [implement]", stepIDsOf(segs[1].Steps))
+	}
+
+	// Logs partitioned by window: investigator owns the first two, not the third.
+	inv := logMessages(segs, 0)
+	if len(inv) != 2 {
+		t.Fatalf("investigator logs = %v, want 2 lines", inv)
+	}
+	for _, m := range inv {
+		if m == "started implementation workflow" {
+			t.Errorf("implementation log leaked into investigator window: %v", inv)
+		}
+	}
+	impl := logMessages(segs, 1)
+	if len(impl) != 1 || impl[0] != "started implementation workflow" {
+		t.Errorf("implementation logs = %v, want [started implementation workflow]", impl)
+	}
+}
+
+func TestGetTaskWorkflowHistory_SingleInstanceOpenWindow(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	const task, cell = "task-2", "cell-2"
+	t0 := time.Date(2026, 6, 6, 9, 0, 0, 0, time.UTC)
+	seedHistory(t, c, "wi_only", "solo", task, cell, InstanceStateRunning, t0, "do")
+	writeLogAt(t, c, cell, "line a", t0.Add(time.Minute))
+	writeLogAt(t, c, cell, "line b", t0.Add(time.Hour)) // open-ended window must still capture it
+
+	segs, err := c.GetTaskWorkflowHistory(ctx, task)
+	if err != nil {
+		t.Fatalf("GetTaskWorkflowHistory: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(segs))
+	}
+	if got := len(segs[0].Logs); got != 2 {
+		t.Errorf("single open-ended window captured %d logs, want 2", got)
+	}
+}
+
+func TestGetTaskWorkflowHistory_NoInstances(t *testing.T) {
+	c := newTestClient(t)
+	segs, err := c.GetTaskWorkflowHistory(context.Background(), "task-unknown")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(segs) != 0 {
+		t.Errorf("expected no segments for unknown task, got %d", len(segs))
+	}
+}
+
+func stepIDsOf(steps []StepRun) []string {
+	out := make([]string, len(steps))
+	for i, s := range steps {
+		out[i] = s.StepID
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

An `InternalTask` can run **several workflow instances** over its lifetime — e.g. an `investigator` workflow runs, classifies and hands off to an `implementation` on the same source item (issue #1948 motivated this). Previously, the views only showed the **last** instance and a **flattened, unattributed** log stream, so you couldn't tell what happened during the investigator phase.

Now the **dashboard and CLI** show the full history: each instance becomes a **labeled section** (workflow · state · time window) with its **steps (pass/fail + summary)** and the **log lines clipped to that instance's window**, in chronological order (oldest first) — read top to bottom like a narrative.

```
── done · investigator · 06-06 14:02 ──
  ✓ classify   complexity=high
  ✓ triage     handoff→implementation
  14:02 INFO  picked up issue #1948
  14:09 INFO  APIARY_PUBLISH → implementation
── running · implementation · 06-06 14:09 ──
  ● implement
  14:09 INFO  started implementation workflow
```

### How
- **`db.GetTaskWorkflowHistory(taskID)`** — the shared core (the dashboard uses it directly; the daemon exposes it via IPC for the CLI, so they don't diverge). `task_logs` is keyed by `cell_id` (shared across instances, no `instance_id`), so each instance isolates its logs by **time window** `[created_at(i), created_at(i+1))`; the most recent instance stays open (`to=nil`) to capture live logs. No migration — justified because hand-offs are sequential (`HasActiveInstanceForRoute`).
- **daemon** — `GET /tasks/history?task=<id>` (or `?source=&item=`, e.g. `github` + `1948`) + `Dispatcher.TaskHistory` mapping to JSON views. `stepRunView` extracted and reused by `InstanceDetail`.
- **cli** — a new `apiary task <id>` (and `--source/--item`) rendering the history; `--json` available.
- **dashboard** — the logs screen (the `l` key) renders the history grouped by instance; **fallback** to the flattened stream for legacy lines / those without `InternalTaskID`. `wfStepRow`, `mapStepRuns`, `mapLogLines`, `taskDetailItem` helpers extracted/reused.

## Test plan

- `cd src && go test ./...` → **all ok**. New tests:
  - `db`: `TestGetTaskWorkflowHistory_*` — a hand-off partitions logs by window; a single instance (open window); zero instances.
  - `daemon`: `TestTaskHistory_*` — order (oldest first), step/log mapping, `nil` when there are no instances.
- `go build ./...` + `go vet` clean; `apiary task --help` registered.

## Limitations (documented in the code)
- The time window assumes **sequential** hand-offs; concurrent fan-out on the same task would interleave logs — migrate to `task_logs.instance_id` if that becomes common.
- `GetTaskLogsInRange` limits to 2000 lines per window.

> Note: `models.go`/`app.go` had a minimal gofmt realignment (a struct and a pre-existing `case` indentation).