### PR TITLE
fix(dashboard): higher-contrast spinner for log loading indicator

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1830,8 +1830,10 @@ func tickCmd() tea.Cmd {
 // refresh tick so the spinner reads as smooth motion while a query is in flight.
 const spinnerInterval = 100 * time.Millisecond
 
-// spinnerFrames are the braille-dot cycle used by every loading indicator.
-var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+// spinnerFrames are the heavy braille "orbit" cycle used by every loading
+// indicator. The filled cells (vs. a sparse dot pattern) give the rotation
+// strong contrast so the motion reads clearly across terminal fonts.
+var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
 func spinnerTickCmd() tea.Cmd {
 	return tea.Tick(spinnerInterval, func(t time.Time) tea.Msg {


### PR DESCRIPTION
## Summary
- Follow-up to #138. The log loading spinner was animating correctly (verified by driving the real Bubble Tea runtime — frames advance and distinct glyphs are emitted), but the sparse braille set (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) renders faintly in many terminal fonts, so the rotation reads as a flicker and appears frozen.
- Switched to the heavy braille orbit (`⣾⣽⣻⢿⡿⣟⣯⣷`) — filled cells with a single moving gap give the rotation strong contrast and clearly visible motion across fonts. Same self-perpetuating 100ms tick mechanism, only the glyph set changed.

## Test plan
- `go build ./...` and `go test ./internal/dashboard/` pass.
- Drove the full dashboard `App` under the real tea runtime with `loading == true`: 6 distinct spinner frames emitted through the log-view render path with the `Loading logs…` text present.