### PR TITLE
fix(daemon): reconcile orphaned workflow instances at startup

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -291,6 +291,17 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		} else if n > 0 {
 			aplog.Info("reconciled %d orphaned running execution(s) from a previous run", n)
 		}
+
+		// Mark any workflow instances left in the 'running' state as interrupted.
+		// These are orphans from a previously-killed daemon that would otherwise
+		// cause tasks to appear stuck (running for longer than daemon uptime).
+		// Marking them interrupted allows the next poll to dispatch fresh instances.
+		// approval_waiting instances are handled separately via rehydrateParkedApprovals.
+		if n, err := d.db.ReconcileOrphanWorkflowInstances(ctx); err != nil {
+			aplog.Warn("reconcile orphan workflow instances: %v", err)
+		} else if n > 0 {
+			aplog.Info("reconciled %d orphaned running workflow instance(s) from a previous run", n)
+		}
 	}
 
 	// Reconstruct workflow instances parked at an approval step into the engine's

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -323,20 +323,21 @@ func (c *Client) GetTaskTitle(ctx context.Context, id string) (string, error) {
 }
 
 // ReconcileOrphanWorkflowInstances marks any instance left in the 'running'
-// state by a previously-killed process as 'interrupted'. Returns the count.
-// approval_waiting instances are intentionally left untouched — their condition
-// is re-evaluated against the live task on the next poll.
+// state by a previously-killed process as 'interrupted'. A fresh daemon process
+// owns no in-flight workflow runs, so rows left 'running' are orphans that would
+// otherwise cause tasks to appear stuck. Marking them interrupted allows the next
+// poll to dispatch fresh instances. approval_waiting instances are deliberately
+// left untouched — they are rehydrated separately via rehydrateParkedApprovals.
 func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, error) {
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE workflow_instances
-		SET state = 'interrupted', updated_at = ?
-		WHERE state = 'running'
-	`, time.Now())
+		SET state = ?, updated_at = ?
+		WHERE state = ?
+	`, InstanceStateInterrupted, time.Now(), InstanceStateRunning)
 	if err != nil {
 		return 0, err
 	}
-	n, _ := res.RowsAffected()
-	return n, nil
+	return res.RowsAffected()
 }
 
 // CreateStepRun inserts a new step run row.

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -257,3 +257,50 @@ func TestStepRun_OrderedByInsertion(t *testing.T) {
 		t.Errorf("unexpected step run order: %+v", runs)
 	}
 }
+
+func TestReconcileOrphanWorkflowInstances_Extended(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// Create instances in various states: running (orphan), approval_waiting (rehydrated),
+	// pending, done, failed (terminal states not reconciled).
+	now := time.Now()
+	instances := []*WorkflowInstance{
+		{ID: "wf_running", WorkflowID: "w", CellID: "c", State: InstanceStateRunning, CreatedAt: now},
+		{ID: "wf_approval", WorkflowID: "w", CellID: "c", State: InstanceStateApprovalWaiting, CreatedAt: now},
+		{ID: "wf_done", WorkflowID: "w", CellID: "c", State: InstanceStateDone, CreatedAt: now},
+		{ID: "wf_failed", WorkflowID: "w", CellID: "c", State: InstanceStateFailed, CreatedAt: now},
+	}
+	for _, inst := range instances {
+		if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+			t.Fatalf("create instance: %v", err)
+		}
+	}
+
+	// Reconcile orphaned instances.
+	n, err := c.ReconcileOrphanWorkflowInstances(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// Should reconcile only 1 instance (running); approval_waiting is rehydrated separately.
+	if n != 1 {
+		t.Fatalf("expected 1 reconciled, got %d", n)
+	}
+
+	// Verify only running was changed to interrupted, others are untouched.
+	for id, expectedState := range map[string]string{
+		"wf_running":   InstanceStateInterrupted,  // running → interrupted
+		"wf_approval":  InstanceStateApprovalWaiting, // approval_waiting (untouched, rehydrated separately)
+		"wf_done":      InstanceStateDone,         // done (unchanged)
+		"wf_failed":    InstanceStateFailed,       // failed (unchanged)
+	} {
+		inst, err := c.GetWorkflowInstance(ctx, id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if inst.State != expectedState {
+			t.Errorf("%s: expected state %q, got %q", id, expectedState, inst.State)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

At daemon startup, automatically mark any `workflow_instances` left in the `running` state from a previously-killed process as `interrupted`. This prevents tasks from appearing stuck and allows them to re-dispatch naturally on the next poll.

**Problem:** When the daemon crashes or is forcefully killed, any running workflow instances are left stranded in the database. On restart, the daemon owns no in-flight runs, so these orphans are never resolved. Tasks appear stuck (showing "running" far longer than daemon uptime) and won't re-dispatch because the dispatcher sees an existing running instance and drops matching routes.

**Solution:** At `Dispatcher.Start()`, reconcile orphaned running instances by marking them `interrupted`. This is analogous to `ReconcileOrphanExecutions` (which handles task_executions). The next poll then dispatches fresh instances naturally.

## Implementation

- Added reconciliation call in `Dispatcher.Start()` after `ReconcileOrphanExecutions`
- `ReconcileOrphanWorkflowInstances` marks only `running` instances as `interrupted`
- `approval_waiting` instances are intentionally untouched (rehydrated separately via `rehydrateParkedApprovals`)
- Added test coverage for the reconciliation logic

## Test Plan

- [x] Unit tests pass: TestReconcileOrphanWorkflowInstances_Extended verifies running → interrupted, approval_waiting untouched
- [x] All integration tests pass (go test ./...)
- [x] Build succeeds (make build)