### PR TITLE
fix(github): aggregate check-runs for CI status (Actions-only repos)

### DIFF
--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -357,48 +357,71 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	var checkRuns checkRunsResponse
 	_ = json.Unmarshal(checksBody, &checkRuns)
 
-	// Synthesize status from both sources.
-	overallStatus := "pending"
-	if commitStatus.State != "" {
-		overallStatus = commitStatus.State
-	}
+	// Synthesize the overall status from BOTH check runs (GitHub Actions) and the
+	// legacy combined commit status. A repo that runs CI purely via Actions has an
+	// EMPTY combined status whose state defaults to "pending" (total_count == 0) —
+	// trusting that alone would report pending forever even when every check is
+	// green. So we aggregate every signal:
+	//   - any failed signal      → failed
+	//   - else any still-running → pending
+	//   - else (≥1 signal, all good) → passed
+	//   - else (no signals at all)   → pending (CI hasn't started)
+	anyFail, anyPending, anySignal := false, false, false
 
-	// Convert GitHub statuses to our normalized form.
-	status := source.CIStatus{
-		Status: normalizeGitHubStatus(overallStatus),
-		URL:    pr.HTMLURL,
-	}
-
-	// Collect check names and statuses.
 	checks := make([]struct {
 		Name   string
 		Status string
 	}, 0)
 
-	// Add checks from check runs.
 	for _, run := range checkRuns.CheckRuns {
+		anySignal = true
+		var norm string
+		if run.Status != "completed" {
+			norm = "pending" // queued / in_progress
+			anyPending = true
+		} else {
+			norm = normalizeGitHubStatus(run.Conclusion) // success/skipped/neutral → passed/skipped; failure/… → failed
+			if norm == "failed" {
+				anyFail = true
+			}
+		}
 		checks = append(checks, struct {
 			Name   string
 			Status string
-		}{
-			Name:   run.Name,
-			Status: normalizeGitHubStatus(run.Conclusion),
-		})
+		}{Name: run.Name, Status: norm})
 	}
 
-	// Add statuses from combined status if not already in check runs.
-	for _, st := range commitStatus.Statuses {
-		checks = append(checks, struct {
-			Name   string
-			Status string
-		}{
-			Name:   st.Context,
-			Status: normalizeGitHubStatus(st.State),
-		})
+	// Legacy commit statuses count only when they actually exist.
+	if commitStatus.TotalCount > 0 {
+		for _, st := range commitStatus.Statuses {
+			anySignal = true
+			norm := normalizeGitHubStatus(st.State)
+			switch norm {
+			case "failed":
+				anyFail = true
+			case "pending":
+				anyPending = true
+			}
+			checks = append(checks, struct {
+				Name   string
+				Status string
+			}{Name: st.Context, Status: norm})
+		}
 	}
 
-	status.Checks = checks
-	return status, nil
+	overall := "pending"
+	switch {
+	case anyFail:
+		overall = "failed"
+	case anyPending:
+		overall = "pending"
+	case anySignal:
+		overall = "passed"
+	default:
+		overall = "pending" // no checks and no statuses yet — CI not started
+	}
+
+	return source.CIStatus{Status: overall, URL: pr.HTMLURL, Checks: checks}, nil
 }
 
 func normalizeGitHubStatus(s string) string {

--- a/src/internal/source/github/pollci_test.go
+++ b/src/internal/source/github/pollci_test.go
@@ -1,0 +1,121 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ciServer stands up a GitHub API stub for an issue (1958) whose PR (1961, head
+// SHA "abc") reports the given combined-status JSON and check-runs JSON.
+func ciServer(t *testing.T, combinedStatus, checkRuns string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/1958"):
+			http.NotFound(w, r) // issue number is not a PR
+		case strings.HasSuffix(r.URL.Path, "/issues/1958/timeline"):
+			_, _ = w.Write([]byte(`[{"event":"cross-referenced","source":{"type":"issue",
+				"issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}}]`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/1961"):
+			_, _ = w.Write([]byte(`{"number":1961,"html_url":"https://gh/pr/1961","head":{"sha":"abc"}}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/status"):
+			_, _ = w.Write([]byte(combinedStatus))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/check-runs"):
+			_, _ = w.Write([]byte(checkRuns))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+}
+
+// The regression: a GitHub-Actions-only repo has an EMPTY combined status (state
+// defaults to "pending", total_count 0) while every check run is green. The
+// overall must be "passed", not "pending".
+func TestPollCIStatus_ActionsOnlyAllGreen(t *testing.T) {
+	a := ciServer(t,
+		`{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[
+			{"name":"CI","status":"completed","conclusion":"success"},
+			{"name":"E2E","status":"completed","conclusion":"success"},
+			{"name":"optional","status":"completed","conclusion":"skipped"}
+		]}`)
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "passed" {
+		t.Errorf("status = %q, want passed (Actions-only repo, all checks green)", got.Status)
+	}
+}
+
+func TestPollCIStatus_FailedCheckRun(t *testing.T) {
+	a := ciServer(t,
+		`{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[
+			{"name":"CI","status":"completed","conclusion":"success"},
+			{"name":"E2E","status":"completed","conclusion":"failure"}
+		]}`)
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "failed" {
+		t.Errorf("status = %q, want failed", got.Status)
+	}
+}
+
+func TestPollCIStatus_StillRunning(t *testing.T) {
+	a := ciServer(t,
+		`{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[
+			{"name":"CI","status":"completed","conclusion":"success"},
+			{"name":"E2E","status":"in_progress","conclusion":null}
+		]}`)
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "pending" {
+		t.Errorf("status = %q, want pending (a check is still in_progress)", got.Status)
+	}
+}
+
+func TestPollCIStatus_NoSignalsYet(t *testing.T) {
+	a := ciServer(t,
+		`{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[]}`)
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "pending" {
+		t.Errorf("status = %q, want pending (CI not started)", got.Status)
+	}
+}
+
+// Legacy commit statuses (non-Actions CI) still work and are aggregated with checks.
+func TestPollCIStatus_LegacyStatusesGreen(t *testing.T) {
+	a := ciServer(t,
+		`{"state":"success","total_count":2,"statuses":[
+			{"context":"ci/lint","state":"success"},
+			{"context":"ci/test","state":"success"}
+		]}`,
+		`{"check_runs":[]}`)
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "passed" {
+		t.Errorf("status = %q, want passed (legacy statuses all green)", got.Status)
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -55,10 +55,13 @@ type pullRequest struct {
 	} `json:"head"`
 }
 
-// commitStatus is the combined status of a commit.
+// commitStatus is the combined legacy status of a commit. TotalCount is 0 when no
+// legacy commit statuses exist — in which case State defaults to "pending" and must
+// be ignored (a GitHub-Actions-only repo reports CI via check runs, not statuses).
 type commitStatus struct {
-	State    string `json:"state"`
-	Statuses []struct {
+	State      string `json:"state"`
+	TotalCount int    `json:"total_count"`
+	Statuses   []struct {
 		Context string `json:"context"`
 		State   string `json:"state"`
 		URL     string `json:"target_url"`


### PR DESCRIPTION
## Bug

`PollCIStatus` read the overall CI verdict from the **legacy combined commit status** (`/commits/{sha}/status`) and ignored **check runs**. A repo that runs CI purely via **GitHub Actions** has an empty combined status whose `state` defaults to `pending` (`total_count: 0`), so the `wait_for` step reported `pending` forever even when all 20 checks were green — the workflow never advanced past `check-ci`.

Verified against project-erp PR #1961: combined status `{state: pending, total_count: 0}`, all check-runs `completed/success`.

## Fix

Aggregate the overall status from **both** check runs and legacy statuses:
- any failed signal → `failed`
- else any still-running (check `status != completed`, or a legacy `pending`) → `pending`
- else (≥1 signal, all good) → `passed`
- else (no checks, no statuses) → `pending` (CI not started)

check-run conclusions map `success`/`skipped`/`neutral` → ok, `failure`/etc → failed. Legacy statuses count only when `total_count > 0` (adds `commitStatus.TotalCount`).

## Tests

`pollci_test.go`: Actions-only all-green → passed; failed check → failed; in_progress → pending; no signals → pending; legacy statuses green → passed. Full suite + vet green.