### PR TITLE
docs(openspec): per-scope env vars (agent/workflow/step)

### DIFF
--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Ativas
 
+### workflow-env-vars
+
+Variáveis de ambiente opcionais por escopo: `agents[].env`, `workflows[].env` e `workflows[].steps[].env`, mescladas por step com precedência STEP > WORKFLOW > AGENT, sobre a camada base de identidade (git + `source_token` → `GITHUB_TOKEN`/`GH_TOKEN`). Merge no executor do daemon (`stepEnv`); engine apenas repassa o env de workflow via `StepRequest.WorkflowEnv`.
+
 ### binary-distribution
 
 Publicação dos binários por release: GoReleaser dirigido por push de tag `v*` produz archives + checksums (GitHub Releases), Homebrew tap, Scoop bucket, winget, pacotes Linux (`.deb`/`.rpm` + AUR) e imagem OCI multi-arch (`ghcr.io`). Assinatura/notarização (macOS/Windows) fica fora do escopo v1. Restrição dominante: `mattn/go-sqlite3` exige cgo, então cross-compile precisa de toolchains C.

--- a/openspec/changes/workflow-env-vars/design.md
+++ b/openspec/changes/workflow-env-vars/design.md
@@ -1,0 +1,161 @@
+# Design: Per-scope environment variables
+
+## Scope of the change
+
+Three config structs gain an `Env map[string]string` field; the engine threads
+the workflow-scope env to the step executor; the executor merges
+agent + workflow + step env (in precedence order) on top of the existing identity
+overlay and assigns the result to `RunRequest.Env`. The runner already overlays
+`RunRequest.Env` onto `os.Environ()`, so no runner change is needed.
+
+## Current state (what exists today)
+
+- `internal/runner/execution/cli.go` (~L81-84): `cmd.Env = os.Environ()` then
+  `for k,v := range req.Env { append k=v }`. **`req.Env` already overrides the
+  inherited environment.** This is the only place env reaches the process.
+- `internal/daemon/workflow.go`:
+  - `ExecuteStep` builds the `RunRequest` with `Env: agentIdentityEnv(req.Agent)`
+    (~L157).
+  - `agentIdentityEnv(agent)` returns git identity + (if `SourceToken != ""`)
+    `GITHUB_TOKEN`/`GH_TOKEN`.
+- `internal/workflow/StepRequest` carries `Step config.StepConfig` and
+  `Agent config.AgentConfig` but **not** the workflow config.
+- `internal/workflow/engine.go runStep` builds `StepRequest`. It does not receive
+  the `WorkflowConfig`; the running `*dagRun` (`dag.go`) holds `wf`. `runStep` is
+  called from `dag.go` (has `r`), `dag_parallel.go`, and `foreach.go` (have only
+  `instID`).
+- `schema/apiary.json` validates the config with `additionalProperties: false` on
+  the agent items, workflow items, and the `StepConfig` definition — so new keys
+  must be added there or validation fails. A worker-scope `env` shape already
+  exists (`{ "type":"object", "additionalProperties": {"type":"string"} }`) and is
+  reused verbatim.
+
+## Design decisions
+
+### 1. Where the merge happens — the daemon executor, not the engine
+
+The merge lives in `internal/daemon/workflow.go`, where the `RunRequest` is
+already assembled and where `agentIdentityEnv` already lives. This keeps the
+workflow engine free of process-environment concerns (it stays a pure
+orchestrator) and keeps all env logic in one file with one test target.
+
+Rename/extend `agentIdentityEnv` into a single builder:
+
+```go
+// stepEnv composes the environment for one agent step, lowest precedence first:
+//   identity overlay (git + source_token→GITHUB_TOKEN/GH_TOKEN)
+//     ← agent.env ← workflow.env ← step.env
+func stepEnv(agent config.AgentConfig, wfEnv, stepEnv map[string]string) map[string]string {
+    env := agentIdentityEnv(agent) // base: git identity + token (existing fn, kept)
+    for k, v := range agent.Env    { env[k] = v }
+    for k, v := range wfEnv        { env[k] = v }
+    for k, v := range stepEnv      { env[k] = v }
+    return env
+}
+```
+
+`agentIdentityEnv` is kept as-is (it already has tests from #1948) and becomes the
+base layer; `stepEnv` is the new public-to-the-package composer used at the call
+site.
+
+### 2. Threading workflow env to the executor — add it to `StepRequest`
+
+`StepRequest` gains one field:
+
+```go
+type StepRequest struct {
+    ...
+    Step        config.StepConfig
+    Agent       config.AgentConfig
+    WorkflowEnv map[string]string // workflow-scope env (engine fills from wf.Env)
+    ...
+}
+```
+
+`runStep` gains a `wfEnv map[string]string` parameter and sets
+`WorkflowEnv: wfEnv` when building `StepRequest`. Its three call sites pass the
+running workflow's env:
+
+- `dag.go` (L204): `r.wf.Env` is in scope — pass it directly.
+- `dag_parallel.go` and `foreach.go`: these helpers receive only `instID`, not the
+  `*dagRun`. Two options:
+  - **(chosen)** add a `wfEnv map[string]string` parameter to
+    `runParallelStep` / `executeForeachStep` / `executeForeachSequential` /
+    `executeForeachConcurrent`, threaded from the `*dagRun` at the dispatch point
+    in `dag.go` (same place that already has `r`). Mechanical, explicit, no new
+    engine state.
+  - (rejected) a `instID → *dagRun` registry lookup — adds shared mutable state
+    for no benefit here.
+
+The call site in `ExecuteStep` becomes:
+
+```go
+Env: stepEnv(req.Agent, req.WorkflowEnv, req.Step.Env),
+```
+
+### 3. Precedence rationale
+
+STEP > WORKFLOW > AGENT matches "most specific wins": the step is the narrowest
+scope, the agent the broadest. The identity overlay sits below all three so the
+`source_token` default still holds, but a deliberate `env: { GITHUB_TOKEN: ... }`
+at any explicit scope can override it (escape hatch; documented, not encouraged).
+
+### 4. Empty maps and nil-safety
+
+All `env` fields are optional (`omitempty`). `stepEnv` starts from
+`agentIdentityEnv` (always non-nil) and ranges over possibly-nil maps (safe in
+Go). No key validation beyond what the runner already does — values are arbitrary
+strings, consistent with the legacy worker `env`.
+
+### 5. Config loading / `${ENV}` expansion
+
+The config loader already expands `${VAR}` / `${{ }}` in string values during
+load (see the `config-lint-removed-directives` and "preserva `${{ }}`" work).
+`env` map values are plain strings and are subject to the same existing expansion
+— no new interpolation code. This lets operators write
+`env: { DEPLOY_URL: "${DEPLOY_URL}" }` to forward a daemon var explicitly, or a
+literal.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `internal/config/config.go` | `AgentConfig.Env map[string]string` (`yaml:"env,omitempty"`) |
+| `internal/config/workflow.go` | `WorkflowConfig.Env` and `StepConfig.Env` |
+| `internal/workflow/engine.go` | `StepRequest.WorkflowEnv`; `runStep` `wfEnv` param + set field |
+| `internal/workflow/dag.go` | pass `r.wf.Env` to `runStep` / fan-out helpers |
+| `internal/workflow/dag_parallel.go` | thread `wfEnv` param to `runStep` |
+| `internal/workflow/foreach.go` | thread `wfEnv` param to `runStep` |
+| `internal/daemon/workflow.go` | new `stepEnv` composer; call site uses it |
+| `schema/apiary.json` | add `env` to agent items, workflow items, `StepConfig` def |
+| `docs/` | document the three scopes + precedence (apiary-guide / config ref) |
+
+## Testing strategy
+
+Unit tests in `internal/daemon` (table-driven, alongside the existing
+`workflow_identity_test.go`):
+
+- agent-only env present.
+- workflow overrides agent for a shared key; agent-only keys survive.
+- step overrides workflow which overrides agent (full 3-way precedence on one key).
+- explicit `env.GITHUB_TOKEN` at step scope overrides the `source_token` overlay.
+- no env anywhere → identical to today's `agentIdentityEnv` output (regression).
+
+Engine-level: extend an existing `workflow_executor_test.go`-style test to assert
+the `fakeRunner` receives the merged `Env` (the runner records `RunRequest.Env`),
+proving `WorkflowEnv` is threaded through `runStep` for a plain step. A foreach /
+parallel threading check can be a follow-up if cheap.
+
+Schema: the repo's pre-commit / JSON-Schema validation (added in #90) must still
+accept a config that uses all three `env` scopes; add such a block to whatever
+example/fixture the schema check runs against.
+
+## Risks
+
+- **Low.** Additive, optional fields; default behaviour byte-identical to today
+  (the merge over an empty set of explicit envs == `agentIdentityEnv`).
+- The only non-mechanical part is threading `wfEnv` through the foreach/parallel
+  helpers; covered by build + existing engine tests.
+- `additionalProperties: false` in the JSON schema means forgetting a schema edit
+  turns a valid config into a validation error — the schema task is mandatory, not
+  optional.

--- a/openspec/changes/workflow-env-vars/proposal.md
+++ b/openspec/changes/workflow-env-vars/proposal.md
@@ -1,0 +1,78 @@
+# Proposal: Per-scope environment variables (agent / workflow / step)
+
+## Why
+
+Agent subprocesses inherit the daemon's environment (`os.Environ()`) plus a small,
+hard-coded overlay built by `agentIdentityEnv` in `internal/daemon/workflow.go`:
+the git author/committer identity and — as of the
+`orlandoburli-enterprise/project-erp#1948` fix — the agent's `source_token`
+exported as `GITHUB_TOKEN`/`GH_TOKEN`.
+
+There is **no way for an operator to pass arbitrary environment variables** to an
+agent run. Real configurations need this routinely:
+
+- A step that runs a deploy or a smoke test needs a target URL, a registry
+  credential, or a feature flag that only that step should see.
+- A whole workflow (e.g. a release pipeline) needs a common set of vars across
+  all its steps.
+- An agent needs a standing variable regardless of which workflow invokes it
+  (e.g. a tool API key tied to that agent's identity).
+
+The legacy, now-superseded `worker` model already had `config.env`
+(`WorkerRunConfig.Env`), but the active agent/workflow/step model dropped it.
+This change restores that capability in the right place and makes it
+**composable across the three scopes** an agent run actually has.
+
+## What Changes
+
+Add an optional `env: { KEY: VALUE }` map at three config scopes and merge them,
+per step, with a well-defined precedence before handing the result to the runner:
+
+| Scope | Field | Applies to |
+|---|---|---|
+| **Agent** | `agents[].env` | every step that runs this agent, in any workflow |
+| **Workflow** | `workflows[].env` | every step of this workflow |
+| **Step** | `workflows[].steps[].env` | only that step |
+
+**Precedence (highest wins): STEP → WORKFLOW → AGENT.** A step `env` value
+overrides the same key set at workflow scope, which overrides the same key at
+agent scope.
+
+The existing automatic identity overlay (git identity + `source_token` →
+`GITHUB_TOKEN`/`GH_TOKEN`) is the **base layer**, below all three explicit
+scopes — so an operator can still deliberately override `GITHUB_TOKEN` for a
+single step if they ever need to, but by default the agent's own token wins as it
+does today.
+
+Final layering applied to the subprocess (later overrides earlier):
+
+```
+os.Environ()                          (daemon-inherited; in the runner)
+  └─ identity overlay (git + source_token → GITHUB_TOKEN/GH_TOKEN)
+       └─ agent.env
+            └─ workflow.env
+                 └─ step.env
+```
+
+## What Stays
+
+- **Runner contract** — `RunRequest.Env` and the `cli.go` overlay loop are
+  unchanged; this change only enriches the map passed in `Env`.
+- **Identity behaviour** — git identity and the `source_token` → token mapping
+  keep working exactly as today when no explicit `env` is set.
+- **Engine DAG / approvals / foreach / parallel** — unchanged execution
+  semantics; the only addition is threading the workflow's `env` to the step
+  executor.
+- **No env interpolation semantics change** — values are passed through verbatim,
+  consistent with how `${{ }}`/`${ }` expansion already works elsewhere in config
+  loading (env vars in values are expanded by the existing config loader before
+  these maps are read).
+
+## Out of Scope
+
+- Secret management / vaulting. Values come from the config (already subject to
+  the loader's `${ENV}` expansion); this change does not add a secrets backend.
+- Per-`foreach`-item env. Item-specific values belong in the prompt/templating
+  layer, not the process environment.
+- Source-adapter (write-back) credentials. Those continue to flow through
+  `source.SourceTokenCtxKey`, unchanged.

--- a/openspec/changes/workflow-env-vars/tasks.md
+++ b/openspec/changes/workflow-env-vars/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Per-scope environment variables
+
+## 1. Config schema (Go structs)
+
+- [ ] 1.1 Add `Env map[string]string \`yaml:"env,omitempty"\`` to `AgentConfig` in `internal/config/config.go`.
+- [ ] 1.2 Add `Env map[string]string \`yaml:"env,omitempty"\`` to `WorkflowConfig` in `internal/config/workflow.go`.
+- [ ] 1.3 Add `Env map[string]string \`yaml:"env,omitempty"\`` to `StepConfig` in `internal/config/workflow.go` (cross-cutting section, near `Publish`/`Spawn`).
+- [ ] 1.4 Confirm the config loader's existing `${VAR}`/`${{ }}` expansion covers map values (add a loader test if not already covered).
+
+## 2. Engine threading (workflow scope → executor)
+
+- [ ] 2.1 Add `WorkflowEnv map[string]string` to `StepRequest` in `internal/workflow/engine.go`.
+- [ ] 2.2 Add a `wfEnv map[string]string` parameter to `runStep`; set `WorkflowEnv: wfEnv` when building `StepRequest`.
+- [ ] 2.3 `dag.go`: pass `r.wf.Env` to `runStep` at the direct call site (L~204).
+- [ ] 2.4 `dag_parallel.go`: thread a `wfEnv` parameter through `runParallelStep` to its `runStep` call.
+- [ ] 2.5 `foreach.go`: thread `wfEnv` through `executeForeachStep` / `executeForeachSequential` / `executeForeachConcurrent` to their `runStep` calls.
+- [ ] 2.6 Update all dispatch points in `dag.go` (where these helpers are invoked) to pass `r.wf.Env`.
+
+## 3. Env composition (daemon executor)
+
+- [ ] 3.1 In `internal/daemon/workflow.go`, add `stepEnv(agent, wfEnv, stepEnv map[string]string) map[string]string` that layers `agentIdentityEnv(agent)` ← `agent.Env` ← `wfEnv` ← `stepEnv` (later wins).
+- [ ] 3.2 Keep `agentIdentityEnv` unchanged as the base/identity layer.
+- [ ] 3.3 Change the `RunRequest` call site to `Env: stepEnv(req.Agent, req.WorkflowEnv, req.Step.Env)`.
+
+## 4. JSON Schema (`schema/apiary.json`)
+
+- [ ] 4.1 Add an `env` property (`{"type":"object","additionalProperties":{"type":"string"}}`) to the agent items object (after `source_name`).
+- [ ] 4.2 Add the same `env` property to the workflow items object.
+- [ ] 4.3 Add the same `env` property to the `StepConfig` definition.
+- [ ] 4.4 Re-run the schema validation / pre-commit hook against a config exercising all three scopes; ensure it passes (`additionalProperties: false` would otherwise reject it).
+
+## 5. Tests
+
+- [ ] 5.1 `internal/daemon`: table-driven `stepEnv` tests — agent-only; workflow-overrides-agent; full step>workflow>agent precedence; explicit step `GITHUB_TOKEN` overrides `source_token` overlay; empty-everywhere == `agentIdentityEnv` (regression).
+- [ ] 5.2 Engine test (in the `workflow_executor_test.go` style): a step with workflow + step env reaches the runner's `RunRequest.Env` merged correctly (assert via a recording `fakeRunner`).
+- [ ] 5.3 `cd src && go build ./... && go test ./internal/daemon/... ./internal/workflow/... ./internal/config/...` all green.
+
+## 6. Docs
+
+- [ ] 6.1 Document the three `env` scopes and the STEP > WORKFLOW > AGENT precedence (and the identity base layer) in the apiary guide / config reference under `docs/`.
+- [ ] 6.2 Note the deliberate-override escape hatch for `GITHUB_TOKEN` and that values pass through `${ENV}` expansion.
+
+## 7. Changelog & archive
+
+- [ ] 7.1 Entry added to `openspec/CHANGELOG.md` under `## Ativas` (done at proposal time).
+- [ ] 7.2 On completion, move the entry to `## Arquivadas` under the merge date.


### PR DESCRIPTION
## Summary

An OpenSpec proposal (design phase) for **per-scope environment variables** in agent runs.

Today the agent subprocess inherits `os.Environ()` from the daemon + a fixed overlay (`agentIdentityEnv`: git identity + `source_token` → `GITHUB_TOKEN`/`GH_TOKEN`). There's no way to pass arbitrary env vars. This change adds an optional `env: { KEY: VALUE }` at three scopes:

| Scope | Field |
|---|---|
| Agent | `agents[].env` |
| Workflow | `workflows[].env` |
| Step | `workflows[].steps[].env` |

**Precedence (highest wins): STEP > WORKFLOW > AGENT**, over the base identity layer (which stays the default — the agent's token wins, but can be overridden explicitly).

Layers applied to the subprocess (the lower one overrides the upper):
`os.Environ()` → identity (git + source_token) → `agent.env` → `workflow.env` → `step.env`.

### Design decisions

- **Merge in the daemon executor** (`stepEnv` in `internal/daemon/workflow.go`), not in the engine — keeps the engine a pure orchestrator and concentrates the env logic in a single file/test. `agentIdentityEnv` is preserved as the base layer (it already has tests from #1948).
- **Threading the workflow env** via a new `StepRequest.WorkflowEnv`, with `runStep` receiving `wfEnv` passed from `r.wf.Env` (includes the `foreach`/`parallel` helpers).
- **The JSON Schema** (`schema/apiary.json`, added in #90) needs to gain `env` on agent/workflow/StepConfig — `additionalProperties:false` would reject the config otherwise.

## Content

- `openspec/changes/workflow-env-vars/proposal.md` — motivation, scope, what changes/stays.
- `openspec/changes/workflow-env-vars/design.md` — current state, decisions, touched files, tests, risks.
- `openspec/changes/workflow-env-vars/tasks.md` — 24 tasks (config structs → engine threading → composition → schema → tests → docs).
- An entry in `openspec/CHANGELOG.md` (## Active).

## Test plan

- Design-only; no code change in this PR. `openspec list` recognizes the change (0/24 tasks).
- The implementation follows in subsequent PR(s) per `tasks.md`, with `go build ./... && go test ./internal/daemon/... ./internal/workflow/... ./internal/config/...`.

Context: follows the follow-up suggested in the `source_token` fix (orlandoburli-enterprise/project-erp#1948 / apiary#89).