### PR TITLE
fix(workflow): re-check parked wait_for instances concurrently

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -72,6 +72,10 @@ type Dispatcher struct {
 	inFlight   sync.Map
 	activeRuns sync.Map
 	runCancel  sync.Map
+	// waitAdvancing guards a parked wait_for instance while its CI re-check (and any
+	// follow-on advance) is in flight, so overlapping poll cycles don't double-check
+	// or double-advance the same instance. Mirrors inFlight for polled cells.
+	waitAdvancing sync.Map
 
 	stats  map[string]*sourceStat
 	statMu sync.RWMutex

--- a/src/internal/daemon/parked_wait_concurrency_test.go
+++ b/src/internal/daemon/parked_wait_concurrency_test.go
@@ -1,0 +1,224 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// ciAdapter is a poll-only source whose per-item CI status the test drives. It
+// implements source.CIStatusPoller so wait_for steps can query it, and counts the
+// queries per item so the test can assert an instance was (or wasn't) re-checked.
+type ciAdapter struct {
+	mu     sync.Mutex
+	status map[string]string // source item id → "pending"|"passed"|"failed"
+	polls  map[string]int    // source item id → number of CI queries
+}
+
+func newCIAdapter() *ciAdapter {
+	return &ciAdapter{status: map[string]string{}, polls: map[string]int{}}
+}
+
+func (a *ciAdapter) ID() string                                                  { return "src" }
+func (a *ciAdapter) Connect(context.Context, map[string]any) error               { return nil }
+func (a *ciAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) { return nil, nil }
+func (a *ciAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *ciAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *ciAdapter) WebhookHandler() http.Handler { return nil }
+
+func (a *ciAdapter) PollCIStatus(_ context.Context, cellID string) (source.CIStatus, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.polls[cellID]++
+	return source.CIStatus{Status: a.status[cellID]}, nil
+}
+
+func (a *ciAdapter) set(cellID, status string) {
+	a.mu.Lock()
+	a.status[cellID] = status
+	a.mu.Unlock()
+}
+
+func (a *ciAdapter) pollCount(cellID string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.polls[cellID]
+}
+
+// gateRunner blocks the run of one specific (cell, step) until released, signalling
+// when it enters; every other run succeeds immediately. It stands in for an agent
+// whose follow-on step (e.g. an engineer fix) takes a long time.
+type gateRunner struct {
+	blockCell string
+	blockStep string
+	entered   chan struct{}
+	release   chan struct{}
+	once      sync.Once
+}
+
+func (r *gateRunner) ID() string                     { return "gate" }
+func (r *gateRunner) Configure(map[string]any) error { return nil }
+func (r *gateRunner) Run(ctx context.Context, rr model.RunRequest) (model.RunResult, error) {
+	if rr.Cell.ID == r.blockCell && rr.StepID == r.blockStep {
+		r.once.Do(func() { close(r.entered) })
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return model.RunResult{Success: false}, ctx.Err()
+		}
+	}
+	return model.RunResult{Success: true}, nil
+}
+
+func ciWorkflow() config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: "ci-wf",
+		Steps: []config.StepConfig{
+			{ID: "implement", Agent: "eng"},
+			{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+				WaitFor: &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"}},
+			{ID: "review", Agent: "eng", DependsOn: []string{"check-ci"}},
+		},
+	}
+}
+
+func waitUntil(t *testing.T, within time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// TestCheckWaits_SlowAdvanceDoesNotStarveRecheck is the regression for the parked
+// wait_for head-of-line blocking: a long-running follow-on agent step on one woken
+// instance must NOT delay the cheap CI re-check of other parked instances, and the
+// re-check must not be gated behind the (now saturated) per-agent semaphore.
+//
+// Two instances park on CI. Instance A's CI turns green and it advances into a
+// "review" agent step that blocks indefinitely (holding the only "eng" slot).
+// Instance B's CI stays pending. The test asserts checkWaits returns promptly and
+// that B keeps getting re-checked while A's advance is wedged.
+func TestCheckWaits_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "waits.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version:   "1",
+		Sources:   []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:    []config.AgentConfig{{ID: "eng", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{ciWorkflow()},
+	}
+
+	adapter := newCIAdapter()
+	// A's slow advance blocks in review; B never reaches review.
+	runner := &gateRunner{blockCell: "A", blockStep: "review",
+		entered: make(chan struct{}), release: make(chan struct{})}
+
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-eng": runner},
+		agentRunner: map[string]string{"eng": "claude"},
+		// Capacity 1: a wedged advance saturates the agent, so a re-check that is
+		// (incorrectly) gated behind it would starve.
+		agentSem: map[string]chan struct{}{"eng": make(chan struct{}, 1)},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	// Bind two source items so each instance's cell id matches its CI key.
+	taskA, err := d.binder.Bind(ctx, model.SourceItem{ID: "A", SourceID: "src", Title: "A"})
+	if err != nil {
+		t.Fatalf("bind A: %v", err)
+	}
+	taskB, err := d.binder.Bind(ctx, model.SourceItem{ID: "B", SourceID: "src", Title: "B"})
+	if err != nil {
+		t.Fatalf("bind B: %v", err)
+	}
+
+	// Both CIs pending: each workflow runs implement then parks at check-ci.
+	adapter.set("A", "pending")
+	adapter.set("B", "pending")
+	eng := d.workflowEngine()
+	instA, _, _ := eng.RunInstance(ctx, ciWorkflow(), taskA)
+	instB, _, _ := eng.RunInstance(ctx, ciWorkflow(), taskB)
+
+	for _, id := range []string{instA, instB} {
+		inst, _ := dbc.GetWorkflowInstance(ctx, id)
+		if inst == nil || inst.State != db.InstanceStateWaiting {
+			t.Fatalf("instance %s not parked at wait_for (state=%v)", id, inst)
+		}
+	}
+
+	// A's CI turns green; B stays pending.
+	adapter.set("A", "passed")
+
+	// checkWaits must NOT block the poll loop on A's wedged advance.
+	done := make(chan struct{})
+	go func() { d.checkWaits(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkWaits blocked on a slow advance — poll loop would stall (head-of-line blocking)")
+	}
+
+	// A advances and wedges in review, holding the only eng slot.
+	select {
+	case <-runner.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("instance A never advanced into its blocking review step")
+	}
+
+	// Drive successive poll cycles while A stays wedged. B must keep getting
+	// re-checked (its CI polled) on each cycle even though the eng semaphore is fully
+	// held by A's advance — the cheap re-check is ungated. Before the fix these
+	// re-checks sat behind A on the single poll goroutine and never ran. A itself,
+	// being mid-advance, must NOT be re-checked (the waitAdvancing guard skips it).
+	aWedged := adapter.pollCount("A")
+	bStart := adapter.pollCount("B")
+	cycles := 0
+	waitUntil(t, 3*time.Second, func() bool {
+		d.checkWaits(ctx) // simulate one poll cycle
+		cycles++
+		return adapter.pollCount("B") >= bStart+3
+	}, "instance B was not repeatedly re-checked while a slow advance held the agent slot")
+
+	if got := adapter.pollCount("A"); got != aWedged {
+		t.Errorf("wedged instance A was re-checked (polls %d→%d) over %d cycles; it should be skipped via waitAdvancing",
+			aWedged, got, cycles)
+	}
+	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateWaiting {
+		t.Errorf("instance B should still be parked (pending CI), got %v", inst)
+	}
+
+	// Release A; it now completes and its review runs.
+	close(runner.release)
+	waitUntil(t, 3*time.Second, func() bool {
+		inst, _ := dbc.GetWorkflowInstance(ctx, instA)
+		return inst != nil && inst.State == db.InstanceStateDone
+	}, "instance A did not complete after its review was released")
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -236,14 +236,56 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 	})
 }
 
-// checkWaits drives the engine's parked-poll re-checks (CI status) once per poll
-// cycle. The engine re-checks via its wired CIStatusChecker, so this needs no
-// per-call poller argument. A nil DB/engine (no run-history) disables it.
+// checkWaits drives the engine's parked-wait re-checks (CI status) once per poll
+// cycle. Each parked instance is handled on its own goroutine so a long-running
+// follow-on agent step on one woken instance cannot delay the cheap CI re-check of
+// any other parked instance — the head-of-line blocking that, on the single poll
+// loop, once left a parked CI wait un-rechecked for 43 minutes while another
+// instance ran a 35-minute agent.
+//
+// Two phases per instance, mirroring fresh dispatch's split:
+//   - RecheckWait: a cheap CI status query, run UNGATED, so a busy agent never
+//     blocks it. A still-pending wait stops here and stays parked.
+//   - WakeWait: the expensive graph advance (may run a follow-on agent), run only
+//     when CI is terminal and admitted through the agent's semaphore so it respects
+//     max_workers — exactly like fanOut.
+//
+// The waitAdvancing guard keeps a slow advance started on one cycle from being
+// re-checked or re-advanced by the next. A nil DB/engine (no run-history) disables
+// it. This does not block the poll loop: it launches the goroutines and returns.
 func (d *Dispatcher) checkWaits(ctx context.Context) {
 	if d.db == nil || d.engine == nil {
 		return
 	}
-	d.engine.CheckParkedWaits(ctx)
+	for _, w := range d.engine.ParkedWaits() {
+		w := w
+		// Skip an instance already being re-checked/advanced by an earlier cycle.
+		if _, busy := d.waitAdvancing.LoadOrStore(w.InstanceID, struct{}{}); busy {
+			continue
+		}
+		agentCh := d.agentSem[w.AgentID]
+		go func() {
+			defer d.waitAdvancing.Delete(w.InstanceID)
+
+			// Cheap CI re-check, ungated. Still pending → leave it parked.
+			if !d.engine.RecheckWait(ctx, w.InstanceID) {
+				return
+			}
+
+			// Terminal: admit the advance through the agent's semaphore (held for
+			// the whole advance, just like fanOut) so a follow-on agent step honours
+			// max_workers. A run waiting for a slot is not yet counted active.
+			if agentCh != nil {
+				select {
+				case agentCh <- struct{}{}:
+				case <-ctx.Done():
+					return // shutting down before a slot freed; never acquired
+				}
+				defer func() { <-agentCh }()
+			}
+			d.engine.WakeWait(ctx, w.InstanceID)
+		}()
+	}
 }
 
 // wfStepExecutor adapts the dispatcher's runner machinery to the workflow

--- a/src/internal/workflow/wait_park.go
+++ b/src/internal/workflow/wait_park.go
@@ -18,12 +18,16 @@ type ParkedWait struct {
 	Task       model.InternalTask
 	Step       config.StepConfig
 	Deadline   time.Time // absolute give-up time (zero = none)
+	// AgentID is the workflow's representative agent — the slot a woken advance is
+	// admitted through so a follow-on agent step respects that agent's max_workers
+	// (see Dispatcher.checkWaits). Empty/unmatched ids gate as ungated.
+	AgentID string
 }
 
-// parkedWaits returns a snapshot of all instances currently suspended at a poll
+// ParkedWaits returns a snapshot of all instances currently suspended at a wait_for
 // step. The parked set is shared with approval-waiting instances, so it filters to
-// runs whose waiting step is a poll.
-func (e *Engine) parkedWaits() []ParkedWait {
+// runs whose waiting step is a wait_for.
+func (e *Engine) ParkedWaits() []ParkedWait {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	out := make([]ParkedWait, 0, len(e.parked))
@@ -36,31 +40,98 @@ func (e *Engine) parkedWaits() []ParkedWait {
 			Task:       r.task,
 			Step:       r.byID[r.waitingStep],
 			Deadline:   r.waitDeadline,
+			AgentID:    representativeAgent(r.wf),
 		})
 	}
 	return out
 }
 
-// CheckParkedWaits re-checks every instance suspended at a wait_for step by waking it:
-// the woken run re-executes the wait_for step (a single CI query via the engine's
-// CIStatusChecker) and either advances past it (CI passed), fails it (CI failed or
-// the deadline elapsed, which drives on_reject/on_fail loop-back), or re-parks it
-// (CI still pending). Called once per dispatcher poll cycle, mirroring
-// CheckParkedApprovals. The poll cadence is therefore the dispatcher's poll
-// interval; a step's check_interval acts as a lower bound only.
+// representativeAgent returns the agent id used to gate a parked wait's advance
+// through the dispatcher's per-agent concurrency semaphore — the workflow's first
+// agent step, mirroring how a fresh dispatch picks its route's agent
+// (router.firstAgentStep). It falls back to the workflow id (which is not a
+// configured agent, so the gate treats it as ungated) when the workflow declares no
+// agent step.
+func representativeAgent(wf config.WorkflowConfig) string {
+	for _, s := range wf.Steps {
+		switch s.StepType() {
+		case config.StepTypeAgent:
+			if s.Agent != "" {
+				return s.Agent
+			}
+		case config.StepTypeForeach:
+			if s.Step != nil && s.Step.Agent != "" {
+				return s.Step.Agent
+			}
+		}
+	}
+	return wf.ID
+}
+
+// CheckParkedWaits re-checks every instance suspended at a wait_for step by waking
+// it: the woken run re-executes the wait_for step (a single CI query via the
+// engine's CIStatusChecker) and either advances past it (CI passed), fails it (CI
+// failed or the deadline elapsed, which drives on_reject/on_fail loop-back), or
+// re-parks it (CI still pending).
+//
+// This is the simple sequential reference path. In production the dispatcher does
+// NOT call it; instead Dispatcher.checkWaits drives the same primitives
+// concurrently (RecheckWait + WakeWait) so a long-running follow-on agent on one
+// woken instance cannot block the cheap CI re-checks of every other parked
+// instance, and so each advance is admitted through the per-agent semaphore.
 func (e *Engine) CheckParkedWaits(ctx context.Context) {
-	for _, p := range e.parkedWaits() {
-		e.wakeWait(ctx, p.InstanceID)
+	for _, p := range e.ParkedWaits() {
+		e.WakeWait(ctx, p.InstanceID)
 	}
 }
 
-// wakeWait resumes a wait-parked instance: it resets the waiting wait_for step to
+// RecheckWait performs ONE cheap CI status check for a wait_for instance WITHOUT
+// advancing its workflow graph, returning whether the wait is now terminal — i.e.
+// CI reached pass/fail (or the deadline elapsed) and the instance has real work to
+// do, so the caller should drive it via WakeWait.
+//
+// It deliberately runs no agent step: a still-pending check leaves the instance
+// parked and returns false. That makes it safe to run every poll cycle for every
+// parked instance, concurrently and WITHOUT holding any agent-concurrency slot — so
+// a busy agent can never delay another instance's CI re-check. The expensive graph
+// advance (which may run a follow-on agent) is left to WakeWait, which the
+// dispatcher gates through the per-agent semaphore. It is a no-op returning false
+// when the instance is no longer parked at a wait_for step.
+//
+// The CI status the re-check observes is re-queried by the subsequent WakeWait
+// (driveDAG re-arms and re-runs the wait_for step), so a terminal transition costs
+// one extra, idempotent CI poll — recorded for audit like any other.
+func (e *Engine) RecheckWait(ctx context.Context, instanceID string) (terminal bool) {
+	e.mu.Lock()
+	r, ok := e.parked[instanceID]
+	if !ok {
+		e.mu.Unlock()
+		return false
+	}
+	step := r.byID[r.waitingStep]
+	sourceID, itemID := r.cell.SourceID, r.cell.ID
+	deadline := r.waitDeadline
+	e.mu.Unlock()
+
+	if step.StepType() != config.StepTypeWaitFor {
+		return false
+	}
+	res, _ := e.RunWaitStep(ctx, instanceID, step, sourceID, itemID, deadline)
+	return !res.Pending
+}
+
+// WakeWait resumes a wait-parked instance: it resets the waiting wait_for step to
 // pending so driveDAG re-dispatches it (a single CI check), then drives the graph
 // to its next terminal or suspended state and settles it. A pending check re-parks
 // the instance (via enterWait, preserving its deadline); a pass/fail advances or
 // loops the workflow through the normal result-processing path. It is a no-op if
-// the instance is no longer parked.
-func (e *Engine) wakeWait(ctx context.Context, instanceID string) {
+// the instance is no longer parked — the claim (delete from e.parked) is atomic, so
+// two concurrent wakes of the same instance are safe: the loser returns early.
+//
+// The dispatcher runs this on its own goroutine, admitted through the per-agent
+// semaphore, so a slow follow-on agent step here neither blocks the poll loop nor
+// exceeds the agent's max_workers.
+func (e *Engine) WakeWait(ctx context.Context, instanceID string) {
 	e.mu.Lock()
 	r, ok := e.parked[instanceID]
 	if ok {

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -58,7 +58,7 @@ func TestWaitFor_SuspendsWhilePending(t *testing.T) {
 		t.Errorf("unexpected execution while CI pending: %v", ids)
 	}
 	// It shows up as a parked poll, not a parked approval.
-	if pp := eng.parkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+	if pp := eng.ParkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
 		t.Fatalf("expected one parked poll for check-ci, got %+v", pp)
 	}
 	if len(eng.ParkedApprovals()) != 0 {
@@ -91,7 +91,7 @@ func TestWaitFor_AdvancesWhenCIPasses(t *testing.T) {
 	if !contains(executedIDs(exec.seen), "review") {
 		t.Error("review should run once CI passed")
 	}
-	if len(eng.parkedWaits()) != 0 {
+	if len(eng.ParkedWaits()) != 0 {
 		t.Error("instance should no longer be parked")
 	}
 }
@@ -191,7 +191,7 @@ func TestWaitFor_RehydrateSurvivesRestart(t *testing.T) {
 		model.InternalTask{ID: "c1"}, priorStepsFor(store, instID)); err != nil {
 		t.Fatalf("rehydrate: %v", err)
 	}
-	if pp := eng2.parkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
+	if pp := eng2.ParkedWaits(); len(pp) != 1 || pp[0].Step.ID != "check-ci" {
 		t.Fatalf("expected rehydrated poll park at check-ci, got %+v", pp)
 	}
 


### PR DESCRIPTION
## Problem

A workflow parked on a `wait_for` step (CI wait) could go **~43 minutes** without a CI re-check while the daemon was alive and busy. The cause is **head-of-line blocking**, not downtime or poll interval.

- `Engine.CheckParkedWaits` (`wait_park.go`) was a sequential for-loop calling `wakeWait` for each parked instance.
- `wakeWait` → `driveDAG`, when CI resolves and the workflow loops back into an agent step (engineer fix / merge), runs that agent subprocess **inline and synchronously** on the calling goroutine.
- `CheckParkedWaits` is invoked once per poll cycle from `Dispatcher.checkWaits` on the single per-source `pollLoop` goroutine.

Net effect: one woken instance that loops into a 35-minute engineer run holds the poll loop captive; every other parked `wait_for` instance is never re-checked for that whole duration. (Fresh source-item dispatch was already made concurrent in #101; only this parked-wait path was left serial.)

## Fix

Split the cheap CI **status query** from the expensive DAG **advance**, and run both off the poll loop:

- **Engine** gains `RecheckWait` — one CI query, no DAG advance, returns whether CI is terminal — and exports `WakeWait` / `ParkedWaits`. `ParkedWait` now carries the workflow's representative `AgentID`.
- **`Dispatcher.checkWaits`** fans out one goroutine per parked instance:
  - `RecheckWait` runs **ungated**, so a busy agent can never delay another instance's CI re-check (this is what fully closes the starvation, even at `max_workers: 1`);
  - only when CI is terminal, `WakeWait` runs the advance **admitted through the same per-agent semaphore** fresh dispatch uses (`d.agentSem`), so follow-on agent steps still honour `max_workers`.
  - A `waitAdvancing` guard (mirrors `inFlight`) stops overlapping poll cycles from double-checking or double-advancing an instance.
- `Engine.CheckParkedWaits` is kept as the sequential reference path the engine tests exercise; production now drives the concurrent split.

A terminal transition costs one extra, idempotent CI poll (the advance re-queries via `driveDAG`); it's recorded for audit like any other.

## Tests

- New dispatcher-level regression `TestCheckWaits_SlowAdvanceDoesNotStarveRecheck`: two instances parked on CI, one whose advance wedges in a blocking agent step (holding the only agent slot). Asserts `checkWaits` does **not** block the poll loop and the other instance keeps getting re-checked while the slot is fully held. Verified it **fails** against the old sequential `checkWaits`.
- Full suite green locally under `-race` (`go test -race ./...`); no Go CI in this repo.

## Impact / safety

- `gitnexus impact` on `CheckParkedWaits`, `wakeWait`, `driveDAG`: **LOW** risk, 0 upstream dependents.
- Per-agent `max_workers` caps still honoured (single source of truth: the existing per-agent semaphores — no parallel limiter introduced).
- Shutdown: a wake waiting on a slot unwinds via `ctx.Done()`; an interrupted in-flight advance is recovered by the existing startup orphan reconcile, same as fresh dispatch.

## Follow-up

`Engine.CheckParkedApprovals` has the **same serial structure and the same latent blocking** (a slow resumed approval blocks re-checks of other parked approvals). Left unchanged here to keep this PR focused; tracked separately for the same concurrent-split treatment.