### PR TITLE
chore(vscode): sync package-lock with version 0.1.3

### DIFF
--- a/tools/vscode-apiary/package-lock.json
+++ b/tools/vscode-apiary/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-apiary",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-apiary",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "AGPL-3.0",
       "dependencies": {
         "js-yaml": "^4.1.0"


### PR DESCRIPTION
## Summary

`tools/vscode-apiary/package.json` is at `0.1.3` (already on `main`), but `package-lock.json` stayed at `0.1.2` — the lock wasn't updated in the version bump. This PR syncs the lock via `npm install --package-lock-only`.

## Test plan

- Only the lock's two `version` lines change (`0.1.2` → `0.1.3`), matching the already-committed `package.json`.