### PR TITLE
docs(schema): fix the runners provider example

### DIFF
--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -31,7 +31,7 @@
           },
           "provider": {
             "type": "string",
-            "description": "Runner provider/adapter (e.g., 'claude', 'script', 'opencode')"
+            "description": "Runner provider/adapter (e.g., 'claude', 'opencode', 'cursor')"
           },
           "config": {
             "type": "object",


### PR DESCRIPTION
## Summary
- Updates the description of the `runners[].provider` field in `schema/apiary.json`.
- Removes the `'script'` example, which doesn't correspond to any registered provider.
- The real providers registered in `src/internal/runner/providers/providers.go` are: `claude-cli`, `opencode-cli`, `cursor-cli`, `opencode-api`. The example now reflects those adapters: `'claude', 'opencode', 'cursor'`.

A description-string-only change in the JSON Schema — no functional impact.

## Test plan
- `python3 -c "import json; json.load(open('schema/apiary.json'))"` confirms the JSON stays valid.
- The diff is limited to a single line (the field's description).