### PR TITLE
feat(workflow): detect PR merge conflicts in wait_for + add on_conflict routing

### DIFF
--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -100,8 +100,8 @@ type TriggerConfig struct {
 
 // StepConfig is one node in a workflow graph. The active fields depend on Type.
 type StepConfig struct {
-	ID        string   `yaml:"id"`
-	Type      string   `yaml:"type,omitempty"` // agent(default)|split|approval|foreach|workflow
+	ID   string `yaml:"id"`
+	Type string `yaml:"type,omitempty"` // agent(default)|split|approval|foreach|workflow
 	// DependsOn is set internally by the v2 lowering pass (parallel, foreach).
 	// It cannot be declared in YAML — the engine uses implicit sequential ordering.
 	DependsOn    []string `yaml:"-"`
@@ -131,6 +131,12 @@ type StepConfig struct {
 	Memory          *MemoryConfig `yaml:"memory,omitempty"`
 	OnPass          *StepNext     `yaml:"on_pass,omitempty"`
 	OnFail          *StepOutcome  `yaml:"on_fail,omitempty"`
+	// OnConflict is the merge-conflict edge of a wait_for/ci step (goto +
+	// max_retries, same shape as on_fail). When the step fails because the PR has
+	// merge conflicts, this route governs the loop-back exclusively, with its own
+	// retry budget separate from on_fail. Absent → a conflict falls through to
+	// on_fail like any other failure.
+	OnConflict *StepOutcome `yaml:"on_conflict,omitempty"`
 	// Publish controls whether an APIARY_PUBLISH payload emitted by this step's
 	// agent is written back to the task's source bindings: auto (default) | off.
 	// Empty inherits the auto default.

--- a/src/internal/config/workflow_graph.go
+++ b/src/internal/config/workflow_graph.go
@@ -32,25 +32,27 @@ func validateStepGraph(ctx string, wf WorkflowConfig, stepIDs map[string]bool) [
 		errs = append(errs, fmt.Errorf("%s: dependency cycle detected involving step %q", ctx, cyc))
 	}
 
-	// on_fail.goto back-edges must target an ancestor (a transitive dependency).
-	// For v2 workflows (no DependsOn edges), sequential order is the implicit graph:
-	// any step that appears earlier in the slice is an ancestor.
+	// on_fail.goto / on_conflict.goto back-edges must target an ancestor (a
+	// transitive dependency). For v2 workflows (no DependsOn edges), sequential
+	// order is the implicit graph: any step earlier in the slice is an ancestor.
 	seqOrder := map[string]int{}
 	for i, s := range wf.Steps {
 		seqOrder[s.ID] = i
 	}
-	for _, s := range wf.Steps {
-		if s.OnFail == nil || s.OnFail.Goto == "" || !stepIDs[s.OnFail.Goto] {
-			continue
-		}
-		var ok bool
+	targetsAncestor := func(stepID, goto_ string) bool {
 		if len(deps) == 0 {
-			ok = seqOrder[s.OnFail.Goto] < seqOrder[s.ID]
-		} else {
-			ok = isAncestor(s.ID, s.OnFail.Goto, deps)
+			return seqOrder[goto_] < seqOrder[stepID]
 		}
-		if !ok {
+		return isAncestor(stepID, goto_, deps)
+	}
+	for _, s := range wf.Steps {
+		if s.OnFail != nil && s.OnFail.Goto != "" && stepIDs[s.OnFail.Goto] &&
+			!targetsAncestor(s.ID, s.OnFail.Goto) {
 			errs = append(errs, fmt.Errorf("%s: step %q on_fail.goto %q must target an ancestor step (a transitive dependency)", ctx, s.ID, s.OnFail.Goto))
+		}
+		if s.OnConflict != nil && s.OnConflict.Goto != "" && stepIDs[s.OnConflict.Goto] &&
+			!targetsAncestor(s.ID, s.OnConflict.Goto) {
+			errs = append(errs, fmt.Errorf("%s: step %q on_conflict.goto %q must target an ancestor step (a transitive dependency)", ctx, s.ID, s.OnConflict.Goto))
 		}
 	}
 

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -146,6 +146,21 @@ func (c *Config) validateStep(
 		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
 	}
 
+	// on_conflict applies to any step type, so validate it here rather than in a
+	// per-type validator. It is only meaningful on a wait_for step (the sole
+	// producer of a conflict) and otherwise mirrors on_fail (goto + max_retries).
+	if s.OnConflict != nil && s.OnConflict.Goto != "" {
+		if s.StepType() != StepTypeWaitFor {
+			errs = append(errs, fmt.Errorf("%s: on_conflict is only valid on a wait_for step", sctx))
+		}
+		if !stepIDs[s.OnConflict.Goto] {
+			errs = append(errs, fmt.Errorf("%s: on_conflict.goto references unknown step %q", sctx, s.OnConflict.Goto))
+		}
+		if s.OnConflict.MaxRetries < 1 {
+			errs = append(errs, fmt.Errorf("%s: on_conflict.max_retries must be >= 1 when goto is set", sctx))
+		}
+	}
+
 	return errs
 }
 
@@ -452,4 +467,3 @@ func (c *Config) sourceIDSet() map[string]bool {
 	}
 	return set
 }
-

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -267,6 +267,44 @@ func TestWorkflow_OnFailGotoNotAncestor(t *testing.T) {
 	assertError(t, cfg, "must target an ancestor")
 }
 
+func TestWorkflow_OnConflictGotoUnknownStep(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "ci", Type: config.StepTypeWaitFor, DependsOn: []string{"a"},
+				WaitFor:    &config.WaitForConfig{Kind: "ci"},
+				OnConflict: &config.StepOutcome{Goto: "ghost", MaxRetries: 1}},
+		}},
+	}
+	assertError(t, cfg, "on_conflict.goto references unknown step")
+}
+
+func TestWorkflow_OnConflictMissingMaxRetries(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "ci", Type: config.StepTypeWaitFor, DependsOn: []string{"a"},
+				WaitFor:    &config.WaitForConfig{Kind: "ci"},
+				OnConflict: &config.StepOutcome{Goto: "a"}},
+		}},
+	}
+	assertError(t, cfg, "on_conflict.max_retries must be >= 1")
+}
+
+func TestWorkflow_OnConflictOnNonWaitForStep(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "b", Agent: "backend-dev", DependsOn: []string{"a"},
+				OnConflict: &config.StepOutcome{Goto: "a", MaxRetries: 1}},
+		}},
+	}
+	assertError(t, cfg, "on_conflict is only valid on a wait_for step")
+}
+
 func TestWorkflow_OnPassNextUnknownStep(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -21,11 +21,11 @@ func init() {
 // Compile-time checks: the GitHub adapter supports the optional source
 // capabilities used by the dispatcher and the workflow engine.
 var (
-	_ source.StateSetter      = (*Adapter)(nil)
-	_ source.LabelAdder       = (*Adapter)(nil)
-	_ source.LabelRemover     = (*Adapter)(nil)
-	_ source.TaskPoller       = (*Adapter)(nil)
-	_ source.CIStatusPoller   = (*Adapter)(nil)
+	_ source.StateSetter    = (*Adapter)(nil)
+	_ source.LabelAdder     = (*Adapter)(nil)
+	_ source.LabelRemover   = (*Adapter)(nil)
+	_ source.TaskPoller     = (*Adapter)(nil)
+	_ source.CIStatusPoller = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -333,6 +333,18 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	var pr pullRequest
 	if err := json.Unmarshal(prBody, &pr); err != nil {
 		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: decoding PR %s: %w", cellID, err)
+	}
+
+	// A PR with merge conflicts can never merge until someone rebases/resolves it,
+	// so waiting for CI on it is pointless. Surface the conflict immediately as a
+	// distinct terminal status and skip the CI aggregation entirely — this lets the
+	// wait_for step abort and hand the conflict back to the engineer agent rather
+	// than burning the whole timeout. mergeable_state == "dirty" is GitHub's
+	// definitive "has conflicts" signal; "unknown"/null means GitHub is still
+	// computing mergeability (lazy, async) so we fall through and keep waiting.
+	if pr.MergeableState == "dirty" {
+		aplog.Info("github: PR #%d for %s has merge conflicts (mergeable_state=dirty)", pr.Number, cellID)
+		return source.CIStatus{Status: "conflict", URL: pr.HTMLURL}, nil
 	}
 
 	headSHA := pr.Head.SHA

--- a/src/internal/source/github/pollci_test.go
+++ b/src/internal/source/github/pollci_test.go
@@ -33,6 +33,80 @@ func ciServer(t *testing.T, combinedStatus, checkRuns string) *Adapter {
 	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
 }
 
+// conflictServer is like ciServer but lets the PR (1961) carry a mergeable_state,
+// so we can exercise the merge-conflict short-circuit. It also fails the test if
+// the CI endpoints are hit, proving a dirty PR never reaches CI aggregation.
+func conflictServer(t *testing.T, mergeableState string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/1958"):
+			http.NotFound(w, r) // issue number is not a PR
+		case strings.HasSuffix(r.URL.Path, "/issues/1958/timeline"):
+			_, _ = w.Write([]byte(`[{"event":"cross-referenced","source":{"type":"issue",
+				"issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}}]`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/1961"):
+			_, _ = w.Write([]byte(`{"number":1961,"html_url":"https://gh/pr/1961","head":{"sha":"abc"},"mergeable":false,"mergeable_state":"` + mergeableState + `"}`))
+		case strings.Contains(r.URL.Path, "/commits/abc/"):
+			t.Errorf("CI endpoint %q hit, but a conflicting PR should short-circuit before CI aggregation", r.URL.Path)
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+}
+
+// A PR with merge conflicts (mergeable_state="dirty") short-circuits to a
+// "conflict" status without ever polling CI.
+func TestPollCIStatus_MergeConflict(t *testing.T) {
+	a := conflictServer(t, "dirty")
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "conflict" {
+		t.Errorf("status = %q, want conflict (PR mergeable_state=dirty)", got.Status)
+	}
+	if got.URL != "https://gh/pr/1961" {
+		t.Errorf("url = %q, want the PR html_url", got.URL)
+	}
+}
+
+// mergeable_state values other than "dirty" (here GitHub still computing it) are
+// NOT treated as conflicts — the step keeps waiting on CI as usual.
+func TestPollCIStatus_UnknownMergeStateIsNotConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/1958"):
+			http.NotFound(w, r)
+		case strings.HasSuffix(r.URL.Path, "/issues/1958/timeline"):
+			_, _ = w.Write([]byte(`[{"event":"cross-referenced","source":{"type":"issue",
+				"issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}}]`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/1961"):
+			_, _ = w.Write([]byte(`{"number":1961,"html_url":"https://gh/pr/1961","head":{"sha":"abc"},"mergeable":null,"mergeable_state":"unknown"}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/status"):
+			_, _ = w.Write([]byte(`{"state":"pending","total_count":0,"statuses":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "pending" {
+		t.Errorf("status = %q, want pending (mergeable_state unknown ≠ conflict)", got.Status)
+	}
+}
+
 // The regression: a GitHub-Actions-only repo has an EMPTY combined status (state
 // defaults to "pending", total_count 0) while every check run is green. The
 // overall must be "passed", not "pending".

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -47,10 +47,19 @@ type labelCreateRequest struct {
 }
 
 // PR (pull request) details for checking CI status.
+//
+// Mergeable / MergeableState are GitHub's merge-conflict signals, populated only
+// on a single-PR GET (the detailed /pulls/{number} endpoint). GitHub computes
+// them lazily and asynchronously: the first read of a PR can return
+// mergeable=null / mergeable_state="unknown" while the computation runs, then a
+// later read returns the real value. The definitive "has conflicts" signal is
+// mergeable_state == "dirty".
 type pullRequest struct {
-	Number  int    `json:"number"`
-	HTMLURL string `json:"html_url"`
-	Head    struct {
+	Number         int    `json:"number"`
+	HTMLURL        string `json:"html_url"`
+	Mergeable      *bool  `json:"mergeable"`
+	MergeableState string `json:"mergeable_state"`
+	Head           struct {
 		SHA string `json:"sha"`
 	} `json:"head"`
 }

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -69,7 +69,7 @@ type TaskPoller interface {
 // CIStatus represents the result of a CI status check. Used by poll steps waiting
 // for CI to complete.
 type CIStatus struct {
-	Status string // "passed", "failed", "pending"
+	Status string // "passed", "failed", "pending", "conflict"
 	URL    string // Link to the CI run
 	Checks []struct {
 		Name   string // Check name (e.g., "test", "lint")

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -13,13 +13,13 @@ import (
 
 // step execution states within a DAG run.
 const (
-	stPending    = "pending"
-	stRunning    = "running"    // dispatched to a worker goroutine, not yet complete
-	stPassed     = "passed"
-	stFailed     = "failed"
-	stSkipped    = "skipped"    // cascade-skipped because a dep failed/was cascade-skipped
+	stPending     = "pending"
+	stRunning     = "running" // dispatched to a worker goroutine, not yet complete
+	stPassed      = "passed"
+	stFailed      = "failed"
+	stSkipped     = "skipped"      // cascade-skipped because a dep failed/was cascade-skipped
 	stCondSkipped = "cond_skipped" // skipped because the step's own condition was false
-	stWaiting    = "waiting"    // an approval step parked awaiting a human response
+	stWaiting     = "waiting"      // an approval step parked awaiting a human response
 )
 
 // dagOutcome is the terminal (or suspended) result of driving a DAG run.
@@ -45,10 +45,11 @@ type dagRun struct {
 	byID  map[string]config.StepConfig
 	order []string // step ids in declaration order (deterministic scheduling)
 
-	state       map[string]string // step id → st* state
-	activated   map[string]bool   // control-flow has reached this step
-	splitTarget map[string]bool   // step id is the goto target of some split branch
-	retries     map[string]int    // on_fail.goto loop counter per failing step
+	state           map[string]string // step id → st* state
+	activated       map[string]bool   // control-flow has reached this step
+	splitTarget     map[string]bool   // step id is the goto target of some split branch
+	retries         map[string]int    // on_fail.goto loop counter per failing step
+	conflictRetries map[string]int    // on_conflict.goto loop counter per conflicting step
 
 	stepStates  map[string]StepState  // terminal states for expression context
 	contrib     map[string]MemoryStep // memory contribution per passed step
@@ -68,20 +69,21 @@ type dagRun struct {
 // is inherited memory for a sub-workflow child; depth tracks nesting.
 func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) *dagRun {
 	r := &dagRun{
-		instID:      instID,
-		wf:          wf,
-		task:        task,
-		bindings:    bindings,
-		cell:        sourceItemView(task, bindings),
-		depth:       depth,
-		seed:        seed,
-		byID:        map[string]config.StepConfig{},
-		state:       map[string]string{},
-		activated:   map[string]bool{},
-		splitTarget: map[string]bool{},
-		retries:     map[string]int{},
-		stepStates:  map[string]StepState{},
-		contrib:     map[string]MemoryStep{},
+		instID:          instID,
+		wf:              wf,
+		task:            task,
+		bindings:        bindings,
+		cell:            sourceItemView(task, bindings),
+		depth:           depth,
+		seed:            seed,
+		byID:            map[string]config.StepConfig{},
+		state:           map[string]string{},
+		activated:       map[string]bool{},
+		splitTarget:     map[string]bool{},
+		retries:         map[string]int{},
+		conflictRetries: map[string]int{},
+		stepStates:      map[string]StepState{},
+		contrib:         map[string]MemoryStep{},
 	}
 	for _, s := range wf.Steps {
 		r.byID[s.ID] = s
@@ -343,8 +345,26 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			continue
 		}
 
-		// Failure: attempt on_fail.goto loop if retries remain.
-		if !termFail && loopTarget == "" &&
+		// Merge-conflict failure with a dedicated on_conflict route: that edge
+		// governs the loop-back exclusively, with its own retry budget separate from
+		// on_fail (a rebase retry must not consume the CI-failure retry budget, and
+		// vice-versa). Once on_conflict's budget is exhausted the failure is terminal
+		// — it does NOT fall through to on_fail. A conflict on a step with no
+		// on_conflict declared skips this block and is handled by on_fail below.
+		conflictGoverned := res.Conflict && step.OnConflict != nil && step.OnConflict.Goto != ""
+		if !termFail && loopTarget == "" && conflictGoverned &&
+			r.conflictRetries[step.ID] < step.OnConflict.MaxRetries {
+			r.conflictRetries[step.ID]++
+			aplog.Info("workflow %s: step %q hit a merge conflict, looping back to %q (retry %d/%d)",
+				r.wf.ID, step.ID, step.OnConflict.Goto, r.conflictRetries[step.ID], step.OnConflict.MaxRetries)
+			r.state[step.ID] = stPending
+			loopTarget = step.OnConflict.Goto
+			continue
+		}
+
+		// Failure: attempt on_fail.goto loop if retries remain. Skipped when a
+		// conflict is governed by on_conflict (its budget is exhausted → terminal).
+		if !termFail && loopTarget == "" && !conflictGoverned &&
 			step.OnFail != nil && step.OnFail.Goto != "" &&
 			r.retries[step.ID] < step.OnFail.MaxRetries {
 			r.retries[step.ID]++

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -106,6 +106,10 @@ type StepResult struct {
 	// pass or a fail). The scheduler suspends the run at the wait_for step instead
 	// of marking it passed/failed. Ignored for all other step types.
 	Pending bool
+	// Conflict marks a failure caused specifically by a merge conflict on the PR
+	// (set only by wait_for/ci steps). The scheduler routes it via the step's
+	// on_conflict edge when one is declared; otherwise it is an ordinary failure.
+	Conflict bool
 	// PublishPayload is the APIARY_PUBLISH text the agent emitted, if any. The
 	// engine writes it back to the task's source bindings as a comment. The
 	// executor clears it when the step sets publish: off.
@@ -152,13 +156,13 @@ type SideEffects interface {
 type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error)
 
 type Engine struct {
-	cfg     *config.Config
-	store   Store
-	exec    StepExecutor
-	side    SideEffects
-	mem     MemoryBuilder
-	spawner WorkflowSpawner
-	tracker TaskTracker
+	cfg       *config.Config
+	store     Store
+	exec      StepExecutor
+	side      SideEffects
+	mem       MemoryBuilder
+	spawner   WorkflowSpawner
+	tracker   TaskTracker
 	ciChecker CIStatusChecker
 
 	now   func() time.Time
@@ -191,7 +195,9 @@ func WithSpawner(s WorkflowSpawner) Option { return func(e *Engine) { e.spawner 
 func WithTaskTracker(t TaskTracker) Option { return func(e *Engine) { e.tracker = t } }
 
 // WithCIStatusChecker sets the CI status checker used by wait_for steps.
-func WithCIStatusChecker(checker CIStatusChecker) Option { return func(e *Engine) { e.ciChecker = checker } }
+func WithCIStatusChecker(checker CIStatusChecker) Option {
+	return func(e *Engine) { e.ciChecker = checker }
+}
 
 // NewEngine builds an Engine. cfg, store, and exec are required.
 func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -19,7 +19,7 @@ func waitForWorkflow() config.WorkflowConfig {
 		{ID: "implement", Agent: "backend-dev"},
 		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
 			WaitFor: &config.WaitForConfig{Kind: "ci", CheckInterval: "30s", MaxDuration: "2h"},
-			OnFail:     &config.StepOutcome{Goto: "implement", MaxRetries: 3}},
+			OnFail:  &config.StepOutcome{Goto: "implement", MaxRetries: 3}},
 		{ID: "review", Agent: "backend-dev", DependsOn: []string{"check-ci"}},
 	}}
 }
@@ -135,6 +135,107 @@ func TestWaitFor_RedCILoopsBackToImplement(t *testing.T) {
 	}
 	if !contains(executedIDs(exec.seen), "review") {
 		t.Error("review should run once the retried CI passed")
+	}
+}
+
+// A merge conflict ceases the CI wait immediately and fails the step terminally
+// (never parks), so the failure is handed back for the conflict to be resolved
+// instead of burning the whole timeout window waiting for CI that can't matter.
+func TestWaitFor_ConflictFailsImmediately(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) {
+		return source.CIStatus{Status: "conflict", URL: "https://gh/pr/1"}, nil
+	}
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	// Poll with no on_fail loop, so a conflict fails the instance outright.
+	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor: &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"}},
+	}}
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a conflicting PR must not report success")
+	}
+	if got := store.instances[instID].State; got != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed (conflict is terminal, not parked)", got)
+	}
+	if len(eng.ParkedWaits()) != 0 {
+		t.Error("a conflict must not leave the instance parked waiting on CI")
+	}
+}
+
+// on_conflict routes a merge conflict back to a resolve step even when no on_fail
+// is declared, with its own retry budget. Here CI conflicts once, loops back to
+// implement via on_conflict, then passes on the retry → the workflow completes.
+func TestWaitFor_OnConflictLoopsBack(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	calls := 0
+	ci := func() (source.CIStatus, error) {
+		calls++
+		if calls == 1 {
+			return source.CIStatus{Status: "conflict", URL: "https://gh/pr/1"}, nil
+		}
+		return source.CIStatus{Status: "passed"}, nil
+	}
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	// No on_fail at all — only on_conflict. Without on_conflict a conflict would be
+	// terminal, so a completed run proves on_conflict drove the loop-back.
+	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor:    &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"},
+			OnConflict: &config.StepOutcome{Goto: "implement", MaxRetries: 3}},
+		{ID: "review", Agent: "backend-dev", DependsOn: []string{"check-ci"}},
+	}}
+	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+
+	if got := store.instances[instID].State; got != db.InstanceStateDone {
+		t.Fatalf("instance state = %q, want done (conflict resolved on retry)", got)
+	}
+	if n := countID(exec.seen, "implement"); n != 2 {
+		t.Errorf("implement should run twice (initial + on_conflict loop-back), got %d", n)
+	}
+	if !contains(executedIDs(exec.seen), "review") {
+		t.Error("review should run once the retried CI passed")
+	}
+}
+
+// on_conflict has its own retry budget and, once exhausted, fails terminally —
+// it does NOT fall through to on_fail. With a persistent conflict, implement runs
+// only initial+1 (on_conflict.max_retries=1), never consuming on_fail's budget.
+func TestWaitFor_OnConflictExhaustsWithoutFallthroughToOnFail(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "conflict"}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	wf := config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor:    &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"},
+			OnConflict: &config.StepOutcome{Goto: "implement", MaxRetries: 1},
+			OnFail:     &config.StepOutcome{Goto: "implement", MaxRetries: 5}},
+	}}
+	instID, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+
+	if success {
+		t.Fatal("a persistent conflict must not report success")
+	}
+	if got := store.instances[instID].State; got != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed (on_conflict budget exhausted)", got)
+	}
+	// initial + exactly 1 on_conflict retry. If a conflict had fallen through to
+	// on_fail (max_retries 5) implement would have run 7 times.
+	if n := countID(exec.seen, "implement"); n != 2 {
+		t.Errorf("implement should run twice (initial + 1 on_conflict retry), got %d", n)
 	}
 }
 

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -112,6 +112,21 @@ func (e *Engine) checkCIWaitStep(
 		}
 		return result, nil
 
+	case "conflict":
+		// A merge conflict cannot be resolved by waiting — stop polling at once and
+		// fail the step (regardless of fail_if_not_passed) so the conflict is handed
+		// straight back to the engineer agent to rebase/resolve.
+		aplog.Info("wait_for step %q: PR has merge conflicts — aborting CI wait", step.ID)
+		return StepResult{
+			Success:  false,
+			Conflict: true,
+			Err:      fmt.Errorf("PR has merge conflicts"),
+			StructuredOutput: map[string]any{
+				"ci_status": "conflict",
+				"url":       status.URL,
+			},
+		}, nil
+
 	case "pending":
 		aplog.Debug("wait_for step %q: CI still pending", step.ID)
 		return StepResult{Pending: true}, nil
@@ -139,7 +154,7 @@ func checksToMap(checks []struct {
 // recorded poll always carries a meaningful, non-empty status.
 func normalizeCIStatus(s string) string {
 	switch s {
-	case "passed", "failed", "pending":
+	case "passed", "failed", "pending", "conflict":
 		return s
 	default:
 		return "unknown"


### PR DESCRIPTION
## Summary

- A `wait_for`/`ci` step now detects a PR **merge conflict** (GitHub `mergeable_state == "dirty"`) and treats it as a distinct terminal outcome instead of polling CI until the timeout fires. `PollCIStatus` short-circuits to a new `"conflict"` status *before* CI aggregation, and the step fails immediately so the conflict is handed back to be resolved rather than burning the whole `max_duration`.
- Adds a new **`on_conflict`** step edge (`goto` + `max_retries`, same shape as `on_fail`) that routes a merge conflict to a recovery step (e.g. back to the implement/engineer step) with its **own retry budget**, independent of `on_fail`.
- Backward compatible: with no `on_conflict` declared, a conflict falls through to `on_fail` (or fails terminally) exactly as before.
- `mergeable_state` values other than `"dirty"` (e.g. `"unknown"`/null while GitHub computes mergeability lazily) are **not** treated as conflicts — the step keeps waiting on CI as usual.

### Behavior
| Situation | Result |
|-----------|--------|
| Conflict + `on_conflict` declared | loops back to `goto` (own budget); terminal once exhausted — does **not** fall through to `on_fail` |
| Conflict + no `on_conflict` | falls through to `on_fail` (or terminal failure) |
| `mergeable_state` unknown/null | keeps polling CI (no false conflict) |

### Validation
- `on_conflict.goto` must reference an existing step, `max_retries >= 1`, and is only valid on a `wait_for` step.
- `on_conflict.goto` must be an ancestor back-edge (same rule as `on_fail`).

## Test plan
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/config/ ./internal/workflow/ ./internal/source/github/` — all pass
- New tests: conflict short-circuits before CI aggregation; conflict fails immediately when no recovery edge; `on_conflict` loops back with its own budget; budget exhaustion is terminal and does not consume `on_fail`'s budget; config validation for unknown goto / missing max_retries / non-`wait_for` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)