### PR TITLE
feat(runner): detect the provider's rate-limit + more useful failure errors

### DIFF
--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -78,6 +78,17 @@ type RunResult struct {
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error
+
+	// RateLimited is true when the provider rejected the run because of a
+	// usage/rate limit (e.g. Claude's 5-hour session limit). Such a run does no
+	// real work — it may even exit 0 with a "you've hit your session limit"
+	// message, so Success alone cannot be trusted. The dispatcher uses this to
+	// back off until RateLimitResetsAt instead of counting the run as a genuine
+	// success or failure.
+	RateLimited bool
+	// RateLimitResetsAt is when the provider's limit resets, when the provider
+	// reported it (zero otherwise). Only meaningful when RateLimited is true.
+	RateLimitResetsAt time.Time
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -93,6 +93,12 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		logs        []model.LogEntry
 		finalResult string
 		usage       model.Usage
+		// Set when the provider emits a rate_limit_event with status "rejected"
+		// (e.g. Claude's 5-hour session limit). resetsAt is epoch seconds, 0 if
+		// the provider did not report it. Guarded by mu (written from the stdout
+		// goroutine).
+		rateLimited       bool
+		rateLimitResetsAt int64
 	)
 
 	emit := func(level, msg string) {
@@ -158,6 +164,14 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 				finalResult = res
 				mu.Unlock()
 			}
+			if resetsAt, rejected := detectRateLimitRejection(line); rejected {
+				mu.Lock()
+				rateLimited = true
+				if resetsAt > 0 {
+					rateLimitResetsAt = resetsAt
+				}
+				mu.Unlock()
+			}
 			accumulateStreamUsage(line, &usage)
 			if pretty, ok := formatStreamLine(line); ok {
 				emit("debug", pretty)
@@ -193,17 +207,28 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		usagePtr = nil
 	}
 	result := model.RunResult{
-		WorkerID: req.WorkerID,
-		Success:  runErr == nil,
-		Output:   output,
-		Logs:     logs,
-		Duration: time.Since(start),
-		Usage:    usagePtr,
+		WorkerID:    req.WorkerID,
+		Success:     runErr == nil,
+		Output:      output,
+		Logs:        logs,
+		Duration:    time.Since(start),
+		Usage:       usagePtr,
+		RateLimited: rateLimited,
+	}
+	if rateLimited && rateLimitResetsAt > 0 {
+		result.RateLimitResetsAt = time.Unix(rateLimitResetsAt, 0)
 	}
 	if runErr != nil {
-		stderr := strings.TrimSpace(errBuf.String())
-		if stderr != "" {
-			result.Error = fmt.Errorf("%w\nstderr: %s", runErr, stderr)
+		// claude often exits non-zero with an empty stderr, leaving a bare
+		// "exit status 1" with no clue why. Fall back to the most meaningful
+		// stdout (final result / last assistant text) so the recorded error is
+		// diagnosable instead of opaque.
+		detail := strings.TrimSpace(errBuf.String())
+		if detail == "" {
+			detail = errorDetail(output)
+		}
+		if detail != "" {
+			result.Error = fmt.Errorf("%w: %s", runErr, detail)
 		} else {
 			result.Error = runErr
 		}
@@ -271,6 +296,55 @@ func accumulateStreamUsage(line string, u *model.Usage) {
 			u.CostUSD = ev.TotalCostUSD
 		}
 	}
+}
+
+// rateLimitEvent is the provider's usage-limit signal in the stream. Claude
+// emits it as {"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
+// "resetsAt":<epoch-seconds>,...}} when a run is blocked by the 5-hour session
+// limit (the run then prints "you've hit your session limit" and may exit 0).
+type rateLimitEvent struct {
+	Type          string `json:"type"`
+	RateLimitInfo *struct {
+		Status   string `json:"status"`
+		ResetsAt int64  `json:"resetsAt"`
+	} `json:"rate_limit_info"`
+}
+
+// detectRateLimitRejection reports whether a stream-json line is a
+// rate_limit_event with status "rejected" (the provider refused the run because
+// of a usage limit), along with the epoch-seconds reset time when present.
+// Other statuses ("allowed", "allowed_warning") are not rejections.
+func detectRateLimitRejection(line string) (resetsAt int64, rejected bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return 0, false
+	}
+	var ev rateLimitEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+		return 0, false
+	}
+	if ev.Type != "rate_limit_event" || ev.RateLimitInfo == nil {
+		return 0, false
+	}
+	if ev.RateLimitInfo.Status != "rejected" {
+		return 0, false
+	}
+	return ev.RateLimitInfo.ResetsAt, true
+}
+
+// errorDetail trims, single-lines, and length-caps an output fragment so it can
+// be folded into a recorded error message without dumping a whole transcript.
+func errorDetail(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	const max = 300
+	if len(s) > max {
+		s = "…" + s[len(s)-max:]
+	}
+	return s
 }
 
 func formatStreamLine(line string) (string, bool) {

--- a/src/internal/runner/execution/ratelimit_test.go
+++ b/src/internal/runner/execution/ratelimit_test.go
@@ -1,0 +1,63 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectRateLimitRejection_Rejected(t *testing.T) {
+	line := `{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1780731000,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}`
+	resetsAt, rejected := detectRateLimitRejection(line)
+	if !rejected {
+		t.Fatal("expected rejected=true")
+	}
+	if resetsAt != 1780731000 {
+		t.Errorf("resetsAt = %d, want 1780731000", resetsAt)
+	}
+}
+
+func TestDetectRateLimitRejection_NotRejected(t *testing.T) {
+	// "allowed" and "allowed_warning" are normal — not rejections. The presence
+	// of overageStatus:"rejected" must NOT be mistaken for a rejected run.
+	cases := []string{
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1780731000,"overageStatus":"rejected"}}`,
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","resetsAt":1780731000,"utilization":0.9}}`,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestDetectRateLimitRejection_OtherLines(t *testing.T) {
+	cases := []string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"result","subtype":"success","result":"done"}`,
+		`plain text, not json`,
+		`{"type":"rate_limit_event"}`, // no rate_limit_info
+		``,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestErrorDetail(t *testing.T) {
+	if got := errorDetail("   "); got != "" {
+		t.Errorf("blank input: got %q, want empty", got)
+	}
+	if got := errorDetail("boom\nstack trace"); got != "boom stack trace" {
+		t.Errorf("newline folding: got %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	got := errorDetail(long)
+	if len([]rune(got)) > 301 { // 300 chars + the ellipsis rune
+		t.Errorf("not capped: len=%d", len([]rune(got)))
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("expected ellipsis prefix when capped, got %q", got[:10])
+	}
+}


### PR DESCRIPTION
## Summary
Foundation for dispatcher rate-limit handling, plus immediately-useful failure diagnostics.

- The claude CLI emits a `rate_limit_event` with `status:"rejected"` (the 5h limit), prints "you've hit your session limit" and **exits with code 0** — so a run blocked by a rate limit was recorded as an **empty success**. We now detect this and expose `RunResult.RateLimited` + `RateLimitResetsAt`.
- On failures with empty stderr, the error wasn't diagnosable ("exit status 1"). It now falls back to the final result / the assistant's last text.
- No dispatch-behavior change yet: the fields are populated but will only be consumed by the rate-limit failover (next PR).

## Test plan
- `go build ./...` ✅
- `go vet ./internal/runner/execution/` ✅
- `go test ./...` ✅ (4 new tests: detectRateLimitRejection rejected/allowed/non-event, errorDetail trim/fold/cap)

Part 1 of 4 of the dispatcher hardening (rate-limit failover, re-dispatch safety-net, non-blocking dispatch). Orphan reconciliation is handled in a separate branch.