### PR TITLE
docs: rate-limit failover, re-dispatch cap and non-blocking dispatch

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -135,6 +135,12 @@ agents:
     runner: claude-cli
     model: claude-sonnet-4-6
     skills: [git-workflow, e2e-before-pr, gitnexus-codebase, handler-error-logging, changelog-contexto]
+    # Rate-limit failover chain: if claude-cli is rejected by the 5h session
+    # limit, retry on these runners (in order) until one isn't rate-limited.
+    # `runner` must be defined above; `model` is optional (omitted = its default).
+    fallbacks:
+      - {runner: opencode-go-cli}
+      - {runner: opencode-zen-cli}
 
   - id: reviewer
     description: "Reviewer — performs code review and quality checks"
@@ -376,6 +382,9 @@ settings:
   log_level: info
   state_lock: true
   result_comment: true
+  # Stop re-dispatching a (task, workflow) after this many consecutive failed
+  # instances (rate-limited runs fail over and don't count). <=0 disables.
+  max_attempts: 3
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/.claude/skills/apiary-guide/SKILL.md
+++ b/.claude/skills/apiary-guide/SKILL.md
@@ -260,6 +260,12 @@ agents:
     # Max concurrency for THIS agent (overrides global settings.concurrency)
     max_workers: 2
 
+    # Rate-limit failover: retry on the next non-paused runner/model when the
+    # primary is rejected by a provider usage limit. See Rate limits & resilience.
+    fallbacks:
+      - {runner: opencode-go, model: opencode-go/deepseek-v4-pro}
+      - {runner: cursor, model: composer-2.5-fast}
+
     # Per-agent route overrides
     match:
       source: my-repo
@@ -278,6 +284,7 @@ agents:
 | `source_email` | no | Git author email (set as `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_EMAIL` in runner env) |
 | `source_name` | no | Git author name (set as `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME` in runner env) |
 | `max_workers` | no | Per-agent concurrency cap (default: global `settings.concurrency`) |
+| `fallbacks` | no | Ordered `{runner, model}` chain to fail over to on a provider rate limit. `runner` must be defined; `model` optional. See Rate limits & resilience |
 
 ### `routes`
 
@@ -327,7 +334,28 @@ settings:
   log_level: info          # debug | info | warn | error
   state_lock: true         # Add "in-progress" label on acknowledge
   result_comment: true     # Post agent output as comment
+  max_attempts: 3          # Re-dispatch failure cap per (task, workflow); <=0 disables
 ```
+
+### Rate limits & resilience
+
+Safeguards that stop a saturated provider or a failing task from becoming a
+runaway loop:
+
+- **Failover on rate limits.** When a runner is rejected by a provider usage
+  limit (the Claude CLI emits `rate_limit_event` `status: rejected`), Apiary pauses
+  that runner type until it resets and retries the step on the agent's next
+  `fallbacks` entry — instead of recording the empty "you've hit your limit" run
+  as a success. Pause is keyed by runner type (all Claude agents share one
+  account). `fallbacks` load at startup.
+- **Re-dispatch cap (`settings.max_attempts`, default 3).** After N consecutive
+  *failed* instances for a `(task, workflow)`, the dispatcher stops re-dispatching
+  it (and applies the workflow's `on_fail` if set). Internal backstop independent
+  of source labels — covers workflows with no `on_fail`. Rate-limited runs fail
+  over and don't count; a success resets the count. `<=0` disables.
+- **Non-blocking dispatch.** A busy agent's `max_workers` slot is acquired inside
+  the dispatch goroutine, so a saturated agent never stalls polling/dispatch for
+  other sources or agents.
 
 ## Dashboard
 

--- a/docs/apiary-guide.md
+++ b/docs/apiary-guide.md
@@ -256,6 +256,14 @@ agents:
     # Max concurrency for THIS agent (overrides global settings.concurrency)
     max_workers: 2
 
+    # Rate-limit failover: if the primary runner is rejected by a provider
+    # usage limit (e.g. Claude's 5-hour session limit), retry on the next
+    # non-paused fallback runner/model instead of stalling. See Rate limits
+    # & resilience below.
+    fallbacks:
+      - {runner: opencode-go, model: opencode-go/deepseek-v4-pro}
+      - {runner: cursor, model: composer-2.5-fast}
+
     # Per-agent route overrides
     match:
       source: my-repo
@@ -274,6 +282,7 @@ agents:
 | `source_email` | no | Git author email (set as `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_EMAIL` in runner env) |
 | `source_name` | no | Git author name (set as `GIT_AUTHOR_NAME`, `GIT_COMMITTER_NAME` in runner env) |
 | `max_workers` | no | Per-agent concurrency cap (default: global `settings.concurrency`) |
+| `fallbacks` | no | Ordered list of `{runner, model}` to fail over to when the primary runner hits a provider rate limit. `runner` must be a defined runner id; `model` is optional (empty = that runner's default). See [Rate limits & resilience](#rate-limits--resilience) |
 | `env` | no | Agent-scope environment variables (map). Lowest-precedence explicit scope — see [Environment variables](#environment-variables) |
 
 ### `routes`
@@ -312,7 +321,65 @@ settings:
   log_level: info          # debug | info | warn | error
   state_lock: true         # Add "in-progress" label on acknowledge
   result_comment: true     # Post agent output as comment
+  max_attempts: 3          # Re-dispatch failure cap per (task, workflow); <=0 disables
 ```
+
+| Field | Default | Description |
+|---|---|---|
+| `concurrency` | 2 | Global worker pool size (informational; real dispatch concurrency is the sum of per-agent `max_workers`) |
+| `log_level` | info | `debug` \| `info` \| `warn` \| `error` |
+| `state_lock` | false | Add an "in-progress" label on acknowledge |
+| `result_comment` | false | Post agent output back as a comment |
+| `max_attempts` | 3 | Stop re-dispatching a `(task, workflow)` after this many **consecutive failed** instances (rate-limited runs don't count). `<=0` disables the cap. See [Rate limits & resilience](#rate-limits--resilience) |
+
+## Rate limits & resilience
+
+Apiary is built around a single dispatch path and a small set of safeguards that
+keep a saturated provider or a failing task from turning into a runaway,
+money-burning loop.
+
+### Provider rate limits → failover
+
+When a runner is rejected by a provider usage limit — e.g. the Claude CLI emits a
+`rate_limit_event` with `status: rejected` ("you've hit your session limit") —
+Apiary does **not** treat the empty run as a success. Instead it:
+
+1. **Pauses that runner type** until the limit resets (`resetsAt`). Because every
+   Claude agent shares one account, pausing is keyed by runner type, so all Claude
+   agents back off together.
+2. **Fails over** to the agent's next `fallbacks` entry whose runner isn't paused,
+   retrying the same step on that runner/model. While the primary is paused, new
+   steps go straight to the fallback (no wasted, pre-failed call).
+
+```yaml
+agents:
+  - id: engineer
+    runner: claude
+    model: claude-sonnet-4-6
+    fallbacks:
+      - {runner: opencode-go, model: opencode-go/deepseek-v4-pro}
+      - {runner: cursor, model: composer-2.5-fast}
+```
+
+Each attempt is recorded as its own execution, so the dashboard shows the
+failover (primary rate-limited → fallback ran). `fallbacks` load at startup —
+changing the chain requires a restart.
+
+### Re-dispatch failure cap
+
+A task whose workflow keeps failing would otherwise be re-dispatched on every poll
+forever (especially workflows with no `on_fail`, like escape-hatch routes). The
+`settings.max_attempts` cap is an **internal** backstop, independent of
+source-side labels: after N consecutive **failed** instances for the same
+`(task, workflow)`, Apiary stops re-dispatching it and applies the workflow's
+`on_fail` hook (if any). Rate-limited runs fail over and are not counted; a single
+success resets the count. Default `3`; set `<=0` to disable.
+
+### Non-blocking dispatch
+
+Each agent's `max_workers` slot is acquired inside the dispatch goroutine, not on
+the poll-loop thread. A fully-busy agent therefore parks its own runs without
+stalling polling or dispatch for any other source or agent.
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary
Documents the dispatcher hardening (PRs #97 / #98 / #100 / #101):

- `agents.fallbacks` (the rate-limit failover chain) — in the agents table + an example.
- `settings.max_attempts` (the re-dispatch failure cap) — in the settings table.
- A new **Rate limits & resilience** section (failover / cap / non-blocking dispatch).

Files: `docs/apiary-guide.md`, the `apiary-guide` skill, and the full example `.apiary/example-apiary-full.yaml` (engineer fallbacks → opencode runners; `settings.max_attempts`).

## Test plan
- The example config loads and validates with no errors on the new fields (`fallbacks` resolve defined runners; `max_attempts` accepted by the KnownFields lint). The `soul_file` errors in the harness are pre-existing (relative paths).