### PR TITLE
fix(workflow): rehydrate parked approvals on daemon startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5497 symbols, 12399 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5580 symbols, 12587 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5497 symbols, 12399 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (5580 symbols, 12587 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -219,6 +219,12 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		}
 	}
 
+	// Reconstruct workflow instances parked at an approval step into the engine's
+	// in-memory parked set. That set is empty after a restart, so without this the
+	// polling loop would never re-evaluate them and their tasks would be stranded
+	// in 'registered' forever (the approval_waiting restart gap).
+	d.rehydrateParkedApprovals(ctx)
+
 	for _, sc := range d.cfg.Sources {
 		sc := sc
 		adapter, ok := d.sources[sc.ID]

--- a/src/internal/daemon/rehydrate_approval_test.go
+++ b/src/internal/daemon/rehydrate_approval_test.go
@@ -1,0 +1,155 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// approvingPoller is a poll-only source whose PollTask always reports an approving
+// comment, so a parked approval's resume_on condition matches on the next check.
+type approvingPoller struct{}
+
+func (approvingPoller) ID() string                                    { return "src" }
+func (approvingPoller) Connect(context.Context, map[string]any) error { return nil }
+func (approvingPoller) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (approvingPoller) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (approvingPoller) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (approvingPoller) WebhookHandler() http.Handler { return nil }
+func (approvingPoller) PollTask(_ context.Context, cellID string) (model.SourceItem, error) {
+	return model.SourceItem{ID: cellID, SourceID: "src",
+		Comments: []model.Comment{{Body: "approve please"}}}, nil
+}
+
+var (
+	_ source.Adapter    = approvingPoller{}
+	_ source.TaskPoller = approvingPoller{}
+)
+
+// TestRehydrateParkedApprovals_ResumesAndSettlesTask is the end-to-end regression
+// test for the approval_waiting restart gap. It seeds a real DB exactly as a
+// previous daemon would have left it — a workflow instance parked at an approval
+// step, its task still carrying one outstanding workflow — then exercises the
+// startup rehydration path. After rehydration the polling loop's approval check
+// must resume the instance and settle the task, instead of leaving it stranded.
+func TestRehydrateParkedApprovals_ResumesAndSettlesTask(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "rehydrate.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents: []config.AgentConfig{
+			{ID: "architect", Model: "test/model"},
+			{ID: "backend-dev", Model: "test/model"},
+		},
+		Settings: config.Settings{StateLock: false, ResultComment: false},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "feature",
+			Trigger: &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src"}},
+			Steps: []config.StepConfig{
+				{ID: "plan", Agent: "architect"},
+				{ID: "gate", Type: config.StepTypeApproval, DependsOn: []string{"plan"},
+					Message:  "Plan ready.",
+					ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"},
+					Timeout:  "48h"},
+				{ID: "implement", Agent: "backend-dev", DependsOn: []string{"gate"}},
+			},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	impl := &countingRunner{}
+	d := &Dispatcher{
+		cfg:     cfg,
+		db:      dbc,
+		router:  r,
+		sources: map[string]source.Adapter{"src": approvingPoller{}},
+		runners: map[string]runnerpkg.Runner{
+			"agent-architect":   &countingRunner{},
+			"agent-backend-dev": impl,
+		},
+		agentRunner: map[string]string{"architect": "claude", "backend-dev": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	// --- seed the DB as if a previous daemon parked an instance at the approval. ---
+	cell := model.SourceItem{ID: "ISSUE-1", SourceID: "src", Number: "#1", Title: "Add feature", State: "todo"}
+	task, err := d.binder.Bind(ctx, cell)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	if _, err := dbc.InternalTasks().IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment outstanding: %v", err)
+	}
+	instID := "wf-parked-1"
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: instID, WorkflowID: "feature", TaskID: task.ID, CellID: cell.ID, SourceID: "src",
+		State: db.InstanceStateApprovalWaiting,
+	}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	started := time.Now()
+	if err := dbc.CreateStepRun(ctx, &db.StepRun{
+		ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", AgentID: "architect",
+		State: db.StepStatePassed, Output: "planned", StartedAt: &started, FinishedAt: &started,
+	}); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+
+	// --- the fix: a fresh daemon rehydrates the parked approval at startup. ---
+	d.rehydrateParkedApprovals(ctx)
+	if d.engine == nil {
+		t.Fatal("rehydration should have built the engine")
+	}
+	parked := d.engine.ParkedApprovals()
+	if len(parked) != 1 || parked[0].InstanceID != instID || parked[0].Step.ID != "gate" {
+		t.Fatalf("expected one rehydrated parked approval at gate, got %+v", parked)
+	}
+
+	// --- the poll loop's approval check now sees the approving comment. ---
+	d.checkApprovals(ctx)
+
+	inst, err := dbc.GetWorkflowInstance(ctx, instID)
+	if err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if inst.State != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done", inst.State)
+	}
+	if got := impl.n.Load(); got != 1 {
+		t.Errorf("implement runner calls = %d, want 1", got)
+	}
+	got, err := dbc.InternalTasks().GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got == nil || got.State != model.TaskStateDone {
+		t.Errorf("task state = %v, want done (the gap left it stuck in 'registered')", got)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -32,6 +32,59 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 	return d.engine
 }
 
+// rehydrateParkedApprovals reconstructs workflow instances persisted in the
+// approval_waiting state and re-registers them in the engine's in-memory parked
+// set, so the polling loop's approval check (checkApprovals → CheckParkedApprovals)
+// re-evaluates them after a daemon restart.
+//
+// The parked set lives only in memory and is empty on a fresh process, so without
+// this an instance left waiting for approval when the daemon stopped would never
+// be re-evaluated: it would stay approval_waiting forever, its task's
+// outstanding-workflow counter would never drain, and the task would stay stuck in
+// 'registered'. ReconcileOrphanWorkflowInstances deliberately leaves
+// approval_waiting rows untouched (interrupting them would lose the wait); this
+// rehydration is what brings them back to life. Called once at startup, after the
+// orphan reconcile and before the poll loops start, so it builds the engine eagerly
+// (via workflowEngine) — that also makes the very first poll's approval check live.
+func (d *Dispatcher) rehydrateParkedApprovals(ctx context.Context) {
+	if d.db == nil {
+		return
+	}
+	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateApprovalWaiting)
+	if err != nil {
+		aplog.Warn("rehydrate parked approvals: list instances: %v", err)
+		return
+	}
+	if len(instances) == 0 {
+		return
+	}
+
+	engine := d.workflowEngine()
+	rehydrated := 0
+	for i := range instances {
+		inst := instances[i]
+		wf, ok := d.workflowByID(inst.WorkflowID)
+		if !ok {
+			aplog.Warn("rehydrate parked approval %s: workflow %q no longer defined — leaving parked", inst.ID, inst.WorkflowID)
+			continue
+		}
+		steps, err := d.db.ListStepRuns(ctx, inst.ID)
+		if err != nil {
+			aplog.Warn("rehydrate parked approval %s: list step runs: %v", inst.ID, err)
+			continue
+		}
+		task := d.taskForInstance(ctx, &inst)
+		if err := engine.RehydrateApproval(ctx, inst.ID, wf, task, steps, inst.UpdatedAt); err != nil {
+			aplog.Warn("rehydrate parked approval %s: %v", inst.ID, err)
+			continue
+		}
+		rehydrated++
+	}
+	if rehydrated > 0 {
+		aplog.Info("rehydrated %d parked approval instance(s) from a previous run", rehydrated)
+	}
+}
+
 // newSpawner builds the WorkflowSpawner backing the APIARY_SPAWN marker: it
 // resolves a named workflow from config, persists the child InternalTask, and
 // runs the workflow through this dispatcher's engine. A nil DB disables spawning

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -155,4 +156,51 @@ func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, s
 			}
 		}
 	}
+}
+
+// ErrNoApprovalStep is returned by RehydrateApproval when the instance has no
+// approval step waiting once its cached steps are restored — i.e. it was not
+// actually parked at an approval (a stale or malformed approval_waiting row). The
+// caller should leave it for manual reconciliation rather than re-parking it.
+var ErrNoApprovalStep = errors.New("no approval step is waiting")
+
+// RehydrateApproval reconstructs an instance persisted in the approval_waiting
+// state and re-registers it in the engine's in-memory parked set, so the next
+// CheckParkedApprovals poll can re-evaluate it against the live source item.
+//
+// The parked set is the only place CheckParkedApprovals looks and it is empty
+// after a process restart: without rehydration an instance left waiting for
+// approval when the daemon stopped would never be re-evaluated, never settle, and
+// its task's outstanding-workflow counter would never drain — stranding the task
+// in 'registered' forever. The startup orphan reconcile deliberately leaves
+// approval_waiting rows untouched (interrupting them would lose the wait); this is
+// what brings them back to life.
+//
+// It replays the instance's passed steps as cached — no re-execution, no re-fired
+// side effects, and crucially no re-posted approval message — then parks the run
+// at its waiting approval step. priorSteps are the instance's persisted step runs
+// in execution order. parkedAt is when the instance originally suspended (the
+// persisted instance's updated_at); preserving it means an approval timeout counts
+// from the original park time and survives the restart rather than resetting on
+// every boot.
+//
+// It returns ErrNoApprovalStep when no approval step is waiting.
+func (e *Engine) RehydrateApproval(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun, parkedAt time.Time) error {
+	bindings := e.bindingsFor(ctx, task.ID)
+	r := e.initDAG(instID, wf, task, bindings, nil, 0)
+	e.restoreCachedSteps(r, priorSteps)
+
+	stepID, ok := r.firstRunnableApproval()
+	if !ok {
+		return ErrNoApprovalStep
+	}
+	r.state[stepID] = stWaiting
+	r.waitingStep = stepID
+	r.parkedAt = parkedAt
+
+	e.mu.Lock()
+	e.parked[instID] = r
+	e.mu.Unlock()
+	aplog.Info("workflow %s: rehydrated parked approval for instance %s at step %q", wf.ID, instID, stepID)
+	return nil
 }

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -376,6 +376,21 @@ func (r *dagRun) resolveApproval(decision ApprovalDecision) {
 	}
 }
 
+// firstRunnableApproval returns the id of the first approval step that is
+// currently runnable (activated, not yet resolved, dependencies satisfied), in
+// declaration order. It identifies which approval step a rehydrated instance is
+// parked at: an approval step never persists a step run of its own, so after the
+// cached passed steps are restored the waiting approval is simply the next
+// runnable approval. Returns false when none is runnable.
+func (r *dagRun) firstRunnableApproval() (string, bool) {
+	for _, id := range r.pickAllRunnable() {
+		if r.byID[id].StepType() == config.StepTypeApproval {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // pickAllRunnable returns the IDs of ALL currently runnable steps (activated,
 // pending, all dependencies passed), in declaration order.
 func (r *dagRun) pickAllRunnable() []string {

--- a/src/internal/workflow/rehydrate_test.go
+++ b/src/internal/workflow/rehydrate_test.go
@@ -1,0 +1,168 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// stepRunsFor returns the persisted step runs for an instance in insertion order,
+// mirroring what *db.Client.ListStepRuns hands the daemon at rehydration time.
+func (f *fakeStore) stepRunsFor(instID string) []db.StepRun {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []db.StepRun
+	for _, id := range f.stepOrder {
+		if sr := f.stepRuns[id]; sr != nil && sr.WorkflowInstanceID == instID {
+			out = append(out, *sr)
+		}
+	}
+	return out
+}
+
+// TestRehydrateApproval_ResolvesAndSettlesTask is the regression test for the
+// approval_waiting restart gap: an instance parked at an approval step is lost
+// from the engine's in-memory parked set across a daemon restart. After
+// rehydration the next approval check must re-evaluate it, resume it, and settle
+// its task — instead of leaving the task stuck in 'registered' forever.
+func TestRehydrateApproval_ResolvesAndSettlesTask(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	store.bindings["c1"] = []model.SourceBinding{{TaskID: "c1", SourceID: "s1", SourceItemID: "c1"}}
+
+	// --- before the restart: run the workflow until it parks at the approval. ---
+	tr1 := newFakeTracker()
+	tr1.outstanding["c1"] = 1 // one outstanding workflow, as fanOut would record
+	eng1 := trackerEngine(cfg, store, &fakeExecutor{}, &fakeSide{}, tr1)
+	instID, success, _ := eng1.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("parked instance should not report success")
+	}
+	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+		t.Fatalf("instance state = %q, want approval_waiting", store.instances[instID].State)
+	}
+
+	// --- simulate the restart: a brand-new engine over the same persisted store,
+	// with an empty in-memory parked set. This is exactly the bug. ---
+	tr2 := newFakeTracker()
+	tr2.outstanding["c1"] = 1
+	side2 := &fakeSide{}
+	exec2 := &fakeExecutor{}
+	eng2 := trackerEngine(cfg, store, exec2, side2, tr2)
+	if len(eng2.ParkedApprovals()) != 0 {
+		t.Fatal("a fresh engine must start with an empty parked set")
+	}
+
+	// Without rehydration the approval check finds nothing to do.
+	eng2.CheckParkedApprovals(context.Background(), approvingPoll)
+	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+		t.Fatal("pre-rehydration: instance must remain stranded in approval_waiting")
+	}
+
+	// --- rehydrate: reconstruct the parked run from persisted state. ---
+	prior := store.stepRunsFor(instID)
+	if err := eng2.RehydrateApproval(context.Background(), instID, approvalWorkflow(),
+		model.InternalTask{ID: "c1"}, prior, time.Unix(1000, 0)); err != nil {
+		t.Fatalf("RehydrateApproval: %v", err)
+	}
+	parked := eng2.ParkedApprovals()
+	if len(parked) != 1 || parked[0].InstanceID != instID || parked[0].Step.ID != "gate" {
+		t.Fatalf("expected one rehydrated parked approval for gate, got %+v", parked)
+	}
+	// Rehydration must not re-post the approval message (it was posted at park time).
+	if len(side2.comments) != 0 {
+		t.Errorf("rehydration must not re-post the approval message, got %v", side2.comments)
+	}
+
+	// --- the live source now carries an approving comment: it resolves. ---
+	eng2.CheckParkedApprovals(context.Background(), approvingPoll)
+
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done after rehydrated approval resolved", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec2.seen), "implement") {
+		t.Error("implement should run after the rehydrated approval resumed")
+	}
+	if len(eng2.ParkedApprovals()) != 0 {
+		t.Error("instance should no longer be parked once resolved")
+	}
+	// The whole point: the task's outstanding counter drained and it settled.
+	if tr2.outstanding["c1"] != 0 {
+		t.Errorf("task outstanding = %d, want 0", tr2.outstanding["c1"])
+	}
+	if s, ok := tr2.state("c1"); !ok || s != model.TaskStateDone {
+		t.Errorf("task state = %q (set=%v), want done", s, ok)
+	}
+}
+
+// TestRehydrateApproval_PreservesTimeout asserts the original park time is carried
+// across the restart, so an approval times out relative to when it first parked
+// rather than resetting its clock on every boot.
+func TestRehydrateApproval_PreservesTimeout(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	store.bindings["c1"] = []model.SourceBinding{{TaskID: "c1", SourceID: "s1", SourceItemID: "c1"}}
+
+	parkedAt := time.Unix(0, 0)
+	clock := parkedAt
+	eng := NewEngine(cfg, store, &fakeExecutor{},
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return clock }),
+		WithIDGen(func(p string) string { return p + "-1" }),
+	)
+
+	// Persist a plan step that already passed; the gate parked with a 48h timeout.
+	instID := "wf_rehydrate_timeout"
+	store.CreateWorkflowInstance(context.Background(), &db.WorkflowInstance{ //nolint:errcheck
+		ID: instID, WorkflowID: "feature", TaskID: "c1", CellID: "c1", State: db.InstanceStateApprovalWaiting})
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed},
+	}
+
+	if err := eng.RehydrateApproval(context.Background(), instID, approvalWorkflow(),
+		model.InternalTask{ID: "c1"}, prior, parkedAt); err != nil {
+		t.Fatalf("RehydrateApproval: %v", err)
+	}
+
+	// Advance past the 48h timeout; the live item offers no resume signal.
+	clock = parkedAt.Add(49 * time.Hour)
+	noSignal := func(sourceID, cellID string) (model.SourceItem, error) {
+		return model.SourceItem{ID: cellID}, nil
+	}
+	eng.CheckParkedApprovals(context.Background(), noSignal)
+
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed after rehydrated approval timed out, got %q", store.instances[instID].State)
+	}
+}
+
+// TestRehydrateApproval_NoApprovalStep guards the malformed/stale-row case: an
+// instance recorded as approval_waiting whose steps leave no approval pending is
+// rejected with ErrNoApprovalStep rather than silently re-parking a bad run.
+func TestRehydrateApproval_NoApprovalStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
+
+	// linearWF has no approval step at all.
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: "x", StepID: "plan", State: db.StepStatePassed},
+	}
+	err := eng.RehydrateApproval(context.Background(), "x", linearWF(),
+		model.InternalTask{ID: "c1"}, prior, time.Unix(1000, 0))
+	if err != ErrNoApprovalStep {
+		t.Errorf("expected ErrNoApprovalStep, got %v", err)
+	}
+	if len(eng.ParkedApprovals()) != 0 {
+		t.Error("nothing should be parked when there is no approval step")
+	}
+}
+
+// approvingPoll returns a live item whose comment satisfies the gate's resume_on.
+func approvingPoll(sourceID, cellID string) (model.SourceItem, error) {
+	return model.SourceItem{ID: cellID, SourceID: sourceID,
+		Comments: []model.Comment{{Body: "approve please"}}}, nil
+}

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -34,10 +34,33 @@ func (e *Engine) ResumeInstance(ctx context.Context, instID string, wf config.Wo
 }
 
 // seedResume restores the graph state of already-passed steps so a resumed run
-// continues from the first incomplete step. It returns nothing; on completion
+// continues from the first incomplete step, and marks each carried-over step run
+// as skipped_cached (display only). It returns nothing; on completion
 // r.passedOrder/contrib/stepStates reflect the cached steps.
 func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.StepRun) {
+	for _, sr := range e.restoreCachedSteps(r, priorSteps) {
+		// Record that this run was carried over a resume (display only).
+		if !sr.SkippedCached {
+			sr.SkippedCached = true
+			_ = e.store.UpdateStepRun(ctx, &sr)
+		}
+	}
+}
+
+// restoreCachedSteps replays already-passed steps into the in-memory graph so a
+// run continues from the first incomplete step. It is purely in-memory and
+// persists nothing, so it is safe both for resume (which then marks the
+// carried-over steps skipped_cached) and for rehydrating an approval-parked
+// instance after a restart (which must NOT rewrite step-run display flags). It
+// returns the passed step runs it restored, in input order (including duplicates
+// produced by on_fail.goto retry loops), so the caller can mark them if desired.
+//
+// Splits carry no side effects and must re-route; they are left pending so
+// driveDAG re-runs them and re-activates the chosen branch target against the
+// restored memory. Failed/running/pending steps re-run.
+func (e *Engine) restoreCachedSteps(r *dagRun, priorSteps []db.StepRun) []db.StepRun {
 	seen := map[string]bool{}
+	var restored []db.StepRun
 	for i := range priorSteps {
 		sr := priorSteps[i]
 		if sr.State != db.StepStatePassed {
@@ -47,9 +70,6 @@ func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.Step
 		if !ok {
 			continue // step no longer exists in the workflow definition
 		}
-		// Splits carry no side effects and must re-route; let driveDAG re-run
-		// them so the chosen branch target is re-activated against restored
-		// memory. Leaving them pending is correct and free.
 		if step.StepType() == config.StepTypeSplit {
 			continue
 		}
@@ -75,10 +95,7 @@ func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.Step
 			r.activated[step.OnPass.Next] = true
 		}
 
-		// Record that this run was carried over a resume (display only).
-		if !sr.SkippedCached {
-			sr.SkippedCached = true
-			_ = e.store.UpdateStepRun(ctx, &sr)
-		}
+		restored = append(restored, sr)
 	}
+	return restored
 }


### PR DESCRIPTION
## Summary

Fixes the *approval_waiting restart gap*: instances persisted in `approval_waiting` were orphaned after a daemon restart. The parked set `e.parked` is in-memory only and `CheckParkedApprovals` only iterates over it — so after the restart, an instance parked in `approval_waiting` was never re-evaluated, never reached *settle*, and the task's `outstanding_workflows` never hit zero, leaving the task stuck in `registered` ("queued") forever. The **running**-orphan reconcile leaves `approval_waiting` intact on purpose (interrupting would lose the wait), so it doesn't cover this case.

The fix is **rehydrating the parked run on startup**:

- **`Engine.RehydrateApproval`** (`workflow/approval.go`): rebuilds the `dagRun` from the workflow definition + persisted `step_runs`, replays the past steps as cache, finds the waiting approval step and re-registers the instance in `e.parked`.
  - Without re-executing steps, without re-firing side effects and **without re-posting the approval message**.
  - Preserves the original `parkedAt` (= the instance's `updated_at`), so the **approval timeout survives the restart** instead of restarting on each boot.
- **`restoreCachedSteps`** (`workflow/resume.go`): extracted from `seedResume` as the purely in-memory part (doesn't rewrite `skipped_cached`), reused by the rehydration. `ResumeInstance` keeps identical behavior.
- **`dagRun.firstRunnableApproval`** (`workflow/dag.go`): deterministically identifies which approval step is waiting after the replay.
- **`Dispatcher.rehydrateParkedApprovals`** (`daemon/workflow.go`): lists the `approval_waiting` instances, builds the engine *eagerly* and rehydrates each; wired into **`Dispatcher.Start`** right after the orphan-execution reconcile (so the 1st poll can already check approvals).

GitNexus impact on `settle` / `CheckParkedApprovals` / `seedResume`: all **LOW**, no signature change.

> There's no issue tracking this bug on GitHub; it came from the project's memory record (`approval-waiting-restart-gap`).

## Test plan

- `rehydrate_test.go` (engine, fakes):
  - **simulated restart → rehydration → approval comment** resolves the instance and *settles* the task (the `outstanding` counter hits zero, state → `done`); pre-rehydration confirms the instance stays stranded.
  - rehydration **doesn't re-post** the approval message.
  - `parkedAt` preserved → the approval **times out** relative to the original park.
  - `ErrNoApprovalStep` for a malformed `approval_waiting` row / with no pending approval.
- `rehydrate_approval_test.go` (daemon, real SQLite): the end-to-end path via `rehydrateParkedApprovals` + `checkApprovals` — the instance and task settle to `done`.
- `go build ./...`, `go vet`, `go test ./...` (the whole module) and `-race` on the `workflow` + `daemon` packages: all passing.