### PR TITLE
feat(dashboard): related files (souls/skills) in the agent detail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5180 symbols, 11622 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5464 symbols, 12294 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5180 symbols, 11622 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5464 symbols, 12294 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -633,6 +634,60 @@ func (a *App) handleAgentSubViewKey(key string) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	// File content viewer has its own scroll key map.
+	if ag.View == AgentViewFileContent {
+		lines := a.agentFileLines()
+		switch key {
+		case "esc", "backspace", "h", "left":
+			ag.View = AgentViewFiles
+			ag.FileContent = ""
+			ag.FileErr = ""
+			ag.FileScroll = 0
+		case "up":
+			if ag.FileScroll > 0 {
+				ag.FileScroll--
+			}
+		case "down":
+			if ag.FileScroll < lastIndex(len(lines)) {
+				ag.FileScroll++
+			}
+		case "g", "home":
+			ag.FileScroll = 0
+		case "G", "end":
+			ag.FileScroll = lastIndex(len(lines))
+		case "pgup", "ctrl+u":
+			ag.FileScroll = clampScroll(ag.FileScroll-a.pageSize(), len(lines))
+		case "pgdown", "ctrl+d", " ":
+			ag.FileScroll = clampScroll(ag.FileScroll+a.pageSize(), len(lines))
+		}
+		return a, nil
+	}
+
+	// Related-files list has its own navigation key map.
+	if ag.View == AgentViewFiles {
+		switch key {
+		case "esc", "backspace", "h", "left":
+			ag.View = AgentViewDetail
+			ag.Files = nil
+			ag.FilesIdx = 0
+		case "up":
+			if ag.FilesIdx > 0 {
+				ag.FilesIdx--
+			}
+		case "down":
+			if ag.FilesIdx < lastIndex(len(ag.Files)) {
+				ag.FilesIdx++
+			}
+		case "g", "home":
+			ag.FilesIdx = 0
+		case "G", "end":
+			ag.FilesIdx = lastIndex(len(ag.Files))
+		case "enter", "l", "right":
+			a.openSelectedAgentFile()
+		}
+		return a, nil
+	}
+
 	switch key {
 	case "esc", "backspace", "h", "left":
 		ag.View = AgentViewList
@@ -643,6 +698,13 @@ func (a *App) handleAgentSubViewKey(key string) (tea.Model, tea.Cmd) {
 		if a2, ok := a.selectedAgent(); ok {
 			ag.Detail = a2
 			ag.View = AgentViewDetail
+		}
+	case "f":
+		// From the detail view: open the agent's related files (soul + skills).
+		if ag.View == AgentViewDetail && ag.Detail != nil {
+			ag.Files = a.buildAgentFiles(ag.Detail)
+			ag.FilesIdx = 0
+			ag.View = AgentViewFiles
 		}
 	case "l", "enter":
 		// From the list/detail: open the agent's activity. From the activity
@@ -2008,6 +2070,7 @@ func (a *App) fetchAgents() tea.Cmd {
 					RunnerType:  ac.Runner,
 					Model:       ac.Model,
 					SoulFile:    ac.SoulFile,
+					Skills:      ac.Skills,
 					Description: ac.Description,
 					SourceName:  ac.SourceName,
 					SourceEmail: ac.SourceEmail,
@@ -2980,6 +3043,10 @@ func (a *App) renderAgentsTab(height int) string {
 		return a.renderAgentActivity(ag, height)
 	case AgentViewTaskLogs:
 		return a.renderAgentTaskLogs(ag, height)
+	case AgentViewFiles:
+		return a.renderAgentFiles(ag, height)
+	case AgentViewFileContent:
+		return a.renderAgentFileContent(ag, height)
 	default:
 		return a.renderAgentList(ag, height)
 	}
@@ -3097,6 +3164,15 @@ func (a *App) renderAgentDetail(ag *AgentsTab, height int) string {
 	if d.SoulFile != "" {
 		row("Soul file", d.SoulFile)
 	}
+	if len(d.Skills) > 0 {
+		row("Skills", strings.Join(d.Skills, ", "))
+	}
+	// Related-files hint: how many files (soul + skills) can be inspected, and
+	// the key that opens the navigable list.
+	if nFiles := len(a.buildAgentFiles(d)); nFiles > 0 {
+		hint := fmt.Sprintf("%d file(s) — press %s to browse", nFiles, StyleAccent.Render("f"))
+		row("Related files", StyleMuted.Render(hint))
+	}
 	if d.SourceName != "" || d.SourceEmail != "" {
 		id := d.SourceName
 		if d.SourceEmail != "" {
@@ -3137,6 +3213,150 @@ func (a *App) renderAgentDetail(ag *AgentsTab, height int) string {
 		}
 	}
 	return a.box("AGENT DETAILS — "+d.ID, b.String(), height)
+}
+
+// buildAgentFiles returns the files related to an agent — its soul prompt and
+// each configured skill — with paths resolved relative to the working directory
+// (where the dashboard runs, the same root the dispatcher reads them from).
+// Files that cannot be found are kept in the list and flagged Missing so the
+// user sees a misconfiguration rather than a silently shorter list.
+func (a *App) buildAgentFiles(d *AgentStatus) []AgentFileItem {
+	if d == nil {
+		return nil
+	}
+	var files []AgentFileItem
+	if d.SoulFile != "" {
+		files = append(files, AgentFileItem{
+			Kind:    "soul",
+			Name:    filepath.Base(d.SoulFile),
+			Path:    d.SoulFile,
+			Missing: !fileExists(d.SoulFile),
+		})
+	}
+	for _, skill := range d.Skills {
+		path := filepath.Join(".claude", "skills", skill, "SKILL.md")
+		files = append(files, AgentFileItem{
+			Kind:    "skill",
+			Name:    skill,
+			Path:    path,
+			Missing: !fileExists(path),
+		})
+	}
+	return files
+}
+
+// fileExists reports whether path names a readable regular file.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// openSelectedAgentFile reads the file under the cursor in the Files list into
+// the model and switches to the content viewer. Read errors are stored on the
+// model (FileErr) and rendered in place rather than aborting the view switch.
+func (a *App) openSelectedAgentFile() {
+	ag := a.model.agentsTab
+	if ag == nil || ag.FilesIdx < 0 || ag.FilesIdx >= len(ag.Files) {
+		return
+	}
+	f := ag.Files[ag.FilesIdx]
+	ag.FileName = f.Name
+	ag.FilePath = f.Path
+	ag.FileContent = ""
+	ag.FileErr = ""
+	ag.FileScroll = 0
+	data, err := os.ReadFile(f.Path)
+	if err != nil {
+		ag.FileErr = err.Error()
+	} else {
+		ag.FileContent = string(data)
+	}
+	ag.View = AgentViewFileContent
+}
+
+// agentFileLines returns the open file's contents wrapped to the box inner width
+// for scrolling and rendering.
+func (a *App) agentFileLines() []string {
+	ag := a.model.agentsTab
+	if ag == nil {
+		return nil
+	}
+	inner := a.model.width - 2
+	if inner < 1 {
+		inner = 1
+	}
+	return wrapPlain(ag.FileContent, inner)
+}
+
+func (a *App) renderAgentFiles(ag *AgentsTab, height int) string {
+	name := "—"
+	if ag.Detail != nil {
+		name = ag.Detail.ID
+	}
+	if len(ag.Files) == 0 {
+		return a.box("AGENT FILES — "+name, StyleMuted.Render("No soul or skill files configured for this agent.")+"\n", height)
+	}
+
+	const (
+		cursorW = 2
+		kindW   = 6
+	)
+	inner := a.model.width - 2
+	nameW := inner - cursorW - kindW - 4
+	if nameW < 10 {
+		nameW = 10
+	}
+
+	var b strings.Builder
+	for i, f := range ag.Files {
+		selected := i == ag.FilesIdx
+		kind := pad(f.Kind, kindW)
+		label := f.Name
+		if f.Missing {
+			label += "  " + StyleError.Render("(missing)")
+		}
+		label = pad(truncate(label, nameW), nameW)
+		path := StyleMuted.Render(f.Path)
+		cursor := "  "
+		if selected {
+			cursor = StyleFocusedArrow.Render("▶") + " "
+			kind = StyleSelectedRow.Render(kind)
+			label = StyleSelectedRow.Render(label)
+		} else {
+			kind = StyleAccent.Render(kind)
+		}
+		b.WriteString(cursor + " " + kind + "  " + label + "  " + path + "\n")
+	}
+	return a.box("AGENT FILES — "+name, b.String(), height)
+}
+
+func (a *App) renderAgentFileContent(ag *AgentsTab, height int) string {
+	title := "FILE — " + valueOr(ag.FileName, ag.FilePath)
+	if ag.FileErr != "" {
+		body := StyleError.Render("Could not read "+ag.FilePath+":") + "\n" + StyleMuted.Render(ag.FileErr) + "\n"
+		return a.box(title, body, height)
+	}
+
+	lines := a.agentFileLines()
+	if len(lines) == 0 {
+		return a.box(title, StyleMuted.Render("(empty file)")+"\n", height)
+	}
+
+	rows := height - 2 // top + bottom borders
+	if rows < 1 {
+		rows = 1
+	}
+	start := clampScroll(ag.FileScroll, len(lines))
+	end := start + rows
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		b.WriteString(lines[i] + "\n")
+	}
+	return a.box(title, b.String(), height)
 }
 
 func (a *App) renderAgentActivity(ag *AgentsTab, height int) string {
@@ -3407,11 +3627,15 @@ func (a *App) footerKeys() []fkey {
 		if ag := a.model.agentsTab; ag != nil {
 			switch ag.View {
 			case AgentViewDetail:
-				return []fkey{{"esc", "back"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"f", "files"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
 			case AgentViewActivity:
 				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"pgup/dn", "page"}, {"q", "quit"}}
 			case AgentViewTaskLogs:
 				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"o", "open"}, {"home/end", "ends"}, {"r", "reload"}, {"q", "quit"}}
+			case AgentViewFiles:
+				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "view"}, {"q", "quit"}}
+			case AgentViewFileContent:
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"pgup/dn", "page"}, {"home/end", "ends"}, {"q", "quit"}}
 			}
 		}
 		return []fkey{{"↑/↓", "select"}, {"enter/l", "activity"}, {"d", "details"}, {"tab", "switch"}, {"r", "refresh"}, {"q", "quit"}}
@@ -3452,6 +3676,14 @@ func (a *App) footerStatus(updated string) string {
 			case AgentViewTaskLogs:
 				if n := len(a.agentTaskLogLines()); n > 0 {
 					pos = fmt.Sprintf("line %d/%d   ", ag.TaskLogIdx+1, n)
+				}
+			case AgentViewFiles:
+				if n := len(ag.Files); n > 0 {
+					pos = fmt.Sprintf("file %d/%d   ", ag.FilesIdx+1, n)
+				}
+			case AgentViewFileContent:
+				if n := len(a.agentFileLines()); n > 0 {
+					pos = fmt.Sprintf("line %d/%d   ", ag.FileScroll+1, n)
 				}
 			}
 		}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -201,7 +201,19 @@ const (
 	AgentViewDetail
 	AgentViewActivity
 	AgentViewTaskLogs
+	AgentViewFiles       // list of files related to the agent (soul + skills)
+	AgentViewFileContent // viewer for one selected related file
 )
+
+// AgentFileItem is one file related to an agent — its soul prompt or one of its
+// skills — shown in the agent's Files sub-view. Path is resolved relative to the
+// working directory; Missing marks a configured file that could not be found.
+type AgentFileItem struct {
+	Kind    string // "soul" or "skill"
+	Name    string // display name (skill id, or the soul file's base name)
+	Path    string // resolved filesystem path
+	Missing bool   // true when the file does not exist / is unreadable
+}
 
 // AgentsTab shows agent status and performance with detail/activity sub-views.
 type AgentsTab struct {
@@ -218,6 +230,15 @@ type AgentsTab struct {
 	LogsTask   *TaskItem   // task detail for the logs header
 	TaskLogs   []LogEntry
 	TaskLogIdx int // vertical scroll within TaskLogs (visual lines)
+
+	// Related files (soul + skills) for the agent in Detail.
+	Files       []AgentFileItem // populated when View == AgentViewFiles
+	FilesIdx    int             // cursor within Files
+	FileName    string          // display name of the file open in AgentViewFileContent
+	FilePath    string          // resolved path of the open file
+	FileContent string          // raw contents of the open file ("" until loaded)
+	FileErr     string          // read error message, if any
+	FileScroll  int             // vertical scroll within the open file (visual lines)
 }
 
 type AgentStatus struct {
@@ -239,6 +260,7 @@ type AgentStatus struct {
 	RunnerType     string
 	Model          string
 	SoulFile       string
+	Skills         []string // skill ids declared on the agent config
 	Description    string
 	SourceName     string // git author name from agent config
 	SourceEmail    string // git author email from agent config

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -237,6 +239,84 @@ func TestAgentActivityDrillToLogs(t *testing.T) {
 	send("esc")
 	if a.model.agentsTab.View != AgentViewActivity {
 		t.Fatalf("esc from task logs → view %d, want AgentViewActivity", a.model.agentsTab.View)
+	}
+}
+
+func TestAgentRelatedFilesFlow(t *testing.T) {
+	// buildAgentFiles resolves paths relative to the working directory, so run
+	// the test from a temp dir laid out like a real project.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	soulPath := filepath.Join("souls", "engineer.md")
+	if err := os.MkdirAll(filepath.Dir(soulPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(soulPath, []byte("# Engineer soul\nbe excellent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillPath := filepath.Join(".claude", "skills", "git-workflow", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(skillPath, []byte("# git-workflow skill\nuse worktrees"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := newTestApp(90, 20)
+	a.model.activeTab = 2 // Agents
+	a.model.agentsTab.Agents = []AgentStatus{
+		{ID: "engineer", Status: "active", MaxWorkers: 2, SoulFile: soulPath, Skills: []string{"git-workflow", "ghost-skill"}},
+	}
+	a.model.agentsTab.Detail = &a.model.agentsTab.Agents[0]
+	a.model.agentsTab.View = AgentViewDetail
+
+	// buildAgentFiles lists soul + every skill; the missing one is flagged.
+	files := a.buildAgentFiles(a.model.agentsTab.Detail)
+	if len(files) != 3 {
+		t.Fatalf("buildAgentFiles → %d files, want 3", len(files))
+	}
+	if files[0].Kind != "soul" || files[0].Missing {
+		t.Errorf("file[0] = %+v, want present soul", files[0])
+	}
+	if files[1].Name != "git-workflow" || files[1].Missing {
+		t.Errorf("file[1] = %+v, want present skill git-workflow", files[1])
+	}
+	if files[2].Name != "ghost-skill" || !files[2].Missing {
+		t.Errorf("file[2] = %+v, want missing skill ghost-skill", files[2])
+	}
+
+	send := func(key string) { a.handleKeyMsg(keyPress(key)) }
+
+	// f opens the files list; it renders framed.
+	send("f")
+	if a.model.agentsTab.View != AgentViewFiles {
+		t.Fatalf("f → view %d, want AgentViewFiles", a.model.agentsTab.View)
+	}
+	assertFramed(t, a.renderAgentsTab(14), 90)
+
+	// ↓ then enter opens the second file's content.
+	send("down")
+	send("enter")
+	if a.model.agentsTab.View != AgentViewFileContent {
+		t.Fatalf("enter → view %d, want AgentViewFileContent", a.model.agentsTab.View)
+	}
+	if !strings.Contains(a.model.agentsTab.FileContent, "git-workflow skill") {
+		t.Errorf("FileContent = %q, want git-workflow skill body", a.model.agentsTab.FileContent)
+	}
+	out := stripANSI(a.renderAgentsTab(14))
+	if !strings.Contains(out, "use worktrees") {
+		t.Errorf("file viewer should show the file body; got:\n%s", out)
+	}
+	assertFramed(t, a.renderAgentsTab(14), 90)
+
+	// esc walks back: content → files → detail.
+	send("esc")
+	if a.model.agentsTab.View != AgentViewFiles {
+		t.Fatalf("esc from content → view %d, want AgentViewFiles", a.model.agentsTab.View)
+	}
+	send("esc")
+	if a.model.agentsTab.View != AgentViewDetail {
+		t.Fatalf("esc from files → view %d, want AgentViewDetail", a.model.agentsTab.View)
 	}
 }
 


### PR DESCRIPTION
## Summary
- In the dashboard (the **Agents** tab), the agent detail now lists the related files — **soul** and **skills** — and offers a shortcut to inspect them.
- The **f** key in the detail opens a navigable list of files (soul + each skill). **enter/l** opens a scrollable viewer with the file content; **esc** goes back level by level (content → list → detail).
- Resolves `soul_file` and `.claude/skills/<id>/SKILL.md` relative to the working directory (the same root the dispatcher reads from). Files that aren't found stay in the list marked `(missing)` instead of silently disappearing.
- The agent detail now shows a **Skills** line and a **Related files** summary with the count and the key hint.
- Footer/hints and the position (scroll) indicator updated for the new views.

### Implementation
- New `AgentViewFiles` and `AgentViewFileContent` states; an `AgentFileItem` type; a `Skills` field on `AgentStatus` and file state in `AgentsTab`.
- `buildAgentFiles` / `openSelectedAgentFile` / `agentFileLines` helpers and `renderAgentFiles` / `renderAgentFileContent` renders.

## Test plan
- `go vet ./internal/dashboard/` — clean
- `go build ./...` — ok
- `go test ./...` — all packages pass
- A new test `TestAgentRelatedFilesFlow`: covers building the list (including `missing` detection), the `f → ↓ → enter` flow, content rendering and `esc` going back level by level.