### PR TITLE
feat(cli): surface wait_for CI poll history in instances and task views

### DIFF
--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -124,23 +124,73 @@ func showInstance(id string, asJSON bool) error {
 
 	if len(detail.Steps) == 0 {
 		fmt.Println(instMuted.Render("No steps recorded."))
-		return nil
-	}
-	fmt.Println(instHeader.Render("Steps"))
-	for _, s := range detail.Steps {
-		state := s.State
-		if s.Cached {
-			state += " (cached)"
+	} else {
+		fmt.Println(instHeader.Render("Steps"))
+		for _, s := range detail.Steps {
+			state := s.State
+			if s.Cached {
+				state += " (cached)"
+			}
+			fmt.Printf("  %s  %-14s  %-16s  %-8s  %s\n",
+				stepGlyph(s.State),
+				truncate(s.StepID, 14),
+				truncate(s.AgentID, 16),
+				s.Duration,
+				stateColor(s.State).Render(state),
+			)
 		}
-		fmt.Printf("  %s  %-14s  %-16s  %-8s  %s\n",
-			stepGlyph(s.State),
-			truncate(s.StepID, 14),
-			truncate(s.AgentID, 16),
-			s.Duration,
-			stateColor(s.State).Render(state),
-		)
 	}
+	printCIPolls(detail.CIPolls)
 	return nil
+}
+
+// printCIPolls prints the wait_for CI poll history — a header with the count and
+// latest status, then the most recent poll rows (oldest of the window first).
+// Nothing is printed when the instance never polled CI.
+func printCIPolls(polls []daemon.CIPollView) {
+	if len(polls) == 0 {
+		return
+	}
+	const window = 10
+	last := polls[len(polls)-1]
+	fmt.Println()
+	fmt.Println(instHeader.Render(fmt.Sprintf("CI Polls (%d)", len(polls))) +
+		"  " + instMuted.Render("last: ") + pollColor(last.Status).Render(last.Status) +
+		instMuted.Render(" · "+last.CheckedAt.Format("2006-01-02 15:04:05")))
+
+	start := 0
+	if len(polls) > window {
+		start = len(polls) - window
+		fmt.Println(instMuted.Render(fmt.Sprintf("  … %d earlier", start)))
+	}
+	for _, p := range polls[start:] {
+		pad := 8 - len(p.Status)
+		if pad < 0 {
+			pad = 0
+		}
+		line := fmt.Sprintf("  %s  %s%s",
+			instMuted.Render(p.CheckedAt.Format("2006-01-02 15:04:05")),
+			pollColor(p.Status).Render(p.Status),
+			strings.Repeat(" ", pad))
+		if p.Detail != "" {
+			line += "  " + instMuted.Render(truncate(p.Detail, 60))
+		}
+		fmt.Println(line)
+	}
+}
+
+// pollColor maps a recorded CI poll status to a display style.
+func pollColor(status string) lipgloss.Style {
+	switch status {
+	case "passed":
+		return instOK
+	case "failed", "timeout", "error":
+		return instErr
+	case "pending":
+		return instWarn
+	default:
+		return instMuted
+	}
 }
 
 // stateCell renders a state column, color-coded and padded to width.

--- a/src/internal/cli/task.go
+++ b/src/internal/cli/task.go
@@ -100,6 +100,8 @@ func renderTaskHistory(resp daemon.TaskHistoryResponse) {
 			}
 		}
 
+		printCIPolls(seg.CIPolls)
+
 		for _, l := range seg.Logs {
 			fmt.Printf("  %s %s %s\n",
 				instMuted.Render(l.Timestamp.Format("15:04:05")), logLevelTag(l.Level), l.Message)

--- a/src/internal/daemon/instance_detail_test.go
+++ b/src/internal/daemon/instance_detail_test.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+// TestInstanceDetail_IncludesCIPolls verifies the wait_for CI poll history is
+// carried into the instance detail view (the payload for `apiary instances <id>`),
+// oldest-first.
+func TestInstanceDetail_IncludesCIPolls(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "detail.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	mustCreateInstance(t, dbc, &db.WorkflowInstance{
+		ID: "wi_ci", WorkflowID: "implementation", CellID: "42", State: db.InstanceStateWaiting,
+	})
+	if err := dbc.CreateStepRun(ctx, &db.StepRun{
+		ID: "wi_ci-implement", WorkflowInstanceID: "wi_ci", StepID: "implement", AgentID: "engineer", State: db.StepStatePassed,
+	}); err != nil {
+		t.Fatalf("create step: %v", err)
+	}
+	for _, st := range []string{"pending", "pending", "passed"} {
+		if err := dbc.RecordCIPollCheck(ctx, &db.CIPollCheck{
+			WorkflowInstanceID: "wi_ci", StepID: "check-ci", Status: st, PRURL: "https://x/pr/9",
+		}); err != nil {
+			t.Fatalf("record poll: %v", err)
+		}
+	}
+
+	detail, err := (&Dispatcher{db: dbc}).InstanceDetail(ctx, "wi_ci")
+	if err != nil {
+		t.Fatalf("InstanceDetail: %v", err)
+	}
+	if detail == nil {
+		t.Fatal("expected detail, got nil")
+	}
+	if len(detail.CIPolls) != 3 {
+		t.Fatalf("CIPolls = %d, want 3", len(detail.CIPolls))
+	}
+	if detail.CIPolls[0].Status != "pending" || detail.CIPolls[2].Status != "passed" {
+		t.Errorf("poll ordering wrong: %q … %q", detail.CIPolls[0].Status, detail.CIPolls[2].Status)
+	}
+	if detail.CIPolls[2].StepID != "check-ci" || detail.CIPolls[2].PRURL != "https://x/pr/9" {
+		t.Errorf("poll fields not carried: %+v", detail.CIPolls[2])
+	}
+}

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -48,10 +48,37 @@ type StepRunView struct {
 	FinishedAt   *time.Time `json:"finished_at"`
 }
 
+// CIPollView is one recorded wait_for CI poll, surfaced in instance and
+// task-history detail so a parked CI wait reports how many times it polled,
+// when, and what each poll returned.
+type CIPollView struct {
+	StepID    string    `json:"step_id"`
+	Status    string    `json:"status"`
+	PRURL     string    `json:"pr_url"`
+	Detail    string    `json:"detail"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
 // InstanceDetail is the payload for `apiary instances <id>`.
 type InstanceDetail struct {
 	InstanceSummary
-	Steps []StepRunView `json:"steps"`
+	Steps   []StepRunView `json:"steps"`
+	CIPolls []CIPollView  `json:"ci_polls"`
+}
+
+// ciPollViews maps stored CI poll rows to their IPC views.
+func ciPollViews(checks []db.CIPollCheck) []CIPollView {
+	out := make([]CIPollView, 0, len(checks))
+	for _, c := range checks {
+		out = append(out, CIPollView{
+			StepID:    c.StepID,
+			Status:    c.Status,
+			PRURL:     c.PRURL,
+			Detail:    c.Detail,
+			CheckedAt: c.CheckedAt,
+		})
+	}
+	return out
 }
 
 // InstancesResponse is the JSON payload returned by GET /instances.
@@ -202,6 +229,9 @@ func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDe
 	for _, s := range steps {
 		detail.Steps = append(detail.Steps, d.stepRunView(ctx, id, s, now))
 	}
+	if polls, err := d.db.ListCIPollChecks(ctx, id); err == nil {
+		detail.CIPolls = ciPollViews(polls)
+	}
 	return detail, nil
 }
 
@@ -252,6 +282,7 @@ type TaskLogLineView struct {
 type TaskHistorySegmentView struct {
 	Instance InstanceSummary   `json:"instance"`
 	Steps    []StepRunView     `json:"steps"`
+	CIPolls  []CIPollView      `json:"ci_polls"`
 	Logs     []TaskLogLineView `json:"logs"`
 }
 
@@ -285,6 +316,9 @@ func (d *Dispatcher) TaskHistory(ctx context.Context, internalTaskID string) (*T
 		sv := TaskHistorySegmentView{Instance: instanceSummary(view, now)}
 		for _, s := range seg.Steps {
 			sv.Steps = append(sv.Steps, d.stepRunView(ctx, seg.Instance.ID, s, now))
+		}
+		if polls, err := d.db.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
+			sv.CIPolls = ciPollViews(polls)
 		}
 		for _, l := range seg.Logs {
 			sv.Logs = append(sv.Logs, TaskLogLineView{Timestamp: l.Timestamp, Level: l.Level, Message: l.Message})


### PR DESCRIPTION
## Summary

Follow-up to [#125](https://github.com/orlandoburli/apiary/pull/125), which recorded `wait_for` CI poll history and showed it in the dashboard. This exposes the same history on the **CLI**, via the IPC layer.

- **IPC**: new `CIPollView`; `InstanceDetail` and `TaskHistorySegmentView` gain a `ci_polls` field, populated from `db.ListCIPollChecks` in `InstanceDetail` and `TaskHistory`.
- **CLI**: `printCIPolls` renders `CI Polls (N)` with the latest status and the most recent poll rows (status color-coded, per-check detail shown). Wired into:
  - `apiary instances <id>` — and it no longer early-returns on "no steps", so a wait-only instance still shows its polls.
  - `apiary task <id>` history segments.
  - `--json` automatically carries the new `ci_polls` field on both endpoints.

Example:
```
Steps
  ✓  implement       engineer          30s       passed

CI Polls (7)  last: pending · 2026-06-08 17:42:10
  … 0 earlier
  2026-06-08 17:38:10  pending
  2026-06-08 17:40:10  pending
  2026-06-08 17:42:10  pending
```

## Test plan
- `go build ./...`, `go vet`, and `go test ./...` all pass.
- New `TestInstanceDetail_IncludesCIPolls`: poll history carried into the instance detail view oldest-first, with step id / PR URL / status preserved.

## Notes
- Pure read/observability; no schema or config changes.