### PR TITLE
feat(dispatcher): internal re-dispatch cap (settings.max_attempts)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -182,12 +182,19 @@ type TasksConfig struct {
 }
 
 type Settings struct {
-	Concurrency   int       `yaml:"concurrency"`
-	LogLevel      string    `yaml:"log_level"`
-	StateLock     bool      `yaml:"state_lock"`
-	ResultComment bool      `yaml:"result_comment"`
-	TaskTimeout   string    `yaml:"task_timeout"`
-	Telemetry     Telemetry `yaml:"telemetry"`
+	Concurrency   int    `yaml:"concurrency"`
+	LogLevel      string `yaml:"log_level"`
+	StateLock     bool   `yaml:"state_lock"`
+	ResultComment bool   `yaml:"result_comment"`
+	TaskTimeout   string `yaml:"task_timeout"`
+	// MaxAttempts caps how many consecutive FAILED workflow instances a single
+	// (task, workflow) pair may accumulate before the dispatcher stops
+	// re-dispatching it and applies the workflow's on_fail hook. Rate-limited
+	// runs are recorded as success (they fail over), so they do not count. This
+	// is an internal backstop independent of source-side labels — it stops
+	// runaway loops even for workflows with no on_fail. Default 3; <=0 disables.
+	MaxAttempts int       `yaml:"max_attempts"`
+	Telemetry   Telemetry `yaml:"telemetry"`
 }
 
 func (s *Settings) TaskTimeoutDuration() time.Duration {
@@ -447,6 +454,9 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Settings.LogLevel == "" {
 		cfg.Settings.LogLevel = "info"
+	}
+	if cfg.Settings.MaxAttempts == 0 {
+		cfg.Settings.MaxAttempts = 3
 	}
 	warnDeprecatedResultComment(&cfg)
 	return &cfg, nil

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -80,6 +80,20 @@ type AgentConfig struct {
 	// this agent, in any workflow. It is the lowest-precedence explicit env scope
 	// (below workflow.env and step.env), layered on top of the identity overlay.
 	Env map[string]string `yaml:"env,omitempty"`
+	// Fallbacks is an ordered chain of alternative runner/model pairs to try when
+	// the primary runner is rejected by a provider rate limit (e.g. Claude's
+	// 5-hour session limit). The dispatcher pauses the rejected runner type until
+	// it resets and retries the step on the next non-paused fallback. Empty means
+	// no failover (the step fails / waits for the limit to reset).
+	Fallbacks []FallbackConfig `yaml:"fallbacks,omitempty"`
+}
+
+// FallbackConfig is one entry in an agent's rate-limit failover chain. Runner
+// must reference a defined runner id; Model is optional (empty uses that
+// runner's default model).
+type FallbackConfig struct {
+	Runner string `yaml:"runner"`
+	Model  string `yaml:"model,omitempty"`
 }
 
 type WorkerConfig struct {

--- a/src/internal/config/fallback_validate_test.go
+++ b/src/internal/config/fallback_validate_test.go
@@ -1,0 +1,53 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func baseCfgWithFallbacks(fbs []config.FallbackConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{{ID: "claude", Type: "claude-cli"}, {ID: "opencode-go", Type: "cli", Provider: "opencode"}},
+		Agents: []config.AgentConfig{{
+			ID: "engineer", Model: "claude-sonnet-4-6", Runner: "claude", Fallbacks: fbs,
+		}},
+	}
+}
+
+func TestValidate_FallbackRunnerDefined(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Runner: "opencode-go", Model: "opencode-go/x"}})
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), "fallback") {
+			t.Errorf("valid fallback flagged: %v", err)
+		}
+	}
+}
+
+func TestValidate_FallbackRunnerUndefined(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Runner: "ghost"}})
+	found := false
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), `fallbacks[0]: runner "ghost" not defined`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected undefined-fallback-runner error, got %v", cfg.Validate())
+	}
+}
+
+func TestValidate_FallbackRunnerRequired(t *testing.T) {
+	cfg := baseCfgWithFallbacks([]config.FallbackConfig{{Model: "only-model"}})
+	found := false
+	for _, err := range cfg.Validate() {
+		if strings.Contains(err.Error(), "fallbacks[0]: runner is required") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected required-runner error, got %v", cfg.Validate())
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -61,6 +61,13 @@ func (c *Config) Validate() []error {
 		if a.Runner != "" && !runnerIDs[a.Runner] {
 			errs = append(errs, fmt.Errorf("agents[%d] %q: runner %q not defined", i, a.ID, a.Runner))
 		}
+		for j, fb := range a.Fallbacks {
+			if fb.Runner == "" {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: fallbacks[%d]: runner is required", i, a.ID, j))
+			} else if !runnerIDs[fb.Runner] {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: fallbacks[%d]: runner %q not defined", i, a.ID, j, fb.Runner))
+			}
+		}
 		if agentIDs[a.ID] {
 			errs = append(errs, fmt.Errorf("agents[%d]: duplicate id %q", i, a.ID))
 		}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -48,6 +48,15 @@ type Dispatcher struct {
 	sources     map[string]source.Adapter
 	runners     map[string]runnerimpl.Runner
 	agentRunner map[string]string
+	// agentFallbacks holds each agent's rate-limit failover chain (primary
+	// excluded), in order. Pre-built at construction so failover is a cheap swap.
+	agentFallbacks map[string][]runnerCandidate
+
+	// rateLimitPaused maps a runner adapter type (e.g. "claude") to the time its
+	// provider rate limit resets. While now is before that time, the dispatcher
+	// routes that runner's steps to a fallback instead. Guarded by rateLimitMu.
+	rateLimitPaused map[string]time.Time
+	rateLimitMu     sync.Mutex
 
 	db     *db.Client
 	logger *logging.Logger
@@ -75,6 +84,40 @@ type Dispatcher struct {
 	engineOnce sync.Once
 }
 
+// runnerCandidate is one rung in an agent's rate-limit failover chain: a
+// configured runner adapter, its adapter type (the rate-limit pause key), and
+// the model to run it with.
+type runnerCandidate struct {
+	adapter    runnerimpl.Runner
+	runnerType string
+	model      string
+}
+
+// runnerPausedUntil returns the time a runner type's provider rate limit resets,
+// or the zero time if it is not paused.
+func (d *Dispatcher) runnerPausedUntil(runnerType string) time.Time {
+	d.rateLimitMu.Lock()
+	defer d.rateLimitMu.Unlock()
+	return d.rateLimitPaused[runnerType]
+}
+
+// pauseRunner records that a runner type was rate-limited until `until`. A zero
+// `until` (provider did not report a reset) defaults to 5 minutes out. Only
+// extends an existing pause, never shortens it.
+func (d *Dispatcher) pauseRunner(runnerType string, until time.Time) {
+	if until.IsZero() {
+		until = time.Now().Add(5 * time.Minute)
+	}
+	d.rateLimitMu.Lock()
+	defer d.rateLimitMu.Unlock()
+	if d.rateLimitPaused == nil {
+		d.rateLimitPaused = make(map[string]time.Time)
+	}
+	if cur, ok := d.rateLimitPaused[runnerType]; !ok || until.After(cur) {
+		d.rateLimitPaused[runnerType] = until
+	}
+}
+
 // New builds and connects a Dispatcher from the given config.
 // Pass nil for db and logger to skip state persistence and logging to SQLite.
 func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger) (*Dispatcher, error) {
@@ -88,9 +131,11 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		configFile:  configFile,
 		startedAt:   time.Now(),
 		router:      r,
-		sources:     make(map[string]source.Adapter),
-		runners:     make(map[string]runnerimpl.Runner),
-		agentRunner: make(map[string]string),
+		sources:         make(map[string]source.Adapter),
+		runners:         make(map[string]runnerimpl.Runner),
+		agentRunner:     make(map[string]string),
+		agentFallbacks:  make(map[string][]runnerCandidate),
+		rateLimitPaused: make(map[string]time.Time),
 		db:          dbClient,
 		logger:      logger,
 		sem:         make(chan struct{}, 1), // poll: one at a time
@@ -187,6 +232,34 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if err := d.writeOpencodeAgent(ctx, ac, rc); err != nil {
 				aplog.Warn("agent %s: write opencode agent config: %v", ac.ID, err)
 			}
+		}
+
+		// Pre-build the rate-limit failover chain so dispatch can swap runners
+		// without re-instantiating adapters on the hot path.
+		for _, fb := range ac.Fallbacks {
+			frc, ok := runnerMap[fb.Runner]
+			if !ok {
+				return nil, fmt.Errorf("agent %q: fallback runner %q not found", ac.ID, fb.Runner)
+			}
+			fAdapterName := frc.AdapterName()
+			fra, ok := runnerimpl.New(fAdapterName)
+			if !ok {
+				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
+			}
+			if err := fra.Configure(frc.Config); err != nil {
+				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
+			}
+			if fAdapterName == "opencode" {
+				if err := d.writeOpencodeAgent(ctx, ac, frc); err != nil {
+					aplog.Warn("agent %s: write opencode fallback agent config: %v", ac.ID, err)
+				}
+			}
+			d.agentFallbacks[ac.ID] = append(d.agentFallbacks[ac.ID], runnerCandidate{
+				adapter:    fra,
+				runnerType: fAdapterName,
+				model:      fb.Model,
+			})
+			aplog.Info("agent %s: fallback #%d runner=%s type=%s model=%s", ac.ID, len(d.agentFallbacks[ac.ID]), fb.Runner, fAdapterName, fb.Model)
 		}
 	}
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -903,6 +903,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		// label-based lock (state_lock / "in-progress"), which is source-specific.
 		if persisted && d.db != nil {
 			matches = d.dropActiveMatches(ctx, task.ID, matches)
+			matches = d.dropCappedMatches(ctx, task, matches)
 		}
 		if len(matches) == 0 {
 			aplog.Debug("cell %s (%q): no matching route, skipping", cell.ID, cell.Title)
@@ -1054,6 +1055,63 @@ func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, match
 		out = append(out, m)
 	}
 	return out
+}
+
+// dropCappedMatches removes matches whose (task, workflow) has reached the
+// consecutive-failure cap (settings.max_attempts), so a workflow that keeps
+// failing is not re-dispatched forever. It is the internal backstop that does
+// not depend on source-side labels — it stops runaway loops even for workflows
+// with no on_fail. When a match is capped, the workflow's on_fail hook is
+// applied best-effort (so an issue parks to needs-attention and leaves the poll
+// set when the workflow defines one). Fail-open: on a count error the match is
+// kept (the cap is a safety net, not a correctness guard).
+func (d *Dispatcher) dropCappedMatches(ctx context.Context, task model.InternalTask, matches []router.Match) []router.Match {
+	limit := d.cfg.Settings.MaxAttempts
+	if limit <= 0 {
+		return matches
+	}
+	out := make([]router.Match, 0, len(matches))
+	for _, m := range matches {
+		n, err := d.db.CountConsecutiveFailedInstances(ctx, task.ID, m.Route.ID)
+		if err != nil {
+			aplog.Error("failure-cap check task %s workflow %s: %v — dispatching anyway", task.ID, m.Route.ID, err)
+			out = append(out, m)
+			continue
+		}
+		if n >= limit {
+			aplog.Warn("task %s: workflow %s hit failure cap (%d/%d consecutive failures), not re-dispatching", task.ID, m.Route.ID, n, limit)
+			d.parkCappedTask(ctx, task, m.Route.ID)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// parkCappedTask applies a capped workflow's on_fail hook to the task's source
+// bindings (set_state / add_labels) using the same machinery the engine uses, so
+// the item parks (e.g. needs-attention) and stops being re-polled. A no-op when
+// the workflow has no on_fail (e.g. the hatch-* escape hatches) — the cap still
+// stops re-dispatch, the item just keeps being polled harmlessly.
+func (d *Dispatcher) parkCappedTask(ctx context.Context, task model.InternalTask, workflowID string) {
+	var onFail *config.OnComplete
+	for i := range d.cfg.Workflows {
+		if d.cfg.Workflows[i].ID == workflowID {
+			onFail = d.cfg.Workflows[i].OnFail
+			break
+		}
+	}
+	if onFail == nil {
+		return
+	}
+	bindings, err := d.db.ListBindingsByTask(ctx, task.ID)
+	if err != nil {
+		aplog.Error("park capped task %s: list bindings: %v", task.ID, err)
+		return
+	}
+	if err := (&wfSideEffects{d: d}).ApplyHook(ctx, task, bindings, *onFail); err != nil {
+		aplog.Error("park capped task %s: apply on_fail: %v", task.ID, err)
+	}
 }
 
 // dispatch acknowledges, runs, and writes the result for a single task.

--- a/src/internal/daemon/failover_test.go
+++ b/src/internal/daemon/failover_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// scriptedRunner returns a fixed result and records its invocation count, so a
+// test can assert which runner in a failover chain actually ran.
+type scriptedRunner struct {
+	result model.RunResult
+	calls  int
+}
+
+func (s *scriptedRunner) ID() string                       { return "scripted" }
+func (s *scriptedRunner) Configure(_ map[string]any) error { return nil }
+func (s *scriptedRunner) Run(_ context.Context, _ model.RunRequest) (model.RunResult, error) {
+	s.calls++
+	return s.result, nil
+}
+
+func newFailoverDispatcher(t *testing.T, primary, fallback runnerpkg.Runner, fbType, fbModel string) (*Dispatcher, *db.Client) {
+	t.Helper()
+	dbc, err := db.New(context.Background(), filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	d := &Dispatcher{
+		cfg:             &config.Config{},
+		db:              dbc,
+		runners:         map[string]runnerpkg.Runner{"agent-engineer": primary},
+		agentRunner:     map[string]string{"engineer": "claude"},
+		agentFallbacks:  map[string][]runnerCandidate{"engineer": {{adapter: fallback, runnerType: fbType, model: fbModel}}},
+		rateLimitPaused: map[string]time.Time{},
+	}
+	return d, dbc
+}
+
+func stepReq(instance, cellID string) workflow.StepRequest {
+	return workflow.StepRequest{
+		InstanceID: instance,
+		Cell:       model.SourceItem{ID: cellID, Title: "T", Number: "#1"},
+		Step:       config.StepConfig{ID: "implement", Agent: "engineer"},
+		Model:      "claude-sonnet-4-6",
+	}
+}
+
+// A rate-limited primary fails over to the fallback runner, the fallback's
+// result is returned, and the primary's runner type is paused.
+func TestWfStepExecutor_RateLimitFailover(t *testing.T) {
+	ctx := context.Background()
+	resets := time.Now().Add(2 * time.Hour)
+	primary := &scriptedRunner{result: model.RunResult{Success: true, RateLimited: true, RateLimitResetsAt: resets, Output: "limit"}}
+	fallback := &scriptedRunner{result: model.RunResult{Success: true, Output: "did the work"}}
+	d, _ := newFailoverDispatcher(t, primary, fallback, "opencode", "opencode-go/deepseek-v4-pro")
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, stepReq("wf_1", "c1"))
+
+	if primary.calls != 1 {
+		t.Errorf("primary calls = %d, want 1", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1 (failover)", fallback.calls)
+	}
+	if !res.Success || res.Output != "did the work" {
+		t.Errorf("expected fallback result, got success=%v output=%q", res.Success, res.Output)
+	}
+	if got := d.runnerPausedUntil("claude"); !got.Equal(resets) {
+		t.Errorf("claude pause = %v, want %v", got, resets)
+	}
+}
+
+// When the primary's runner type is already paused, the primary is skipped and
+// the fallback runs directly — no wasted rate-limited call.
+func TestWfStepExecutor_SkipsPausedPrimary(t *testing.T) {
+	ctx := context.Background()
+	primary := &scriptedRunner{result: model.RunResult{Success: true}}
+	fallback := &scriptedRunner{result: model.RunResult{Success: true, Output: "fallback ran"}}
+	d, _ := newFailoverDispatcher(t, primary, fallback, "opencode", "m")
+	d.pauseRunner("claude", time.Now().Add(time.Hour))
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, stepReq("wf_1", "c1"))
+
+	if primary.calls != 0 {
+		t.Errorf("primary calls = %d, want 0 (paused, skipped)", primary.calls)
+	}
+	if fallback.calls != 1 {
+		t.Errorf("fallback calls = %d, want 1", fallback.calls)
+	}
+	if res.Output != "fallback ran" {
+		t.Errorf("output = %q, want fallback", res.Output)
+	}
+}
+
+func TestPauseRunner(t *testing.T) {
+	d := &Dispatcher{}
+	if !d.runnerPausedUntil("claude").IsZero() {
+		t.Error("unset runner should not be paused")
+	}
+	// nil-map safe + zero reset defaults to ~5m out.
+	d.pauseRunner("claude", time.Time{})
+	if got := d.runnerPausedUntil("claude"); got.Before(time.Now().Add(4*time.Minute)) {
+		t.Errorf("zero reset should default ~5m out, got %v", got)
+	}
+	// Only extends, never shortens.
+	far := time.Now().Add(2 * time.Hour)
+	d.pauseRunner("claude", far)
+	d.pauseRunner("claude", time.Now().Add(time.Minute))
+	if got := d.runnerPausedUntil("claude"); !got.Equal(far) {
+		t.Errorf("pause shortened: got %v, want %v", got, far)
+	}
+}

--- a/src/internal/daemon/redispatch_cap_test.go
+++ b/src/internal/daemon/redispatch_cap_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// dropCappedMatches drops a (task, workflow) that has hit max_attempts
+// consecutive failures, keeps one still under the cap, and respects disabling.
+func TestDropCappedMatches(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	for i := 0; i < 3; i++ { // capped workflow: 3 consecutive failures
+		_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+			ID: fmt.Sprintf("f%d", i), WorkflowID: "impl", CellID: "1", TaskID: "T1", State: db.InstanceStateFailed,
+		})
+	}
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ // under cap
+		ID: "h0", WorkflowID: "hatch", CellID: "1", TaskID: "T1", State: db.InstanceStateFailed,
+	})
+
+	d := &Dispatcher{cfg: &config.Config{Settings: config.Settings{MaxAttempts: 3}}, db: dbc}
+	task := model.InternalTask{ID: "T1"}
+	matches := []router.Match{
+		{Route: config.RouteConfig{ID: "impl"}},
+		{Route: config.RouteConfig{ID: "hatch"}},
+	}
+
+	out := d.dropCappedMatches(ctx, task, matches)
+	if len(out) != 1 || out[0].Route.ID != "hatch" {
+		t.Fatalf("expected only 'hatch' kept, got %+v", out)
+	}
+
+	// max_attempts <= 0 disables the cap entirely.
+	d.cfg.Settings.MaxAttempts = 0
+	if got := d.dropCappedMatches(ctx, task, matches); len(got) != 2 {
+		t.Errorf("disabled cap should keep all, got %d", len(got))
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -173,32 +173,59 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		}
 	}
 
-	// Record a task_executions row for this step so the dashboard (Tasks
-	// history, Usage/cost, agent stats, live "running" status) observes
-	// workflow steps the same way it observed legacy single-shot runs. Each
-	// step is one execution; usage and PID/heartbeat are wired through.
-	exec := x.beginExecution(ctx, req)
-	if exec != nil {
-		execID := exec.ID
-		rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
-		rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
-	}
+	// Run chain: the agent's primary runner first, then its rate-limit failover
+	// chain. A candidate whose runner type is currently paused by a provider rate
+	// limit is skipped (unless it is the last resort). Each attempt is its own
+	// task_executions row — recorded the same way legacy single-shot runs were —
+	// so the dashboard (Tasks history, Usage/cost, agent stats, live "running")
+	// shows the failover. usage and PID/heartbeat are wired through per attempt.
+	candidates := append([]runnerCandidate{{
+		adapter:    ra,
+		runnerType: x.d.agentRunner[req.Step.Agent],
+		model:      req.Model,
+	}}, x.d.agentFallbacks[req.Step.Agent]...)
 
-	runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
-	// Register the cancel func so `apiary restart` / ForceRestart can interrupt
-	// an in-flight step. A single key per cell mirrors legacy behaviour.
-	x.d.runCancel.Store(req.Cell.ID, cancel)
-	defer func() {
+	var res model.RunResult
+	for i, c := range candidates {
+		last := i == len(candidates)-1
+		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
+			aplog.Info("[%s] runner %q paused by rate limit, skipping to fallback", req.Cell.ID, c.runnerType)
+			continue
+		}
+
+		rr.Model = c.model
+		exec := x.beginExecution(ctx, req, c.model, c.runnerType)
+		if exec != nil {
+			execID := exec.ID
+			rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
+			rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
+		}
+
+		runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)
+		// Register the cancel func so `apiary restart` / ForceRestart can interrupt
+		// an in-flight step. A single key per cell mirrors legacy behaviour.
+		x.d.runCancel.Store(req.Cell.ID, cancel)
+		out, err := c.adapter.Run(runCtx, rr)
 		cancel()
 		x.d.runCancel.Delete(req.Cell.ID)
-	}()
+		if err != nil && out.Error == nil {
+			out.Error = err
+		}
+		x.finishExecution(ctx, exec, out)
+		res = out
 
-	res, err := ra.Run(runCtx, rr)
-	if err != nil && res.Error == nil {
-		res.Error = err
+		// On a provider rate-limit rejection, pause this runner type until it
+		// resets and fail over to the next candidate. Not a genuine failure — the
+		// run did no work — so we do not return it while a fallback remains.
+		if out.RateLimited {
+			x.d.pauseRunner(c.runnerType, out.RateLimitResetsAt)
+			if !last {
+				aplog.Info("[%s] runner %q rate-limited, failing over to next runner", req.Cell.ID, c.runnerType)
+				continue
+			}
+		}
+		break
 	}
-
-	x.finishExecution(ctx, exec, res)
 
 	// publish: off suppresses write-back before the engine ever sees the payload,
 	// even when the agent emitted an APIARY_PUBLISH block.
@@ -227,7 +254,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 // beginExecution creates the task_executions row for a step run, or returns nil
 // when no run-history DB is configured. The attempt number continues the cell's
 // execution history so retries/steps accumulate rather than reset.
-func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRequest) *db.Execution {
+func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRequest, model, runnerType string) *db.Execution {
 	if x.d.db == nil {
 		return nil
 	}
@@ -235,9 +262,8 @@ func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRe
 	if last, _ := x.d.db.GetLastExecution(ctx, req.Cell.ID); last != nil {
 		attempt = last.Attempt + 1
 	}
-	runnerType := x.d.agentRunner[req.Step.Agent]
 	exec, err := x.d.db.CreateExecution(ctx, req.Cell.ID, req.Step.Agent, req.Cell.Title,
-		req.Cell.Number, req.Cell.URL, req.Model, runnerType, attempt)
+		req.Cell.Number, req.Cell.URL, model, runnerType, attempt)
 	if err != nil {
 		aplog.Error("cell %s: create execution record: %v", req.Cell.ID, err)
 		return nil

--- a/src/internal/db/redispatch_cap_test.go
+++ b/src/internal/db/redispatch_cap_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestCountConsecutiveFailedInstances(t *testing.T) {
+	ctx := context.Background()
+	c, err := New(ctx, filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	mk := func(id, wf, state string) {
+		if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: id, WorkflowID: wf, CellID: "1", TaskID: "T1", State: state}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	count := func() int {
+		n, err := c.CountConsecutiveFailedInstances(ctx, "T1", "impl")
+		if err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	if count() != 0 {
+		t.Fatalf("empty: want 0, got %d", count())
+	}
+	mk("i1", "impl", InstanceStateFailed)
+	mk("i2", "impl", InstanceStateFailed)
+	if count() != 2 {
+		t.Errorf("two failures: want 2, got %d", count())
+	}
+	// A success resets the consecutive run.
+	mk("i3", "impl", InstanceStateDone)
+	if count() != 0 {
+		t.Errorf("after success: want 0, got %d", count())
+	}
+	mk("i4", "impl", InstanceStateFailed)
+	if count() != 1 {
+		t.Errorf("one failure after success: want 1, got %d", count())
+	}
+	// A different workflow's failures are not counted.
+	mk("o1", "other", InstanceStateFailed)
+	mk("o2", "other", InstanceStateFailed)
+	if count() != 1 {
+		t.Errorf("cross-workflow leak: want 1, got %d", count())
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -126,6 +126,27 @@ func (c *Client) HasFailedInstance(ctx context.Context, taskID string) (bool, er
 	return n > 0, err
 }
 
+// CountConsecutiveFailedInstances returns how many of the most recent workflow
+// instances for (task, workflow) are in the failed state, counting back from the
+// newest until a non-failed one (or the start). A later success/done resets the
+// count to zero. Ordered by rowid (insertion order) so it is robust to the
+// timestamp format stored in created_at. Used as the re-dispatch failure cap.
+func (c *Client) CountConsecutiveFailedInstances(ctx context.Context, taskID, workflowID string) (int, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_instances
+		WHERE task_id = ? AND workflow_id = ? AND state = ?
+		  AND rowid > COALESCE((
+		    SELECT MAX(rowid) FROM workflow_instances
+		    WHERE task_id = ? AND workflow_id = ? AND state != ?
+		  ), 0)
+	`, taskID, workflowID, InstanceStateFailed, taskID, workflowID, InstanceStateFailed).Scan(&n)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return n, err
+}
+
 // HasActiveInstanceForRoute reports whether the task already has a non-terminal
 // instance for the given workflow — running or approval_waiting. The dispatcher
 // uses it as a source-agnostic in-flight guard: it stops a later poll from

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -78,6 +78,17 @@ type RunResult struct {
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error
+
+	// RateLimited is true when the provider rejected the run because of a
+	// usage/rate limit (e.g. Claude's 5-hour session limit). Such a run does no
+	// real work — it may even exit 0 with a "you've hit your session limit"
+	// message, so Success alone cannot be trusted. The dispatcher uses this to
+	// back off until RateLimitResetsAt instead of counting the run as a genuine
+	// success or failure.
+	RateLimited bool
+	// RateLimitResetsAt is when the provider's limit resets, when the provider
+	// reported it (zero otherwise). Only meaningful when RateLimited is true.
+	RateLimitResetsAt time.Time
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -93,6 +93,12 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		logs        []model.LogEntry
 		finalResult string
 		usage       model.Usage
+		// Set when the provider emits a rate_limit_event with status "rejected"
+		// (e.g. Claude's 5-hour session limit). resetsAt is epoch seconds, 0 if
+		// the provider did not report it. Guarded by mu (written from the stdout
+		// goroutine).
+		rateLimited       bool
+		rateLimitResetsAt int64
 	)
 
 	emit := func(level, msg string) {
@@ -158,6 +164,14 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 				finalResult = res
 				mu.Unlock()
 			}
+			if resetsAt, rejected := detectRateLimitRejection(line); rejected {
+				mu.Lock()
+				rateLimited = true
+				if resetsAt > 0 {
+					rateLimitResetsAt = resetsAt
+				}
+				mu.Unlock()
+			}
 			accumulateStreamUsage(line, &usage)
 			if pretty, ok := formatStreamLine(line); ok {
 				emit("debug", pretty)
@@ -193,17 +207,28 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		usagePtr = nil
 	}
 	result := model.RunResult{
-		WorkerID: req.WorkerID,
-		Success:  runErr == nil,
-		Output:   output,
-		Logs:     logs,
-		Duration: time.Since(start),
-		Usage:    usagePtr,
+		WorkerID:    req.WorkerID,
+		Success:     runErr == nil,
+		Output:      output,
+		Logs:        logs,
+		Duration:    time.Since(start),
+		Usage:       usagePtr,
+		RateLimited: rateLimited,
+	}
+	if rateLimited && rateLimitResetsAt > 0 {
+		result.RateLimitResetsAt = time.Unix(rateLimitResetsAt, 0)
 	}
 	if runErr != nil {
-		stderr := strings.TrimSpace(errBuf.String())
-		if stderr != "" {
-			result.Error = fmt.Errorf("%w\nstderr: %s", runErr, stderr)
+		// claude often exits non-zero with an empty stderr, leaving a bare
+		// "exit status 1" with no clue why. Fall back to the most meaningful
+		// stdout (final result / last assistant text) so the recorded error is
+		// diagnosable instead of opaque.
+		detail := strings.TrimSpace(errBuf.String())
+		if detail == "" {
+			detail = errorDetail(output)
+		}
+		if detail != "" {
+			result.Error = fmt.Errorf("%w: %s", runErr, detail)
 		} else {
 			result.Error = runErr
 		}
@@ -271,6 +296,55 @@ func accumulateStreamUsage(line string, u *model.Usage) {
 			u.CostUSD = ev.TotalCostUSD
 		}
 	}
+}
+
+// rateLimitEvent is the provider's usage-limit signal in the stream. Claude
+// emits it as {"type":"rate_limit_event","rate_limit_info":{"status":"rejected",
+// "resetsAt":<epoch-seconds>,...}} when a run is blocked by the 5-hour session
+// limit (the run then prints "you've hit your session limit" and may exit 0).
+type rateLimitEvent struct {
+	Type          string `json:"type"`
+	RateLimitInfo *struct {
+		Status   string `json:"status"`
+		ResetsAt int64  `json:"resetsAt"`
+	} `json:"rate_limit_info"`
+}
+
+// detectRateLimitRejection reports whether a stream-json line is a
+// rate_limit_event with status "rejected" (the provider refused the run because
+// of a usage limit), along with the epoch-seconds reset time when present.
+// Other statuses ("allowed", "allowed_warning") are not rejections.
+func detectRateLimitRejection(line string) (resetsAt int64, rejected bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return 0, false
+	}
+	var ev rateLimitEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+		return 0, false
+	}
+	if ev.Type != "rate_limit_event" || ev.RateLimitInfo == nil {
+		return 0, false
+	}
+	if ev.RateLimitInfo.Status != "rejected" {
+		return 0, false
+	}
+	return ev.RateLimitInfo.ResetsAt, true
+}
+
+// errorDetail trims, single-lines, and length-caps an output fragment so it can
+// be folded into a recorded error message without dumping a whole transcript.
+func errorDetail(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	const max = 300
+	if len(s) > max {
+		s = "…" + s[len(s)-max:]
+	}
+	return s
 }
 
 func formatStreamLine(line string) (string, bool) {

--- a/src/internal/runner/execution/ratelimit_test.go
+++ b/src/internal/runner/execution/ratelimit_test.go
@@ -1,0 +1,63 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectRateLimitRejection_Rejected(t *testing.T) {
+	line := `{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1780731000,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled","isUsingOverage":false}}`
+	resetsAt, rejected := detectRateLimitRejection(line)
+	if !rejected {
+		t.Fatal("expected rejected=true")
+	}
+	if resetsAt != 1780731000 {
+		t.Errorf("resetsAt = %d, want 1780731000", resetsAt)
+	}
+}
+
+func TestDetectRateLimitRejection_NotRejected(t *testing.T) {
+	// "allowed" and "allowed_warning" are normal — not rejections. The presence
+	// of overageStatus:"rejected" must NOT be mistaken for a rejected run.
+	cases := []string{
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1780731000,"overageStatus":"rejected"}}`,
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","resetsAt":1780731000,"utilization":0.9}}`,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestDetectRateLimitRejection_OtherLines(t *testing.T) {
+	cases := []string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`,
+		`{"type":"result","subtype":"success","result":"done"}`,
+		`plain text, not json`,
+		`{"type":"rate_limit_event"}`, // no rate_limit_info
+		``,
+	}
+	for _, line := range cases {
+		if _, rejected := detectRateLimitRejection(line); rejected {
+			t.Errorf("expected rejected=false for %q", line)
+		}
+	}
+}
+
+func TestErrorDetail(t *testing.T) {
+	if got := errorDetail("   "); got != "" {
+		t.Errorf("blank input: got %q, want empty", got)
+	}
+	if got := errorDetail("boom\nstack trace"); got != "boom stack trace" {
+		t.Errorf("newline folding: got %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	got := errorDetail(long)
+	if len([]rune(got)) > 301 { // 300 chars + the ellipsis rune
+		t.Errorf("not capped: len=%d", len([]rune(got)))
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("expected ellipsis prefix when capped, got %q", got[:10])
+	}
+}


### PR DESCRIPTION
## Summary
An internal backstop against re-dispatch loops — **independent of source labels**.

- `settings.max_attempts` (default **3**, `<=0` disables): after N consecutive FAILED instances of the same (task, workflow), the dispatcher stops re-dispatching (`dropCappedMatches`, alongside `dropActiveMatches`).
- Does a best-effort **park** via the workflow's `on_fail` using the engine's own machinery (`ApplyHook`) — without duplicating label/state logic. A no-op for workflows with no `on_fail` (e.g. the `hatch-*` ones), but the cap still cuts the runs.
- Runs blocked by a rate limit are recorded as success (they fail over, PR #98), so they **don't count** toward the cap — only genuine failures do.
- The consecutive count via `CountConsecutiveFailedInstances`, ordered by `rowid` (robust to the `created_at` format); a success resets the count.

Resolves the cause of #1932's 202-attempt loop: the `hatch-*` workflows have no `on_fail`, so a genuine failure re-dispatched forever.

## Test plan
- `go build ./...` ✅ · `go vet` ✅ · `go test ./...` ✅
- Tests: counting (resets on success, per-workflow isolation); drops at the cap, keeps below, disables at 0.

## Notes
- **Stacked on #98** (base `feat/ratelimit-failover`). Fail-open on a count error.

Part 3 of 4 of the dispatcher hardening.