### PR TITLE
feat(workflow): record per-step token usage, cost, and prompts

### DIFF
--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -308,6 +308,11 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 	}}, x.d.agentFallbacks[req.Step.Agent]...)
 
 	var res model.RunResult
+	// summedUsage accumulates token/cost across every attempt (primary + failovers)
+	// so the step run reflects everything the step actually cost, not just the
+	// winning attempt. Per-attempt detail stays in each task_executions row.
+	var summedUsage model.Usage
+	var anyUsage bool
 	for i, c := range candidates {
 		last := i == len(candidates)-1
 		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
@@ -336,6 +341,16 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		x.finishExecution(ctx, exec, out)
 		res = out
 
+		if out.Usage != nil {
+			anyUsage = true
+			summedUsage.InputTokens += out.Usage.InputTokens
+			summedUsage.OutputTokens += out.Usage.OutputTokens
+			summedUsage.TotalTokens += out.Usage.TotalTokens
+			summedUsage.NumTurns += out.Usage.NumTurns
+			summedUsage.NumToolCalls += out.Usage.NumToolCalls
+			summedUsage.CostUSD += out.Usage.CostUSD
+		}
+
 		// On a provider rate-limit rejection, pause this runner type until it
 		// resets and fail over to the next candidate. Not a genuine failure — the
 		// run did no work — so we do not return it while a fallback remains.
@@ -356,10 +371,16 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		publishPayload = ""
 	}
 
+	var usage *model.Usage
+	if anyUsage {
+		u := summedUsage
+		usage = &u
+	}
+
 	// A malformed APIARY_SPAWN block is a step-level error so the workflow fails
 	// with a descriptive message rather than silently dropping the request.
 	if res.SpawnError != nil {
-		return workflow.StepResult{Success: false, Output: res.Output, Err: res.SpawnError}
+		return workflow.StepResult{Success: false, Output: res.Output, Usage: usage, InputPrompt: res.InputPrompt, Err: res.SpawnError}
 	}
 
 	return workflow.StepResult{
@@ -369,6 +390,8 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		Summary:          res.Summary,
 		PublishPayload:   publishPayload,
 		SpawnRequest:     res.SpawnRequest,
+		Usage:            usage,
+		InputPrompt:      res.InputPrompt,
 		Err:              res.Error,
 	}
 }
@@ -420,6 +443,8 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 		exec.NumToolCalls = res.Usage.NumToolCalls
 		exec.CostUSD = res.Usage.CostUSD
 	}
+	exec.InputPrompt = res.InputPrompt
+	exec.OutputText = res.Output
 	if err := x.d.db.UpdateExecution(ctx, exec); err != nil {
 		aplog.Error("cell %s: update execution record: %v", exec.TaskID, err)
 	}

--- a/src/internal/daemon/workflow_executor_test.go
+++ b/src/internal/daemon/workflow_executor_test.go
@@ -36,10 +36,11 @@ func TestWfStepExecutor_RecordsExecution(t *testing.T) {
 	t.Cleanup(func() { _ = dbc.Close() })
 
 	runner := &fakeRunner{result: model.RunResult{
-		Success:  true,
-		Output:   "done",
-		Duration: 1200 * time.Millisecond,
-		Usage:    &model.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.02, NumTurns: 3},
+		Success:     true,
+		Output:      "done",
+		InputPrompt: "system + cell + instruction",
+		Duration:    1200 * time.Millisecond,
+		Usage:       &model.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.02, NumTurns: 3},
 	}}
 
 	d := &Dispatcher{
@@ -64,7 +65,16 @@ func TestWfStepExecutor_RecordsExecution(t *testing.T) {
 		t.Fatalf("expected success, got %+v", res)
 	}
 
-	// A terminal task_executions row must exist with the recorded usage.
+	// The StepResult carries usage and the composed prompt to the engine, which
+	// persists them onto the step run.
+	if res.Usage == nil || res.Usage.TotalTokens != 150 || res.Usage.CostUSD != 0.02 {
+		t.Errorf("StepResult.Usage not propagated: %+v", res.Usage)
+	}
+	if res.InputPrompt != "system + cell + instruction" {
+		t.Errorf("StepResult.InputPrompt = %q, want propagated", res.InputPrompt)
+	}
+
+	// A terminal task_executions row must exist with the recorded usage and prompts.
 	exec, err := dbc.GetLastExecution(ctx, "c1")
 	if err != nil {
 		t.Fatalf("GetLastExecution: %v", err)
@@ -81,8 +91,72 @@ func TestWfStepExecutor_RecordsExecution(t *testing.T) {
 	if exec.TotalTokens != 150 || exec.CostUSD != 0.02 {
 		t.Errorf("usage not recorded: tokens=%d cost=%.4f", exec.TotalTokens, exec.CostUSD)
 	}
+	if exec.InputPrompt != "system + cell + instruction" || exec.OutputText != "done" {
+		t.Errorf("prompts not recorded: in=%q out=%q", exec.InputPrompt, exec.OutputText)
+	}
 	if exec.DurationMs != 1200 {
 		t.Errorf("duration = %dms, want 1200", exec.DurationMs)
+	}
+}
+
+// TestWfStepExecutor_SumsUsageAcrossFailover verifies that when the primary
+// runner is rate-limited and the step fails over to a fallback, the StepResult's
+// usage is the sum of both attempts (the user paid for both), while each attempt
+// remains its own task_executions row.
+func TestWfStepExecutor_SumsUsageAcrossFailover(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	primary := &fakeRunner{result: model.RunResult{
+		Success:     false,
+		RateLimited: true,
+		Output:      "rate limited",
+		Usage:       &model.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, CostUSD: 0.001, NumTurns: 1, NumToolCalls: 1},
+	}}
+	fallback := &fakeRunner{result: model.RunResult{
+		Success: true,
+		Output:  "done",
+		Usage:   &model.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.02, NumTurns: 3, NumToolCalls: 4},
+	}}
+
+	d := &Dispatcher{
+		cfg:         &config.Config{},
+		db:          dbc,
+		runners:     map[string]runnerpkg.Runner{"agent-architect": primary},
+		agentRunner: map[string]string{"architect": "claude"},
+		agentFallbacks: map[string][]runnerCandidate{
+			"architect": {{adapter: fallback, runnerType: "claude-2", model: "claude-sonnet-4-6"}},
+		},
+	}
+	x := &wfStepExecutor{d: d}
+
+	res := x.ExecuteStep(ctx, workflow.StepRequest{
+		InstanceID: "wf_1",
+		Cell:       model.SourceItem{ID: "c1"},
+		Step:       config.StepConfig{ID: "plan", Agent: "architect"},
+	})
+
+	if !primary.ran || !fallback.ran {
+		t.Fatalf("expected both runners to run: primary=%v fallback=%v", primary.ran, fallback.ran)
+	}
+	if !res.Success {
+		t.Fatalf("expected fallback success, got %+v", res)
+	}
+	if res.Usage == nil {
+		t.Fatal("expected summed usage, got nil")
+	}
+	if res.Usage.TotalTokens != 165 || res.Usage.InputTokens != 110 || res.Usage.OutputTokens != 55 {
+		t.Errorf("tokens not summed across failover: %+v", res.Usage)
+	}
+	if res.Usage.NumTurns != 4 || res.Usage.NumToolCalls != 5 {
+		t.Errorf("turns/tool-calls not summed: %+v", res.Usage)
+	}
+	if diff := res.Usage.CostUSD - 0.021; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost not summed: got %v, want 0.021", res.Usage.CostUSD)
 	}
 }
 

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -219,7 +219,17 @@ func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.St
 		StartedAt:  s.StartedAt,
 		FinishedAt: s.FinishedAt,
 	}
-	if usage, err := d.db.GetStepUsage(ctx, instanceID, s.StepID); err == nil && usage != nil {
+	// Prefer the step's own usage rollup (summed across failover attempts). Fall
+	// back to the latest task_execution for rows written before step_runs carried
+	// these columns.
+	if db.StepRunHasUsage(s) {
+		srv.InputTokens = s.InputTokens
+		srv.OutputTokens = s.OutputTokens
+		srv.TotalTokens = s.TotalTokens
+		srv.CostUSD = s.CostUSD
+		srv.NumTurns = s.NumTurns
+		srv.NumToolCalls = s.NumToolCalls
+	} else if usage, err := d.db.GetStepUsage(ctx, instanceID, s.StepID); err == nil && usage != nil {
 		srv.InputTokens = usage.InputTokens
 		srv.OutputTokens = usage.OutputTokens
 		srv.TotalTokens = usage.TotalTokens

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1321,7 +1321,14 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 				StartedAt:  s.StartedAt,
 				FinishedAt: s.FinishedAt,
 			}
-			if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
+			if db.StepRunHasUsage(s) {
+				si.InputTokens = s.InputTokens
+				si.OutputTokens = s.OutputTokens
+				si.TotalTokens = s.TotalTokens
+				si.CostUSD = s.CostUSD
+				si.NumTurns = s.NumTurns
+				si.NumToolCalls = s.NumToolCalls
+			} else if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
 				si.InputTokens = usage.InputTokens
 				si.OutputTokens = usage.OutputTokens
 				si.TotalTokens = usage.TotalTokens
@@ -2054,13 +2061,19 @@ func mapStepRuns(steps []db.StepRun, now time.Time) []WorkflowStepItem {
 	out := make([]WorkflowStepItem, 0, len(steps))
 	for _, s := range steps {
 		out = append(out, WorkflowStepItem{
-			StepID:   s.StepID,
-			Agent:    s.AgentID,
-			State:    s.State,
-			Duration: wfStepDuration(s, now),
-			Cached:   s.SkippedCached,
-			Output:   s.Output,
-			Summary:  s.Summary,
+			StepID:       s.StepID,
+			Agent:        s.AgentID,
+			State:        s.State,
+			Duration:     wfStepDuration(s, now),
+			Cached:       s.SkippedCached,
+			Output:       s.Output,
+			Summary:      s.Summary,
+			InputTokens:  s.InputTokens,
+			OutputTokens: s.OutputTokens,
+			TotalTokens:  s.TotalTokens,
+			CostUSD:      s.CostUSD,
+			NumTurns:     s.NumTurns,
+			NumToolCalls: s.NumToolCalls,
 		})
 	}
 	return out

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -155,6 +155,11 @@ type Execution struct {
 	CostUSD            float64
 	WorkflowInstanceID string
 	StepID             string
+	// InputPrompt is the full composed prompt sent to the agent for this attempt;
+	// OutputText is the agent's raw output. Both are persisted for cost auditing
+	// and replay. Empty when the runner does not report a prompt.
+	InputPrompt string
+	OutputText  string
 }
 
 func (c *Client) CreateExecution(ctx context.Context, taskID, agentID, title, number, taskURL, model, runner string, attempt int) (*Execution, error) {
@@ -192,10 +197,12 @@ func (c *Client) UpdateExecution(ctx context.Context, exec *Execution) error {
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE task_executions
 		SET status = ?, completed_at = ?, duration_ms = ?, error_message = ?, can_retry = ?, next_retry_at = ?,
-		    input_tokens = ?, output_tokens = ?, total_tokens = ?, num_turns = ?, num_tool_calls = ?, cost_usd = ?
+		    input_tokens = ?, output_tokens = ?, total_tokens = ?, num_turns = ?, num_tool_calls = ?, cost_usd = ?,
+		    input_prompt = ?, output_text = ?
 		WHERE id = ?
 	`, exec.Status, exec.CompletedAt, exec.DurationMs, exec.ErrorMsg, exec.CanRetry, exec.NextRetryAt,
 		exec.InputTokens, exec.OutputTokens, exec.TotalTokens, exec.NumTurns, exec.NumToolCalls, exec.CostUSD,
+		nullStr(exec.InputPrompt), nullStr(exec.OutputText),
 		exec.ID)
 	return err
 }
@@ -275,7 +282,8 @@ func (c *Client) GetLastExecution(ctx context.Context, taskID string) (*Executio
 		SELECT id, task_id, agent_id, attempt, status, started_at, completed_at, duration_ms,
 		       error_message, can_retry, next_retry_at, created_at,
 		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
-		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0)
+		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0),
+		       COALESCE(input_prompt,''), COALESCE(output_text,'')
 		FROM task_executions
 		WHERE task_id = ?
 		ORDER BY attempt DESC
@@ -287,7 +295,8 @@ func (c *Client) GetLastExecution(ctx context.Context, taskID string) (*Executio
 		&exec.StartedAt, &exec.CompletedAt, &exec.DurationMs, &exec.ErrorMsg, &exec.CanRetry,
 		&exec.NextRetryAt, &exec.CreatedAt,
 		&exec.InputTokens, &exec.OutputTokens, &exec.TotalTokens,
-		&exec.NumTurns, &exec.NumToolCalls, &exec.CostUSD)
+		&exec.NumTurns, &exec.NumToolCalls, &exec.CostUSD,
+		&exec.InputPrompt, &exec.OutputText)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -213,6 +213,23 @@ var migrations = []string{
 	`ALTER TABLE step_runs ADD COLUMN publish_payload TEXT`,
 	`ALTER TABLE step_runs ADD COLUMN publish_state TEXT`,
 	`ALTER TABLE step_runs ADD COLUMN spawned_task_id TEXT REFERENCES internal_tasks(id)`,
+	// Per-step prompt capture: the full composed input prompt sent to the runner
+	// and the raw agent output text, persisted alongside the token/cost columns
+	// for cost auditing and replay. task_executions already carries the token and
+	// cost columns (one row per runner invocation, so failovers stay distinct).
+	`ALTER TABLE task_executions ADD COLUMN input_prompt TEXT`,
+	`ALTER TABLE task_executions ADD COLUMN output_text TEXT`,
+	// Per-step usage rollup on the logical step record: token counts and cost are
+	// summed across the step's failover attempts; input_prompt holds the final
+	// (winning) attempt's composed prompt. Timing (started_at/finished_at) and the
+	// output text already live on step_runs.
+	`ALTER TABLE step_runs ADD COLUMN input_prompt TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN input_tokens INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN output_tokens INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN total_tokens INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN num_turns INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN num_tool_calls INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN cost_usd REAL DEFAULT 0.0`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -70,8 +70,18 @@ type StepRun struct {
 	// SpawnedTaskID is the child InternalTask id created when the step emitted an
 	// APIARY_SPAWN request. Empty when the step spawned nothing.
 	SpawnedTaskID string
-	StartedAt     *time.Time
-	FinishedAt    *time.Time
+	// InputPrompt is the composed prompt of the step's final (winning) attempt.
+	InputPrompt string
+	// Token/cost rollup, summed across the step's failover attempts. Per-attempt
+	// detail lives in the linked task_executions rows.
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	NumTurns     int
+	NumToolCalls int
+	CostUSD      float64
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
@@ -342,18 +352,27 @@ func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, e
 	return res.RowsAffected()
 }
 
+// StepRunHasUsage reports whether a step run carries its own token/cost rollup
+// (populated since step_runs gained the usage columns). Rows written earlier
+// leave these at zero, in which case callers fall back to GetStepUsage.
+func StepRunHasUsage(s StepRun) bool {
+	return s.TotalTokens > 0 || s.InputTokens > 0 || s.OutputTokens > 0 || s.CostUSD > 0
+}
+
 // CreateStepRun inserts a new step run row.
 func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO step_runs
 		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
 		   summary, exit_code, skipped_cached, publish_payload, publish_state, spawned_task_id,
+		   input_prompt, input_tokens, output_tokens, total_tokens, num_turns, num_tool_calls, cost_usd,
 		   started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
-		nullStr(sr.SpawnedTaskID), sr.StartedAt, sr.FinishedAt)
+		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
+		sr.TotalTokens, sr.NumTurns, sr.NumToolCalls, sr.CostUSD, sr.StartedAt, sr.FinishedAt)
 	return err
 }
 
@@ -364,11 +383,14 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		UPDATE step_runs
 		SET state = ?, output = ?, structured_output = ?, summary = ?,
 		    exit_code = ?, skipped_cached = ?, publish_payload = ?, publish_state = ?,
-		    spawned_task_id = ?, started_at = ?, finished_at = ?
+		    spawned_task_id = ?, input_prompt = ?, input_tokens = ?, output_tokens = ?,
+		    total_tokens = ?, num_turns = ?, num_tool_calls = ?, cost_usd = ?,
+		    started_at = ?, finished_at = ?
 		WHERE id = ?
 	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
-		nullStr(sr.SpawnedTaskID), sr.StartedAt, sr.FinishedAt, sr.ID)
+		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
+		sr.TotalTokens, sr.NumTurns, sr.NumToolCalls, sr.CostUSD, sr.StartedAt, sr.FinishedAt, sr.ID)
 	return err
 }
 
@@ -379,7 +401,10 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		       COALESCE(output,''), COALESCE(structured_output,''), COALESCE(summary,''),
 		       COALESCE(exit_code,0), COALESCE(skipped_cached,0),
 		       COALESCE(publish_payload,''), COALESCE(publish_state,''),
-		       COALESCE(spawned_task_id,''), started_at, finished_at
+		       COALESCE(spawned_task_id,''), COALESCE(input_prompt,''),
+		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
+		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0.0),
+		       started_at, finished_at
 		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
 	`, instanceID)
 	if err != nil {
@@ -392,7 +417,9 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		var sr StepRun
 		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
 			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
-			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.StartedAt, &sr.FinishedAt); err != nil {
+			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.InputPrompt,
+			&sr.InputTokens, &sr.OutputTokens, &sr.TotalTokens, &sr.NumTurns, &sr.NumToolCalls,
+			&sr.CostUSD, &sr.StartedAt, &sr.FinishedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, sr)

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -215,6 +215,13 @@ func TestStepRun_CRUD(t *testing.T) {
 	sr.Output = "did the work"
 	sr.StructuredOutput = `{"complexity":"high"}`
 	sr.Summary = "- planned it"
+	sr.InputPrompt = "you are an architect; plan it"
+	sr.InputTokens = 120
+	sr.OutputTokens = 80
+	sr.TotalTokens = 200
+	sr.NumTurns = 3
+	sr.NumToolCalls = 5
+	sr.CostUSD = 0.0123
 	sr.FinishedAt = &finished
 	if err := c.UpdateStepRun(ctx, sr); err != nil {
 		t.Fatalf("update step run: %v", err)
@@ -239,6 +246,24 @@ func TestStepRun_CRUD(t *testing.T) {
 	}
 	if got.FinishedAt == nil {
 		t.Error("finished_at not persisted")
+	}
+	if got.InputPrompt != "you are an architect; plan it" {
+		t.Errorf("input prompt wrong: %q", got.InputPrompt)
+	}
+	if got.InputTokens != 120 || got.OutputTokens != 80 || got.TotalTokens != 200 {
+		t.Errorf("token columns wrong: %+v", got)
+	}
+	if got.NumTurns != 3 || got.NumToolCalls != 5 {
+		t.Errorf("turn/tool-call columns wrong: %+v", got)
+	}
+	if got.CostUSD != 0.0123 {
+		t.Errorf("cost wrong: %v", got.CostUSD)
+	}
+	if !StepRunHasUsage(got) {
+		t.Error("StepRunHasUsage should be true for a row with tokens/cost")
+	}
+	if StepRunHasUsage(StepRun{}) {
+		t.Error("StepRunHasUsage should be false for an empty row")
 	}
 }
 

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -58,6 +58,12 @@ type RunResult struct {
 	Error    error
 	Usage    *Usage // populated by runners that support usage reporting
 
+	// InputPrompt is the full composed prompt the runner sent to the agent (system
+	// prepend + cell details + system append, exactly as buildPrompt assembled it).
+	// Persisted per execution for cost auditing and replay. Empty for runners that
+	// do not report it.
+	InputPrompt string
+
 	// StructuredOutput is the parsed JSON object from the APIARY_OUTPUT: sentinel
 	// line, when present. Nil for runs that emit no structured output. The
 	// sentinel line is stripped from Output.

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -213,6 +213,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		Logs:        logs,
 		Duration:    time.Since(start),
 		Usage:       usagePtr,
+		InputPrompt: prompt,
 		RateLimited: rateLimited,
 	}
 	if rateLimited && rateLimitResetsAt > 0 {

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -85,7 +85,14 @@ type StepResult struct {
 	// SpawnRequest is the parsed APIARY_SPAWN request the agent emitted, if any.
 	// The engine creates a child task and dispatches the named workflow.
 	SpawnRequest *model.SpawnRequest
-	Err          error
+	// Usage is the token/cost rollup for the step, summed across the step's
+	// failover attempts (each attempt is also its own task_executions row). Nil
+	// when the runner reported no usage. The engine persists it onto the step run.
+	Usage *model.Usage
+	// InputPrompt is the composed prompt of the final (winning) attempt, persisted
+	// onto the step run for cost auditing and replay.
+	InputPrompt string
+	Err         error
 }
 
 // StepExecutor performs the actual runner invocation for a single agent step.
@@ -386,6 +393,15 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	sr.FinishedAt = &finished
 	sr.Output = res.Output
 	sr.Summary = res.Summary
+	sr.InputPrompt = res.InputPrompt
+	if res.Usage != nil {
+		sr.InputTokens = res.Usage.InputTokens
+		sr.OutputTokens = res.Usage.OutputTokens
+		sr.TotalTokens = res.Usage.TotalTokens
+		sr.NumTurns = res.Usage.NumTurns
+		sr.NumToolCalls = res.Usage.NumToolCalls
+		sr.CostUSD = res.Usage.CostUSD
+	}
 	if res.StructuredOutput != nil {
 		if data, err := json.Marshal(res.StructuredOutput); err == nil {
 			sr.StructuredOutput = string(data)


### PR DESCRIPTION
## Summary

Gives every workflow step full cost/usage detail — start/end time, token counts, money spent, the input prompt sent to the agent, and the agent's output — stored in **both** execution layers:

- **`task_executions`** (one row per runner invocation, so failovers stay distinct) gains `input_prompt` and `output_text`. It already carried tokens, cost, and timing.
- **`step_runs`** (one row per logical step) gains `input_prompt` plus a token/cost rollup (`input_tokens`, `output_tokens`, `total_tokens`, `num_turns`, `num_tool_calls`, `cost_usd`) **summed across the step's failover attempts**. Timing and output text already lived here.

### Plumbing
- `model.RunResult` gains `InputPrompt`; the CLI runner sets it to the composed prompt from `buildPrompt`.
- `finishExecution` writes `InputPrompt`/`OutputText` onto each `task_executions` row.
- `workflow.StepResult` gains `Usage` + `InputPrompt`; `ExecuteStep` sums usage across failover candidates and threads them to the engine, which persists them onto the step run.
- Dashboard step views (`stepRunView`, instance detail, `mapStepRuns`) now prefer the authoritative `step_runs` rollup — so displayed cost includes failover attempts — and fall back to `GetStepUsage` (latest `task_execution`) for pre-migration rows via the new `db.StepRunHasUsage` helper.

### Notes
- All changes are additive: new nullable columns (idempotent `ALTER` migrations), new struct fields, new optional `StepResult` fields. No renames or signature breaks. Impact risk: low.
- Schema migrations run on both fresh and existing DBs; old `step_runs` rows simply read back zeros and fall back to the per-execution view.

## Test plan
- `make check` (build + full test suite) passes; `go vet ./...` clean.
- Extended `TestStepRun_CRUD` to round-trip the new `step_runs` usage/prompt columns and cover `StepRunHasUsage`.
- Extended `TestWfStepExecutor_RecordsExecution` to assert prompts + usage propagate to `StepResult` and `task_executions`.
- Added `TestWfStepExecutor_SumsUsageAcrossFailover` verifying tokens/cost are summed when a rate-limited primary fails over to a fallback runner.