### PR TITLE
fix(runner): parse APIARY_OUTPUT sentinel when wrapped in markdown

### DIFF
--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -59,14 +59,18 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 			publishLines = append(publishLines, line)
 		case inSpawn:
 			spawnLines = append(spawnLines, line)
-		case strings.HasPrefix(trimmed, apiaryOutputPrefix):
-			jsonPart := strings.TrimSpace(strings.TrimPrefix(trimmed, apiaryOutputPrefix))
-			var obj map[string]any
-			if err := json.Unmarshal([]byte(jsonPart), &obj); err == nil {
-				structured = obj
-			}
-			// The sentinel line is stripped whether or not it parsed.
 		default:
+			// The APIARY_OUTPUT: sentinel may arrive bare, or wrapped by an
+			// agent in markdown — inline backticks, code fences, or list /
+			// blockquote prefixes. outputSentinelJSON tolerates all of these.
+			if jsonPart, ok := outputSentinelJSON(trimmed); ok {
+				var obj map[string]any
+				if err := json.Unmarshal([]byte(jsonPart), &obj); err == nil {
+					structured = obj
+				}
+				// The sentinel line is stripped whether or not it parsed.
+				continue
+			}
 			kept = append(kept, line)
 		}
 	}
@@ -76,6 +80,92 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 	publish = strings.TrimSpace(strings.Join(publishLines, "\n"))
 	spawn = strings.TrimSpace(strings.Join(spawnLines, "\n"))
 	return cleaned, structured, summary, publish, spawn
+}
+
+// outputSentinelJSON reports whether a trimmed line carries an APIARY_OUTPUT:
+// sentinel and, when it does, returns the JSON payload that follows it. The
+// sentinel is recognized even when an agent wraps it in markdown — inline
+// backticks (`APIARY_OUTPUT: {...}`), code-fence markers, or a list/blockquote
+// prefix — so legitimate verdicts are not silently dropped. Anything before the
+// sentinel must be markdown wrapper noise; a prose line that merely mentions
+// the sentinel is left untouched. The JSON is read up to its balanced closing
+// brace, which naturally ignores a trailing backtick or fence marker.
+func outputSentinelJSON(trimmed string) (string, bool) {
+	idx := strings.Index(trimmed, apiaryOutputPrefix)
+	if idx < 0 {
+		return "", false
+	}
+	if !isMarkdownWrapper(trimmed[:idx]) {
+		return "", false
+	}
+	rest := strings.TrimSpace(trimmed[idx+len(apiaryOutputPrefix):])
+	if payload := balancedJSON(rest); payload != "" {
+		return payload, true
+	}
+	// No balanced object/array present (e.g. an empty or malformed sentinel).
+	// Strip any surrounding fence/backtick noise and hand back what remains so
+	// the line is still recognized as a sentinel and stripped from the output.
+	return strings.TrimSpace(strings.Trim(rest, "`")), true
+}
+
+// isMarkdownWrapper reports whether s consists solely of characters an agent
+// might place before the sentinel when wrapping it in markdown: backticks,
+// fence tildes, list bullets, blockquote markers, and whitespace.
+func isMarkdownWrapper(s string) bool {
+	for _, r := range s {
+		switch r {
+		case '`', '~', '-', '*', '+', '>', ' ', '\t':
+			// wrapper noise, keep scanning
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// balancedJSON returns the first balanced {…} or […] span in s, respecting
+// quoted strings and escape sequences, or "" when none is present. It lets the
+// caller pull a JSON payload out of a line that has trailing markdown (e.g. a
+// closing backtick) after the object.
+func balancedJSON(s string) string {
+	start := strings.IndexAny(s, "{[")
+	if start < 0 {
+		return ""
+	}
+	open := s[start]
+	close := byte('}')
+	if open == '[' {
+		close = ']'
+	}
+	depth := 0
+	inStr := false
+	esc := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case open:
+			depth++
+		case close:
+			depth--
+			if depth == 0 {
+				return s[start : i+1]
+			}
+		}
+	}
+	return ""
 }
 
 // applyStructured post-processes a RunResult's Output, moving any structured

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -66,6 +66,91 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 	}
 }
 
+func TestExtractStructured_BareLineRegression(t *testing.T) {
+	raw := strings.Join([]string{
+		"real output",
+		`APIARY_OUTPUT: {"review_verdict":"rejected","reason":"missing tests"}`,
+	}, "\n")
+	cleaned, structured, _, _, _ := extractStructured(raw)
+	if structured == nil {
+		t.Fatal("expected structured output for bare sentinel, got nil")
+	}
+	if structured["review_verdict"] != "rejected" {
+		t.Errorf("structured parsed incorrectly: %#v", structured)
+	}
+	if strings.Contains(cleaned, "APIARY_OUTPUT") {
+		t.Errorf("sentinel line not stripped:\n%s", cleaned)
+	}
+	if cleaned != "real output" {
+		t.Errorf("unexpected cleaned output: %q", cleaned)
+	}
+}
+
+func TestExtractStructured_InlineBacktickWrapped(t *testing.T) {
+	raw := strings.Join([]string{
+		"Here is my verdict:",
+		"`APIARY_OUTPUT: {\"review_verdict\": \"rejected\", \"reason\": \"flaky test\"}`",
+	}, "\n")
+	cleaned, structured, _, _, _ := extractStructured(raw)
+	if structured == nil {
+		t.Fatal("expected structured output for backtick-wrapped sentinel, got nil")
+	}
+	if structured["review_verdict"] != "rejected" {
+		t.Errorf("verdict lost when wrapped in backticks: %#v", structured)
+	}
+	if structured["reason"] != "flaky test" {
+		t.Errorf("reason parsed incorrectly: %#v", structured)
+	}
+	if strings.Contains(cleaned, "APIARY_OUTPUT") || strings.Contains(cleaned, "review_verdict") {
+		t.Errorf("backtick-wrapped sentinel not stripped:\n%s", cleaned)
+	}
+	if cleaned != "Here is my verdict:" {
+		t.Errorf("unexpected cleaned output: %q", cleaned)
+	}
+}
+
+func TestExtractStructured_FencedCodeBlock(t *testing.T) {
+	raw := strings.Join([]string{
+		"Result below.",
+		"```json",
+		`APIARY_OUTPUT: {"review_verdict":"approved"}`,
+		"```",
+	}, "\n")
+	_, structured, _, _, _ := extractStructured(raw)
+	if structured == nil {
+		t.Fatal("expected structured output inside fenced block, got nil")
+	}
+	if structured["review_verdict"] != "approved" {
+		t.Errorf("verdict lost inside fenced block: %#v", structured)
+	}
+}
+
+func TestExtractStructured_WrappedLastWins(t *testing.T) {
+	raw := strings.Join([]string{
+		`APIARY_OUTPUT: {"review_verdict":"approved"}`,
+		"some reconsideration",
+		"`APIARY_OUTPUT: {\"review_verdict\": \"rejected\"}`",
+	}, "\n")
+	_, structured, _, _, _ := extractStructured(raw)
+	if structured == nil {
+		t.Fatal("expected structured output, got nil")
+	}
+	if structured["review_verdict"] != "rejected" {
+		t.Errorf("expected last (wrapped) APIARY_OUTPUT to win, got: %#v", structured)
+	}
+}
+
+func TestExtractStructured_ProseMentionNotStripped(t *testing.T) {
+	raw := "I will now emit APIARY_OUTPUT: with the final verdict."
+	cleaned, structured, _, _, _ := extractStructured(raw)
+	if structured != nil {
+		t.Errorf("prose mention should not parse as structured, got: %#v", structured)
+	}
+	if cleaned != raw {
+		t.Errorf("prose line mentioning the sentinel should be preserved, got: %q", cleaned)
+	}
+}
+
 func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
 	raw := "real output\nAPIARY_OUTPUT: {not valid json}"
 	cleaned, structured, _, _, _ := extractStructured(raw)


### PR DESCRIPTION
## Summary

- Root-cause fix in `src/internal/runner/execution/structured.go`: `extractStructured` only recognized the `APIARY_OUTPUT:` sentinel when the **trimmed line started** with the prefix (`strings.HasPrefix`). When an agent wrapped the line in markdown — an inline code span (`` `APIARY_OUTPUT: {...}` ``) or a fenced ```` ```json ```` block — the line fell through to the `default` branch: it stayed as visible output and the structured verdict was **silently dropped** (`structured` stayed `nil`).
- **Observed impact:** a reviewer that legitimately rejected a PR (`review_verdict: rejected`) wrapped its `APIARY_OUTPUT` in backticks. The engine saw no structured output, so `reject_when` / `memory.review_verdict` never fired — the review step was treated as `passed`, the `on_reject` loop-back was skipped, and the workflow proceeded to QA→merge and closed the issue with the PR still open. Legitimate rejections were being swallowed.
- The `default` branch now uses `outputSentinelJSON`, which detects the sentinel **anywhere** in a line whose leading characters are only markdown wrapper noise (backticks, fence tildes, `-`/`*`/`+` list bullets, `>` blockquote, whitespace), and extracts the JSON with a **balanced-brace scan** (`balancedJSON`) that respects quoted strings and ignores a trailing backtick/fence after the object.
- Preserved behaviour: bare-line parsing (regression), the "last `APIARY_OUTPUT` wins" rule, sentinel-line stripping even on invalid JSON, and prose lines that merely mention the sentinel are left untouched (the prefix must be wrapper-only).

## Test plan

- `make test` — full suite green.
- New tests in `structured_test.go`:
  - `TestExtractStructured_BareLineRegression` — bare line still parses.
  - `TestExtractStructured_InlineBacktickWrapped` — `` `APIARY_OUTPUT: {...}` `` parses; line stripped.
  - `TestExtractStructured_FencedCodeBlock` — sentinel inside a ```` ```json ```` block parses.
  - `TestExtractStructured_WrappedLastWins` — a later wrapped sentinel overrides an earlier bare one.
  - `TestExtractStructured_ProseMentionNotStripped` — prose mentioning the sentinel is preserved, not parsed.
- `gofmt -l` clean, `go vet ./internal/runner/execution/` clean.