### PR TITLE
fix(workflow): park poll steps so CI waits survive restarts

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -310,6 +310,11 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// in 'registered' forever (the approval_waiting restart gap).
 	d.rehydrateParkedApprovals(ctx)
 
+	// Same for instances parked at a poll step (e.g. waiting for CI): the engine's
+	// in-memory parked set is empty after a restart, so without this a poll-waiting
+	// instance would never be re-checked and its task would be stranded.
+	d.rehydrateParkedPolls(ctx)
+
 	for _, sc := range d.cfg.Sources {
 		sc := sc
 		adapter, ok := d.sources[sc.ID]
@@ -530,7 +535,7 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 		} else {
 			for _, inst := range insts {
 				switch inst.State {
-				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePending:
+				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePollWaiting, db.InstanceStatePending:
 					if err := d.db.UpdateWorkflowInstanceState(ctx, inst.ID, db.InstanceStateInterrupted); err != nil {
 						aplog.Error("force-restart %s: interrupt instance %s: %v", cellID, inst.ID, err)
 					} else {
@@ -918,6 +923,10 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	// Re-evaluate any workflows parked at approval steps against their live tasks
 	// on each poll cycle (resume/abort/timeout) before fetching new work.
 	d.checkApprovals(ctx)
+
+	// Re-check any workflows parked at poll steps (e.g. waiting for CI) so they
+	// advance, fail, or keep waiting based on live status.
+	d.checkPolls(ctx)
 
 	aplog.Debug("polling source %s (since %s)", sc.ID, since.Format(time.RFC3339))
 	cells, err := adapter.Poll(ctx, since)

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -97,6 +97,53 @@ func (d *Dispatcher) rehydrateParkedApprovals(ctx context.Context) {
 	}
 }
 
+// rehydrateParkedPolls reconstructs workflow instances persisted in the
+// poll_waiting state and re-registers them in the engine's in-memory parked set,
+// so the polling loop's poll check (checkPolls → CheckParkedPolls) re-checks them
+// after a daemon restart. It mirrors rehydrateParkedApprovals: the parked set
+// lives only in memory and is empty on a fresh process, and
+// ReconcileOrphanWorkflowInstances deliberately leaves poll_waiting rows untouched
+// (interrupting them would lose the wait). Called once at startup, after the orphan
+// reconcile and before the poll loops start.
+func (d *Dispatcher) rehydrateParkedPolls(ctx context.Context) {
+	if d.db == nil {
+		return
+	}
+	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStatePollWaiting)
+	if err != nil {
+		aplog.Warn("rehydrate parked polls: list instances: %v", err)
+		return
+	}
+	if len(instances) == 0 {
+		return
+	}
+
+	engine := d.workflowEngine()
+	rehydrated := 0
+	for i := range instances {
+		inst := instances[i]
+		wf, ok := d.workflowByID(inst.WorkflowID)
+		if !ok {
+			aplog.Warn("rehydrate parked poll %s: workflow %q no longer defined — leaving parked", inst.ID, inst.WorkflowID)
+			continue
+		}
+		steps, err := d.db.ListStepRuns(ctx, inst.ID)
+		if err != nil {
+			aplog.Warn("rehydrate parked poll %s: list step runs: %v", inst.ID, err)
+			continue
+		}
+		task := d.taskForInstance(ctx, &inst)
+		if err := engine.RehydratePoll(ctx, inst.ID, wf, task, steps); err != nil {
+			aplog.Warn("rehydrate parked poll %s: %v", inst.ID, err)
+			continue
+		}
+		rehydrated++
+	}
+	if rehydrated > 0 {
+		aplog.Info("rehydrated %d parked poll instance(s) from a previous run", rehydrated)
+	}
+}
+
 // newSpawner builds the WorkflowSpawner backing the APIARY_SPAWN marker: it
 // resolves a named workflow from config, persists the child InternalTask, and
 // runs the workflow through this dispatcher's engine. A nil DB disables spawning
@@ -187,6 +234,16 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 		}
 		return poller.PollTask(ctx, cellID)
 	})
+}
+
+// checkPolls drives the engine's parked-poll re-checks (CI status) once per poll
+// cycle. The engine re-checks via its wired CIStatusChecker, so this needs no
+// per-call poller argument. A nil DB/engine (no run-history) disables it.
+func (d *Dispatcher) checkPolls(ctx context.Context) {
+	if d.db == nil || d.engine == nil {
+		return
+	}
+	d.engine.CheckParkedPolls(ctx)
 }
 
 // wfStepExecutor adapts the dispatcher's runner machinery to the workflow

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -301,7 +301,7 @@ func instanceSummary(v db.WorkflowInstanceView, now time.Time) InstanceSummary {
 // interrupted/pending where no meaningful span exists.
 func instanceDuration(inst db.WorkflowInstance, now time.Time) string {
 	switch inst.State {
-	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting:
+	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePollWaiting:
 		return humanDuration(now.Sub(inst.CreatedAt))
 	case db.InstanceStateDone, db.InstanceStateFailed:
 		return humanDuration(inst.UpdatedAt.Sub(inst.CreatedAt))

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -2833,6 +2833,8 @@ func wfInstanceBadge(state string) string {
 		return StyleWarning.Render("running")
 	case db.InstanceStateApprovalWaiting:
 		return StyleWarning.Render("approval_waiting")
+	case db.InstanceStatePollWaiting:
+		return StyleWarning.Render("poll_waiting")
 	case db.InstanceStateInterrupted:
 		return StyleError.Render("interrupted")
 	default:

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -11,6 +11,7 @@ const (
 	InstanceStatePending         = "pending"
 	InstanceStateRunning         = "running"
 	InstanceStateApprovalWaiting = "approval_waiting"
+	InstanceStatePollWaiting     = "poll_waiting"
 	InstanceStateInterrupted     = "interrupted"
 	InstanceStateDone            = "done"
 	InstanceStateFailed          = "failed"
@@ -148,19 +149,19 @@ func (c *Client) CountConsecutiveFailedInstances(ctx context.Context, taskID, wo
 }
 
 // HasActiveInstanceForRoute reports whether the task already has a non-terminal
-// instance for the given workflow — running or approval_waiting. The dispatcher
-// uses it as a source-agnostic in-flight guard: it stops a later poll from
-// dispatching a duplicate while the workflow runs or, crucially, waits at an
-// approval step (where the in-memory inFlight marker has already been released).
-// Keyed on (task, workflow) so a completed earlier workflow (e.g. triage) does not
-// block the next one a hand-off routes to. terminal/interrupted states do not
-// block — they remain eligible for retry or manual resume.
+// instance for the given workflow — running, approval_waiting, or poll_waiting.
+// The dispatcher uses it as a source-agnostic in-flight guard: it stops a later
+// poll from dispatching a duplicate while the workflow runs or, crucially, waits
+// at an approval or poll step (where the in-memory inFlight marker has already
+// been released). Keyed on (task, workflow) so a completed earlier workflow (e.g.
+// triage) does not block the next one a hand-off routes to. terminal/interrupted
+// states do not block — they remain eligible for retry or manual resume.
 func (c *Client) HasActiveInstanceForRoute(ctx context.Context, taskID, workflowID string) (bool, error) {
 	var n int
 	err := c.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM workflow_instances
-		WHERE task_id = ? AND workflow_id = ? AND state IN (?, ?)
-	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting).Scan(&n)
+		WHERE task_id = ? AND workflow_id = ? AND state IN (?, ?, ?)
+	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting, InstanceStatePollWaiting).Scan(&n)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -326,8 +327,9 @@ func (c *Client) GetTaskTitle(ctx context.Context, id string) (string, error) {
 // state by a previously-killed process as 'interrupted'. A fresh daemon process
 // owns no in-flight workflow runs, so rows left 'running' are orphans that would
 // otherwise cause tasks to appear stuck. Marking them interrupted allows the next
-// poll to dispatch fresh instances. approval_waiting instances are deliberately
-// left untouched — they are rehydrated separately via rehydrateParkedApprovals.
+// poll to dispatch fresh instances. approval_waiting and poll_waiting instances
+// are deliberately left untouched (the WHERE only matches 'running') — they are
+// rehydrated separately via rehydrateParkedApprovals / rehydrateParkedPolls.
 func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, error) {
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE workflow_instances

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -86,11 +86,17 @@ type ParkedApproval struct {
 }
 
 // ParkedApprovals returns a snapshot of all instances currently awaiting approval.
+// The parked set is shared with poll-waiting instances, so it filters to runs whose
+// waiting step is an approval — a poll park is resolved by CheckParkedPolls, not by
+// the approval checker.
 func (e *Engine) ParkedApprovals() []ParkedApproval {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	out := make([]ParkedApproval, 0, len(e.parked))
 	for id, r := range e.parked {
+		if r.byID[r.waitingStep].StepType() != config.StepTypeApproval {
+			continue
+		}
 		out = append(out, ParkedApproval{
 			InstanceID: id,
 			Task:       r.task,

--- a/src/internal/workflow/ci_poll.go
+++ b/src/internal/workflow/ci_poll.go
@@ -9,12 +9,19 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 )
 
-// RunPollStep executes a poll step, actively querying the external system
-// (e.g., CI status) at regular intervals until success, failure, or timeout.
+// RunPollStep performs ONE check of the external system (e.g. CI status) and
+// returns either a terminal result (pass/fail) or StepResult{Pending: true} when
+// there is no answer yet. It does NOT loop or block: the scheduler parks the
+// instance on a Pending result and calls this again on a later poll cycle, so a
+// long CI wait survives daemon restarts instead of holding a worker for hours.
+//
+// deadline is the absolute time the wait gives up (zero = no deadline). Past the
+// deadline the step returns a terminal failure with ci_status=timeout.
 func (e *Engine) RunPollStep(
 	ctx context.Context,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
+	deadline time.Time,
 ) (StepResult, error) {
 	if step.PollConfig == nil {
 		return StepResult{}, fmt.Errorf("poll step %q missing poll config", step.ID)
@@ -23,17 +30,20 @@ func (e *Engine) RunPollStep(
 	cfg := step.PollConfig
 	switch cfg.Kind {
 	case "", "ci":
-		return e.runCIPollStep(ctx, step, sourceID, sourceItemID)
+		return e.checkCIPollStep(ctx, step, sourceID, sourceItemID, deadline)
 	default:
 		return StepResult{}, fmt.Errorf("poll step %q unsupported kind: %q", step.ID, cfg.Kind)
 	}
 }
 
-// runCIPollStep polls the CI status of a PR/branch until it passes, fails, or times out.
-func (e *Engine) runCIPollStep(
+// checkCIPollStep performs a single CI status check. Transient errors and a
+// still-running CI both yield Pending (retry next cycle); a passed/failed CI is
+// terminal; passing the deadline is a terminal timeout failure.
+func (e *Engine) checkCIPollStep(
 	ctx context.Context,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
+	deadline time.Time,
 ) (StepResult, error) {
 	if e.ciChecker == nil {
 		return StepResult{
@@ -44,84 +54,60 @@ func (e *Engine) runCIPollStep(
 
 	cfg := step.PollConfig
 
-	checkInterval := cfg.ParsedCheckInterval()
-	maxDuration := cfg.ParsedMaxDuration()
-	deadline := time.Now().Add(maxDuration)
+	// Timeout: give up waiting once past the deadline.
+	if !deadline.IsZero() && e.now().After(deadline) {
+		aplog.Info("poll step %q: CI wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
+		return StepResult{
+			Success: false,
+			StructuredOutput: map[string]any{
+				"ci_status": "timeout",
+				"reason":    fmt.Sprintf("CI did not complete within %v", cfg.ParsedMaxDuration()),
+			},
+		}, nil
+	}
 
-	ticker := time.NewTicker(checkInterval)
-	defer ticker.Stop()
+	status, err := e.ciChecker(ctx, sourceID, sourceItemID)
+	if err != nil {
+		// Transient error; treat as not-yet-resolved and retry next cycle.
+		aplog.Debug("poll step %q: CI check failed (will retry): %v", step.ID, err)
+		return StepResult{Pending: true}, nil
+	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return StepResult{
-				Success: false,
-				Err:     ctx.Err(),
-			}, nil
+	switch status.Status {
+	case "passed":
+		return StepResult{
+			Success: true,
+			StructuredOutput: map[string]any{
+				"ci_status": "passed",
+				"url":       status.URL,
+			},
+		}, nil
 
-		case <-time.After(time.Until(deadline)):
-			// Timeout reached.
-			return StepResult{
-				Success: false,
-				StructuredOutput: map[string]any{
-					"ci_status": "timeout",
-					"reason":    fmt.Sprintf("CI did not complete within %v", maxDuration),
-				},
-			}, nil
-
-		case <-ticker.C:
-			// Query current CI status.
-			status, err := e.ciChecker(ctx, sourceID, sourceItemID)
-			if err != nil {
-				// Transient error; retry.
-				aplog.Debug("poll step %q: CI check failed (retrying): %v", step.ID, err)
-				continue
-			}
-
-			switch status.Status {
-			case "passed":
-				// CI is green; step succeeds.
-				return StepResult{
-					Success: true,
-					StructuredOutput: map[string]any{
-						"ci_status": "passed",
-						"url":       status.URL,
-					},
-				}, nil
-
-			case "failed":
-				// CI is red; step fails (or continues based on config).
-				result := StepResult{
-					StructuredOutput: map[string]any{
-						"ci_status": "failed",
-						"url":       status.URL,
-						"checks":    checksToMap(status.Checks),
-					},
-				}
-				if cfg.ShouldFailIfNotPassed() {
-					result.Success = false
-					result.Err = fmt.Errorf("CI checks failed")
-				} else {
-					result.Success = true
-				}
-				return result, nil
-
-			case "pending":
-				// Still running; keep polling.
-				aplog.Debug("poll step %q: CI still pending, retrying in %v", step.ID, checkInterval)
-				continue
-
-			default:
-				// Unknown status.
-				return StepResult{
-					Success: false,
-					StructuredOutput: map[string]any{
-						"ci_status": status.Status,
-						"reason":    "Unknown CI status",
-					},
-				}, nil
-			}
+	case "failed":
+		result := StepResult{
+			StructuredOutput: map[string]any{
+				"ci_status": "failed",
+				"url":       status.URL,
+				"checks":    checksToMap(status.Checks),
+			},
 		}
+		if cfg.ShouldFailIfNotPassed() {
+			result.Success = false
+			result.Err = fmt.Errorf("CI checks failed")
+		} else {
+			result.Success = true
+		}
+		return result, nil
+
+	case "pending":
+		aplog.Debug("poll step %q: CI still pending", step.ID)
+		return StepResult{Pending: true}, nil
+
+	default:
+		// Unknown/empty status: keep waiting rather than failing spuriously. The
+		// deadline guarantees this cannot loop forever.
+		aplog.Debug("poll step %q: CI status %q not yet conclusive", step.ID, status.Status)
+		return StepResult{Pending: true}, nil
 	}
 }
 

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -54,8 +54,13 @@ type dagRun struct {
 	contrib     map[string]MemoryStep // memory contribution per passed step
 	passedOrder []string              // step ids in the order they passed
 
-	waitingStep string    // id of the approval step currently parked, if any
+	waitingStep string    // id of the approval/poll step currently parked, if any
 	parkedAt    time.Time // when the current approval parked (for timeout)
+
+	// pollDeadline is the absolute time a parked poll step gives up waiting for
+	// CI (set when the poll first parks, preserved across re-checks, cleared once
+	// the poll produces a terminal pass/fail). Zero means "no deadline yet".
+	pollDeadline time.Time
 }
 
 // initDAG builds the in-memory state for a workflow instance's step graph. The
@@ -176,6 +181,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			r.state[id] = stRunning
 			snap := r.memSteps()
 			contribSnap := r.contribSnapshot()
+			pollDeadline := r.pollDeadline // captured for the poll worker (value copy, safe)
 			inFlight++
 			go func(step config.StepConfig, memSnap []MemoryStep, contribSnap map[string]MemoryStep) {
 				sem <- struct{}{}
@@ -201,7 +207,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				case config.StepTypeWorkflow:
 					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
 				case config.StepTypePoll:
-					res, _ = e.RunPollStep(ctx, step, r.cell.SourceID, r.cell.ID)
+					res, _ = e.RunPollStep(ctx, step, r.cell.SourceID, r.cell.ID, pollDeadline)
 				default: // StepTypeAgent
 					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
 				}
@@ -262,6 +268,25 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		}
 
 		res := wr.res
+
+		// Poll step with no terminal result yet: suspend the instance at this step
+		// (releasing the worker) and resume it on a later poll cycle, exactly like
+		// an approval park. Drain any siblings first (poll workflows are sequential
+		// in practice, so this is normally a no-op). The deadline persists across
+		// re-checks via enterPoll so the timeout is measured from the first park.
+		if step.StepType() == config.StepTypePoll && res.Pending {
+			for inFlight > 0 {
+				<-resultCh
+				inFlight--
+			}
+			e.enterPoll(r, step)
+			return outcomeWaiting
+		}
+		// Terminal poll result (pass/fail): clear the deadline so a future loop-back
+		// to this poll (on_reject.restart_from) starts a fresh waiting window.
+		if step.StepType() == config.StepTypePoll {
+			r.pollDeadline = time.Time{}
+		}
 
 		// on_missing_output: fail — declared output schema required structured output.
 		if res.Success && step.OutputSchema != nil &&
@@ -365,6 +390,22 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 	aplog.Info("workflow %s: instance %s parked at approval step %q", r.wf.ID, r.instID, step.ID)
 }
 
+// enterPoll parks the run at a poll step: it records the waiting step and, on the
+// first park, sets the absolute deadline after which the poll gives up (from the
+// step's max_duration). Re-parks of the same poll (CI still pending) preserve the
+// original deadline so the timeout is measured from the first wait, not reset each
+// cycle. Unlike an approval, a poll park posts no message — it waits silently.
+func (e *Engine) enterPoll(r *dagRun, step config.StepConfig) {
+	r.state[step.ID] = stWaiting
+	r.waitingStep = step.ID
+	if r.pollDeadline.IsZero() && step.PollConfig != nil {
+		if md := step.PollConfig.ParsedMaxDuration(); md > 0 {
+			r.pollDeadline = e.now().Add(md)
+		}
+	}
+	aplog.Info("workflow %s: instance %s parked at poll step %q", r.wf.ID, r.instID, step.ID)
+}
+
 // resolveApproval applies an approval decision to the parked step so the run can
 // continue: a resume marks it passed, an abort marks it failed.
 func (r *dagRun) resolveApproval(decision ApprovalDecision) {
@@ -387,6 +428,20 @@ func (r *dagRun) resolveApproval(decision ApprovalDecision) {
 func (r *dagRun) firstRunnableApproval() (string, bool) {
 	for _, id := range r.pickAllRunnable() {
 		if r.byID[id].StepType() == config.StepTypeApproval {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// firstRunnablePoll returns the id of the first poll step that is currently
+// runnable, in declaration order. It identifies which poll step a rehydrated
+// instance is parked at: poll steps persist no step run of their own, so after the
+// cached passed steps are restored the waiting poll is simply the next runnable
+// poll. Returns false when none is runnable.
+func (r *dagRun) firstRunnablePoll() (string, bool) {
+	for _, id := range r.pickAllRunnable() {
+		if r.byID[id].StepType() == config.StepTypePoll {
 			return id, true
 		}
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -73,6 +73,11 @@ type StepResult struct {
 	Output           string
 	StructuredOutput map[string]any
 	Summary          string
+	// Pending is set only by poll steps to signal "no terminal result yet —
+	// park the instance and re-check on a later poll cycle" (as opposed to a
+	// pass or a fail). The scheduler suspends the run at the poll step instead
+	// of marking it passed/failed. Ignored for all other step types.
+	Pending bool
 	// PublishPayload is the APIARY_PUBLISH text the agent emitted, if any. The
 	// engine writes it back to the task's source bindings as a comment. The
 	// executor clears it when the step sets publish: off.
@@ -255,7 +260,15 @@ func sourceItemView(task model.InternalTask, bindings []model.SourceBinding) mod
 // instance completed successfully (false for failed or waiting).
 func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool {
 	if outcome == outcomeWaiting {
-		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, db.InstanceStateApprovalWaiting)
+		// A run suspends at either an approval step or a poll step; persist the
+		// matching waiting state so the right rehydration path picks it up after a
+		// restart (approval_waiting → rehydrateParkedApprovals, poll_waiting →
+		// rehydrateParkedPolls).
+		waitState := db.InstanceStateApprovalWaiting
+		if r.byID[r.waitingStep].StepType() == config.StepTypePoll {
+			waitState = db.InstanceStatePollWaiting
+		}
+		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, waitState)
 		e.mu.Lock()
 		e.parked[r.instID] = r
 		e.mu.Unlock()

--- a/src/internal/workflow/poll_park.go
+++ b/src/internal/workflow/poll_park.go
@@ -1,0 +1,130 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// ParkedPoll describes an instance suspended at a poll step waiting for an
+// external signal (e.g. CI completion).
+type ParkedPoll struct {
+	InstanceID string
+	Task       model.InternalTask
+	Step       config.StepConfig
+	Deadline   time.Time // absolute give-up time (zero = none)
+}
+
+// parkedPolls returns a snapshot of all instances currently suspended at a poll
+// step. The parked set is shared with approval-waiting instances, so it filters to
+// runs whose waiting step is a poll.
+func (e *Engine) parkedPolls() []ParkedPoll {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]ParkedPoll, 0, len(e.parked))
+	for id, r := range e.parked {
+		if r.byID[r.waitingStep].StepType() != config.StepTypePoll {
+			continue
+		}
+		out = append(out, ParkedPoll{
+			InstanceID: id,
+			Task:       r.task,
+			Step:       r.byID[r.waitingStep],
+			Deadline:   r.pollDeadline,
+		})
+	}
+	return out
+}
+
+// CheckParkedPolls re-checks every instance suspended at a poll step by waking it:
+// the woken run re-executes the poll step (a single CI query via the engine's
+// CIStatusChecker) and either advances past it (CI passed), fails it (CI failed or
+// the deadline elapsed, which drives on_reject/on_fail loop-back), or re-parks it
+// (CI still pending). Called once per dispatcher poll cycle, mirroring
+// CheckParkedApprovals. The poll cadence is therefore the dispatcher's poll
+// interval; a step's check_interval acts as a lower bound only.
+func (e *Engine) CheckParkedPolls(ctx context.Context) {
+	for _, p := range e.parkedPolls() {
+		e.wakePoll(ctx, p.InstanceID)
+	}
+}
+
+// wakePoll resumes a poll-parked instance: it resets the waiting poll step to
+// pending so driveDAG re-dispatches it (a single CI check), then drives the graph
+// to its next terminal or suspended state and settles it. A pending check re-parks
+// the instance (via enterPoll, preserving its deadline); a pass/fail advances or
+// loops the workflow through the normal result-processing path. It is a no-op if
+// the instance is no longer parked.
+func (e *Engine) wakePoll(ctx context.Context, instanceID string) {
+	e.mu.Lock()
+	r, ok := e.parked[instanceID]
+	if ok {
+		delete(e.parked, instanceID)
+	}
+	e.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	step := r.waitingStep
+	r.waitingStep = ""
+	r.state[step] = stPending // re-arm the poll step for re-dispatch
+
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
+	outcome := e.driveDAG(ctx, r)
+	e.settle(ctx, r, outcome)
+}
+
+// ErrNoPollStep is returned by RehydratePoll when the instance has no poll step
+// waiting once its cached steps are restored — i.e. it was not actually parked at a
+// poll (a stale or malformed poll_waiting row). The caller leaves it for manual
+// reconciliation rather than re-parking it.
+var ErrNoPollStep = errors.New("no poll step is waiting")
+
+// RehydratePoll reconstructs an instance persisted in the poll_waiting state and
+// re-registers it in the engine's in-memory parked set, so the next
+// CheckParkedPolls cycle re-checks it against the live CI status.
+//
+// The parked set is the only place CheckParkedPolls looks and it is empty after a
+// process restart: without rehydration an instance left waiting for CI when the
+// daemon stopped would never be re-checked, never settle, and its task's
+// outstanding-workflow counter would never drain — stranding the task. The startup
+// orphan reconcile deliberately leaves poll_waiting rows untouched (interrupting
+// them would lose the wait); this is what brings them back to life.
+//
+// It replays the instance's passed steps as cached (no re-execution, no re-fired
+// side effects) then parks the run at its waiting poll step. priorSteps are the
+// instance's persisted step runs in execution order. The wait deadline is set
+// fresh from the poll step's max_duration: a poll step persists no step run of its
+// own, so the original park time is not recoverable across a restart — the timeout
+// effectively restarts, which is acceptable for a safety bound.
+//
+// It returns ErrNoPollStep when no poll step is waiting.
+func (e *Engine) RehydratePoll(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun) error {
+	bindings := e.bindingsFor(ctx, task.ID)
+	r := e.initDAG(instID, wf, task, bindings, nil, 0)
+	e.restoreCachedSteps(r, priorSteps)
+
+	stepID, ok := r.firstRunnablePoll()
+	if !ok {
+		return ErrNoPollStep
+	}
+	r.state[stepID] = stWaiting
+	r.waitingStep = stepID
+	if pc := r.byID[stepID].PollConfig; pc != nil {
+		if md := pc.ParsedMaxDuration(); md > 0 {
+			r.pollDeadline = e.now().Add(md)
+		}
+	}
+
+	e.mu.Lock()
+	e.parked[instID] = r
+	e.mu.Unlock()
+	aplog.Info("workflow %s: rehydrated parked poll for instance %s at step %q", wf.ID, instID, stepID)
+	return nil
+}

--- a/src/internal/workflow/poll_park_test.go
+++ b/src/internal/workflow/poll_park_test.go
@@ -1,0 +1,235 @@
+package workflow
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// pollWorkflow: implement (agent) → check-ci (poll) → review (agent). The poll
+// step loops back to implement on a red CI, up to 3 times.
+func pollWorkflow() config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypePoll, DependsOn: []string{"implement"},
+			PollConfig: &config.PollConfig{Kind: "ci", CheckInterval: "30s", MaxDuration: "2h"},
+			OnFail:     &config.StepOutcome{Goto: "implement", MaxRetries: 3}},
+		{ID: "review", Agent: "backend-dev", DependsOn: []string{"check-ci"}},
+	}}
+}
+
+// pollEngine builds a test engine with a controllable clock and CI checker.
+func pollEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects,
+	clock *time.Time, ci func() (source.CIStatus, error)) *Engine {
+	var seq atomic.Int64
+	return NewEngine(cfg, store, exec,
+		WithSideEffects(side),
+		WithClock(func() time.Time { return *clock }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+		WithCIStatusChecker(func(_ context.Context, _, _ string) (source.CIStatus, error) {
+			return ci()
+		}),
+	)
+}
+
+func TestPoll_SuspendsWhilePending(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, success, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a poll-parked instance should not report success")
+	}
+	if store.instances[instID].State != db.InstanceStatePollWaiting {
+		t.Errorf("instance state = %q, want poll_waiting", store.instances[instID].State)
+	}
+	// implement ran; review must not have.
+	ids := executedIDs(exec.seen)
+	if !contains(ids, "implement") || contains(ids, "review") {
+		t.Errorf("unexpected execution while CI pending: %v", ids)
+	}
+	// It shows up as a parked poll, not a parked approval.
+	if pp := eng.parkedPolls(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+		t.Fatalf("expected one parked poll for check-ci, got %+v", pp)
+	}
+	if len(eng.ParkedApprovals()) != 0 {
+		t.Error("a poll park must not surface as an approval park")
+	}
+}
+
+func TestPoll_AdvancesWhenCIPasses(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	status := "pending"
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: status}, nil }
+	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, _, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+
+	// Still pending → stays parked.
+	eng.CheckParkedPolls(context.Background())
+	if store.instances[instID].State != db.InstanceStatePollWaiting {
+		t.Fatalf("expected still poll_waiting, got %q", store.instances[instID].State)
+	}
+
+	// CI turns green → next check advances the workflow to done.
+	status = "passed"
+	eng.CheckParkedPolls(context.Background())
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected done after CI passed, got %q", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec.seen), "review") {
+		t.Error("review should run once CI passed")
+	}
+	if len(eng.parkedPolls()) != 0 {
+		t.Error("instance should no longer be parked")
+	}
+}
+
+func TestPoll_RedCILoopsBackToImplement(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	// Realistic sequence: the first CI run is red → on_fail loops back to implement
+	// (a new commit), whose CI is pending → the poll re-parks waiting for it.
+	calls := 0
+	override := "" // when set, forces the CI status (mutated by the test below)
+	ci := func() (source.CIStatus, error) {
+		if override != "" {
+			return source.CIStatus{Status: override}, nil
+		}
+		calls++
+		if calls == 1 {
+			return source.CIStatus{Status: "failed"}, nil // initial run's CI is red
+		}
+		return source.CIStatus{Status: "pending"}, nil // the loop-back's new CI is still running
+	}
+	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, _, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+	if got := store.instances[instID].State; got != db.InstanceStatePollWaiting {
+		t.Fatalf("after red CI loop-back, want poll_waiting, got %q", got)
+	}
+	if n := countID(exec.seen, "implement"); n != 2 {
+		t.Errorf("implement should have run twice (initial + loop-back), got %d", n)
+	}
+	if contains(executedIDs(exec.seen), "review") {
+		t.Error("review must not run while the retried CI is still pending")
+	}
+
+	// The retried CI goes green → completes.
+	override = "passed"
+	eng.CheckParkedPolls(context.Background())
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected done after green retry, got %q", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec.seen), "review") {
+		t.Error("review should run once the retried CI passed")
+	}
+}
+
+func TestPoll_TimesOut(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	// Workflow whose poll has no on_fail loop, so a timeout fails the instance.
+	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypePoll, DependsOn: []string{"implement"},
+			PollConfig: &config.PollConfig{Kind: "ci", MaxDuration: "2h"}},
+	}}
+	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if store.instances[instID].State != db.InstanceStatePollWaiting {
+		t.Fatalf("expected poll_waiting, got %q", store.instances[instID].State)
+	}
+
+	// Advance past the 2h deadline; the next check times out and fails the step.
+	clock = clock.Add(3 * time.Hour)
+	eng.CheckParkedPolls(context.Background())
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed after timeout, got %q", store.instances[instID].State)
+	}
+}
+
+// TestPoll_RehydrateSurvivesRestart is the core regression: an instance parked at
+// a poll step when the daemon stopped must be reconstructed (not restarted from the
+// top) so it resumes from the poll and advances past it — without re-running the
+// already-passed implement step.
+func TestPoll_RehydrateSurvivesRestart(t *testing.T) {
+	store := newFakeStore()
+	clock := time.Unix(1000, 0)
+
+	// First engine: run until parked at the poll step (CI pending).
+	exec1 := &fakeExecutor{}
+	ci1 := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng1 := pollEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
+	instID, _, _ := eng1.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+	if store.instances[instID].State != db.InstanceStatePollWaiting {
+		t.Fatalf("expected poll_waiting before restart, got %q", store.instances[instID].State)
+	}
+
+	// Simulate a daemon restart: a brand-new engine with an empty parked set, CI now
+	// green. Rehydrate from the persisted step runs, then a poll check advances it.
+	exec2 := &fakeExecutor{}
+	ci2 := func() (source.CIStatus, error) { return source.CIStatus{Status: "passed"}, nil }
+	eng2 := pollEngine(baseCfg(), store, exec2, &fakeSide{}, &clock, ci2)
+
+	if err := eng2.RehydratePoll(context.Background(), instID, pollWorkflow(),
+		model.InternalTask{ID: "c1"}, priorStepsFor(store, instID)); err != nil {
+		t.Fatalf("rehydrate: %v", err)
+	}
+	if pp := eng2.parkedPolls(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+		t.Fatalf("expected rehydrated poll park at check-ci, got %+v", pp)
+	}
+
+	eng2.CheckParkedPolls(context.Background())
+
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected done after rehydrated poll passed, got %q", store.instances[instID].State)
+	}
+	// implement must NOT re-run on the new engine — it was cached/replayed.
+	if contains(executedIDs(exec2.seen), "implement") {
+		t.Error("implement must not re-run after rehydration (it already passed)")
+	}
+	// review should run on the new engine once CI passed.
+	if !contains(executedIDs(exec2.seen), "review") {
+		t.Error("review should run after the rehydrated poll passed")
+	}
+}
+
+// priorStepsFor returns the instance's persisted step runs in creation order,
+// mirroring db.Client.ListStepRuns for the rehydration path.
+func priorStepsFor(f *fakeStore, instID string) []db.StepRun {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []db.StepRun
+	for _, id := range f.stepOrder {
+		if sr, ok := f.stepRuns[id]; ok && sr.WorkflowInstanceID == instID {
+			out = append(out, *sr)
+		}
+	}
+	return out
+}
+
+func countID(seen []StepRequest, id string) int {
+	n := 0
+	for _, s := range seen {
+		if s.Step.ID == id {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Problem

The poll step (`type: poll`) ran a **blocking in-process loop** that held a worker for up to `max_duration` (2h). A daemon restart killed the loop, the instance was reconciled as an orphan (`running` → `interrupted`), and the next poll dispatched a **fresh instance from the top**. A workflow waiting on CI could therefore never advance across a restart — every restart replayed from `implement`.

## Fix

Rework the poll step to **park** like an approval step instead of blocking. The codebase already had the park/rehydrate machinery for approvals; poll now uses the same model.

- `RunPollStep` does a **single** CI check and returns `StepResult{Pending: true}` when there's no terminal result yet (no internal loop/ticker).
- `driveDAG` suspends the instance at the poll step on `Pending` (`outcomeWaiting`), releasing the worker; the run persists as a new **`poll_waiting`** instance state.
- `CheckParkedPolls` runs each dispatcher poll cycle (next to `CheckParkedApprovals`) and wakes parked polls: a single re-check **advances** on green CI, **loops back** via `on_reject`/`on_fail` on red CI, or **re-parks** while pending. The `max_duration` deadline is preserved across re-checks.
- `RehydratePoll` reconstructs `poll_waiting` instances after a restart (cached steps replayed, no re-execution, no re-fired side effects), wired via `rehydrateParkedPolls` at startup beside `rehydrateParkedApprovals`.
- `poll_waiting` blocks duplicate dispatch (`HasActiveInstanceForRoute`), is interrupted by `apiary restart`, and renders in the dashboard/status.

## Tests

New `poll_park_test.go`:
- suspends while CI pending (parks as a poll, not an approval)
- advances when CI passes
- red CI loops back to `implement`, then completes on the green retry
- times out past `max_duration`
- **rehydration survives a simulated restart** — resumes from the poll without re-running `implement`

`go vet ./...` clean; full `go test ./...` green; real project-erp config validates.