### PR TITLE
fix(workflow): re-check parked approvals concurrently

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -76,6 +76,10 @@ type Dispatcher struct {
 	// follow-on advance) is in flight, so overlapping poll cycles don't double-check
 	// or double-advance the same instance. Mirrors inFlight for polled cells.
 	waitAdvancing sync.Map
+	// approvalAdvancing is the approval-path twin of waitAdvancing: it guards a parked
+	// approval instance while its cheap re-evaluation (and any follow-on resume/abort
+	// advance) is in flight, so overlapping poll cycles don't double-advance it.
+	approvalAdvancing sync.Map
 
 	stats  map[string]*sourceStat
 	statMu sync.RWMutex

--- a/src/internal/daemon/parked_approval_concurrency_test.go
+++ b/src/internal/daemon/parked_approval_concurrency_test.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// approvalAdapter is a poll-only source whose per-task comments the test drives. It
+// implements source.TaskPoller so approval steps can re-evaluate it, and counts the
+// PollTask calls per item so the test can assert an instance was (or wasn't)
+// re-evaluated.
+type approvalAdapter struct {
+	mu       sync.Mutex
+	comments map[string][]string // source item id → comment bodies
+	polls    map[string]int      // source item id → number of PollTask calls
+}
+
+func newApprovalAdapter() *approvalAdapter {
+	return &approvalAdapter{comments: map[string][]string{}, polls: map[string]int{}}
+}
+
+func (a *approvalAdapter) ID() string                                                  { return "src" }
+func (a *approvalAdapter) Connect(context.Context, map[string]any) error               { return nil }
+func (a *approvalAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) { return nil, nil }
+func (a *approvalAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *approvalAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *approvalAdapter) WebhookHandler() http.Handler { return nil }
+
+func (a *approvalAdapter) PollTask(_ context.Context, cellID string) (model.SourceItem, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.polls[cellID]++
+	item := model.SourceItem{ID: cellID, SourceID: "src"}
+	for _, body := range a.comments[cellID] {
+		item.Comments = append(item.Comments, model.Comment{Body: body})
+	}
+	return item, nil
+}
+
+func (a *approvalAdapter) addComment(cellID, body string) {
+	a.mu.Lock()
+	a.comments[cellID] = append(a.comments[cellID], body)
+	a.mu.Unlock()
+}
+
+func (a *approvalAdapter) pollCount(cellID string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.polls[cellID]
+}
+
+func approvalWorkflow() config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: "appr-wf",
+		Steps: []config.StepConfig{
+			{ID: "plan", Agent: "eng"},
+			{ID: "gate", Type: config.StepTypeApproval, DependsOn: []string{"plan"},
+				ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"}},
+			{ID: "build", Agent: "eng", DependsOn: []string{"gate"}},
+		},
+	}
+}
+
+// TestCheckApprovals_SlowAdvanceDoesNotStarveRecheck is the regression for the
+// parked-approval head-of-line blocking: a long-running follow-on agent step on one
+// resumed instance must NOT delay the cheap re-evaluation of other parked approvals,
+// and the re-evaluation must not be gated behind the (now saturated) per-agent
+// semaphore.
+//
+// Two instances park at an approval gate. Instance A is approved and advances into a
+// "build" agent step that blocks indefinitely (holding the only "eng" slot).
+// Instance B stays un-approved. The test asserts checkApprovals returns promptly and
+// that B keeps getting re-evaluated (its task re-polled) while A's advance is wedged.
+//
+// Against the old sequential checkApprovals (CheckParkedApprovals calling
+// ResolveApproval inline on the poll goroutine), A's wedged advance blocks
+// checkApprovals itself, so it never returns and B is never re-evaluated — both
+// assertions below fail.
+func TestCheckApprovals_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "approvals.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version:   "1",
+		Sources:   []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:    []config.AgentConfig{{ID: "eng", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{approvalWorkflow()},
+	}
+
+	adapter := newApprovalAdapter()
+	// A's resumed advance blocks in build; B never reaches build.
+	runner := &gateRunner{blockCell: "A", blockStep: "build",
+		entered: make(chan struct{}), release: make(chan struct{})}
+
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-eng": runner},
+		agentRunner: map[string]string{"eng": "claude"},
+		// Capacity 1: a wedged advance saturates the agent, so a re-evaluation that is
+		// (incorrectly) gated behind it would starve.
+		agentSem: map[string]chan struct{}{"eng": make(chan struct{}, 1)},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	// Bind two source items so each instance's cell id matches its poll key.
+	taskA, err := d.binder.Bind(ctx, model.SourceItem{ID: "A", SourceID: "src", Title: "A"})
+	if err != nil {
+		t.Fatalf("bind A: %v", err)
+	}
+	taskB, err := d.binder.Bind(ctx, model.SourceItem{ID: "B", SourceID: "src", Title: "B"})
+	if err != nil {
+		t.Fatalf("bind B: %v", err)
+	}
+
+	// Each workflow runs plan then parks at the approval gate.
+	eng := d.workflowEngine()
+	instA, _, _ := eng.RunInstance(ctx, approvalWorkflow(), taskA)
+	instB, _, _ := eng.RunInstance(ctx, approvalWorkflow(), taskB)
+
+	for _, id := range []string{instA, instB} {
+		inst, _ := dbc.GetWorkflowInstance(ctx, id)
+		if inst == nil || inst.State != db.InstanceStateApprovalWaiting {
+			t.Fatalf("instance %s not parked at approval (state=%v)", id, inst)
+		}
+	}
+
+	// A is approved; B stays un-approved.
+	adapter.addComment("A", "please approve this")
+
+	// checkApprovals must NOT block the poll loop on A's wedged advance.
+	done := make(chan struct{})
+	go func() { d.checkApprovals(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkApprovals blocked on a slow advance — poll loop would stall (head-of-line blocking)")
+	}
+
+	// A resumes and wedges in build, holding the only eng slot.
+	select {
+	case <-runner.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("instance A never advanced into its blocking build step")
+	}
+
+	// Drive successive poll cycles while A stays wedged. B must keep getting
+	// re-evaluated (its task re-polled) on each cycle even though the eng semaphore is
+	// fully held by A's advance — the cheap re-evaluation is ungated. Before the fix
+	// these re-checks sat behind A on the single poll goroutine and never ran. A
+	// itself, being mid-advance, must NOT be re-checked (the approvalAdvancing guard
+	// skips it).
+	aWedged := adapter.pollCount("A")
+	bStart := adapter.pollCount("B")
+	cycles := 0
+	waitUntil(t, 3*time.Second, func() bool {
+		d.checkApprovals(ctx) // simulate one poll cycle
+		cycles++
+		return adapter.pollCount("B") >= bStart+3
+	}, "instance B was not repeatedly re-evaluated while a slow advance held the agent slot")
+
+	if got := adapter.pollCount("A"); got != aWedged {
+		t.Errorf("wedged instance A was re-evaluated (polls %d→%d) over %d cycles; it should be skipped via approvalAdvancing",
+			aWedged, got, cycles)
+	}
+	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateApprovalWaiting {
+		t.Errorf("instance B should still be parked (un-approved), got %v", inst)
+	}
+
+	// Release A; it now completes and its build runs.
+	close(runner.release)
+	waitUntil(t, 3*time.Second, func() bool {
+		inst, _ := dbc.GetWorkflowInstance(ctx, instA)
+		return inst != nil && inst.State == db.InstanceStateDone
+	}, "instance A did not complete after its build was released")
+}

--- a/src/internal/daemon/rehydrate_approval_test.go
+++ b/src/internal/daemon/rehydrate_approval_test.go
@@ -132,8 +132,17 @@ func TestRehydrateParkedApprovals_ResumesAndSettlesTask(t *testing.T) {
 		t.Fatalf("expected one rehydrated parked approval at gate, got %+v", parked)
 	}
 
-	// --- the poll loop's approval check now sees the approving comment. ---
+	// --- the poll loop's approval check now sees the approving comment. The check
+	// fans each parked approval out onto its own goroutine (so a slow resume never
+	// blocks the poll loop), so the resume + settle happen asynchronously. settle
+	// marks the instance done first and then transitions the task, so await the task
+	// state — the last signal — which implies the whole resume completed.
 	d.checkApprovals(ctx)
+
+	waitUntil(t, 3*time.Second, func() bool {
+		got, _ := dbc.InternalTasks().GetTask(ctx, task.ID)
+		return got != nil && got.State == model.TaskStateDone
+	}, "rehydrated approval was not resumed and settled (task left stuck in 'registered')")
 
 	inst, err := dbc.GetWorkflowInstance(ctx, instID)
 	if err != nil {
@@ -144,12 +153,5 @@ func TestRehydrateParkedApprovals_ResumesAndSettlesTask(t *testing.T) {
 	}
 	if got := impl.n.Load(); got != 1 {
 		t.Errorf("implement runner calls = %d, want 1", got)
-	}
-	got, err := dbc.InternalTasks().GetTask(ctx, task.ID)
-	if err != nil {
-		t.Fatalf("get task: %v", err)
-	}
-	if got == nil || got.State != model.TaskStateDone {
-		t.Errorf("task state = %v, want done (the gap left it stuck in 'registered')", got)
 	}
 }

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -216,14 +216,30 @@ func (d *Dispatcher) resolveWorkflow(match router.Match) config.WorkflowConfig {
 	return config.WorkflowConfig{}
 }
 
-// checkApprovals drives the engine's parked-approval evaluation using each
-// source's TaskPoller. Called once per poll cycle. Sources that do not implement
-// TaskPoller cannot resolve approvals (the instance stays parked).
+// checkApprovals drives the engine's parked-approval re-checks once per poll cycle.
+// Each parked instance is handled on its own goroutine so a long-running follow-on
+// agent step on one resumed instance cannot delay the cheap re-evaluation of any
+// other parked approval — the head-of-line blocking that, on the single poll loop,
+// mirrors the parked wait_for starvation fixed in checkWaits.
+//
+// Two phases per instance, mirroring checkWaits / fresh dispatch's split:
+//   - RecheckApproval: a cheap timeout + per-binding TaskPoller evaluation, run
+//     UNGATED, so a busy agent never blocks it. A still-waiting approval stops here
+//     and stays parked.
+//   - ResolveApproval: the expensive graph advance (may run a follow-on agent), run
+//     only when the decision is resume/abort and admitted through the agent's
+//     semaphore so it respects max_workers — exactly like fanOut and WakeWait.
+//
+// The approvalAdvancing guard keeps a slow advance started on one cycle from being
+// re-checked or re-advanced by the next. Sources that do not implement TaskPoller
+// cannot resolve approvals (poll errors, the instance stays parked). A nil DB/engine
+// (no run-history) disables it. This does not block the poll loop: it launches the
+// goroutines and returns.
 func (d *Dispatcher) checkApprovals(ctx context.Context) {
 	if d.db == nil || d.engine == nil {
 		return
 	}
-	d.engine.CheckParkedApprovals(ctx, func(sourceID, cellID string) (model.SourceItem, error) {
+	poll := func(sourceID, cellID string) (model.SourceItem, error) {
 		adapter, ok := d.sources[sourceID]
 		if !ok {
 			return model.SourceItem{}, fmt.Errorf("source %q not found", sourceID)
@@ -233,7 +249,38 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 			return model.SourceItem{}, fmt.Errorf("source %q does not support per-task polling (approvals)", sourceID)
 		}
 		return poller.PollTask(ctx, cellID)
-	})
+	}
+
+	for _, p := range d.engine.ParkedApprovals() {
+		p := p
+		// Skip an instance already being re-checked/advanced by an earlier cycle.
+		if _, busy := d.approvalAdvancing.LoadOrStore(p.InstanceID, struct{}{}); busy {
+			continue
+		}
+		agentCh := d.agentSem[p.AgentID]
+		go func() {
+			defer d.approvalAdvancing.Delete(p.InstanceID)
+
+			// Cheap re-evaluation, ungated. Still waiting → leave it parked.
+			decision := d.engine.RecheckApproval(ctx, p.InstanceID, poll)
+			if decision == workflow.ApprovalWait {
+				return
+			}
+
+			// Resume/abort: admit the advance through the agent's semaphore (held for
+			// the whole advance, just like fanOut) so a follow-on agent step honours
+			// max_workers. A run waiting for a slot is not yet counted active.
+			if agentCh != nil {
+				select {
+				case agentCh <- struct{}{}:
+				case <-ctx.Done():
+					return // shutting down before a slot freed; never acquired
+				}
+				defer func() { <-agentCh }()
+			}
+			_, _ = d.engine.ResolveApproval(ctx, p.InstanceID, decision)
+		}()
+	}
 }
 
 // checkWaits drives the engine's parked-wait re-checks (CI status) once per poll

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -83,6 +83,10 @@ type ParkedApproval struct {
 	Bindings   []model.SourceBinding
 	Step       config.StepConfig // the waiting approval step (resume_on/abort_on/timeout)
 	ParkedAt   time.Time
+	// AgentID is the workflow's representative agent — the slot a resumed advance is
+	// admitted through so a follow-on agent step respects that agent's max_workers
+	// (see Dispatcher.checkApprovals). Empty/unmatched ids gate as ungated.
+	AgentID string
 }
 
 // ParkedApprovals returns a snapshot of all instances currently awaiting approval.
@@ -103,6 +107,7 @@ func (e *Engine) ParkedApprovals() []ParkedApproval {
 			Bindings:   r.bindings,
 			Step:       r.byID[r.waitingStep],
 			ParkedAt:   r.parkedAt,
+			AgentID:    representativeAgent(r.wf),
 		})
 	}
 	return out
@@ -128,6 +133,55 @@ func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decisio
 	return e.settle(ctx, r, outcome), nil
 }
 
+// RecheckApproval performs ONE cheap evaluation of a parked approval instance
+// WITHOUT advancing its workflow graph, returning the decision (wait/resume/abort)
+// so the caller can decide whether to drive the expensive ResolveApproval advance.
+//
+// It mirrors RecheckWait: the timeout is checked first (an elapsed timeout aborts),
+// then the live source item is polled per binding (poll is keyed by source id +
+// source item id) and evaluated via EvaluateApproval — the first binding whose item
+// satisfies a resume/abort condition decides, a poll error skips that binding. It
+// runs no agent step, so it is safe to run every poll cycle for every parked
+// instance, concurrently and WITHOUT holding any agent-concurrency slot — a busy
+// agent can never delay another instance's approval re-check. The expensive graph
+// advance is left to ResolveApproval, which the dispatcher gates through the
+// per-agent semaphore.
+//
+// It returns ApprovalWait (a no-op) when the instance is no longer parked at an
+// approval step. A binding-less (spawned) task can only ever reach ApprovalAbort
+// via timeout, mirroring CheckParkedApprovals.
+func (e *Engine) RecheckApproval(ctx context.Context, instanceID string, poll func(sourceID, sourceItemID string) (model.SourceItem, error)) ApprovalDecision {
+	e.mu.Lock()
+	r, ok := e.parked[instanceID]
+	if !ok {
+		e.mu.Unlock()
+		return ApprovalWait
+	}
+	step := r.byID[r.waitingStep]
+	bindings := r.bindings
+	parkedAt := r.parkedAt
+	e.mu.Unlock()
+
+	if step.StepType() != config.StepTypeApproval {
+		return ApprovalWait
+	}
+	if to := step.ParsedTimeout(); to > 0 && e.now().Sub(parkedAt) >= to {
+		aplog.Info("workflow: approval on instance %s timed out after %s — aborting", instanceID, to)
+		return ApprovalAbort
+	}
+	for _, b := range bindings {
+		item, err := poll(b.SourceID, b.SourceItemID)
+		if err != nil {
+			aplog.Debug("workflow: poll item %s/%s for approval check failed: %v", b.SourceID, b.SourceItemID, err)
+			continue
+		}
+		if decision := EvaluateApproval(step, item); decision != ApprovalWait {
+			return decision
+		}
+	}
+	return ApprovalWait
+}
+
 // CheckParkedApprovals evaluates every parked instance against its live source
 // item(s) and resumes, aborts, or times it out as conditions dictate. The live
 // item is fetched per source binding (poll is keyed by source id + source item
@@ -136,6 +190,13 @@ func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decisio
 // condition decides the instance; when poll errors for a binding it is skipped.
 // A binding-less (spawned) task cannot be resolved via a source and stays parked
 // until it times out.
+//
+// This is the simple sequential reference path used by the engine tests. In
+// production the dispatcher does NOT call it; instead Dispatcher.checkApprovals
+// drives the same primitives concurrently (RecheckApproval + ResolveApproval) so a
+// long-running follow-on agent on one resumed instance cannot block the cheap
+// re-checks of every other parked approval, and so each advance is admitted through
+// the per-agent semaphore.
 func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, sourceItemID string) (model.SourceItem, error)) {
 	for _, p := range e.ParkedApprovals() {
 		if to := p.Step.ParsedTimeout(); to > 0 && e.now().Sub(p.ParkedAt) >= to {


### PR DESCRIPTION
## Summary

The parked-approval re-check path had the same head-of-line blocking that [#134](https://github.com/orlandoburli/apiary/pull/134) just fixed for parked `wait_for` instances. `Engine.CheckParkedApprovals` is a sequential loop that calls `ResolveApproval` inline on the single per-source poll-loop goroutine; when a resumed/aborted approval loops into an agent step, that subprocess runs **synchronously** on that goroutine — so one slow resume blocks the re-checks of every other parked approval and stalls the poll loop.

This mirrors the `wait_for` fix (`Dispatcher.checkWaits` + `RecheckWait`/`WakeWait`):

- **`Engine.RecheckApproval`** (new) — evaluates a single parked approval cheaply (per-binding `TaskPoller` poll + `EvaluateApproval` + timeout check) **without advancing the DAG**, returning the decision (wait/resume/abort). `ResolveApproval` remains the expensive advance.
- **`CheckParkedApprovals`** is kept as the sequential reference path used by the engine tests.
- **`ParkedApproval`** now carries the representative `AgentID` (`representativeAgent(wf)`, reused from `wait_park.go`).
- **`Dispatcher.checkApprovals`** rewritten to fan out one goroutine per parked approval: the cheap `RecheckApproval` runs **ungated**, and only a resume/abort drives `ResolveApproval` admitted through the per-agent semaphore (`d.agentSem[...]`, same as `fanOut`/`checkWaits`). A new `approvalAdvancing sync.Map` guards against overlapping poll cycles double-advancing the same instance.

The approval re-check keeps using the per-binding `source.TaskPoller` exactly as before.

## Test plan

- New `internal/daemon/parked_approval_concurrency_test.go` (mirrors `parked_wait_concurrency_test.go`): two instances park at an approval gate; A is approved and wedges in a blocking agent step holding the only agent slot; asserts `checkApprovals` returns promptly and that B keeps being re-evaluated (ungated) while A is wedged, and that the wedged A is skipped via `approvalAdvancing`.
- Confirmed the new test **fails against the old sequential `checkApprovals`** (`checkApprovals blocked on a slow advance`).
- Updated `rehydrate_approval_test.go` to await the now-async resume (it previously asserted synchronous settlement).
- `go build ./...`, `go vet`, and `go test -race ./...` all pass (no Go CI in this repo; verified locally).

Impact analysis (gitnexus, upstream) on `CheckParkedApprovals`, `ResolveApproval`, `EvaluateApproval`: all **LOW** risk.