### PR TITLE
fix(dashboard): show all workflows for a task in the monitor

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -98,8 +98,8 @@ type logsDataMsg struct{ logs []LogEntry }
 type usageDataMsg struct{ data UsageTab }
 type workflowsConfigMsg struct{ workflows []WorkflowConfigItem }
 type workflowMonitorMsg struct {
-	taskID   string
-	instance *WorkflowInstanceItem
+	taskID    string
+	instances []*WorkflowInstanceItem // all instances for the task, newest-first
 }
 type workflowStepLogsMsg struct {
 	stepID string
@@ -241,8 +241,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.model.lastRefresh = time.Now()
 
 	case workflowMonitorMsg:
-		if a.model.tasksTab != nil {
-			a.model.tasksTab.WorkflowInstance = msg.instance
+		if a.model.tasksTab != nil && len(msg.instances) > 0 {
+			a.model.tasksTab.WorkflowInstances = msg.instances
+			a.model.tasksTab.WorkflowInstanceIdx = 0
+			a.model.tasksTab.WorkflowInstance = msg.instances[0]
 			a.model.tasksTab.WorkflowStepIdx = 0
 			a.model.tasksTab.WorkflowLogs = nil
 			a.model.tasksTab.WorkflowLogScroll = 0
@@ -260,9 +262,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.model.loading = false
 
 	case workflowMonitorRefreshMsg:
-		if a.model.tasksTab != nil && msg.instance != nil {
-			// Update step states without resetting the cursor position.
-			a.model.tasksTab.WorkflowInstance = msg.instance
+		if t := a.model.tasksTab; t != nil && msg.instance != nil {
+			// Update step states without resetting the cursor position. Write the
+			// refreshed instance back into the slice too, so switching away and
+			// back keeps the live state.
+			t.WorkflowInstance = msg.instance
+			if t.WorkflowInstanceIdx >= 0 && t.WorkflowInstanceIdx < len(t.WorkflowInstances) {
+				t.WorkflowInstances[t.WorkflowInstanceIdx] = msg.instance
+			}
 		}
 		a.model.loading = false
 	}
@@ -987,6 +994,19 @@ func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
 			t.WorkflowStepIdx = clampScroll(t.WorkflowStepIdx+a.pageSize(), len(inst.Steps))
 		}
 
+	case "]", ">":
+		// Switch to a newer workflow instance (forward in time). The slice is
+		// newest-first, so newer = a lower index.
+		if !t.WorkflowShowLogs && t.WorkflowInstanceIdx > 0 {
+			a.selectWorkflowInstance(t, t.WorkflowInstanceIdx-1)
+		}
+
+	case "[", "<":
+		// Switch to an older workflow instance (back in time, e.g. triage).
+		if !t.WorkflowShowLogs && t.WorkflowInstanceIdx < len(t.WorkflowInstances)-1 {
+			a.selectWorkflowInstance(t, t.WorkflowInstanceIdx+1)
+		}
+
 	case "l", "enter":
 		// Open logs for the selected step.
 		if !t.WorkflowShowLogs && t.WorkflowStepIdx < len(inst.Steps) {
@@ -1013,6 +1033,20 @@ func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
 		a.model.confirmTaskID = inst.CellID
 	}
 	return a, nil
+}
+
+// selectWorkflowInstance points the monitor at a different workflow instance for
+// the same task and resets the step cursor and log panel to that instance.
+func (a *App) selectWorkflowInstance(t *TasksTab, idx int) {
+	if idx < 0 || idx >= len(t.WorkflowInstances) {
+		return
+	}
+	t.WorkflowInstanceIdx = idx
+	t.WorkflowInstance = t.WorkflowInstances[idx]
+	t.WorkflowStepIdx = 0
+	t.WorkflowLogs = nil
+	t.WorkflowLogScroll = 0
+	t.WorkflowShowLogs = false
 }
 
 // handleWorkflowsKey handles keys in the static Workflows config tab.
@@ -1242,49 +1276,63 @@ func (a *App) openWorkflowMonitorOrLogs(taskID string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
 		if dbConn != nil {
-			inst, err := dbConn.GetLatestInstanceByCell(ctx, taskID)
-			if err == nil && inst != nil {
-				item := &WorkflowInstanceItem{
-					ID:       inst.ID,
-					Workflow: inst.WorkflowID,
-					State:    inst.State,
-					CellID:   inst.CellID,
+			// A task can fan out to several workflow instances over its life
+			// (e.g. triage → implementation); load all of them, newest first, so
+			// the monitor can switch between them with [ and ].
+			insts, err := dbConn.ListWorkflowInstancesByCell(ctx, taskID)
+			if err == nil && len(insts) > 0 {
+				items := make([]*WorkflowInstanceItem, 0, len(insts))
+				for i := range insts {
+					items = append(items, buildWorkflowInstanceItem(ctx, dbConn, &insts[i]))
 				}
-				if inst.State == "approval_waiting" {
-					item.Message = "Awaiting human approval — reply on the task to resume or abort."
-				}
-				steps, err := dbConn.ListStepRuns(ctx, inst.ID)
-				if err == nil {
-					now := time.Now()
-					for _, s := range steps {
-						si := WorkflowStepItem{
-							StepID:     s.StepID,
-							Agent:      s.AgentID,
-							State:      s.State,
-							Duration:   wfStepDuration(s, now),
-							Cached:     s.SkippedCached,
-							Output:     s.Output,
-							Summary:    s.Summary,
-							StartedAt:  s.StartedAt,
-							FinishedAt: s.FinishedAt,
-						}
-						if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
-							si.InputTokens = usage.InputTokens
-							si.OutputTokens = usage.OutputTokens
-							si.TotalTokens = usage.TotalTokens
-							si.CostUSD = usage.CostUSD
-							si.NumTurns = usage.NumTurns
-							si.NumToolCalls = usage.NumToolCalls
-						}
-						item.Steps = append(item.Steps, si)
-					}
-				}
-				return workflowMonitorMsg{taskID: taskID, instance: item}
+				return workflowMonitorMsg{taskID: taskID, instances: items}
 			}
 		}
 		// No workflow instance — fall back to logs view.
 		return taskLogsMsg{taskID: taskID, logs: nil, detail: nil}
 	}
+}
+
+// buildWorkflowInstanceItem hydrates a WorkflowInstanceItem (steps + per-step
+// usage) from a stored workflow instance, for the live monitor views.
+func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.WorkflowInstance) *WorkflowInstanceItem {
+	item := &WorkflowInstanceItem{
+		ID:        inst.ID,
+		Workflow:  inst.WorkflowID,
+		State:     inst.State,
+		CellID:    inst.CellID,
+		CreatedAt: inst.CreatedAt,
+	}
+	if inst.State == "approval_waiting" {
+		item.Message = "Awaiting human approval — reply on the task to resume or abort."
+	}
+	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
+	if err == nil {
+		now := time.Now()
+		for _, s := range steps {
+			si := WorkflowStepItem{
+				StepID:     s.StepID,
+				Agent:      s.AgentID,
+				State:      s.State,
+				Duration:   wfStepDuration(s, now),
+				Cached:     s.SkippedCached,
+				Output:     s.Output,
+				Summary:    s.Summary,
+				StartedAt:  s.StartedAt,
+				FinishedAt: s.FinishedAt,
+			}
+			if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
+				si.InputTokens = usage.InputTokens
+				si.OutputTokens = usage.OutputTokens
+				si.TotalTokens = usage.TotalTokens
+				si.CostUSD = usage.CostUSD
+				si.NumTurns = usage.NumTurns
+				si.NumToolCalls = usage.NumToolCalls
+			}
+			item.Steps = append(item.Steps, si)
+		}
+	}
+	return item
 }
 
 // refreshWorkflowMonitor re-fetches a workflow instance and its steps for the
@@ -1301,43 +1349,8 @@ func (a *App) refreshWorkflowMonitor(instanceID, cellID string) tea.Cmd {
 		if err != nil || inst == nil {
 			return nil
 		}
-		item := &WorkflowInstanceItem{
-			ID:       inst.ID,
-			Workflow: inst.WorkflowID,
-			State:    inst.State,
-			CellID:   inst.CellID,
-		}
-		if inst.State == "approval_waiting" {
-			item.Message = "Awaiting human approval — reply on the task to resume or abort."
-		}
-		steps, err := dbConn.ListStepRuns(ctx, instanceID)
-		if err == nil {
-			now := time.Now()
-			for _, s := range steps {
-				si := WorkflowStepItem{
-					StepID:     s.StepID,
-					Agent:      s.AgentID,
-					State:      s.State,
-					Duration:   wfStepDuration(s, now),
-					Cached:     s.SkippedCached,
-					Output:     s.Output,
-					Summary:    s.Summary,
-					StartedAt:  s.StartedAt,
-					FinishedAt: s.FinishedAt,
-				}
-				if usage, err := dbConn.GetStepUsage(ctx, instanceID, s.StepID); err == nil && usage != nil {
-					si.InputTokens = usage.InputTokens
-					si.OutputTokens = usage.OutputTokens
-					si.TotalTokens = usage.TotalTokens
-					si.CostUSD = usage.CostUSD
-					si.NumTurns = usage.NumTurns
-					si.NumToolCalls = usage.NumToolCalls
-				}
-				item.Steps = append(item.Steps, si)
-			}
-		}
 		// Preserve the step cursor — return a monitor refresh, not a full reset.
-		return workflowMonitorRefreshMsg{instance: item}
+		return workflowMonitorRefreshMsg{instance: buildWorkflowInstanceItem(ctx, dbConn, inst)}
 	}
 }
 
@@ -3764,7 +3777,11 @@ func (a *App) footerKeys() []fkey {
 				if t.WorkflowShowLogs {
 					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
 				}
-				return []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}, {"r", "refresh"}, {"X", "stop"}, {"R", "restart"}, {"esc", "back"}, {"q", "quit"}}
+				keys := []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}}
+				if len(t.WorkflowInstances) > 1 {
+					keys = append(keys, fkey{"[ ]", "workflow"})
+				}
+				return append(keys, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
 			}
 		}
 		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
@@ -3962,6 +3979,11 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 	}
 
 	label := "WORKFLOW  " + StyleValueStrong.Render(inst.Workflow) + "  " + wfInstanceBadge(inst.State)
+	// When the task fanned out to several workflows, show this one's chronological
+	// position (oldest = 1) and a hint that [ / ] switch between them.
+	if n := len(t.WorkflowInstances); n > 1 {
+		label += "   " + StyleMuted.Render(fmt.Sprintf("workflow %d/%d · [ ] switch", n-t.WorkflowInstanceIdx, n))
+	}
 
 	// ── left panel: step list ───────────────────────────────────────────────
 	var left strings.Builder

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -28,27 +28,27 @@ type Model struct {
 
 // OverviewTab shows dispatcher status and summary metrics.
 type AgentCount struct {
-	ID          string
-	Running     int
-	MaxWorkers  int
+	ID         string
+	Running    int
+	MaxWorkers int
 }
 
 type OverviewTab struct {
-	Status           string
-	Uptime           string
-	Concurrency      int
-	ActiveAgents     int
-	ActiveRuns       int
-	QueuedTasks      int
-	CompletedToday   int
-	FailedToday      int
-	ThroughputRatio  string
-	AvgDuration      string
-	SuccessRate      string
-	AgentBreakdown   []AgentCount
-	TodayCostUSD     float64
-	TodayTokens      int
-	TodayInputTokens int
+	Status            string
+	Uptime            string
+	Concurrency       int
+	ActiveAgents      int
+	ActiveRuns        int
+	QueuedTasks       int
+	CompletedToday    int
+	FailedToday       int
+	ThroughputRatio   string
+	AvgDuration       string
+	SuccessRate       string
+	AgentBreakdown    []AgentCount
+	TodayCostUSD      float64
+	TodayTokens       int
+	TodayInputTokens  int
 	TodayOutputTokens int
 }
 
@@ -56,7 +56,7 @@ type OverviewTab struct {
 type TaskView int
 
 const (
-	TaskViewList     TaskView = iota
+	TaskViewList TaskView = iota
 	TaskViewDetail
 	TaskViewLogs
 	TaskViewWorkflow // live workflow instance monitor
@@ -75,11 +75,13 @@ type TasksTab struct {
 	LogScroll       int
 
 	// Workflow monitor sub-view (View == TaskViewWorkflow).
-	WorkflowInstance *WorkflowInstanceItem // instance being monitored
-	WorkflowStepIdx  int                   // selected step index in monitor
-	WorkflowLogs     []LogEntry            // logs for the selected step
-	WorkflowLogScroll int
-	WorkflowShowLogs bool // true when the log panel is expanded
+	WorkflowInstances   []*WorkflowInstanceItem // all instances for the task, newest-first
+	WorkflowInstanceIdx int                     // index into WorkflowInstances of the one being shown
+	WorkflowInstance    *WorkflowInstanceItem   // instance being monitored (== WorkflowInstances[WorkflowInstanceIdx])
+	WorkflowStepIdx     int                     // selected step index in monitor
+	WorkflowLogs        []LogEntry              // logs for the selected step
+	WorkflowLogScroll   int
+	WorkflowShowLogs    bool // true when the log panel is expanded
 
 	// Scroll / filter / sort
 	ScrollOffset int    // first visible row index
@@ -227,7 +229,7 @@ type AgentsTab struct {
 
 	// Drill-down: logs of the task selected in the activity list.
 	LogsTaskID string
-	LogsTask   *TaskItem   // task detail for the logs header
+	LogsTask   *TaskItem // task detail for the logs header
 	TaskLogs   []LogEntry
 	TaskLogIdx int // vertical scroll within TaskLogs (visual lines)
 
@@ -265,18 +267,18 @@ type AgentStatus struct {
 	HeartbeatCount  int
 
 	// Config fields (enriched from apiary.yaml)
-	MaxWorkers     int
-	RunnerType     string
-	Model          string
-	SoulFile       string
-	Skills         []string // skill ids declared on the agent config
-	Description    string
-	SourceName     string // git author name from agent config
-	SourceEmail    string // git author email from agent config
-	Runners        []string // all available runner IDs for cycling
-	RunnerModels   []string // models declared on the current runner config
-	TotalCostUSD   float64
-	TotalTokens    int
+	MaxWorkers   int
+	RunnerType   string
+	Model        string
+	SoulFile     string
+	Skills       []string // skill ids declared on the agent config
+	Description  string
+	SourceName   string   // git author name from agent config
+	SourceEmail  string   // git author email from agent config
+	Runners      []string // all available runner IDs for cycling
+	RunnerModels []string // models declared on the current runner config
+	TotalCostUSD float64
+	TotalTokens  int
 }
 
 // UsageTab shows token/cost charts over time and per agent.
@@ -329,11 +331,11 @@ const (
 
 // WorkflowsTab shows the static workflow config definitions (read-only).
 type WorkflowsTab struct {
-	Workflows    []WorkflowConfigItem
-	SelectedIdx  int // selected workflow in the left panel
-	StepIdx      int // selected step in the right panel
-	StepScroll   int // scroll offset in the step list
-	Focus        WorkflowsView
+	Workflows   []WorkflowConfigItem
+	SelectedIdx int // selected workflow in the left panel
+	StepIdx     int // selected step in the right panel
+	StepScroll  int // scroll offset in the step list
+	Focus       WorkflowsView
 }
 
 // NewModel creates a new dashboard model.
@@ -353,7 +355,7 @@ func NewModel() *Model {
 		agentsTab: &AgentsTab{
 			Agents: []AgentStatus{},
 		},
-		usageTab:     &UsageTab{},
+		usageTab: &UsageTab{},
 		logsTab: &LogsTab{
 			Logs:        []LogEntry{},
 			FilterLevel: "All",

--- a/src/internal/dashboard/workflow_monitor_instances_test.go
+++ b/src/internal/dashboard/workflow_monitor_instances_test.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+// TestOpenWorkflowMonitorLoadsAllInstances verifies that pressing Enter on a task
+// that fanned out to several workflows (e.g. triage → implementation) loads every
+// instance, newest-first, rather than only the latest one.
+func TestOpenWorkflowMonitorLoadsAllInstances(t *testing.T) {
+	ctx := context.Background()
+	c, err := db.New(ctx, filepath.Join(t.TempDir(), "monitor.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	base := time.Date(2026, 6, 6, 9, 0, 0, 0, time.UTC)
+	// Two workflows on the same cell: triage first, then implementation.
+	_ = c.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "triage", CellID: "ISSUE-9", State: db.InstanceStateDone, CreatedAt: base.Add(time.Minute)})
+	_ = c.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "implementation", CellID: "ISSUE-9", State: db.InstanceStateRunning, CreatedAt: base.Add(2 * time.Minute)})
+
+	a := &App{model: NewModel(), dbConn: c}
+	msg, ok := a.openWorkflowMonitorOrLogs("ISSUE-9")().(workflowMonitorMsg)
+	if !ok {
+		t.Fatalf("expected workflowMonitorMsg")
+	}
+	if len(msg.instances) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(msg.instances))
+	}
+	// Newest-first: implementation (i2) then triage (i1).
+	if msg.instances[0].ID != "i2" || msg.instances[1].ID != "i1" {
+		t.Fatalf("instances not newest-first: %s, %s", msg.instances[0].ID, msg.instances[1].ID)
+	}
+	if msg.instances[1].Workflow != "triage" {
+		t.Errorf("older instance should be the triage workflow, got %q", msg.instances[1].Workflow)
+	}
+}
+
+// TestSwitchWorkflowInstanceKeys verifies [ and ] move between a task's workflow
+// instances and reset the step cursor, clamping at both ends.
+func TestSwitchWorkflowInstanceKeys(t *testing.T) {
+	a := &App{model: NewModel()}
+	insts := []*WorkflowInstanceItem{
+		{ID: "i2", Workflow: "implementation", State: "running", Steps: []WorkflowStepItem{{StepID: "a"}, {StepID: "b"}}},
+		{ID: "i1", Workflow: "triage", State: "done", Steps: []WorkflowStepItem{{StepID: "x"}}},
+	}
+	a.model.tasksTab = &TasksTab{
+		View:              TaskViewWorkflow,
+		WorkflowInstances: insts,
+		WorkflowInstance:  insts[0],
+		WorkflowStepIdx:   1,
+	}
+	t0 := a.model.tasksTab
+
+	// "[" → older (triage, i1); step cursor resets.
+	a.handleWorkflowMonitorKey("[")
+	if t0.WorkflowInstanceIdx != 1 || t0.WorkflowInstance.ID != "i1" {
+		t.Fatalf("[ should move to older instance i1, got idx=%d id=%s", t0.WorkflowInstanceIdx, t0.WorkflowInstance.ID)
+	}
+	if t0.WorkflowStepIdx != 0 {
+		t.Errorf("step cursor should reset on switch, got %d", t0.WorkflowStepIdx)
+	}
+
+	// "[" again clamps at the oldest.
+	a.handleWorkflowMonitorKey("[")
+	if t0.WorkflowInstanceIdx != 1 {
+		t.Errorf("[ at oldest should stay at idx 1, got %d", t0.WorkflowInstanceIdx)
+	}
+
+	// "]" → newer (implementation, i2).
+	a.handleWorkflowMonitorKey("]")
+	if t0.WorkflowInstanceIdx != 0 || t0.WorkflowInstance.ID != "i2" {
+		t.Fatalf("] should move to newer instance i2, got idx=%d id=%s", t0.WorkflowInstanceIdx, t0.WorkflowInstance.ID)
+	}
+
+	// "]" again clamps at the newest.
+	a.handleWorkflowMonitorKey("]")
+	if t0.WorkflowInstanceIdx != 0 {
+		t.Errorf("] at newest should stay at idx 0, got %d", t0.WorkflowInstanceIdx)
+	}
+}


### PR DESCRIPTION
## Summary

- Pressing **Enter** on a task opened the live workflow monitor via `GetLatestInstanceByCell` (`ORDER BY created_at DESC LIMIT 1`), so only the **newest** instance (e.g. `implementation`) was ever shown — earlier workflows for the same task (e.g. `triage`) were present in the DB but never surfaced on that path.
- The monitor now loads **every** instance for the task via `ListWorkflowInstancesByCell` (newest-first) and lets you switch between them with `[` (older / back in time) and `]` (newer / forward), defaulting to the newest/active workflow.
- Added a position indicator in the monitor header (`workflow 2/2 · [ ] switch`, chronological) and a footer hint, both shown only when a task has more than one workflow.
- Live refresh writes the refreshed instance back into the slice so toggling between workflows keeps the active one's live state.
- Extracted the duplicated step/usage-hydration logic (previously copy-pasted across `openWorkflowMonitorOrLogs` and `refreshWorkflowMonitor`) into a single `buildWorkflowInstanceItem` helper.

## Test plan

- `go build ./...`, `go vet ./internal/dashboard/...` — clean.
- `go test ./internal/dashboard/` — passes, including new `workflow_monitor_instances_test.go`:
  - `TestOpenWorkflowMonitorLoadsAllInstances` — all instances loaded newest-first against a real DB.
  - `TestSwitchWorkflowInstanceKeys` — `[`/`]` move between workflows, reset the step cursor, and clamp at both ends.