### PR TITLE
fix(tasks): reopen a finished task when a later stage is dispatched

### DIFF
--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -158,12 +158,24 @@ func (s *InternalTaskStore) UpdateTaskMetadata(ctx context.Context, id, title, d
 
 // IncrementOutstanding adds delta to a task's outstanding workflow counter and
 // returns the new count. The dispatcher uses this at fan-out time (delta = N).
+//
+// A re-dispatch also reopens a finished task: when delta > 0 and the task sits in
+// a terminal state ('done'/'failed'), the same UPDATE flips it back to 'running'.
+// Multi-stage pipelines fan out across separate poll cycles (e.g. triage labels an
+// issue, then a later poll matches the implementation workflow), so the counter
+// drains to zero and completeTask marks the task terminal *between* stages. Without
+// this reopen the task would read 'done' in the list while the next stage's
+// instance is still running/waiting in the detail view. completeTask sets the real
+// terminal state again once the new stage settles. The literals mirror
+// model.TaskState ('done'/'failed'/'running').
 func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string, delta int) (int, error) {
 	if _, err := s.db.ExecContext(ctx, `
 		UPDATE internal_tasks
-		SET outstanding_workflows = outstanding_workflows + ?, updated_at = ?
+		SET outstanding_workflows = outstanding_workflows + ?,
+		    state = CASE WHEN ? > 0 AND state IN ('done','failed') THEN 'running' ELSE state END,
+		    updated_at = ?
 		WHERE id = ?
-	`, delta, time.Now(), id); err != nil {
+	`, delta, delta, time.Now(), id); err != nil {
 		return 0, err
 	}
 	return s.outstanding(ctx, id)

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -243,6 +243,46 @@ func TestInternalTask_OutstandingCounter(t *testing.T) {
 	}
 }
 
+// TestInternalTask_IncrementReopensTerminal locks in that a re-dispatch reopens a
+// finished task. Multi-stage pipelines fan out across separate poll cycles, so the
+// counter drains to zero and the task is marked terminal between stages; the next
+// stage's IncrementOutstanding must flip 'done'/'failed' back to 'running' so the
+// task list does not read terminal while a later instance is still in flight.
+func TestInternalTask_IncrementReopensTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+
+	for _, terminal := range []model.TaskState{model.TaskStateDone, model.TaskStateFailed} {
+		task := &model.InternalTask{Title: "t", State: terminal}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create (%s): %v", terminal, err)
+		}
+		if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+			t.Fatalf("increment (%s): %v", terminal, err)
+		}
+		got, _ := store.GetTask(ctx, task.ID)
+		if got.State != model.TaskStateRunning {
+			t.Errorf("reopen from %s: state = %q, want running", terminal, got.State)
+		}
+	}
+
+	// A non-terminal state is left untouched — increment must not clobber an
+	// active task's lifecycle (e.g. approval_waiting).
+	for _, keep := range []model.TaskState{model.TaskStateRegistered, model.TaskStateApprovalWait} {
+		task := &model.InternalTask{Title: "t", State: keep}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create (%s): %v", keep, err)
+		}
+		if _, err := store.IncrementOutstanding(ctx, task.ID, 2); err != nil {
+			t.Fatalf("increment (%s): %v", keep, err)
+		}
+		got, _ := store.GetTask(ctx, task.ID)
+		if got.State != keep {
+			t.Errorf("increment must preserve %q, got %q", keep, got.State)
+		}
+	}
+}
+
 func TestInternalTask_ListByState(t *testing.T) {
 	ctx := context.Background()
 	store := newTestClient(t).InternalTasks()


### PR DESCRIPTION
## Summary

A task can show **done** in the dashboard Tasks list while its detail view still shows a **running**/**waiting** workflow instance or step. Root cause traced from a live case (project-erp issue #2084):

- A task's lifecycle state is driven purely by the `outstanding_workflows` counter, which is incremented **per fan-out call** (`dispatcher.fanOut` → `IncrementOutstanding`), not per task lifetime.
- Multi-stage pipelines fan out across **separate poll cycles**: `triage` runs first; the `implementation` workflow only matches *after* triage labels the issue (in #2084 there was a 33s gap between triage finishing and implementation starting).
- So the counter drains to zero when `triage` completes → `completeTask` marks the task **done**. The later poll re-increments the counter for `implementation`, but nothing reset the state — leaving the task reading `done` for ~66 min while the implementation instance ran (and parked on a `wait_for`).

The detail view reads the live instance/step rows, so it correctly showed running/waiting — hence the mismatch.

## Fix

`IncrementOutstanding` now reopens a finished task atomically: when `delta > 0` and the task is in a terminal state (`done`/`failed`), the same `UPDATE` flips it back to `running`. `completeTask` still sets the real terminal state once the new stage settles. Non-terminal states (`registered`, `approval_waiting`) are left untouched.

This guarantees the invariant: **`outstanding_workflows > 0` ⇒ the task is not terminal.**

## Test plan

- New `TestInternalTask_IncrementReopensTerminal`: re-increment from `done`/`failed` → `running`; `registered`/`approval_waiting` preserved.
- `go build ./...` clean.
- `go test ./internal/db/... ./internal/daemon/... ./internal/workflow/...` all pass (covers fan-out and task-completion suites).

## Impact analysis

`gitnexus detect-changes`: 2 files, **0 affected processes, risk LOW**. Sole production caller of `IncrementOutstanding` is `dispatcher.fanOut`; no signature change.