### PR TITLE
feat(tokens): store cache_creation/cache_read tokens separately + capture Cursor

### DIFF
--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -138,6 +138,16 @@ func showInstance(id string, asJSON bool) error {
 				s.Duration,
 				stateColor(s.State).Render(state),
 			)
+			if s.TotalTokens > 0 {
+				usage := fmt.Sprintf("%d in / %d out / %d total", s.InputTokens, s.OutputTokens, s.TotalTokens)
+				if s.CacheCreationTokens > 0 || s.CacheReadTokens > 0 {
+					usage += fmt.Sprintf("  ·  cache %d write / %d read", s.CacheCreationTokens, s.CacheReadTokens)
+				}
+				if s.CostUSD > 0 {
+					usage += fmt.Sprintf("  ·  $%.5f", s.CostUSD)
+				}
+				fmt.Printf("       %s\n", instMuted.Render(usage))
+			}
 		}
 	}
 	printCIPolls(detail.CIPolls)

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -346,6 +346,8 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 			summedUsage.InputTokens += out.Usage.InputTokens
 			summedUsage.OutputTokens += out.Usage.OutputTokens
 			summedUsage.TotalTokens += out.Usage.TotalTokens
+			summedUsage.CacheCreationTokens += out.Usage.CacheCreationTokens
+			summedUsage.CacheReadTokens += out.Usage.CacheReadTokens
 			summedUsage.NumTurns += out.Usage.NumTurns
 			summedUsage.NumToolCalls += out.Usage.NumToolCalls
 			summedUsage.CostUSD += out.Usage.CostUSD
@@ -439,6 +441,8 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 		exec.InputTokens = res.Usage.InputTokens
 		exec.OutputTokens = res.Usage.OutputTokens
 		exec.TotalTokens = res.Usage.TotalTokens
+		exec.CacheCreationTokens = res.Usage.CacheCreationTokens
+		exec.CacheReadTokens = res.Usage.CacheReadTokens
 		exec.NumTurns = res.Usage.NumTurns
 		exec.NumToolCalls = res.Usage.NumToolCalls
 		exec.CostUSD = res.Usage.CostUSD

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -31,21 +31,23 @@ type InstanceSummary struct {
 
 // StepRunView is one step row in an instance detail.
 type StepRunView struct {
-	StepID       string     `json:"step_id"`
-	AgentID      string     `json:"agent_id"`
-	State        string     `json:"state"`
-	Duration     string     `json:"duration"`
-	Cached       bool       `json:"cached"`
-	Output       string     `json:"output"`
-	Summary      string     `json:"summary"`
-	InputTokens  int        `json:"input_tokens"`
-	OutputTokens int        `json:"output_tokens"`
-	TotalTokens  int        `json:"total_tokens"`
-	CostUSD      float64    `json:"cost_usd"`
-	NumTurns     int        `json:"num_turns"`
-	NumToolCalls int        `json:"num_tool_calls"`
-	StartedAt    *time.Time `json:"started_at"`
-	FinishedAt   *time.Time `json:"finished_at"`
+	StepID              string     `json:"step_id"`
+	AgentID             string     `json:"agent_id"`
+	State               string     `json:"state"`
+	Duration            string     `json:"duration"`
+	Cached              bool       `json:"cached"`
+	Output              string     `json:"output"`
+	Summary             string     `json:"summary"`
+	InputTokens         int        `json:"input_tokens"`
+	OutputTokens        int        `json:"output_tokens"`
+	TotalTokens         int        `json:"total_tokens"`
+	CacheCreationTokens int        `json:"cache_creation_tokens"`
+	CacheReadTokens     int        `json:"cache_read_tokens"`
+	CostUSD             float64    `json:"cost_usd"`
+	NumTurns            int        `json:"num_turns"`
+	NumToolCalls        int        `json:"num_tool_calls"`
+	StartedAt           *time.Time `json:"started_at"`
+	FinishedAt          *time.Time `json:"finished_at"`
 }
 
 // CIPollView is one recorded wait_for CI poll, surfaced in instance and
@@ -256,6 +258,8 @@ func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.St
 		srv.InputTokens = s.InputTokens
 		srv.OutputTokens = s.OutputTokens
 		srv.TotalTokens = s.TotalTokens
+		srv.CacheCreationTokens = s.CacheCreationTokens
+		srv.CacheReadTokens = s.CacheReadTokens
 		srv.CostUSD = s.CostUSD
 		srv.NumTurns = s.NumTurns
 		srv.NumToolCalls = s.NumToolCalls
@@ -263,6 +267,8 @@ func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.St
 		srv.InputTokens = usage.InputTokens
 		srv.OutputTokens = usage.OutputTokens
 		srv.TotalTokens = usage.TotalTokens
+		srv.CacheCreationTokens = usage.CacheCreationTokens
+		srv.CacheReadTokens = usage.CacheReadTokens
 		srv.CostUSD = usage.CostUSD
 		srv.NumTurns = usage.NumTurns
 		srv.NumToolCalls = usage.NumToolCalls

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1431,6 +1431,8 @@ func aggregateInstance(item *WorkflowInstanceItem) {
 		item.InputTokens += s.InputTokens
 		item.OutputTokens += s.OutputTokens
 		item.TotalTokens += s.TotalTokens
+		item.CacheCreationTokens += s.CacheCreationTokens
+		item.CacheReadTokens += s.CacheReadTokens
 		item.CostUSD += s.CostUSD
 	}
 }
@@ -2816,7 +2818,7 @@ func (a *App) filteredTasks(t *TasksTab) []TaskItem {
 // entire run rather than only the last execution row (e.g. the merge step). It
 // falls back to the detail instance when the task has no internal-task instance
 // list, and to the execution-row values when neither carries a span/usage.
-func taskRollup(d *TaskItem, detail *WorkflowInstanceItem) (started, completed *time.Time, inTok, outTok, totalTok int, cost float64) {
+func taskRollup(d *TaskItem, detail *WorkflowInstanceItem) (started, completed *time.Time, inTok, outTok, totalTok, cacheCreate, cacheRead int, cost float64) {
 	insts := d.Instances
 	if len(insts) == 0 && detail != nil {
 		insts = []WorkflowInstanceItem{*detail}
@@ -2831,6 +2833,8 @@ func taskRollup(d *TaskItem, detail *WorkflowInstanceItem) (started, completed *
 		inTok += in.InputTokens
 		outTok += in.OutputTokens
 		totalTok += in.TotalTokens
+		cacheCreate += in.CacheCreationTokens
+		cacheRead += in.CacheReadTokens
 		cost += in.CostUSD
 	}
 	if started == nil {
@@ -2851,7 +2855,7 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 		return a.box("TASK DETAILS", StyleMuted.Render("No details")+"\n", height)
 	}
 
-	rStart, rEnd, inTok, outTok, totalTok, cost := taskRollup(d, t.DetailInstance)
+	rStart, rEnd, inTok, outTok, totalTok, cacheCreate, cacheRead, cost := taskRollup(d, t.DetailInstance)
 	started, completed, dur := "—", "—", "—"
 	if rStart != nil {
 		started = rStart.Format("2006-01-02 15:04:05")
@@ -2895,6 +2899,9 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	row(endedLabel, completed)
 	row("Duration", dur)
 	row("Tokens", fmt.Sprintf("%d in / %d out / %d total", inTok, outTok, totalTok))
+	if cacheCreate > 0 || cacheRead > 0 {
+		row("Cache", fmt.Sprintf("%d write / %d read", cacheCreate, cacheRead))
+	}
 	row("Turns / Calls", fmt.Sprintf("%d / %d", d.NumTurns, d.NumToolCalls))
 	row("Cost", fmt.Sprintf("$%.4f", cost))
 	if d.URL != "" {
@@ -3134,6 +3141,9 @@ func wfInstanceSummary(inst *WorkflowInstanceItem) string {
 		parts = append(parts, inst.FinishedAt.Sub(*inst.StartedAt).Round(time.Second).String())
 	}
 	parts = append(parts, fmtTokensShort(inst.TotalTokens)+" tokens")
+	if inst.CacheCreationTokens > 0 || inst.CacheReadTokens > 0 {
+		parts = append(parts, fmtTokensShort(inst.CacheCreationTokens+inst.CacheReadTokens)+" cache")
+	}
 	if inst.CostUSD > 0 {
 		parts = append(parts, fmt.Sprintf("$%.4f", inst.CostUSD))
 	}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -2209,21 +2209,23 @@ func mapStepRuns(steps []db.StepRun, now time.Time) []WorkflowStepItem {
 	out := make([]WorkflowStepItem, 0, len(steps))
 	for _, s := range steps {
 		out = append(out, WorkflowStepItem{
-			StepID:       s.StepID,
-			Agent:        s.AgentID,
-			State:        s.State,
-			Duration:     wfStepDuration(s, now),
-			Cached:       s.SkippedCached,
-			Output:       s.Output,
-			Summary:      s.Summary,
-			InputTokens:  s.InputTokens,
-			OutputTokens: s.OutputTokens,
-			TotalTokens:  s.TotalTokens,
-			CostUSD:      s.CostUSD,
-			NumTurns:     s.NumTurns,
-			NumToolCalls: s.NumToolCalls,
-			StartedAt:    s.StartedAt,
-			FinishedAt:   s.FinishedAt,
+			StepID:              s.StepID,
+			Agent:               s.AgentID,
+			State:               s.State,
+			Duration:            wfStepDuration(s, now),
+			Cached:              s.SkippedCached,
+			Output:              s.Output,
+			Summary:             s.Summary,
+			InputTokens:         s.InputTokens,
+			OutputTokens:        s.OutputTokens,
+			TotalTokens:         s.TotalTokens,
+			CacheCreationTokens: s.CacheCreationTokens,
+			CacheReadTokens:     s.CacheReadTokens,
+			CostUSD:             s.CostUSD,
+			NumTurns:            s.NumTurns,
+			NumToolCalls:        s.NumToolCalls,
+			StartedAt:           s.StartedAt,
+			FinishedAt:          s.FinishedAt,
 		})
 	}
 	return out
@@ -4512,6 +4514,9 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 
 		if s.TotalTokens > 0 {
 			row2("Tokens", fmt.Sprintf("%d in / %d out / %d total", s.InputTokens, s.OutputTokens, s.TotalTokens))
+			if s.CacheCreationTokens > 0 || s.CacheReadTokens > 0 {
+				row2("Cache", fmt.Sprintf("%d write / %d read", s.CacheCreationTokens, s.CacheReadTokens))
+			}
 			row2("Cost", fmt.Sprintf("$%.5f", s.CostUSD))
 			row2("Turns", fmt.Sprintf("%d turns / %d calls", s.NumTurns, s.NumToolCalls))
 			right.WriteString("\n")

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -116,12 +116,14 @@ type WorkflowInstanceItem struct {
 	// earliest step start, FinishedAt = latest step finish). Used for the per-
 	// workflow timing/usage line and to roll up the whole-task header, so the
 	// detail no longer reflects only the last execution row.
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
-	InputTokens  int
-	OutputTokens int
-	TotalTokens  int
-	CostUSD      float64
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
+	InputTokens         int
+	OutputTokens        int
+	TotalTokens         int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	CostUSD             float64
 }
 
 // CIPollItem is one recorded poll of a wait_for step's CI status, shown in the

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -168,21 +168,23 @@ type TaskLineageItem struct {
 
 // WorkflowStepItem is one step row within a WorkflowInstanceItem.
 type WorkflowStepItem struct {
-	StepID       string
-	Agent        string
-	State        string // pending, running, passed, failed, skipped, skipped_cached
-	Duration     string
-	Cached       bool
-	Output       string
-	Summary      string
-	InputTokens  int
-	OutputTokens int
-	TotalTokens  int
-	CostUSD      float64
-	NumTurns     int
-	NumToolCalls int
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
+	StepID              string
+	Agent               string
+	State               string // pending, running, passed, failed, skipped, skipped_cached
+	Duration            string
+	Cached              bool
+	Output              string
+	Summary             string
+	InputTokens         int
+	OutputTokens        int
+	TotalTokens         int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	CostUSD             float64
+	NumTurns            int
+	NumToolCalls        int
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
 }
 
 // TaskItem is one row in the Tasks tab. Since Phase 9 the list is keyed on the

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -159,9 +159,10 @@ func TestTaskRollup_SpansAllInstances(t *testing.T) {
 		Instances: []WorkflowInstanceItem{{
 			StartedAt: at("2026-06-08T13:42:01Z"), FinishedAt: at("2026-06-08T15:47:35Z"),
 			InputTokens: 90000, OutputTokens: 34533, TotalTokens: 124533, CostUSD: 0.95,
+			CacheCreationTokens: 7000, CacheReadTokens: 60000,
 		}},
 	}
-	start, end, in, out, total, cost := taskRollup(d, nil)
+	start, end, in, out, total, cacheCreate, cacheRead, cost := taskRollup(d, nil)
 	if start == nil || !start.Equal(*at("2026-06-08T13:42:01Z")) {
 		t.Errorf("rollup start should be the first workflow start, got %v", start)
 	}
@@ -170,6 +171,9 @@ func TestTaskRollup_SpansAllInstances(t *testing.T) {
 	}
 	if in != 90000 || out != 34533 || total != 124533 {
 		t.Errorf("rollup tokens should sum instances, got %d/%d/%d", in, out, total)
+	}
+	if cacheCreate != 7000 || cacheRead != 60000 {
+		t.Errorf("rollup cache tokens should sum instances, got %d write / %d read", cacheCreate, cacheRead)
 	}
 	if cost != 0.95 {
 		t.Errorf("rollup cost should sum instances, got %v", cost)
@@ -184,7 +188,7 @@ func TestTaskRollup_FallsBackToExecutionRow(t *testing.T) {
 		StartedAt: at("2026-06-08T10:00:00Z"), CompletedAt: at("2026-06-08T10:05:00Z"),
 		InputTokens: 10, OutputTokens: 20, TotalTokens: 30, CostUSD: 0.01,
 	}
-	start, end, in, out, total, cost := taskRollup(d, nil)
+	start, end, in, out, total, _, _, cost := taskRollup(d, nil)
 	if start == nil || end == nil || in != 10 || out != 20 || total != 30 || cost != 0.01 {
 		t.Errorf("expected execution-row fallback, got start=%v end=%v %d/%d/%d $%v", start, end, in, out, total, cost)
 	}

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -138,34 +138,36 @@ func (c *Client) UpdateTaskOutput(ctx context.Context, taskID, output string, su
 // Execution tracking (for crash recovery)
 
 type Execution struct {
-	ID             int64
-	TaskID         string
-	AgentID        string
-	Title          string
-	Number         string
-	URL            string
-	Model          string
-	Runner         string
-	Attempt        int
-	Status         string
-	PID            int
-	HeartbeatAt    *time.Time
-	HeartbeatCount int
-	StartedAt      *time.Time
-	CompletedAt    *time.Time
-	DurationMs     int64
-	ErrorMsg       string
-	CanRetry       bool
-	NextRetryAt    *time.Time
-	CreatedAt      time.Time
-	InputTokens        int
-	OutputTokens       int
-	TotalTokens        int
-	NumTurns           int
-	NumToolCalls       int
-	CostUSD            float64
-	WorkflowInstanceID string
-	StepID             string
+	ID                  int64
+	TaskID              string
+	AgentID             string
+	Title               string
+	Number              string
+	URL                 string
+	Model               string
+	Runner              string
+	Attempt             int
+	Status              string
+	PID                 int
+	HeartbeatAt         *time.Time
+	HeartbeatCount      int
+	StartedAt           *time.Time
+	CompletedAt         *time.Time
+	DurationMs          int64
+	ErrorMsg            string
+	CanRetry            bool
+	NextRetryAt         *time.Time
+	CreatedAt           time.Time
+	InputTokens         int
+	OutputTokens        int
+	TotalTokens         int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	NumTurns            int
+	NumToolCalls        int
+	CostUSD             float64
+	WorkflowInstanceID  string
+	StepID              string
 	// InputPrompt is the full composed prompt sent to the agent for this attempt;
 	// OutputText is the agent's raw output. Both are persisted for cost auditing
 	// and replay. Empty when the runner does not report a prompt.
@@ -208,11 +210,13 @@ func (c *Client) UpdateExecution(ctx context.Context, exec *Execution) error {
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE task_executions
 		SET status = ?, completed_at = ?, duration_ms = ?, error_message = ?, can_retry = ?, next_retry_at = ?,
-		    input_tokens = ?, output_tokens = ?, total_tokens = ?, num_turns = ?, num_tool_calls = ?, cost_usd = ?,
+		    input_tokens = ?, output_tokens = ?, total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
+		    num_turns = ?, num_tool_calls = ?, cost_usd = ?,
 		    input_prompt = ?, output_text = ?
 		WHERE id = ?
 	`, exec.Status, exec.CompletedAt, exec.DurationMs, exec.ErrorMsg, exec.CanRetry, exec.NextRetryAt,
-		exec.InputTokens, exec.OutputTokens, exec.TotalTokens, exec.NumTurns, exec.NumToolCalls, exec.CostUSD,
+		exec.InputTokens, exec.OutputTokens, exec.TotalTokens, exec.CacheCreationTokens, exec.CacheReadTokens,
+		exec.NumTurns, exec.NumToolCalls, exec.CostUSD,
 		nullStr(exec.InputPrompt), nullStr(exec.OutputText),
 		exec.ID)
 	return err
@@ -250,13 +254,17 @@ func (c *Client) SetStepLink(ctx context.Context, execID int64, instanceID, step
 // specific step within a workflow instance.
 func (c *Client) GetStepUsage(ctx context.Context, instanceID, stepID string) (*Execution, error) {
 	row := c.db.QueryRowContext(ctx, `
-		SELECT input_tokens, output_tokens, total_tokens, num_turns, num_tool_calls, cost_usd
+		SELECT input_tokens, output_tokens, total_tokens,
+		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
+		       num_turns, num_tool_calls, cost_usd
 		FROM task_executions
 		WHERE workflow_instance_id = ? AND step_id = ?
 		ORDER BY created_at DESC LIMIT 1
 	`, instanceID, stepID)
 	var e Execution
-	err := row.Scan(&e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.NumTurns, &e.NumToolCalls, &e.CostUSD)
+	err := row.Scan(&e.InputTokens, &e.OutputTokens, &e.TotalTokens,
+		&e.CacheCreationTokens, &e.CacheReadTokens,
+		&e.NumTurns, &e.NumToolCalls, &e.CostUSD)
 	if err != nil {
 		return nil, err
 	}
@@ -272,6 +280,7 @@ func (c *Client) GetInstanceStepUsage(ctx context.Context, instanceID string) (m
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT step_id,
 		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
+		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
 		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0)
 		FROM task_executions
 		WHERE workflow_instance_id = ?
@@ -285,7 +294,9 @@ func (c *Client) GetInstanceStepUsage(ctx context.Context, instanceID string) (m
 	for rows.Next() {
 		var stepID sql.NullString
 		var e Execution
-		if err := rows.Scan(&stepID, &e.InputTokens, &e.OutputTokens, &e.TotalTokens, &e.NumTurns, &e.NumToolCalls, &e.CostUSD); err != nil {
+		if err := rows.Scan(&stepID, &e.InputTokens, &e.OutputTokens, &e.TotalTokens,
+			&e.CacheCreationTokens, &e.CacheReadTokens,
+			&e.NumTurns, &e.NumToolCalls, &e.CostUSD); err != nil {
 			continue
 		}
 		out[stepID.String] = e // ASC order: the last write per step_id is the most recent
@@ -323,6 +334,7 @@ func (c *Client) GetLastExecution(ctx context.Context, taskID string) (*Executio
 		SELECT id, task_id, agent_id, attempt, status, started_at, completed_at, duration_ms,
 		       error_message, can_retry, next_retry_at, created_at,
 		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
+		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
 		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0),
 		       COALESCE(input_prompt,''), COALESCE(output_text,'')
 		FROM task_executions
@@ -336,6 +348,7 @@ func (c *Client) GetLastExecution(ctx context.Context, taskID string) (*Executio
 		&exec.StartedAt, &exec.CompletedAt, &exec.DurationMs, &exec.ErrorMsg, &exec.CanRetry,
 		&exec.NextRetryAt, &exec.CreatedAt,
 		&exec.InputTokens, &exec.OutputTokens, &exec.TotalTokens,
+		&exec.CacheCreationTokens, &exec.CacheReadTokens,
 		&exec.NumTurns, &exec.NumToolCalls, &exec.CostUSD,
 		&exec.InputPrompt, &exec.OutputText)
 	if err == sql.ErrNoRows {

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -211,6 +211,11 @@ var migrations = []string{
 	`ALTER TABLE task_executions ADD COLUMN input_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN output_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN total_tokens INTEGER DEFAULT 0`,
+	// Cache token breakdown of the input (input_tokens already includes these;
+	// pure uncached input = input_tokens - cache_creation - cache_read). Reported
+	// by the Claude and Cursor CLIs; zero for runners that don't surface it.
+	`ALTER TABLE task_executions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN num_turns INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN num_tool_calls INTEGER DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN cost_usd REAL DEFAULT 0.0`,
@@ -243,6 +248,10 @@ var migrations = []string{
 	`ALTER TABLE step_runs ADD COLUMN input_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN output_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN total_tokens INTEGER DEFAULT 0`,
+	// Cache token breakdown, summed across the step's failover attempts. See the
+	// task_executions cache columns above for semantics.
+	`ALTER TABLE step_runs ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN cache_read_tokens INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN num_turns INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN num_tool_calls INTEGER DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN cost_usd REAL DEFAULT 0.0`,

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -74,14 +74,16 @@ type StepRun struct {
 	InputPrompt string
 	// Token/cost rollup, summed across the step's failover attempts. Per-attempt
 	// detail lives in the linked task_executions rows.
-	InputTokens  int
-	OutputTokens int
-	TotalTokens  int
-	NumTurns     int
-	NumToolCalls int
-	CostUSD      float64
-	StartedAt    *time.Time
-	FinishedAt   *time.Time
+	InputTokens         int
+	OutputTokens        int
+	TotalTokens         int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	NumTurns            int
+	NumToolCalls        int
+	CostUSD             float64
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
@@ -383,14 +385,16 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 		INSERT INTO step_runs
 		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
 		   summary, exit_code, skipped_cached, publish_payload, publish_state, spawned_task_id,
-		   input_prompt, input_tokens, output_tokens, total_tokens, num_turns, num_tool_calls, cost_usd,
+		   input_prompt, input_tokens, output_tokens, total_tokens,
+		   cache_creation_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd,
 		   started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
-		sr.TotalTokens, sr.NumTurns, sr.NumToolCalls, sr.CostUSD, sr.StartedAt, sr.FinishedAt)
+		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
+		sr.CostUSD, sr.StartedAt, sr.FinishedAt)
 	return err
 }
 
@@ -402,13 +406,15 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		SET state = ?, output = ?, structured_output = ?, summary = ?,
 		    exit_code = ?, skipped_cached = ?, publish_payload = ?, publish_state = ?,
 		    spawned_task_id = ?, input_prompt = ?, input_tokens = ?, output_tokens = ?,
-		    total_tokens = ?, num_turns = ?, num_tool_calls = ?, cost_usd = ?,
+		    total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
+		    num_turns = ?, num_tool_calls = ?, cost_usd = ?,
 		    started_at = ?, finished_at = ?
 		WHERE id = ?
 	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
-		sr.TotalTokens, sr.NumTurns, sr.NumToolCalls, sr.CostUSD, sr.StartedAt, sr.FinishedAt, sr.ID)
+		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
+		sr.CostUSD, sr.StartedAt, sr.FinishedAt, sr.ID)
 	return err
 }
 
@@ -421,6 +427,7 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		       COALESCE(publish_payload,''), COALESCE(publish_state,''),
 		       COALESCE(spawned_task_id,''), COALESCE(input_prompt,''),
 		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
+		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
 		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0.0),
 		       started_at, finished_at
 		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
@@ -436,7 +443,8 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
 			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
 			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.InputPrompt,
-			&sr.InputTokens, &sr.OutputTokens, &sr.TotalTokens, &sr.NumTurns, &sr.NumToolCalls,
+			&sr.InputTokens, &sr.OutputTokens, &sr.TotalTokens,
+			&sr.CacheCreationTokens, &sr.CacheReadTokens, &sr.NumTurns, &sr.NumToolCalls,
 			&sr.CostUSD, &sr.StartedAt, &sr.FinishedAt); err != nil {
 			return nil, err
 		}

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -298,6 +298,8 @@ func TestStepRun_CRUD(t *testing.T) {
 	sr.InputTokens = 120
 	sr.OutputTokens = 80
 	sr.TotalTokens = 200
+	sr.CacheCreationTokens = 60
+	sr.CacheReadTokens = 40
 	sr.NumTurns = 3
 	sr.NumToolCalls = 5
 	sr.CostUSD = 0.0123
@@ -331,6 +333,9 @@ func TestStepRun_CRUD(t *testing.T) {
 	}
 	if got.InputTokens != 120 || got.OutputTokens != 80 || got.TotalTokens != 200 {
 		t.Errorf("token columns wrong: %+v", got)
+	}
+	if got.CacheCreationTokens != 60 || got.CacheReadTokens != 40 {
+		t.Errorf("cache token columns wrong: %+v", got)
 	}
 	if got.NumTurns != 3 || got.NumToolCalls != 5 {
 		t.Errorf("turn/tool-call columns wrong: %+v", got)
@@ -394,10 +399,10 @@ func TestReconcileOrphanWorkflowInstances_Extended(t *testing.T) {
 
 	// Verify only running was changed to interrupted, others are untouched.
 	for id, expectedState := range map[string]string{
-		"wf_running":   InstanceStateInterrupted,  // running → interrupted
-		"wf_approval":  InstanceStateApprovalWaiting, // approval_waiting (untouched, rehydrated separately)
-		"wf_done":      InstanceStateDone,         // done (unchanged)
-		"wf_failed":    InstanceStateFailed,       // failed (unchanged)
+		"wf_running":  InstanceStateInterrupted,     // running → interrupted
+		"wf_approval": InstanceStateApprovalWaiting, // approval_waiting (untouched, rehydrated separately)
+		"wf_done":     InstanceStateDone,            // done (unchanged)
+		"wf_failed":   InstanceStateFailed,          // failed (unchanged)
 	} {
 		inst, err := c.GetWorkflowInstance(ctx, id)
 		if err != nil {

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -44,9 +44,16 @@ type Usage struct {
 	InputTokens  int
 	OutputTokens int
 	TotalTokens  int
-	NumTurns     int
-	NumToolCalls int
-	CostUSD      float64
+	// CacheCreationTokens and CacheReadTokens break down the cache portion of the
+	// input. InputTokens already includes them (it is the full billed input), so
+	// pure uncached input = InputTokens - CacheCreationTokens - CacheReadTokens.
+	// Reported by the Claude and Cursor CLIs; zero for runners that don't surface
+	// cache usage.
+	CacheCreationTokens int
+	CacheReadTokens     int
+	NumTurns            int
+	NumToolCalls        int
+	CostUSD             float64
 }
 
 type RunResult struct {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -266,18 +266,31 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	return result, nil
 }
 
-// cliUsage mirrors the usage object the Claude CLI reports on both `assistant`
-// message events and the final `result` event. Cache tokens are real input the
-// model processed (and are billed), so inputTotal folds them into the input side.
+// cliUsage mirrors the usage object the CLIs report on `assistant` message
+// events and the final `result` event. It accepts both the Claude CLI's
+// snake_case fields (input_tokens, cache_creation_input_tokens, …) and the
+// Cursor agent CLI's camelCase fields (inputTokens, cacheWriteTokens, …); only
+// one naming is present per event, so the accessors sum the pair. Cache tokens
+// are real input the model processed (and are billed), so inputTotal folds them
+// into the input side; cacheCreation/cacheRead expose the breakdown separately.
 type cliUsage struct {
 	InputTokens              int `json:"input_tokens"`
+	InputTokensCamel         int `json:"inputTokens"`
 	OutputTokens             int `json:"output_tokens"`
+	OutputTokensCamel        int `json:"outputTokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheWriteTokensCamel    int `json:"cacheWriteTokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheReadTokensCamel     int `json:"cacheReadTokens"`
 }
 
+func (u cliUsage) input() int         { return u.InputTokens + u.InputTokensCamel }
+func (u cliUsage) output() int        { return u.OutputTokens + u.OutputTokensCamel }
+func (u cliUsage) cacheCreation() int { return u.CacheCreationInputTokens + u.CacheWriteTokensCamel }
+func (u cliUsage) cacheRead() int     { return u.CacheReadInputTokens + u.CacheReadTokensCamel }
+
 func (u cliUsage) inputTotal() int {
-	return u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+	return u.input() + u.cacheCreation() + u.cacheRead()
 }
 
 // stream-json event types (Claude CLI output format). The CLI emits complete-
@@ -313,6 +326,18 @@ type streamEvent struct {
 // `tool_use` blocks in `assistant` messages. The per-assistant usage is also
 // recorded as a fallback so a run that dies before the `result` event still
 // reports the last message's counts rather than zeros.
+// applyUsage records a parsed CLI usage object onto the running totals.
+// InputTokens stays the full billed input (cache folded in) so totals and the
+// existing in/out/total displays are unchanged; the cache breakdown is recorded
+// separately. TotalTokens = full input + output (cache already lives in input).
+func applyUsage(u *model.Usage, cu *cliUsage) {
+	u.InputTokens = cu.inputTotal()
+	u.OutputTokens = cu.output()
+	u.CacheCreationTokens = cu.cacheCreation()
+	u.CacheReadTokens = cu.cacheRead()
+	u.TotalTokens = u.InputTokens + u.OutputTokens
+}
+
 func accumulateStreamUsage(line string, u *model.Usage) {
 	var ev streamEvent
 	if err := json.Unmarshal([]byte(line), &ev); err != nil || ev.Type == "" {
@@ -326,9 +351,7 @@ func accumulateStreamUsage(line string, u *model.Usage) {
 			}
 		}
 		if ev.Message.Usage != nil {
-			u.InputTokens = ev.Message.Usage.inputTotal()
-			u.OutputTokens = ev.Message.Usage.OutputTokens
-			u.TotalTokens = u.InputTokens + u.OutputTokens
+			applyUsage(u, ev.Message.Usage)
 		}
 	case "result":
 		u.NumTurns = ev.NumTurns
@@ -336,9 +359,7 @@ func accumulateStreamUsage(line string, u *model.Usage) {
 			u.CostUSD = ev.TotalCostUSD
 		}
 		if ev.Usage != nil { // authoritative cumulative totals
-			u.InputTokens = ev.Usage.inputTotal()
-			u.OutputTokens = ev.Usage.OutputTokens
-			u.TotalTokens = u.InputTokens + u.OutputTokens
+			applyUsage(u, ev.Usage)
 		}
 	}
 }

--- a/src/internal/runner/execution/stream_test.go
+++ b/src/internal/runner/execution/stream_test.go
@@ -76,11 +76,43 @@ func TestAccumulateStreamUsage_Full(t *testing.T) {
 	if u.TotalTokens != 24867+142 {
 		t.Errorf("TotalTokens = %d, want %d", u.TotalTokens, 24867+142)
 	}
+	// The cache portion of the input is also recorded separately (folded into
+	// InputTokens above, broken out here).
+	if u.CacheCreationTokens != 6804 {
+		t.Errorf("CacheCreationTokens = %d, want 6804", u.CacheCreationTokens)
+	}
+	if u.CacheReadTokens != 18053 {
+		t.Errorf("CacheReadTokens = %d, want 18053", u.CacheReadTokens)
+	}
 	if u.NumTurns != 4 {
 		t.Errorf("NumTurns = %d, want 4", u.NumTurns)
 	}
 	if u.CostUSD != 0.087 {
 		t.Errorf("CostUSD = %.4f, want 0.087", u.CostUSD)
+	}
+}
+
+// The Cursor agent CLI emits a result event with the same shape but camelCase
+// usage keys (inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens).
+// Verified against live `cursor-agent -p --output-format stream-json` output.
+func TestAccumulateStreamUsage_CursorCamelCase(t *testing.T) {
+	var u model.Usage
+	accumulateStreamUsage(`{"type":"result","subtype":"success","is_error":false,"result":"hi","usage":{"inputTokens":6,"outputTokens":12,"cacheReadTokens":1500,"cacheWriteTokens":29135}}`, &u)
+	// input folds the cache: 6 + 29135(write) + 1500(read) = 30641.
+	if u.InputTokens != 30641 {
+		t.Errorf("InputTokens = %d, want 30641 (input + cache write + cache read)", u.InputTokens)
+	}
+	if u.OutputTokens != 12 {
+		t.Errorf("OutputTokens = %d, want 12", u.OutputTokens)
+	}
+	if u.CacheCreationTokens != 29135 {
+		t.Errorf("CacheCreationTokens = %d, want 29135 (cacheWriteTokens)", u.CacheCreationTokens)
+	}
+	if u.CacheReadTokens != 1500 {
+		t.Errorf("CacheReadTokens = %d, want 1500", u.CacheReadTokens)
+	}
+	if u.TotalTokens != 30641+12 {
+		t.Errorf("TotalTokens = %d, want %d", u.TotalTokens, 30641+12)
 	}
 }
 

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -426,6 +426,8 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 		sr.InputTokens = res.Usage.InputTokens
 		sr.OutputTokens = res.Usage.OutputTokens
 		sr.TotalTokens = res.Usage.TotalTokens
+		sr.CacheCreationTokens = res.Usage.CacheCreationTokens
+		sr.CacheReadTokens = res.Usage.CacheReadTokens
 		sr.NumTurns = res.Usage.NumTurns
 		sr.NumToolCalls = res.Usage.NumToolCalls
 		sr.CostUSD = res.Usage.CostUSD


### PR DESCRIPTION
## What

Token usage previously **folded cache tokens into the input side**, so the dashboard could show input/output/total/cost but not the cache breakdown — even though cache writes and cache reads are priced very differently. This stores the two cache token types as their own columns and surfaces them in the Task Detail.

It also **fixes Cursor token capture**: the Cursor agent CLI emits a `result` event with the same shape as Claude but **camelCase** usage keys (`inputTokens`/`outputTokens`/`cacheWriteTokens`/`cacheReadTokens`), so its tokens were silently recording as zero. The parser now accepts both namings. Verified against live `cursor-agent -p --output-format stream-json` output.

## Design

`InputTokens` **stays the full billed input** (cache folded in), so every existing total/in/out display and aggregate `SUM` is unchanged. The cache breakdown rides alongside as `CacheCreationTokens` / `CacheReadTokens`. Pure uncached input is therefore `input − creation − read`. Fully additive — zero behavior change for existing data; legacy rows read 0 for the new columns.

## Changes

- **model.Usage** — `CacheCreationTokens` / `CacheReadTokens`.
- **runner/execution/cli.go** — parser accepts Claude (snake_case) and Cursor (camelCase) usage; records the cache split; `applyUsage` helper.
- **db** — `cache_creation_tokens` + `cache_read_tokens` columns on `task_executions` and `step_runs`; threaded through `Execution`/`StepRun` structs, INSERT/UPDATE/SELECT, and the step/instance usage rollups.
- **daemon/workflow.go, workflow/engine.go, workflow_ipc.go** — threaded through per-attempt → per-step → per-instance summing and the IPC step payload.
- **dashboard** — Task Detail step view shows a `Cache: N write / N read` line when present.

## Not included

`opencode-cli` still reports no tokens — it runs without a structured output format and its JSON mode surfaces no usage event. Capturing it would need an invocation change + a new event shape, out of scope here.

## Tests

- `TestAccumulateStreamUsage_Full` extended with cache-breakdown assertions.
- New `TestAccumulateStreamUsage_CursorCamelCase` (live-verified Cursor shape).
- `StepRun` persistence test round-trips the new columns.
- `go build ./...`, `go vet ./...`, and full `go test ./...` all green.