### PR TITLE
docs: update README and docs for the public beta (v0.2.0)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -53,12 +53,13 @@ apiary/
 │   │   ├── cli/            # Cobra commands
 │   │   ├── config/         # apiary.yaml parsing and validation
 │   │   ├── daemon/         # Dispatcher, IPC socket server, status types
-│   │   ├── model/          # Cell, RunRequest, RunResult, ActiveRun
+│   │   ├── model/          # task model, RunRequest, RunResult, ActiveRun
 │   │   ├── router/         # Rule matching engine
 │   │   ├── runner/         # Runner adapter interface + registry
-│   │   │   ├── cli/        # CLI subprocess runner (opencode, gemini, …)
-│   │   │   └── script/     # Shell script runner
+│   │   │   ├── execution/  # cli + api execution engines
+│   │   │   └── providers/  # claude, opencode, cursor presets
 │   │   ├── source/         # Source adapter interface + registry
+│   │   │   ├── github/     # GitHub Issues source adapter
 │   │   │   └── plane/      # Plane source adapter
 │   │   └── tui/            # Bubble Tea terminal UI
 │   ├── sdk/                # Public SDK for custom adapters (planned)
@@ -79,35 +80,43 @@ cd /your/project
 apiary init          # scaffolds apiary.yaml — edit it before running
 ```
 
-Minimal working config (using the `script` runner for local testing without a real agent CLI):
+Minimal working config — a GitHub source routed to a single Claude agent:
 
 ```yaml
 version: "1"
 
-sources:
-  - id: my-plane
-    type: plane
+runners:
+  - id: claude
+    type: cli
+    provider: claude
     config:
-      workspace: your-workspace-slug
-      project: your-project-uuid
-      api_key: ${PLANE_API_KEY}
+      args: ["--output-format", "stream-json", "--verbose"]
+
+sources:
+  - id: my-repo
+    type: github
+    config:
+      repo: my-org/my-repo
+      api_key: ${GITHUB_TOKEN}
     poll_interval: 30s
     filters:
       labels: [ai-ready]
 
-workers:
-  - id: echo-worker
-    runner: script
-    model: none
-    runner_config:
-      command: echo "would run agent on: $APIARY_CELL_TITLE"
+agents:
+  - id: engineer
+    description: "Implements tasks"
+    runner: claude
+    model: claude-sonnet-4-6
 
-routes:
+workflows:
   - id: default
-    priority: 99
-    match:
-      source: my-plane
-    worker: echo-worker
+    trigger:
+      priority: 99
+      match:
+        source: my-repo
+    steps:
+      - id: run
+        agent: engineer
 
 settings:
   concurrency: 1
@@ -119,7 +128,7 @@ Create a `.env` file next to your `apiary.yaml` with your secrets:
 
 ```sh
 # .env  (never committed — already in .gitignore)
-PLANE_API_KEY=your_key_here
+GITHUB_TOKEN=your_token_here
 ```
 
 Apiary loads `.env` automatically on every command. Already-set shell variables always take precedence. To point at a different file:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 Apiary is an open-source harness that connects project management tools (Jira, Plane, GitHub Issues, Linear) to AI agent runners and routes each task to the right agent profile and LLM model based on declarative rules.
 
 ```
-Task System ──► Apiary ──► Agent Profile ──► LLM Model
-   (Plane)      (router)    (backend-dev)     (gpt-4o)
+Task System ──► Apiary ──► Agent ──► LLM Model
+  (GitHub)      (router)  (backend-dev)  (claude-sonnet-4-6)
 ```
 
 ## Why Apiary?
@@ -22,48 +22,75 @@ Most AI coding agents require a human to manually pick a task, paste context, an
 | Term | Meaning |
 |---|---|
 | **Hive** | A configured Apiary instance (`apiary.yaml`) |
-| **Source** | A task system integration (Plane, Jira, Linear…) |
-| **Worker** | An agent profile — a named combo of runner + model + prompt context |
-| **Route** | A rule that maps task attributes to a Worker |
-| **Cell** | A single task unit flowing through the system |
+| **Source** | A task system integration that polls work items and writes results back (GitHub, Plane, Jira, Linear…) |
+| **Runner** | How an agent executes — a CLI subprocess (`cli`) or API call (`api`) |
+| **Agent** | A named LLM persona: runner + model + soul/skills, with optional fallbacks |
+| **Workflow** | A pipeline of steps, fired by a `trigger` that matches tasks; each step runs an agent |
+| **Task** | A unit of work flowing through the system (an issue or item from a Source) |
 
 ## Quick Example
 
 ```yaml
 # apiary.yaml
-sources:
-  - id: main-plane
-    type: plane
+version: "1"
+
+runners:
+  - id: claude
+    type: cli
+    provider: claude
     config:
-      workspace: my-workspace
-      project: my-project
-      api_key: ${PLANE_API_KEY}
+      args: ["--output-format", "stream-json", "--verbose"]
+
+sources:
+  - id: main-repo
+    type: github
+    config:
+      repo: my-org/my-repo
+      api_key: ${GITHUB_TOKEN}
+    poll_interval: 120s
     filters:
       labels: [ai-ready]
 
-workers:
+agents:
   - id: backend-dev
-    runner: opencode
-    model: openai/gpt-4o
-    config:
-      working_dir: /workspace/my-project
-      max_turns: 10
+    description: "Implements backend tasks"
+    runner: claude
+    model: claude-sonnet-4-6
 
-routes:
+# A workflow fires when its trigger matches a task, then runs its steps.
+workflows:
   - id: backend-bugs
-    priority: 10
-    match:
-      labels: [backend, bug]
-    worker: backend-dev
+    trigger:
+      priority: 10        # lower number = evaluated first
+      match:
+        labels: [backend, bug]
+    steps:
+      - id: run
+        agent: backend-dev
+    on_complete:
+      set_state: closed
 ```
 
 ```sh
 apiary run
 ```
 
+## What's in the beta
+
+Apiary runs end-to-end today and ships with the safeguards that make unattended agent dispatch safe to leave running:
+
+- **Rate-limit failover** — when a provider rejects a run on a usage limit, Apiary pauses that runner type until it resets and fails over to the agent's next `fallbacks` entry, instead of burning the task on a pre-failed call.
+- **Re-dispatch cap** (`settings.max_attempts`) — a task whose workflow keeps failing stops being re-dispatched after N consecutive failures, so a broken task can't loop forever.
+- **Non-blocking dispatch** — a busy agent parks its own runs without stalling polling or dispatch for any other source or agent.
+- **Approval rehydration** — runs parked on a manual-approval gate survive a daemon restart.
+- **Scoped env vars** — set environment variables per agent, workflow, or step, merged with precedence.
+- **Schema-validated config** — `apiary.yaml` is validated against a JSON Schema, with live validation in the VS Code extension.
+
+See the [Apiary Guide](docs/apiary-guide.md#rate-limits--resilience) for details.
+
 ## Installation
 
-> **Pre-alpha.** Direct downloads, `.deb`/`.rpm`, and the Docker image are published on every release ([Releases](https://github.com/orlandoburli/apiary/releases)). The Homebrew and Scoop channels activate with the first **stable** tag (`v0.1.0`).
+> **Public beta.** Every channel below is live — Homebrew, Scoop, Docker, `.deb`/`.rpm`, and direct downloads are published on each release ([Releases](https://github.com/orlandoburli/apiary/releases)).
 
 **macOS / Linux — Homebrew**
 
@@ -123,14 +150,20 @@ All specs live in [`openspec/`](openspec/):
 Apiary supports a `cli` runner adapter that invokes agent CLI tools (such as `opencode`, `gemini`, or similar) as subprocesses on your local machine.
 
 ```yaml
-workers:
-  - id: my-worker
-    runner: cli
-    model: openai/gpt-4o
+runners:
+  - id: opencode
+    type: cli
+    provider: opencode
     config:
-      command: opencode       # CLI binary on your PATH
+      binary: opencode        # CLI binary on your PATH
       model_flag: "--model"   # flag used to pass the model
-      working_dir: /my/repo
+
+agents:
+  - id: my-agent
+    runner: opencode          # references the runner above
+    model: opencode-go/deepseek-v4-pro
+    config:
+      working_dir: /my/repo   # where the agent runs
 ```
 
 **Important:** Apiary never handles, stores, intercepts, or transmits authentication credentials of any kind. CLI tools manage their own authentication independently. The `cli` runner simply invokes the binary — it has no knowledge of how the tool authenticates.
@@ -166,7 +199,9 @@ the diagram shows. The extension source lives under
 
 ## Status
 
-> Pre-alpha. Implementation in progress.
+> **Public beta.** Apiary works end-to-end and is in active use. Config and adapter
+> APIs may still change before `v1.0` — pin a version for anything you depend on, and
+> [file issues](https://github.com/orlandoburli/apiary/issues) for anything rough.
 
 ## License
 

--- a/docs/SCHEMA_SETUP.md
+++ b/docs/SCHEMA_SETUP.md
@@ -134,7 +134,7 @@ git commit --no-verify
 | `runners` | No | Runner definitions |
 | `sources` | No | Task sources (GitHub, Jira, Linear, etc.) |
 | `agents` | No | Agent definitions |
-| `workers` | No | Worker definitions |
+| `default_runner` | No | Default runner ID used when an agent omits `runner` |
 | `workflows` | No | Workflow definitions |
 | `settings` | No | Global settings |
 | `tasks` | No | Task-level hooks |

--- a/docs/apiary-guide.md
+++ b/docs/apiary-guide.md
@@ -51,12 +51,15 @@ agents:
     runner: claude
     model: claude-sonnet-4-6
 
-routes:
+workflows:
   - id: implement
-    priority: 10
-    match:
-      source: my-repo
-    agent: engineer
+    trigger:
+      priority: 10
+      match:
+        source: my-repo
+    steps:
+      - id: run
+        agent: engineer
     on_complete:
       set_state: closed
 
@@ -82,7 +85,7 @@ apiary dashboard     # watch in another terminal
 │              │  write    │                   │   result     │            │
 └──────────────┘           │  ┌─────────────┐  │              └────────────┘
                            │  │   Router    │  │
-                           │  │ (routes.*)  │  │
+                           │  │ (triggers)  │  │
                            │  └─────────────┘  │
                            │  ┌─────────────┐  │
                            │  │ SQLite store │  │
@@ -263,12 +266,10 @@ agents:
     fallbacks:
       - {runner: opencode-go, model: opencode-go/deepseek-v4-pro}
       - {runner: cursor, model: composer-2.5-fast}
-
-    # Per-agent route overrides
-    match:
-      source: my-repo
-      labels: [agent:engineer]
 ```
+
+Which tasks reach this agent is decided by a [workflow `trigger`](#workflows), not the
+agent itself.
 
 | Field | Required | Description |
 |---|---|---|
@@ -285,33 +286,39 @@ agents:
 | `fallbacks` | no | Ordered list of `{runner, model}` to fail over to when the primary runner hits a provider rate limit. `runner` must be a defined runner id; `model` is optional (empty = that runner's default). See [Rate limits & resilience](#rate-limits--resilience) |
 | `env` | no | Agent-scope environment variables (map). Lowest-precedence explicit scope — see [Environment variables](#environment-variables) |
 
-### `routes`
+### `workflows`
 
-Match rules that decide which agent handles each task. Lower `priority` is evaluated first.
+A workflow fires when its `trigger` matches a task, then runs its `steps` in order.
+Lower trigger `priority` is evaluated first. The simplest workflow has a single step —
+that one-step form replaces what used to be a `route`.
 
 ```yaml
-routes:
+workflows:
   - id: complex-design
-    priority: 10
-    match:
-      source: project-erp
-      labels: [agent:staff]
-    agent: staff
+    trigger:
+      priority: 10
+      match:
+        source: project-erp
+        labels: [agent:staff]
+    steps:
+      - id: run
+        agent: staff
     on_complete:
       set_state: in review
 ```
 
 | Field | Description |
 |---|---|
-| `priority` | Lower number = evaluated first |
-| `match.source` | Source ID to match |
-| `match.labels` | Cell must have ALL these labels |
-| `match.types` | Cell types to match (GitHub Cells are always `issue`) |
-| `match.states` | Cell states to match |
-| `match.exclude_label_prefix` | Exclude cells with labels starting with prefix (e.g. `agent:`) |
-| `agent` | Target agent ID |
-| `on_complete.set_state` | State to set on source when done |
-| `on_complete.add_labels` | Labels to add on source when done |
+| `trigger.priority` | Lower number = evaluated first |
+| `trigger.match.source` | Source ID to match |
+| `trigger.match.labels` | Task must have ALL these labels |
+| `trigger.match.types` | Task types to match (GitHub tasks are always `issue`) |
+| `trigger.match.states` | Task states to match |
+| `trigger.match.exclude_label_prefix` | Exclude tasks with labels starting with prefix (e.g. `agent:`) |
+| `steps[].agent` | Agent that runs this step |
+| `on_complete.set_state` | State to set on source when the workflow succeeds |
+| `on_complete.add_labels` | Labels to add on source when the workflow succeeds |
+| `on_fail` | Hook applied when the workflow fails (same shape as `on_complete`) |
 
 ### `settings`
 
@@ -429,12 +436,12 @@ In detail view: `m` cycles model, `r` cycles runner, `w` cycles max_workers. Cha
 
 | Term | Description |
 |---|---|
-| **Cell** | Unit of work from a source (issue, PR, etc.) |
+| **Task** | Unit of work from a source (an issue or item) |
 | **Source** | Adapter that polls an external issue tracker and writes results back |
 | **Agent** | An LLM persona that processes tasks |
 | **Runner** | How an agent executes (CLI subprocess or API call) |
-| **Route** | Rule that matches Cells to Agents |
-| **Dispatcher** | Core loop that polls sources, routes Cells, dispatches to agents |
+| **Route** | Rule that matches Tasks to Agents |
+| **Dispatcher** | Core loop that polls sources, routes Tasks, dispatches to agents |
 | **inFlight** | Map of task IDs currently being processed — prevents double-dispatch |
 | **Soul file** | System prompt / persona definition for an agent |
 | **IPC Socket** | Unix socket (`apiary.sock`) for dashboard ↔ dispatcher communication |

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -42,8 +42,8 @@ sources:
 | **Poll** | `GET /repos/{owner}/{repo}/issues?state=open&sort=updated&direction=desc` | Every `poll_interval` |
 | **Acknowledge** | `POST /repos/{owner}/{repo}/issues/{number}/labels` (adds `in-progress`) | When `settings.state_lock: true` |
 | **WriteResult** | `POST /repos/{owner}/{repo}/issues/{number}/comments` | When `settings.result_comment: true` |
-| **SetState** | `PATCH /repos/{owner}/{repo}/issues/{number}` (sets `state`) | Via `route.on_complete.set_state` |
-| **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `route.on_complete.add_labels` |
+| **SetState** | `PATCH /repos/{owner}/{repo}/issues/{number}` (sets `state`) | Via `workflow.on_complete.set_state` |
+| **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `workflow.on_complete.add_labels` |
 
 GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
 them out during polling — only plain issues become cells (always
@@ -128,45 +128,50 @@ agents:
 Default is 1 if not set. Polls are serialized (one source at a time) regardless
 of `settings.concurrency`.
 
-## Routing (`routes`)
+## Routing (`workflows`)
 
-Routes are evaluated in `priority` ascending order. The first match wins.
+A workflow's `trigger` decides which tasks it handles. Triggers are evaluated in
+`priority` ascending order (lower first); the first match wins. The match fields
+below live under `trigger.match`.
 
 ### `match` fields
 
 | Field | Type | Description |
 |---|---|---|
-| `source` | `string` | Only match cells from this source ID |
-| `labels` | `[string]` | Cell must have **all** of these labels (case-insensitive) |
-| `exclude_labels` | `[string]` | Cell must NOT have any of these labels |
-| `exclude_label_prefix` | `string` | Cell must not have a label starting with this prefix |
-| `states` | `[string]` | Only match cells whose state is in this list |
-| `types` | `[string]` | Only match cells whose type is in this list (GitHub cells are always `"issue"`) |
-| `title_regex` | `string` | Cell title must match this Go regexp |
-| `priority` | `[string]` | Only match cells whose priority is in this list |
+| `source` | `string` | Only match tasks from this source ID |
+| `labels` | `[string]` | Task must have **all** of these labels (case-insensitive) |
+| `exclude_labels` | `[string]` | Task must NOT have any of these labels |
+| `exclude_label_prefix` | `string` | Task must not have a label starting with this prefix |
+| `states` | `[string]` | Only match tasks whose state is in this list |
+| `types` | `[string]` | Only match tasks whose type is in this list (GitHub tasks are always `"issue"`) |
+| `title_regex` | `string` | Task title must match this Go regexp |
+| `priority` | `[string]` | Only match tasks whose priority is in this list |
 
 ### `on_complete` fields
 
 | Field | Type | Description |
 |---|---|---|
-| `set_state` | `string` | Transition the cell to this state after a successful run |
-| `add_labels` | `[string]` | Add these labels to the cell after a successful run |
+| `set_state` | `string` | Transition the task to this state after a successful run |
+| `add_labels` | `[string]` | Add these labels to the task after a successful run |
 
-### Example: route by label
+### Example: trigger by label
 
 ```yaml
-routes:
+workflows:
   - id: engineer-implement
-    priority: 20
-    match:
-      source: my-repo
-      labels: [agent:engineer]
-    agent: engineer
+    trigger:
+      priority: 20
+      match:
+        source: my-repo
+        labels: [agent:engineer]
+    steps:
+      - id: run
+        agent: engineer
     on_complete:
       set_state: closed
 ```
 
-The route matches any cell carrying the `agent:engineer` label and dispatches
+The trigger matches any task carrying the `agent:engineer` label and dispatches
 it to the engineer agent, closing the issue when the run succeeds.
 
 ## Environment variables

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,9 @@
 # Installation
 
-!!! warning "Pre-alpha"
-    Direct downloads, `.deb`/`.rpm`, and the Docker image are published on every
-    release ([Releases](https://github.com/orlandoburli/apiary/releases)). The
-    Homebrew and Scoop channels activate with the first **stable** tag (`v0.1.0`).
+!!! note "Public beta"
+    Every channel below is live — Homebrew, Scoop, Docker, `.deb`/`.rpm`, and direct
+    downloads are published on each release
+    ([Releases](https://github.com/orlandoburli/apiary/releases)).
 
 ## macOS / Linux — Homebrew
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -266,7 +266,7 @@
             "properties": {
               "priority": {
                 "type": "integer",
-                "description": "Trigger priority (higher = earlier evaluation)"
+                "description": "Trigger priority (lower number = evaluated first)"
               },
               "exclusive": {
                 "type": "boolean",


### PR DESCRIPTION
## Summary

Aligns the documentation with the current code and prepares the **public beta (v0.2.0)** launch.

- Replaces the old vocabulary (`workers`/`Worker`/`Cell`/`routes`) with the current model: `runners` + `agents` + `workflows[].trigger`.
- `README.md`: status **Pre-alpha → public beta**; updated install note (Homebrew/Scoop/Docker now active); a new **What's in the beta** section (rate-limit failover, `max_attempts`, non-blocking dispatch, approval rehydration, per-scope env, schema-validated config).
- `docs/installation.md`: Pre-alpha → beta notice.
- `docs/apiary-guide.md` + `docs/github-source.md`: routing section `routes` → `workflows`/`trigger`; removes the invalid `match` field from the agent example.
- `docs/SCHEMA_SETUP.md`: removes the non-existent top-level `workers` field.
- `schema/apiary.json`: fixes the `trigger.priority` description (lower number = evaluated first), matching `router.go`.

## Test plan

- `make check` (build + tests) — green.
- `apiary validate` on the new README and DEVELOPMENT.md examples — `✓ config is valid`.
- A sweep for obsolete terms (`Cell`/`Worker`/`workers:`/`routes:`/`Pre-alpha`/`openai/gpt-4o`) — clean.