### PR TITLE
fix(daemon): ForceRestart interrupts non-terminal workflow instances

### DIFF
--- a/.apiary/souls/backend.md
+++ b/.apiary/souls/backend.md
@@ -36,3 +36,7 @@ Always follow the project's patterns for error logging, validation, and data han
 - Consider concurrent access patterns
 - Optimize for clarity first, performance second
 - Document public APIs and complex logic
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/engineer.md
+++ b/.apiary/souls/engineer.md
@@ -6,3 +6,7 @@ You are a senior software engineer with expertise in:
 - Database optimization
 
 Focus on code quality, performance, and maintainability.
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/frontend.md
+++ b/.apiary/souls/frontend.md
@@ -32,3 +32,7 @@ Always leverage the project's web-components-ui suite for consistency. Use the e
 - Test edge cases and error states
 - Consider accessibility and keyboard navigation
 - Optimize bundle size and performance
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/investigator.md
+++ b/.apiary/souls/investigator.md
@@ -68,3 +68,7 @@ APIARY_OUTPUT: {"agent": "engineer"}
   emit conflicting ones.
 - Always ground your decision in real context (`gitnexus_query`, the description,
   related specs) — not assumptions.
+
+## Language
+
+Write your analysis, summaries, and any GitHub comments in **English**, regardless of the issue's language.

--- a/.apiary/souls/po.md
+++ b/.apiary/souls/po.md
@@ -43,3 +43,7 @@ When you receive a task from Plane, you must:
 - ALWAYS use `gitnexus_query` before proposing any new capability
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
 - Use model: `claude-opus-4-8` — use all available reasoning
+
+## Language
+
+Always write everything you produce — issue/sub-task titles and descriptions, acceptance criteria, specs, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/qa.md
+++ b/.apiary/souls/qa.md
@@ -52,3 +52,7 @@ When you receive a QA task from Plane, you must:
 - Be fair and accurate in reporting bugs
 - Request clarification if acceptance criteria are unclear
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
+
+## Language
+
+Always write everything you produce — test reports, findings, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/reviewer.md
+++ b/.apiary/souls/reviewer.md
@@ -7,3 +7,7 @@ You are an experienced code reviewer with a focus on:
 - Performance considerations
 
 Provide constructive feedback that improves code quality.
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.apiary/souls/staff.md
+++ b/.apiary/souls/staff.md
@@ -61,3 +61,7 @@ When you receive a complex task from Plane, you must:
 - Document your reasoning in the issue
 - Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
 - Use model: `claude-opus-4-8` — use all available reasoning
+
+## Language
+
+Always write everything you produce — issue/sub-task titles and descriptions, design notes, and all GitHub comments — in **English**, regardless of the issue's language.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -91,14 +91,15 @@ cd <worktree>
 gitnexus analyze
 git diff --quiet AGENTS.md CLAUDE.md || \
   git add AGENTS.md CLAUDE.md && \
-  git commit -m "chore: atualiza AGENTS.md e CLAUDE.md (gitnexus reindex)"
+  git commit -m "chore: update AGENTS.md and CLAUDE.md (gitnexus reindex)"
 ```
 
 Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge, o passo 9 usa `--skip-agents-md` porque o PR já atualizou os arquivos.
 
 ## PR requirements
 
-- Title: concise summary in Portuguese.
+- **Language: write ALL commit messages, PR titles, and PR descriptions in English.** This is mandatory and non-negotiable — the repo's history and PRs are English-only. Never write git commit messages or PR text in Portuguese.
+- Title: concise summary in English.
 - Body: `## Summary` with bullet points + `## Test plan`.
 - Body MUST include `Closes #<issue>` to auto-link and auto-close the issue on merge.
 - CI required status check: **CI** (gate job that aggregates all per-area checks, including E2E).
@@ -106,4 +107,4 @@ Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge
 ## Naming conventions
 
 - Branches: `feat/`, `fix/`, `refactor/`, `chore/`, `docs/` prefixes.
-- Commits: conventional commits in Portuguese (e.g. `feat:`, `fix:`, `ci:`).
+- Commits: conventional commits **in English** (e.g. `feat:`, `fix:`, `ci:`).

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -507,6 +507,27 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 
 		// Reset task state so it can be re-dispatched
 		_ = d.db.UpdateTaskState(ctx, cellID, "pending")
+
+		// Mark every non-terminal workflow_instance for the cell as interrupted.
+		// A daemon restart can strand a `running` (or approval_waiting/pending)
+		// instance; while it stays non-terminal, dropActiveMatches shadows the
+		// workflow on every poll and the cell never re-dispatches. Clearing the
+		// legacy task_executions/tasks rows above is not enough — the workflow
+		// engine routes on workflow_instances. Mirrors StopInstance.
+		if insts, err := d.db.ListWorkflowInstancesByCell(ctx, cellID); err != nil {
+			aplog.Error("force-restart %s: list workflow instances: %v", cellID, err)
+		} else {
+			for _, inst := range insts {
+				switch inst.State {
+				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePending:
+					if err := d.db.UpdateWorkflowInstanceState(ctx, inst.ID, db.InstanceStateInterrupted); err != nil {
+						aplog.Error("force-restart %s: interrupt instance %s: %v", cellID, inst.ID, err)
+					} else {
+						aplog.Info("force-restart %s: interrupted workflow instance %s (was %s)", cellID, inst.ID, inst.State)
+					}
+				}
+			}
+		}
 	}
 
 	// Reset the source state (set back to todo) so the next poll picks it up

--- a/src/internal/daemon/forcerestart_workflow_test.go
+++ b/src/internal/daemon/forcerestart_workflow_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// TestForceRestart_InterruptsWorkflowInstance covers the stuck-queue case a daemon
+// restart creates: a `running` workflow_instance that was stranded (orphaned) and
+// then shadows its workflow on every poll via dropActiveMatches, so the cell never
+// re-dispatches. ForceRestart used to touch only the legacy task_executions/tasks
+// rows and leave the instance `running`. It must now mark every non-terminal
+// instance for the cell interrupted, which also clears the dropActiveMatches shadow.
+func TestForceRestart_InterruptsWorkflowInstance(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	taskID, instID := seedBoundTask(ctx, t, dbc, "github", "1956")
+
+	// Sanity: the running instance shadows its workflow before the restart.
+	match := router.Match{Route: config.RouteConfig{ID: "wf"}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	if kept := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 0 {
+		t.Fatalf("precondition: running instance should shadow the workflow, got %d kept", len(kept))
+	}
+
+	if err := d.ForceRestart(ctx, "1956"); err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+
+	// The stranded instance is now interrupted (terminal), not running.
+	inst, err := dbc.GetWorkflowInstance(ctx, instID)
+	if err != nil || inst == nil {
+		t.Fatalf("get instance: inst=%v err=%v", inst, err)
+	}
+	if inst.State != db.InstanceStateInterrupted {
+		t.Fatalf("instance state = %q, want %q", inst.State, db.InstanceStateInterrupted)
+	}
+
+	// dropActiveMatches no longer shadows the workflow, so the next poll re-dispatches.
+	if kept := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 1 {
+		t.Fatalf("after restart the workflow should re-dispatch, got %d kept", len(kept))
+	}
+}


### PR DESCRIPTION
## Summary

`apiary restart <cell>` could not unstick a task running on the workflow engine. `Dispatcher.ForceRestart` cancelled the in-memory run and reset only the **legacy** `task_executions`/`tasks` rows — it never marked the cell's non-terminal `workflow_instances` terminal.

After a daemon restart that strands a `running` instance (orphan), the stranded instance stays `running`, and `dropActiveMatches` drops any workflow that has a non-terminal instance for the task. Every poll then logs "no matching route, skipping" and the cell never re-dispatches (observed live on cell 1956 in the project-erp pipeline).

### Fix
- In `ForceRestart`, after clearing in-memory tracking and the legacy rows, enumerate instances via `Client.ListWorkflowInstancesByCell` and mark every `running` / `approval_waiting` / `pending` one `interrupted` via `UpdateWorkflowInstanceState` — mirroring what `Dispatcher.StopInstance` already does. This clears the `dropActiveMatches` shadow so the next poll re-dispatches.

## Test plan
- New `TestForceRestart_InterruptsWorkflowInstance` (`src/internal/daemon/forcerestart_workflow_test.go`): seeds a `running` instance, asserts it shadows the workflow via `dropActiveMatches` (precondition), runs `ForceRestart`, then asserts the instance is `interrupted` and `dropActiveMatches` no longer drops the match.
- Existing `TestForceRestart_StripsControlLabels` still passes (no regression in the label-stripping path).
- `make build`, `make vet`, full `go test ./...` all green locally. No Go CI.

## Notes
- The existing local `fix/orphan-workflow-reconcile` branch (which reconciles running-orphans at daemon startup, fixing the strand at its source) is complementary, but predates the PT→EN history rewrite — its commits are on stale, diverged SHAs and it cannot be cleanly merged. It should be re-created against current `main` as a separate change rather than merged.
- The `POST /instances/stop/<instanceID>` socket workaround (`StopInstance`) is untouched and still works.