### PR TITLE
fix(daemon): fix task delete (HTTP 500) by resolving via cell_id/source:item/id

### DIFF
--- a/src/internal/cli/delete.go
+++ b/src/internal/cli/delete.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -66,6 +68,14 @@ func newDeleteCmd() *cobra.Command {
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				detail := strings.TrimSpace(string(body))
+				if resp.StatusCode == http.StatusNotFound {
+					return fmt.Errorf("no task matched %q — pass the task id, the source item id, or --source/--item", taskID)
+				}
+				if detail != "" {
+					return fmt.Errorf("delete failed (HTTP %d): %s", resp.StatusCode, detail)
+				}
 				return fmt.Errorf("delete failed: HTTP %d", resp.StatusCode)
 			}
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -820,7 +821,11 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			return
 		}
 		if err := d.DeleteTask(ctx, taskRef); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrTaskNotFound) {
+				status = http.StatusNotFound
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/src/internal/daemon/workflow_delete_test.go
+++ b/src/internal/daemon/workflow_delete_test.go
@@ -1,0 +1,117 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// seedBoundTask creates a source-bound InternalTask with one workflow instance
+// (keyed by both task id and cell id) plus a task log, mirroring how a dispatched
+// GitHub-sourced task looks in the database. The cell id equals the source item id
+// — the GitHub adapter sets SourceItem.ID to the issue number — which is exactly
+// what a user passes to `apiary delete <issue-number>`.
+func seedBoundTask(ctx context.Context, t *testing.T, dbc *db.Client, sourceID, itemID string) (taskID, instID string) {
+	t.Helper()
+	task := &model.InternalTask{Title: "Fix the thing", State: model.TaskStateRunning}
+	binding := &model.SourceBinding{SourceID: sourceID, SourceItemID: itemID, SourceItemNumber: "#" + itemID}
+	if err := dbc.CreateTaskWithBinding(ctx, task, binding); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	inst := &db.WorkflowInstance{
+		ID: "wf_" + itemID, WorkflowID: "wf", TaskID: task.ID,
+		CellID: itemID, SourceID: sourceID, State: db.InstanceStateRunning,
+	}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	if err := dbc.WriteTaskLog(ctx, itemID, "info", "started"); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+	return task.ID, inst.ID
+}
+
+func openTestDB(ctx context.Context, t *testing.T) *db.Client {
+	t.Helper()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "del.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	return dbc
+}
+
+// TestDeleteTask_Resolution proves a task is fully removed regardless of which
+// reference form the user supplies: the bare source-item id (the original bug —
+// `apiary delete 1956`), the source:item pair, or the canonical InternalTask id.
+func TestDeleteTask_Resolution(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		ref  func(taskID, itemID string) string
+	}{
+		{"by bare source-item id", func(_, itemID string) string { return itemID }},
+		{"by source:item", func(_, itemID string) string { return "github:" + itemID }},
+		{"by internal task id", func(taskID, _ string) string { return taskID }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbc := openTestDB(ctx, t)
+			taskID, instID := seedBoundTask(ctx, t, dbc, "github", "1956")
+
+			d := &Dispatcher{db: dbc}
+			if err := d.DeleteTask(ctx, tc.ref(taskID, "1956")); err != nil {
+				t.Fatalf("DeleteTask: %v", err)
+			}
+
+			if tk, err := dbc.InternalTasks().GetTask(ctx, taskID); err != nil || tk != nil {
+				t.Fatalf("task row should be gone: task=%v err=%v", tk, err)
+			}
+			if bs, err := dbc.ListBindingsByTask(ctx, taskID); err != nil || len(bs) != 0 {
+				t.Fatalf("bindings should be gone: %v err=%v", bs, err)
+			}
+			if inst, err := dbc.GetWorkflowInstance(ctx, instID); err != nil || inst != nil {
+				t.Fatalf("instance should be gone: %v err=%v", inst, err)
+			}
+		})
+	}
+}
+
+// TestDeleteTask_NotFound asserts an unresolvable reference yields ErrTaskNotFound,
+// which the IPC handler maps to HTTP 404 (not a bare 500).
+func TestDeleteTask_NotFound(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	d := &Dispatcher{db: dbc}
+	if err := d.DeleteTask(ctx, "does-not-exist"); !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("want ErrTaskNotFound, got %v", err)
+	}
+}
+
+// TestDeleteTask_OrphanedCell covers the stuck-queue case: a workflow instance
+// keyed by a cell id whose task row is already gone. Deleting by that cell id must
+// still clean up the instance without erroring on the missing task.
+func TestDeleteTask_OrphanedCell(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	inst := &db.WorkflowInstance{ID: "wf_orphan", WorkflowID: "wf", CellID: "orphan-1", State: db.InstanceStateRunning}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+
+	d := &Dispatcher{db: dbc}
+	if err := d.DeleteTask(ctx, "orphan-1"); err != nil {
+		t.Fatalf("DeleteTask: %v", err)
+	}
+	if got, err := dbc.GetWorkflowInstance(ctx, "wf_orphan"); err != nil || got != nil {
+		t.Fatalf("orphan instance should be gone: %v err=%v", got, err)
+	}
+}

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -10,6 +12,11 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 )
+
+// ErrTaskNotFound is returned by DeleteTask when no task, binding, or workflow
+// instance resolves the given reference. The IPC handler maps it to HTTP 404 so
+// the CLI can distinguish "nothing to delete" from a real server-side failure.
+var ErrTaskNotFound = errors.New("task not found")
 
 // InstanceSummary is one row in the `apiary instances` list.
 type InstanceSummary struct {
@@ -314,47 +321,29 @@ func stepDuration(s db.StepRun, now time.Time) string {
 	return humanDuration(end.Sub(*s.StartedAt))
 }
 
-// DeleteTask removes a task by its internal task ID or by source reference (source:item).
-// It cancels any running execution, clears tracking state, and deletes all associated
-// workflow instances, steps, and logs from the database.
+// DeleteTask permanently removes a task and everything attached to it. The
+// reference may be (1) a source:item pair (e.g. "github:1956"), (2) the canonical
+// InternalTask id, or (3) a bare source-item id / dashboard DrillKey (e.g. a
+// GitHub issue number "1956", which is the workflow_instances.cell_id). It cancels
+// any in-flight run, clears tracking state, and deletes the workflow instances,
+// step runs, task logs, source bindings, and the internal_tasks row — so the same
+// source item rebinds to a fresh task on the next dispatch cycle. Returns
+// ErrTaskNotFound (wrapped) when the reference resolves to nothing.
 func (d *Dispatcher) DeleteTask(ctx context.Context, taskRef string) error {
 	if d.db == nil {
 		return nil
 	}
 
-	// Resolve the task ID from the reference. If taskRef contains ":", it's source:item.
-	var taskID string
-	instances, err := d.db.ListWorkflowInstances(ctx, 10000)
+	taskID, cellID, err := d.resolveTaskRef(ctx, taskRef)
 	if err != nil {
-		return fmt.Errorf("list instances: %w", err)
+		return err
 	}
 
-	// Find matching instances by task ID or source reference.
-	var instancesToDelete []string
-	var cellID string
-	for _, inst := range instances {
-		// Check if this instance matches our task reference.
-		if inst.ID == taskRef {
-			instancesToDelete = append(instancesToDelete, inst.ID)
-			taskID = inst.ID
-			cellID = inst.CellID
-		} else if taskRef != "" && inst.WorkflowID != "" {
-			// Could be source:item reference, would need to check bindings.
-			// For now, match by instance ID (task ID stored in workflow instance).
-		}
-	}
-
-	if len(instancesToDelete) == 0 {
-		return fmt.Errorf("task not found: %s", taskRef)
-	}
-
-	// Cancel any running execution.
+	// Cancel any in-flight run and free its slot, keyed by cell id.
 	if val, ok := d.runCancel.LoadAndDelete(cellID); ok {
 		cancel := val.(context.CancelFunc)
 		cancel()
 	}
-
-	// Remove from in-flight tracking.
 	d.inFlight.Delete(cellID)
 	d.activeRuns.Range(func(key, val any) bool {
 		run := val.(model.ActiveRun)
@@ -364,14 +353,124 @@ func (d *Dispatcher) DeleteTask(ctx context.Context, taskRef string) error {
 		return true
 	})
 
-	// Delete workflow instances and their step runs.
-	// The database cascade deletes should handle step_runs (FK to workflow_instances),
-	// but we may need explicit cleanup for task_logs, etc.
-	if err := d.db.DeleteWorkflowInstances(ctx, instancesToDelete); err != nil {
-		aplog.Error("delete task %s: %v", taskID, err)
+	// Workflow instances (and their step runs) attached to the task or its cell.
+	instanceIDs, err := d.instanceIDsForDelete(ctx, taskID, cellID)
+	if err != nil {
+		aplog.Error("delete task %s: list instances: %v", taskRef, err)
+		return err
+	}
+	if len(instanceIDs) > 0 {
+		if err := d.db.DeleteWorkflowInstances(ctx, instanceIDs); err != nil {
+			aplog.Error("delete task %s: instances: %v", taskRef, err)
+			return err
+		}
+	}
+
+	// Task logs and executions are keyed by cell id.
+	if err := d.db.ClearTaskLogs(ctx, cellID); err != nil {
+		aplog.Error("delete task %s: logs: %v", taskRef, err)
 		return err
 	}
 
-	aplog.Info("deleted task %s (cell %s): %d instance(s)", taskID, cellID, len(instancesToDelete))
+	// Bindings and the canonical task row. Skipped for orphaned cells (taskID == "").
+	if taskID != "" {
+		if err := d.db.SourceBindings().DeleteBindingsByTask(ctx, taskID); err != nil {
+			aplog.Error("delete task %s: bindings: %v", taskRef, err)
+			return err
+		}
+		if err := d.db.InternalTasks().DeleteTask(ctx, taskID); err != nil {
+			aplog.Error("delete task %s: task row: %v", taskRef, err)
+			return err
+		}
+	}
+
+	aplog.Info("deleted task %s (task=%q cell=%q): %d instance(s)", taskRef, taskID, cellID, len(instanceIDs))
 	return nil
+}
+
+// resolveTaskRef maps a user-supplied task reference to its canonical task id and
+// cell id. See DeleteTask for the accepted reference forms. taskID is empty only
+// for an orphaned cell (workflow instances whose task row is already gone); cellID
+// is always set on success. Returns a wrapped ErrTaskNotFound when nothing matches.
+func (d *Dispatcher) resolveTaskRef(ctx context.Context, taskRef string) (taskID, cellID string, err error) {
+	bindings := d.db.SourceBindings()
+	tasks := d.db.InternalTasks()
+
+	// 1. Explicit source:item reference.
+	if src, item, ok := strings.Cut(taskRef, ":"); ok && src != "" && item != "" {
+		b, err := bindings.GetBindingBySourceItem(ctx, src, item)
+		if err != nil {
+			return "", "", err
+		}
+		if b != nil {
+			return b.TaskID, b.SourceItemID, nil
+		}
+		return "", "", fmt.Errorf("%w: %s", ErrTaskNotFound, taskRef)
+	}
+
+	// 2. Canonical InternalTask id.
+	if t, err := tasks.GetTask(ctx, taskRef); err != nil {
+		return "", "", err
+	} else if t != nil {
+		return t.ID, d.cellIDForTask(ctx, t.ID), nil
+	}
+
+	// 3. Bare source-item id / DrillKey (e.g. a GitHub issue number).
+	if b, err := bindings.GetBindingBySourceItemID(ctx, taskRef); err != nil {
+		return "", "", err
+	} else if b != nil {
+		return b.TaskID, b.SourceItemID, nil
+	}
+
+	// 4. Orphaned cell: workflow instances keyed by this cell id with no task row.
+	if inst, err := d.db.GetLatestInstanceByCell(ctx, taskRef); err != nil {
+		return "", "", err
+	} else if inst != nil {
+		return inst.TaskID, taskRef, nil
+	}
+
+	return "", "", fmt.Errorf("%w: %s", ErrTaskNotFound, taskRef)
+}
+
+// cellIDForTask returns the cell id a task's legacy machinery (instances, logs,
+// executions) is keyed by: the primary binding's source-item id when bound,
+// otherwise the task's own id (the engine uses it as the cell id for spawned,
+// binding-less tasks). Mirrors the dashboard's drillKeyFor.
+func (d *Dispatcher) cellIDForTask(ctx context.Context, taskID string) string {
+	if bs, err := d.db.ListBindingsByTask(ctx, taskID); err == nil && len(bs) > 0 {
+		return bs[0].SourceItemID
+	}
+	return taskID
+}
+
+// instanceIDsForDelete collects the workflow-instance ids to delete for a task,
+// matching both by task id and by cell id (the latter catches orphaned instances
+// whose task row is gone, and legacy instances written before task_id existed).
+func (d *Dispatcher) instanceIDsForDelete(ctx context.Context, taskID, cellID string) ([]string, error) {
+	seen := make(map[string]bool)
+	var ids []string
+	add := func(insts []db.WorkflowInstance) {
+		for _, inst := range insts {
+			if !seen[inst.ID] {
+				seen[inst.ID] = true
+				ids = append(ids, inst.ID)
+			}
+		}
+	}
+
+	if taskID != "" {
+		byTask, err := d.db.ListWorkflowInstancesByTask(ctx, taskID)
+		if err != nil {
+			return nil, err
+		}
+		add(byTask)
+	}
+
+	byCell, err := d.db.ListWorkflowInstancesByCell(ctx, cellID)
+	if err != nil {
+		return nil, err
+	}
+	add(byCell)
+
+	return ids, nil
 }

--- a/src/internal/db/binding_store.go
+++ b/src/internal/db/binding_store.go
@@ -66,6 +66,33 @@ func (s *SourceBindingStore) GetBindingBySourceItem(ctx context.Context, sourceI
 	return b, err
 }
 
+// GetBindingBySourceItemID returns the first binding whose source_item_id
+// matches, regardless of source, or (nil, nil) if none exists. It resolves a bare
+// source-item reference (e.g. a GitHub issue number / the dashboard DrillKey) to a
+// task when the caller does not know the source id. The (source_id, source_item_id)
+// pair is unique, but the same item id may exist under different sources; the oldest
+// binding wins, and callers wanting precision should pass source:item instead.
+func (s *SourceBindingStore) GetBindingBySourceItemID(ctx context.Context, sourceItemID string) (*model.SourceBinding, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, source_id, source_item_id, COALESCE(source_item_url,''),
+		       COALESCE(source_item_number,''), created_at
+		FROM source_bindings WHERE source_item_id = ? ORDER BY created_at ASC LIMIT 1
+	`, sourceItemID)
+	b, err := scanBinding(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return b, err
+}
+
+// DeleteBindingsByTask removes all source bindings for a task. Used when a task is
+// deleted so the same source item rebinds to a fresh task on the next poll instead
+// of resolving to the now-deleted task id (which the SourceBinder treats as fatal).
+func (s *SourceBindingStore) DeleteBindingsByTask(ctx context.Context, taskID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM source_bindings WHERE task_id = ?`, taskID)
+	return err
+}
+
 // ListBindingsByTask returns all source bindings for a task, oldest first. It is
 // a Client-level convenience so the workflow engine can resolve a task's bindings
 // (for side-effect fan-out) through the same Store it already holds.

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -172,6 +172,14 @@ func (s *InternalTaskStore) outstanding(ctx context.Context, id string) (int, er
 	return n, err
 }
 
+// DeleteTask removes a task row by ID. Workflow instances, bindings, and logs are
+// removed by their own stores; this only drops the internal_tasks row. Deleting a
+// non-existent id is a no-op (no error), so it is safe to call for orphaned cells.
+func (s *InternalTaskStore) DeleteTask(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM internal_tasks WHERE id = ?`, id)
+	return err
+}
+
 // ListTasksByState returns all tasks in the given state, oldest first.
 func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.TaskState) ([]model.InternalTask, error) {
 	rows, err := s.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -213,6 +213,22 @@ func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*W
 	return inst, err
 }
 
+// ListWorkflowInstancesByCell returns every workflow instance keyed by a cell id,
+// newest first. Used by task deletion to catch orphaned instances and instances
+// written before task_id existed, which ListWorkflowInstancesByTask would miss.
+func (c *Client) ListWorkflowInstancesByCell(ctx context.Context, cellID string) ([]WorkflowInstance, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC
+	`, cellID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
 // ListWorkflowInstancesByTask returns every workflow instance bound to an
 // InternalTask, newest first. A task may fan out to several workflows (Phase 4),
 // so the dashboard lists all of them per task. Backed by idx_wf_instances_task.


### PR DESCRIPTION
## Summary

`apiary delete <id>` returned **HTTP 500** for any normal task reference.

The cause: `DeleteTask` compared the argument only with the `workflow_instance` ID (a `newID()` UUID), never with the `cell_id` nor with the `InternalTask` ID. For a task coming from GitHub the `cell_id` is the issue number (the adapter sets `SourceItem.ID = item.Number`), so `apiary delete 1956` never matched → `task not found` → the handler mapped any error to 500 → the CLI discarded the body and showed only `HTTP 500`. In practice you could only delete by passing an instance UUID, which no user has.

There was also a latent bug: even when it matched, the delete only removed `workflow_instances` + `step_runs`, leaving `internal_tasks`, `source_bindings` and `task_logs` behind — and the `SourceBinder` treats a binding pointing at a non-existent task as a fatal error on the next poll.

### Changes

- **Reference resolution** (`resolveTaskRef`): accepts `source:item` (`github:1956`), the canonical `InternalTask` ID, and the `cell_id`/DrillKey (the source item's number). It also handles *orphan cells* (instances with no task — the stuck-queue case).
- **Full delete**: removes `workflow_instances`, `step_runs`, `task_logs`, `task_executions`, `source_bindings` and the `internal_tasks` row. So the source item re-binds to a new task on the next dispatch (the command's documented intent).
- **Readable errors**: the handler returns **404** (`ErrTaskNotFound`) instead of 500; the CLI now shows the response body with guidance.
- **New store methods**: `ListWorkflowInstancesByCell`, `GetBindingBySourceItemID`, `SourceBindingStore.DeleteBindingsByTask`, `InternalTaskStore.DeleteTask`.

## Test plan

- `make build` and `make vet` — OK
- `make test` — the whole suite passes
- New tests in `workflow_delete_test.go`:
  - `TestDeleteTask_Resolution` — delete by cell_id (the original bug), by `source:item` and by the internal ID; confirms the task, bindings and instance disappear
  - `TestDeleteTask_NotFound` — a non-existent reference → `ErrTaskNotFound` (→ 404)
  - `TestDeleteTask_OrphanedCell` — an orphan instance with no task row is cleaned without error

> No associated issue — reported directly. Add `Closes #N` if there is one.