### PR TITLE
feat(dashboard): scroll the task detail view

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -201,6 +201,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case taskDetailMsg:
 		if a.model.tasksTab != nil {
+			// A fresh open (d/enter/r) resets the scroll to the top; the in-place
+			// live refresh (taskDetailRefreshMsg) preserves the reader's position.
+			if a.model.tasksTab.Detail == nil || a.model.tasksTab.Detail.TaskID != msg.detail.TaskID {
+				a.model.tasksTab.DetailScroll = 0
+			}
 			a.model.tasksTab.Detail = msg.detail
 			a.model.tasksTab.DetailInstance = msg.instance
 			a.model.tasksTab.View = TaskViewDetail
@@ -1003,6 +1008,7 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		t.Logs = nil
 		t.InstanceHistory = nil
 		t.LogScroll = 0
+		t.DetailScroll = 0
 		t.LogTaskID = ""
 		t.LogHasMore = false
 		t.LogLoadingMore = false
@@ -1031,18 +1037,26 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			} else if cmd := a.loadOlderLogsCmd(t); cmd != nil {
 				return a, cmd // at top — pull in the next older page
 			}
+		} else if t.View == TaskViewDetail && t.DetailScroll > 0 {
+			t.DetailScroll--
 		}
 	case "down":
 		if t.View == TaskViewLogs && t.LogScroll < len(a.taskLogLines())-1 {
 			t.LogScroll++
+		} else if t.View == TaskViewDetail {
+			t.DetailScroll++ // render clamps to the last full page
 		}
 	case "g", "home":
 		if t.View == TaskViewLogs {
 			t.LogScroll = 0
+		} else if t.View == TaskViewDetail {
+			t.DetailScroll = 0
 		}
 	case "G", "end":
 		if t.View == TaskViewLogs {
 			t.LogScroll = lastIndex(len(a.taskLogLines()))
+		} else if t.View == TaskViewDetail {
+			t.DetailScroll = len(a.taskDetailLines(t)) // render clamps to the last full page
 		}
 	case "pgup", "ctrl+u":
 		if t.View == TaskViewLogs {
@@ -1052,10 +1066,17 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 				}
 			}
 			t.LogScroll = clampScroll(t.LogScroll-a.pageSize(), len(a.taskLogLines()))
+		} else if t.View == TaskViewDetail {
+			t.DetailScroll -= a.pageSize()
+			if t.DetailScroll < 0 {
+				t.DetailScroll = 0
+			}
 		}
 	case "pgdown", "ctrl+d", " ":
 		if t.View == TaskViewLogs {
 			t.LogScroll = clampScroll(t.LogScroll+a.pageSize(), len(a.taskLogLines()))
+		} else if t.View == TaskViewDetail {
+			t.DetailScroll += a.pageSize() // render clamps to the last full page
 		}
 	}
 	return a, nil
@@ -3108,6 +3129,43 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 		return a.box("TASK DETAILS", StyleMuted.Render("No details")+"\n", height)
 	}
 
+	lines := a.taskDetailLines(t)
+	label := taskDetailLabel(d)
+
+	rows := height - 2 // top + bottom borders
+	if rows < 1 {
+		rows = 1
+	}
+	// Clamp the scroll offset so the window always shows real content: never past
+	// the line that leaves a single page visible at the bottom.
+	maxStart := len(lines) - rows
+	if maxStart < 0 {
+		maxStart = 0
+	}
+	if t.DetailScroll > maxStart {
+		t.DetailScroll = maxStart
+	}
+	if t.DetailScroll < 0 {
+		t.DetailScroll = 0
+	}
+	start := t.DetailScroll
+	end := start + rows
+	if end > len(lines) {
+		end = len(lines)
+	}
+
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		b.WriteString(lines[i] + "\n")
+	}
+	return a.box(label, b.String(), height)
+}
+
+// taskDetailLines builds the full, styled content of the task detail view as
+// individual visual lines. renderTaskDetail windows these by DetailScroll so a
+// task with many workflow instances/children scrolls instead of being cut off.
+func (a *App) taskDetailLines(t *TasksTab) []string {
+	d := t.Detail
 	rStart, rEnd, inTok, outTok, totalTok, cacheCreate, cacheRead, cost := taskRollup(d, t.DetailInstance)
 	started, completed, dur := "—", "—", "—"
 	if rStart != nil {
@@ -3171,8 +3229,7 @@ func (a *App) renderTaskDetail(t *TasksTab, height int) string {
 	b.WriteString(renderSourceBindings(d))
 	b.WriteString(renderTaskLineage(d))
 	b.WriteString(renderTaskInstances(d))
-	label := taskDetailLabel(d)
-	return a.box(label, b.String(), height)
+	return strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
 }
 
 // renderSourceBindings renders a task's source bindings (9.1.2): one row per
@@ -4438,7 +4495,7 @@ func (a *App) footerKeys() []fkey {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewDetail:
-				return []fkey{{"esc", "back"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
 				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"C", "clear"}, {"q", "quit"}}
 			case TaskViewWorkflow:
@@ -4498,9 +4555,16 @@ func (a *App) footerStatus(updated string) string {
 	pos := ""
 	switch a.model.ActiveTab() {
 	case "Tasks":
-		if t := a.model.tasksTab; t != nil && t.View == TaskViewLogs {
-			if n := len(a.taskLogLines()); n > 0 {
-				pos = fmt.Sprintf("line %d/%d   ", t.LogScroll+1, n)
+		if t := a.model.tasksTab; t != nil {
+			switch t.View {
+			case TaskViewLogs:
+				if n := len(a.taskLogLines()); n > 0 {
+					pos = fmt.Sprintf("line %d/%d   ", t.LogScroll+1, n)
+				}
+			case TaskViewDetail:
+				if n := len(a.taskDetailLines(t)); n > 0 {
+					pos = fmt.Sprintf("line %d/%d   ", t.DetailScroll+1, n)
+				}
 			}
 		}
 	case "Logs":

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -71,6 +71,7 @@ type TasksTab struct {
 	View            TaskView
 	Detail          *TaskItem                // populated when View == TaskViewDetail
 	DetailInstance  *WorkflowInstanceItem    // workflow instance for Detail, if any
+	DetailScroll    int                      // first visible content line in the detail view
 	Logs            []LogEntry               // legacy flat stream (TaskViewLogs, legacy rows)
 	InstanceHistory []TaskHistorySegmentItem // per-instance history (TaskViewLogs, InternalTask rows)
 	LogScroll       int

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -569,6 +570,79 @@ func TestTaskDetailDoneKeepsCompletedRow(t *testing.T) {
 	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 20))
 	if !strings.Contains(out, "Completed:") {
 		t.Errorf("done task should keep the 'Completed' row; got:\n%s", out)
+	}
+}
+
+// detailWithManyChildren builds a task whose content far exceeds a short box,
+// so the detail view must scroll rather than truncate the tail.
+func detailWithManyChildren(n int) *TaskItem {
+	children := make([]TaskLineageItem, n)
+	for i := range children {
+		children[i] = TaskLineageItem{
+			TaskID:        fmt.Sprintf("tk_child_%02d", i),
+			Title:         fmt.Sprintf("child task number %02d", i),
+			State:         "running",
+			InstanceCount: 1,
+		}
+	}
+	return &TaskItem{
+		TaskID:   "T-scroll",
+		Title:    "parent with many children",
+		Status:   "running",
+		Children: children,
+	}
+}
+
+// A task with more content than the box is tall must scroll: at the top the tail
+// is hidden, and scrolling to the end reveals it while hiding the header.
+func TestTaskDetailScrolls(t *testing.T) {
+	a := newTestApp(90, 24)
+	tt := a.model.tasksTab
+	tt.View = TaskViewDetail
+	tt.Detail = detailWithManyChildren(40)
+
+	const height = 20 // 18 body rows — far fewer than the ~55 content lines
+
+	top := stripANSI(a.renderTaskDetail(tt, height))
+	if !strings.Contains(top, "Number") {
+		t.Fatalf("at scroll 0 the header should be visible; got:\n%s", top)
+	}
+	if strings.Contains(top, "child task number 39") {
+		t.Errorf("at scroll 0 the last child should be cut off; got:\n%s", top)
+	}
+
+	// Jump to the end via the key handler, then render (render applies the clamp).
+	tt.View = TaskViewDetail
+	a.handleTaskSubViewKey("G")
+	bottom := stripANSI(a.renderTaskDetail(tt, height))
+	if !strings.Contains(bottom, "child task number 39") {
+		t.Errorf("after scrolling to the end the last child should be visible; got:\n%s", bottom)
+	}
+	if strings.Contains(bottom, "Number") {
+		t.Errorf("after scrolling to the end the header should be off-screen; got:\n%s", bottom)
+	}
+
+	// The scroll offset must never run past the last full page.
+	lines := a.taskDetailLines(tt)
+	if max := len(lines) - (height - 2); tt.DetailScroll != max {
+		t.Errorf("DetailScroll = %d, want clamped to %d", tt.DetailScroll, max)
+	}
+
+	// The box stays framed at every scroll position.
+	assertFramed(t, a.renderTaskDetail(tt, height), 90)
+}
+
+// Short content (fits the box) must never scroll, and the up/down keys are no-ops.
+func TestTaskDetailNoScrollWhenContentFits(t *testing.T) {
+	a := newTestApp(90, 40)
+	tt := a.model.tasksTab
+	tt.View = TaskViewDetail
+	tt.Detail = &TaskItem{TaskID: "T-1", Title: "tiny", Status: "done"}
+
+	a.handleTaskSubViewKey("down")
+	a.renderTaskDetail(tt, 36) // render clamps
+	if tt.DetailScroll != 0 {
+		t.Errorf("DetailScroll = %d, want 0 when content fits", tt.DetailScroll)
 	}
 }
 


### PR DESCRIPTION
## Summary

The task detail sub-view (`TaskViewDetail`) was the only Tasks sub-view without scrolling — `box()` rendered just the first N lines and silently dropped the rest. Tasks whose agents have many interactions (long error text, many workflow instances, many children) had their tail cut off with no way to reach it.

This applies the same viewport pattern the Logs and Workflow Monitor views already use:

- Add `TasksTab.DetailScroll`; `renderTaskDetail` now builds the full content via a new `taskDetailLines()` helper and windows it by the offset, clamping so it never scrolls past the last full page (`box()` itself is untouched).
- Wire `up`/`down`, `g`/`G`/`home`/`end`, and `pgup`/`pgdn` for `TaskViewDetail` in `handleTaskSubViewKey`.
- Reset scroll on back-to-list and when opening a *different* task; the in-place live refresh (`taskDetailRefreshMsg`) and reloading the same task (`r`) **preserve** the reader's position so an auto-refresh won't jump to the top mid-read.
- Footer advertises `↑/↓ scroll` and the status bar shows `line X/N`.

## Test plan

- `go build ./internal/dashboard/` and `go vet` clean.
- Full dashboard test suite passes, including two new tests:
  - `TestTaskDetailScrolls` — tail hidden at top, revealed after scrolling to the end, offset clamps to the last page, box stays framed at every position.
  - `TestTaskDetailNoScrollWhenContentFits` — short content never scrolls; up/down are no-ops.