### PR TITLE
feat(dashboard): add (p) key to open a task's latest pull request

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -768,6 +768,28 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(hist)
 	})
+	mux.HandleFunc("/tasks/pulls/refresh/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		ref := strings.TrimPrefix(r.URL.Path, "/tasks/pulls/refresh/")
+		if ref == "" {
+			http.Error(w, "missing task ref", http.StatusBadRequest)
+			return
+		}
+		resp, err := d.RefreshTaskPullRequests(r.Context(), ref)
+		if err != nil {
+			if errors.Is(err, ErrTaskNotFound) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
 	mux.HandleFunc("/resume/", func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimPrefix(r.URL.Path, "/resume/")
 		if id == "" {

--- a/src/internal/daemon/task_pulls_test.go
+++ b/src/internal/daemon/task_pulls_test.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// prListerAdapter is a minimal source.Adapter that also implements
+// source.PullRequestLister, returning a scripted result (or error).
+type prListerAdapter struct {
+	prs []source.PullRequestRef
+	err error
+}
+
+func (a *prListerAdapter) ID() string                                    { return "fake" }
+func (a *prListerAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *prListerAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (a *prListerAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *prListerAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *prListerAdapter) WebhookHandler() http.Handler { return nil }
+func (a *prListerAdapter) ListPullRequests(context.Context, string) ([]source.PullRequestRef, error) {
+	return a.prs, a.err
+}
+
+func newPRTestClient(t *testing.T) *db.Client {
+	t.Helper()
+	c, err := db.New(context.Background(), filepath.Join(t.TempDir(), "pulls.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestRefreshTaskPullRequests_PersistsAndReturns(t *testing.T) {
+	ctx := context.Background()
+	c := newPRTestClient(t)
+	taskID, _ := seedBoundTask(ctx, t, c, "github", "42")
+
+	adapter := &prListerAdapter{prs: []source.PullRequestRef{
+		{Number: 7, URL: "https://gh/pr/7"},
+		{Number: 9, URL: "https://gh/pr/9"},
+	}}
+	d := &Dispatcher{db: c, sources: map[string]source.Adapter{"github": adapter}}
+
+	resp, err := d.RefreshTaskPullRequests(ctx, taskID)
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if len(resp.Pulls) != 2 || resp.Pulls[len(resp.Pulls)-1].Number != 9 {
+		t.Fatalf("got %+v, want 2 PRs with #9 last", resp.Pulls)
+	}
+	// Persisted, so a later read (e.g. the dashboard) sees the same set.
+	stored, _ := c.ListTaskPullRequests(ctx, taskID)
+	if len(stored) != 2 {
+		t.Fatalf("persisted %d rows, want 2", len(stored))
+	}
+}
+
+func TestRefreshTaskPullRequests_ListerErrorKeepsLastGood(t *testing.T) {
+	ctx := context.Background()
+	c := newPRTestClient(t)
+	taskID, _ := seedBoundTask(ctx, t, c, "github", "42")
+
+	// Seed a last-good set directly.
+	if err := c.ReplaceTaskPullRequests(ctx, taskID, "github",
+		[]db.TaskPullRequest{{SourceID: "github", PRNumber: 1, PRURL: "https://gh/pr/1"}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	adapter := &prListerAdapter{err: errors.New("boom")}
+	d := &Dispatcher{db: c, sources: map[string]source.Adapter{"github": adapter}}
+
+	resp, err := d.RefreshTaskPullRequests(ctx, taskID)
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	// The transient error must not wipe the persisted rows.
+	if len(resp.Pulls) != 1 || resp.Pulls[0].Number != 1 {
+		t.Fatalf("got %+v, want the last-good PR #1 preserved", resp.Pulls)
+	}
+}
+
+func TestRefreshTaskPullRequests_NonListerSourceNoop(t *testing.T) {
+	ctx := context.Background()
+	c := newPRTestClient(t)
+	taskID, _ := seedBoundTask(ctx, t, c, "github", "42")
+
+	d := &Dispatcher{db: c, sources: map[string]source.Adapter{"github": plainAdapterNoLister{}}}
+	resp, err := d.RefreshTaskPullRequests(ctx, taskID)
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if len(resp.Pulls) != 0 {
+		t.Fatalf("got %+v, want none (source can't list PRs)", resp.Pulls)
+	}
+}
+
+func TestRefreshTaskPullRequests_UnknownTask(t *testing.T) {
+	c := newPRTestClient(t)
+	d := &Dispatcher{db: c, sources: map[string]source.Adapter{}}
+	if _, err := d.RefreshTaskPullRequests(context.Background(), "nope"); !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("err = %v, want ErrTaskNotFound", err)
+	}
+}
+
+// plainAdapterNoLister implements source.Adapter but NOT source.PullRequestLister.
+type plainAdapterNoLister struct{}
+
+func (plainAdapterNoLister) ID() string                                    { return "plain" }
+func (plainAdapterNoLister) Connect(context.Context, map[string]any) error { return nil }
+func (plainAdapterNoLister) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (plainAdapterNoLister) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (plainAdapterNoLister) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (plainAdapterNoLister) WebhookHandler() http.Handler { return nil }

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
 )
 
 // ErrTaskNotFound is returned by DeleteTask when no task, binding, or workflow
@@ -86,6 +87,113 @@ func ciPollViews(checks []db.CIPollCheck) []CIPollView {
 // InstancesResponse is the JSON payload returned by GET /instances.
 type InstancesResponse struct {
 	Instances []InstanceSummary `json:"instances"`
+}
+
+// PullRequestView is one pull request linked to a task, returned by the PR-refresh
+// endpoint.
+type PullRequestView struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+	State  string `json:"state"`
+}
+
+// TaskPullRequestsResponse is the JSON payload returned by
+// POST /tasks/pulls/refresh/{ref}. Pulls is ordered oldest first; the last entry
+// is the most recent PR.
+type TaskPullRequestsResponse struct {
+	TaskID string            `json:"task_id"`
+	Pulls  []PullRequestView `json:"pulls"`
+}
+
+// RefreshTaskPullRequests resolves a task's source bindings, asks each source that
+// can enumerate PRs for the ones linked to the bound item(s), persists the result,
+// and returns the merged set. It is the daemon-side half of the dashboard's "open
+// PR" shortcut: the dashboard reads its own DB for display, while only the daemon
+// holds the source adapters/credentials to discover PRs.
+//
+// A source that errors or cannot list PRs is skipped WITHOUT touching its persisted
+// rows, so a transient GitHub/auth failure never wipes the last-good PR list.
+func (d *Dispatcher) RefreshTaskPullRequests(ctx context.Context, taskRef string) (*TaskPullRequestsResponse, error) {
+	if d.db == nil {
+		return &TaskPullRequestsResponse{}, nil
+	}
+	taskID, _, err := d.resolveTaskRef(ctx, taskRef)
+	if err != nil {
+		return nil, err
+	}
+	bindings, err := d.db.ListBindingsByTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group bound item ids by source so a task with several bindings on the same
+	// source is replaced in one shot (a per-binding replace would clobber the
+	// earlier binding's rows, since the delete is scoped to source_id).
+	itemsBySource := make(map[string][]string)
+	order := make([]string, 0)
+	for _, b := range bindings {
+		if _, seen := itemsBySource[b.SourceID]; !seen {
+			order = append(order, b.SourceID)
+		}
+		itemsBySource[b.SourceID] = append(itemsBySource[b.SourceID], b.SourceItemID)
+	}
+
+	for _, sourceID := range order {
+		adapter, ok := d.sources[sourceID]
+		if !ok {
+			continue
+		}
+		lister, ok := adapter.(source.PullRequestLister)
+		if !ok {
+			continue // source can't enumerate PRs (e.g. Plane) — leave its rows alone
+		}
+
+		var refs []source.PullRequestRef
+		failed := false
+		seen := make(map[int]bool)
+		for _, itemID := range itemsBySource[sourceID] {
+			prs, err := lister.ListPullRequests(ctx, itemID)
+			if err != nil {
+				// Transient/auth error: keep last-good rows for this source.
+				aplog.Debug("refresh PRs for task %s (%s/%s): %v", taskID, sourceID, itemID, err)
+				failed = true
+				break
+			}
+			for _, p := range prs {
+				if seen[p.Number] {
+					continue
+				}
+				seen[p.Number] = true
+				refs = append(refs, p)
+			}
+		}
+		if failed {
+			continue
+		}
+
+		rows := make([]db.TaskPullRequest, 0, len(refs))
+		for _, p := range refs {
+			rows = append(rows, db.TaskPullRequest{
+				SourceID: sourceID,
+				PRNumber: p.Number,
+				PRURL:    p.URL,
+				PRState:  p.State,
+			})
+		}
+		if err := d.db.ReplaceTaskPullRequests(ctx, taskID, sourceID, rows); err != nil {
+			return nil, err
+		}
+	}
+
+	stored, err := d.db.ListTaskPullRequests(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	resp := &TaskPullRequestsResponse{TaskID: taskID}
+	for _, p := range stored {
+		resp.Pulls = append(resp.Pulls, PullRequestView{Number: p.PRNumber, URL: p.PRURL, State: p.PRState})
+	}
+	return resp, nil
 }
 
 // WorkflowStepDef is one step in a workflow definition, for the Workflows tab.

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -81,6 +81,12 @@ type taskDetailMsg struct {
 	detail   *TaskItem
 	instance *WorkflowInstanceItem
 }
+
+// taskPullsRefreshedMsg is emitted after the daemon has (re)discovered and
+// persisted a task's pull requests, so the open detail can reload and pick them up.
+type taskPullsRefreshedMsg struct {
+	internalTaskID string
+}
 type taskLogsMsg struct {
 	taskID   string
 	logs     []LogEntry
@@ -200,6 +206,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.model.tasksTab.View = TaskViewDetail
 		}
 		a.model.loading = false
+
+	case taskPullsRefreshedMsg:
+		// Daemon persisted fresh PRs; reload the open detail so they appear and the
+		// (p) shortcut targets the latest one.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewDetail && t.Detail != nil &&
+			t.Detail.InternalTaskID == msg.internalTaskID && msg.internalTaskID != "" {
+			return a, a.refreshTaskDetail(t.Detail.DrillKey, msg.internalTaskID)
+		}
 
 	case taskLogsMsg:
 		if t := a.model.tasksTab; t != nil {
@@ -393,6 +407,14 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Open the focused task in the browser, from any task-oriented view.
 	if key == "o" {
 		if u, ok := a.focusedTaskURL(); ok {
+			return a, openURLCmd(u)
+		}
+		return a, nil
+	}
+
+	// Open the focused task's most recent pull request in the browser.
+	if key == "p" {
+		if u, ok := a.focusedTaskPRURL(); ok {
 			return a, openURLCmd(u)
 		}
 		return a, nil
@@ -676,7 +698,7 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "Tasks":
 			if row, ok := a.selectedTask(); ok {
 				a.model.loading = true
-				return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
+				return a, tea.Batch(a.fetchTaskDetail(row.TaskID, row.InternalTaskID), a.refreshTaskPullsCmd(row.InternalTaskID))
 			}
 		case "Agents":
 			// Detail uses the already-loaded stats — no DB round-trip needed.
@@ -987,7 +1009,7 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 	case "d":
 		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
-			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
+			return a, tea.Batch(a.fetchTaskDetail(row.TaskID, row.InternalTaskID), a.refreshTaskPullsCmd(row.InternalTaskID))
 		}
 	case "l", "enter":
 		if row, ok := a.selectedTask(); ok {
@@ -1000,7 +1022,7 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			if t.View == TaskViewLogs {
 				return a, a.fetchTaskHistory(row.InternalTaskID, row.TaskID)
 			}
-			return a, a.fetchTaskDetail(row.TaskID, row.InternalTaskID)
+			return a, tea.Batch(a.fetchTaskDetail(row.TaskID, row.InternalTaskID), a.refreshTaskPullsCmd(row.InternalTaskID))
 		}
 	case "up":
 		if t.View == TaskViewLogs {
@@ -1298,6 +1320,48 @@ func (a *App) focusedTaskURL() (string, bool) {
 	return "", false
 }
 
+// focusedTaskPulls returns the persisted pull requests of the task the user is
+// currently looking at, across the same views as focusedTaskURL. Reports false
+// when there is no focused task.
+func (a *App) focusedTaskPulls() ([]PullRequestItem, bool) {
+	switch a.model.ActiveTab() {
+	case "Tasks":
+		t := a.model.tasksTab
+		if t == nil {
+			return nil, false
+		}
+		if t.View == TaskViewDetail && t.Detail != nil {
+			return t.Detail.PullRequests, true
+		}
+		if rows := a.filteredTasks(t); t.SelectedIdx >= 0 && t.SelectedIdx < len(rows) {
+			return rows[t.SelectedIdx].PullRequests, true
+		}
+	case "Agents":
+		ag := a.model.agentsTab
+		if ag == nil {
+			return nil, false
+		}
+		if ag.View == AgentViewActivity || ag.View == AgentViewTaskLogs {
+			if ag.ActivityIdx >= 0 && ag.ActivityIdx < len(ag.Activity) {
+				return ag.Activity[ag.ActivityIdx].PullRequests, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// focusedTaskPRURL returns the most recent pull request URL of the focused task —
+// the tail of its PR list, since the list is ordered oldest-first. Reports false
+// when the task has no PR (then the (p) key is a no-op, like (o) with no URL).
+func (a *App) focusedTaskPRURL() (string, bool) {
+	prs, ok := a.focusedTaskPulls()
+	if !ok || len(prs) == 0 {
+		return "", false
+	}
+	u := prs[len(prs)-1].URL
+	return u, u != ""
+}
+
 // focusedTaskID returns the task ID the user is currently focused on.
 func (a *App) focusedTaskID() (string, bool) {
 	switch a.model.ActiveTab() {
@@ -1343,6 +1407,36 @@ func (a *App) restartTaskCmd(taskID string) tea.Cmd {
 		}
 		resp.Body.Close()
 		return nil
+	}
+}
+
+// refreshTaskPullsCmd asks the daemon to (re)discover the task's pull requests from
+// its source and persist them. The daemon holds the source adapters/credentials;
+// the dashboard then reads the persisted list from its own DB. No-op for rows with
+// no internal task id (e.g. Agents-tab history rows). On success it emits a
+// taskPullsRefreshedMsg so the open detail reloads with the fresh PRs.
+func (a *App) refreshTaskPullsCmd(internalTaskID string) tea.Cmd {
+	if internalTaskID == "" {
+		return nil
+	}
+	socketPath := a.socketPath
+	return func() tea.Msg {
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		}
+		client := &http.Client{Transport: transport, Timeout: 8 * time.Second}
+		url := fmt.Sprintf("http://apiary/tasks/pulls/refresh/%s", internalTaskID)
+		resp, err := client.Post(url, "application/json", nil)
+		if err != nil {
+			return nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			return nil
+		}
+		return taskPullsRefreshedMsg{internalTaskID: internalTaskID}
 	}
 }
 
@@ -1820,7 +1914,8 @@ func (a *App) fetchTasks() tea.Cmd {
 			if tasks, err := dbConn.InternalTasks().ListTasks(ctx, 100); err == nil {
 				for _, tk := range tasks {
 					bindings, _ := dbConn.ListBindingsByTask(ctx, tk.ID)
-					items = append(items, taskItemFromInternal(tk, bindings))
+					prs, _ := dbConn.ListTaskPullRequests(ctx, tk.ID)
+					items = append(items, taskItemFromInternal(tk, bindings, prs))
 				}
 			}
 		}
@@ -1832,7 +1927,7 @@ func (a *App) fetchTasks() tea.Cmd {
 // dashboard Tasks-tab row. Execution-scoped fields (Agent/Model/tokens/duration)
 // are left zero here and hydrated on drill-down; StartedAt/CompletedAt mirror the
 // task timestamps so the list's "when" column and time sort stay meaningful.
-func taskItemFromInternal(t model.InternalTask, bindings []model.SourceBinding) TaskItem {
+func taskItemFromInternal(t model.InternalTask, bindings []model.SourceBinding, prs []db.TaskPullRequest) TaskItem {
 	created := t.CreatedAt
 	item := TaskItem{
 		TaskID:               drillKeyFor(t, bindings), // legacy machinery key (== DrillKey)
@@ -1844,6 +1939,7 @@ func taskItemFromInternal(t model.InternalTask, bindings []model.SourceBinding) 
 		ParentTaskID:         t.ParentTaskID,
 		OutstandingWorkflows: t.OutstandingWorkflows,
 		Bindings:             mapBindings(bindings),
+		PullRequests:         mapPullRequests(prs),
 	}
 	if t.State == model.TaskStateDone || t.State == model.TaskStateFailed {
 		updated := t.UpdatedAt
@@ -1880,6 +1976,18 @@ func mapBindings(bindings []model.SourceBinding) []SourceBindingItem {
 			ItemURL:    b.SourceItemURL,
 			ItemID:     b.SourceItemID,
 		})
+	}
+	return out
+}
+
+// mapPullRequests converts persisted PR rows (oldest first) to their view items.
+func mapPullRequests(prs []db.TaskPullRequest) []PullRequestItem {
+	if len(prs) == 0 {
+		return nil
+	}
+	out := make([]PullRequestItem, 0, len(prs))
+	for _, p := range prs {
+		out = append(out, PullRequestItem{Number: p.PRNumber, URL: p.PRURL, State: p.PRState})
 	}
 	return out
 }
@@ -2083,6 +2191,12 @@ func (a *App) augmentTaskDetail(ctx context.Context, dbConn *db.Client, detail *
 	}
 	if insts, _ := dbConn.ListWorkflowInstancesByTask(ctx, internalTaskID); len(insts) > 0 {
 		detail.Instances = mapInstances(ctx, dbConn, insts)
+	}
+	// PRs are persisted by the daemon (refreshed on detail open); read them back so
+	// the (p) shortcut and the detail panel stay in sync. Re-runs of this function
+	// from the live tick pick up freshly-discovered PRs automatically.
+	if prs, _ := dbConn.ListTaskPullRequests(ctx, internalTaskID); len(prs) > 0 {
+		detail.PullRequests = mapPullRequests(prs)
 	}
 	return detail
 }
@@ -4322,9 +4436,9 @@ func (a *App) footerKeys() []fkey {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewDetail:
-				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
-				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"C", "clear"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"C", "clear"}, {"q", "quit"}}
 			case TaskViewWorkflow:
 				if t.WorkflowShowLogs {
 					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
@@ -4336,7 +4450,7 @@ func (a *App) footerKeys() []fkey {
 				return append(keys, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
 	case "Workflows":
 		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
 			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}
@@ -4348,9 +4462,9 @@ func (a *App) footerKeys() []fkey {
 			case AgentViewDetail:
 				return []fkey{{"esc", "back"}, {"f", "files"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
 			case AgentViewActivity:
-				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"pgup/dn", "page"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"pgup/dn", "page"}, {"q", "quit"}}
 			case AgentViewTaskLogs:
-				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"o", "open"}, {"home/end", "ends"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"home/end", "ends"}, {"r", "reload"}, {"q", "quit"}}
 			case AgentViewFiles:
 				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "view"}, {"q", "quit"}}
 			case AgentViewFileContent:

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -234,6 +234,16 @@ type TaskItem struct {
 	Lineage              []TaskLineageItem      // ancestors root-first incl. self (detail only)
 	Children             []TaskLineageItem      // direct children / spawned tasks (detail only)
 	Instances            []WorkflowInstanceItem // all workflow instances for this task (detail only)
+	PullRequests         []PullRequestItem      // persisted PRs, oldest first; last = most recent
+}
+
+// PullRequestItem is one pull request linked to a task, persisted by the daemon
+// (discovered from the source on detail open) and read back from the local DB so
+// the dashboard can open the latest PR with the (p) key.
+type PullRequestItem struct {
+	Number int
+	URL    string
+	State  string
 }
 
 // AgentView is which sub-screen the Agents tab is showing.

--- a/src/internal/dashboard/task_fetch_test.go
+++ b/src/internal/dashboard/task_fetch_test.go
@@ -31,9 +31,16 @@ func TestTaskItemFromInternal(t *testing.T) {
 		CreatedAt: created, UpdatedAt: updated, OutstandingWorkflows: 0,
 	}
 	bindings := []model.SourceBinding{{SourceID: "github", SourceItemID: "ISSUE-9", SourceItemNumber: "#9", SourceItemURL: "https://x/9"}}
-	it := taskItemFromInternal(done, bindings)
+	prs := []db.TaskPullRequest{
+		{SourceID: "github", PRNumber: 11, PRURL: "https://x/pull/11", Seq: 0},
+		{SourceID: "github", PRNumber: 12, PRURL: "https://x/pull/12", Seq: 1},
+	}
+	it := taskItemFromInternal(done, bindings, prs)
 	if it.InternalTaskID != "tk_done" || it.DrillKey != "ISSUE-9" || it.TaskID != "ISSUE-9" {
 		t.Errorf("ids wrong: InternalTaskID=%q DrillKey=%q TaskID=%q", it.InternalTaskID, it.DrillKey, it.TaskID)
+	}
+	if len(it.PullRequests) != 2 || it.PullRequests[len(it.PullRequests)-1].URL != "https://x/pull/12" {
+		t.Errorf("PullRequests not mapped (tail should be the most recent): %+v", it.PullRequests)
 	}
 	if it.Status != "done" || it.Number != "#9" || it.URL != "https://x/9" {
 		t.Errorf("mapping wrong: Status=%q Number=%q URL=%q", it.Status, it.Number, it.URL)
@@ -50,7 +57,7 @@ func TestTaskItemFromInternal(t *testing.T) {
 
 	// Binding-less running task: drill key = task id, no CompletedAt.
 	running := model.InternalTask{ID: "tk_run", Title: "spawned", State: model.TaskStateRunning, CreatedAt: created}
-	r := taskItemFromInternal(running, nil)
+	r := taskItemFromInternal(running, nil, nil)
 	if r.DrillKey != "tk_run" || r.TaskID != "tk_run" {
 		t.Errorf("binding-less drill key should be the task id, got %q", r.DrillKey)
 	}

--- a/src/internal/db/pullrequest_store.go
+++ b/src/internal/db/pullrequest_store.go
@@ -1,0 +1,71 @@
+package db
+
+import "context"
+
+// TaskPullRequest is one pull request linked to an InternalTask, discovered from
+// the source (e.g. a GitHub issue's cross-referenced PRs). Seq is the source-order
+// position; the row with the highest Seq is the most recent PR.
+type TaskPullRequest struct {
+	ID       string
+	TaskID   string
+	SourceID string
+	PRNumber int
+	PRURL    string
+	PRState  string
+	Seq      int
+}
+
+// ReplaceTaskPullRequests atomically swaps the persisted PR set for a single
+// (taskID, sourceID) pair: it deletes the existing rows for that pair and inserts
+// prs in order (seq = slice index). Callers MUST invoke this only after a
+// successful source listing — a transient/auth error should skip the call so the
+// last-good data survives. Other sources' rows for the same task are untouched.
+func (c *Client) ReplaceTaskPullRequests(ctx context.Context, taskID, sourceID string, prs []TaskPullRequest) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM task_pull_requests WHERE task_id = ? AND source_id = ?`,
+		taskID, sourceID); err != nil {
+		return err
+	}
+	for i, p := range prs {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO task_pull_requests
+			  (id, task_id, source_id, pr_number, pr_url, pr_state, seq)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`, newID(), taskID, sourceID, p.PRNumber, p.PRURL, nullStr(p.PRState), i); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// ListTaskPullRequests returns all PRs linked to a task across sources, ordered
+// oldest first (seq ASC). The tail is the most recent PR — what the dashboard's
+// "open PR" shortcut opens.
+func (c *Client) ListTaskPullRequests(ctx context.Context, taskID string) ([]TaskPullRequest, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, task_id, source_id, pr_number, pr_url, COALESCE(pr_state,''), seq
+		FROM task_pull_requests WHERE task_id = ?
+		ORDER BY seq ASC, pr_number ASC
+	`, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []TaskPullRequest
+	for rows.Next() {
+		var p TaskPullRequest
+		if err := rows.Scan(&p.ID, &p.TaskID, &p.SourceID, &p.PRNumber,
+			&p.PRURL, &p.PRState, &p.Seq); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}

--- a/src/internal/db/pullrequest_store_test.go
+++ b/src/internal/db/pullrequest_store_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTaskPullRequests_ReplaceAndList(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// Initial set of two PRs, oldest first.
+	in := []TaskPullRequest{
+		{SourceID: "github", PRNumber: 10, PRURL: "https://gh/pr/10"},
+		{SourceID: "github", PRNumber: 11, PRURL: "https://gh/pr/11"},
+	}
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "github", in); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	got, err := c.ListTaskPullRequests(ctx, "task1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2", len(got))
+	}
+	if got[0].PRNumber != 10 || got[1].PRNumber != 11 {
+		t.Errorf("order = [%d, %d], want [10, 11]", got[0].PRNumber, got[1].PRNumber)
+	}
+	if got[0].Seq != 0 || got[1].Seq != 1 {
+		t.Errorf("seq = [%d, %d], want [0, 1]", got[0].Seq, got[1].Seq)
+	}
+	// The tail is the most recent PR — what the (p) shortcut opens.
+	if last := got[len(got)-1]; last.PRNumber != 11 {
+		t.Errorf("tail = %d, want 11 (most recent)", last.PRNumber)
+	}
+}
+
+func TestTaskPullRequests_ReplaceShrinksAndDropsStale(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	first := []TaskPullRequest{
+		{SourceID: "github", PRNumber: 1, PRURL: "https://gh/pr/1"},
+		{SourceID: "github", PRNumber: 2, PRURL: "https://gh/pr/2"},
+		{SourceID: "github", PRNumber: 3, PRURL: "https://gh/pr/3"},
+	}
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "github", first); err != nil {
+		t.Fatalf("replace 1: %v", err)
+	}
+	// Replace with a single PR — the stale rows must be gone.
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "github",
+		[]TaskPullRequest{{SourceID: "github", PRNumber: 3, PRURL: "https://gh/pr/3"}}); err != nil {
+		t.Fatalf("replace 2: %v", err)
+	}
+	got, err := c.ListTaskPullRequests(ctx, "task1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || got[0].PRNumber != 3 || got[0].Seq != 0 {
+		t.Fatalf("after shrink got %+v, want single PR #3 at seq 0", got)
+	}
+}
+
+func TestTaskPullRequests_PerSourceIsolation(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "github",
+		[]TaskPullRequest{{SourceID: "github", PRNumber: 1, PRURL: "https://gh/pr/1"}}); err != nil {
+		t.Fatalf("replace github: %v", err)
+	}
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "gitlab",
+		[]TaskPullRequest{{SourceID: "gitlab", PRNumber: 9, PRURL: "https://gl/mr/9"}}); err != nil {
+		t.Fatalf("replace gitlab: %v", err)
+	}
+	// Replacing one source must not touch the other's rows.
+	got, err := c.ListTaskPullRequests(ctx, "task1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per source)", len(got))
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -176,6 +176,23 @@ CREATE TABLE IF NOT EXISTS source_bindings (
   UNIQUE(source_id, source_item_id)
 );
 
+-- Pull requests linked to an InternalTask, discovered from the source (e.g. a
+-- GitHub issue's cross-referenced PRs) when a task's detail is opened. Persisted
+-- so the dashboard can offer "open the latest PR" from the list, not just detail.
+-- seq is the source-order position; MAX(seq) is the most recent PR.
+CREATE TABLE IF NOT EXISTS task_pull_requests (
+  id TEXT PRIMARY KEY,                          -- ulid
+  task_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,                      -- e.g. "github"
+  pr_number INTEGER NOT NULL,
+  pr_url TEXT NOT NULL,                         -- browser deep-link
+  pr_state TEXT,                                -- open|closed|merged, nullable
+  seq INTEGER NOT NULL DEFAULT 0,               -- source order; MAX(seq) = most recent
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(task_id) REFERENCES internal_tasks(id),
+  UNIQUE(task_id, source_id, pr_number)
+);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_executions_task ON task_executions(task_id);
 CREATE INDEX IF NOT EXISTS idx_executions_retry ON task_executions(next_retry_at) WHERE status='failed';
@@ -193,6 +210,7 @@ CREATE INDEX IF NOT EXISTS idx_internal_tasks_state ON internal_tasks(state);
 CREATE INDEX IF NOT EXISTS idx_internal_tasks_parent ON internal_tasks(parent_task_id);
 CREATE INDEX IF NOT EXISTS idx_source_bindings_task ON source_bindings(task_id);
 CREATE INDEX IF NOT EXISTS idx_source_bindings_item ON source_bindings(source_id, source_item_id);
+CREATE INDEX IF NOT EXISTS idx_task_pull_requests_task ON task_pull_requests(task_id);
 `
 
 // migrations are idempotent ALTER statements applied to databases created

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -430,6 +430,55 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	return source.CIStatus{Status: overall, URL: pr.HTMLURL, Checks: checks}, nil
 }
 
+// ListPullRequests returns every pull request cross-referenced from the issue,
+// oldest first. It makes a single API call (the issue timeline) and derives each
+// PR's html_url from owner/repo/number, so the cost is constant regardless of how
+// many PRs are linked — the dashboard only needs a URL to open in the browser.
+// Implements source.PullRequestLister.
+func (a *Adapter) ListPullRequests(ctx context.Context, cellID string) ([]source.PullRequestRef, error) {
+	timelinePath := fmt.Sprintf("/repos/%s/%s/issues/%s/timeline", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, timelinePath)
+	if err != nil {
+		return nil, fmt.Errorf("github: fetching timeline for issue %s: %w", cellID, err)
+	}
+
+	var timeline []struct {
+		Event  string `json:"event"`
+		Source struct {
+			Type  string `json:"type"`
+			Issue struct {
+				Number      int `json:"number"`
+				PullRequest struct {
+					URL string `json:"url"`
+				} `json:"pull_request"`
+			} `json:"issue"`
+		} `json:"source"`
+	}
+	if err := json.Unmarshal(body, &timeline); err != nil {
+		return nil, fmt.Errorf("github: decoding timeline for issue %s: %w", cellID, err)
+	}
+
+	// A PR can be cross-referenced more than once; dedup by number while keeping
+	// first-seen (chronological) order so the caller's tail is the most recent PR.
+	var prs []source.PullRequestRef
+	seen := make(map[int]bool)
+	for _, e := range timeline {
+		if e.Event != "cross-referenced" || e.Source.Type != "issue" || e.Source.Issue.PullRequest.URL == "" {
+			continue
+		}
+		n := e.Source.Issue.Number
+		if n == 0 || seen[n] {
+			continue
+		}
+		seen[n] = true
+		prs = append(prs, source.PullRequestRef{
+			Number: n,
+			URL:    fmt.Sprintf("https://github.com/%s/%s/pull/%d", a.owner, a.repo, n),
+		})
+	}
+	return prs, nil
+}
+
 // isAuthError reports whether a client error is a GitHub authorization failure
 // (401 Unauthorized or 403 Forbidden) — typically a missing token permission,
 // which is permanent until the token is fixed (not a transient blip to retry past).

--- a/src/internal/source/github/listprs_test.go
+++ b/src/internal/source/github/listprs_test.go
@@ -1,0 +1,76 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// timelineServer stands up a GitHub API stub that serves the given JSON for the
+// issue 1958 timeline and 404s everything else.
+func timelineServer(t *testing.T, timelineJSON string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/issues/1958/timeline") {
+			_, _ = w.Write([]byte(timelineJSON))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+}
+
+func TestListPullRequests_OrderedDedupedDerivedURL(t *testing.T) {
+	// Two distinct PRs cross-referenced, plus a non-PR cross-reference and a
+	// duplicate of the first PR. Expect [1961, 1970] in timeline order, deduped,
+	// with html_url derived from owner/repo/number.
+	a := timelineServer(t, `[
+		{"event":"cross-referenced","source":{"type":"issue","issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}},
+		{"event":"commented","source":{"type":"issue","issue":{"number":9999}}},
+		{"event":"cross-referenced","source":{"type":"issue","issue":{"number":5000}}},
+		{"event":"cross-referenced","source":{"type":"issue","issue":{"number":1970,"pull_request":{"url":"https://api/pulls/1970"}}}},
+		{"event":"cross-referenced","source":{"type":"issue","issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}}
+	]`)
+
+	prs, err := a.ListPullRequests(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("got %d PRs, want 2: %+v", len(prs), prs)
+	}
+	if prs[0].Number != 1961 || prs[1].Number != 1970 {
+		t.Errorf("order = [%d, %d], want [1961, 1970]", prs[0].Number, prs[1].Number)
+	}
+	if want := "https://github.com/o/r/pull/1961"; prs[0].URL != want {
+		t.Errorf("URL = %q, want %q", prs[0].URL, want)
+	}
+}
+
+func TestListPullRequests_EmptyTimeline(t *testing.T) {
+	a := timelineServer(t, `[]`)
+	prs, err := a.ListPullRequests(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("ListPullRequests: %v", err)
+	}
+	if prs != nil {
+		t.Errorf("got %+v, want nil for empty timeline", prs)
+	}
+}
+
+func TestListPullRequests_HTTPError(t *testing.T) {
+	// No timeline handler registered → 404 → error surfaced (not silently empty),
+	// so the daemon can preserve last-good persisted data.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+
+	if _, err := a.ListPullRequests(context.Background(), "1958"); err == nil {
+		t.Fatal("expected an error when the timeline request fails")
+	}
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -85,6 +85,23 @@ type CIStatusPoller interface {
 	PollCIStatus(ctx context.Context, cellID string) (CIStatus, error)
 }
 
+// PullRequestRef is one pull request linked to a source item (e.g. a PR that
+// cross-references a GitHub issue). State is best-effort and may be empty when
+// the source does not fetch it.
+type PullRequestRef struct {
+	Number int    // PR number
+	URL    string // browser deep-link (html_url)
+	State  string // "open", "closed", "merged", or "" when unknown
+}
+
+// PullRequestLister is an optional interface a source may implement to enumerate
+// every pull request linked to one of its items, oldest first. The dashboard
+// uses it to offer an "open the latest PR" shortcut. Sources that do not
+// implement it simply have no PRs to show.
+type PullRequestLister interface {
+	ListPullRequests(ctx context.Context, cellID string) ([]PullRequestRef, error)
+}
+
 // Factory creates a new, unconfigured Adapter instance.
 type Factory func() Adapter
 


### PR DESCRIPTION
## Summary
- Adds a **(p)** keyboard shortcut to the dashboard TUI, mirroring **(o)**: where (o) opens a task's GitHub issue, (p) opens its **most recent pull request**.
- A task can have more than one PR, so the per-task PR list is **persisted**; (p) opens the last (most recent) one. Works in the same views as (o) (Tasks list, Task Detail, Task Logs, Agents activity/logs).

## How it works
The dashboard reads tasks/detail directly from its local DB, but only the daemon holds the source adapters/credentials. So:
- **source**: new `PullRequestLister` interface + GitHub adapter `ListPullRequests` — enumerates all cross-referenced PRs from an issue timeline in one API call, deduped, with `html_url` derived from `owner/repo/number` (no per-PR fetch).
- **db**: new `task_pull_requests` table + `ReplaceTaskPullRequests`/`ListTaskPullRequests`. Replace is scoped per source so a transient/auth error never wipes last-good data.
- **daemon**: `POST /tasks/pulls/refresh/{ref}` resolves the task's bindings, lists PRs via the adapter, persists them, and returns the merged set.
- **dashboard**: `TaskItem.PullRequests` hydrated from the local DB in the list and detail; a refresh is fired on detail open; `focusedTaskPRURL` + the `(p)` handler mirror `focusedTaskURL`/`(o)`; footer shows `p open PR`.

## Edge cases
- No PR / no GitHub binding / Agents-history rows → (p) is a silent no-op, like (o) with no URL.
- Transient GitHub/auth error → persisted list untouched (replace only after a successful list).
- Multiple GitHub bindings on one task → merged per source before a single replace.

## Test plan
- `go build ./...` and `go test ./...` from `src/` — all pass; `go vet ./...` clean.
- New unit tests:
  - `internal/source/github/listprs_test.go` — ordering/dedup/derived URL, empty timeline, HTTP error surfaced.
  - `internal/db/pullrequest_store_test.go` — seq order, replace shrinks/drops stale, per-source isolation.
  - `internal/daemon/task_pulls_test.go` — persists+returns, lister error keeps last-good, non-lister source no-op, unknown task → ErrTaskNotFound.
  - extended `internal/dashboard/task_fetch_test.go` for PR mapping.
- Manual: open a task with a linked PR, press `p` → most recent PR opens in the browser; a task with no PR does nothing; footer shows `p open PR`.