### PR TITLE
fix(db): store SQLite-parseable timestamps + backfill legacy rows

### DIFF
--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -35,13 +35,20 @@ func New(ctx context.Context, dbPath string) (*Client, error) {
 	//   cache_size=-20000 — ~20MB page cache; task_logs rows are ~10KB of agent
 	//                   stream text, so a bigger cache cuts cold-read disk hits.
 	//   temp_store=MEMORY — sorts/temp b-trees stay in RAM.
+	//   _time_format=sqlite — write time.Time as "2006-01-02 15:04:05.999999999
+	//                   -07:00". modernc's default is time.Time.String(), which
+	//                   appends " MST m=±…" (monotonic clock) — a form SQLite's
+	//                   DATE()/datetime() cannot parse, so every windowed/grouped
+	//                   query (dashboard daily charts, 24h totals) silently drops
+	//                   those rows. See normalizeLegacyTimestamps for the backfill.
 	dsn := dbPath
 	if !strings.Contains(dsn, "?") {
 		dsn += "?_pragma=busy_timeout(5000)" +
 			"&_pragma=journal_mode(WAL)" +
 			"&_pragma=synchronous(NORMAL)" +
 			"&_pragma=cache_size(-20000)" +
-			"&_pragma=temp_store(MEMORY)"
+			"&_pragma=temp_store(MEMORY)" +
+			"&_time_format=sqlite"
 	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const schema = `
@@ -294,5 +295,139 @@ func InitSchema(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("migrate (%s): %w", m, err)
 		}
 	}
+	if err := normalizeLegacyTimestamps(ctx, db); err != nil {
+		return fmt.Errorf("normalize legacy timestamps: %w", err)
+	}
 	return nil
+}
+
+// legacyTimestampColumns lists every TIMESTAMP column written from a time.Time.
+// Older builds (and beta binaries before the _time_format=sqlite DSN fix) used
+// modernc's default time.Time.String() encoding — "2006-01-02 15:04:05.999999999
+// -0700 MST m=±…" — which SQLite's DATE()/datetime() cannot parse. Those rows
+// vanish from windowed/grouped dashboard queries. normalizeLegacyTimestamps
+// rewrites them in place to the canonical SQLite layout.
+var legacyTimestampColumns = []struct{ table, column string }{
+	{"task_executions", "started_at"},
+	{"task_executions", "completed_at"},
+	{"task_executions", "next_retry_at"},
+	{"task_executions", "created_at"},
+	{"task_executions", "heartbeat_at"},
+	{"tasks", "started_at"},
+	{"tasks", "completed_at"},
+	{"tasks", "created_at"},
+	{"tasks", "updated_at"},
+	{"task_checkpoints", "created_at"},
+	{"workflow_instances", "created_at"},
+	{"workflow_instances", "updated_at"},
+	{"step_runs", "started_at"},
+	{"step_runs", "finished_at"},
+	{"internal_tasks", "created_at"},
+	{"internal_tasks", "updated_at"},
+	{"source_bindings", "created_at"},
+	{"source_bindings", "updated_at"},
+	{"task_logs", "timestamp"},
+	{"service_logs", "timestamp"},
+}
+
+// sqliteTimeLayout is the canonical on-disk format (parseTimeFormats[0] in
+// modernc) that DATE()/datetime() parse and that _time_format=sqlite now writes.
+const sqliteTimeLayout = "2006-01-02 15:04:05.999999999-07:00"
+
+// normalizeLegacyTimestamps rewrites Go-native time.Time.String() values (which
+// carry two-plus space-separated tokens, e.g. " -0700 MST m=…") into the
+// canonical SQLite layout. It is idempotent: already-canonical values have a
+// single space and are skipped by the LIKE filter, so re-runs on a clean DB are
+// a no-op. Per column, all updates run in one transaction.
+func normalizeLegacyTimestamps(ctx context.Context, db *sql.DB) error {
+	for _, tc := range legacyTimestampColumns {
+		// A canonical value has exactly one space (date/time separator); the
+		// broken Go encoding always has two or more ("… -0700 MST [m=…]").
+		// CAST(... AS TEXT) is essential: scanning a TIMESTAMP column into a Go
+		// string makes modernc auto-parse and reformat it to RFC3339, hiding the
+		// raw bytes we need to normalize. The CAST strips the column's type
+		// affinity so the literal stored text comes through unchanged.
+		q := fmt.Sprintf(
+			"SELECT rowid, CAST(%s AS TEXT) FROM %s WHERE %s LIKE '%% %% %%'",
+			tc.column, tc.table, tc.column,
+		)
+		rows, err := db.QueryContext(ctx, q)
+		if err != nil {
+			// Table/column absent on this DB (e.g. partial schema) — skip.
+			if strings.Contains(err.Error(), "no such table") ||
+				strings.Contains(err.Error(), "no such column") {
+				continue
+			}
+			return err
+		}
+		type fix struct {
+			rowid int64
+			val   string
+		}
+		var fixes []fix
+		for rows.Next() {
+			var rowid int64
+			var raw string
+			if err := rows.Scan(&rowid, &raw); err != nil {
+				rows.Close()
+				return err
+			}
+			if norm, ok := normalizeGoTime(raw); ok {
+				fixes = append(fixes, fix{rowid, norm})
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(fixes) == 0 {
+			continue
+		}
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		upd := fmt.Sprintf("UPDATE %s SET %s = ? WHERE rowid = ?", tc.table, tc.column)
+		stmt, err := tx.PrepareContext(ctx, upd)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		for _, f := range fixes {
+			if _, err := stmt.ExecContext(ctx, f.val, f.rowid); err != nil {
+				stmt.Close()
+				_ = tx.Rollback()
+				return err
+			}
+		}
+		stmt.Close()
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeGoTime converts a Go time.Time.String() rendering — e.g.
+// "2026-06-06 18:14:37.630756 -0400 -04 m=+301.17" — into the canonical SQLite
+// layout "2026-06-06 18:14:37.630756-04:00". It returns ok=false for values it
+// cannot parse, leaving them untouched. Already-canonical values never reach
+// here (filtered out by the caller's single-space LIKE).
+func normalizeGoTime(s string) (string, bool) {
+	if i := strings.Index(s, " m="); i >= 0 {
+		s = s[:i] // drop the monotonic-clock suffix
+	}
+	// Fields: date, time, numeric-offset, [zone-abbrev]. The abbreviation is
+	// redundant given the numeric offset, so parse only the first three.
+	parts := strings.Fields(s)
+	if len(parts) < 3 {
+		return "", false
+	}
+	base := parts[0] + " " + parts[1] + " " + parts[2]
+	t, err := time.Parse("2006-01-02 15:04:05.999999999 -0700", base)
+	if err != nil {
+		return "", false
+	}
+	return t.Format(sqliteTimeLayout), true
 }

--- a/src/internal/db/timestamp_backfill_test.go
+++ b/src/internal/db/timestamp_backfill_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeGoTime(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"2026-06-06 18:14:37.630756 -0400 -04 m=+301.172927834", "2026-06-06 18:14:37.630756-04:00", true},
+		{"2026-06-06 18:17:07 -0400 -04 m=+451.0", "2026-06-06 18:17:07-04:00", true},
+		{"2026-06-07 00:00:55.034507 +0000 UTC", "2026-06-07 00:00:55.034507+00:00", true},
+		// Already-canonical values are never passed in by the caller, but if they
+		// were, the single-space form has too few fields and is left untouched.
+		{"2026-06-05 08:39:10.944026-04:00", "", false},
+		{"", "", false},
+	}
+	for _, c := range cases {
+		got, ok := normalizeGoTime(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("normalizeGoTime(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestNormalizeLegacyTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.db")
+	ctx := context.Background()
+	c, err := New(ctx, path)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	// Seed a broken Go-native timestamp directly (bypassing the now-fixed writer).
+	broken := "2026-06-06 18:14:37.630756 -0400 -04 m=+301.172927834"
+	if _, err := c.db.ExecContext(ctx,
+		`INSERT INTO task_executions (task_id, agent_id, status, created_at, cost_usd, total_tokens)
+		 VALUES ('tk','ag','success', ?, 1.25, 100)`, broken); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Before normalization DATE() cannot parse it.
+	var dnull sql.NullString
+	_ = c.db.QueryRowContext(ctx, `SELECT DATE(created_at) FROM task_executions`).Scan(&dnull)
+	if dnull.Valid {
+		t.Fatalf("expected DATE() to be NULL on broken value, got %q", dnull.String)
+	}
+
+	if err := normalizeLegacyTimestamps(ctx, c.db); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	// CAST(... AS TEXT) reads the raw stored bytes; a plain string scan would get
+	// modernc's RFC3339 auto-reformat instead of the on-disk value.
+	var day, raw string
+	if err := c.db.QueryRowContext(ctx, `SELECT DATE(created_at), CAST(created_at AS TEXT) FROM task_executions`).Scan(&day, &raw); err != nil {
+		t.Fatalf("post-scan: %v", err)
+	}
+	if day != "2026-06-06" {
+		t.Errorf("DATE(created_at) = %q, want 2026-06-06 (raw=%q)", day, raw)
+	}
+	if raw != "2026-06-06 18:14:37.630756-04:00" {
+		t.Errorf("normalized value = %q", raw)
+	}
+
+	// Idempotent: a second pass changes nothing and leaves zero broken rows.
+	if err := normalizeLegacyTimestamps(ctx, c.db); err != nil {
+		t.Fatalf("normalize 2nd: %v", err)
+	}
+	var broke int
+	_ = c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM task_executions WHERE created_at LIKE '% % %'`).Scan(&broke)
+	if broke != 0 {
+		t.Errorf("expected 0 broken rows after normalize, got %d", broke)
+	}
+}
+
+// TestNormalizeRealDBCopy runs the backfill against a real DB snapshot when
+// APIARY_TEST_DB points at one, then asserts no broken timestamps remain. Skipped
+// in CI. Use: APIARY_TEST_DB=/tmp/apiary-test-copy.db go test -run RealDBCopy ./internal/db/
+func TestNormalizeRealDBCopy(t *testing.T) {
+	path := os.Getenv("APIARY_TEST_DB")
+	if path == "" {
+		t.Skip("set APIARY_TEST_DB to a DB copy to run")
+	}
+	ctx := context.Background()
+	c, err := New(ctx, path) // New runs InitSchema -> normalizeLegacyTimestamps
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer c.Close()
+
+	for _, col := range []struct{ table, column string }{
+		{"task_executions", "created_at"},
+		{"step_runs", "started_at"},
+		{"workflow_instances", "created_at"},
+		{"task_logs", "timestamp"},
+		{"service_logs", "timestamp"},
+	} {
+		var n int
+		q := "SELECT COUNT(*) FROM " + col.table + " WHERE " + col.column + " LIKE '% % %'"
+		if err := c.db.QueryRowContext(ctx, q).Scan(&n); err != nil {
+			t.Fatalf("%s.%s: %v", col.table, col.column, err)
+		}
+		if n != 0 {
+			t.Errorf("%s.%s still has %d broken rows", col.table, col.column, n)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The dashboard's **Daily Cost — last 14 days** chart rendered a flat two-point line (~\$50.37 → \$53.21) and **Daily Tokens** showed *"No token data yet"*, even though real spend was far higher. The headline 24h usage figure was similarly understated.

## Root cause

`modernc.org/sqlite` serializes a `time.Time` argument using its **default** encoding — `time.Time.String()` — which produces values like:

```
2026-06-06 18:14:37.630756 -0400 -04 m=+301.172927834
```

SQLite's C `DATE()` / `datetime()` functions **cannot parse** that form (extra space-separated tokens + monotonic-clock suffix), so `DATE(created_at)` returns `NULL` and every windowed/grouped dashboard query silently drops the row. Confirmed in the driver source (`conn.go` `formatTime`): when `writeTimeFormat == ""` it falls back to `t.String()`.

The break began when the CGO `mattn/go-sqlite3` dev build was replaced by the pure-Go `modernc.org/sqlite` release binary — the older rows (written by go-sqlite3 in `…-04:00` form) were the only ones the charts could still see.

## Fix

1. **Stop the bleed** — add `&_time_format=sqlite` to the DSN so `time.Time` is written as `2006-01-02 15:04:05.999999999-07:00`, the format `DATE()` parses (and the format the old working rows already use). One option covers *every* `time.Time` write and query bound.
2. **Backfill** — `normalizeLegacyTimestamps`, run after migrations in `InitSchema`, rewrites existing Go-native timestamps in place across all affected `TIMESTAMP` columns (`task_executions`, `step_runs`, `workflow_instances`, `internal_tasks`, `source_bindings`, `tasks`, `task_checkpoints`, `task_logs`, `service_logs`). Idempotent — canonical single-space values are skipped, so steady-state startups are a no-op.
   - Reads raw bytes via `CAST(col AS TEXT)`: scanning a `TIMESTAMP` column into a Go `string` triggers modernc's RFC3339 auto-reformat and hides the on-disk value.

## Validation

Against a snapshot of a real affected DB, the daily-cost chart query goes from 2 visible days to the full series:

| Day | Before | After |
|-----|--------|-------|
| Jun 05 | \$50.37 | \$50.37 |
| Jun 06 | \$53.21 | \$55.16 |
| Jun 07 | hidden | \$67.30 |
| Jun 08 | hidden | \$137.16 |
| Jun 09 | hidden | \$48.12 |

Broken-row counts across all columns → 0 after backfill (incl. ~161k log rows).

## Tests

- `TestNormalizeGoTime` — format conversion incl. no-fraction and UTC variants.
- `TestNormalizeLegacyTimestamps` — seeds a broken row, asserts `DATE()` parses post-backfill, asserts idempotency.
- `TestNormalizeRealDBCopy` — env-gated (`APIARY_TEST_DB`) check against a real snapshot; skipped in CI.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.