### PR TITLE
feat(dispatcher): rate-limit failover to a runner/model chain

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -80,6 +80,20 @@ type AgentConfig struct {
 	// this agent, in any workflow. It is the lowest-precedence explicit env scope
 	// (below workflow.env and step.env), layered on top of the identity overlay.
 	Env map[string]string `yaml:"env,omitempty"`
+	// Fallbacks is an ordered chain of alternative runner/model pairs to try when
+	// the primary runner is rejected by a provider rate limit (e.g. Claude's
+	// 5-hour session limit). The dispatcher pauses the rejected runner type until
+	// it resets and retries the step on the next non-paused fallback. Empty means
+	// no failover (the step fails / waits for the limit to reset).
+	Fallbacks []FallbackConfig `yaml:"fallbacks,omitempty"`
+}
+
+// FallbackConfig is one entry in an agent's rate-limit failover chain. Runner
+// must reference a defined runner id; Model is optional (empty uses that
+// runner's default model).
+type FallbackConfig struct {
+	Runner string `yaml:"runner"`
+	Model  string `yaml:"model,omitempty"`
 }
 
 type WorkerConfig struct {

--- a/src/internal/config/fallback_validate_test.go
+++ b/src/internal/config/fallback_validate_test.go
@@ -1,0 +1,53 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func baseCfgWithFallbacks(fbs []config.FallbackConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{{ID: "claude", Type: "claude-cli"}, {ID: "opencode-go", Type: "cli", Provider: "opencode"}},
+		Agents: []config.AgentConfig{{
+			ID: "engineer", Model: "claude-sonnet-4-6", Runner: "claude", Fallbacks: fbs,
+		}},
+	}
+}
+
+func TestValidate_FallbackRunnerDefined(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Runner: "opencode-go", Model: "opencode-go/x"}})
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), "fallback") {
+			t.Errorf("valid fallback flagged: %v", err)
+		}
+	}
+}
+
+func TestValidate_FallbackRunnerUndefined(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Runner: "ghost"}})
+	found := false
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), `fallbacks[0]: runner "ghost" not defined`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected undefined-fallback-runner error, got %v", cfg.Validate())
+	}
+}
+
+func TestValidate_FallbackRunnerRequired(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Model: "only-model"}})
+	found := false
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), "fallbacks[0]: runner is required") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected required-runner error, got %v", cfg.Validate())
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -61,6 +61,13 @@ func (c *Config) Validate() []error {
 		if a.Runner != "" && !runnerIDs[a.Runner] {
 			errs = append(errs, fmt.Errorf("agents[%d] %q: runner %q not defined", i, a.ID, a.Runner))
 		}
+		for j, fb := range a.Fallbacks {
+			if fb.Runner == "" {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: fallbacks[%d]: runner is required", i, a.ID, j))
+			} else if !runnerIDs[fb.Runner] {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: fallbacks[%d]: runner %q not defined", i, a.ID, j, fb.Runner))
+			}
+		}
 		if agentIDs[a.ID] {
 			errs = append(errs, fmt.Errorf("agents[%d]: duplicate id %q", i, a.ID))
 		}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -48,6 +48,15 @@ type Dispatcher struct {
 	sources     map[string]source.Adapter
 	runners     map[string]runnerimpl.Runner
 	agentRunner map[string]string
+	// agentFallbacks holds each agent's rate-limit failover chain (primary
+	// excluded), in order. Pre-built at construction so failover is a cheap swap.
+	agentFallbacks map[string][]runnerCandidate
+
+	// rateLimitPaused maps a runner adapter type (e.g. "claude") to the time its
+	// provider rate limit resets. While now is before that time, the dispatcher
+	// routes that runner's steps to a fallback instead. Guarded by rateLimitMu.
+	rateLimitPaused map[string]time.Time
+	rateLimitMu     sync.Mutex
 
 	db     *db.Client
 	logger *logging.Logger
@@ -75,6 +84,40 @@ type Dispatcher struct {
 	engineOnce sync.Once
 }
 
+// runnerCandidate is one rung in an agent's rate-limit failover chain: a
+// configured runner adapter, its adapter type (the rate-limit pause key), and
+// the model to run it with.
+type runnerCandidate struct {
+	adapter    runnerimpl.Runner
+	runnerType string
+	model      string
+}
+
+// runnerPausedUntil returns the time a runner type's provider rate limit resets,
+// or the zero time if it is not paused.
+func (d *Dispatcher) runnerPausedUntil(runnerType string) time.Time {
+	d.rateLimitMu.Lock()
+	defer d.rateLimitMu.Unlock()
+	return d.rateLimitPaused[runnerType]
+}
+
+// pauseRunner records that a runner type was rate-limited until `until`. A zero
+// `until` (provider did not report a reset) defaults to 5 minutes out. Only
+// extends an existing pause, never shortens it.
+func (d *Dispatcher) pauseRunner(runnerType string, until time.Time) {
+	if until.IsZero() {
+		until = time.Now().Add(5 * time.Minute)
+	}
+	d.rateLimitMu.Lock()
+	defer d.rateLimitMu.Unlock()
+	if d.rateLimitPaused == nil {
+		d.rateLimitPaused = make(map[string]time.Time)
+	}
+	if cur, ok := d.rateLimitPaused[runnerType]; !ok || until.After(cur) {
+		d.rateLimitPaused[runnerType] = until
+	}
+}
+
 // New builds and connects a Dispatcher from the given config.
 // Pass nil for db and logger to skip state persistence and logging to SQLite.
 func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger) (*Dispatcher, error) {
@@ -88,9 +131,11 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		configFile:  configFile,
 		startedAt:   time.Now(),
 		router:      r,
-		sources:     make(map[string]source.Adapter),
-		runners:     make(map[string]runnerimpl.Runner),
-		agentRunner: make(map[string]string),
+		sources:         make(map[string]source.Adapter),
+		runners:         make(map[string]runnerimpl.Runner),
+		agentRunner:     make(map[string]string),
+		agentFallbacks:  make(map[string][]runnerCandidate),
+		rateLimitPaused: make(map[string]time.Time),
 		db:          dbClient,
 		logger:      logger,
 		sem:         make(chan struct{}, 1), // poll: one at a time
@@ -187,6 +232,34 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if err := d.writeOpencodeAgent(ctx, ac, rc); err != nil {
 				aplog.Warn("agent %s: write opencode agent config: %v", ac.ID, err)
 			}
+		}
+
+		// Pre-build the rate-limit failover chain so dispatch can swap runners
+		// without re-instantiating adapters on the hot path.
+		for _, fb := range ac.Fallbacks {
+			frc, ok := runnerMap[fb.Runner]
+			if !ok {
+				return nil, fmt.Errorf("agent %q: fallback runner %q not found", ac.ID, fb.Runner)
+			}
+			fAdapterName := frc.AdapterName()
+			fra, ok := runnerimpl.New(fAdapterName)
+			if !ok {
+				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
+			}
+			if err := fra.Configure(frc.Config); err != nil {
+				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
+			}
+			if fAdapterName == "opencode" {
+				if err := d.writeOpencodeAgent(ctx, ac, frc); err != nil {
+					aplog.Warn("agent %s: write opencode fallback agent config: %v", ac.ID, err)
+				}
+			}
+			d.agentFallbacks[ac.ID] = append(d.agentFallbacks[ac.ID], runnerCandidate{
+				adapter:    fra,
+				runnerType: fAdapterName,
+				model:      fb.Model,
+			})
+			aplog.Info("agent %s: fallback #%d runner=%s type=%s model=%s", ac.ID, len(d.agentFallbacks[ac.ID]), fb.Runner, fAdapterName, fb.Model)
 		}
 	}
 

--- a/src/internal/daemon/failover_test.go
+++ b/src/internal/daemon/failover_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// scriptedRunner returns a fixed result and records its invocation count, so a
+// test can assert which runner in a failover chain actually ran.
+type scriptedRunner struct {
+	result model.RunResult
+	calls  int
+}
+
+func (s *scriptedRunner) ID() string                       { return "scripted" }
+func (s *scriptedRunner) Configure(_ map[string]any) error { return nil }
+func (s *scriptedRunner) Run(_ context.Context, _ model.RunRequest) (model.RunResult, error) {
+	s.calls++
+	return s.result, nil
+}
+
+func newFailoverDispatcher(t *testing.T, primary, fallback runnerpkg.Runner, fbType, fbModel string) (*Dispatcher, *db.Client) {
+	t.Helper()
+	dbc, err := db.New(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	d := &Dispatcher{
+		cfg:             &config.Config{},
+		db:              dbc,
+		runners:         map[string]runnerpkg.Runner{"agent-engineer": primary},
+		agentRunner:     map[string]string{"engineer": "claude"},
+		agentFallbacks:  map[string][]runnerCandidate{"engineer": {{adapter: fallback, runnerType: fbType, model: fbModel}}},
+		rateLimitPaused: map[string]time.Time{},
+	}
+	return d, dbc
+}
+
+func stepReq(instance, cellID string) workflow.StepRequest {
+	return workflow.StepRequest{
+		InstanceID: instance,
+		Cell:       model.SourceItem{ID: cellID, Title: "T", Number: "#1"},
+		Step:       config.StepConfig{ID: "implement", Agent: "engineer"},
+		Model:      "claude-sonnet-4-6",
+	}
+}
+
+// A rate-limited primary fails over to the fallback runner, the fallback's
+// result is returned, and the primary's runner type is paused.
+func TestWfStepExecutor_RateLimitFailover(t *testing.T) {
+	ctx := context.Background()
+	resets := time.Now().Add(2 * time.Hour)
+	primary := &scriptedRunner{result: model.RunResult{Success: true, RateLimited: true, RateLimitResetsAt: resets, Output: "limit"}}
+	fallback := &scriptedRunner{result: model.RunResult{Success: true, Output: "did the work"}}
+	d, _ := newFailoverDispatcher(t, primary, fallback, "opencode", "opencode-go/deepseek-v4-pro")
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, stepReq("wf_1", "c1"))
+
+	if primary.calls != 1 {
+		t.Errorf("primary calls = %d, want 1", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1 (failover)", fallback.calls)
+	}
+	if !res.Success || res.Output != "did the work" {
+		t.Errorf("expected fallback result, got success=%v output=%q", res.Success, res.Output)
+	}
+	if got := d.runnerPausedUntil("claude"); !got.Equal(resets) {
+		t.Errorf("claude pause = %v, want %v", got, resets)
+	}
+}
+
+// When the primary's runner type is already paused, the primary is skipped and
+// the fallback runs directly — no wasted rate-limited call.
+func TestWfStepExecutor_SkipsPausedPrimary(t *testing.T) {
+	ctx := context.Background()
+	primary := &scriptedRunner{result: model.RunResult{Success: true}}
+	fallback := &scriptedRunner{result: model.RunResult{Success: true, Output: "fallback ran"}}
+	d, _ := newFailoverDispatcher(t, primary, fallback, "opencode", "m")
+	d.pauseRunner("claude", time.Now().Add(time.Hour))
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, stepReq("wf_1", "c1"))
+
+	if primary.calls != 0 {
+		t.Errorf("primary calls = %d, want 0 (paused, skipped)", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1", fallback.calls)
+	}
+	if res.Output != "fallback ran" {
+		t.Errorf("output = %q, want fallback", res.Output)
+	}
+}
+
+func TestPauseRunner(t *testing.T) {
+	d := &Dispatcher{}
+	if !d.runnerPausedUntil("claude").IsZero() {
+		t.Error("unset runner should not be paused")
+	}
+	// nil-map safe + zero reset defaults to ~5m out.
+	d.pauseRunner("claude", time.Time{})
+	if got := d.runnerPausedUntil("claude"); got.Before(time.Now().Add(4*time.Minute)) {
+		t.Errorf("zero reset should default ~5m out, got %v", got)
+	}
+	// Only extends, never shortens.
+	far := time.Now().Add(2 * time.Hour)
+	d.pauseRunner("claude", far)
+	d.pauseRunner("claude", time.Now().Add(time.Minute))
+	if got := d.runnerPausedUntil("claude"); !got.Equal(far) {
+		t.Errorf("pause shortened: got %v, want %v", got, far)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -173,32 +173,59 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		}
 	}
 
-	// Record a task_executions row for this step so the dashboard (Tasks
-	// history, Usage/cost, agent stats, live "running" status) observes
-	// workflow steps the same way it observed legacy single-shot runs. Each
-	// step is one execution; usage and PID/heartbeat are wired through.
-	exec := x.beginExecution(ctx, req)
-	if exec != nil {
-		execID := exec.ID
-		rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
-		rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
-	}
+	// Run chain: the agent's primary runner first, then its rate-limit failover
+	// chain. A candidate whose runner type is currently paused by a provider rate
+	// limit is skipped (unless it is the last resort). Each attempt is its own
+	// task_executions row — recorded the same way legacy single-shot runs were —
+	// so the dashboard (Tasks history, Usage/cost, agent stats, live "running")
+	// shows the failover. usage and PID/heartbeat are wired through per attempt.
+	candidates := append([]runnerCandidate{{
+		adapter:    ra,
+		runnerType: x.d.agentRunner[req.Step.Agent],
+		model:      req.Model,
+	}}, x.d.agentFallbacks[req.Step.Agent]...)
 
-	runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
-	// Register the cancel func so `apiary restart` / ForceRestart can interrupt
-	// an in-flight step. A single key per cell mirrors legacy behaviour.
-	x.d.runCancel.Store(req.Cell.ID, cancel)
-	defer func() {
+	var res model.RunResult
+	for i, c := range candidates {
+		last := i == len(candidates)-1
+		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
+			aplog.Info("[%s] runner %q paused by rate limit, skipping to fallback", req.Cell.ID, c.runnerType)
+			continue
+		}
+
+		rr.Model = c.model
+		exec := x.beginExecution(ctx, req, c.model, c.runnerType)
+		if exec != nil {
+			execID := exec.ID
+			rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
+			rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
+		}
+
+		runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
+		// Register the cancel func so `apiary restart` / ForceRestart can interrupt
+		// an in-flight step. A single key per cell mirrors legacy behaviour.
+		x.d.runCancel.Store(req.Cell.ID, cancel)
+		out, err := c.adapter.Run(runCtx, rr)
 		cancel()
 		x.d.runCancel.Delete(req.Cell.ID)
-	}()
+		if err != nil && out.Error == nil {
+			out.Error = err
+		}
+		x.finishExecution(ctx, exec, out)
+		res = out
 
-	res, err := ra.Run(runCtx, rr)
-	if err != nil && res.Error == nil {
-		res.Error = err
+		// On a provider rate-limit rejection, pause this runner type until it
+		// resets and fail over to the next candidate. Not a genuine failure — the
+		// run did no work — so we do not return it while a fallback remains.
+		if out.RateLimited {
+			x.d.pauseRunner(c.runnerType, out.RateLimitResetsAt)
+			if !last {
+				aplog.Info("[%s] runner %q rate-limited, failing over to next runner", req.Cell.ID, c.runnerType)
+				continue
+			}
+		}
+		break
 	}
-
-	x.finishExecution(ctx, exec, res)
 
 	// publish: off suppresses write-back before the engine ever sees the payload,
 	// even when the agent emitted an APIARY_PUBLISH block.
@@ -227,7 +254,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 // beginExecution creates the task_executions row for a step run, or returns nil
 // when no run-history DB is configured. The attempt number continues the cell's
 // execution history so retries/steps accumulate rather than reset.
-func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRequest) *db.Execution {
+func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRequest, model, runnerType string) *db.Execution {
 	if x.d.db == nil {
 		return nil
 	}
@@ -235,9 +262,8 @@ func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRe
 	if last, _ := x.d.db.GetLastExecution(ctx, req.Cell.ID); last != nil {
 		attempt = last.Attempt + 1
 	}
-	runnerType := x.d.agentRunner[req.Step.Agent]
 	exec, err := x.d.db.CreateExecution(ctx, req.Cell.ID, req.Step.Agent, req.Cell.Title,
-		req.Cell.Number, req.Cell.URL, req.Model, runnerType, attempt)
+		req.Cell.Number, req.Cell.URL, model, runnerType, attempt)
 	if err != nil {
 		aplog.Error("cell %s: create execution record: %v", req.Cell.ID, err)
 		return nil

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -78,6 +78,17 @@ type RunResult struct {
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error
+
+	// RateLimited is true when the provider rejected the run because of a
+	// usage/rate limit (e.g. Claude's 5-hour session limit). Such a run does no
+	// real work — it may even exit 0 with a "you've hit your session limit"
+	// message, so Success alone cannot be trusted. The dispatcher uses this to
+	// back off until RateLimitResetsAt instead of counting the run as a genuine
+	// success or failure.
+	RateLimited bool
+	// RateLimitResetsAt is when the provider's limit resets, when the provider
+	// reported it (zero otherwise). Only meaningful when RateLimited is true.
+	RateLimitResetsAt time.Time
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -93,6 +93,12 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		logs        []model.LogEntry
 		finalResult string
 		usage       model.Usage
+		// Set when the provider emits a rate_limit_event with status "rejected"
+		// (e.g. Claude's 5-hour session limit). resetsAt is epoch seconds, 0 if
+		// the provider did not report it. Guarded by mu (written from the stdout
+		// goroutine).
+		rateLimited       bool
+		rateLimitResetsAt int64
 	)
 
 	emit := func(level, msg string) {
@@ -158,6 +164,14 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 				finalResult = res
 				mu.Unlock()
 			}
+			if resetsAt, rejected := detectRateLimitRejection(line); rejected {
+				mu.Lock()
+				rateLimited = true
+				if resetsAt > 0 {
+					rateLimitResetsAt = resetsAt
+				}
+				mu.Unlock()
+			}
 			accumulateStreamUsage(line, &usage)
 			if pretty, ok := formatStreamLine(line); ok {
 				emit("debug", pretty)
@@ -193,17 +207,28 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		usagePtr = nil
 	}
 	result := model.RunResult{
-		WorkerID: req.WorkerID,
-		Success:  runErr == nil,
-		Output:   output,
-		Logs:     logs,
-		Duration: time.Since(start),
-		Usage:    usagePtr,
+		WorkerID:    req.WorkerID,
+		Success:     runErr == nil,
+		Output:      output,
+		Logs:        logs,
+		Duration:    time.Since(start),
+		Usage:       usagePtr,
+		RateLimited: rateLimited,
+	}
+	if rateLimited && rateLimitResetsAt > 0 {
+		result.RateLimitResetsAt = time.Unix(rateLimitResetsAt, 0)
 	}
 	if runErr != nil {
-		stderr := strings.TrimSpace(errBuf.String())
-		if stderr != "" {
-			result.Error = fmt.Errorf("%w\nstderr: %s", runErr, stderr)
+		// claude often exits non-zero with an empty stderr, leaving a bare
+		// "exit status 1" with no clue why. Fall back to the most meaningful
+		// stdout (final result / last assistant text) so the recorded error is
+		// diagnosable instead of opaque.
+		detail := strings.TrimSpace(errBuf.String())
+		if detail == "" {
+			detail = errorDetail(output)
+		}
+		if detail != "" {
+			result.Error = fmt.Errorf("%w: %s", runErr, detail)
 		} else {
 			result.Error = runErr
 		}
@@ -271,6 +296,55 @@ func accumulateStreamUsage(line string, u *model.Usage) {
 			u.CostUSD = ev.TotalCostUSD
 		}
 	}
+}
+
+// rateLimitEvent is the provider's usage-limit signal in the stream. Claude
+// emits it as {"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
+// "resetsAt":<epoch-seconds>,...}} when a run is blocked by the 5-hour session
+// limit (the run then prints "you've hit your session limit" and may exit 0).
+type rateLimitEvent struct {
+	Type          string `json:"type"`
+	RateLimitInfo *struct {
+		Status   string `json:"status"`
+		ResetsAt int64  `json:"resetsAt"`
+	} `json:"rate_limit_info"`
+}
+
+// detectRateLimitRejection reports whether a stream-json line is a
+// rate_limit_event with status "rejected" (the provider refused the run because
+// of a usage limit), along with the epoch-seconds reset time when present.
+// Other statuses ("allowed", "allowed_warning") are not rejections.
+func detectRateLimitRejection(line string) (resetsAt int64, rejected bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return 0, false
+	}
+	var ev rateLimitEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+		return 0, false
+	}
+	if ev.Type != "rate_limit_event" || ev.RateLimitInfo == nil {
+		return 0, false
+	}
+	if ev.RateLimitInfo.Status != "rejected" {
+		return 0, false
+	}
+	return ev.RateLimitInfo.ResetsAt, true
+}
+
+// errorDetail trims, single-lines, and length-caps an output fragment so it can
+// be folded into a recorded error message without dumping a whole transcript.
+func errorDetail(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	const max = 300
+	if len(s) > max {
+		s = "…" + s[len(s)-max:]
+	}
+	return s
 }
 
 func formatStreamLine(line string) (string, bool) {

--- a/src/internal/runner/execution/ratelimit_test.go
+++ b/src/internal/runner/execution/ratelimit_test.go
@@ -1,0 +1,63 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectRateLimitRejection_Rejected(t *testing.T) {
+	line := `{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1780731000,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}`
+	resetsAt, rejected := detectRateLimitRejection(line)
+	if !rejected {
+		t.Fatal("expected rejected=true")
+	}
+	if resetsAt != 1780731000 {
+		t.Errorf("resetsAt = %d, want 1780731000", resetsAt)
+	}
+}
+
+func TestDetectRateLimitRejection_NotRejected(t *testing.T) {
+	// "allowed" and "allowed_warning" are normal — not rejections. The presence
+	// of overageStatus:"rejected" must NOT be mistaken for a rejected run.
+	cases := []string{
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1780731000,"overageStatus":"rejected"}}`,
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","resetsAt":1780731000,"utilization":0.9}}`,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestDetectRateLimitRejection_OtherLines(t *testing.T) {
+	cases := []string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"result","subtype":"success","result":"done"}`,
+		`plain text, not json`,
+		`{"type":"rate_limit_event"}`, // no rate_limit_info
+		``,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestErrorDetail(t *testing.T) {
+	if got := errorDetail("   "); got != "" {
+		t.Errorf("blank input: got %q, want empty", got)
+	}
+	if got := errorDetail("boom\nstack trace"); got != "boom stack trace" {
+		t.Errorf("newline folding: got %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	got := errorDetail(long)
+	if len([]rune(got)) > 301 { // 300 chars + the ellipsis rune
+		t.Errorf("not capped: len=%d", len([]rune(got)))
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("expected ellipsis prefix when capped, got %q", got[:10])
+	}
+}


### PR DESCRIPTION
## Summary
When the provider rejects a run with a rate limit (Claude's 5h limit), the step now **fails over** instead of churning empty "successes" in a loop.

- Agents gain `fallbacks: [{runner, model}]` (an ordered chain; each runner must be defined — validated).
- On a rate-limit rejection, the dispatcher **pauses that runner type** until `resetsAt` and tries the next non-paused fallback. While paused, that type's steps go straight to the fallback (no wasted call).
- Each attempt is its own row in `task_executions` → the dashboard shows the failover.

```yaml
agents:
  - id: engineer
    runner: claude
    model: claude-sonnet-4-6
    fallbacks:
      - {runner: opencode-go, model: opencode-go/deepseek-v4-pro}
      - {runner: cursor, model: composer-2.5-fast}
```

## Test plan
- `go build ./...` ✅ · `go vet` ✅ · `go test ./...` ✅
- New tests: failover runs the fallback + records the pause; a paused primary is skipped; the pause only extends/zero→+5min; config validation (runner defined / required).

## Notes
- **Stacked on #97** (uses `RateLimited`/`RateLimitResetsAt`). Base = `feat/runner-rate-limit-detect`; review/merge #97 first.
- `fallbacks` load at startup (live-edit via `UpdateAgentConfig` unchanged — requires a restart to change the chain).

Part 2 of 4 of the dispatcher hardening.