### PR TITLE
feat(dashboard): render markdown inline in logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5478 symbols, 12337 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5497 symbols, 12399 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5478 symbols, 12337 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5497 symbols, 12399 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -42,6 +42,12 @@ type App struct {
 	dbConn     *db.Client
 	socketPath string
 	cfg        *config.Config
+
+	// logMDCache memoizes glamour-rendered markdown log messages, keyed by the
+	// message text. glamour is expensive, so each distinct message renders once;
+	// the cache is dropped whenever the render width changes (logMDWidth).
+	logMDCache map[string][]string
+	logMDWidth int
 }
 
 func New(dbConn *db.Client, socketPath string, cfg *config.Config) *App {
@@ -3001,7 +3007,7 @@ func (a *App) logEntryLines(logs []LogEntry) []string {
 	for _, entry := range logs {
 		ts := StyleMuted.Render(entry.Timestamp.Format("15:04:05"))
 		level := levelStyle(entry.Level).Render(fmt.Sprintf("%-5s", entry.Level))
-		wrapped := wrapPlain(entry.Message, msgWidth)
+		wrapped := a.logMessageLines(entry.Message, msgWidth)
 		if len(wrapped) == 0 {
 			wrapped = []string{""}
 		}
@@ -3014,6 +3020,61 @@ func (a *App) logEntryLines(logs []LogEntry) []string {
 		}
 	}
 	return out
+}
+
+// logMessageLines renders a log message to display lines at the given content
+// width. Messages that look like markdown (agent outputs — headings, lists,
+// bold, code fences) are rendered with glamour and memoized; everything else
+// (operational one-liners) falls back to plain wrapping. Rendered output is
+// clamped so it never overflows the column.
+func (a *App) logMessageLines(msg string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	if !looksLikeMarkdown(msg) {
+		return wrapPlain(msg, width)
+	}
+
+	// Cache is width-scoped; drop it wholesale when the width changes.
+	if a.logMDCache == nil || a.logMDWidth != width {
+		a.logMDCache = make(map[string][]string)
+		a.logMDWidth = width
+	}
+	if lines, ok := a.logMDCache[msg]; ok {
+		return lines
+	}
+
+	lines := wrapPlain(msg, width) // fallback if glamour errors
+	if rendered, err := renderMarkdown(msg, width); err == nil {
+		lines = clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), width)
+	}
+	a.logMDCache[msg] = lines
+	return lines
+}
+
+// looksLikeMarkdown is a cheap heuristic: only multi-line messages with at least
+// one markdown marker (heading, list item, blockquote, code fence, table, or
+// bold) are treated as markdown. Single-line operational logs stay plain.
+func looksLikeMarkdown(s string) bool {
+	if !strings.Contains(s, "\n") {
+		return false
+	}
+	for _, ln := range strings.Split(s, "\n") {
+		t := strings.TrimSpace(ln)
+		switch {
+		case strings.HasPrefix(t, "#"),
+			strings.HasPrefix(t, "- "),
+			strings.HasPrefix(t, "* "),
+			strings.HasPrefix(t, "> "),
+			strings.HasPrefix(t, "```"),
+			strings.HasPrefix(t, "|"):
+			return true
+		}
+		if strings.Contains(t, "**") {
+			return true
+		}
+	}
+	return false
 }
 
 // wrapPlain splits s on newlines and hard-wraps each line to width runes,
@@ -3629,7 +3690,7 @@ func (a *App) logVisualLines() []string {
 		msg := entry.Message
 
 		if l.Wrap {
-			wrapped := wrapPlain(msg, msgWidth)
+			wrapped := a.logMessageLines(msg, msgWidth)
 			if len(wrapped) == 0 {
 				wrapped = []string{""}
 			}

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -103,6 +103,67 @@ func TestTabsRenderFramedAndAligned(t *testing.T) {
 	assertFramed(t, a.renderAgentsTab(12), 100)
 }
 
+func TestLogMarkdownInlineRender(t *testing.T) {
+	a := newTestApp(90, 24)
+	md := "## Status\n\n- done\n- **verified**\n"
+	plain := "dispatching to agent=investigator model=claude-opus-4-8 runner=cli"
+
+	// Heuristic: multi-line markdown is detected; the operational one-liner isn't.
+	if !looksLikeMarkdown(md) {
+		t.Fatal("multi-line markdown should be detected")
+	}
+	if looksLikeMarkdown(plain) {
+		t.Fatal("operational one-liner should not be treated as markdown")
+	}
+
+	msgWidth := a.model.width - 2 - 15 // prefix column is 15 wide
+	rendered := a.logMessageLines(md, msgWidth)
+	if len(rendered) == 0 {
+		t.Fatal("no rendered lines for markdown log")
+	}
+	// Rendered markdown reflows differently from a plain wrap, but keeps the text.
+	if strings.Join(rendered, "\n") == strings.Join(wrapPlain(md, msgWidth), "\n") {
+		t.Error("markdown log should render differently from plain wrapping")
+	}
+	joined := stripANSI(strings.Join(rendered, "\n"))
+	if !strings.Contains(joined, "Status") || !strings.Contains(joined, "verified") {
+		t.Errorf("rendered markdown lost its text: %s", joined)
+	}
+	// No rendered line exceeds the content width (box border stays aligned).
+	for i, ln := range rendered {
+		if w := lipgloss.Width(ln); w > msgWidth {
+			t.Errorf("rendered line %d width %d exceeds msgWidth %d: %q", i, w, msgWidth, stripANSI(ln))
+		}
+	}
+
+	// Plain operational lines pass through wrapPlain untouched.
+	if got := a.logMessageLines(plain, msgWidth); strings.Join(got, "\n") != strings.Join(wrapPlain(plain, msgWidth), "\n") {
+		t.Error("plain message should pass through wrapPlain unchanged")
+	}
+
+	// The markdown render is memoized.
+	if a.logMDWidth != msgWidth || len(a.logMDCache) == 0 {
+		t.Errorf("markdown cache not populated: width=%d size=%d", a.logMDWidth, len(a.logMDCache))
+	}
+
+	// All three log paths render framed with the markdown entry inline.
+	now := time.Now()
+	entries := []LogEntry{
+		{Timestamp: now, Level: "INFO", Message: plain},
+		{Timestamp: now, Level: "INFO", Message: md},
+	}
+	a.model.activeTab = 4 // Logs
+	a.model.logsTab.Wrap = true
+	a.model.logsTab.Logs = entries
+	assertFramed(t, a.renderLogsTab(16), 90)
+
+	// logEntryLines feeds the Tasks- and Agents-tab task-log views.
+	taskLines := a.logEntryLines(entries)
+	if len(taskLines) < 4 { // 1 plain + several rendered markdown lines
+		t.Errorf("expected inline markdown to expand task logs, got %d lines", len(taskLines))
+	}
+}
+
 func TestLogsTabWrapAndScroll(t *testing.T) {
 	now := time.Now()
 	long := "this is a very long operational log message that certainly exceeds the available width of the logs panel and must either wrap onto multiple lines or be horizontally scrollable by the user"


### PR DESCRIPTION
## Summary
- Agents' final outputs are written to the logs as **markdown** (`##` headings, lists, `**bold**`). Previously they appeared with the raw markers in the stream; now they're **rendered inline** via glamour.
- Applied in **all three** log views: **Logs** (Logs tab, wrap mode), the **Tasks** tab's **task logs**, and the **Agents** tab's **task logs** — all go through the same `logEntryLines`/`logVisualLines`.
- Single-line operational logs (e.g. `dispatching to agent=…`) stay as plain text — only multi-line messages with markdown markers are rendered (the `looksLikeMarkdown` heuristic).

### Implementation
- `logMessageLines(msg, width)`: decides between glamour and `wrapPlain`; reuses `renderMarkdown`/`clampToWidth` from the file viewer.
- **Memoization** in `App.logMDCache` by `(width, message)`: glamour runs once per message; the cache is dropped when the width changes (resize).
- `clampToWidth` ensures no rendered line overflows the column (the box border stays aligned).

## Test plan
- `go vet ./internal/dashboard/` — clean
- `go build ./...` — ok
- `go test ./...` — all packages pass
- A new `TestLogMarkdownInlineRender`: the heuristic (multi-line markdown vs operational one-liner), rendering differs from plain wrap but preserves the text, no line exceeds the width, a plain message stays unchanged, the cache is populated, and the Logs tab framing + expansion in the task-logs path. Existing log tests stay green.