### PR TITLE
feat(runner): expose MCP servers to CLI agents (claude, opencode, cursor)

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -11,6 +11,12 @@ runners:
       - claude-opus-4-8
       - claude-sonnet-4-6
       - claude-haiku-4-5
+    # GitNexus code-intelligence MCP — exposed to every agent on this runner.
+    # `mcp` serves all repos already indexed via `gitnexus analyze`.
+    mcps:
+      - name: gitnexus
+        command: npx
+        args: ["-y", "gitnexus@latest", "mcp"]
 
 default_runner: claude
 

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -9,6 +9,17 @@ runners:
     provider: claude
     config:
       args: ["--output-format", "stream-json", "--verbose"]
+    # Model Context Protocol servers exposed to every agent on this runner.
+    # Each provider writes them into its own native MCP config: claude uses a
+    # temp file + `--mcp-config`, cursor merges ~/.cursor/mcp.json + `--approve-mcps`,
+    # opencode merges the global opencode.json `mcp` block. Agent-level `mcps:`
+    # (see agents below) override these by name.
+    mcps:
+      - name: gitnexus
+        command: npx
+        args: ["-y", "gitnexus@latest", "mcp"]
+        # env:                       # optional; ${VAR} refs are expanded at load
+        #   GITNEXUS_TOKEN: ${GITNEXUS_TOKEN}
 
   # Claude API runner (Anthropic API with full model access) — requires provider
   - id: claude-api
@@ -141,6 +152,12 @@ agents:
     fallbacks:
       - {runner: opencode-go-cli}
       - {runner: opencode-zen-cli}
+    # Agent-scope MCP servers are layered over the runner's `mcps:` (override by
+    # name, new names appended). Use this to give one agent an extra tool.
+    # mcps:
+    #   - name: playwright
+    #     command: npx
+    #     args: ["-y", "@playwright/mcp@latest"]
 
   - id: reviewer
     description: "Reviewer — performs code review and quality checks"
@@ -338,11 +355,20 @@ workflows:
   # workflows above; it is claimed by this workflow alone. (With exclusive: false,
   # the default, a task fans out to EVERY matching workflow, each as its own
   # instance, and the top-level `tasks:` hook below fires once all of them finish.)
+  #
+  # `once: true` — run this workflow at most once per task. Once it has a completed
+  # (done) instance for the task, later polls do NOT re-dispatch it even if the task
+  # still matches the trigger. Essential for a fan-out / decomposition workflow whose
+  # source item stays in its trigger set after it succeeds (e.g. it spawns children
+  # but does not change its own labels/state): without `once`, every poll would
+  # re-dispatch and create a DUPLICATE set of children (issue #119). Failed runs are
+  # not blocked — they stay eligible for retry up to settings.max_attempts.
   - id: incident-triage
     description: "Triage an incident, write a summary back to the issue, and spawn a collection task."
     trigger:
       priority: 5
       exclusive: true
+      once: true
       match:
         source: project-erp
         labels: [incident]
@@ -358,10 +384,17 @@ workflows:
           APIARY_PUBLISH_END
 
           APIARY_SPAWN_BEGIN
-          {"workflow": "collect-logs", "title": "Collect logs for incident", "input": {"severity": "high"}}
+          {"workflow": "collect-logs", "title": "Collect logs for incident", "input": {"severity": "high"}, "key": "incident/collect-logs"}
           APIARY_SPAWN_END
         publish: auto   # write the APIARY_PUBLISH payload back to the task's source bindings
         spawn: await    # block until the spawned collect-logs task is terminal; its failure fails this step
+        # "key" is OPTIONAL and makes spawning idempotent per parent task: re-running
+        # this step (or this whole workflow) with the same key resolves to the child
+        # already created instead of fanning out a duplicate. Use a stable per-task key
+        # (e.g. "<spec>/<task>") when one spec decomposes into a fixed set of sub-tasks,
+        # so a re-decomposition can never produce two of the same. When "key" is omitted
+        # the spawner derives one from (workflow, title, input), so byte-identical spawns
+        # still dedup; supply an explicit key whenever the title/input may vary across runs.
     on_complete:
       set_state: in review
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -127,6 +127,7 @@ erDiagram
         TEXT title
         TEXT description
         TEXT input "JSON from spawner"
+        TEXT dedup_key "idempotent spawn: UNIQUE(parent_task_id, dedup_key)"
         TEXT state "registered|running|approval_waiting|done|failed"
         TEXT metadata "JSON: labels, priority, type"
         INTEGER outstanding_workflows

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 type Config struct {
@@ -54,6 +55,11 @@ type RunnerConfig struct {
 	Provider string         `yaml:"provider,omitempty"` // adapter name: cli, opencode, script, claude, etc.
 	Config   map[string]any `yaml:"config"`
 	Models   []string       `yaml:"models,omitempty"`
+	// MCPs are Model Context Protocol servers exposed to every agent that uses
+	// this runner. Each CLI provider writes them into its own native MCP config
+	// format/location (see runner/execution). Agent-scope MCPs (AgentConfig.MCPs)
+	// are layered on top of these, overriding by name.
+	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
 }
 
 // AdapterName returns the runner adapter name as "{provider}-{type}" when both
@@ -86,6 +92,10 @@ type AgentConfig struct {
 	// it resets and retries the step on the next non-paused fallback. Empty means
 	// no failover (the step fails / waits for the limit to reset).
 	Fallbacks []FallbackConfig `yaml:"fallbacks,omitempty"`
+	// MCPs are Model Context Protocol servers scoped to this agent. They are
+	// layered on top of the runner's MCPs (RunnerConfig.MCPs), overriding any
+	// runner-scope server with the same name.
+	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner
@@ -137,6 +147,10 @@ type RouteConfig struct {
 	// RouteAll from considering any lower-priority route. Set by the Router when it
 	// synthesizes routes from workflow triggers.
 	Exclusive bool `yaml:"-"`
+	// Once mirrors TriggerConfig.Once: the dispatcher drops this route on a re-poll
+	// once the task already has a completed instance of it, so a run-at-most-once
+	// workflow does not re-dispatch. Set by the Router from the workflow trigger.
+	Once bool `yaml:"-"`
 }
 
 type RouteMatch struct {

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -3,7 +3,30 @@ package config
 import (
 	"fmt"
 	"os"
+
+	"github.com/orlandoburli/apiary/internal/model"
 )
+
+// validateMCPs checks that each MCP server has a name and command, and that
+// names are unique within the scope. `scope` is a human label for error
+// messages (e.g. `runners[0] "claude"`).
+func validateMCPs(scope string, mcps []model.MCPServer) []error {
+	var errs []error
+	seen := map[string]bool{}
+	for j, m := range mcps {
+		if m.Name == "" {
+			errs = append(errs, fmt.Errorf("%s: mcps[%d]: name is required", scope, j))
+		}
+		if m.Command == "" {
+			errs = append(errs, fmt.Errorf("%s: mcps[%d] %q: command is required", scope, j, m.Name))
+		}
+		if m.Name != "" && seen[m.Name] {
+			errs = append(errs, fmt.Errorf("%s: mcps[%d]: duplicate name %q", scope, j, m.Name))
+		}
+		seen[m.Name] = true
+	}
+	return errs
+}
 
 // Validate checks the config for structural errors.
 func (c *Config) Validate() []error {
@@ -25,6 +48,7 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("runners[%d]: duplicate id %q", i, r.ID))
 		}
 		runnerIDs[r.ID] = true
+		errs = append(errs, validateMCPs(fmt.Sprintf("runners[%d] %q", i, r.ID), r.MCPs)...)
 	}
 
 	if c.DefaultRunner != "" && !runnerIDs[c.DefaultRunner] {
@@ -72,6 +96,7 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("agents[%d]: duplicate id %q", i, a.ID))
 		}
 		agentIDs[a.ID] = true
+		errs = append(errs, validateMCPs(fmt.Sprintf("agents[%d] %q", i, a.ID), a.MCPs)...)
 	}
 
 	workerIDs := map[string]bool{}

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 func TestValidate_Valid(t *testing.T) {
@@ -29,6 +30,39 @@ func TestValidate_Valid(t *testing.T) {
 func TestValidate_MissingVersion(t *testing.T) {
 	cfg := &config.Config{}
 	assertError(t, cfg, "version is required")
+}
+
+func TestValidate_MCPMissingCommand(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "claude", Type: "cli", MCPs: []model.MCPServer{{Name: "gitnexus"}}},
+		},
+	}
+	assertError(t, cfg, "command is required")
+}
+
+func TestValidate_MCPMissingName(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Agents: []config.AgentConfig{
+			{ID: "a-1", Model: "m", MCPs: []model.MCPServer{{Command: "npx"}}},
+		},
+	}
+	assertError(t, cfg, "name is required")
+}
+
+func TestValidate_MCPDuplicateName(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "claude", Type: "cli", MCPs: []model.MCPServer{
+				{Name: "gitnexus", Command: "npx"},
+				{Name: "gitnexus", Command: "npx"},
+			}},
+		},
+	}
+	assertError(t, cfg, "duplicate name")
 }
 
 func TestValidate_MissingSourceID(t *testing.T) {

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -86,8 +86,16 @@ type TriggerConfig struct {
 	// Exclusive, when true, stops trigger evaluation after this trigger matches:
 	// no lower-priority trigger is considered. Use it for a terminal classifier or
 	// catch-all that must own a task alone rather than fan out alongside others.
-	Exclusive bool       `yaml:"exclusive"`
-	Match     RouteMatch `yaml:"match"`
+	Exclusive bool `yaml:"exclusive"`
+	// Once, when true, makes the workflow run at most once per task: once it has a
+	// completed (done) instance for the task, later polls do not re-dispatch it even
+	// if the task still matches the trigger. Use it for a decomposition/fan-out
+	// workflow whose source item (e.g. a spec issue) stays in its trigger set after
+	// the workflow succeeds — without it, every poll re-dispatches and produces a
+	// duplicate set of children (issue #119). Failed runs are not blocked (they
+	// remain eligible for retry up to settings.max_attempts).
+	Once  bool       `yaml:"once"`
+	Match RouteMatch `yaml:"match"`
 }
 
 // StepConfig is one node in a workflow graph. The active fields depend on Type.

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -220,7 +220,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			return nil, fmt.Errorf("agent %q: runner type %q not found", ac.ID, rc.Type)
 		}
 
-		if err := ra.Configure(rc.Config); err != nil {
+		if err := ra.Configure(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)); err != nil {
 			return nil, fmt.Errorf("agent %q: configure runner: %w", ac.ID, err)
 		}
 
@@ -247,7 +247,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
 			}
-			if err := fra.Configure(frc.Config); err != nil {
+			if err := fra.Configure(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)); err != nil {
 				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
 			}
 			if fAdapterName == "opencode" {
@@ -955,6 +955,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		// label-based lock (state_lock / "in-progress"), which is source-specific.
 		if persisted && d.db != nil {
 			matches = d.dropActiveMatches(ctx, task.ID, matches)
+			matches = d.dropOnceMatches(ctx, task.ID, matches)
 			matches = d.dropCappedMatches(ctx, task, matches)
 		}
 		if len(matches) == 0 {
@@ -1107,6 +1108,35 @@ func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, match
 		}
 		if active {
 			aplog.Debug("task %s: workflow %s already active (running/approval_waiting), skipping re-dispatch", taskID, m.Route.ID)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// dropOnceMatches removes matches whose trigger declared `once: true` and that
+// already have a completed (done) instance for this task. It is the source-agnostic
+// run-at-most-once guard: a decomposition / fan-out workflow whose source item (a
+// spec issue) stays in its trigger set after succeeding would otherwise be
+// re-dispatched on every poll, fanning out a duplicate set of children (issue
+// #119). Only routes that opt in via `once` are checked; all others pass through.
+// Fail-closed: on a query error the (once) match is dropped — skip this poll and
+// retry next, rather than risk a duplicate fan-out.
+func (d *Dispatcher) dropOnceMatches(ctx context.Context, taskID string, matches []router.Match) []router.Match {
+	out := make([]router.Match, 0, len(matches))
+	for _, m := range matches {
+		if !m.Route.Once {
+			out = append(out, m)
+			continue
+		}
+		done, err := d.db.HasCompletedInstanceForRoute(ctx, taskID, m.Route.ID)
+		if err != nil {
+			aplog.Error("once check task %s workflow %s: %v — skipping this poll", taskID, m.Route.ID, err)
+			continue
+		}
+		if done {
+			aplog.Debug("task %s: workflow %s already completed and is once-only, skipping re-dispatch", taskID, m.Route.ID)
 			continue
 		}
 		out = append(out, m)
@@ -1328,6 +1358,24 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		return err
 	}
 	return os.WriteFile(globalConfigPath, raw, 0644)
+}
+
+// runnerConfigWithMCPs returns the runner's config map augmented with the
+// resolved MCP servers (runner-scope defaults overlaid by agent-scope overrides,
+// keyed by name) under the "mcps" key, which CliRunner.Configure consumes. The
+// base map is never mutated — a shallow copy is returned only when there are
+// servers to inject, so MCP-less runners keep their original config untouched.
+func runnerConfigWithMCPs(base map[string]any, runnerMCPs, agentMCPs []model.MCPServer) map[string]any {
+	merged := model.MergeMCPServers(runnerMCPs, agentMCPs)
+	if len(merged) == 0 {
+		return base
+	}
+	out := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["mcps"] = merged
+	return out
 }
 
 func workerRunConfig(wc config.WorkerConfig) map[string]any {

--- a/src/internal/daemon/once_guard_test.go
+++ b/src/internal/daemon/once_guard_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// TestDropOnceMatches verifies the run-at-most-once guard (issue #119): a route
+// that opted into `once: true` is dropped once the task has a completed (done)
+// instance of it, so a spec/decomposition workflow whose source item stays in its
+// trigger set is not re-dispatched into a duplicate fan-out. Routes without `once`
+// are never dropped here, and a once-route that has not yet completed still runs.
+func TestDropOnceMatches(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "once.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	// task T1: the decomposition (once) workflow already ran to done; a second
+	// once-workflow only ever failed (not done); a normal workflow is also done.
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "decompose", CellID: "1986", TaskID: "T1", State: db.InstanceStateDone})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "decompose-retry", CellID: "1986", TaskID: "T1", State: db.InstanceStateFailed})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i3", WorkflowID: "implementation", CellID: "1986", TaskID: "T1", State: db.InstanceStateDone})
+
+	d := &Dispatcher{db: dbc}
+
+	matches := []router.Match{
+		{Route: config.RouteConfig{ID: "decompose", Once: true}},       // once + done → dropped
+		{Route: config.RouteConfig{ID: "decompose-retry", Once: true}}, // once but only failed → kept (retryable)
+		{Route: config.RouteConfig{ID: "implementation", Once: false}}, // not once → kept even though done
+		{Route: config.RouteConfig{ID: "po-spec", Once: true}},         // once but never ran → kept
+	}
+	got := d.dropOnceMatches(ctx, "T1", matches)
+
+	kept := map[string]bool{}
+	for _, m := range got {
+		kept[m.Route.ID] = true
+	}
+	if kept["decompose"] {
+		t.Error("decompose is once-only and already done; it must be dropped")
+	}
+	if !kept["decompose-retry"] {
+		t.Error("decompose-retry only failed (not done); once must not block a retry")
+	}
+	if !kept["implementation"] {
+		t.Error("implementation did not opt into once; it must be kept")
+	}
+	if !kept["po-spec"] {
+		t.Error("po-spec is once but never completed; it must be kept")
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 kept matches, got %d", len(got))
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -230,6 +230,12 @@ var migrations = []string{
 	`ALTER TABLE step_runs ADD COLUMN num_turns INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN num_tool_calls INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN cost_usd REAL DEFAULT 0.0`,
+	// Idempotent spawn (issue #119): a deterministic per-parent key so a re-run of
+	// the same decomposition resolves to the existing child instead of creating a
+	// duplicate set of sub-issues. The partial unique index enforces at-most-one
+	// child per (parent, dedup_key); NULL/empty keys (source-bound tasks) are exempt.
+	`ALTER TABLE internal_tasks ADD COLUMN dedup_key TEXT`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_internal_tasks_dedup ON internal_tasks(parent_task_id, dedup_key) WHERE dedup_key IS NOT NULL AND dedup_key != ''`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -79,12 +79,39 @@ func insertTask(ctx context.Context, ex execer, task *model.InternalTask) error 
 	_, err = ex.ExecContext(ctx, `
 		INSERT INTO internal_tasks
 		  (id, parent_task_id, title, description, input, state, metadata,
-		   outstanding_workflows, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		   outstanding_workflows, created_at, updated_at, dedup_key)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, task.ID, nullStr(task.ParentTaskID), task.Title, nullStr(task.Description),
 		inputJSON, string(task.State), string(metaJSON), task.OutstandingWorkflows,
-		task.CreatedAt, task.UpdatedAt)
+		task.CreatedAt, task.UpdatedAt, nullStr(task.DedupKey))
 	return err
+}
+
+// FindChildByDedupKey returns the child of parentTaskID whose dedup_key matches,
+// or (nil, nil) when none exists. It backs the spawner's idempotency check: a
+// re-run of the same decomposition resolves to the already-created child instead
+// of spawning a duplicate. An empty dedupKey never matches (returns nil, nil) —
+// only spawned tasks carry one. Backed by idx_internal_tasks_dedup.
+func (s *InternalTaskStore) FindChildByDedupKey(ctx context.Context, parentTaskID, dedupKey string) (*model.InternalTask, error) {
+	if dedupKey == "" {
+		return nil, nil
+	}
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks
+		WHERE parent_task_id = ? AND dedup_key = ?
+	`, parentTaskID, dedupKey)
+	task, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	task.DedupKey = dedupKey
+	return task, nil
 }
 
 // GetTask fetches a task by ID, or (nil, nil) if not found.

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -53,6 +53,70 @@ func TestInternalTask_CRUD(t *testing.T) {
 	}
 }
 
+func TestInternalTask_FindChildByDedupKey(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+
+	parent := &model.InternalTask{Title: "spec"}
+	if err := store.CreateTask(ctx, parent); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	child := &model.InternalTask{
+		ParentTaskID: parent.ID,
+		Title:        "DB Migration",
+		DedupKey:     "spec/db",
+	}
+	if err := store.CreateTask(ctx, child); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	got, err := store.FindChildByDedupKey(ctx, parent.ID, "spec/db")
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if got == nil || got.ID != child.ID {
+		t.Fatalf("FindChildByDedupKey returned %+v, want child %s", got, child.ID)
+	}
+
+	// Empty key never matches; a different key under the same parent misses.
+	if g, _ := store.FindChildByDedupKey(ctx, parent.ID, ""); g != nil {
+		t.Errorf("empty key should not match, got %+v", g)
+	}
+	if g, _ := store.FindChildByDedupKey(ctx, parent.ID, "spec/other"); g != nil {
+		t.Errorf("unknown key should not match, got %+v", g)
+	}
+}
+
+func TestInternalTask_DedupKeyUniquePerParent(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+
+	parent := &model.InternalTask{Title: "spec"}
+	if err := store.CreateTask(ctx, parent); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	first := &model.InternalTask{ParentTaskID: parent.ID, Title: "Backend", DedupKey: "spec/backend"}
+	if err := store.CreateTask(ctx, first); err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	// A second child with the same (parent, dedup_key) must be rejected by the
+	// partial unique index — this is what stops the duplicate fan-out (issue #119).
+	dup := &model.InternalTask{ParentTaskID: parent.ID, Title: "Backend", DedupKey: "spec/backend"}
+	if err := store.CreateTask(ctx, dup); err == nil {
+		t.Fatal("expected unique-constraint error for duplicate (parent, dedup_key), got nil")
+	}
+
+	// Empty dedup keys are exempt: multiple source-bound children may share a
+	// parent with no key.
+	for i := 0; i < 2; i++ {
+		if err := store.CreateTask(ctx, &model.InternalTask{ParentTaskID: parent.ID, Title: "no-key"}); err != nil {
+			t.Fatalf("empty-key child %d should be allowed: %v", i, err)
+		}
+	}
+}
+
 func TestInternalTask_GetMissing(t *testing.T) {
 	ctx := context.Background()
 	store := newTestClient(t).InternalTasks()

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -178,6 +178,24 @@ func (c *Client) HasActiveInstanceForRoute(ctx context.Context, taskID, workflow
 	return n > 0, err
 }
 
+// HasCompletedInstanceForRoute reports whether the task already has a successfully
+// completed (done) instance of the given workflow. The dispatcher uses it to honor
+// a trigger's `once: true`: a run-at-most-once workflow (e.g. a spec decomposition)
+// is not re-dispatched after it has succeeded, even when its source item stays in
+// the trigger set — the guard against duplicate fan-out (issue #119). Only the
+// done state counts; a failed instance stays eligible for retry.
+func (c *Client) HasCompletedInstanceForRoute(ctx context.Context, taskID, workflowID string) (bool, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_instances
+		WHERE task_id = ? AND workflow_id = ? AND state = ?
+	`, taskID, workflowID, InstanceStateDone).Scan(&n)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return n > 0, err
+}
+
 // ListWorkflowInstancesByState returns all instances in the given state, oldest first.
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -162,6 +162,40 @@ func TestHasActiveInstanceForRoute(t *testing.T) {
 	}
 }
 
+func TestHasCompletedInstanceForRoute(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// task T1: decompose done; T2: decompose still running; T3: decompose failed.
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-dec", WorkflowID: "decompose", CellID: "1986", TaskID: "T1", State: InstanceStateDone})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-dec", WorkflowID: "decompose", CellID: "1987", TaskID: "T2", State: InstanceStateRunning})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-dec", WorkflowID: "decompose", CellID: "1988", TaskID: "T3", State: InstanceStateFailed})
+
+	cases := []struct {
+		name       string
+		taskID     string
+		workflowID string
+		want       bool
+	}{
+		{"done blocks re-dispatch", "T1", "decompose", true},
+		{"running is not yet complete", "T2", "decompose", false},
+		{"failed does not count as completed", "T3", "decompose", false},
+		{"different workflow on same task", "T1", "implementation", false},
+		{"unknown task", "T9", "decompose", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := c.HasCompletedInstanceForRoute(ctx, tc.taskID, tc.workflowID)
+			if err != nil {
+				t.Fatalf("HasCompletedInstanceForRoute: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("HasCompletedInstanceForRoute(%q,%q) = %v, want %v", tc.taskID, tc.workflowID, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWorkflowInstance_ListByTask(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)

--- a/src/internal/model/mcp.go
+++ b/src/internal/model/mcp.go
@@ -1,0 +1,50 @@
+package model
+
+// MCPServer is a provider-agnostic Model Context Protocol server definition.
+// It is declared once in apiary.yaml (at runner and/or agent scope) and each
+// CLI runner serialises it into that provider's native MCP config format and
+// location (claude `.mcp.json`, cursor `.cursor/mcp.json`, opencode `mcp` block).
+//
+// Only stdio (local subprocess) servers are modelled — the common case for
+// code-intelligence tools like GitNexus. Remote/HTTP MCP servers are not yet
+// supported.
+type MCPServer struct {
+	// Name is the server key the agent sees (e.g. "gitnexus"). Required.
+	Name string `yaml:"name" json:"name"`
+	// Command is the executable launched over stdio (e.g. "npx"). Required.
+	Command string `yaml:"command" json:"command"`
+	// Args are the command arguments (e.g. ["-y", "gitnexus@latest", "mcp"]).
+	Args []string `yaml:"args,omitempty" json:"args,omitempty"`
+	// Env is the environment overlay for the server subprocess. ${VAR} references
+	// are already expanded by the config loader before they reach the runner.
+	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+}
+
+// MergeMCPServers overlays `overrides` on top of `base`, keyed by Name. An entry
+// in overrides with the same Name replaces the base entry; new names are
+// appended. Order is stable: base entries first (in their original order, with
+// any overridden in place), then any override-only entries. Used to layer
+// agent-scope MCP servers over runner-scope defaults.
+func MergeMCPServers(base, overrides []MCPServer) []MCPServer {
+	if len(overrides) == 0 {
+		return base
+	}
+	if len(base) == 0 {
+		return overrides
+	}
+	idx := make(map[string]int, len(base))
+	out := make([]MCPServer, len(base))
+	copy(out, base)
+	for i, s := range out {
+		idx[s.Name] = i
+	}
+	for _, o := range overrides {
+		if i, ok := idx[o.Name]; ok {
+			out[i] = o
+			continue
+		}
+		idx[o.Name] = len(out)
+		out = append(out, o)
+	}
+	return out
+}

--- a/src/internal/model/mcp_test.go
+++ b/src/internal/model/mcp_test.go
@@ -1,0 +1,46 @@
+package model
+
+import "testing"
+
+func names(mcps []MCPServer) []string {
+	out := make([]string, len(mcps))
+	for i, m := range mcps {
+		out[i] = m.Name
+	}
+	return out
+}
+
+func TestMergeMCPServers_AgentOverridesRunnerByName(t *testing.T) {
+	base := []MCPServer{
+		{Name: "gitnexus", Command: "npx", Args: []string{"runner"}},
+		{Name: "shared", Command: "shared-cmd"},
+	}
+	overrides := []MCPServer{
+		{Name: "gitnexus", Command: "npx", Args: []string{"agent"}}, // overrides
+		{Name: "extra", Command: "extra-cmd"},                       // appended
+	}
+	got := MergeMCPServers(base, overrides)
+
+	if want := []string{"gitnexus", "shared", "extra"}; len(got) != 3 {
+		t.Fatalf("expected order %v, got %v", want, names(got))
+	}
+	if got[0].Args[0] != "agent" {
+		t.Errorf("gitnexus should be overridden by agent scope, got args %v", got[0].Args)
+	}
+	if names(got)[2] != "extra" {
+		t.Errorf("expected 'extra' appended last, got %v", names(got))
+	}
+}
+
+func TestMergeMCPServers_Empties(t *testing.T) {
+	base := []MCPServer{{Name: "a", Command: "x"}}
+	if got := MergeMCPServers(base, nil); len(got) != 1 || got[0].Name != "a" {
+		t.Errorf("nil overrides should return base, got %v", names(got))
+	}
+	if got := MergeMCPServers(nil, base); len(got) != 1 || got[0].Name != "a" {
+		t.Errorf("nil base should return overrides, got %v", names(got))
+	}
+	if got := MergeMCPServers(nil, nil); len(got) != 0 {
+		t.Errorf("both nil should return empty, got %v", names(got))
+	}
+}

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -17,11 +17,16 @@ const (
 // created from a source binding (see SourceBinding) or spawned by a workflow
 // step (see SpawnRequest), in which case ParentTaskID and Input are populated.
 type InternalTask struct {
-	ID                   string
-	ParentTaskID         string // empty if root task
-	Title                string
-	Description          string
-	Input                map[string]any // structured input from spawner, nil for source-bound tasks
+	ID           string
+	ParentTaskID string // empty if root task
+	Title        string
+	Description  string
+	Input        map[string]any // structured input from spawner, nil for source-bound tasks
+	// DedupKey makes spawning idempotent: it is a deterministic key, unique within
+	// a parent, derived from the spawn request (or the caller-supplied SpawnRequest.Key).
+	// A re-run of the same decomposition resolves to the existing child instead of
+	// creating a duplicate. Empty for source-bound (non-spawned) tasks.
+	DedupKey             string
 	State                TaskState
 	Metadata             TaskMetadata
 	OutstandingWorkflows int
@@ -64,11 +69,16 @@ type SourceBinding struct {
 // SpawnRequest describes a new InternalTask requested by a workflow step via the
 // APIARY_SPAWN marker. WorkflowSpawner (internal/workflow) consumes it to create
 // the child task and dispatch the named workflow. The JSON tags map the marker's
-// payload ({"workflow","title","input"}) onto this struct; ParentTaskID is never
-// taken from agent output — the engine sets it to the spawning task's id.
+// payload ({"workflow","title","input","key"}) onto this struct; ParentTaskID is
+// never taken from agent output — the engine sets it to the spawning task's id.
 type SpawnRequest struct {
 	ParentTaskID string         `json:"-"`
 	WorkflowID   string         `json:"workflow"`
 	Title        string         `json:"title"`
 	Input        map[string]any `json:"input"`
+	// Key is an optional caller-supplied idempotency key (the per-spec "task_key"):
+	// when set, two spawns with the same Key under the same parent resolve to the
+	// same child. When empty the spawner derives a key from (workflow, title, input)
+	// so identical re-runs still dedup. See WorkflowSpawner.Spawn.
+	Key string `json:"key,omitempty"`
 }

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -60,6 +60,7 @@ func New(cfg *config.Config) (*Router, error) {
 			Match:     wf.Trigger.Match,
 			Agent:     firstAgentStep(wf),
 			Exclusive: wf.Trigger.Exclusive,
+			Once:      wf.Trigger.Once,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -27,6 +27,14 @@ type CliRunner struct {
 	promptFlag       string
 	turnsFlag        string
 	promptPositional bool // pass prompt as last positional arg instead of a flag
+	// mcpFormat selects how MCP servers are serialised into the provider's native
+	// config ("claude" | "cursor" | "opencode"); empty disables MCP support.
+	mcpFormat string
+	// mcps are the resolved (runner + agent) MCP servers for this runner instance.
+	mcps []model.MCPServer
+	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
+	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
+	mcpRunArgs []string
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -56,6 +64,22 @@ func (r *CliRunner) Configure(config map[string]any) error {
 			}
 		}
 	}
+	if v, ok := config["mcp_format"].(string); ok && v != "" {
+		r.mcpFormat = v
+	}
+	if v, ok := config["mcps"].([]model.MCPServer); ok {
+		r.mcps = v
+	}
+	// Materialise the provider's MCP config (and any per-run CLI args) once the
+	// servers are known. Configure runs at load time, sequentially across agents,
+	// so the global-config merges (cursor/opencode) are race-free.
+	if len(r.mcps) > 0 {
+		args, err := r.setupMCP()
+		if err != nil {
+			return fmt.Errorf("cli runner: setup MCP: %w", err)
+		}
+		r.mcpRunArgs = args
+	}
 	return nil
 }
 
@@ -64,6 +88,9 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	prompt := buildPrompt(req)
 
 	argv := append([]string{}, r.args...)
+	// Inject MCP activation args (e.g. claude's "--mcp-config <path>") before the
+	// model/prompt flags; the provider config itself was written by setupMCP.
+	argv = append(argv, r.mcpRunArgs...)
 	if r.modelFlag != "" && req.Model != "" {
 		argv = append(argv, r.modelFlag, req.Model)
 	}

--- a/src/internal/runner/execution/cli_mcp.go
+++ b/src/internal/runner/execution/cli_mcp.go
@@ -1,0 +1,158 @@
+package execution
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// setupMCP writes the runner's MCP servers into the provider's native config
+// format/location and returns extra CLI args to inject into every run.
+//
+// Each provider differs in both the on-disk format and how the CLI is told to
+// load it:
+//
+//   - claude   → a temp `{"mcpServers":{…}}` file, activated per run with the
+//     trusted `--mcp-config <path>` flag (no approval prompt, no workdir mutation).
+//   - cursor   → merged into the user's global `~/.cursor/mcp.json` (mcpServers
+//     format), activated with `--approve-mcps`.
+//   - opencode → merged into the global `~/.config/opencode/opencode.json` under
+//     the `mcp` key (local format); opencode auto-discovers it, so no run args.
+//
+// Called once from Configure (load time, sequential across agents) so the
+// global-config merges are race-free. Returns nil args when there are no servers
+// or the provider has no MCP support.
+func (r *CliRunner) setupMCP() ([]string, error) {
+	if len(r.mcps) == 0 {
+		return nil, nil
+	}
+	switch r.mcpFormat {
+	case "claude":
+		return r.setupClaudeMCP()
+	case "cursor":
+		return r.setupCursorMCP()
+	case "opencode":
+		return r.setupOpencodeMCP()
+	default:
+		return nil, nil
+	}
+}
+
+// setupClaudeMCP writes a temp .mcp.json and returns the --mcp-config flag.
+func (r *CliRunner) setupClaudeMCP() ([]string, error) {
+	doc := map[string]any{"mcpServers": mcpServersObject(r.mcps)}
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal claude mcp: %w", err)
+	}
+	f, err := os.CreateTemp("", "apiary-mcp-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create claude mcp file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(raw); err != nil {
+		return nil, fmt.Errorf("write claude mcp file: %w", err)
+	}
+	return []string{"--mcp-config", f.Name()}, nil
+}
+
+// setupCursorMCP merges the servers into ~/.cursor/mcp.json and returns the
+// --approve-mcps flag so the headless agent auto-trusts them.
+func (r *CliRunner) setupCursorMCP() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("home dir: %w", err)
+	}
+	path := filepath.Join(home, ".cursor", "mcp.json")
+	if err := mergeMCPServersFile(path, r.mcps); err != nil {
+		return nil, fmt.Errorf("merge cursor mcp: %w", err)
+	}
+	return []string{"--approve-mcps"}, nil
+}
+
+// setupOpencodeMCP merges the servers into the global opencode.json `mcp` block.
+// opencode auto-discovers the global config, so no per-run args are needed.
+func (r *CliRunner) setupOpencodeMCP() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("home dir: %w", err)
+	}
+	path := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, fmt.Errorf("create opencode config dir: %w", err)
+	}
+	doc := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		_ = json.Unmarshal(data, &doc)
+	}
+	mcp, _ := doc["mcp"].(map[string]any)
+	if mcp == nil {
+		mcp = map[string]any{}
+	}
+	for _, m := range r.mcps {
+		entry := map[string]any{
+			"type":    "local",
+			"command": append([]string{m.Command}, m.Args...),
+			"enabled": true,
+		}
+		if len(m.Env) > 0 {
+			entry["environment"] = m.Env
+		}
+		mcp[m.Name] = entry
+	}
+	doc["mcp"] = mcp
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal opencode config: %w", err)
+	}
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		return nil, fmt.Errorf("write opencode config: %w", err)
+	}
+	return nil, nil
+}
+
+// mcpServersObject builds the `mcpServers` map shared by the claude and cursor
+// formats: {name: {command, args?, env?}}.
+func mcpServersObject(mcps []model.MCPServer) map[string]any {
+	out := make(map[string]any, len(mcps))
+	for _, m := range mcps {
+		entry := map[string]any{"command": m.Command}
+		if len(m.Args) > 0 {
+			entry["args"] = m.Args
+		}
+		if len(m.Env) > 0 {
+			entry["env"] = m.Env
+		}
+		out[m.Name] = entry
+	}
+	return out
+}
+
+// mergeMCPServersFile reads an existing {"mcpServers":{…}} JSON file (claude /
+// cursor format), overlays the given servers by name, and writes it back,
+// preserving any servers the user configured by hand.
+func mergeMCPServersFile(path string, mcps []model.MCPServer) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	doc := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil && len(data) > 0 {
+		_ = json.Unmarshal(data, &doc)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	for name, entry := range mcpServersObject(mcps) {
+		servers[name] = entry
+	}
+	doc["mcpServers"] = servers
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0644)
+}

--- a/src/internal/runner/execution/cli_mcp_test.go
+++ b/src/internal/runner/execution/cli_mcp_test.go
@@ -1,0 +1,151 @@
+package execution
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+var gitnexusMCP = model.MCPServer{
+	Name:    "gitnexus",
+	Command: "npx",
+	Args:    []string{"-y", "gitnexus@latest", "mcp"},
+	Env:     map[string]string{"GITNEXUS_REPO": "project-erp"},
+}
+
+func TestSetupMCP_ClaudeWritesFileAndFlag(t *testing.T) {
+	r := &CliRunner{mcpFormat: "claude", mcps: []model.MCPServer{gitnexusMCP}}
+	args, err := r.setupMCP()
+	if err != nil {
+		t.Fatalf("setupMCP: %v", err)
+	}
+	if len(args) != 2 || args[0] != "--mcp-config" {
+		t.Fatalf("expected [--mcp-config <path>], got %v", args)
+	}
+	path := args[1]
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read mcp file: %v", err)
+	}
+	var doc struct {
+		MCPServers map[string]struct {
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	gn, ok := doc.MCPServers["gitnexus"]
+	if !ok {
+		t.Fatalf("gitnexus server missing: %s", data)
+	}
+	if gn.Command != "npx" || len(gn.Args) != 3 || gn.Env["GITNEXUS_REPO"] != "project-erp" {
+		t.Fatalf("unexpected server entry: %+v", gn)
+	}
+}
+
+func TestSetupMCP_CursorMergesGlobalFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed an existing hand-configured server to verify the merge preserves it.
+	cursorPath := filepath.Join(home, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(cursorPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"mcpServers":{"other":{"command":"foo"}}}`
+	if err := os.WriteFile(cursorPath, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &CliRunner{mcpFormat: "cursor", mcps: []model.MCPServer{gitnexusMCP}}
+	args, err := r.setupMCP()
+	if err != nil {
+		t.Fatalf("setupMCP: %v", err)
+	}
+	if len(args) != 1 || args[0] != "--approve-mcps" {
+		t.Fatalf("expected [--approve-mcps], got %v", args)
+	}
+
+	data, _ := os.ReadFile(cursorPath)
+	var doc struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := doc.MCPServers["other"]; !ok {
+		t.Errorf("merge dropped the pre-existing 'other' server: %s", data)
+	}
+	if _, ok := doc.MCPServers["gitnexus"]; !ok {
+		t.Errorf("gitnexus not added: %s", data)
+	}
+}
+
+func TestSetupMCP_OpencodeMergesLocalFormat(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r := &CliRunner{mcpFormat: "opencode", mcps: []model.MCPServer{gitnexusMCP}}
+	args, err := r.setupMCP()
+	if err != nil {
+		t.Fatalf("setupMCP: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("opencode auto-discovers config; expected no run args, got %v", args)
+	}
+
+	path := filepath.Join(home, ".config", "opencode", "opencode.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read opencode config: %v", err)
+	}
+	var doc struct {
+		MCP map[string]struct {
+			Type    string            `json:"type"`
+			Command []string          `json:"command"`
+			Enabled bool              `json:"enabled"`
+			Env     map[string]string `json:"environment"`
+		} `json:"mcp"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	gn, ok := doc.MCP["gitnexus"]
+	if !ok {
+		t.Fatalf("gitnexus missing: %s", data)
+	}
+	if gn.Type != "local" || !gn.Enabled {
+		t.Errorf("expected type=local enabled=true, got %+v", gn)
+	}
+	want := []string{"npx", "-y", "gitnexus@latest", "mcp"}
+	if len(gn.Command) != len(want) {
+		t.Fatalf("command mismatch: got %v want %v", gn.Command, want)
+	}
+	for i := range want {
+		if gn.Command[i] != want[i] {
+			t.Fatalf("command[%d] = %q, want %q", i, gn.Command[i], want[i])
+		}
+	}
+	if gn.Env["GITNEXUS_REPO"] != "project-erp" {
+		t.Errorf("environment not mapped: %+v", gn.Env)
+	}
+}
+
+func TestSetupMCP_UnknownFormatNoop(t *testing.T) {
+	r := &CliRunner{mcpFormat: "", mcps: []model.MCPServer{gitnexusMCP}}
+	args, err := r.setupMCP()
+	if err != nil {
+		t.Fatalf("setupMCP: %v", err)
+	}
+	if args != nil {
+		t.Fatalf("expected nil args for unsupported provider, got %v", args)
+	}
+}

--- a/src/internal/runner/providers/providers.go
+++ b/src/internal/runner/providers/providers.go
@@ -21,12 +21,17 @@ func init() {
 		}
 	}
 
-	runner.Register("claude-cli", cliFactory("claude", nil))
+	// mcp_format selects how the CLI runner serialises MCP servers into the
+	// provider's native config (see execution.CliRunner.setupMCP).
+	runner.Register("claude-cli", cliFactory("claude", map[string]any{
+		"mcp_format": "claude",
+	}))
 
 	runner.Register("opencode-cli", cliFactory("opencode", map[string]any{
 		"args":              []any{"run"},
 		"prompt_flag":       "",
 		"prompt_positional": true,
+		"mcp_format":        "opencode",
 	}))
 
 	// Cursor agent CLI — requires the `agent` binary from https://cursor.com/install.
@@ -35,6 +40,7 @@ func init() {
 		"args":              []any{"-p", "--output-format", "stream-json", "--force"},
 		"prompt_flag":       "",
 		"prompt_positional": true,
+		"mcp_format":        "cursor",
 	}))
 
 	// ── API providers ──────────────────────────────────────────────────────────

--- a/src/internal/workflow/spawner.go
+++ b/src/internal/workflow/spawner.go
@@ -2,11 +2,16 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -25,10 +30,12 @@ type WorkflowSpawner interface {
 	Await(ctx context.Context, taskID string) (bool, error)
 }
 
-// taskCreator persists a new InternalTask, filling in any unset id/timestamps.
-// *db.InternalTaskStore satisfies it.
+// taskCreator persists a new InternalTask and looks one up by its idempotency
+// key. *db.InternalTaskStore satisfies it. FindChildByDedupKey returns (nil, nil)
+// when no child matches; the spawner uses it to dedup re-runs (issue #119).
 type taskCreator interface {
 	CreateTask(ctx context.Context, task *model.InternalTask) error
+	FindChildByDedupKey(ctx context.Context, parentTaskID, dedupKey string) (*model.InternalTask, error)
 }
 
 // DefaultSpawner is the production WorkflowSpawner. It resolves the named
@@ -83,10 +90,29 @@ func NewDefaultSpawner(
 // parent id and input, and launches the workflow on its own goroutine. The child
 // is returned immediately in the registered state; spawn:await callers block via
 // Await. A missing workflow or a persistence failure is returned synchronously.
+//
+// Spawning is idempotent within a parent (issue #119): each request carries a
+// deterministic dedup key (req.Key, or one derived from workflow+title+input).
+// If a child with that key already exists under the same parent, Spawn returns
+// it without creating a duplicate or launching the workflow again — so re-running
+// the same decomposition does not fan out a second, duplicate set of sub-issues.
 func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error) {
 	wf, ok := s.resolve(req.WorkflowID)
 	if !ok {
 		return model.InternalTask{}, fmt.Errorf("workflow %q not found", req.WorkflowID)
+	}
+
+	dedupKey := spawnDedupKey(req)
+
+	// Idempotency check: a re-run of the same decomposition resolves to the
+	// existing child rather than spawning a duplicate.
+	if existing, err := s.creator.FindChildByDedupKey(ctx, req.ParentTaskID, dedupKey); err != nil {
+		return model.InternalTask{}, fmt.Errorf("dedup-check spawned task: %w", err)
+	} else if existing != nil {
+		aplog.Info("spawn deduped: parent %s already has child %s for key %q (workflow %q) — not re-spawning",
+			req.ParentTaskID, existing.ID, dedupKey, req.WorkflowID)
+		s.trackExisting(*existing)
+		return *existing, nil
 	}
 
 	now := s.now()
@@ -95,12 +121,22 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 		ParentTaskID: req.ParentTaskID,
 		Title:        req.Title,
 		Input:        req.Input,
+		DedupKey:     dedupKey,
 		State:        model.TaskStateRegistered,
 		Metadata:     model.TaskMetadata{Type: "internal"},
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
 	if err := s.creator.CreateTask(ctx, &child); err != nil {
+		// Lost a race against a concurrent spawn of the same key: the unique index
+		// on (parent_task_id, dedup_key) rejected the insert. Resolve to the child
+		// the winner created instead of surfacing the constraint error.
+		if existing, ferr := s.creator.FindChildByDedupKey(ctx, req.ParentTaskID, dedupKey); ferr == nil && existing != nil {
+			aplog.Info("spawn deduped (race): parent %s resolved to child %s for key %q",
+				req.ParentTaskID, existing.ID, dedupKey)
+			s.trackExisting(*existing)
+			return *existing, nil
+		}
 		return model.InternalTask{}, fmt.Errorf("create spawned task: %w", err)
 	}
 
@@ -119,6 +155,48 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 	}()
 
 	return child, nil
+}
+
+// trackExisting registers a completion handle for a child resolved via dedup, so
+// a spawn:await caller can still observe its outcome. If the child is already
+// tracked in this process (its workflow is in flight here), the live handle is
+// kept. Otherwise a pre-closed handle is registered reporting success only when
+// the child has already reached the done state — a deduped child is virtually
+// always terminal, since the parent step that re-spawns ran after the first
+// completed.
+func (s *DefaultSpawner) trackExisting(child model.InternalTask) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.running[child.ID]; ok {
+		return
+	}
+	done := make(chan struct{})
+	close(done)
+	s.running[child.ID] = &spawnHandle{done: done, success: child.State == model.TaskStateDone}
+}
+
+// spawnDedupKey returns the deterministic idempotency key for a spawn request,
+// scoped to its parent via the (parent_task_id, dedup_key) unique index. A caller
+// -supplied req.Key is used verbatim (the per-spec "task_key"). Otherwise the key
+// is derived by hashing the workflow id, title, and canonical input, so two
+// identical spawns (the duplicate-decomposition case) collapse to one child.
+func spawnDedupKey(req model.SpawnRequest) string {
+	if k := strings.TrimSpace(req.Key); k != "" {
+		return k
+	}
+	// json.Marshal sorts map keys, so the input encoding is stable. A nil input
+	// marshals to "null"; any marshal error falls back to the title alone.
+	inputJSON, err := json.Marshal(req.Input)
+	if err != nil {
+		inputJSON = nil
+	}
+	h := sha256.New()
+	h.Write([]byte(req.WorkflowID))
+	h.Write([]byte{0x1f})
+	h.Write([]byte(req.Title))
+	h.Write([]byte{0x1f})
+	h.Write(inputJSON)
+	return "auto:" + hex.EncodeToString(h.Sum(nil))
 }
 
 // Await blocks until the workflow launched for taskID reaches a terminal state,

--- a/src/internal/workflow/spawner_test.go
+++ b/src/internal/workflow/spawner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,8 @@ import (
 )
 
 // fakeCreator records created tasks. CreateTask mimics the store's behaviour of
-// leaving a caller-supplied id in place.
+// leaving a caller-supplied id in place, and FindChildByDedupKey mimics the
+// (parent_task_id, dedup_key) unique index so idempotency can be exercised.
 type fakeCreator struct {
 	mu    sync.Mutex
 	tasks []model.InternalTask
@@ -20,9 +22,31 @@ type fakeCreator struct {
 
 func (f *fakeCreator) CreateTask(_ context.Context, t *model.InternalTask) error {
 	f.mu.Lock()
+	defer f.mu.Unlock()
+	if t.DedupKey != "" {
+		for _, existing := range f.tasks {
+			if existing.ParentTaskID == t.ParentTaskID && existing.DedupKey == t.DedupKey {
+				return fmt.Errorf("UNIQUE constraint failed: internal_tasks.dedup_key")
+			}
+		}
+	}
 	f.tasks = append(f.tasks, *t)
-	f.mu.Unlock()
 	return nil
+}
+
+func (f *fakeCreator) FindChildByDedupKey(_ context.Context, parentTaskID, dedupKey string) (*model.InternalTask, error) {
+	if dedupKey == "" {
+		return nil, nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := range f.tasks {
+		if f.tasks[i].ParentTaskID == parentTaskID && f.tasks[i].DedupKey == dedupKey {
+			found := f.tasks[i]
+			return &found, nil
+		}
+	}
+	return nil, nil
 }
 
 func (f *fakeCreator) created() []model.InternalTask {
@@ -94,6 +118,87 @@ func TestDefaultSpawner_CreatesChildAndRuns(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("named workflow was not dispatched")
+	}
+}
+
+// TestDefaultSpawner_IdempotentPerSpec covers issue #119: re-running the same
+// decomposition (same parent + workflow + title + input, or an explicit key)
+// must resolve to the existing child instead of fanning out a duplicate set of
+// sub-issues. The workflow is launched exactly once.
+func TestDefaultSpawner_IdempotentPerSpec(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		req  model.SpawnRequest
+	}{
+		{"derived key (identical title+input)", model.SpawnRequest{
+			ParentTaskID: "spec-1986",
+			WorkflowID:   "implementation",
+			Title:        "DB Migration: fabricantes",
+			Input:        map[string]any{"task": "db", "table": "fabricantes"},
+		}},
+		{"explicit task_key", model.SpawnRequest{
+			ParentTaskID: "spec-1986",
+			WorkflowID:   "implementation",
+			Title:        "Backend CRUD",
+			Key:          "spec-1986/backend",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			creator := &fakeCreator{}
+			var runs int32
+			run := func(_ context.Context, _ config.WorkflowConfig, _ model.InternalTask) (bool, error) {
+				atomic.AddInt32(&runs, 1)
+				return true, nil
+			}
+			s := NewDefaultSpawner(
+				func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "implementation"}, true },
+				creator, run, testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+			)
+
+			first, err := s.Spawn(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("first Spawn: %v", err)
+			}
+			second, err := s.Spawn(context.Background(), tc.req)
+			if err != nil {
+				t.Fatalf("second Spawn: %v", err)
+			}
+
+			if second.ID != first.ID {
+				t.Errorf("second spawn created a new child %q, want existing %q", second.ID, first.ID)
+			}
+			if created := creator.created(); len(created) != 1 {
+				t.Fatalf("created %d child tasks, want 1 (duplicate spawn not deduped)", len(created))
+			}
+			// Give the (single) launched workflow a moment, then assert it ran once.
+			time.Sleep(50 * time.Millisecond)
+			if n := atomic.LoadInt32(&runs); n != 1 {
+				t.Errorf("workflow launched %d times, want 1", n)
+			}
+		})
+	}
+}
+
+// TestDefaultSpawner_DistinctTasksNotDeduped guards against over-eager dedup:
+// different tasks of the same spec (distinct titles) must each get their own
+// child.
+func TestDefaultSpawner_DistinctTasksNotDeduped(t *testing.T) {
+	creator := &fakeCreator{}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "implementation"}, true },
+		creator,
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+	for _, title := range []string{"DB Migration", "Backend CRUD", "Frontend", "E2E"} {
+		if _, err := s.Spawn(context.Background(), model.SpawnRequest{
+			ParentTaskID: "spec-1986", WorkflowID: "implementation", Title: title,
+		}); err != nil {
+			t.Fatalf("Spawn %q: %v", title, err)
+		}
+	}
+	if created := creator.created(); len(created) != 4 {
+		t.Fatalf("created %d children, want 4 distinct", len(created))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a provider-agnostic `mcps:` block to **runners** and **agents** in `apiary.yaml`. Each CLI provider serialises the servers into its **own native MCP config format and location**, so a single declaration works across all three CLIs.

| Provider | Format | Location | Activation |
|----------|--------|----------|------------|
| **claude** | `{"mcpServers":{…}}` | temp file | `--mcp-config <path>` (trusted, no approval, no workdir mutation) |
| **cursor** | `{"mcpServers":{…}}` | `~/.cursor/mcp.json` (merged) | `--approve-mcps` |
| **opencode** | `{"mcp":{…}}` (local) | global `opencode.json` (merged) | auto-discovered |

### Scoping & merge
- **Runner-scope** `mcps:` → defaults inherited by every agent on that runner.
- **Agent-scope** `mcps:` → layered on top, **override by name**, new names appended.
- `${VAR}` refs in `env` are expanded by the existing config loader.

### GitNexus wired in
`.apiary/apiary.yaml` now exposes GitNexus to every agent, so agents can run impact analysis and query the code graph per the project's `CLAUDE.md` conventions.

## How it works

```yaml
runners:
  - id: claude
    type: cli
    provider: claude
    mcps:
      - name: gitnexus
        command: npx
        args: ["-y", "gitnexus@latest", "mcp"]
```

## Changes
- **model**: `MCPServer` type + `MergeMCPServers` (runner+agent overlay)
- **config**: `MCPs` field on `RunnerConfig`/`AgentConfig` + validation (name/command required, dup names)
- **runner/execution**: `CliRunner.setupMCP` writes per-provider config + injects run args
- **daemon**: inject resolved MCPs into runner `Configure` (primary + fallback chains)
- **docs**: `example-apiary-full.yaml` documents runner + agent-level usage

## Testing
- `make build` ✓ · `go test ./...` ✓ · `go vet` ✓ · `apiary validate` ✓ (both configs)
- **End-to-end**: confirmed `claude --mcp-config <generated>` loads all 13 `gitnexus_*` tools.
- New unit tests: `MergeMCPServers`, the 3 provider serialisers (claude/cursor/opencode), validation.

## ⚠️ Carried WIP
This branch also carries **pre-existing in-progress work** for the run-at-most-once workflow guard (issue #119) — entangled in `config.go`, `dispatcher.go`, `example-apiary-full.yaml`, plus the `db/`, `workflow/`, `router/`, `model/task.go` changes and `once_guard_test.go`. It could not be cleanly separated without stashing. Review/split before merge if you want the MCP feature isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)