### PR TITLE
fix(daemon): reconcile orphan step_runs at startup

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -302,6 +302,18 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		} else if n > 0 {
 			aplog.Info("reconciled %d orphaned running workflow instance(s) from a previous run", n)
 		}
+
+		// Mark step_runs left non-terminal under the instances just interrupted
+		// above. Without this, a step that was mid-flight when the daemon died
+		// stays 'running' in the DB forever and the dashboard Task Detail view
+		// renders a phantom in-progress step under an interrupted instance. Must
+		// run after ReconcileOrphanWorkflowInstances so the orphaned parents are
+		// already 'interrupted'.
+		if n, err := d.db.ReconcileOrphanStepRuns(ctx); err != nil {
+			aplog.Warn("reconcile orphan step runs: %v", err)
+		} else if n > 0 {
+			aplog.Info("reconciled %d orphaned step run(s) from a previous run", n)
+		}
 	}
 
 	// Reconstruct workflow instances parked at an approval step into the engine's

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -3499,6 +3499,8 @@ func wfStepGlyph(state string) string {
 		return StyleError.Render("✗")
 	case db.StepStateRunning:
 		return StyleWarning.Render("●")
+	case db.StepStateInterrupted:
+		return StyleError.Render("⊗")
 	case db.StepStateSkipped, db.StepStateSkippedCached:
 		return StyleMuted.Render("⊘")
 	default:
@@ -3510,7 +3512,7 @@ func wfStateStyle(state string) lipgloss.Style {
 	switch state {
 	case db.StepStatePassed:
 		return StyleSuccess
-	case db.StepStateFailed:
+	case db.StepStateFailed, db.StepStateInterrupted:
 		return StyleError
 	case db.StepStateRunning:
 		return StyleWarning
@@ -4809,7 +4811,7 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 			}
 		}
 
-		if s.State == db.StepStateRunning || s.State == db.StepStatePassed || s.State == db.StepStateFailed {
+		if s.State == db.StepStateRunning || s.State == db.StepStatePassed || s.State == db.StepStateFailed || s.State == db.StepStateInterrupted {
 			right.WriteString("\n  " + StyleMuted.Render("enter/l: logs  X: stop workflow  R: restart workflow") + "\n")
 		}
 	} else {

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -25,6 +25,10 @@ const (
 	StepStateFailed        = "failed"
 	StepStateSkipped       = "skipped"
 	StepStateSkippedCached = "skipped_cached"
+	// StepStateInterrupted marks a step left non-terminal (running/pending) by a
+	// previously-killed daemon. It is the step-level companion to
+	// InstanceStateInterrupted and is set by ReconcileOrphanStepRuns at startup.
+	StepStateInterrupted = "interrupted"
 )
 
 // Publish states for a step run's APIARY_PUBLISH write-back.
@@ -366,6 +370,31 @@ func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, e
 		SET state = ?, updated_at = ?
 		WHERE state = ?
 	`, InstanceStateInterrupted, time.Now(), InstanceStateRunning)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// ReconcileOrphanStepRuns marks step_runs left in a non-terminal state
+// (running or pending) as 'interrupted' when their parent workflow_instance is
+// itself interrupted. It is the step-level companion to
+// ReconcileOrphanWorkflowInstances: when a daemon dies mid-step the step_runs
+// row stays 'running' forever, and the dashboard renders a phantom in-progress
+// step under an instance that is actually interrupted. Restricting the update to
+// children of interrupted instances means a live step under a genuinely running
+// instance is never disturbed; it must therefore be called *after*
+// ReconcileOrphanWorkflowInstances has flipped the orphaned parents. finished_at
+// is stamped only when absent so an already-recorded end time is preserved.
+func (c *Client) ReconcileOrphanStepRuns(ctx context.Context) (int64, error) {
+	res, err := c.db.ExecContext(ctx, `
+		UPDATE step_runs
+		SET state = ?, finished_at = COALESCE(finished_at, ?)
+		WHERE state IN (?, ?)
+		  AND workflow_instance_id IN (
+		    SELECT id FROM workflow_instances WHERE state = ?
+		  )
+	`, StepStateInterrupted, time.Now(), StepStateRunning, StepStatePending, InstanceStateInterrupted)
 	if err != nil {
 		return 0, err
 	}

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -413,3 +413,74 @@ func TestReconcileOrphanWorkflowInstances_Extended(t *testing.T) {
 		}
 	}
 }
+
+func TestReconcileOrphanStepRuns(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// One interrupted instance (an orphan reconciled at startup) and one done
+	// instance (a genuinely finished run). Only step_runs under the interrupted
+	// instance should be touched.
+	instances := []*WorkflowInstance{
+		{ID: "wf_interrupted", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted},
+		{ID: "wf_done", WorkflowID: "w", CellID: "c", State: InstanceStateDone},
+	}
+	for _, inst := range instances {
+		if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+			t.Fatalf("create instance: %v", err)
+		}
+	}
+
+	// Step runs in a mix of states across both instances.
+	steps := []*StepRun{
+		// Under the interrupted parent: the two non-terminal ones are orphans.
+		{ID: "sr_run", WorkflowInstanceID: "wf_interrupted", StepID: "implement", State: StepStateRunning},
+		{ID: "sr_pend", WorkflowInstanceID: "wf_interrupted", StepID: "review", State: StepStatePending},
+		{ID: "sr_pass", WorkflowInstanceID: "wf_interrupted", StepID: "classify", State: StepStatePassed},
+		// Under the done parent: a leftover 'running' here must NOT be touched,
+		// since its parent was not reconciled to interrupted.
+		{ID: "sr_done_run", WorkflowInstanceID: "wf_done", StepID: "implement", State: StepStateRunning},
+	}
+	for _, sr := range steps {
+		if err := c.CreateStepRun(ctx, sr); err != nil {
+			t.Fatalf("create step run: %v", err)
+		}
+	}
+
+	n, err := c.ReconcileOrphanStepRuns(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	// Only the running + pending steps under the interrupted instance.
+	if n != 2 {
+		t.Fatalf("expected 2 reconciled, got %d", n)
+	}
+
+	want := map[string]string{
+		"sr_run":      StepStateInterrupted, // running under interrupted → interrupted
+		"sr_pend":     StepStateInterrupted, // pending under interrupted → interrupted
+		"sr_pass":     StepStatePassed,      // terminal, unchanged
+		"sr_done_run": StepStateRunning,     // running but parent is done, untouched
+	}
+	got := map[string]StepRun{}
+	for _, instID := range []string{"wf_interrupted", "wf_done"} {
+		runs, err := c.ListStepRuns(ctx, instID)
+		if err != nil {
+			t.Fatalf("list step runs: %v", err)
+		}
+		for _, r := range runs {
+			got[r.ID] = r
+		}
+	}
+	for id, wantState := range want {
+		if got[id].State != wantState {
+			t.Errorf("%s: expected state %q, got %q", id, wantState, got[id].State)
+		}
+	}
+
+	// A reconciled step should get a finished_at stamp so the dashboard can
+	// render a duration instead of an open-ended in-progress step.
+	if got["sr_run"].FinishedAt == nil {
+		t.Error("sr_run: expected finished_at to be stamped on reconcile")
+	}
+}


### PR DESCRIPTION
## Summary

- A daemon crash/restart left `step_runs` rows stuck in `state='running'` forever. `ReconcileOrphanWorkflowInstances` flips the parent `workflow_instances` `running` → `interrupted` at startup, but the step-level rows were never touched — so the dashboard Task Detail view rendered phantom "in progress" steps under instances that are actually interrupted.
- Add `ReconcileOrphanStepRuns` (db layer): marks `step_runs` left `running`/`pending` under an `interrupted` instance as a new terminal `StepStateInterrupted`, stamping `finished_at` (preserved if already set). Scoping to interrupted parents means a live step under a genuinely running instance is never disturbed.
- Wire it into `Dispatcher.Start` immediately after `ReconcileOrphanWorkflowInstances`, so the orphaned parents are already `interrupted` when the step reconcile runs.
- Render the new step state sensibly in the dashboard: error-styled glyph (`⊗`) in `wfStepGlyph`, error style in `wfStateStyle`, and the logs/stop/restart footer now shows for interrupted steps.
- Add a db-layer test mirroring `TestReconcileOrphanWorkflowInstances_Extended`.

## Test plan

- `go build ./...` — passes
- `go vet ./internal/db/ ./internal/daemon/ ./internal/dashboard/` — clean
- `go test ./internal/db/ ./internal/dashboard/ ./internal/daemon/` — all pass, including new `TestReconcileOrphanStepRuns` (verifies running+pending under an interrupted parent become `interrupted` with a `finished_at` stamp, while a `running` step under a `done` parent is untouched).