### PR TITLE
Speed up first open of a task's logs

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -31,6 +31,13 @@ const refreshInterval = 2 * time.Second
 // queryTimeout bounds each database query so a locked DB never blocks the UI.
 const queryTimeout = 2 * time.Second
 
+// taskLogTailLimit caps how many of a task's most recent log lines are loaded
+// when the logs view opens. task_logs rows are large (~10KB of agent stream), so
+// loading the full history cold is the main cause of a slow first open; a tail of
+// this size keeps it fast, and older lines load on scroll-to-top (see
+// fetchOlderTaskLogs).
+const taskLogTailLimit = 1000
+
 // App is the main dashboard application.
 //
 // It follows the Elm architecture used by Bubble Tea: commands run in
@@ -75,9 +82,20 @@ type taskDetailMsg struct {
 	instance *WorkflowInstanceItem
 }
 type taskLogsMsg struct {
-	taskID string
-	logs   []LogEntry
-	detail *TaskItem
+	taskID   string
+	logs     []LogEntry
+	detail   *TaskItem
+	oldestID int64 // row id of the oldest loaded line (older-page cursor)
+	hasMore  bool  // an older page may exist
+}
+
+// olderTaskLogsMsg carries an older page of flat task logs lazily loaded when the
+// logs view is scrolled to the top.
+type olderTaskLogsMsg struct {
+	taskID   string
+	logs     []LogEntry
+	oldestID int64
+	hasMore  bool
 }
 type taskHistoryMsg struct {
 	taskID   string
@@ -163,22 +181,44 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.model.loading = false
 
 	case taskLogsMsg:
-		if a.model.tasksTab != nil {
-			a.model.tasksTab.Logs = msg.logs
-			a.model.tasksTab.InstanceHistory = nil
-			a.model.tasksTab.Detail = msg.detail
-			a.model.tasksTab.LogScroll = 0
-			a.model.tasksTab.View = TaskViewLogs
+		if t := a.model.tasksTab; t != nil {
+			t.Logs = msg.logs
+			t.InstanceHistory = nil
+			t.Detail = msg.detail
+			t.LogScroll = 0
+			t.View = TaskViewLogs
+			t.LogTaskID = msg.taskID
+			t.LogOldestID = msg.oldestID
+			t.LogHasMore = msg.hasMore
+			t.LogLoadingMore = false
 		}
 		a.model.loading = false
 
+	case olderTaskLogsMsg:
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewLogs && msg.taskID == t.LogTaskID {
+			t.LogLoadingMore = false
+			if len(msg.logs) > 0 {
+				// Prepend older lines and keep the viewport anchored: the prior top
+				// line shifts down by the number of visual lines the new entries add.
+				delta := len(a.logEntryLines(msg.logs))
+				t.Logs = append(append([]LogEntry{}, msg.logs...), t.Logs...)
+				t.LogScroll += delta
+				t.LogOldestID = msg.oldestID
+			}
+			t.LogHasMore = msg.hasMore
+		}
+
 	case taskHistoryMsg:
-		if a.model.tasksTab != nil {
-			a.model.tasksTab.InstanceHistory = msg.segments
-			a.model.tasksTab.Logs = nil
-			a.model.tasksTab.Detail = msg.detail
-			a.model.tasksTab.LogScroll = 0
-			a.model.tasksTab.View = TaskViewLogs
+		if t := a.model.tasksTab; t != nil {
+			t.InstanceHistory = msg.segments
+			t.Logs = nil
+			t.Detail = msg.detail
+			t.LogScroll = 0
+			t.View = TaskViewLogs
+			// History (per-instance) path is segment-bounded — no flat-log cursor.
+			t.LogTaskID = ""
+			t.LogHasMore = false
+			t.LogLoadingMore = false
 		}
 		a.model.loading = false
 
@@ -876,6 +916,9 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		t.Logs = nil
 		t.InstanceHistory = nil
 		t.LogScroll = 0
+		t.LogTaskID = ""
+		t.LogHasMore = false
+		t.LogLoadingMore = false
 	case "d":
 		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
@@ -895,8 +938,12 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
 		}
 	case "up":
-		if t.View == TaskViewLogs && t.LogScroll > 0 {
-			t.LogScroll--
+		if t.View == TaskViewLogs {
+			if t.LogScroll > 0 {
+				t.LogScroll--
+			} else if cmd := a.loadOlderLogsCmd(t); cmd != nil {
+				return a, cmd // at top — pull in the next older page
+			}
 		}
 	case "down":
 		if t.View == TaskViewLogs && t.LogScroll < len(a.taskLogLines())-1 {
@@ -912,6 +959,11 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "pgup", "ctrl+u":
 		if t.View == TaskViewLogs {
+			if t.LogScroll == 0 {
+				if cmd := a.loadOlderLogsCmd(t); cmd != nil {
+					return a, cmd
+				}
+			}
 			t.LogScroll = clampScroll(t.LogScroll-a.pageSize(), len(a.taskLogLines()))
 		}
 	case "pgdown", "ctrl+d", " ":
@@ -1308,6 +1360,7 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 	}
 	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
 	if err == nil {
+		usage := loadStepUsageFallback(ctx, dbConn, inst.ID, steps)
 		now := time.Now()
 		for _, s := range steps {
 			si := WorkflowStepItem{
@@ -1322,7 +1375,7 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 				FinishedAt: s.FinishedAt,
 			}
 			si.InputTokens, si.OutputTokens, si.TotalTokens, si.NumTurns, si.NumToolCalls, si.CostUSD =
-				resolveStepUsage(ctx, dbConn, inst.ID, s)
+				stepUsageFromMap(s, usage)
 			item.Steps = append(item.Steps, si)
 		}
 		aggregateInstance(item)
@@ -1333,16 +1386,32 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 	return item
 }
 
-// resolveStepUsage returns a step's token/turn/cost rollup, preferring the
-// step_runs row's own summed columns and falling back to the linked
-// task_executions rows for older steps that predate the rollup (StepRunHasUsage
-// is false). Returns zeros when neither carries usage.
-func resolveStepUsage(ctx context.Context, dbConn *db.Client, instID string, s db.StepRun) (in, out, total, turns, calls int, cost float64) {
+// loadStepUsageFallback fetches the per-instance executions usage map, but only
+// when at least one step lacks its own rollup — modern instances (every step_run
+// carries usage) skip the query entirely. This replaces the old per-step
+// GetStepUsage fan-out (N+1) with at most one query per instance.
+func loadStepUsageFallback(ctx context.Context, dbConn *db.Client, instID string, steps []db.StepRun) map[string]db.Execution {
+	for _, s := range steps {
+		if !db.StepRunHasUsage(s) {
+			if m, err := dbConn.GetInstanceStepUsage(ctx, instID); err == nil {
+				return m
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// stepUsageFromMap returns a step's token/turn/cost rollup, preferring the
+// step_runs row's own summed columns and falling back to the per-instance usage
+// map (loadStepUsageFallback) for older steps that predate the rollup. Returns
+// zeros when neither carries usage.
+func stepUsageFromMap(s db.StepRun, usage map[string]db.Execution) (in, out, total, turns, calls int, cost float64) {
 	if db.StepRunHasUsage(s) {
 		return s.InputTokens, s.OutputTokens, s.TotalTokens, s.NumTurns, s.NumToolCalls, s.CostUSD
 	}
-	if usage, err := dbConn.GetStepUsage(ctx, instID, s.StepID); err == nil && usage != nil {
-		return usage.InputTokens, usage.OutputTokens, usage.TotalTokens, usage.NumTurns, usage.NumToolCalls, usage.CostUSD
+	if u, ok := usage[s.StepID]; ok {
+		return u.InputTokens, u.OutputTokens, u.TotalTokens, u.NumTurns, u.NumToolCalls, u.CostUSD
 	}
 	return 0, 0, 0, 0, 0, 0
 }
@@ -1808,7 +1877,7 @@ func (a *App) fetchAgentTaskLogs(taskID string) tea.Cmd {
 					CostUSD:      r.CostUSD,
 				}
 			}
-			if rows, err := dbConn.GetTaskLogs(ctx, taskID, 5000); err == nil {
+			if rows, err := dbConn.GetTaskLogs(ctx, taskID, taskLogTailLimit); err == nil {
 				for _, l := range rows {
 					logs = append(logs, LogEntry{
 						Timestamp: l.Timestamp,
@@ -1951,10 +2020,11 @@ func mapInstances(ctx context.Context, dbConn *db.Client, insts []db.WorkflowIns
 			CreatedAt:        in.CreatedAt,
 		}
 		if steps, err := dbConn.ListStepRuns(ctx, in.ID); err == nil {
+			usage := loadStepUsageFallback(ctx, dbConn, in.ID, steps)
 			for _, s := range steps {
 				si := WorkflowStepItem{StartedAt: s.StartedAt, FinishedAt: s.FinishedAt}
 				si.InputTokens, si.OutputTokens, si.TotalTokens, si.NumTurns, si.NumToolCalls, si.CostUSD =
-					resolveStepUsage(ctx, dbConn, in.ID, s)
+					stepUsageFromMap(s, usage)
 				item.Steps = append(item.Steps, si)
 			}
 			aggregateInstance(&item)
@@ -2003,13 +2073,54 @@ func (a *App) fetchTaskLogs(taskID string) tea.Cmd {
 
 		var detail *TaskItem
 		logs := make([]LogEntry, 0)
+		var oldestID int64
+		var hasMore bool
 		if dbConn != nil {
 			detail = taskDetailItem(ctx, dbConn, taskID)
-			if rows, err := dbConn.GetTaskLogs(ctx, taskID, 5000); err == nil {
+			if rows, err := dbConn.GetTaskLogs(ctx, taskID, taskLogTailLimit); err == nil {
 				logs = mapLogLines(rows)
+				if len(rows) > 0 {
+					oldestID = rows[0].ID // chronological: first row is the oldest loaded
+				}
+				hasMore = len(rows) == taskLogTailLimit // a full page implies older rows exist
 			}
 		}
-		return taskLogsMsg{taskID: taskID, logs: logs, detail: detail}
+		return taskLogsMsg{taskID: taskID, logs: logs, detail: detail, oldestID: oldestID, hasMore: hasMore}
+	}
+}
+
+// loadOlderLogsCmd starts a lazy fetch of the next older page of flat task logs
+// when the logs view is scrolled to the top and an older page may exist. Returns
+// nil when there is nothing to load (history view, no cursor, already loading, or
+// no more pages).
+func (a *App) loadOlderLogsCmd(t *TasksTab) tea.Cmd {
+	if t.View != TaskViewLogs || len(t.InstanceHistory) > 0 ||
+		t.LogTaskID == "" || !t.LogHasMore || t.LogLoadingMore {
+		return nil
+	}
+	t.LogLoadingMore = true
+	return a.fetchOlderTaskLogs(t.LogTaskID, t.LogOldestID)
+}
+
+// fetchOlderTaskLogs lazily loads the page of flat task logs immediately older
+// than beforeID, for the scroll-to-top tail-pagination of the logs view.
+func (a *App) fetchOlderTaskLogs(taskID string, beforeID int64) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+
+		msg := olderTaskLogsMsg{taskID: taskID}
+		if dbConn != nil {
+			if rows, err := dbConn.GetTaskLogsBefore(ctx, taskID, beforeID, taskLogTailLimit); err == nil {
+				msg.logs = mapLogLines(rows)
+				if len(rows) > 0 {
+					msg.oldestID = rows[0].ID
+				}
+				msg.hasMore = len(rows) == taskLogTailLimit
+			}
+		}
+		return msg
 	}
 }
 
@@ -3174,6 +3285,19 @@ func (a *App) renderTaskLogs(t *TasksTab, height int) string {
 	if rows < 1 {
 		rows = 1
 	}
+	// A "load older" hint takes the top row when the flat-log tail is scrolled to
+	// its start and an older page is available (or being fetched).
+	hint := ""
+	if t.LogScroll == 0 && len(t.InstanceHistory) == 0 {
+		if t.LogLoadingMore {
+			hint = "↑ loading older logs…"
+		} else if t.LogHasMore {
+			hint = "↑ older logs — press ↑/PgUp to load"
+		}
+	}
+	if hint != "" && rows > 1 {
+		rows-- // reserve a row for the hint so the box height is unchanged
+	}
 	start := t.LogScroll
 	if start > len(lines)-1 {
 		start = len(lines) - 1
@@ -3187,6 +3311,9 @@ func (a *App) renderTaskLogs(t *TasksTab, height int) string {
 	}
 
 	var b strings.Builder
+	if hint != "" {
+		b.WriteString(StyleMuted.Render(hint) + "\n")
+	}
 	for i := start; i < end; i++ {
 		b.WriteString(lines[i] + "\n")
 	}

--- a/src/internal/dashboard/log_pagination_test.go
+++ b/src/internal/dashboard/log_pagination_test.go
@@ -1,0 +1,54 @@
+package dashboard
+
+import "testing"
+
+// An older page of flat logs is prepended and the viewport stays anchored: the
+// scroll offset advances by the visual-line count of the newly prepended entries,
+// so the line the user was looking at doesn't jump.
+func TestOlderTaskLogs_PrependAnchorsScroll(t *testing.T) {
+	a := newTestApp(90, 44)
+	tt := a.model.tasksTab
+	tt.View = TaskViewLogs
+	tt.LogTaskID = "42"
+	tt.LogHasMore = true
+	tt.LogLoadingMore = true
+	tt.LogScroll = 0
+	tt.Logs = []LogEntry{{Level: "info", Message: "newest"}}
+
+	older := []LogEntry{{Level: "info", Message: "old-1"}, {Level: "info", Message: "old-2"}}
+	delta := len(a.logEntryLines(older))
+
+	a.Update(olderTaskLogsMsg{taskID: "42", logs: older, oldestID: 5, hasMore: false})
+
+	if len(tt.Logs) != 3 || tt.Logs[0].Message != "old-1" || tt.Logs[2].Message != "newest" {
+		t.Fatalf("older logs not prepended in order: %+v", tt.Logs)
+	}
+	if tt.LogScroll != delta {
+		t.Errorf("LogScroll = %d, want %d (anchored by prepended visual-line count)", tt.LogScroll, delta)
+	}
+	if tt.LogOldestID != 5 {
+		t.Errorf("cursor LogOldestID = %d, want 5", tt.LogOldestID)
+	}
+	if tt.LogHasMore {
+		t.Error("LogHasMore should be false after the final page")
+	}
+	if tt.LogLoadingMore {
+		t.Error("LogLoadingMore should be cleared after the page lands")
+	}
+}
+
+// A late older-logs message for a different task (the user navigated away and
+// opened another task's logs) must be ignored, not prepended.
+func TestOlderTaskLogs_IgnoresStaleTask(t *testing.T) {
+	a := newTestApp(90, 44)
+	tt := a.model.tasksTab
+	tt.View = TaskViewLogs
+	tt.LogTaskID = "current"
+	tt.Logs = []LogEntry{{Level: "info", Message: "keep"}}
+
+	a.Update(olderTaskLogsMsg{taskID: "stale", logs: []LogEntry{{Message: "drop"}}, hasMore: true})
+
+	if len(tt.Logs) != 1 || tt.Logs[0].Message != "keep" {
+		t.Errorf("stale older-logs msg should be ignored, got: %+v", tt.Logs)
+	}
+}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -74,6 +74,13 @@ type TasksTab struct {
 	InstanceHistory []TaskHistorySegmentItem // per-instance history (TaskViewLogs, InternalTask rows)
 	LogScroll       int
 
+	// Flat-log tail pagination (Logs path only): the view loads the most recent
+	// taskLogTailLimit lines, then fetches older pages on scroll-to-top.
+	LogTaskID      string // task whose flat logs are loaded (cursor scope)
+	LogOldestID    int64  // row id of the oldest loaded line (the older-page cursor)
+	LogHasMore     bool   // an older page may exist (last load filled the limit)
+	LogLoadingMore bool   // an older-page fetch is in flight (de-dupe guard)
+
 	// Workflow monitor sub-view (View == TaskViewWorkflow).
 	WorkflowInstances   []*WorkflowInstanceItem // all instances for the task, newest-first
 	WorkflowInstanceIdx int                     // index into WorkflowInstances of the one being shown

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -25,12 +25,23 @@ type execer interface {
 
 // New opens a SQLite database and initializes schema.
 func New(ctx context.Context, dbPath string) (*Client, error) {
-	// busy_timeout lets a writer wait for a held lock instead of failing
-	// immediately with SQLITE_BUSY — required for the concurrent SourceBinder
-	// path, where two pollers may bind the same item at once.
+	// Connection pragmas:
+	//   busy_timeout  — wait for a held lock instead of failing immediately with
+	//                   SQLITE_BUSY (concurrent SourceBinder path: two pollers may
+	//                   bind the same item at once).
+	//   journal_mode=WAL — readers don't block the writer and vice versa, so the
+	//                   dashboard's large cold log reads don't stall the daemon.
+	//   synchronous=NORMAL — safe under WAL, far fewer fsyncs.
+	//   cache_size=-20000 — ~20MB page cache; task_logs rows are ~10KB of agent
+	//                   stream text, so a bigger cache cuts cold-read disk hits.
+	//   temp_store=MEMORY — sorts/temp b-trees stay in RAM.
 	dsn := dbPath
 	if !strings.Contains(dsn, "?") {
-		dsn += "?_pragma=busy_timeout(5000)"
+		dsn += "?_pragma=busy_timeout(5000)" +
+			"&_pragma=journal_mode(WAL)" +
+			"&_pragma=synchronous(NORMAL)" +
+			"&_pragma=cache_size(-20000)" +
+			"&_pragma=temp_store(MEMORY)"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -250,6 +261,36 @@ func (c *Client) GetStepUsage(ctx context.Context, instanceID, stepID string) (*
 		return nil, err
 	}
 	return &e, nil
+}
+
+// GetInstanceStepUsage returns the latest token/cost totals per step for a whole
+// workflow instance in a single query — the batched form of GetStepUsage, so
+// building an instance's step list doesn't fan out into one query per step (the
+// N+1 that made opening a task's workflow view slow). Keyed by step_id; rows are
+// scanned in ascending execution order so the most recent execution per step wins.
+func (c *Client) GetInstanceStepUsage(ctx context.Context, instanceID string) (map[string]Execution, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT step_id,
+		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
+		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0)
+		FROM task_executions
+		WHERE workflow_instance_id = ?
+		ORDER BY created_at ASC, id ASC
+	`, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string]Execution)
+	for rows.Next() {
+		var stepID sql.NullString
+		var e Execution
+		if err := rows.Scan(&stepID, &e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.NumTurns, &e.NumToolCalls, &e.CostUSD); err != nil {
+			continue
+		}
+		out[stepID.String] = e // ASC order: the last write per step_id is the most recent
+	}
+	return out, nil
 }
 
 // ReconcileOrphanExecutions marks any executions still in the 'running' state

--- a/src/internal/db/dashboard.go
+++ b/src/internal/db/dashboard.go
@@ -452,20 +452,35 @@ func (c *Client) GetTaskDetail(ctx context.Context, taskID string) (*TaskHistory
 
 // TaskLogLine is a single per-task log record.
 type TaskLogLine struct {
+	ID        int64
 	Timestamp time.Time
 	Level     string
 	Message   string
 }
 
-// GetTaskLogs returns per-task log lines in chronological order.
+// GetTaskLogs returns the most recent `limit` log lines for a task, in
+// chronological order (oldest first).
 func (c *Client) GetTaskLogs(ctx context.Context, taskID string, limit int) ([]TaskLogLine, error) {
+	return c.taskLogsPage(ctx, taskID, 0, limit)
+}
+
+// GetTaskLogsBefore returns up to `limit` log lines older than beforeID (a row
+// id cursor), in chronological order. Used to lazily load earlier history when
+// the logs view is scrolled to the top, so the first open only pays for a tail.
+func (c *Client) GetTaskLogsBefore(ctx context.Context, taskID string, beforeID int64, limit int) ([]TaskLogLine, error) {
+	return c.taskLogsPage(ctx, taskID, beforeID, limit)
+}
+
+// taskLogsPage returns up to `limit` of a task's log lines with id < beforeID
+// (beforeID == 0 means no upper bound — the newest page), ordered oldest-first.
+func (c *Client) taskLogsPage(ctx context.Context, taskID string, beforeID int64, limit int) ([]TaskLogLine, error) {
 	rows, err := c.db.QueryContext(ctx, `
-		SELECT timestamp, level, message
+		SELECT id, timestamp, level, message
 		FROM task_logs
-		WHERE task_id = ?
+		WHERE task_id = ? AND (? = 0 OR id < ?)
 		ORDER BY id DESC
 		LIMIT ?
-	`, taskID, limit)
+	`, taskID, beforeID, beforeID, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +490,7 @@ func (c *Client) GetTaskLogs(ctx context.Context, taskID string, limit int) ([]T
 	for rows.Next() {
 		var l TaskLogLine
 		var level, msg sql.NullString
-		if err := rows.Scan(&l.Timestamp, &level, &msg); err != nil {
+		if err := rows.Scan(&l.ID, &l.Timestamp, &level, &msg); err != nil {
 			continue
 		}
 		l.Level = level.String

--- a/src/internal/db/instance_usage_test.go
+++ b/src/internal/db/instance_usage_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GetInstanceStepUsage returns the latest token/cost totals per step for a whole
+// instance in one query (the batched replacement for per-step GetStepUsage).
+func TestGetInstanceStepUsage(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	base := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	ins := func(step string, total int, cost float64, at time.Time) {
+		t.Helper()
+		_, err := c.db.ExecContext(ctx, `
+			INSERT INTO task_executions
+			  (task_id, agent_id, workflow_instance_id, step_id, status,
+			   input_tokens, output_tokens, total_tokens, cost_usd, created_at)
+			VALUES (?, ?, ?, ?, 'done', ?, ?, ?, ?, ?)`,
+			"42", "engineer", "wf_1", step, total/2, total/2, total, cost, at)
+		if err != nil {
+			t.Fatalf("insert exec: %v", err)
+		}
+	}
+	// 'implement' ran twice (a re-dispatch); the later row must win.
+	ins("implement", 100, 0.10, base)
+	ins("implement", 200, 0.20, base.Add(time.Minute))
+	ins("review", 50, 0.05, base.Add(2*time.Minute))
+	// A different instance must not leak in.
+	_, _ = c.db.ExecContext(ctx, `INSERT INTO task_executions
+		(task_id, agent_id, workflow_instance_id, step_id, status, total_tokens, created_at)
+		VALUES ('42','engineer','wf_other','implement','done',9999,?)`, base)
+
+	usage, err := c.GetInstanceStepUsage(ctx, "wf_1")
+	if err != nil {
+		t.Fatalf("GetInstanceStepUsage: %v", err)
+	}
+	if got := usage["implement"].TotalTokens; got != 200 {
+		t.Errorf("implement TotalTokens = %d, want 200 (latest execution wins)", got)
+	}
+	if got := usage["implement"].CostUSD; got != 0.20 {
+		t.Errorf("implement CostUSD = %v, want 0.20", got)
+	}
+	if got := usage["review"].TotalTokens; got != 50 {
+		t.Errorf("review TotalTokens = %d, want 50", got)
+	}
+	// wf_other's row (9999) must not leak in: only the two wf_1 steps.
+	if len(usage) != 2 {
+		t.Errorf("usage has %d steps, want 2 (no cross-instance leak)", len(usage))
+	}
+}
+
+// New opens the DB in WAL journal mode so the dashboard's large cold log reads
+// don't block the daemon's writes.
+func TestNew_WALEnabled(t *testing.T) {
+	c := newTestClient(t)
+	var mode string
+	if err := c.db.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("PRAGMA journal_mode: %v", err)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		t.Errorf("journal_mode = %q, want wal", mode)
+	}
+}

--- a/src/internal/db/task_logs_page_test.go
+++ b/src/internal/db/task_logs_page_test.go
@@ -1,0 +1,58 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// GetTaskLogs returns the newest page; GetTaskLogsBefore walks older pages via an
+// id cursor with no overlap, draining cleanly to the start.
+func TestGetTaskLogs_CursorPagination(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	for i := 1; i <= 10; i++ {
+		if err := c.WriteTaskLog(ctx, "42", "info", fmt.Sprintf("line-%d", i)); err != nil {
+			t.Fatalf("write log: %v", err)
+		}
+	}
+
+	// Newest page of 3 → chronological line-8, line-9, line-10.
+	page, err := c.GetTaskLogs(ctx, "42", 3)
+	if err != nil {
+		t.Fatalf("GetTaskLogs: %v", err)
+	}
+	if len(page) != 3 || page[0].Message != "line-8" || page[2].Message != "line-10" {
+		t.Fatalf("tail page wrong: %+v", page)
+	}
+
+	// Walk older pages via the cursor, reassembling the full ordered history.
+	seen := messages(page)
+	for len(page) > 0 {
+		older, err := c.GetTaskLogsBefore(ctx, "42", page[0].ID, 3)
+		if err != nil {
+			t.Fatalf("GetTaskLogsBefore: %v", err)
+		}
+		if len(older) > 0 && older[len(older)-1].ID >= page[0].ID {
+			t.Fatalf("older page overlaps the cursor: older=%+v cursor=%d", older, page[0].ID)
+		}
+		seen = append(messages(older), seen...)
+		page = older
+	}
+
+	want := make([]string, 10)
+	for i := range want {
+		want[i] = fmt.Sprintf("line-%d", i+1)
+	}
+	if fmt.Sprint(seen) != fmt.Sprint(want) {
+		t.Errorf("reassembled history = %v, want %v", seen, want)
+	}
+}
+
+func messages(rows []TaskLogLine) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.Message)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

The first time a task's logs (or workflow view) is opened it was slow, then fast forever after — the classic cold-read signature. Root causes, in impact order:

- **Volume**: `task_logs` rows are ~10KB each (full agent stream lines). The logs view loaded up to **5000** rows → ~50MB read off disk cold.
- **N+1**: opening a task's workflow view ran one `GetStepUsage` query *per step* per instance.
- **DB tuning**: SQLite opened with only `busy_timeout` — no WAL, small cache — so the dashboard's big reads contended with the daemon's writes.

### Fixes
- **WAL + cache pragmas** (`perf(db)`): open with `journal_mode=WAL`, `synchronous=NORMAL`, `cache_size=-20000` (~20MB), `temp_store=MEMORY`. Readers no longer block the writer; cold reads hit disk less.
- **Batch step usage** (`perf(db)`): new `GetInstanceStepUsage` returns a whole instance's per-step token/cost rollup in **one** query (latest execution per step wins), replacing the per-step fan-out. The fallback query now runs at most once per instance, and only for legacy instances whose `step_runs` predate the rollup.
- **Cap the tail at 1000** (`perf(dashboard)`): load the most recent 1000 log lines (~10MB cold instead of ~50MB).
- **Lazy older-page load** (`perf(dashboard)`): scroll to the top to pull the next older page via an id cursor (`GetTaskLogsBefore`). The viewport stays anchored (scroll offset advances by the prepended lines' visual height), a `↑ older logs` hint shows at the top, and stale/cross-task pages are ignored. Large logs are now bounded regardless of task size.

Net: first open reads ~5× less data, on a WAL DB with a bigger cache, with the monitor's query-burst collapsed to one query per instance.

## Test plan
- `go build ./...`, `go vet ./...` — clean
- `go test ./...` — all packages pass
- New tests: `TestNew_WALEnabled`, `TestGetInstanceStepUsage` (latest-per-step, no cross-instance leak), `TestGetTaskLogs_CursorPagination` (no-overlap cursor walk reassembles full history), `TestOlderTaskLogs_PrependAnchorsScroll`, `TestOlderTaskLogs_IgnoresStaleTask`

Note: the pagination *logic* is unit-tested, but the on-screen scroll *feel* (hint + anchor on load) wasn't exercised in a live TUI — worth a quick manual check.

No PR-gated CI runs for these paths (release-check only triggers on goreleaser/Dockerfile/go.mod); verified locally per project convention.