### PR TITLE
fix(github): surface PR-fetch auth errors instead of masking as pending

### DIFF
--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -316,11 +316,17 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 			return source.CIStatus{Status: "pending"}, nil // No PR found yet; still pending
 		}
 
-		// Fetch the PR details
+		// Fetch the PR details. A failure here is NOT "pending": we found a real PR
+		// but can't read it. Surface it as an error so the caller logs it instead of
+		// masking a permanent problem (e.g. a token lacking Pull requests: Read,
+		// which returns 403) as an endless wait.
 		prPath = fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, prNumber)
 		prBody, err = a.client.get(ctx, prPath)
 		if err != nil {
-			return source.CIStatus{Status: "pending"}, nil
+			if isAuthError(err) {
+				return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: cannot read PR #%d for issue %s — the configured token likely lacks 'Pull requests: Read' (and 'Contents: Read'): %w", prNumber, cellID, err)
+			}
+			return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: fetching PR #%d for issue %s: %w", prNumber, cellID, err)
 		}
 	}
 
@@ -422,6 +428,17 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	}
 
 	return source.CIStatus{Status: overall, URL: pr.HTMLURL, Checks: checks}, nil
+}
+
+// isAuthError reports whether a client error is a GitHub authorization failure
+// (401 Unauthorized or 403 Forbidden) — typically a missing token permission,
+// which is permanent until the token is fixed (not a transient blip to retry past).
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "status 401") || strings.Contains(msg, "status 403")
 }
 
 func normalizeGitHubStatus(s string) string {

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -68,8 +68,11 @@ func (e *Engine) checkCIWaitStep(
 
 	status, err := e.ciChecker(ctx, sourceID, sourceItemID)
 	if err != nil {
-		// Transient error; treat as not-yet-resolved and retry next cycle.
-		aplog.Debug("wait_for step %q: CI check failed (will retry): %v", step.ID, err)
+		// Surface at WARN (not DEBUG): a persistent error here — e.g. a token
+		// missing 'Pull requests: Read' (403) — would otherwise masquerade as an
+		// endless "pending" with no visible cause. Still retried next cycle so it
+		// self-heals once the underlying problem (token, transient outage) is fixed.
+		aplog.Warn("wait_for step %q: CI check failed (will retry next cycle): %v", step.ID, err)
 		return StepResult{Pending: true}, nil
 	}
 


### PR DESCRIPTION
## Problem

`PollCIStatus` resolves the PR from the issue timeline, then fetches `/pulls/{n}`. When that fetch failed it returned `CIStatus{pending}` with a **nil error** — so a *permanent* failure (most commonly a token lacking **Pull requests: Read**, which returns 403) looked like an endless CI "pending" with no visible cause. Diagnosing it required manually replaying the API calls.

## Fix

- `PollCIStatus` returns an **error** when a known PR can't be fetched, with a targeted message naming the likely missing permission on 401/403 (new `isAuthError` helper). The legitimate "no PR found yet" path still returns `pending`.
- The `wait_for` step logs `CIStatusChecker` errors at **WARN** (was DEBUG), so they're visible by default. It still returns `Pending` and retries next cycle, so the wait **self-heals** once the token/outage is fixed.

No behavior change when everything is healthy. Full suite + vet green.