### PR TITLE
ci: upgrade GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Copy root docs into docs/
         run: |
@@ -45,7 +45,7 @@ jobs:
           sed -i 's|openspec/specs/plugin-api/spec.md|https://github.com/orlandoburli/apiary/blob/main/openspec/specs/plugin-api/spec.md|g' docs/development.md
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -56,7 +56,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -17,10 +17,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 
@@ -49,7 +49,7 @@ jobs:
         run: vsce publish -p $VSCE_PAT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: vscode-apiary-v${{ steps.version.outputs.version }}
           body: |

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -19,25 +19,25 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
       # snapshot builds the Docker images (no push) — needs QEMU + buildx
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: check
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,25 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full history so GoReleaser can build the changelog
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
       # Multi-arch Docker: QEMU emulates arm64, buildx drives the builds.
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Summary

The v0.2.0 release run warned that our Node 20 JS actions are deprecated — GitHub forces them to Node 24 on **2026-06-16** and removes Node 20 from runners on **2026-09-16**. This bumps every action across all four workflows to its latest major (all run on Node 24):

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |
| actions/setup-python | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| docker/login-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |
| goreleaser/goreleaser-action | v6 | v7 |
| softprops/action-gh-release | v1 | v3 |

All input usages are compatible across these majors:
- `goreleaser-action` v7's only breaking change is the Node 24 migration; `version: "~> v2"` + `args` are unchanged.
- `setup-python` keeps `python-version`, `upload-pages-artifact` keeps `path`, `action-gh-release` keeps `tag_name`/`body`/`draft`/`prerelease`.
- `upload-pages-artifact` v5 + `deploy-pages` v5 are a matched pair.

## Test plan

- `release-check` runs on this PR (it triggers on `.github/workflows/release*.yml`) and exercises the upgraded `checkout`/`setup-go`/`setup-qemu`/`setup-buildx`/`goreleaser-action` via `goreleaser check` + `release --snapshot --clean`. Green = the release-critical pipeline works on the new versions.
- `pages` / `publish-vscode-extension` action bumps are version-only with identical inputs.