### PR TITLE
feat(workflow): record per-poll CI wait history

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -21,6 +21,7 @@ erDiagram
     workflow_instances ||--o{ workflow_instances : "sub-workflow (parent_instance_id)"
     workflow_instances ||--o{ step_runs : "steps"
     workflow_instances ||--o{ task_executions : "step attempt (instance_id, step_id)"
+    workflow_instances ||--o{ ci_poll_checks : "wait_for CI polls"
     step_runs ||--o| internal_tasks : "APIARY_SPAWN (spawned_task_id)"
 
     agents {
@@ -121,6 +122,16 @@ erDiagram
         TIMESTAMP finished_at
     }
 
+    ci_poll_checks {
+        INTEGER id PK
+        TEXT workflow_instance_id FK "-> workflow_instances.id"
+        TEXT step_id "wait_for step config id"
+        TEXT status "passed|failed|pending|timeout|error|unknown"
+        TEXT pr_url
+        TEXT detail "JSON of per-check states, or error message"
+        TIMESTAMP checked_at "one row per poll"
+    }
+
     internal_tasks {
         TEXT id PK "ulid; canonical unit of work"
         TEXT parent_task_id FK "lineage (self)"
@@ -208,3 +219,13 @@ Per-step cost/usage detail is recorded in **both** layers:
 
 The cost figure originates from the harness: the CLI runner parses the model's
 streamed `total_cost_usd` and token counts — it is reported, not estimated.
+
+### CI poll history (wait_for steps)
+
+A `wait_for` step does not get a `step_runs` row — it parks the workflow
+instance (`workflow_instances.state = 'waiting'`) and is re-evaluated each poll
+cycle. Every one of those polls is appended to **`ci_poll_checks`**: one row per
+poll with its `status` (passed/failed/pending/timeout/error/unknown), the PR
+`pr_url`, the per-check `detail` (JSON), and `checked_at`. This makes a parked CI
+wait auditable — how many times it polled, when, and what each poll returned —
+which the dashboard surfaces in the task detail and history views.

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1339,7 +1339,25 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 			item.Steps = append(item.Steps, si)
 		}
 	}
+	if polls, err := dbConn.ListCIPollChecks(ctx, inst.ID); err == nil {
+		item.CIPolls = mapCIPolls(polls)
+	}
 	return item
+}
+
+// mapCIPolls converts recorded CI poll rows into dashboard view-models.
+func mapCIPolls(checks []db.CIPollCheck) []CIPollItem {
+	out := make([]CIPollItem, 0, len(checks))
+	for _, c := range checks {
+		out = append(out, CIPollItem{
+			StepID:    c.StepID,
+			Status:    c.Status,
+			PRURL:     c.PRURL,
+			Detail:    c.Detail,
+			CheckedAt: c.CheckedAt,
+		})
+	}
+	return out
 }
 
 // refreshWorkflowMonitor re-fetches a workflow instance and its steps for the
@@ -1941,6 +1959,9 @@ func (a *App) fetchWorkflowInstance(ctx context.Context, dbConn *db.Client, task
 			Cached:   s.SkippedCached,
 		})
 	}
+	if polls, err := dbConn.ListCIPollChecks(ctx, inst.ID); err == nil {
+		item.CIPolls = mapCIPolls(polls)
+	}
 	return item
 }
 
@@ -2003,6 +2024,9 @@ func (a *App) fetchTaskHistory(internalTaskID, drillKey string) tea.Cmd {
 				for _, seg := range segs {
 					item := mapInstances([]db.WorkflowInstance{seg.Instance})[0]
 					item.Steps = mapStepRuns(seg.Steps, now)
+					if polls, err := dbConn.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
+						item.CIPolls = mapCIPolls(polls)
+					}
 					if item.State == db.InstanceStateApprovalWaiting {
 						item.Message = "Awaiting human approval — reply on the task to resume or abort."
 					}
@@ -2839,7 +2863,52 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 	if m := wfFailureMarker(inst); m != "" {
 		b.WriteString("  " + m + "\n")
 	}
+	b.WriteString(renderCIPolls(inst.CIPolls))
 	return b.String()
+}
+
+// renderCIPolls renders the wait_for CI poll history: a header with the count
+// and the latest status, then the most recent poll rows (oldest of the window
+// first). Empty when the instance never polled CI.
+func renderCIPolls(polls []CIPollItem) string {
+	if len(polls) == 0 {
+		return ""
+	}
+	const window = 8
+	var b strings.Builder
+	last := polls[len(polls)-1]
+	b.WriteString("\n  " + StyleLabel.Render(fmt.Sprintf("CI Polls (%d)", len(polls))) +
+		"   " + StyleMuted.Render("last: ") + ciPollStatusStyle(last.Status).Render(last.Status) +
+		StyleMuted.Render(" · "+last.CheckedAt.Format("01-02 15:04:05")) + "\n")
+
+	start := 0
+	if len(polls) > window {
+		start = len(polls) - window
+		b.WriteString("    " + StyleMuted.Render(fmt.Sprintf("… %d earlier", start)) + "\n")
+	}
+	for _, p := range polls[start:] {
+		row := StyleMuted.Render(pad(p.CheckedAt.Format("01-02 15:04:05"), 17)) + "  " +
+			ciPollStatusStyle(p.Status).Render(pad(p.Status, 8))
+		if p.Detail != "" {
+			row += "  " + StyleMuted.Render(truncate(p.Detail, 50))
+		}
+		b.WriteString("    " + row + "\n")
+	}
+	return b.String()
+}
+
+// ciPollStatusStyle maps a recorded CI poll status to a display style.
+func ciPollStatusStyle(status string) lipgloss.Style {
+	switch status {
+	case "passed":
+		return StyleSuccess
+	case "failed", "timeout", "error":
+		return StyleError
+	case "pending":
+		return StyleWarning
+	default:
+		return StyleMuted
+	}
 }
 
 // wfFailureMarker returns a one-line notice when an instance is failed but none
@@ -3024,6 +3093,9 @@ func (a *App) taskHistoryLines() []string {
 		}
 		if m := wfFailureMarker(&seg.Instance); m != "" {
 			out = append(out, "  "+m)
+		}
+		if polls := renderCIPolls(seg.Instance.CIPolls); polls != "" {
+			out = append(out, strings.Split(strings.Trim(polls, "\n"), "\n")...)
 		}
 		out = append(out, a.logEntryLines(seg.Logs)...)
 	}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -103,6 +103,18 @@ type WorkflowInstanceItem struct {
 	ResumedFrom      string // set when this instance resumed a prior one
 	CreatedAt        time.Time
 	Steps            []WorkflowStepItem
+	CIPolls          []CIPollItem // recorded wait_for CI poll history (oldest first)
+}
+
+// CIPollItem is one recorded poll of a wait_for step's CI status, shown in the
+// Task Detail / monitor so a parked CI wait reports how many times it polled,
+// when, and what each poll returned.
+type CIPollItem struct {
+	StepID    string
+	Status    string // passed|failed|pending|timeout|error|unknown
+	PRURL     string
+	Detail    string // JSON of per-check states, or an error message
+	CheckedAt time.Time
 }
 
 // TaskHistorySegmentItem is one workflow instance's slice of a task's history in

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -3,7 +3,48 @@ package dashboard
 import (
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestRenderWorkflowSteps_CIPolls(t *testing.T) {
+	base := time.Date(2026, 6, 8, 17, 40, 0, 0, time.UTC)
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_ci",
+		Workflow: "implementation",
+		State:    "waiting",
+		Steps: []WorkflowStepItem{
+			{StepID: "implement", Agent: "engineer", State: "passed", Duration: "30s"},
+		},
+		CIPolls: []CIPollItem{
+			{StepID: "check-ci", Status: "pending", CheckedAt: base},
+			{StepID: "check-ci", Status: "pending", CheckedAt: base.Add(time.Minute)},
+			{StepID: "check-ci", Status: "failed", Detail: `{"build":"failure"}`, CheckedAt: base.Add(2 * time.Minute)},
+		},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "CI Polls (3)") {
+		t.Errorf("expected CI poll count header; got:\n%s", out)
+	}
+	if !strings.Contains(out, "last: failed") {
+		t.Errorf("expected latest poll status in header; got:\n%s", out)
+	}
+	if !strings.Contains(out, `{"build":"failure"}`) {
+		t.Errorf("expected per-check detail in a poll row; got:\n%s", out)
+	}
+}
+
+func TestRenderWorkflowSteps_NoCIPolls(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID:       "wf_plain",
+		Workflow: "implementation",
+		State:    "done",
+		Steps:    []WorkflowStepItem{{StepID: "implement", Agent: "engineer", State: "passed"}},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if strings.Contains(out, "CI Polls") {
+		t.Errorf("instance with no polls should not render a CI Polls section:\n%s", out)
+	}
+}
 
 func TestRenderWorkflowSteps(t *testing.T) {
 	inst := &WorkflowInstanceItem{

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -133,6 +133,21 @@ CREATE TABLE IF NOT EXISTS step_runs (
   FOREIGN KEY(workflow_instance_id) REFERENCES workflow_instances(id)
 );
 
+-- CI poll checks: one row per poll of a wait_for step's external status (CI).
+-- A parked CI wait re-polls the PR every cycle; recording each poll makes the
+-- wait auditable — how many times it checked, when, and what each poll returned
+-- (passed|failed|pending|timeout|error) — instead of an opaque "waiting".
+CREATE TABLE IF NOT EXISTS ci_poll_checks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workflow_instance_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  status TEXT NOT NULL,           -- passed|failed|pending|timeout|error|unknown
+  pr_url TEXT,
+  detail TEXT,                    -- JSON of per-check states, or an error message
+  checked_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(workflow_instance_id) REFERENCES workflow_instances(id)
+);
+
 -- Canonical internal task registry: the source-independent unit of work.
 CREATE TABLE IF NOT EXISTS internal_tasks (
   id TEXT PRIMARY KEY,                          -- ulid
@@ -173,6 +188,7 @@ CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_parent ON workflow_instances(parent_instance_id);
 CREATE INDEX IF NOT EXISTS idx_step_runs_instance ON step_runs(workflow_instance_id);
+CREATE INDEX IF NOT EXISTS idx_ci_poll_checks_instance ON ci_poll_checks(workflow_instance_id, step_id);
 CREATE INDEX IF NOT EXISTS idx_internal_tasks_state ON internal_tasks(state);
 CREATE INDEX IF NOT EXISTS idx_internal_tasks_parent ON internal_tasks(parent_task_id);
 CREATE INDEX IF NOT EXISTS idx_source_bindings_task ON source_bindings(task_id);

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -445,6 +445,55 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 	return out, rows.Err()
 }
 
+// CIPollCheck is one poll of a wait_for step's external status (e.g. a CI status
+// check on a PR). One row is written per poll, giving an auditable history of
+// how many times the step polled, when, and what each poll returned.
+type CIPollCheck struct {
+	ID                 int64
+	WorkflowInstanceID string
+	StepID             string
+	Status             string // passed|failed|pending|timeout|error|unknown
+	PRURL              string
+	Detail             string // JSON of per-check states, or an error message
+	CheckedAt          time.Time
+}
+
+// RecordCIPollCheck appends one CI poll result for a wait_for step. checked_at is
+// set by the database default (CURRENT_TIMESTAMP).
+func (c *Client) RecordCIPollCheck(ctx context.Context, p *CIPollCheck) error {
+	_, err := c.db.ExecContext(ctx, `
+		INSERT INTO ci_poll_checks
+		  (workflow_instance_id, step_id, status, pr_url, detail)
+		VALUES (?, ?, ?, ?, ?)
+	`, p.WorkflowInstanceID, p.StepID, p.Status, nullStr(p.PRURL), nullStr(p.Detail))
+	return err
+}
+
+// ListCIPollChecks returns all CI poll checks for an instance, oldest first.
+func (c *Client) ListCIPollChecks(ctx context.Context, instanceID string) ([]CIPollCheck, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_instance_id, step_id, status,
+		       COALESCE(pr_url,''), COALESCE(detail,''), checked_at
+		FROM ci_poll_checks WHERE workflow_instance_id = ?
+		ORDER BY checked_at ASC, id ASC
+	`, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CIPollCheck
+	for rows.Next() {
+		var p CIPollCheck
+		if err := rows.Scan(&p.ID, &p.WorkflowInstanceID, &p.StepID, &p.Status,
+			&p.PRURL, &p.Detail, &p.CheckedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
 // scanner abstracts *sql.Row and *sql.Rows for shared scanning.
 type scanner interface {
 	Scan(dest ...any) error

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -56,6 +56,51 @@ func TestWorkflowInstance_CRUD(t *testing.T) {
 	}
 }
 
+func TestCIPollChecks_RecordAndList(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	inst := &WorkflowInstance{ID: "wf_ci", WorkflowID: "implementation", CellID: "42", State: InstanceStateWaiting}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	polls := []CIPollCheck{
+		{WorkflowInstanceID: "wf_ci", StepID: "check-ci", Status: "pending", PRURL: "https://x/pr/1"},
+		{WorkflowInstanceID: "wf_ci", StepID: "check-ci", Status: "pending", PRURL: "https://x/pr/1"},
+		{WorkflowInstanceID: "wf_ci", StepID: "check-ci", Status: "failed", PRURL: "https://x/pr/1", Detail: `{"build":"failure"}`},
+		{WorkflowInstanceID: "wf_ci", StepID: "check-ci", Status: "passed", PRURL: "https://x/pr/1"},
+	}
+	for i := range polls {
+		if err := c.RecordCIPollCheck(ctx, &polls[i]); err != nil {
+			t.Fatalf("record poll %d: %v", i, err)
+		}
+	}
+
+	got, err := c.ListCIPollChecks(ctx, "wf_ci")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d polls, want 4", len(got))
+	}
+	// Oldest-first ordering and round-tripped fields.
+	if got[0].Status != "pending" || got[3].Status != "passed" {
+		t.Errorf("ordering wrong: %q … %q", got[0].Status, got[3].Status)
+	}
+	if got[2].Status != "failed" || got[2].Detail != `{"build":"failure"}` {
+		t.Errorf("detail not round-tripped: %+v", got[2])
+	}
+	if got[0].PRURL != "https://x/pr/1" || got[0].CheckedAt.IsZero() {
+		t.Errorf("pr_url/checked_at not populated: %+v", got[0])
+	}
+
+	// Isolated per instance.
+	if other, _ := c.ListCIPollChecks(ctx, "wf_none"); len(other) != 0 {
+		t.Errorf("expected no polls for unknown instance, got %d", len(other))
+	}
+}
+
 func TestWorkflowInstance_NotFound(t *testing.T) {
 	c := newTestClient(t)
 	got, err := c.GetWorkflowInstance(context.Background(), "missing")

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -207,7 +207,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				case config.StepTypeWorkflow:
 					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
 				case config.StepTypeWaitFor:
-					res, _ = e.RunWaitStep(ctx, step, r.cell.SourceID, r.cell.ID, waitDeadline)
+					res, _ = e.RunWaitStep(ctx, r.instID, step, r.cell.SourceID, r.cell.ID, waitDeadline)
 				default: // StepTypeAgent
 					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
 				}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -31,6 +31,34 @@ type bindingLister interface {
 	ListBindingsByTask(ctx context.Context, taskID string) ([]model.SourceBinding, error)
 }
 
+// ciPollRecorder is the optional capability the engine uses to persist each CI
+// poll of a wait_for step (count, timestamp, returned status). *db.Client
+// satisfies it; fake stores in tests that omit it simply record nothing.
+type ciPollRecorder interface {
+	RecordCIPollCheck(ctx context.Context, p *db.CIPollCheck) error
+}
+
+// recordCIPoll persists one CI poll result for a wait_for step when the store
+// supports it. Best-effort: a recording failure never affects the poll outcome.
+func (e *Engine) recordCIPoll(ctx context.Context, instID, stepID, status, url, detail string) {
+	if instID == "" {
+		return
+	}
+	rec, ok := e.store.(ciPollRecorder)
+	if !ok {
+		return
+	}
+	if err := rec.RecordCIPollCheck(ctx, &db.CIPollCheck{
+		WorkflowInstanceID: instID,
+		StepID:             stepID,
+		Status:             status,
+		PRURL:              url,
+		Detail:             detail,
+	}); err != nil {
+		aplog.Debug("wait_for step %q: record CI poll: %v", stepID, err)
+	}
+}
+
 // TaskTracker is the optional capability the engine uses to apply the top-level
 // tasks: completion hook. When an instance reaches a terminal state the engine
 // decrements the task's outstanding-workflow counter; when it hits zero it flips

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -37,6 +37,7 @@ type fakeStore struct {
 	stepRuns  map[string]*db.StepRun
 	stepOrder []string
 	bindings  map[string][]model.SourceBinding // task id → bindings (for bindingLister)
+	ciPolls   []db.CIPollCheck                 // recorded wait_for CI polls (for ciPollRecorder)
 }
 
 func newFakeStore() *fakeStore {
@@ -45,6 +46,27 @@ func newFakeStore() *fakeStore {
 		stepRuns:  map[string]*db.StepRun{},
 		bindings:  map[string][]model.SourceBinding{},
 	}
+}
+
+// RecordCIPollCheck satisfies ciPollRecorder so the engine persists each CI poll
+// the same way the production *db.Client does.
+func (f *fakeStore) RecordCIPollCheck(_ context.Context, p *db.CIPollCheck) error {
+	cp := *p
+	f.mu.Lock()
+	f.ciPolls = append(f.ciPolls, cp)
+	f.mu.Unlock()
+	return nil
+}
+
+// pollStatuses returns the recorded CI poll statuses in order, for assertions.
+func (f *fakeStore) pollStatuses() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.ciPolls))
+	for i, p := range f.ciPolls {
+		out[i] = p.Status
+	}
+	return out
 }
 
 // ListBindingsByTask satisfies bindingLister so the engine resolves a task's

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -210,6 +210,75 @@ func TestWaitFor_RehydrateSurvivesRestart(t *testing.T) {
 	}
 }
 
+// TestWaitFor_RecordsEachPoll verifies every CI poll is persisted with its
+// returned status, so a parked wait reports how many times it polled and what
+// each poll returned.
+func TestWaitFor_RecordsEachPoll(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	status := "pending"
+	url := "https://example.test/pr/1"
+	ci := func() (source.CIStatus, error) {
+		return source.CIStatus{Status: status, URL: url}, nil
+	}
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	// Initial run polls once (pending → park).
+	instID, _, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
+	// Two more pending re-checks, then green.
+	eng.CheckParkedWaits(context.Background())
+	eng.CheckParkedWaits(context.Background())
+	status = "passed"
+	eng.CheckParkedWaits(context.Background())
+
+	got := store.pollStatuses()
+	want := []string{"pending", "pending", "pending", "passed"}
+	if len(got) != len(want) {
+		t.Fatalf("recorded %d polls (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("poll %d status = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+	// The PR URL and instance/step are carried on each record.
+	store.mu.Lock()
+	last := store.ciPolls[len(store.ciPolls)-1]
+	store.mu.Unlock()
+	if last.WorkflowInstanceID != instID || last.StepID != "check-ci" || last.PRURL != url {
+		t.Errorf("poll record = %+v, want inst=%s step=check-ci url=%s", last, instID, url)
+	}
+}
+
+// TestWaitFor_RecordsErrorAndTimeout verifies a failed CI check and a timeout are
+// each recorded with a distinct status.
+func TestWaitFor_RecordsErrorAndTimeout(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) {
+		return source.CIStatus{}, context.DeadlineExceeded // transient checker error
+	}
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor: &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"}},
+	}}
+	eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+
+	// Past the deadline: next check records a timeout.
+	clock = clock.Add(3 * time.Hour)
+	eng.CheckParkedWaits(context.Background())
+
+	got := store.pollStatuses()
+	if len(got) != 2 || got[0] != "error" || got[1] != "timeout" {
+		t.Errorf("recorded polls = %v, want [error timeout]", got)
+	}
+}
+
 // priorStepsFor returns the instance's persisted step runs in creation order,
 // mirroring db.Client.ListStepRuns for the rehydration path.
 func priorStepsFor(f *fakeStore, instID string) []db.StepRun {

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -2,11 +2,12 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
-	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
 )
 
 // RunWaitStep performs ONE check of the external system (e.g. CI status) and
@@ -19,6 +20,7 @@ import (
 // deadline the step returns a terminal failure with ci_status=timeout.
 func (e *Engine) RunWaitStep(
 	ctx context.Context,
+	instID string,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
 	deadline time.Time,
@@ -30,7 +32,7 @@ func (e *Engine) RunWaitStep(
 	cfg := step.WaitFor
 	switch cfg.Kind {
 	case "", "ci":
-		return e.checkCIWaitStep(ctx, step, sourceID, sourceItemID, deadline)
+		return e.checkCIWaitStep(ctx, instID, step, sourceID, sourceItemID, deadline)
 	default:
 		return StepResult{}, fmt.Errorf("wait_for step %q unsupported kind: %q", step.ID, cfg.Kind)
 	}
@@ -41,6 +43,7 @@ func (e *Engine) RunWaitStep(
 // terminal; passing the deadline is a terminal timeout failure.
 func (e *Engine) checkCIWaitStep(
 	ctx context.Context,
+	instID string,
 	step config.StepConfig,
 	sourceID, sourceItemID string,
 	deadline time.Time,
@@ -57,6 +60,8 @@ func (e *Engine) checkCIWaitStep(
 	// Timeout: give up waiting once past the deadline.
 	if !deadline.IsZero() && e.now().After(deadline) {
 		aplog.Info("wait_for step %q: CI wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
+		e.recordCIPoll(ctx, instID, step.ID, "timeout", "",
+			fmt.Sprintf("CI did not complete within %v", cfg.ParsedMaxDuration()))
 		return StepResult{
 			Success: false,
 			StructuredOutput: map[string]any{
@@ -73,8 +78,13 @@ func (e *Engine) checkCIWaitStep(
 		// endless "pending" with no visible cause. Still retried next cycle so it
 		// self-heals once the underlying problem (token, transient outage) is fixed.
 		aplog.Warn("wait_for step %q: CI check failed (will retry next cycle): %v", step.ID, err)
+		e.recordCIPoll(ctx, instID, step.ID, "error", "", err.Error())
 		return StepResult{Pending: true}, nil
 	}
+
+	// Record every poll result (passed/failed/pending/unknown) with the per-check
+	// detail, so the wait's full history is auditable from the dashboard.
+	e.recordCIPoll(ctx, instID, step.ID, normalizeCIStatus(status.Status), status.URL, encodeChecks(status.Checks))
 
 	switch status.Status {
 	case "passed":
@@ -123,4 +133,31 @@ func checksToMap(checks []struct {
 		m[c.Name] = c.Status
 	}
 	return m
+}
+
+// normalizeCIStatus maps an empty/unrecognized CI status to "unknown" so a
+// recorded poll always carries a meaningful, non-empty status.
+func normalizeCIStatus(s string) string {
+	switch s {
+	case "passed", "failed", "pending":
+		return s
+	default:
+		return "unknown"
+	}
+}
+
+// encodeChecks renders the per-check name→status map as compact JSON for the
+// recorded poll's detail column. Returns "" when there are no checks.
+func encodeChecks(checks []struct {
+	Name   string
+	Status string
+}) string {
+	if len(checks) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(checksToMap(checks))
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }


### PR DESCRIPTION
## Summary

`wait_for` steps park the workflow instance (`state = waiting`) and re-poll the PR's CI every cycle, but **nothing was persisted per poll** — a parked CI wait was an opaque "waiting" with no record of how many times it checked the PR or what each poll returned. This adds a full, auditable poll history and surfaces it in the dashboard.

### Storage
- New **`ci_poll_checks`** table: one row per poll — `status` (passed/failed/pending/timeout/error/unknown), `pr_url`, per-check `detail` (JSON), `checked_at`. Indexed on `(workflow_instance_id, step_id)`.
- `db.CIPollCheck` struct + `RecordCIPollCheck` / `ListCIPollChecks`.

### Engine
- Optional `ciPollRecorder` capability, type-asserted off the store (same pattern as `bindingLister`), so existing fake stores are unaffected.
- `checkCIWaitStep` records **every** poll: passed/failed/pending/unknown with the per-check detail, plus distinct `error` (checker failure) and `timeout` records. Best-effort — a recording failure never changes the poll outcome. `instID` is threaded through `RunWaitStep → checkCIWaitStep`.

### Dashboard
- `WorkflowInstanceItem` gains `CIPolls`, populated in all instance builders (task detail, monitor, history).
- `renderCIPolls` shows `CI Polls (N)` with the latest status + the most recent poll rows; surfaced in the task-detail step panel and the history/logs view.

### Docs
- `docs/data-model.md`: `ci_poll_checks` added to the ER diagram + a prose note.

## Test plan
- `go build ./...` and `go vet` clean.
- `go test ./...` — all packages pass, including new cases:
  - **db**: record/list round-trip, oldest-first ordering, detail/pr_url/checked_at populated, per-instance isolation.
  - **workflow**: each poll recorded across the wait lifecycle (pending×3 → passed); distinct `error` + `timeout` records; PR URL + instance/step carried on each record.
  - **dashboard**: `renderCIPolls` shows count/last-status/detail; no section when there are no polls.

## Notes
- No new config: `wait_for` already exists; this is pure observability, no schema changes to the config.
- Pre-existing gofmt deviations in `engine.go`/`dag.go` are untouched (they were already non-gofmt-clean on `main`); only my additions were added, which are gofmt-clean.