### PR TITLE
feat(dashboard): live-refresh Task Detail and Logs sub-views

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -86,6 +86,7 @@ type taskLogsMsg struct {
 	logs     []LogEntry
 	detail   *TaskItem
 	oldestID int64 // row id of the oldest loaded line (older-page cursor)
+	newestID int64 // row id of the newest loaded line (live-tail cursor)
 	hasMore  bool  // an older page may exist
 }
 
@@ -99,6 +100,25 @@ type olderTaskLogsMsg struct {
 }
 type taskHistoryMsg struct {
 	taskID   string
+	drillKey string // legacy cell id, kept so the open view can re-fetch itself
+	segments []TaskHistorySegmentItem
+	detail   *TaskItem
+}
+
+// Live-refresh messages for the open Detail/Logs sub-views. Mirroring
+// workflowMonitorRefreshMsg, their handlers update data in place and never touch
+// View or the scroll cursor, so a refresh that lands after the user has navigated
+// away is harmless.
+type taskDetailRefreshMsg struct {
+	detail   *TaskItem
+	instance *WorkflowInstanceItem
+}
+type tailTaskLogsMsg struct {
+	taskID   string // must match LogTaskID for the append to apply
+	logs     []LogEntry
+	newestID int64
+}
+type taskHistoryRefreshMsg struct {
 	segments []TaskHistorySegmentItem
 	detail   *TaskItem
 }
@@ -153,6 +173,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		// Re-query the active tab and schedule the next tick.
+		a.model.tickCount++
 		return a, tea.Batch(a.fetchActiveTab(), tickCmd())
 
 	case overviewDataMsg:
@@ -189,8 +210,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			t.View = TaskViewLogs
 			t.LogTaskID = msg.taskID
 			t.LogOldestID = msg.oldestID
+			t.LogNewestID = msg.newestID
 			t.LogHasMore = msg.hasMore
 			t.LogLoadingMore = false
+			// Flat-log mode: refresh by drill key, not internal id.
+			t.LogDrillKey = msg.taskID
+			t.LogInternalTaskID = ""
 		}
 		a.model.loading = false
 
@@ -219,6 +244,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			t.LogTaskID = ""
 			t.LogHasMore = false
 			t.LogLoadingMore = false
+			// History mode: refresh re-runs the full per-instance history by id.
+			t.LogInternalTaskID = msg.taskID
+			t.LogDrillKey = msg.drillKey
 		}
 		a.model.loading = false
 
@@ -312,6 +340,43 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		a.model.loading = false
+
+	case taskDetailRefreshMsg:
+		// Live-refresh the open detail panel in place. Skip a nil detail (a transient
+		// query miss) so the panel keeps its last good content instead of blanking.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewDetail && msg.detail != nil {
+			t.Detail = msg.detail
+			t.DetailInstance = msg.instance
+		}
+
+	case tailTaskLogsMsg:
+		// Append newly-arrived flat-log lines. Follow the tail only when the viewport
+		// is already pinned to the bottom (matches the G/end semantics); otherwise the
+		// appended lines sit below and the reader's position is left untouched.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewLogs &&
+			len(t.InstanceHistory) == 0 && msg.taskID == t.LogTaskID && len(msg.logs) > 0 {
+			following := t.LogScroll >= lastIndex(len(a.taskLogLines()))
+			t.Logs = append(t.Logs, msg.logs...)
+			t.LogNewestID = msg.newestID
+			if following {
+				t.LogScroll = lastIndex(len(a.taskLogLines()))
+			}
+		}
+
+	case taskHistoryRefreshMsg:
+		// Live-refresh the per-instance history view, preserving scroll. Earlier
+		// (terminal) segments keep a stable line count, so a scrolled-up reader's
+		// top-anchored position holds; a bottom-pinned reader follows the tail.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewLogs && len(t.InstanceHistory) > 0 {
+			following := t.LogScroll >= lastIndex(len(a.taskLogLines()))
+			t.InstanceHistory = msg.segments
+			if msg.detail != nil {
+				t.Detail = msg.detail
+			}
+			if following {
+				t.LogScroll = lastIndex(len(a.taskLogLines()))
+			}
+		}
 	}
 
 	return a, nil
@@ -1640,17 +1705,35 @@ func (a *App) fetchActiveTab() tea.Cmd {
 	case "Overview":
 		return a.fetchOverview()
 	case "Tasks":
-		// When the workflow monitor is open, refresh the instance on each tick.
-		if t := a.model.tasksTab; t != nil && t.View == TaskViewWorkflow && t.WorkflowInstance != nil {
-			return a.refreshWorkflowMonitor(t.WorkflowInstance.ID, t.WorkflowInstance.CellID)
-		}
-		// Only refresh the list while the list itself is showing. While a detail
-		// or logs sub-view is open we must not refetch — re-sorting History under
-		// the cursor would make the SelectedIdx-keyed reload (r/d/l) target a
-		// different task than the one on screen. The sub-view content is static
-		// until the user reloads it; returning to the list resumes auto-refresh.
-		if t := a.model.tasksTab; t != nil && t.View != TaskViewList {
-			return nil
+		// Sub-views live-refresh by id (not by list index), so the open Detail/Logs
+		// stay current without re-sorting History under the cursor — which would make
+		// the SelectedIdx-keyed reload (r/d/l) target a different task than the one on
+		// screen. The list itself is only re-queried while it (not a sub-view) shows.
+		if t := a.model.tasksTab; t != nil {
+			switch t.View {
+			case TaskViewWorkflow:
+				if t.WorkflowInstance != nil {
+					return a.refreshWorkflowMonitor(t.WorkflowInstance.ID, t.WorkflowInstance.CellID)
+				}
+				return nil
+			case TaskViewDetail:
+				if t.Detail != nil {
+					return a.refreshTaskDetail(t.Detail.TaskID, t.Detail.InternalTaskID)
+				}
+				return nil
+			case TaskViewLogs:
+				// The history query is heavier — throttle it to every other tick (~4s).
+				if a.model.tickCount%2 != 0 {
+					return nil
+				}
+				if t.LogInternalTaskID != "" {
+					return a.refreshTaskHistory(t.LogInternalTaskID, t.LogDrillKey)
+				}
+				if t.LogTaskID != "" {
+					return a.tailTaskLogs(t.LogTaskID, t.LogNewestID)
+				}
+				return nil
+			}
 		}
 		return a.fetchTasks()
 	case "Agents":
@@ -1901,39 +1984,56 @@ func (a *App) fetchTaskDetail(drillKey, internalTaskID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
+		detail, instance := a.loadTaskDetail(ctx, dbConn, drillKey, internalTaskID)
+		return taskDetailMsg{taskID: drillKey, detail: detail, instance: instance}
+	}
+}
 
-		var detail *TaskItem
-		if dbConn != nil {
-			if r, err := dbConn.GetTaskDetail(ctx, drillKey); err == nil && r != nil {
-				detail = &TaskItem{
-					TaskID:       r.TaskID,
-					Number:       r.Number,
-					URL:          r.URL,
-					Title:        r.Title,
-					Agent:        r.AgentID,
-					Model:        r.Model,
-					Runner:       r.Runner,
-					Status:       r.Status,
-					Attempt:      r.Attempt,
-					Duration:     time.Duration(r.DurationMs) * time.Millisecond,
-					StartedAt:    r.StartedAt,
-					CompletedAt:  r.CompletedAt,
-					Error:        r.Error,
-					InputTokens:  r.InputTokens,
-					OutputTokens: r.OutputTokens,
-					TotalTokens:  r.TotalTokens,
-					NumTurns:     r.NumTurns,
-					NumToolCalls: r.NumToolCalls,
-					CostUSD:      r.CostUSD,
-				}
-			}
-			if internalTaskID != "" {
-				detail = a.augmentTaskDetail(ctx, dbConn, detail, drillKey, internalTaskID)
+// loadTaskDetail builds the detail panel (the execution row, augmented with
+// InternalTask bindings/lineage/instances) plus its workflow instance. Shared by
+// the initial open (fetchTaskDetail) and the live refresh (refreshTaskDetail).
+func (a *App) loadTaskDetail(ctx context.Context, dbConn *db.Client, drillKey, internalTaskID string) (*TaskItem, *WorkflowInstanceItem) {
+	var detail *TaskItem
+	if dbConn != nil {
+		if r, err := dbConn.GetTaskDetail(ctx, drillKey); err == nil && r != nil {
+			detail = &TaskItem{
+				TaskID:       r.TaskID,
+				Number:       r.Number,
+				URL:          r.URL,
+				Title:        r.Title,
+				Agent:        r.AgentID,
+				Model:        r.Model,
+				Runner:       r.Runner,
+				Status:       r.Status,
+				Attempt:      r.Attempt,
+				Duration:     time.Duration(r.DurationMs) * time.Millisecond,
+				StartedAt:    r.StartedAt,
+				CompletedAt:  r.CompletedAt,
+				Error:        r.Error,
+				InputTokens:  r.InputTokens,
+				OutputTokens: r.OutputTokens,
+				TotalTokens:  r.TotalTokens,
+				NumTurns:     r.NumTurns,
+				NumToolCalls: r.NumToolCalls,
+				CostUSD:      r.CostUSD,
 			}
 		}
+		if internalTaskID != "" {
+			detail = a.augmentTaskDetail(ctx, dbConn, detail, drillKey, internalTaskID)
+		}
+	}
+	return detail, a.fetchWorkflowInstance(ctx, dbConn, drillKey)
+}
 
-		instance := a.fetchWorkflowInstance(ctx, dbConn, drillKey)
-		return taskDetailMsg{taskID: drillKey, detail: detail, instance: instance}
+// refreshTaskDetail re-loads the open detail panel by id (not by list index), so
+// status/tokens/instances stay live without re-sorting the list under the cursor.
+func (a *App) refreshTaskDetail(drillKey, internalTaskID string) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		detail, instance := a.loadTaskDetail(ctx, dbConn, drillKey, internalTaskID)
+		return taskDetailRefreshMsg{detail: detail, instance: instance}
 	}
 }
 
@@ -2073,19 +2173,39 @@ func (a *App) fetchTaskLogs(taskID string) tea.Cmd {
 
 		var detail *TaskItem
 		logs := make([]LogEntry, 0)
-		var oldestID int64
+		var oldestID, newestID int64
 		var hasMore bool
 		if dbConn != nil {
 			detail = taskDetailItem(ctx, dbConn, taskID)
 			if rows, err := dbConn.GetTaskLogs(ctx, taskID, taskLogTailLimit); err == nil {
 				logs = mapLogLines(rows)
 				if len(rows) > 0 {
-					oldestID = rows[0].ID // chronological: first row is the oldest loaded
+					oldestID = rows[0].ID           // chronological: first row is the oldest loaded
+					newestID = rows[len(rows)-1].ID // …and the last is the newest (live-tail cursor)
 				}
 				hasMore = len(rows) == taskLogTailLimit // a full page implies older rows exist
 			}
 		}
-		return taskLogsMsg{taskID: taskID, logs: logs, detail: detail, oldestID: oldestID, hasMore: hasMore}
+		return taskLogsMsg{taskID: taskID, logs: logs, detail: detail, oldestID: oldestID, newestID: newestID, hasMore: hasMore}
+	}
+}
+
+// tailTaskLogs fetches flat-log lines newer than afterID for the live logs view,
+// so a running task's logs stream in without resetting the scroll position.
+func (a *App) tailTaskLogs(taskID string, afterID int64) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+
+		msg := tailTaskLogsMsg{taskID: taskID, newestID: afterID}
+		if dbConn != nil {
+			if rows, err := dbConn.GetTaskLogsAfter(ctx, taskID, afterID, taskLogTailLimit); err == nil && len(rows) > 0 {
+				msg.logs = mapLogLines(rows)
+				msg.newestID = rows[len(rows)-1].ID
+			}
+		}
+		return msg
 	}
 }
 
@@ -2138,30 +2258,49 @@ func (a *App) fetchTaskHistory(internalTaskID, drillKey string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
+		detail, segments := a.buildTaskHistory(ctx, dbConn, internalTaskID, drillKey)
+		return taskHistoryMsg{taskID: internalTaskID, drillKey: drillKey, segments: segments, detail: detail}
+	}
+}
 
-		var detail *TaskItem
-		segments := make([]TaskHistorySegmentItem, 0)
-		if dbConn != nil {
-			detail = taskDetailItem(ctx, dbConn, drillKey)
-			if segs, err := dbConn.GetTaskWorkflowHistory(ctx, internalTaskID); err == nil {
-				now := time.Now()
-				for _, seg := range segs {
-					item := mapInstances(ctx, dbConn, []db.WorkflowInstance{seg.Instance})[0]
-					item.Steps = mapStepRuns(seg.Steps, now)
-					if polls, err := dbConn.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
-						item.CIPolls = mapCIPolls(polls)
-					}
-					if item.State == db.InstanceStateApprovalWaiting {
-						item.Message = "Awaiting human approval — reply on the task to resume or abort."
-					}
-					segments = append(segments, TaskHistorySegmentItem{
-						Instance: item,
-						Logs:     mapLogLines(seg.Logs),
-					})
+// buildTaskHistory assembles the per-instance history (each workflow instance with
+// its steps, CI polls, and time-scoped logs) plus the detail header. Shared by the
+// initial open (fetchTaskHistory) and the live refresh (refreshTaskHistory).
+func (a *App) buildTaskHistory(ctx context.Context, dbConn *db.Client, internalTaskID, drillKey string) (*TaskItem, []TaskHistorySegmentItem) {
+	var detail *TaskItem
+	segments := make([]TaskHistorySegmentItem, 0)
+	if dbConn != nil {
+		detail = taskDetailItem(ctx, dbConn, drillKey)
+		if segs, err := dbConn.GetTaskWorkflowHistory(ctx, internalTaskID); err == nil {
+			now := time.Now()
+			for _, seg := range segs {
+				item := mapInstances(ctx, dbConn, []db.WorkflowInstance{seg.Instance})[0]
+				item.Steps = mapStepRuns(seg.Steps, now)
+				if polls, err := dbConn.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
+					item.CIPolls = mapCIPolls(polls)
 				}
+				if item.State == db.InstanceStateApprovalWaiting {
+					item.Message = "Awaiting human approval — reply on the task to resume or abort."
+				}
+				segments = append(segments, TaskHistorySegmentItem{
+					Instance: item,
+					Logs:     mapLogLines(seg.Logs),
+				})
 			}
 		}
-		return taskHistoryMsg{taskID: internalTaskID, segments: segments, detail: detail}
+	}
+	return detail, segments
+}
+
+// refreshTaskHistory re-builds the open per-instance history view by id, so a
+// running task's steps and logs stay live. The handler preserves scroll.
+func (a *App) refreshTaskHistory(internalTaskID, drillKey string) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		detail, segments := a.buildTaskHistory(ctx, dbConn, internalTaskID, drillKey)
+		return taskHistoryRefreshMsg{segments: segments, detail: detail}
 	}
 }
 

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -21,6 +21,7 @@ type Model struct {
 	lastRefresh    time.Time
 	lastTabRefresh map[int]time.Time // Track refresh per tab
 	loading        bool              // Show loading state
+	tickCount      int               // refresh ticks elapsed; throttles the heavier logs refresh
 
 	confirmAction string // "restart" or "clear" or "stop" when awaiting confirmation
 	confirmTaskID string
@@ -78,8 +79,14 @@ type TasksTab struct {
 	// taskLogTailLimit lines, then fetches older pages on scroll-to-top.
 	LogTaskID      string // task whose flat logs are loaded (cursor scope)
 	LogOldestID    int64  // row id of the oldest loaded line (the older-page cursor)
+	LogNewestID    int64  // row id of the newest loaded line (the live-tail cursor)
 	LogHasMore     bool   // an older page may exist (last load filled the limit)
 	LogLoadingMore bool   // an older-page fetch is in flight (de-dupe guard)
+
+	// Identifiers kept so the open Logs view can re-fetch itself by id on each
+	// tick (live-tail). The detail header (Detail) does not carry the internal id.
+	LogInternalTaskID string // canonical InternalTask id (history-mode refresh), "" for flat mode
+	LogDrillKey       string // legacy cell id used to hydrate the detail header
 
 	// Workflow monitor sub-view (View == TaskViewWorkflow).
 	WorkflowInstances   []*WorkflowInstanceItem // all instances for the task, newest-first

--- a/src/internal/db/dashboard.go
+++ b/src/internal/db/dashboard.go
@@ -9,18 +9,18 @@ import (
 
 // DashboardStats holds overview statistics.
 type DashboardStats struct {
-	DispatcherStatus string
-	Uptime           time.Duration
-	ActiveAgents     int
-	ActiveRuns       int
-	QueuedTasks      int
-	CompletedToday   int
-	FailedToday      int
-	AvgDurationMs    int64
-	SuccessRate      float64
-	TodayCostUSD     float64
-	TodayTokens      int
-	TodayInputTokens int
+	DispatcherStatus  string
+	Uptime            time.Duration
+	ActiveAgents      int
+	ActiveRuns        int
+	QueuedTasks       int
+	CompletedToday    int
+	FailedToday       int
+	AvgDurationMs     int64
+	SuccessRate       float64
+	TodayCostUSD      float64
+	TodayTokens       int
+	TodayInputTokens  int
 	TodayOutputTokens int
 }
 
@@ -504,6 +504,37 @@ func (c *Client) taskLogsPage(ctx context.Context, taskID string, beforeID int64
 	return logs, nil
 }
 
+// GetTaskLogsAfter returns up to `limit` log lines newer than afterID (a row id
+// cursor), in chronological order (oldest first). Used to live-tail the logs view
+// while a task is running: pass the newest loaded row id to pull only the lines
+// appended since.
+func (c *Client) GetTaskLogsAfter(ctx context.Context, taskID string, afterID int64, limit int) ([]TaskLogLine, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, timestamp, level, message
+		FROM task_logs
+		WHERE task_id = ? AND id > ?
+		ORDER BY id ASC
+		LIMIT ?
+	`, taskID, afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var logs []TaskLogLine
+	for rows.Next() {
+		var l TaskLogLine
+		var level, msg sql.NullString
+		if err := rows.Scan(&l.ID, &l.Timestamp, &level, &msg); err != nil {
+			continue
+		}
+		l.Level = level.String
+		l.Message = msg.String
+		logs = append(logs, l)
+	}
+	return logs, nil
+}
+
 // GetTaskLogsInRange returns log lines for a task within a time window, used to
 // isolate logs belonging to a specific workflow step run.
 func (c *Client) GetTaskLogsInRange(ctx context.Context, taskID string, from, to *time.Time) ([]TaskLogLine, error) {
@@ -666,10 +697,10 @@ func (c *Client) GetDailyUsage(ctx context.Context, days int) ([]DailyUsage, err
 
 // AgentUsage holds per-agent usage aggregates.
 type AgentUsage struct {
-	AgentID    string
+	AgentID     string
 	TotalTokens int
-	CostUSD    float64
-	RunCount   int
+	CostUSD     float64
+	RunCount    int
 }
 
 // GetAgentUsage returns per-agent usage totals.

--- a/src/internal/db/task_logs_page_test.go
+++ b/src/internal/db/task_logs_page_test.go
@@ -49,6 +49,49 @@ func TestGetTaskLogs_CursorPagination(t *testing.T) {
 	}
 }
 
+// GetTaskLogsAfter returns only the lines newer than the cursor, oldest-first, so
+// the logs view can live-tail by passing its newest loaded row id.
+func TestGetTaskLogsAfter_Cursor(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	for i := 1; i <= 6; i++ {
+		if err := c.WriteTaskLog(ctx, "7", "info", fmt.Sprintf("line-%d", i)); err != nil {
+			t.Fatalf("write log: %v", err)
+		}
+	}
+
+	// Load a tail of 3 (line-4..line-6), then tail forward from its newest id.
+	tail, err := c.GetTaskLogs(ctx, "7", 3)
+	if err != nil {
+		t.Fatalf("GetTaskLogs: %v", err)
+	}
+	cursor := tail[len(tail)-1].ID
+
+	// Nothing newer yet.
+	if more, err := c.GetTaskLogsAfter(ctx, "7", cursor, 100); err != nil {
+		t.Fatalf("GetTaskLogsAfter: %v", err)
+	} else if len(more) != 0 {
+		t.Fatalf("expected no new lines, got %+v", more)
+	}
+
+	// Two more lines arrive; only those come back, oldest-first.
+	for i := 7; i <= 8; i++ {
+		if err := c.WriteTaskLog(ctx, "7", "info", fmt.Sprintf("line-%d", i)); err != nil {
+			t.Fatalf("write log: %v", err)
+		}
+	}
+	more, err := c.GetTaskLogsAfter(ctx, "7", cursor, 100)
+	if err != nil {
+		t.Fatalf("GetTaskLogsAfter: %v", err)
+	}
+	if got := messages(more); fmt.Sprint(got) != fmt.Sprint([]string{"line-7", "line-8"}) {
+		t.Errorf("tail-after = %v, want [line-7 line-8]", got)
+	}
+	if more[0].ID <= cursor {
+		t.Errorf("returned a line at/under the cursor: id=%d cursor=%d", more[0].ID, cursor)
+	}
+}
+
 func messages(rows []TaskLogLine) []string {
 	out := make([]string, 0, len(rows))
 	for _, r := range rows {


### PR DESCRIPTION
## Summary

The dashboard ticks every 2s, but `fetchActiveTab` deliberately returned early whenever a task **Detail** or **Logs** sub-view was open — so those views were frozen snapshots until you pressed `r`. Only the Workflow Monitor live-refreshed. The freeze existed because the only reload path was `SelectedIdx`-keyed (re-sorting the list under the cursor would retarget `r`/`d`/`l`).

This refreshes the sub-views **by task id** instead — the same pattern the workflow monitor already uses ([workflowMonitorRefreshMsg](src/internal/dashboard/app.go)) — so they stay live without disturbing the list or the cursor.

- **New DB query**: `GetTaskLogsAfter(taskID, afterID, limit)` for incremental log tailing (chronological, `id > cursor`).
- **View-preserving refresh messages** (`taskDetailRefreshMsg`, `tailTaskLogsMsg`, `taskHistoryRefreshMsg`) + commands that re-fetch by id. Their handlers update data in place and **never** reset `View` or scroll, so a refresh that lands after you navigate away is harmless.
- Shared builders extracted (`loadTaskDetail`, `buildTaskHistory`) so the initial open and the live refresh share one code path.
- **Logs scroll**: follow the tail only when already pinned to the bottom (matches `G`/`end` semantics); a scrolled-up reader keeps their position as new lines append below.
- **Cadence**: Detail refreshes every tick (2s); the heavier per-instance history query is throttled to every other tick (~4s) via `model.tickCount`.

No change to manual `r` reload, `G`/`end`, or older-page pagination.

## Test plan

- [x] `go build ./...`, `go vet ./internal/dashboard/... ./internal/db/...`, `gofmt` clean.
- [x] Unit: `TestGetTaskLogsAfter_Cursor` (only rows past the cursor, oldest-first) — `go test ./internal/db/...` passes; `go test ./internal/dashboard/...` passes.
- [ ] Manual: with `apiary run` + a live task, `apiary dashboard` → open Detail (`d`) and confirm status/tokens/instances tick without pressing `r`; open Logs (`l`/`enter`) and confirm new lines stream in; scroll up mid-stream and confirm the viewport stays put while lines append below; press `G` and confirm it then follows the tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)