### PR TITLE
Task Detail timings rollup + Claude CLI token capture

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1321,28 +1321,49 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 				StartedAt:  s.StartedAt,
 				FinishedAt: s.FinishedAt,
 			}
-			if db.StepRunHasUsage(s) {
-				si.InputTokens = s.InputTokens
-				si.OutputTokens = s.OutputTokens
-				si.TotalTokens = s.TotalTokens
-				si.CostUSD = s.CostUSD
-				si.NumTurns = s.NumTurns
-				si.NumToolCalls = s.NumToolCalls
-			} else if usage, err := dbConn.GetStepUsage(ctx, inst.ID, s.StepID); err == nil && usage != nil {
-				si.InputTokens = usage.InputTokens
-				si.OutputTokens = usage.OutputTokens
-				si.TotalTokens = usage.TotalTokens
-				si.CostUSD = usage.CostUSD
-				si.NumTurns = usage.NumTurns
-				si.NumToolCalls = usage.NumToolCalls
-			}
+			si.InputTokens, si.OutputTokens, si.TotalTokens, si.NumTurns, si.NumToolCalls, si.CostUSD =
+				resolveStepUsage(ctx, dbConn, inst.ID, s)
 			item.Steps = append(item.Steps, si)
 		}
+		aggregateInstance(item)
 	}
 	if polls, err := dbConn.ListCIPollChecks(ctx, inst.ID); err == nil {
 		item.CIPolls = mapCIPolls(polls)
 	}
 	return item
+}
+
+// resolveStepUsage returns a step's token/turn/cost rollup, preferring the
+// step_runs row's own summed columns and falling back to the linked
+// task_executions rows for older steps that predate the rollup (StepRunHasUsage
+// is false). Returns zeros when neither carries usage.
+func resolveStepUsage(ctx context.Context, dbConn *db.Client, instID string, s db.StepRun) (in, out, total, turns, calls int, cost float64) {
+	if db.StepRunHasUsage(s) {
+		return s.InputTokens, s.OutputTokens, s.TotalTokens, s.NumTurns, s.NumToolCalls, s.CostUSD
+	}
+	if usage, err := dbConn.GetStepUsage(ctx, instID, s.StepID); err == nil && usage != nil {
+		return usage.InputTokens, usage.OutputTokens, usage.TotalTokens, usage.NumTurns, usage.NumToolCalls, usage.CostUSD
+	}
+	return 0, 0, 0, 0, 0, 0
+}
+
+// aggregateInstance fills an instance's span and token totals from its steps:
+// StartedAt = earliest step start, FinishedAt = latest step finish, tokens/cost
+// summed. This lets a workflow report its true wall-clock span and spend rather
+// than inheriting only the last execution's numbers.
+func aggregateInstance(item *WorkflowInstanceItem) {
+	for _, s := range item.Steps {
+		if s.StartedAt != nil && (item.StartedAt == nil || s.StartedAt.Before(*item.StartedAt)) {
+			item.StartedAt = s.StartedAt
+		}
+		if s.FinishedAt != nil && (item.FinishedAt == nil || s.FinishedAt.After(*item.FinishedAt)) {
+			item.FinishedAt = s.FinishedAt
+		}
+		item.InputTokens += s.InputTokens
+		item.OutputTokens += s.OutputTokens
+		item.TotalTokens += s.TotalTokens
+		item.CostUSD += s.CostUSD
+	}
 }
 
 // mapCIPolls converts recorded CI poll rows into dashboard view-models.
@@ -1890,7 +1911,7 @@ func (a *App) augmentTaskDetail(ctx context.Context, dbConn *db.Client, detail *
 		detail.Children = mapLineage(ctx, dbConn, kids)
 	}
 	if insts, _ := dbConn.ListWorkflowInstancesByTask(ctx, internalTaskID); len(insts) > 0 {
-		detail.Instances = mapInstances(insts)
+		detail.Instances = mapInstances(ctx, dbConn, insts)
 	}
 	return detail
 }
@@ -1913,11 +1934,14 @@ func mapLineage(ctx context.Context, dbConn *db.Client, tasks []model.InternalTa
 	return out
 }
 
-// mapInstances converts db workflow-instance rows into dashboard view-models.
-func mapInstances(insts []db.WorkflowInstance) []WorkflowInstanceItem {
+// mapInstances converts db workflow-instance rows into dashboard view-models,
+// enriching each with its span and token totals (aggregated from its step runs)
+// so the Workflow Instances list can show per-workflow start/end and spend, and
+// the task header can roll them up across every instance.
+func mapInstances(ctx context.Context, dbConn *db.Client, insts []db.WorkflowInstance) []WorkflowInstanceItem {
 	out := make([]WorkflowInstanceItem, 0, len(insts))
 	for _, in := range insts {
-		out = append(out, WorkflowInstanceItem{
+		item := WorkflowInstanceItem{
 			ID:               in.ID,
 			Workflow:         in.WorkflowID,
 			State:            in.State,
@@ -1925,7 +1949,18 @@ func mapInstances(insts []db.WorkflowInstance) []WorkflowInstanceItem {
 			ParentInstanceID: in.ParentInstanceID,
 			ResumedFrom:      in.ResumedFrom,
 			CreatedAt:        in.CreatedAt,
-		})
+		}
+		if steps, err := dbConn.ListStepRuns(ctx, in.ID); err == nil {
+			for _, s := range steps {
+				si := WorkflowStepItem{StartedAt: s.StartedAt, FinishedAt: s.FinishedAt}
+				si.InputTokens, si.OutputTokens, si.TotalTokens, si.NumTurns, si.NumToolCalls, si.CostUSD =
+					resolveStepUsage(ctx, dbConn, in.ID, s)
+				item.Steps = append(item.Steps, si)
+			}
+			aggregateInstance(&item)
+			item.Steps = nil // the list view shows only the rollup, not the rows
+		}
+		out = append(out, item)
 	}
 	return out
 }
@@ -1940,29 +1975,7 @@ func (a *App) fetchWorkflowInstance(ctx context.Context, dbConn *db.Client, task
 	if err != nil || inst == nil {
 		return nil
 	}
-	item := &WorkflowInstanceItem{ID: inst.ID, Workflow: inst.WorkflowID, State: inst.State}
-	if inst.State == db.InstanceStateApprovalWaiting {
-		item.Message = "Awaiting human approval — reply on the task to resume or abort."
-	}
-
-	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
-	if err != nil {
-		return item
-	}
-	now := time.Now()
-	for _, s := range steps {
-		item.Steps = append(item.Steps, WorkflowStepItem{
-			StepID:   s.StepID,
-			Agent:    s.AgentID,
-			State:    s.State,
-			Duration: wfStepDuration(s, now),
-			Cached:   s.SkippedCached,
-		})
-	}
-	if polls, err := dbConn.ListCIPollChecks(ctx, inst.ID); err == nil {
-		item.CIPolls = mapCIPolls(polls)
-	}
-	return item
+	return buildWorkflowInstanceItem(ctx, dbConn, inst)
 }
 
 // wfStepDuration renders a short duration for a step run: final span for a
@@ -2022,7 +2035,7 @@ func (a *App) fetchTaskHistory(internalTaskID, drillKey string) tea.Cmd {
 			if segs, err := dbConn.GetTaskWorkflowHistory(ctx, internalTaskID); err == nil {
 				now := time.Now()
 				for _, seg := range segs {
-					item := mapInstances([]db.WorkflowInstance{seg.Instance})[0]
+					item := mapInstances(ctx, dbConn, []db.WorkflowInstance{seg.Instance})[0]
 					item.Steps = mapStepRuns(seg.Steps, now)
 					if polls, err := dbConn.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
 						item.CIPolls = mapCIPolls(polls)
@@ -2098,6 +2111,8 @@ func mapStepRuns(steps []db.StepRun, now time.Time) []WorkflowStepItem {
 			CostUSD:      s.CostUSD,
 			NumTurns:     s.NumTurns,
 			NumToolCalls: s.NumToolCalls,
+			StartedAt:    s.StartedAt,
+			FinishedAt:   s.FinishedAt,
 		})
 	}
 	return out
@@ -2683,20 +2698,58 @@ func (a *App) filteredTasks(t *TasksTab) []TaskItem {
 	return out
 }
 
+// taskRollup derives the whole-task span and token totals from its workflow
+// instances (each already aggregated from its steps), so the header reflects the
+// entire run rather than only the last execution row (e.g. the merge step). It
+// falls back to the detail instance when the task has no internal-task instance
+// list, and to the execution-row values when neither carries a span/usage.
+func taskRollup(d *TaskItem, detail *WorkflowInstanceItem) (started, completed *time.Time, inTok, outTok, totalTok int, cost float64) {
+	insts := d.Instances
+	if len(insts) == 0 && detail != nil {
+		insts = []WorkflowInstanceItem{*detail}
+	}
+	for _, in := range insts {
+		if in.StartedAt != nil && (started == nil || in.StartedAt.Before(*started)) {
+			started = in.StartedAt
+		}
+		if in.FinishedAt != nil && (completed == nil || in.FinishedAt.After(*completed)) {
+			completed = in.FinishedAt
+		}
+		inTok += in.InputTokens
+		outTok += in.OutputTokens
+		totalTok += in.TotalTokens
+		cost += in.CostUSD
+	}
+	if started == nil {
+		started = d.StartedAt
+	}
+	if completed == nil {
+		completed = d.CompletedAt
+	}
+	if totalTok == 0 { // no instance-level usage — fall back to the execution row
+		inTok, outTok, totalTok, cost = d.InputTokens, d.OutputTokens, d.TotalTokens, d.CostUSD
+	}
+	return
+}
+
 func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	d := t.Detail
 	if d == nil {
 		return a.box("TASK DETAILS", StyleMuted.Render("No details")+"\n", height)
 	}
 
+	rStart, rEnd, inTok, outTok, totalTok, cost := taskRollup(d, t.DetailInstance)
 	started, completed, dur := "—", "—", "—"
-	if d.StartedAt != nil {
-		started = d.StartedAt.Format("2006-01-02 15:04:05")
+	if rStart != nil {
+		started = rStart.Format("2006-01-02 15:04:05")
 	}
-	if d.CompletedAt != nil {
-		completed = d.CompletedAt.Format("2006-01-02 15:04:05")
+	if rEnd != nil {
+		completed = rEnd.Format("2006-01-02 15:04:05")
 	}
-	if d.Duration > 0 {
+	switch {
+	case rStart != nil && rEnd != nil:
+		dur = rEnd.Sub(*rStart).Round(time.Second).String()
+	case d.Duration > 0:
 		dur = d.Duration.Round(time.Second).String()
 	}
 
@@ -2728,9 +2781,9 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	}
 	row(endedLabel, completed)
 	row("Duration", dur)
-	row("Tokens", fmt.Sprintf("%d in / %d out / %d total", d.InputTokens, d.OutputTokens, d.TotalTokens))
+	row("Tokens", fmt.Sprintf("%d in / %d out / %d total", inTok, outTok, totalTok))
 	row("Turns / Calls", fmt.Sprintf("%d / %d", d.NumTurns, d.NumToolCalls))
-	row("Cost", fmt.Sprintf("$%.4f", d.CostUSD))
+	row("Cost", fmt.Sprintf("$%.4f", cost))
 	if d.URL != "" {
 		row("URL", StyleInfo.Render(d.URL))
 	}
@@ -2817,24 +2870,39 @@ func renderTaskInstances(d *TaskItem) string {
 	if len(d.Instances) == 0 {
 		return ""
 	}
+	const (
+		colState = 12
+		colWf    = 18
+	)
 	var b strings.Builder
 	b.WriteString("\n  " + StyleLabel.Render(fmt.Sprintf("Workflow Instances (%d)", len(d.Instances))) + "\n")
+	b.WriteString("    " + StyleLabel.Render(fmt.Sprintf("%s %s %s %s %s %s",
+		pad("STATE", colState),
+		pad("WORKFLOW", colWf),
+		pad("STARTED", colTime),
+		pad("ENDED", colTime),
+		padLeft("DURATION", colDur),
+		padLeft("TOKENS", colTok),
+	)) + "\n")
 	for _, in := range d.Instances {
-		when := "—"
-		if !in.CreatedAt.IsZero() {
-			when = in.CreatedAt.Format("01-02 15:04")
-		}
 		marker := ""
 		switch {
 		case in.ResumedFrom != "":
-			marker = StyleMuted.Render(" (resumed)")
+			marker = StyleMuted.Render("  (resumed)")
 		case in.ParentInstanceID != "":
-			marker = StyleMuted.Render(" (sub)")
+			marker = StyleMuted.Render("  (sub)")
 		}
-		b.WriteString(fmt.Sprintf("    %s  %s  %s%s\n",
-			wfInstanceBadge(in.State),
-			pad(truncate(in.Workflow, 18), 18),
-			StyleMuted.Render(when),
+		dur := "—"
+		if in.StartedAt != nil && in.FinishedAt != nil {
+			dur = in.FinishedAt.Sub(*in.StartedAt).Round(time.Second).String()
+		}
+		b.WriteString(fmt.Sprintf("    %s %s %s %s %s %s%s\n",
+			pad(wfInstanceBadge(in.State), colState),
+			pad(truncate(in.Workflow, colWf), colWf),
+			StyleMuted.Render(pad(tsCell(in.StartedAt), colTime)),
+			StyleMuted.Render(pad(tsCell(in.FinishedAt), colTime)),
+			StyleMuted.Render(padLeft(dur, colDur)),
+			StyleMuted.Render(padLeft(fmtTokensShort(in.TotalTokens), colTok)),
 			marker,
 		))
 	}
@@ -2850,13 +2918,23 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 		StyleValueStrong.Render(valueOr(inst.Workflow, "—")) + "  " +
 		wfInstanceBadge(inst.State) + "\n")
 
+	if summary := wfInstanceSummary(inst); summary != "" {
+		b.WriteString("              " + summary + "\n")
+	}
+
 	if inst.State == db.InstanceStateApprovalWaiting && inst.Message != "" {
 		b.WriteString("  " + StyleWarning.Render("⏸ "+inst.Message) + "\n")
 	}
 
 	if len(inst.Steps) > 0 {
 		b.WriteString("\n  " + StyleLabel.Render("Steps") + "\n")
-		for _, s := range inst.Steps {
+		b.WriteString("    " + wfStepHeader() + "\n")
+		for i, s := range inst.Steps {
+			if i > 0 {
+				if w := wfWaitRow(inst.Steps[i-1], s); w != "" {
+					b.WriteString("    " + w + "\n")
+				}
+			}
 			b.WriteString("    " + wfStepRow(s) + "\n")
 		}
 	}
@@ -2931,19 +3009,90 @@ func wfFailureMarker(inst *WorkflowInstanceItem) string {
 	return StyleError.Render("✗ workflow failed " + after + " — no further steps recorded")
 }
 
-// wfStepRow formats a single workflow step as one display row (glyph, step id,
-// agent, duration, state) without indentation or trailing newline, so callers can
-// place it in a panel or a flattened log-line list.
+// wfInstanceSummary renders a one-line dated-span/duration/token/cost rollup for
+// an instance, or "" when it has no recorded span (e.g. a pending instance with no
+// started step). Shown under the Workflow header.
+func wfInstanceSummary(inst *WorkflowInstanceItem) string {
+	if inst.StartedAt == nil {
+		return ""
+	}
+	parts := []string{datedSpan(inst.StartedAt, inst.FinishedAt)}
+	if inst.FinishedAt != nil {
+		parts = append(parts, inst.FinishedAt.Sub(*inst.StartedAt).Round(time.Second).String())
+	}
+	parts = append(parts, fmtTokensShort(inst.TotalTokens)+" tokens")
+	if inst.CostUSD > 0 {
+		parts = append(parts, fmt.Sprintf("$%.4f", inst.CostUSD))
+	}
+	return StyleMuted.Render(strings.Join(parts, "  ·  "))
+}
+
+// Step/instance table column widths, shared by header and rows so they align.
+// colTime fits tsTimeFmt ("01-02 15:04:05").
+const (
+	colStep  = 14
+	colAgent = 14
+	colTime  = 14
+	colDur   = 8
+	colTok   = 8
+)
+
+// stepGapColumn is the number of characters from the start of a step row (after
+// the caller's indent) to where the STARTED cell begins: glyph + sep + step +
+// sep + agent + sep. The wait-between-steps marker is padded to it so it sits
+// under the timestamps.
+const stepGapColumn = 1 + 1 + colStep + 1 + colAgent + 1
+
+// minStepWait is the smallest inter-step gap worth showing: below it the gap is
+// just dispatch/queue latency (a few seconds), which would only add noise lines.
+const minStepWait = 30 * time.Second
+
+// wfWaitRow renders the idle gap between a finished step and the next step's
+// start (CI waits, approvals, queue time), aligned under the STARTED column.
+// Returns "" when either timestamp is missing or the gap is below minStepWait.
+func wfWaitRow(prev, cur WorkflowStepItem) string {
+	if prev.FinishedAt == nil || cur.StartedAt == nil {
+		return ""
+	}
+	gap := cur.StartedAt.Sub(*prev.FinishedAt).Round(time.Second)
+	if gap < minStepWait {
+		return ""
+	}
+	return strings.Repeat(" ", stepGapColumn) + StyleMuted.Render("↓ "+gap.String()+" waiting")
+}
+
+// wfStepHeader renders the column header for the step table. The leading single
+// space stands in for the per-row status glyph so "STEP" aligns over the step id.
+func wfStepHeader() string {
+	return StyleLabel.Render(fmt.Sprintf("%s %s %s %s %s %s %s  %s",
+		" ",
+		pad("STEP", colStep),
+		pad("AGENT", colAgent),
+		pad("STARTED", colTime),
+		pad("ENDED", colTime),
+		padLeft("DURATION", colDur),
+		padLeft("TOKENS", colTok),
+		"STATE",
+	))
+}
+
+// wfStepRow formats a single workflow step as one columnar display row (glyph,
+// step id, agent, started, ended, duration, tokens, state) without indentation or
+// trailing newline, aligned under wfStepHeader. Callers add the indent.
 func wfStepRow(s WorkflowStepItem) string {
 	state := s.State
 	if s.Cached {
 		state += " (cached)"
 	}
-	return fmt.Sprintf("%s  %s  %s  %s",
+	return fmt.Sprintf("%s %s %s %s %s %s %s  %s",
 		wfStepGlyph(s.State),
-		pad(truncate(s.StepID, 16), 16),
-		pad(truncate(s.Agent, 16), 16),
-		StyleMuted.Render(pad(s.Duration, 8))+"  "+wfStateStyle(s.State).Render(state),
+		pad(truncate(s.StepID, colStep), colStep),
+		pad(truncate(s.Agent, colAgent), colAgent),
+		StyleMuted.Render(pad(tsCell(s.StartedAt), colTime)),
+		StyleMuted.Render(pad(tsCell(s.FinishedAt), colTime)),
+		StyleMuted.Render(padLeft(valueOr(s.Duration, "—"), colDur)),
+		StyleMuted.Render(padLeft(fmtTokensShort(s.TotalTokens), colTok)),
+		wfStateStyle(s.State).Render(state),
 	)
 }
 
@@ -3085,7 +3234,15 @@ func (a *App) taskHistoryLines() []string {
 		if seg.Instance.State == db.InstanceStateApprovalWaiting && seg.Instance.Message != "" {
 			out = append(out, "  "+StyleWarning.Render("⏸ "+seg.Instance.Message))
 		}
-		for _, s := range seg.Instance.Steps {
+		if len(seg.Instance.Steps) > 0 {
+			out = append(out, "  "+wfStepHeader())
+		}
+		for i, s := range seg.Instance.Steps {
+			if i > 0 {
+				if w := wfWaitRow(seg.Instance.Steps[i-1], s); w != "" {
+					out = append(out, "  "+w)
+				}
+			}
 			out = append(out, "  "+wfStepRow(s))
 			if s.Summary != "" {
 				out = append(out, "      "+StyleMuted.Render(truncate(s.Summary, sw)))
@@ -4003,6 +4160,46 @@ func valueOr(s, fallback string) string {
 		return fallback
 	}
 	return s
+}
+
+// fmtTokensShort renders a token count compactly (842, 1.2k, 3.4M); "—" for zero.
+func fmtTokensShort(n int) string {
+	switch {
+	case n <= 0:
+		return "—"
+	case n < 1000:
+		return fmt.Sprintf("%d", n)
+	case n < 1_000_000:
+		return fmt.Sprintf("%.1fk", float64(n)/1000)
+	default:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	}
+}
+
+// tsTimeFmt is the fixed-width timestamp shown in step/instance table cells:
+// month-day plus wall-clock, so a run that spans days (or midnight) is unambiguous.
+const tsTimeFmt = "01-02 15:04:05"
+
+// tsCell renders a single timestamp table cell, or "—" when absent.
+func tsCell(t *time.Time) string {
+	if t == nil {
+		return "—"
+	}
+	return t.Format(tsTimeFmt)
+}
+
+// datedSpan renders "01-02 15:04:05 → 01-02 15:04:05" for a start/end pair, used
+// in the one-line workflow rollup: an unfinished span ends with "…", an unstarted
+// one is "—".
+func datedSpan(start, end *time.Time) string {
+	if start == nil {
+		return "—"
+	}
+	e := "…"
+	if end != nil {
+		e = end.Format(tsTimeFmt)
+	}
+	return start.Format(tsTimeFmt) + " → " + e
 }
 
 // pad right-pads s with spaces to a minimum display width.

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -104,6 +104,17 @@ type WorkflowInstanceItem struct {
 	CreatedAt        time.Time
 	Steps            []WorkflowStepItem
 	CIPolls          []CIPollItem // recorded wait_for CI poll history (oldest first)
+
+	// Span and token totals aggregated across this instance's steps (StartedAt =
+	// earliest step start, FinishedAt = latest step finish). Used for the per-
+	// workflow timing/usage line and to roll up the whole-task header, so the
+	// detail no longer reflects only the last execution row.
+	StartedAt    *time.Time
+	FinishedAt   *time.Time
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	CostUSD      float64
 }
 
 // CIPollItem is one recorded poll of a wait_for step's CI status, shown in the

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -147,6 +147,98 @@ func TestRenderWorkflowSteps_FailedNoSteps(t *testing.T) {
 	}
 }
 
+// The task header span/usage must reflect the whole run: earliest step start,
+// latest step finish, and tokens/cost summed across every instance — not just the
+// last execution row (which would show only the final merge step).
+func TestTaskRollup_SpansAllInstances(t *testing.T) {
+	at := func(s string) *time.Time { v, _ := time.Parse(time.RFC3339, s); return &v }
+	d := &TaskItem{
+		// Execution-row values reflect only the last step (the merge): wrong for the header.
+		StartedAt: at("2026-06-08T15:46:53Z"), CompletedAt: at("2026-06-08T15:47:35Z"),
+		InputTokens: 0, OutputTokens: 0, TotalTokens: 0, CostUSD: 0.1312,
+		Instances: []WorkflowInstanceItem{{
+			StartedAt: at("2026-06-08T13:42:01Z"), FinishedAt: at("2026-06-08T15:47:35Z"),
+			InputTokens: 90000, OutputTokens: 34533, TotalTokens: 124533, CostUSD: 0.95,
+		}},
+	}
+	start, end, in, out, total, cost := taskRollup(d, nil)
+	if start == nil || !start.Equal(*at("2026-06-08T13:42:01Z")) {
+		t.Errorf("rollup start should be the first workflow start, got %v", start)
+	}
+	if end == nil || !end.Equal(*at("2026-06-08T15:47:35Z")) {
+		t.Errorf("rollup end should be the last step finish, got %v", end)
+	}
+	if in != 90000 || out != 34533 || total != 124533 {
+		t.Errorf("rollup tokens should sum instances, got %d/%d/%d", in, out, total)
+	}
+	if cost != 0.95 {
+		t.Errorf("rollup cost should sum instances, got %v", cost)
+	}
+}
+
+// With no instance-level usage the rollup falls back to the execution-row values
+// so legacy single-shot tasks still report a span and spend.
+func TestTaskRollup_FallsBackToExecutionRow(t *testing.T) {
+	at := func(s string) *time.Time { v, _ := time.Parse(time.RFC3339, s); return &v }
+	d := &TaskItem{
+		StartedAt: at("2026-06-08T10:00:00Z"), CompletedAt: at("2026-06-08T10:05:00Z"),
+		InputTokens: 10, OutputTokens: 20, TotalTokens: 30, CostUSD: 0.01,
+	}
+	start, end, in, out, total, cost := taskRollup(d, nil)
+	if start == nil || end == nil || in != 10 || out != 20 || total != 30 || cost != 0.01 {
+		t.Errorf("expected execution-row fallback, got start=%v end=%v %d/%d/%d $%v", start, end, in, out, total, cost)
+	}
+}
+
+// Each step row carries its started/ended timestamps (with date) and token count
+// under a column header; the workflow header carries the dated rollup line.
+func TestRenderWorkflowSteps_StepSpanAndTokens(t *testing.T) {
+	at := func(s string) *time.Time { v, _ := time.Parse("2006-01-02 15:04:05", s); return &v }
+	inst := &WorkflowInstanceItem{
+		ID: "wf_s", Workflow: "implementation", State: "done",
+		StartedAt: at("2026-06-08 13:42:01"), FinishedAt: at("2026-06-08 13:52:11"), TotalTokens: 50300,
+		Steps: []WorkflowStepItem{
+			{StepID: "implement", Agent: "engineer", State: "passed", Duration: "8m15s",
+				StartedAt: at("2026-06-08 13:42:01"), FinishedAt: at("2026-06-08 13:50:16"), TotalTokens: 42100},
+		},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	for _, want := range []string{
+		"STARTED", "ENDED", "DURATION", "TOKENS", "STATE", // column header
+		"06-08 13:42:01", "06-08 13:50:16", "42.1k", // step row cells
+		"06-08 13:42:01 → 06-08 13:52:11", "50.3k tokens", // instance rollup
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered steps missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A meaningful idle gap between a step's end and the next step's start (CI waits,
+// approvals, queue) is shown as a "waiting" connector; a short dispatch-latency
+// gap below minStepWait is not.
+func TestRenderWorkflowSteps_WaitBetweenSteps(t *testing.T) {
+	at := func(s string) *time.Time { v, _ := time.Parse("2006-01-02 15:04:05", s); return &v }
+	inst := &WorkflowInstanceItem{
+		ID: "wf_w", Workflow: "implementation", State: "running",
+		Steps: []WorkflowStepItem{
+			{StepID: "implement", Agent: "engineer", State: "passed",
+				StartedAt: at("2026-06-08 13:42:01"), FinishedAt: at("2026-06-08 13:50:16")},
+			{StepID: "review", Agent: "reviewer", State: "passed", // 4s gap (< minStepWait) → no connector
+				StartedAt: at("2026-06-08 13:50:20"), FinishedAt: at("2026-06-08 13:52:11")},
+			{StepID: "merge", Agent: "engineer", State: "running", // ~2h CI/approval wait
+				StartedAt: at("2026-06-08 15:46:53")},
+		},
+	}
+	out := stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "↓ 1h54m42s waiting") {
+		t.Errorf("expected the long inter-step wait to be shown:\n%s", out)
+	}
+	if strings.Count(out, "waiting") != 1 {
+		t.Errorf("a short sub-threshold gap should not render a wait connector; got %d:\n%s", strings.Count(out, "waiting"), out)
+	}
+}
+
 // A non-failed instance never gets the marker.
 func TestRenderWorkflowSteps_NoMarkerWhenDone(t *testing.T) {
 	inst := &WorkflowInstanceItem{

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -266,7 +266,24 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	return result, nil
 }
 
-// stream-json event types (Claude output format)
+// cliUsage mirrors the usage object the Claude CLI reports on both `assistant`
+// message events and the final `result` event. Cache tokens are real input the
+// model processed (and are billed), so inputTotal folds them into the input side.
+type cliUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+func (u cliUsage) inputTotal() int {
+	return u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+}
+
+// stream-json event types (Claude CLI output format). The CLI emits complete-
+// message events — `system`, `assistant`, `user`, `result` — not the raw
+// Anthropic API's `message_start`/`message_delta` token deltas. Usage rides on
+// the `assistant` message and (authoritatively) on the final `result` event.
 type streamEvent struct {
 	Type    string `json:"type"`
 	Subtype string `json:"subtype"`
@@ -281,47 +298,47 @@ type streamEvent struct {
 			Input   json.RawMessage `json:"input"`
 			Content json.RawMessage `json:"content"`
 		} `json:"content"`
-		Usage *struct {
-			InputTokens int `json:"input_tokens"`
-		} `json:"usage"`
+		Usage *cliUsage `json:"usage"`
 	} `json:"message"`
-	ContentBlock *struct {
-		Type  string          `json:"type"`
-		Name  string          `json:"name"`
-		Input json.RawMessage `json:"input"`
-	} `json:"content_block"`
-	Usage *struct {
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
-	DurationMs   int64   `json:"duration_ms"`
-	NumTurns     int     `json:"num_turns"`
-	TotalCostUSD float64 `json:"total_cost_usd"`
-	IsError      bool    `json:"is_error"`
+	Usage        *cliUsage `json:"usage"` // present on the `result` event
+	DurationMs   int64     `json:"duration_ms"`
+	NumTurns     int       `json:"num_turns"`
+	TotalCostUSD float64   `json:"total_cost_usd"`
+	IsError      bool      `json:"is_error"`
 }
 
+// accumulateStreamUsage folds one stream-json line into the running usage. Token
+// totals come from the final `result` event's usage — authoritative, matches
+// total_cost_usd, and includes cache tokens. Tool calls are counted from the
+// `tool_use` blocks in `assistant` messages. The per-assistant usage is also
+// recorded as a fallback so a run that dies before the `result` event still
+// reports the last message's counts rather than zeros.
 func accumulateStreamUsage(line string, u *model.Usage) {
 	var ev streamEvent
 	if err := json.Unmarshal([]byte(line), &ev); err != nil || ev.Type == "" {
 		return
 	}
 	switch ev.Type {
-	case "message_start":
+	case "assistant":
+		for _, c := range ev.Message.Content {
+			if c.Type == "tool_use" {
+				u.NumToolCalls++
+			}
+		}
 		if ev.Message.Usage != nil {
-			u.InputTokens = ev.Message.Usage.InputTokens
-		}
-	case "message_delta":
-		if ev.Usage != nil {
-			u.OutputTokens = ev.Usage.OutputTokens
-		}
-		u.TotalTokens = u.InputTokens + u.OutputTokens
-	case "content_block_start":
-		if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
-			u.NumToolCalls++
+			u.InputTokens = ev.Message.Usage.inputTotal()
+			u.OutputTokens = ev.Message.Usage.OutputTokens
+			u.TotalTokens = u.InputTokens + u.OutputTokens
 		}
 	case "result":
 		u.NumTurns = ev.NumTurns
 		if ev.TotalCostUSD > 0 {
 			u.CostUSD = ev.TotalCostUSD
+		}
+		if ev.Usage != nil { // authoritative cumulative totals
+			u.InputTokens = ev.Usage.inputTotal()
+			u.OutputTokens = ev.Usage.OutputTokens
+			u.TotalTokens = u.InputTokens + u.OutputTokens
 		}
 	}
 }

--- a/src/internal/runner/execution/stream_test.go
+++ b/src/internal/runner/execution/stream_test.go
@@ -50,34 +50,47 @@ func TestFormatStreamLine_UserToolResult(t *testing.T) {
 	}
 }
 
+// Event shapes match the real Claude CLI `--output-format stream-json` output:
+// tool calls come from `tool_use` blocks in `assistant` messages, and token
+// totals from the final `result` event's usage (which folds in cache tokens).
 func TestAccumulateStreamUsage_Full(t *testing.T) {
 	var u model.Usage
 
-	accumulateStreamUsage(`{"type":"message_start","message":{"usage":{"input_tokens":523}}}`, &u)
-	if u.InputTokens != 523 {
-		t.Errorf("InputTokens = %d, want 523", u.InputTokens)
-	}
-
-	accumulateStreamUsage(`{"type":"message_delta","usage":{"output_tokens":142}}`, &u)
-	if u.OutputTokens != 142 {
-		t.Errorf("OutputTokens = %d, want 142", u.OutputTokens)
-	}
-	if u.TotalTokens != 523+142 {
-		t.Errorf("TotalTokens = %d, want %d", u.TotalTokens, 523+142)
-	}
-
-	accumulateStreamUsage(`{"type":"content_block_start","content_block":{"type":"tool_use","name":"Bash","input":{"command":"ls"}}}`, &u)
-	accumulateStreamUsage(`{"type":"content_block_start","content_block":{"type":"tool_use","name":"Read","input":{"file":"x"}}}`, &u)
+	// Two assistant turns, each issuing a tool call. The per-message usage is a
+	// fallback; the authoritative totals arrive on the result event below.
+	accumulateStreamUsage(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}],"usage":{"input_tokens":10,"cache_read_input_tokens":1800,"output_tokens":20}}}`, &u)
+	accumulateStreamUsage(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file":"x"}}],"usage":{"input_tokens":12,"cache_read_input_tokens":1900,"output_tokens":30}}}`, &u)
 	if u.NumToolCalls != 2 {
 		t.Errorf("NumToolCalls = %d, want 2", u.NumToolCalls)
 	}
 
-	accumulateStreamUsage(`{"type":"result","subtype":"success","num_turns":4,"duration_ms":12000,"result":"done","total_cost_usd":0.087}`, &u)
+	// The result event's usage is authoritative and includes cache tokens on the
+	// input side: input = 10 + 6804(creation) + 18053(read) = 24867.
+	accumulateStreamUsage(`{"type":"result","subtype":"success","num_turns":4,"duration_ms":12000,"result":"done","total_cost_usd":0.087,"usage":{"input_tokens":10,"cache_creation_input_tokens":6804,"cache_read_input_tokens":18053,"output_tokens":142}}`, &u)
+	if u.InputTokens != 24867 {
+		t.Errorf("InputTokens = %d, want 24867 (input + cache creation + cache read)", u.InputTokens)
+	}
+	if u.OutputTokens != 142 {
+		t.Errorf("OutputTokens = %d, want 142", u.OutputTokens)
+	}
+	if u.TotalTokens != 24867+142 {
+		t.Errorf("TotalTokens = %d, want %d", u.TotalTokens, 24867+142)
+	}
 	if u.NumTurns != 4 {
 		t.Errorf("NumTurns = %d, want 4", u.NumTurns)
 	}
 	if u.CostUSD != 0.087 {
 		t.Errorf("CostUSD = %.4f, want 0.087", u.CostUSD)
+	}
+}
+
+// When a run ends without a result event (e.g. killed/timed out), the last
+// assistant message's usage is reported rather than zeros.
+func TestAccumulateStreamUsage_AssistantFallback(t *testing.T) {
+	var u model.Usage
+	accumulateStreamUsage(`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":5,"cache_read_input_tokens":1000,"output_tokens":8}}}`, &u)
+	if u.InputTokens != 1005 || u.OutputTokens != 8 || u.TotalTokens != 1013 {
+		t.Errorf("assistant fallback usage = %d in / %d out / %d total, want 1005/8/1013", u.InputTokens, u.OutputTokens, u.TotalTokens)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related fixes to how a task's time and token usage are captured and shown in the dashboard Task Detail view.

**Runner — capture Claude CLI token usage (`fix`)**
- `accumulateStreamUsage` parsed usage from `message_start` / `message_delta` / `content_block_start` — raw Anthropic API SSE event types the Claude CLI **never emits** under `--output-format stream-json`. Only the `result` case fired, so cost and turns were recorded but **input/output/total tokens and tool-call counts stayed at 0** (the "cost present, tokens zero" symptom).
- Now reads the authoritative usage from the `result` event. Cache-creation and cache-read tokens are folded into the input side so the count is consistent with `total_cost_usd`. Tool calls are counted from `tool_use` blocks in `assistant` messages, with a fallback to the last assistant message's usage if a run dies before the `result` event.
- Verified against live `claude --output-format stream-json --verbose` output: a sample that previously recorded `0/0/0` tokens now parses `24867 in / 43 out / 24910 total` matching its `result.usage`.

**Dashboard — whole-run rollup + per-step/workflow timings & tokens (`feat`)**
- The header read only the latest `task_executions` row (e.g. the 42s merge step), so `Started`/`Completed`/`Duration`/`Tokens` misrepresented the run. It now rolls up the whole task: earliest step start → latest finish, tokens/cost summed across the task's workflow instances, falling back to the execution row for legacy single-shot tasks.
- `Steps` and `Workflow Instances` now render as aligned tables with column headers (`STARTED ENDED DURATION TOKENS STATE`), dated timestamps, and per-step / per-workflow token totals.
- Inter-step idle gaps over 30s (CI waits, approvals, queue) show as a `↓ … waiting` connector under the timeline.

Note: only the CLI runners are affected; the `api` runner path is intentionally left as-is (no longer a supported target). Existing rows keep their stored zeros — the fix applies to new runs.

## Test plan
- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all packages pass
- New/updated unit tests: `TestAccumulateStreamUsage_Full` + `TestAccumulateStreamUsage_AssistantFallback` (real CLI event shapes), `TestTaskRollup_*`, `TestRenderWorkflowSteps_StepSpanAndTokens`, `TestRenderWorkflowSteps_WaitBetweenSteps`
- End-to-end: replayed a captured live `claude` stream through the parser and confirmed non-zero token extraction matching `result.usage` + `total_cost_usd`

No PR-gated CI runs for these paths (release-check only triggers on goreleaser/Dockerfile/go.mod changes); verified locally per project convention.