### PR TITLE
chore(agents): require agents to write commits, PRs and comments in English

### DIFF
--- a/.apiary/souls/backend.md
+++ b/.apiary/souls/backend.md
@@ -36,3 +36,7 @@ Always follow the project's patterns for error logging, validation, and data han
 - Consider concurrent access patterns
 - Optimize for clarity first, performance second
 - Document public APIs and complex logic
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/engineer.md
+++ b/.apiary/souls/engineer.md
@@ -6,3 +6,7 @@ You are a senior software engineer with expertise in:
 - Database optimization
 
 Focus on code quality, performance, and maintainability.
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/frontend.md
+++ b/.apiary/souls/frontend.md
@@ -32,3 +32,7 @@ Always leverage the project's web-components-ui suite for consistency. Use the e
 - Test edge cases and error states
 - Consider accessibility and keyboard navigation
 - Optimize bundle size and performance
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/investigator.md
+++ b/.apiary/souls/investigator.md
@@ -68,3 +68,7 @@ APIARY_OUTPUT: {"agent": "engineer"}
   emit conflicting ones.
 - Always ground your decision in real context (`gitnexus_query`, the description,
   related specs) — not assumptions.
+
+## Language
+
+Write your analysis, summaries, and any GitHub comments in **English**, regardless of the issue's language.

--- a/.apiary/souls/po.md
+++ b/.apiary/souls/po.md
@@ -43,3 +43,7 @@ When you receive a task from Plane, you must:
 - ALWAYS use `gitnexus_query` before proposing any new capability
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
 - Use model: `claude-opus-4-8` — use all available reasoning
+
+## Language
+
+Always write everything you produce — issue/sub-task titles and descriptions, acceptance criteria, specs, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/qa.md
+++ b/.apiary/souls/qa.md
@@ -52,3 +52,7 @@ When you receive a QA task from Plane, you must:
 - Be fair and accurate in reporting bugs
 - Request clarification if acceptance criteria are unclear
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
+
+## Language
+
+Always write everything you produce — test reports, findings, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/reviewer.md
+++ b/.apiary/souls/reviewer.md
@@ -7,3 +7,7 @@ You are an experienced code reviewer with a focus on:
 - Performance considerations
 
 Provide constructive feedback that improves code quality.
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/staff.md
+++ b/.apiary/souls/staff.md
@@ -61,3 +61,7 @@ When you receive a complex task from Plane, you must:
 - Document your reasoning in the issue
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
 - Use model: `claude-opus-4-8` — use all available reasoning
+
+## Language
+
+Always write everything you produce — issue/sub-task titles and descriptions, design notes, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -91,14 +91,15 @@ cd <worktree>
 gitnexus analyze
 git diff --quiet AGENTS.md CLAUDE.md || \
   git add AGENTS.md CLAUDE.md && \
-  git commit -m "chore: atualiza AGENTS.md e CLAUDE.md (gitnexus reindex)"
+  git commit -m "chore: update AGENTS.md and CLAUDE.md (gitnexus reindex)"
 ```
 
 Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge, o passo 9 usa `--skip-agents-md` porque o PR já atualizou os arquivos.
 
 ## PR requirements
 
-- Title: concise summary in Portuguese.
+- **Language: write ALL commit messages, PR titles, and PR descriptions in English.** This is mandatory and non-negotiable — the repo's history and PRs are English-only. Never write git commit messages or PR text in Portuguese.
+- Title: concise summary in English.
 - Body: `## Summary` with bullet points + `## Test plan`.
 - Body MUST include `Closes #<issue>` to auto-link and auto-close the issue on merge.
 - CI required status check: **CI** (gate job that aggregates all per-area checks, including E2E).
@@ -106,4 +107,4 @@ Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge
 ## Naming conventions
 
 - Branches: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/` prefixes.
-- Commits: conventional commits in Portuguese (e.g. `feat:`, `fix:`, `ci:`).
+- Commits: conventional commits **in English** (e.g. `feat:`, `fix:`, `ci:`).


### PR DESCRIPTION
## Summary

The autonomous apiary agents were authoring commits and PRs in Portuguese because the `git-workflow` skill explicitly mandated it (`Title: concise summary in Portuguese`, `Commits: conventional commits in Portuguese`). After the repo history + all PRs were translated to English, this is the remaining root cause of recurrence.

- **`.claude/skills/git-workflow/SKILL.md`**: PR-title and commit directives flipped to **English**; added a bold, mandatory "write ALL commit messages, PR titles and descriptions in English" rule; translated the example commit message.
- **`.apiary/souls/*.md`** (all 8 agents — investigator, po, staff, engineer, backend, frontend, reviewer, qa): added a `## Language` section requiring **English** for everything they produce (commit messages, PR text, issue/sub-task titles & descriptions, and GitHub comments), regardless of the issue's language.

## Test plan

- Config/docs only — no code change.
- The next agent run reads the updated soul + skill and writes English commit messages and PR text.