### PR TITLE
refactor(workflow): rename poll step to wait_for

### DIFF
--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -9,7 +9,7 @@ const (
 	StepTypeApproval = "approval"
 	StepTypeForeach  = "foreach"
 	StepTypeWorkflow = "workflow"
-	StepTypePoll     = "poll"
+	StepTypeWaitFor  = "wait_for"
 	// StepTypeParallel is emitted by the v2 lowering pass for `parallel:` steps.
 	// Children run concurrently (§8e); the step's outcome = the join policy.
 	StepTypeParallel = "parallel"
@@ -145,9 +145,10 @@ type StepConfig struct {
 	AbortOn  *ApprovalTrigger `yaml:"abort_on,omitempty"`
 	Timeout  string           `yaml:"timeout,omitempty"`
 
-	// ── poll step ─────────────────────────────────────────────────
-	// PollConfig holds configuration for polling-based steps (e.g., wait for CI).
-	PollConfig *PollConfig `yaml:"poll,omitempty"`
+	// ── wait_for step ─────────────────────────────────────────────
+	// WaitFor holds configuration for a wait_for step (e.g., wait for CI). The
+	// step suspends the workflow until the awaited condition resolves.
+	WaitFor *WaitForConfig `yaml:"wait_for,omitempty"`
 
 	// ── foreach step ──────────────────────────────────────────────
 	Items       string      `yaml:"items,omitempty"`
@@ -274,9 +275,10 @@ func (t ApprovalTrigger) IsEmpty() bool {
 	return t.CommentContains == "" && t.LabelAdded == "" && t.StateChanged == ""
 }
 
-// PollConfig configures a poll step that actively checks the CI status or other
-// external state at regular intervals until a condition is met or a timeout occurs.
-type PollConfig struct {
+// WaitForConfig configures a wait_for step that suspends the workflow until an
+// external condition (e.g. CI status) resolves, re-checking each poll cycle until
+// the condition is met or a timeout occurs.
+type WaitForConfig struct {
 	// Kind specifies what to poll: "ci" for GitHub/GitLab CI status.
 	Kind string `yaml:"kind,omitempty"`
 	// CheckInterval is how often to query the status (e.g., "30s"). Defaults to 1m.
@@ -291,7 +293,7 @@ type PollConfig struct {
 }
 
 // ParsedCheckInterval returns the check interval duration, defaulting to 1 minute.
-func (p *PollConfig) ParsedCheckInterval() time.Duration {
+func (p *WaitForConfig) ParsedCheckInterval() time.Duration {
 	if p == nil || p.CheckInterval == "" {
 		return time.Minute
 	}
@@ -303,7 +305,7 @@ func (p *PollConfig) ParsedCheckInterval() time.Duration {
 }
 
 // ParsedMaxDuration returns the maximum polling duration, defaulting to 2 hours.
-func (p *PollConfig) ParsedMaxDuration() time.Duration {
+func (p *WaitForConfig) ParsedMaxDuration() time.Duration {
 	if p == nil || p.MaxDuration == "" {
 		return 2 * time.Hour
 	}
@@ -315,7 +317,7 @@ func (p *PollConfig) ParsedMaxDuration() time.Duration {
 }
 
 // ShouldFailIfNotPassed returns whether to reject the step on non-green CI, defaulting to true.
-func (p *PollConfig) ShouldFailIfNotPassed() bool {
+func (p *WaitForConfig) ShouldFailIfNotPassed() bool {
 	if p == nil || p.FailIfNotPassed == nil {
 		return true
 	}

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -140,8 +140,8 @@ func (c *Config) validateStep(
 		errs = append(errs, c.validateForeachStep(sctx, s, wf, agentIDs)...)
 	case StepTypeWorkflow:
 		errs = append(errs, validateWorkflowStep(sctx, s, wf, wfByID)...)
-	case StepTypePoll:
-		errs = append(errs, validatePollStep(sctx, s)...)
+	case StepTypeWaitFor:
+		errs = append(errs, validateWaitForStep(sctx, s)...)
 	default:
 		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
 	}
@@ -323,39 +323,39 @@ func validateWorkflowStep(sctx string, s StepConfig, parent WorkflowConfig, wfBy
 	return errs
 }
 
-// validatePollStep validates a type: poll step.
-func validatePollStep(sctx string, s StepConfig) []error {
+// validateWaitForStep validates a type: wait_for step.
+func validateWaitForStep(sctx string, s StepConfig) []error {
 	var errs []error
 
 	if s.Agent != "" {
-		errs = append(errs, fmt.Errorf("%s: poll step must not have an agent field", sctx))
+		errs = append(errs, fmt.Errorf("%s: wait_for step must not have an agent field", sctx))
 	}
 
-	if s.PollConfig == nil {
-		errs = append(errs, fmt.Errorf("%s: poll step requires a poll config block", sctx))
+	if s.WaitFor == nil {
+		errs = append(errs, fmt.Errorf("%s: wait_for step requires a wait_for config block", sctx))
 		return errs
 	}
 
-	cfg := s.PollConfig
+	cfg := s.WaitFor
 
 	// Validate kind
 	if cfg.Kind == "" {
 		// Default is "ci", which is valid
 	} else if cfg.Kind != "ci" {
-		errs = append(errs, fmt.Errorf("%s: poll step kind %q not supported (currently only 'ci')", sctx, cfg.Kind))
+		errs = append(errs, fmt.Errorf("%s: wait_for step kind %q not supported (currently only 'ci')", sctx, cfg.Kind))
 	}
 
 	// Validate check_interval
 	if cfg.CheckInterval != "" {
 		if _, err := time.ParseDuration(cfg.CheckInterval); err != nil {
-			errs = append(errs, fmt.Errorf("%s: invalid poll check_interval %q: %v", sctx, cfg.CheckInterval, err))
+			errs = append(errs, fmt.Errorf("%s: invalid wait_for check_interval %q: %v", sctx, cfg.CheckInterval, err))
 		}
 	}
 
 	// Validate max_duration
 	if cfg.MaxDuration != "" {
 		if _, err := time.ParseDuration(cfg.MaxDuration); err != nil {
-			errs = append(errs, fmt.Errorf("%s: invalid poll max_duration %q: %v", sctx, cfg.MaxDuration, err))
+			errs = append(errs, fmt.Errorf("%s: invalid wait_for max_duration %q: %v", sctx, cfg.MaxDuration, err))
 		}
 	}
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -310,10 +310,10 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// in 'registered' forever (the approval_waiting restart gap).
 	d.rehydrateParkedApprovals(ctx)
 
-	// Same for instances parked at a poll step (e.g. waiting for CI): the engine's
+	// Same for instances parked at a wait_for step (e.g. waiting for CI): the engine's
 	// in-memory parked set is empty after a restart, so without this a poll-waiting
 	// instance would never be re-checked and its task would be stranded.
-	d.rehydrateParkedPolls(ctx)
+	d.rehydrateParkedWaits(ctx)
 
 	for _, sc := range d.cfg.Sources {
 		sc := sc
@@ -535,7 +535,7 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 		} else {
 			for _, inst := range insts {
 				switch inst.State {
-				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePollWaiting, db.InstanceStatePending:
+				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStateWaiting, db.InstanceStatePending:
 					if err := d.db.UpdateWorkflowInstanceState(ctx, inst.ID, db.InstanceStateInterrupted); err != nil {
 						aplog.Error("force-restart %s: interrupt instance %s: %v", cellID, inst.ID, err)
 					} else {
@@ -924,9 +924,9 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	// on each poll cycle (resume/abort/timeout) before fetching new work.
 	d.checkApprovals(ctx)
 
-	// Re-check any workflows parked at poll steps (e.g. waiting for CI) so they
+	// Re-check any workflows parked at wait_for steps (e.g. waiting for CI) so they
 	// advance, fail, or keep waiting based on live status.
-	d.checkPolls(ctx)
+	d.checkWaits(ctx)
 
 	aplog.Debug("polling source %s (since %s)", sc.ID, since.Format(time.RFC3339))
 	cells, err := adapter.Poll(ctx, since)

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -27,7 +27,7 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 				workflow.WithTaskTracker(dbTaskTracker{db: d.db}),
 			)
 		}
-		// Wire up CI status polling for poll steps.
+		// Wire up CI status polling for wait_for steps.
 		opts = append(opts, workflow.WithCIStatusChecker(func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error) {
 			adapter, ok := d.sources[sourceID]
 			if !ok {
@@ -97,21 +97,21 @@ func (d *Dispatcher) rehydrateParkedApprovals(ctx context.Context) {
 	}
 }
 
-// rehydrateParkedPolls reconstructs workflow instances persisted in the
-// poll_waiting state and re-registers them in the engine's in-memory parked set,
-// so the polling loop's poll check (checkPolls → CheckParkedPolls) re-checks them
+// rehydrateParkedWaits reconstructs workflow instances persisted in the
+// waiting state and re-registers them in the engine's in-memory parked set,
+// so the polling loop's poll check (checkWaits → CheckParkedWaits) re-checks them
 // after a daemon restart. It mirrors rehydrateParkedApprovals: the parked set
 // lives only in memory and is empty on a fresh process, and
-// ReconcileOrphanWorkflowInstances deliberately leaves poll_waiting rows untouched
+// ReconcileOrphanWorkflowInstances deliberately leaves waiting rows untouched
 // (interrupting them would lose the wait). Called once at startup, after the orphan
 // reconcile and before the poll loops start.
-func (d *Dispatcher) rehydrateParkedPolls(ctx context.Context) {
+func (d *Dispatcher) rehydrateParkedWaits(ctx context.Context) {
 	if d.db == nil {
 		return
 	}
-	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStatePollWaiting)
+	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateWaiting)
 	if err != nil {
-		aplog.Warn("rehydrate parked polls: list instances: %v", err)
+		aplog.Warn("rehydrate parked waits: list instances: %v", err)
 		return
 	}
 	if len(instances) == 0 {
@@ -124,23 +124,23 @@ func (d *Dispatcher) rehydrateParkedPolls(ctx context.Context) {
 		inst := instances[i]
 		wf, ok := d.workflowByID(inst.WorkflowID)
 		if !ok {
-			aplog.Warn("rehydrate parked poll %s: workflow %q no longer defined — leaving parked", inst.ID, inst.WorkflowID)
+			aplog.Warn("rehydrate parked wait %s: workflow %q no longer defined — leaving parked", inst.ID, inst.WorkflowID)
 			continue
 		}
 		steps, err := d.db.ListStepRuns(ctx, inst.ID)
 		if err != nil {
-			aplog.Warn("rehydrate parked poll %s: list step runs: %v", inst.ID, err)
+			aplog.Warn("rehydrate parked wait %s: list step runs: %v", inst.ID, err)
 			continue
 		}
 		task := d.taskForInstance(ctx, &inst)
-		if err := engine.RehydratePoll(ctx, inst.ID, wf, task, steps); err != nil {
-			aplog.Warn("rehydrate parked poll %s: %v", inst.ID, err)
+		if err := engine.RehydrateWait(ctx, inst.ID, wf, task, steps); err != nil {
+			aplog.Warn("rehydrate parked wait %s: %v", inst.ID, err)
 			continue
 		}
 		rehydrated++
 	}
 	if rehydrated > 0 {
-		aplog.Info("rehydrated %d parked poll instance(s) from a previous run", rehydrated)
+		aplog.Info("rehydrated %d parked wait instance(s) from a previous run", rehydrated)
 	}
 }
 
@@ -236,14 +236,14 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 	})
 }
 
-// checkPolls drives the engine's parked-poll re-checks (CI status) once per poll
+// checkWaits drives the engine's parked-poll re-checks (CI status) once per poll
 // cycle. The engine re-checks via its wired CIStatusChecker, so this needs no
 // per-call poller argument. A nil DB/engine (no run-history) disables it.
-func (d *Dispatcher) checkPolls(ctx context.Context) {
+func (d *Dispatcher) checkWaits(ctx context.Context) {
 	if d.db == nil || d.engine == nil {
 		return
 	}
-	d.engine.CheckParkedPolls(ctx)
+	d.engine.CheckParkedWaits(ctx)
 }
 
 // wfStepExecutor adapts the dispatcher's runner machinery to the workflow

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -301,7 +301,7 @@ func instanceSummary(v db.WorkflowInstanceView, now time.Time) InstanceSummary {
 // interrupted/pending where no meaningful span exists.
 func instanceDuration(inst db.WorkflowInstance, now time.Time) string {
 	switch inst.State {
-	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStatePollWaiting:
+	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStateWaiting:
 		return humanDuration(now.Sub(inst.CreatedAt))
 	case db.InstanceStateDone, db.InstanceStateFailed:
 		return humanDuration(inst.UpdatedAt.Sub(inst.CreatedAt))

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -2833,8 +2833,8 @@ func wfInstanceBadge(state string) string {
 		return StyleWarning.Render("running")
 	case db.InstanceStateApprovalWaiting:
 		return StyleWarning.Render("approval_waiting")
-	case db.InstanceStatePollWaiting:
-		return StyleWarning.Render("poll_waiting")
+	case db.InstanceStateWaiting:
+		return StyleWarning.Render("waiting")
 	case db.InstanceStateInterrupted:
 		return StyleError.Render("interrupted")
 	default:

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -11,7 +11,7 @@ const (
 	InstanceStatePending         = "pending"
 	InstanceStateRunning         = "running"
 	InstanceStateApprovalWaiting = "approval_waiting"
-	InstanceStatePollWaiting     = "poll_waiting"
+	InstanceStateWaiting         = "waiting"
 	InstanceStateInterrupted     = "interrupted"
 	InstanceStateDone            = "done"
 	InstanceStateFailed          = "failed"
@@ -149,7 +149,7 @@ func (c *Client) CountConsecutiveFailedInstances(ctx context.Context, taskID, wo
 }
 
 // HasActiveInstanceForRoute reports whether the task already has a non-terminal
-// instance for the given workflow — running, approval_waiting, or poll_waiting.
+// instance for the given workflow — running, approval_waiting, or waiting.
 // The dispatcher uses it as a source-agnostic in-flight guard: it stops a later
 // poll from dispatching a duplicate while the workflow runs or, crucially, waits
 // at an approval or poll step (where the in-memory inFlight marker has already
@@ -161,7 +161,7 @@ func (c *Client) HasActiveInstanceForRoute(ctx context.Context, taskID, workflow
 	err := c.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM workflow_instances
 		WHERE task_id = ? AND workflow_id = ? AND state IN (?, ?, ?)
-	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting, InstanceStatePollWaiting).Scan(&n)
+	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting, InstanceStateWaiting).Scan(&n)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -327,9 +327,9 @@ func (c *Client) GetTaskTitle(ctx context.Context, id string) (string, error) {
 // state by a previously-killed process as 'interrupted'. A fresh daemon process
 // owns no in-flight workflow runs, so rows left 'running' are orphans that would
 // otherwise cause tasks to appear stuck. Marking them interrupted allows the next
-// poll to dispatch fresh instances. approval_waiting and poll_waiting instances
+// poll to dispatch fresh instances. approval_waiting and waiting instances
 // are deliberately left untouched (the WHERE only matches 'running') — they are
-// rehydrated separately via rehydrateParkedApprovals / rehydrateParkedPolls.
+// rehydrated separately via rehydrateParkedApprovals / rehydrateParkedWaits.
 func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, error) {
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE workflow_instances

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -86,8 +86,8 @@ type ParkedApproval struct {
 }
 
 // ParkedApprovals returns a snapshot of all instances currently awaiting approval.
-// The parked set is shared with poll-waiting instances, so it filters to runs whose
-// waiting step is an approval — a poll park is resolved by CheckParkedPolls, not by
+// The parked set is shared with wait-waiting instances, so it filters to runs whose
+// waiting step is an approval — a wait park is resolved by CheckParkedWaits, not by
 // the approval checker.
 func (e *Engine) ParkedApprovals() []ParkedApproval {
 	e.mu.Lock()

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -54,13 +54,13 @@ type dagRun struct {
 	contrib     map[string]MemoryStep // memory contribution per passed step
 	passedOrder []string              // step ids in the order they passed
 
-	waitingStep string    // id of the approval/poll step currently parked, if any
+	waitingStep string    // id of the approval/wait_for step currently parked, if any
 	parkedAt    time.Time // when the current approval parked (for timeout)
 
-	// pollDeadline is the absolute time a parked poll step gives up waiting for
-	// CI (set when the poll first parks, preserved across re-checks, cleared once
-	// the poll produces a terminal pass/fail). Zero means "no deadline yet".
-	pollDeadline time.Time
+	// waitDeadline is the absolute time a parked wait_for step gives up waiting for
+	// CI (set when the wait first parks, preserved across re-checks, cleared once
+	// the wait produces a terminal pass/fail). Zero means "no deadline yet".
+	waitDeadline time.Time
 }
 
 // initDAG builds the in-memory state for a workflow instance's step graph. The
@@ -181,7 +181,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			r.state[id] = stRunning
 			snap := r.memSteps()
 			contribSnap := r.contribSnapshot()
-			pollDeadline := r.pollDeadline // captured for the poll worker (value copy, safe)
+			waitDeadline := r.waitDeadline // captured for the wait worker (value copy, safe)
 			inFlight++
 			go func(step config.StepConfig, memSnap []MemoryStep, contribSnap map[string]MemoryStep) {
 				sem <- struct{}{}
@@ -206,8 +206,8 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 					foreachExitCode = fr.failed
 				case config.StepTypeWorkflow:
 					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
-				case config.StepTypePoll:
-					res, _ = e.RunPollStep(ctx, step, r.cell.SourceID, r.cell.ID, pollDeadline)
+				case config.StepTypeWaitFor:
+					res, _ = e.RunWaitStep(ctx, step, r.cell.SourceID, r.cell.ID, waitDeadline)
 				default: // StepTypeAgent
 					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
 				}
@@ -269,23 +269,23 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 
 		res := wr.res
 
-		// Poll step with no terminal result yet: suspend the instance at this step
+		// Wait_for step with no terminal result yet: suspend the instance at this step
 		// (releasing the worker) and resume it on a later poll cycle, exactly like
-		// an approval park. Drain any siblings first (poll workflows are sequential
+		// an approval park. Drain any siblings first (wait_for workflows are sequential
 		// in practice, so this is normally a no-op). The deadline persists across
-		// re-checks via enterPoll so the timeout is measured from the first park.
-		if step.StepType() == config.StepTypePoll && res.Pending {
+		// re-checks via enterWait so the timeout is measured from the first park.
+		if step.StepType() == config.StepTypeWaitFor && res.Pending {
 			for inFlight > 0 {
 				<-resultCh
 				inFlight--
 			}
-			e.enterPoll(r, step)
+			e.enterWait(r, step)
 			return outcomeWaiting
 		}
 		// Terminal poll result (pass/fail): clear the deadline so a future loop-back
 		// to this poll (on_reject.restart_from) starts a fresh waiting window.
-		if step.StepType() == config.StepTypePoll {
-			r.pollDeadline = time.Time{}
+		if step.StepType() == config.StepTypeWaitFor {
+			r.waitDeadline = time.Time{}
 		}
 
 		// on_missing_output: fail — declared output schema required structured output.
@@ -390,20 +390,20 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 	aplog.Info("workflow %s: instance %s parked at approval step %q", r.wf.ID, r.instID, step.ID)
 }
 
-// enterPoll parks the run at a poll step: it records the waiting step and, on the
-// first park, sets the absolute deadline after which the poll gives up (from the
+// enterWait parks the run at a wait_for step: it records the waiting step and, on the
+// first park, sets the absolute deadline after which the wait gives up (from the
 // step's max_duration). Re-parks of the same poll (CI still pending) preserve the
 // original deadline so the timeout is measured from the first wait, not reset each
-// cycle. Unlike an approval, a poll park posts no message — it waits silently.
-func (e *Engine) enterPoll(r *dagRun, step config.StepConfig) {
+// cycle. Unlike an approval, a wait park posts no message — it waits silently.
+func (e *Engine) enterWait(r *dagRun, step config.StepConfig) {
 	r.state[step.ID] = stWaiting
 	r.waitingStep = step.ID
-	if r.pollDeadline.IsZero() && step.PollConfig != nil {
-		if md := step.PollConfig.ParsedMaxDuration(); md > 0 {
-			r.pollDeadline = e.now().Add(md)
+	if r.waitDeadline.IsZero() && step.WaitFor != nil {
+		if md := step.WaitFor.ParsedMaxDuration(); md > 0 {
+			r.waitDeadline = e.now().Add(md)
 		}
 	}
-	aplog.Info("workflow %s: instance %s parked at poll step %q", r.wf.ID, r.instID, step.ID)
+	aplog.Info("workflow %s: instance %s parked at wait_for step %q", r.wf.ID, r.instID, step.ID)
 }
 
 // resolveApproval applies an approval decision to the parked step so the run can
@@ -434,14 +434,14 @@ func (r *dagRun) firstRunnableApproval() (string, bool) {
 	return "", false
 }
 
-// firstRunnablePoll returns the id of the first poll step that is currently
-// runnable, in declaration order. It identifies which poll step a rehydrated
-// instance is parked at: poll steps persist no step run of their own, so after the
+// firstRunnableWait returns the id of the first wait_for step that is currently
+// runnable, in declaration order. It identifies which wait_for step a rehydrated
+// instance is parked at: wait_for steps persist no step run of their own, so after the
 // cached passed steps are restored the waiting poll is simply the next runnable
 // poll. Returns false when none is runnable.
-func (r *dagRun) firstRunnablePoll() (string, bool) {
+func (r *dagRun) firstRunnableWait() (string, bool) {
 	for _, id := range r.pickAllRunnable() {
-		if r.byID[id].StepType() == config.StepTypePoll {
+		if r.byID[id].StepType() == config.StepTypeWaitFor {
 			return id, true
 		}
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -73,9 +73,9 @@ type StepResult struct {
 	Output           string
 	StructuredOutput map[string]any
 	Summary          string
-	// Pending is set only by poll steps to signal "no terminal result yet —
+	// Pending is set only by wait_for steps to signal "no terminal result yet —
 	// park the instance and re-check on a later poll cycle" (as opposed to a
-	// pass or a fail). The scheduler suspends the run at the poll step instead
+	// pass or a fail). The scheduler suspends the run at the wait_for step instead
 	// of marking it passed/failed. Ignored for all other step types.
 	Pending bool
 	// PublishPayload is the APIARY_PUBLISH text the agent emitted, if any. The
@@ -112,7 +112,7 @@ type SideEffects interface {
 // runs, threads workflow memory between steps, and applies side effects. In
 // Phase 2 it executes agent steps sequentially in declaration order (single-step
 // and linear chains); the DAG executor with splits/foreach arrives in Phase 3.
-// CIStatusChecker is called by poll steps to check the current CI status of a PR/branch.
+// CIStatusChecker is called by wait_for steps to check the current CI status of a PR/branch.
 // It returns a CIStatus or an error if the check fails (transient or permanent).
 type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error)
 
@@ -155,7 +155,7 @@ func WithSpawner(s WorkflowSpawner) Option { return func(e *Engine) { e.spawner 
 // outstanding-workflow counter and apply the top-level tasks: hook.
 func WithTaskTracker(t TaskTracker) Option { return func(e *Engine) { e.tracker = t } }
 
-// WithCIStatusChecker sets the CI status checker used by poll steps.
+// WithCIStatusChecker sets the CI status checker used by wait_for steps.
 func WithCIStatusChecker(checker CIStatusChecker) Option { return func(e *Engine) { e.ciChecker = checker } }
 
 // NewEngine builds an Engine. cfg, store, and exec are required.
@@ -260,13 +260,13 @@ func sourceItemView(task model.InternalTask, bindings []model.SourceBinding) mod
 // instance completed successfully (false for failed or waiting).
 func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool {
 	if outcome == outcomeWaiting {
-		// A run suspends at either an approval step or a poll step; persist the
+		// A run suspends at either an approval step or a wait_for step; persist the
 		// matching waiting state so the right rehydration path picks it up after a
-		// restart (approval_waiting → rehydrateParkedApprovals, poll_waiting →
-		// rehydrateParkedPolls).
+		// restart (approval_waiting → rehydrateParkedApprovals, waiting →
+		// rehydrateParkedWaits).
 		waitState := db.InstanceStateApprovalWaiting
-		if r.byID[r.waitingStep].StepType() == config.StepTypePoll {
-			waitState = db.InstanceStatePollWaiting
+		if r.byID[r.waitingStep].StepType() == config.StepTypeWaitFor {
+			waitState = db.InstanceStateWaiting
 		}
 		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, waitState)
 		e.mu.Lock()

--- a/src/internal/workflow/wait_park.go
+++ b/src/internal/workflow/wait_park.go
@@ -11,56 +11,56 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
-// ParkedPoll describes an instance suspended at a poll step waiting for an
+// ParkedWait describes an instance suspended at a wait_for step waiting for an
 // external signal (e.g. CI completion).
-type ParkedPoll struct {
+type ParkedWait struct {
 	InstanceID string
 	Task       model.InternalTask
 	Step       config.StepConfig
 	Deadline   time.Time // absolute give-up time (zero = none)
 }
 
-// parkedPolls returns a snapshot of all instances currently suspended at a poll
+// parkedWaits returns a snapshot of all instances currently suspended at a poll
 // step. The parked set is shared with approval-waiting instances, so it filters to
 // runs whose waiting step is a poll.
-func (e *Engine) parkedPolls() []ParkedPoll {
+func (e *Engine) parkedWaits() []ParkedWait {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	out := make([]ParkedPoll, 0, len(e.parked))
+	out := make([]ParkedWait, 0, len(e.parked))
 	for id, r := range e.parked {
-		if r.byID[r.waitingStep].StepType() != config.StepTypePoll {
+		if r.byID[r.waitingStep].StepType() != config.StepTypeWaitFor {
 			continue
 		}
-		out = append(out, ParkedPoll{
+		out = append(out, ParkedWait{
 			InstanceID: id,
 			Task:       r.task,
 			Step:       r.byID[r.waitingStep],
-			Deadline:   r.pollDeadline,
+			Deadline:   r.waitDeadline,
 		})
 	}
 	return out
 }
 
-// CheckParkedPolls re-checks every instance suspended at a poll step by waking it:
-// the woken run re-executes the poll step (a single CI query via the engine's
+// CheckParkedWaits re-checks every instance suspended at a wait_for step by waking it:
+// the woken run re-executes the wait_for step (a single CI query via the engine's
 // CIStatusChecker) and either advances past it (CI passed), fails it (CI failed or
 // the deadline elapsed, which drives on_reject/on_fail loop-back), or re-parks it
 // (CI still pending). Called once per dispatcher poll cycle, mirroring
 // CheckParkedApprovals. The poll cadence is therefore the dispatcher's poll
 // interval; a step's check_interval acts as a lower bound only.
-func (e *Engine) CheckParkedPolls(ctx context.Context) {
-	for _, p := range e.parkedPolls() {
-		e.wakePoll(ctx, p.InstanceID)
+func (e *Engine) CheckParkedWaits(ctx context.Context) {
+	for _, p := range e.parkedWaits() {
+		e.wakeWait(ctx, p.InstanceID)
 	}
 }
 
-// wakePoll resumes a poll-parked instance: it resets the waiting poll step to
+// wakeWait resumes a wait-parked instance: it resets the waiting wait_for step to
 // pending so driveDAG re-dispatches it (a single CI check), then drives the graph
 // to its next terminal or suspended state and settles it. A pending check re-parks
-// the instance (via enterPoll, preserving its deadline); a pass/fail advances or
+// the instance (via enterWait, preserving its deadline); a pass/fail advances or
 // loops the workflow through the normal result-processing path. It is a no-op if
 // the instance is no longer parked.
-func (e *Engine) wakePoll(ctx context.Context, instanceID string) {
+func (e *Engine) wakeWait(ctx context.Context, instanceID string) {
 	e.mu.Lock()
 	r, ok := e.parked[instanceID]
 	if ok {
@@ -73,58 +73,58 @@ func (e *Engine) wakePoll(ctx context.Context, instanceID string) {
 
 	step := r.waitingStep
 	r.waitingStep = ""
-	r.state[step] = stPending // re-arm the poll step for re-dispatch
+	r.state[step] = stPending // re-arm the wait_for step for re-dispatch
 
 	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
 	outcome := e.driveDAG(ctx, r)
 	e.settle(ctx, r, outcome)
 }
 
-// ErrNoPollStep is returned by RehydratePoll when the instance has no poll step
+// ErrNoWaitStep is returned by RehydrateWait when the instance has no wait_for step
 // waiting once its cached steps are restored — i.e. it was not actually parked at a
-// poll (a stale or malformed poll_waiting row). The caller leaves it for manual
+// poll (a stale or malformed waiting row). The caller leaves it for manual
 // reconciliation rather than re-parking it.
-var ErrNoPollStep = errors.New("no poll step is waiting")
+var ErrNoWaitStep = errors.New("no wait_for step is waiting")
 
-// RehydratePoll reconstructs an instance persisted in the poll_waiting state and
+// RehydrateWait reconstructs an instance persisted in the waiting state and
 // re-registers it in the engine's in-memory parked set, so the next
-// CheckParkedPolls cycle re-checks it against the live CI status.
+// CheckParkedWaits cycle re-checks it against the live CI status.
 //
-// The parked set is the only place CheckParkedPolls looks and it is empty after a
+// The parked set is the only place CheckParkedWaits looks and it is empty after a
 // process restart: without rehydration an instance left waiting for CI when the
 // daemon stopped would never be re-checked, never settle, and its task's
 // outstanding-workflow counter would never drain — stranding the task. The startup
-// orphan reconcile deliberately leaves poll_waiting rows untouched (interrupting
+// orphan reconcile deliberately leaves waiting rows untouched (interrupting
 // them would lose the wait); this is what brings them back to life.
 //
 // It replays the instance's passed steps as cached (no re-execution, no re-fired
-// side effects) then parks the run at its waiting poll step. priorSteps are the
+// side effects) then parks the run at its waiting wait_for step. priorSteps are the
 // instance's persisted step runs in execution order. The wait deadline is set
-// fresh from the poll step's max_duration: a poll step persists no step run of its
+// fresh from the wait_for step's max_duration: a wait_for step persists no step run of its
 // own, so the original park time is not recoverable across a restart — the timeout
 // effectively restarts, which is acceptable for a safety bound.
 //
-// It returns ErrNoPollStep when no poll step is waiting.
-func (e *Engine) RehydratePoll(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun) error {
+// It returns ErrNoWaitStep when no wait_for step is waiting.
+func (e *Engine) RehydrateWait(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun) error {
 	bindings := e.bindingsFor(ctx, task.ID)
 	r := e.initDAG(instID, wf, task, bindings, nil, 0)
 	e.restoreCachedSteps(r, priorSteps)
 
-	stepID, ok := r.firstRunnablePoll()
+	stepID, ok := r.firstRunnableWait()
 	if !ok {
-		return ErrNoPollStep
+		return ErrNoWaitStep
 	}
 	r.state[stepID] = stWaiting
 	r.waitingStep = stepID
-	if pc := r.byID[stepID].PollConfig; pc != nil {
+	if pc := r.byID[stepID].WaitFor; pc != nil {
 		if md := pc.ParsedMaxDuration(); md > 0 {
-			r.pollDeadline = e.now().Add(md)
+			r.waitDeadline = e.now().Add(md)
 		}
 	}
 
 	e.mu.Lock()
 	e.parked[instID] = r
 	e.mu.Unlock()
-	aplog.Info("workflow %s: rehydrated parked poll for instance %s at step %q", wf.ID, instID, stepID)
+	aplog.Info("workflow %s: rehydrated parked wait for instance %s at step %q", wf.ID, instID, stepID)
 	return nil
 }

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -12,20 +12,20 @@ import (
 	"github.com/orlandoburli/apiary/internal/source"
 )
 
-// pollWorkflow: implement (agent) → check-ci (poll) → review (agent). The poll
+// waitForWorkflow: implement (agent) → check-ci (poll) → review (agent). The poll
 // step loops back to implement on a red CI, up to 3 times.
-func pollWorkflow() config.WorkflowConfig {
+func waitForWorkflow() config.WorkflowConfig {
 	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
 		{ID: "implement", Agent: "backend-dev"},
-		{ID: "check-ci", Type: config.StepTypePoll, DependsOn: []string{"implement"},
-			PollConfig: &config.PollConfig{Kind: "ci", CheckInterval: "30s", MaxDuration: "2h"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor: &config.WaitForConfig{Kind: "ci", CheckInterval: "30s", MaxDuration: "2h"},
 			OnFail:     &config.StepOutcome{Goto: "implement", MaxRetries: 3}},
 		{ID: "review", Agent: "backend-dev", DependsOn: []string{"check-ci"}},
 	}}
 }
 
-// pollEngine builds a test engine with a controllable clock and CI checker.
-func pollEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects,
+// waitForEngine builds a test engine with a controllable clock and CI checker.
+func waitForEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEffects,
 	clock *time.Time, ci func() (source.CIStatus, error)) *Engine {
 	var seq atomic.Int64
 	return NewEngine(cfg, store, exec,
@@ -38,18 +38,18 @@ func pollEngine(cfg *config.Config, store Store, exec StepExecutor, side SideEff
 	)
 }
 
-func TestPoll_SuspendsWhilePending(t *testing.T) {
+func TestWaitFor_SuspendsWhilePending(t *testing.T) {
 	store := newFakeStore()
 	exec := &fakeExecutor{}
 	clock := time.Unix(1000, 0)
 	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
-	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
 
-	instID, success, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+	instID, success, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
 	if success {
 		t.Fatal("a poll-parked instance should not report success")
 	}
-	if store.instances[instID].State != db.InstanceStatePollWaiting {
+	if store.instances[instID].State != db.InstanceStateWaiting {
 		t.Errorf("instance state = %q, want poll_waiting", store.instances[instID].State)
 	}
 	// implement ran; review must not have.
@@ -58,7 +58,7 @@ func TestPoll_SuspendsWhilePending(t *testing.T) {
 		t.Errorf("unexpected execution while CI pending: %v", ids)
 	}
 	// It shows up as a parked poll, not a parked approval.
-	if pp := eng.parkedPolls(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+	if pp := eng.parkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
 		t.Fatalf("expected one parked poll for check-ci, got %+v", pp)
 	}
 	if len(eng.ParkedApprovals()) != 0 {
@@ -66,37 +66,37 @@ func TestPoll_SuspendsWhilePending(t *testing.T) {
 	}
 }
 
-func TestPoll_AdvancesWhenCIPasses(t *testing.T) {
+func TestWaitFor_AdvancesWhenCIPasses(t *testing.T) {
 	store := newFakeStore()
 	exec := &fakeExecutor{}
 	clock := time.Unix(1000, 0)
 	status := "pending"
 	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: status}, nil }
-	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
 
-	instID, _, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
+	instID, _, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
 
 	// Still pending → stays parked.
-	eng.CheckParkedPolls(context.Background())
-	if store.instances[instID].State != db.InstanceStatePollWaiting {
+	eng.CheckParkedWaits(context.Background())
+	if store.instances[instID].State != db.InstanceStateWaiting {
 		t.Fatalf("expected still poll_waiting, got %q", store.instances[instID].State)
 	}
 
 	// CI turns green → next check advances the workflow to done.
 	status = "passed"
-	eng.CheckParkedPolls(context.Background())
+	eng.CheckParkedWaits(context.Background())
 	if store.instances[instID].State != db.InstanceStateDone {
 		t.Errorf("expected done after CI passed, got %q", store.instances[instID].State)
 	}
 	if !contains(executedIDs(exec.seen), "review") {
 		t.Error("review should run once CI passed")
 	}
-	if len(eng.parkedPolls()) != 0 {
+	if len(eng.parkedWaits()) != 0 {
 		t.Error("instance should no longer be parked")
 	}
 }
 
-func TestPoll_RedCILoopsBackToImplement(t *testing.T) {
+func TestWaitFor_RedCILoopsBackToImplement(t *testing.T) {
 	store := newFakeStore()
 	exec := &fakeExecutor{}
 	clock := time.Unix(1000, 0)
@@ -114,10 +114,10 @@ func TestPoll_RedCILoopsBackToImplement(t *testing.T) {
 		}
 		return source.CIStatus{Status: "pending"}, nil // the loop-back's new CI is still running
 	}
-	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
 
-	instID, _, _ := eng.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
-	if got := store.instances[instID].State; got != db.InstanceStatePollWaiting {
+	instID, _, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
+	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
 		t.Fatalf("after red CI loop-back, want poll_waiting, got %q", got)
 	}
 	if n := countID(exec.seen, "implement"); n != 2 {
@@ -129,7 +129,7 @@ func TestPoll_RedCILoopsBackToImplement(t *testing.T) {
 
 	// The retried CI goes green → completes.
 	override = "passed"
-	eng.CheckParkedPolls(context.Background())
+	eng.CheckParkedWaits(context.Background())
 	if store.instances[instID].State != db.InstanceStateDone {
 		t.Errorf("expected done after green retry, got %q", store.instances[instID].State)
 	}
@@ -138,46 +138,46 @@ func TestPoll_RedCILoopsBackToImplement(t *testing.T) {
 	}
 }
 
-func TestPoll_TimesOut(t *testing.T) {
+func TestWaitFor_TimesOut(t *testing.T) {
 	store := newFakeStore()
 	exec := &fakeExecutor{}
 	clock := time.Unix(1000, 0)
 	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
-	eng := pollEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
 
 	// Workflow whose poll has no on_fail loop, so a timeout fails the instance.
 	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
 		{ID: "implement", Agent: "backend-dev"},
-		{ID: "check-ci", Type: config.StepTypePoll, DependsOn: []string{"implement"},
-			PollConfig: &config.PollConfig{Kind: "ci", MaxDuration: "2h"}},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor: &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"}},
 	}}
 	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStatePollWaiting {
+	if store.instances[instID].State != db.InstanceStateWaiting {
 		t.Fatalf("expected poll_waiting, got %q", store.instances[instID].State)
 	}
 
 	// Advance past the 2h deadline; the next check times out and fails the step.
 	clock = clock.Add(3 * time.Hour)
-	eng.CheckParkedPolls(context.Background())
+	eng.CheckParkedWaits(context.Background())
 	if store.instances[instID].State != db.InstanceStateFailed {
 		t.Errorf("expected failed after timeout, got %q", store.instances[instID].State)
 	}
 }
 
-// TestPoll_RehydrateSurvivesRestart is the core regression: an instance parked at
+// TestWaitFor_RehydrateSurvivesRestart is the core regression: an instance parked at
 // a poll step when the daemon stopped must be reconstructed (not restarted from the
 // top) so it resumes from the poll and advances past it — without re-running the
 // already-passed implement step.
-func TestPoll_RehydrateSurvivesRestart(t *testing.T) {
+func TestWaitFor_RehydrateSurvivesRestart(t *testing.T) {
 	store := newFakeStore()
 	clock := time.Unix(1000, 0)
 
 	// First engine: run until parked at the poll step (CI pending).
 	exec1 := &fakeExecutor{}
 	ci1 := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
-	eng1 := pollEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
-	instID, _, _ := eng1.RunInstance(context.Background(), pollWorkflow(), model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStatePollWaiting {
+	eng1 := waitForEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
+	instID, _, _ := eng1.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
+	if store.instances[instID].State != db.InstanceStateWaiting {
 		t.Fatalf("expected poll_waiting before restart, got %q", store.instances[instID].State)
 	}
 
@@ -185,17 +185,17 @@ func TestPoll_RehydrateSurvivesRestart(t *testing.T) {
 	// green. Rehydrate from the persisted step runs, then a poll check advances it.
 	exec2 := &fakeExecutor{}
 	ci2 := func() (source.CIStatus, error) { return source.CIStatus{Status: "passed"}, nil }
-	eng2 := pollEngine(baseCfg(), store, exec2, &fakeSide{}, &clock, ci2)
+	eng2 := waitForEngine(baseCfg(), store, exec2, &fakeSide{}, &clock, ci2)
 
-	if err := eng2.RehydratePoll(context.Background(), instID, pollWorkflow(),
+	if err := eng2.RehydrateWait(context.Background(), instID, waitForWorkflow(),
 		model.InternalTask{ID: "c1"}, priorStepsFor(store, instID)); err != nil {
 		t.Fatalf("rehydrate: %v", err)
 	}
-	if pp := eng2.parkedPolls(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+	if pp := eng2.parkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
 		t.Fatalf("expected rehydrated poll park at check-ci, got %+v", pp)
 	}
 
-	eng2.CheckParkedPolls(context.Background())
+	eng2.CheckParkedWaits(context.Background())
 
 	if store.instances[instID].State != db.InstanceStateDone {
 		t.Errorf("expected done after rehydrated poll passed, got %q", store.instances[instID].State)

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -9,7 +9,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 )
 
-// RunPollStep performs ONE check of the external system (e.g. CI status) and
+// RunWaitStep performs ONE check of the external system (e.g. CI status) and
 // returns either a terminal result (pass/fail) or StepResult{Pending: true} when
 // there is no answer yet. It does NOT loop or block: the scheduler parks the
 // instance on a Pending result and calls this again on a later poll cycle, so a
@@ -17,29 +17,29 @@ import (
 //
 // deadline is the absolute time the wait gives up (zero = no deadline). Past the
 // deadline the step returns a terminal failure with ci_status=timeout.
-func (e *Engine) RunPollStep(
+func (e *Engine) RunWaitStep(
 	ctx context.Context,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
 	deadline time.Time,
 ) (StepResult, error) {
-	if step.PollConfig == nil {
-		return StepResult{}, fmt.Errorf("poll step %q missing poll config", step.ID)
+	if step.WaitFor == nil {
+		return StepResult{}, fmt.Errorf("wait_for step %q missing wait_for config", step.ID)
 	}
 
-	cfg := step.PollConfig
+	cfg := step.WaitFor
 	switch cfg.Kind {
 	case "", "ci":
-		return e.checkCIPollStep(ctx, step, sourceID, sourceItemID, deadline)
+		return e.checkCIWaitStep(ctx, step, sourceID, sourceItemID, deadline)
 	default:
-		return StepResult{}, fmt.Errorf("poll step %q unsupported kind: %q", step.ID, cfg.Kind)
+		return StepResult{}, fmt.Errorf("wait_for step %q unsupported kind: %q", step.ID, cfg.Kind)
 	}
 }
 
-// checkCIPollStep performs a single CI status check. Transient errors and a
+// checkCIWaitStep performs a single CI status check. Transient errors and a
 // still-running CI both yield Pending (retry next cycle); a passed/failed CI is
 // terminal; passing the deadline is a terminal timeout failure.
-func (e *Engine) checkCIPollStep(
+func (e *Engine) checkCIWaitStep(
 	ctx context.Context,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
@@ -52,11 +52,11 @@ func (e *Engine) checkCIPollStep(
 		}, nil
 	}
 
-	cfg := step.PollConfig
+	cfg := step.WaitFor
 
 	// Timeout: give up waiting once past the deadline.
 	if !deadline.IsZero() && e.now().After(deadline) {
-		aplog.Info("poll step %q: CI wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
+		aplog.Info("wait_for step %q: CI wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
 		return StepResult{
 			Success: false,
 			StructuredOutput: map[string]any{
@@ -69,7 +69,7 @@ func (e *Engine) checkCIPollStep(
 	status, err := e.ciChecker(ctx, sourceID, sourceItemID)
 	if err != nil {
 		// Transient error; treat as not-yet-resolved and retry next cycle.
-		aplog.Debug("poll step %q: CI check failed (will retry): %v", step.ID, err)
+		aplog.Debug("wait_for step %q: CI check failed (will retry): %v", step.ID, err)
 		return StepResult{Pending: true}, nil
 	}
 
@@ -100,13 +100,13 @@ func (e *Engine) checkCIPollStep(
 		return result, nil
 
 	case "pending":
-		aplog.Debug("poll step %q: CI still pending", step.ID)
+		aplog.Debug("wait_for step %q: CI still pending", step.ID)
 		return StepResult{Pending: true}, nil
 
 	default:
 		// Unknown/empty status: keep waiting rather than failing spuriously. The
 		// deadline guarantees this cannot loop forever.
-		aplog.Debug("poll step %q: CI status %q not yet conclusive", step.ID, status.Status)
+		aplog.Debug("wait_for step %q: CI status %q not yet conclusive", step.ID, status.Status)
 		return StepResult{Pending: true}, nil
 	}
 }


### PR DESCRIPTION
## Why

`poll` named the *mechanism*; the step's *intent* is "wait until a condition holds." Rebranded to `wait_for`. **Hard rename — no backward-compatible alias** (per request).

```yaml
- id: check-ci
  type: wait_for
  wait_for:
    kind: ci
    check_interval: 30s
    max_duration: 2h
    fail_if_not_passed: true
  on_reject: { restart_from: implement, max: 5 }
```

## What changed

**Config (user-facing):** `type: poll` → `type: wait_for`; block `poll:` → `wait_for:`; `StepTypePoll`→`StepTypeWaitFor`; `PollConfig`→`WaitForConfig`; `StepConfig.PollConfig`→`StepConfig.WaitFor`; validation renamed + messages updated.

**Engine internals:** `RunPollStep`→`RunWaitStep` (`ci_poll.go`→`wait_step.go`); `poll_park.go`→`wait_park.go` with `ParkedPoll`→`ParkedWait`, `parkedPolls`→`parkedWaits`, `CheckParkedPolls`→`CheckParkedWaits`, `wakePoll`→`wakeWait`, `RehydratePoll`→`RehydrateWait`, `enterPoll`→`enterWait`, `firstRunnablePoll`→`firstRunnableWait`, `dagRun.pollDeadline`→`waitDeadline`; daemon `checkPolls`→`checkWaits`, `rehydrateParkedPolls`→`rehydrateParkedWaits`.

**Instance state:** `poll_waiting` → `waiting` (`InstanceStatePollWaiting`→`InstanceStateWaiting`).

**Kept:** the CI-polling *mechanism* (`source.CIStatusPoller`, `PollCIStatus`, the dispatcher's source poll loop) — it genuinely polls; only the workflow **step** is rebranded.

## Verification

`go vet ./...` clean; full `go test ./...` green (tests renamed `TestWaitFor_*`, still cover suspend / advance-on-green / red-CI loop-back / timeout / restart-rehydration). project-erp config updated to `wait_for` and validates. The one live `poll_waiting` DB row was migrated to `waiting`.