### PR TITLE
fix(dashboard): don't show failed tasks as completed

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -2695,7 +2695,14 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	row("Runner", valueOr(d.Runner, "—"))
 	row("Attempts", fmt.Sprintf("%d", d.Attempt))
 	row("Started", started)
-	row("Completed", completed)
+	// Label the terminal timestamp by outcome: a failed task that shows
+	// "Completed: <time>" reads as success even though the Status badge says
+	// failed. CompletedAt is populated for both done and failed terminal states.
+	endedLabel := "Completed"
+	if d.Status == "failed" {
+		endedLabel = "Failed at"
+	}
+	row(endedLabel, completed)
 	row("Duration", dur)
 	row("Tokens", fmt.Sprintf("%d in / %d out / %d total", d.InputTokens, d.OutputTokens, d.TotalTokens))
 	row("Turns / Calls", fmt.Sprintf("%d / %d", d.NumTurns, d.NumToolCalls))
@@ -2823,14 +2830,36 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 		b.WriteString("  " + StyleWarning.Render("⏸ "+inst.Message) + "\n")
 	}
 
-	if len(inst.Steps) == 0 {
-		return b.String()
+	if len(inst.Steps) > 0 {
+		b.WriteString("\n  " + StyleLabel.Render("Steps") + "\n")
+		for _, s := range inst.Steps {
+			b.WriteString("    " + wfStepRow(s) + "\n")
+		}
 	}
-	b.WriteString("\n  " + StyleLabel.Render("Steps") + "\n")
-	for _, s := range inst.Steps {
-		b.WriteString("    " + wfStepRow(s) + "\n")
+	if m := wfFailureMarker(inst); m != "" {
+		b.WriteString("  " + m + "\n")
 	}
 	return b.String()
+}
+
+// wfFailureMarker returns a one-line notice when an instance is failed but none
+// of its recorded steps is — i.e. the run died after (or between) the steps that
+// were persisted (e.g. a later CI-wait or gate), so the all-passed step list
+// would otherwise read as a completed run.
+func wfFailureMarker(inst *WorkflowInstanceItem) string {
+	if inst.State != db.InstanceStateFailed {
+		return ""
+	}
+	for _, s := range inst.Steps {
+		if s.State == db.StepStateFailed {
+			return "" // the failing step is already visible in the list
+		}
+	}
+	after := "before any step completed"
+	if n := len(inst.Steps); n > 0 {
+		after = "after step '" + inst.Steps[n-1].StepID + "'"
+	}
+	return StyleError.Render("✗ workflow failed " + after + " — no further steps recorded")
 }
 
 // wfStepRow formats a single workflow step as one display row (glyph, step id,
@@ -2992,6 +3021,9 @@ func (a *App) taskHistoryLines() []string {
 			if s.Summary != "" {
 				out = append(out, "      "+StyleMuted.Render(truncate(s.Summary, sw)))
 			}
+		}
+		if m := wfFailureMarker(&seg.Instance); m != "" {
+			out = append(out, "  "+m)
 		}
 		out = append(out, a.logEntryLines(seg.Logs)...)
 	}

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -535,6 +535,43 @@ func TestTaskDetailShowsUsageWhenZero(t *testing.T) {
 	}
 }
 
+// A failed task populates CompletedAt too, so the terminal-timestamp row must
+// be relabeled "Failed at" rather than "Completed" (which reads as success).
+func TestTaskDetailFailedRelabelsCompletedRow(t *testing.T) {
+	now := time.Now()
+	a := newTestApp(80, 24)
+	a.model.tasksTab.View = TaskViewDetail
+	a.model.tasksTab.Detail = &TaskItem{
+		TaskID:      "T-9",
+		Title:       "failed task",
+		Status:      "failed",
+		CompletedAt: &now,
+	}
+	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 20))
+	if !strings.Contains(out, "Failed at:") {
+		t.Errorf("failed task should show a 'Failed at' row; got:\n%s", out)
+	}
+	if strings.Contains(out, "Completed:") {
+		t.Errorf("failed task should not show a 'Completed' row; got:\n%s", out)
+	}
+}
+
+func TestTaskDetailDoneKeepsCompletedRow(t *testing.T) {
+	now := time.Now()
+	a := newTestApp(80, 24)
+	a.model.tasksTab.View = TaskViewDetail
+	a.model.tasksTab.Detail = &TaskItem{
+		TaskID:      "T-10",
+		Title:       "done task",
+		Status:      "done",
+		CompletedAt: &now,
+	}
+	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 20))
+	if !strings.Contains(out, "Completed:") {
+		t.Errorf("done task should keep the 'Completed' row; got:\n%s", out)
+	}
+}
+
 func TestContextualFooter(t *testing.T) {
 	a := newTestApp(100, 24)
 

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -57,3 +57,65 @@ func TestRenderWorkflowSteps_NoSteps(t *testing.T) {
 		t.Errorf("should not render a Steps header when there are no steps:\n%s", out)
 	}
 }
+
+// A failed instance whose recorded steps all passed (the run died in a later
+// step that never persisted a step_run) must not read as a completed run — a
+// marker should call out where it failed.
+func TestRenderWorkflowSteps_FailedAfterPassedSteps(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_f1",
+		Workflow: "implementation",
+		State:    "failed",
+		Steps: []WorkflowStepItem{
+			{StepID: "implement", Agent: "engineer", State: "passed", Duration: "30s"},
+		},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "no further steps recorded") {
+		t.Errorf("expected a failure marker for an all-passed failed instance:\n%s", out)
+	}
+	if !strings.Contains(out, "after step 'implement'") {
+		t.Errorf("marker should name the last recorded step:\n%s", out)
+	}
+}
+
+// When the failing step is itself recorded, the list already shows it — no
+// redundant marker.
+func TestRenderWorkflowSteps_FailedStepVisible(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_f2",
+		Workflow: "implementation",
+		State:    "failed",
+		Steps: []WorkflowStepItem{
+			{StepID: "implement", Agent: "engineer", State: "passed", Duration: "30s"},
+			{StepID: "review", Agent: "reviewer", State: "failed", Duration: "12s"},
+		},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if strings.Contains(out, "no further steps recorded") {
+		t.Errorf("should not add a marker when a failed step is already visible:\n%s", out)
+	}
+}
+
+// A failed instance with zero recorded steps still gets a marker.
+func TestRenderWorkflowSteps_FailedNoSteps(t *testing.T) {
+	inst := &WorkflowInstanceItem{ID: "wf_f3", Workflow: "implementation", State: "failed"}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "before any step completed") {
+		t.Errorf("expected a failure marker for a failed instance with no steps:\n%s", out)
+	}
+}
+
+// A non-failed instance never gets the marker.
+func TestRenderWorkflowSteps_NoMarkerWhenDone(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_ok",
+		Workflow: "implementation",
+		State:    "done",
+		Steps:    []WorkflowStepItem{{StepID: "implement", Agent: "engineer", State: "passed"}},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if strings.Contains(out, "workflow failed") {
+		t.Errorf("done instance should not show a failure marker:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

A failed task could read as *completed* in the dashboard, even though its status badge said `failed`:

- The task **detail** view rendered a `Completed: <timestamp>` row for failed tasks — `CompletedAt` is populated for both `done` *and* `failed` terminal states ([app.go](src/internal/dashboard/app.go)).
- The **step timeline** showed an all-green ✓ list when a run died in a later step that never persisted a `step_run` (e.g. a CI-wait or gate), so the timeline had no failed step and read as a complete run.

### Changes
- Relabel the terminal-timestamp row **"Failed at"** when the task failed; keep **"Completed"** for done tasks.
- Add `wfFailureMarker`: when an instance is `failed` but none of its recorded steps is, append a marker naming the last recorded step — `✗ workflow failed after step 'X' — no further steps recorded` (or `before any step completed` when there are zero steps). Wired into both `renderWorkflowSteps` (detail) and `taskHistoryLines` (history/logs). No marker is added when a failed step is already visible in the list.
- Tests for both renderers.

## Test plan
- `go test ./internal/dashboard/` — all pass, including new cases:
  - failed instance with all-passed steps shows the marker naming the last step
  - failed instance with a recorded failed step shows **no** redundant marker
  - failed instance with zero steps shows the "before any step completed" marker
  - done instance shows no marker
  - failed task detail shows "Failed at" and not "Completed"; done task keeps "Completed"
- `go vet ./internal/dashboard/` clean.