### PR TITLE
fix(workflow): the agent uses its own source_token for gh commands

### DIFF
--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -154,7 +154,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		StepID:             req.Step.ID,
 		WorkflowInstanceID: req.InstanceID,
 		WorkingDir:         "/",
-		Env:                gitIdentityEnv(req.Agent),
+		Env:                agentIdentityEnv(req.Agent),
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
 	}
 
@@ -385,9 +385,17 @@ func readSoulFile(agent config.AgentConfig, cellID string) string {
 	return string(data)
 }
 
-// gitIdentityEnv returns the git author/committer identity env vars derived from
-// the agent's source identity, so commits use the agent's account.
-func gitIdentityEnv(agent config.AgentConfig) map[string]string {
+// agentIdentityEnv returns the environment that makes an agent subprocess act as
+// its own GitHub account: the git author/committer identity derived from the
+// agent's source identity (so commits are attributed correctly), plus the
+// agent's source token exported as GITHUB_TOKEN / GH_TOKEN (so any `gh` commands
+// the agent runs itself authenticate as the agent, not the daemon's inherited
+// default account). The `gh` CLI honours both variables; we set both for safety.
+//
+// These overlay os.Environ() at the call site (Env on the RunRequest, applied
+// after the inherited environment in the runner), so the agent's token wins over
+// any GITHUB_TOKEN the daemon inherited.
+func agentIdentityEnv(agent config.AgentConfig) map[string]string {
 	env := map[string]string{}
 	if agent.SourceName != "" {
 		env["GIT_AUTHOR_NAME"] = agent.SourceName
@@ -396,6 +404,10 @@ func gitIdentityEnv(agent config.AgentConfig) map[string]string {
 	if agent.SourceEmail != "" {
 		env["GIT_AUTHOR_EMAIL"] = agent.SourceEmail
 		env["GIT_COMMITTER_EMAIL"] = agent.SourceEmail
+	}
+	if agent.SourceToken != "" {
+		env["GITHUB_TOKEN"] = agent.SourceToken
+		env["GH_TOKEN"] = agent.SourceToken
 	}
 	return env
 }

--- a/src/internal/daemon/workflow_identity_test.go
+++ b/src/internal/daemon/workflow_identity_test.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// TestAgentIdentityEnv_WithSourceToken verifies that an agent declaring a
+// source_token gets it exported to the subprocess as both GITHUB_TOKEN and
+// GH_TOKEN (so `gh` commands the agent runs authenticate as the agent's own
+// account), alongside the git author/committer identity. Regression for
+// orlandoburli-enterprise/project-erp#1948.
+func TestAgentIdentityEnv_WithSourceToken(t *testing.T) {
+	env := agentIdentityEnv(config.AgentConfig{
+		SourceName:  "orlandodeveloper01",
+		SourceEmail: "orlando.developer01@gmail.com",
+		SourceToken: "ghp_reviewertoken",
+	})
+
+	want := map[string]string{
+		"GIT_AUTHOR_NAME":     "orlandodeveloper01",
+		"GIT_COMMITTER_NAME":  "orlandodeveloper01",
+		"GIT_AUTHOR_EMAIL":    "orlando.developer01@gmail.com",
+		"GIT_COMMITTER_EMAIL": "orlando.developer01@gmail.com",
+		"GITHUB_TOKEN":        "ghp_reviewertoken",
+		"GH_TOKEN":            "ghp_reviewertoken",
+	}
+	for k, v := range want {
+		if env[k] != v {
+			t.Errorf("env[%q] = %q, want %q", k, env[k], v)
+		}
+	}
+}
+
+// TestAgentIdentityEnv_NoSourceToken verifies that without a source_token, no
+// GitHub token env vars are emitted, so the agent falls back to the daemon's
+// inherited credentials. The git identity is still set from name/email.
+func TestAgentIdentityEnv_NoSourceToken(t *testing.T) {
+	env := agentIdentityEnv(config.AgentConfig{
+		SourceName:  "orlandodeveloper01",
+		SourceEmail: "orlando.developer01@gmail.com",
+	})
+
+	if _, ok := env["GITHUB_TOKEN"]; ok {
+		t.Errorf("GITHUB_TOKEN should be absent without a source_token, got %q", env["GITHUB_TOKEN"])
+	}
+	if _, ok := env["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN should be absent without a source_token, got %q", env["GH_TOKEN"])
+	}
+	if env["GIT_AUTHOR_NAME"] != "orlandodeveloper01" {
+		t.Errorf("GIT_AUTHOR_NAME = %q, want orlandodeveloper01", env["GIT_AUTHOR_NAME"])
+	}
+	if env["GIT_COMMITTER_EMAIL"] != "orlando.developer01@gmail.com" {
+		t.Errorf("GIT_COMMITTER_EMAIL = %q, want orlando.developer01@gmail.com", env["GIT_COMMITTER_EMAIL"])
+	}
+}


### PR DESCRIPTION
## Summary

- Workflow agents declare their own GitHub identity (`source_token`, `source_name`, `source_email`). The `source_token` was injected **only** into the Go context (`source.SourceTokenCtxKey`), used exclusively by Apiary's internal GitHub adapter for write-backs (labels, state transitions). The agent's subprocess **never** received the token.
- Consequence: when the agent itself runs `gh` commands (e.g. the reviewer running `gh pr review --approve` and `gh issue comment`), `gh` authenticated with the `GITHUB_TOKEN` inherited from the daemon — the engineer's account — so the PR approval and comments appeared on the wrong account.
- Fix: `gitIdentityEnv` was renamed to `agentIdentityEnv` and now also exports `GITHUB_TOKEN` and `GH_TOKEN` with the `source_token` (when set), alongside the git author/committer identity. Since `req.Env` is applied **after** `os.Environ()` in the runner (`internal/runner/execution/cli.go`), the agent's token overrides the inherited `GITHUB_TOKEN` — exactly the desired behavior.

## Test plan

- `cd src && go build ./...`
- `cd src && go test ./internal/daemon/...` (all pass)
- New tests in `workflow_identity_test.go`:
  - `TestAgentIdentityEnv_WithSourceToken`: with a `source_token`, the env contains `GITHUB_TOKEN`/`GH_TOKEN` equal to the token + the `GIT_AUTHOR_*`/`GIT_COMMITTER_*` variables.
  - `TestAgentIdentityEnv_NoSourceToken`: with no token, the `GITHUB_TOKEN`/`GH_TOKEN` keys are absent; the git identity is still present.

## Possible follow-up (not included)

An explicit per-step `env:` override in the workflow YAML (setting arbitrary variables per step) would be useful, but it requires touching the config schema and the step executor — left as a separate follow-up, not bundled here. The automatic `source_token` → `GITHUB_TOKEN` injection in this PR is the primary fix.

Ref: orlandoburli-enterprise/project-erp#1948