### PR TITLE
feat(workflow): materialize spawned children as deduped sub-issues

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -102,12 +102,25 @@ workflows:
   - id: po-spec
     trigger:
       priority: 15
+      # once: the PO decomposition runs at most once per issue. After it has a
+      # completed instance, later polls do not re-dispatch it — so a spec issue that
+      # lingers in the trigger set (e.g. before on_complete closes it) never fans out
+      # a second set of sub-issues. The spawn dedup key + the materialize binding
+      # check already make sub-issue creation idempotent (issue #119); once: also
+      # avoids re-running the (expensive) PO agent.
+      once: true
       match:
         source: project-erp
         labels: [agent:po]
     steps:
       - id: run
         agent: po
+        # materialize: each sub-task the PO emits via APIARY_SPAWN is published as a
+        # GitHub sub-issue under this issue, exactly once. The new sub-issues carry
+        # agent:* labels, so the normal poll→route loop dispatches the right
+        # implementer. Re-running the PO resolves to the same children (by spawn key)
+        # and never duplicates them.
+        materialize: sub_issue
     on_complete:
       set_state: closed
 
@@ -215,6 +228,11 @@ workflows:
       - id: spec
         agent: po
         prompt: "Produce the spec / acceptance criteria for this issue."
+        # Same as po-spec: sub-tasks the PO emits via APIARY_SPAWN are published as
+        # GitHub sub-issues exactly once, deduped by spawn key. The whole triage
+        # workflow runs once per issue (on_complete closes it), so the decomposition
+        # is not repeated.
+        materialize: sub_issue
 
       - id: design
         agent: staff

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -408,6 +408,50 @@ workflows:
         agent: investigator
         prompt: "Gather the relevant logs and metrics for the incident described in the task input."
 
+  # ── Decomposition into sub-issues (materialize) ──────────────────────────────
+  # A spec/PO workflow that fans an issue out into several sub-issues — the right
+  # tool when a downstream agent should pick each piece up as its own GitHub issue
+  # (rather than running inline as a spawned child workflow, like collect-logs).
+  #
+  # `materialize: sub_issue` makes each APIARY_SPAWN entry into a real GitHub issue
+  # under the parent, EXACTLY ONCE. Two guards make it idempotent so a re-run never
+  # duplicates the set (issue #119): the spawn `key` (one child per key per parent)
+  # and the source-binding unique constraint (one sub-issue per child). Combined with
+  # `once: true`, even the agent does not re-run after success.
+  #
+  # The spawn entries here are "materialize-only": they carry NO `workflow` field, so
+  # no inline workflow runs. The created sub-issues carry agent:* labels, so the
+  # normal poll→route loop dispatches the right implementer on the next cycle — the
+  # same path a human-filed issue takes.
+  - id: spec-decompose
+    description: "Turn a spec issue into a deduplicated set of implementer sub-issues."
+    trigger:
+      priority: 15
+      once: true
+      match:
+        source: project-erp
+        labels: [agent:po]
+    steps:
+      - id: spec
+        agent: po
+        materialize: sub_issue   # publish each spawned child as a GitHub sub-issue, exactly once
+        prompt: |
+          Decompose this issue into implementer sub-tasks. Emit ONE APIARY_SPAWN
+          block whose body is a JSON array — one object per sub-task, each with a
+          stable `key` (so a re-run dedups), `labels` (the implementer), and a `body`
+          (the spec). Do not include a `workflow` field.
+
+          APIARY_SPAWN_BEGIN
+          [
+            {"title": "Add customer CRUD endpoints", "body": "GIVEN ... THEN ...", "labels": ["agent:backend"], "key": "customer-crud-endpoint"},
+            {"title": "Customer list screen", "body": "GIVEN ... THEN ...", "labels": ["agent:frontend"], "key": "customer-list-screen"}
+          ]
+          APIARY_SPAWN_END
+        # materialize: sub_issue is incompatible with spawn: await (a materialized
+        # child runs no inline workflow to await) — config lint rejects the pair.
+    on_complete:
+      set_state: closed
+
 
 # ── Settings ───────────────────────────────────────────────────────────────────
 settings:

--- a/.apiary/souls/po.md
+++ b/.apiary/souls/po.md
@@ -6,7 +6,7 @@ You represent the voice of the product: you define WHAT and WHY — never the HO
 
 ## Your Responsibilities
 
-When you receive a task from Plane, you must:
+When you receive an issue, you must:
 
 1. **Discovery** — Understand the context
    - Use `gitnexus_query` to discover if something similar already exists in the codebase
@@ -25,9 +25,35 @@ When you receive a task from Plane, you must:
      - **Urgency**: immediate / next sprint / backlog
      - **Dependencies**: issues or specs that must be completed first
 
-4. **Decomposition** — Create technical sub-tasks
-   - **Complex task** (multiple modules, architectural decisions): create sub-task with label `agent:engineer`
-   - **Direct task** (clear scope, 1-2 files): create sub-task with label `agent:engineer`
+4. **Decomposition** — Request technical sub-tasks via APIARY_SPAWN
+   - Do **NOT** create sub-issues yourself by calling the GitHub API. Apiary
+     materializes them for you, exactly once, so that re-running this step never
+     produces a duplicate set of sub-issues.
+   - Emit a **single** `APIARY_SPAWN` block containing a **JSON array** — one object
+     per sub-task. Each object has:
+     - `title` — short, imperative sub-task title (English).
+     - `body` — the sub-task's spec / acceptance criteria, in business language.
+     - `labels` — the implementer label: `["agent:backend"]`, `["agent:frontend"]`,
+       or `["agent:engineer"]` (the default when scope spans both or is unclear).
+     - `key` — a **stable, deterministic** slug that identifies this sub-task within
+       the issue (lowercase kebab-case, e.g. `customer-crud-endpoint`). The key is
+       the idempotency anchor: re-running the decomposition with the same key
+       resolves to the same sub-issue instead of creating a new one, so always
+       derive the key from the sub-task's purpose, never from a timestamp or a
+       counter. Keys must be unique within this issue.
+   - Do **not** include a `workflow` field — these are materialize-only spawns; the
+     created sub-issue is picked up by its label on the next poll.
+
+   Example (emit verbatim, replacing the contents):
+
+   ```
+   APIARY_SPAWN_BEGIN
+   [
+     {"title": "Add customer CRUD endpoints", "body": "GIVEN ... WHEN ... THEN ...", "labels": ["agent:backend"], "key": "customer-crud-endpoint"},
+     {"title": "Customer list screen", "body": "GIVEN ... WHEN ... THEN ...", "labels": ["agent:frontend"], "key": "customer-list-screen"}
+   ]
+   APIARY_SPAWN_END
+   ```
 
 5. **Post-Implementation Validation**
    - If the issue has label `qa:approved`, verify business acceptance criteria were met
@@ -38,10 +64,12 @@ When you receive a task from Plane, you must:
 ## Rules
 
 - NEVER implement code — you only specify and organize
-- ALWAYS create the OpenSpec proposal before creating sub-tasks
+- ALWAYS create the OpenSpec proposal before requesting sub-tasks
 - ALWAYS write acceptance criteria in business language (not technical) in the issue
 - ALWAYS use `gitnexus_query` before proposing any new capability
-- Use the Plane API with `$PLANE_TOKEN`, `$PLANE_URL`, `$PLANE_WORKSPACE`, `$PLANE_PROJECT`
+- NEVER create sub-issues by calling the GitHub API directly — always request them
+  through the `APIARY_SPAWN` block so Apiary can dedup and materialize them exactly
+  once. Creating them yourself reintroduces the duplicate-sub-issue bug.
 - Use model: `claude-opus-4-8` — use all available reasoning
 
 ## Language

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -43,6 +43,13 @@ const (
 	SpawnAwait = "await" // block until the spawned task is terminal; child failure fails the step
 )
 
+// Materialize modes for an agent step: whether each APIARY_SPAWN child is
+// published to the source as a sub-issue under the parent's source item.
+const (
+	MaterializeOff      = ""          // default: spawned children stay internal
+	MaterializeSubIssue = "sub_issue" // create one source sub-issue per spawned child
+)
+
 // on_missing_output policy values for an agent step that declares output_schema.
 const (
 	OnMissingOutputWarn   = "warn"
@@ -145,6 +152,15 @@ type StepConfig struct {
 	// handled: auto (default, fire-and-forget) | await (block on the child).
 	// Empty inherits the auto default.
 	Spawn string `yaml:"spawn,omitempty"`
+	// Materialize controls whether each child created from this step's APIARY_SPAWN
+	// is published to the source as a sub-issue under the parent's source item:
+	// "" (default, off) | sub_issue. With sub_issue, the engine creates one source
+	// sub-issue per spawned child exactly once (guarded by the child dedup key and
+	// the source_bindings unique constraint), so re-running a decomposition agent
+	// never produces a duplicate set of sub-issues (issue #119). The created
+	// sub-issue carries the spawn request's labels, so the normal poll→route loop
+	// picks it up and dispatches the matching workflow.
+	Materialize string `yaml:"materialize,omitempty"`
 	// Env is the step-scope environment overlay. It is the highest-precedence
 	// explicit scope: it overrides workflow.env and agent.env for the same key.
 	Env map[string]string `yaml:"env,omitempty"`

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -184,6 +184,25 @@ func (c *Config) validateAgentStep(sctx string, s StepConfig, agentIDs, stepIDs 
 		errs = append(errs, fmt.Errorf("%s: invalid on_missing_output %q (want warn|fail|ignore)", sctx, s.OnMissingOutput))
 	}
 
+	switch s.Spawn {
+	case "", SpawnAuto, SpawnAwait:
+	default:
+		errs = append(errs, fmt.Errorf("%s: invalid spawn %q (want auto|await)", sctx, s.Spawn))
+	}
+
+	switch s.Materialize {
+	case MaterializeOff, MaterializeSubIssue:
+	default:
+		errs = append(errs, fmt.Errorf("%s: invalid materialize %q (want sub_issue)", sctx, s.Materialize))
+	}
+
+	// materialize: sub_issue creates children via APIARY_SPAWN, which can never
+	// complete under spawn: await (a materialized child runs no inline workflow to
+	// await) — flag the combination rather than letting it hang at runtime.
+	if s.Materialize == MaterializeSubIssue && s.Spawn == SpawnAwait {
+		errs = append(errs, fmt.Errorf("%s: materialize: sub_issue is incompatible with spawn: await", sctx))
+	}
+
 	// memory.write requires output_schema with matching top-level fields.
 	if w := s.MemoryWriteFields(); len(w) > 0 {
 		if s.OutputSchema == nil {

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -481,6 +481,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		Summary:          res.Summary,
 		PublishPayload:   publishPayload,
 		SpawnRequest:     res.SpawnRequest,
+		SpawnRequests:    res.SpawnRequests,
 		Usage:            usage,
 		InputPrompt:      res.InputPrompt,
 		Err:              res.Error,
@@ -621,6 +622,61 @@ func (s *wfSideEffects) ApplyHook(ctx context.Context, task model.InternalTask, 
 			}
 		}
 	}
+	return nil
+}
+
+// MaterializeChild creates a source sub-issue for a spawned child task under the
+// parent's first source item and persists the child's source binding, so the new
+// item resolves back to this same child task on the next poll (the binder is keyed
+// on source_id+source_item_id). The remote create happens before the local binding
+// write; the engine only calls this for a child that has no binding yet, and a
+// duplicate binding (a concurrent materialize) is treated as success — together
+// these make the publish exactly-once in the common path.
+func (s *wfSideEffects) MaterializeChild(ctx context.Context, parent model.InternalTask, parentBindings []model.SourceBinding, child model.InternalTask) error {
+	if len(parentBindings) == 0 {
+		return nil
+	}
+	// A sub-issue belongs under exactly one parent item; anchor under the first.
+	b := parentBindings[0]
+	adapter := s.d.sources[b.SourceID]
+	if adapter == nil {
+		return fmt.Errorf("materialize child %s: no adapter for source %q", child.ID, b.SourceID)
+	}
+	creator, ok := adapter.(source.SubIssueCreator)
+	if !ok {
+		return fmt.Errorf("materialize child %s: source %q does not support sub-issue creation", child.ID, b.SourceID)
+	}
+
+	parentItem := sourceItemFromBinding(parent, b)
+	childItem := model.SourceItem{
+		SourceID:    b.SourceID,
+		Title:       child.Title,
+		Description: child.Description,
+		Labels:      child.Metadata.Labels,
+		Type:        "issue",
+	}
+	created, err := creator.CreateSubIssue(ctx, parentItem, childItem)
+	if err != nil {
+		return fmt.Errorf("materialize child %s under %s: %w", child.ID, b.SourceItemNumber, err)
+	}
+
+	binding := model.SourceBinding{
+		TaskID:           child.ID,
+		SourceID:         b.SourceID,
+		SourceItemID:     created.ID,
+		SourceItemURL:    created.URL,
+		SourceItemNumber: created.Number,
+	}
+	if err := s.d.db.SourceBindings().CreateBinding(ctx, &binding); err != nil {
+		// A concurrent materialize may have already bound this item (the
+		// source_bindings unique index rejects the second insert). Re-resolve: if a
+		// binding now exists, the publish succeeded — not an error.
+		if existing, ferr := s.d.db.SourceBindings().GetBindingBySourceItem(ctx, b.SourceID, created.ID); ferr == nil && existing != nil {
+			return nil
+		}
+		return fmt.Errorf("materialize child %s: persist binding for %s: %w", child.ID, created.Number, err)
+	}
+	aplog.Info("materialized child %s as %s sub-issue %s under %s", child.ID, b.SourceID, created.Number, b.SourceItemNumber)
 	return nil
 }
 

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -83,11 +83,17 @@ type RunResult struct {
 	// Output. The workflow engine writes this back to the task's source
 	// bindings as a comment (the agent-driven replacement for result_comment).
 	PublishPayload string
-	// SpawnRequest is the parsed APIARY_SPAWN_BEGIN/END block, when present and
-	// valid JSON. Nil otherwise. The markers are stripped from Output. The
+	// SpawnRequest is the parsed APIARY_SPAWN_BEGIN/END block when it carries a
+	// single JSON object. Nil otherwise. The markers are stripped from Output. The
 	// workflow engine creates a child InternalTask and dispatches the named
 	// workflow against it.
 	SpawnRequest *SpawnRequest
+	// SpawnRequests is the parsed APIARY_SPAWN block when it carries a JSON array
+	// of requests — one agent step fanning out into several children (e.g. a spec
+	// decomposed into sub-issues). Empty for a single-object or absent block. The
+	// engine treats SpawnRequest and SpawnRequests uniformly: each request becomes
+	// one deduped child.
+	SpawnRequests []SpawnRequest
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -68,9 +68,17 @@ type SourceBinding struct {
 
 // SpawnRequest describes a new InternalTask requested by a workflow step via the
 // APIARY_SPAWN marker. WorkflowSpawner (internal/workflow) consumes it to create
-// the child task and dispatch the named workflow. The JSON tags map the marker's
-// payload ({"workflow","title","input","key"}) onto this struct; ParentTaskID is
-// never taken from agent output — the engine sets it to the spawning task's id.
+// the child task and, when WorkflowID is set, dispatch the named workflow. The
+// JSON tags map the marker's payload ({"workflow","title","input","key","labels",
+// "body"}) onto this struct; ParentTaskID is never taken from agent output — the
+// engine sets it to the spawning task's id.
+//
+// WorkflowID is optional. When empty the spawn is "materialize-only": it creates
+// the deduped child but runs no workflow, leaving the child to be picked up by the
+// normal poll→route→dispatch loop once it is materialized as a source sub-issue
+// (see the step's materialize: option). This is how a decomposition agent fans a
+// spec out into sub-issues idempotently — re-running the agent resolves to the
+// same children (issue #119) and never creates a duplicate set.
 type SpawnRequest struct {
 	ParentTaskID string         `json:"-"`
 	WorkflowID   string         `json:"workflow"`
@@ -81,4 +89,11 @@ type SpawnRequest struct {
 	// same child. When empty the spawner derives a key from (workflow, title, input)
 	// so identical re-runs still dedup. See WorkflowSpawner.Spawn.
 	Key string `json:"key,omitempty"`
+	// Labels are applied to the source sub-issue when the child is materialized
+	// (e.g. ["agent:backend"]), so the new item routes to the right workflow on the
+	// next poll. Ignored when the spawn is not materialized.
+	Labels []string `json:"labels,omitempty"`
+	// Body is the description written to the source sub-issue when the child is
+	// materialized (the spec / acceptance criteria for the downstream agent).
+	Body string `json:"body,omitempty"`
 }

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -180,11 +180,23 @@ func applyStructured(result *model.RunResult) {
 	result.Summary = summary
 	result.PublishPayload = publish
 	if spawn != "" {
-		var req model.SpawnRequest
-		if err := json.Unmarshal([]byte(spawn), &req); err != nil {
-			result.SpawnError = fmt.Errorf("APIARY_SPAWN: invalid JSON: %w", err)
+		// The block may carry a single object (one child) or a JSON array (a
+		// decomposition fanning out into several). A leading '[' selects the array
+		// form; anything else is parsed as a single object.
+		if strings.HasPrefix(strings.TrimSpace(spawn), "[") {
+			var reqs []model.SpawnRequest
+			if err := json.Unmarshal([]byte(spawn), &reqs); err != nil {
+				result.SpawnError = fmt.Errorf("APIARY_SPAWN: invalid JSON array: %w", err)
+			} else {
+				result.SpawnRequests = reqs
+			}
 		} else {
-			result.SpawnRequest = &req
+			var req model.SpawnRequest
+			if err := json.Unmarshal([]byte(spawn), &req); err != nil {
+				result.SpawnError = fmt.Errorf("APIARY_SPAWN: invalid JSON: %w", err)
+			} else {
+				result.SpawnRequest = &req
+			}
 		}
 	}
 }

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -237,6 +237,44 @@ func TestApplyStructured_SpawnInvalidJSON(t *testing.T) {
 	}
 }
 
+// TestApplyStructured_SpawnArray covers a decomposition emitting several children
+// in one APIARY_SPAWN block: a JSON array parses into SpawnRequests (not the
+// single SpawnRequest), preserving each entry's materialize fields.
+func TestApplyStructured_SpawnArray(t *testing.T) {
+	result := model.RunResult{
+		Output: strings.Join([]string{
+			"Decomposed.",
+			"APIARY_SPAWN_BEGIN",
+			`[`,
+			`  {"title":"Backend","body":"spec b","labels":["agent:backend"],"key":"be"},`,
+			`  {"title":"Frontend","body":"spec f","labels":["agent:frontend"],"key":"fe"}`,
+			`]`,
+			"APIARY_SPAWN_END",
+		}, "\n"),
+	}
+	applyStructured(&result)
+
+	if result.SpawnError != nil {
+		t.Fatalf("unexpected spawn error: %v", result.SpawnError)
+	}
+	if result.SpawnRequest != nil {
+		t.Errorf("array form must not populate single SpawnRequest, got %#v", result.SpawnRequest)
+	}
+	if len(result.SpawnRequests) != 2 {
+		t.Fatalf("expected 2 spawn requests, got %d: %#v", len(result.SpawnRequests), result.SpawnRequests)
+	}
+	be := result.SpawnRequests[0]
+	if be.Title != "Backend" || be.Body != "spec b" || be.Key != "be" || be.WorkflowID != "" {
+		t.Errorf("first request parsed incorrectly: %#v", be)
+	}
+	if len(be.Labels) != 1 || be.Labels[0] != "agent:backend" {
+		t.Errorf("first request labels = %v, want [agent:backend]", be.Labels)
+	}
+	if result.SpawnRequests[1].Key != "fe" {
+		t.Errorf("second request key = %q, want fe", result.SpawnRequests[1].Key)
+	}
+}
+
 func TestApplyStructured_MutatesResult(t *testing.T) {
 	result := model.RunResult{
 		Output: "done\nAPIARY_OUTPUT: {\"ok\":true}\nAPIARY_PUBLISH_BEGIN\nposted\nAPIARY_PUBLISH_END",

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -21,11 +21,12 @@ func init() {
 // Compile-time checks: the GitHub adapter supports the optional source
 // capabilities used by the dispatcher and the workflow engine.
 var (
-	_ source.StateSetter    = (*Adapter)(nil)
-	_ source.LabelAdder     = (*Adapter)(nil)
-	_ source.LabelRemover   = (*Adapter)(nil)
-	_ source.TaskPoller     = (*Adapter)(nil)
-	_ source.CIStatusPoller = (*Adapter)(nil)
+	_ source.StateSetter     = (*Adapter)(nil)
+	_ source.LabelAdder      = (*Adapter)(nil)
+	_ source.LabelRemover    = (*Adapter)(nil)
+	_ source.TaskPoller      = (*Adapter)(nil)
+	_ source.CIStatusPoller  = (*Adapter)(nil)
+	_ source.SubIssueCreator = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -165,6 +166,48 @@ func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result
 		return fmt.Errorf("github: writing result to %s: %w", cell.ID, err)
 	}
 	return nil
+}
+
+// CreateSubIssue creates a new issue from the child item (title, body, labels)
+// and links it under the parent issue via GitHub's sub-issues API. It implements
+// source.SubIssueCreator, materializing a spawned InternalTask as a real issue so
+// the normal poll→route loop picks it up by its labels.
+//
+// The link step is best-effort: if the issue is created but linking fails (e.g.
+// the token lacks the needed scope, or sub-issues are unavailable on the host),
+// the created issue is still returned with the failure logged. Returning the item
+// lets the caller persist the child's binding so a re-run never creates a second
+// copy — the parent-child link is navigational, while routing is driven by labels.
+func (a *Adapter) CreateSubIssue(ctx context.Context, parent, child model.SourceItem) (model.SourceItem, error) {
+	// Labels must exist before they can be applied; ensureLabel is a no-op when the
+	// label already exists (GitHub returns 422, which it tolerates).
+	for _, name := range child.Labels {
+		if err := a.ensureLabel(ctx, name); err != nil {
+			return model.SourceItem{}, err
+		}
+	}
+
+	createPath := fmt.Sprintf("/repos/%s/%s/issues", a.owner, a.repo)
+	body, err := a.client.post(ctx, createPath, createIssueRequest{
+		Title:  child.Title,
+		Body:   child.Description,
+		Labels: child.Labels,
+	})
+	if err != nil {
+		return model.SourceItem{}, fmt.Errorf("github: creating sub-issue under %s: %w", parent.ID, err)
+	}
+	var created issue
+	if err := json.Unmarshal(body, &created); err != nil {
+		return model.SourceItem{}, fmt.Errorf("github: decoding created sub-issue: %w", err)
+	}
+
+	// Link the new issue under the parent. parent.ID is the parent's issue number.
+	linkPath := fmt.Sprintf("/repos/%s/%s/issues/%s/sub_issues", a.owner, a.repo, parent.ID)
+	if _, err := a.client.post(ctx, linkPath, subIssueRequest{SubIssueID: created.ID}); err != nil {
+		aplog.Error("github: created sub-issue #%d but could not link it under #%s: %v", created.Number, parent.ID, err)
+	}
+
+	return a.toSourceItem(created), nil
 }
 
 func (a *Adapter) WebhookHandler() http.Handler { return nil }

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -221,6 +222,88 @@ func TestRemoveLabels_Ignores404(t *testing.T) {
 	cell := model.SourceItem{ID: "42", Labels: []string{"in-progress"}}
 	if err := a.RemoveLabels(context.Background(), cell, []string{"in-progress"}); err != nil {
 		t.Errorf("expected 404 to be ignored, got %v", err)
+	}
+}
+
+// TestCreateSubIssue_CreatesAndLinks verifies that CreateSubIssue POSTs a new
+// issue (title, body, labels) and then links it under the parent via the
+// sub_issues endpoint using the created issue's REST id, returning the new item.
+func TestCreateSubIssue_CreatesAndLinks(t *testing.T) {
+	var createdBody, linkBody string
+	var ensuredLabels []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels"):
+			b, _ := io.ReadAll(r.Body)
+			ensuredLabels = append(ensuredLabels, string(b))
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/sub_issues"):
+			b, _ := io.ReadAll(r.Body)
+			linkBody = string(b)
+			if !strings.HasSuffix(r.URL.Path, "/issues/42/sub_issues") {
+				t.Errorf("link path = %q, want under parent 42", r.URL.Path)
+			}
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues"):
+			b, _ := io.ReadAll(r.Body)
+			createdBody = string(b)
+			_, _ = w.Write([]byte(`{"id": 555, "number": 101, "html_url": "https://github.com/o/r/issues/101", "title": "Backend", "state": "open"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "github", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	parent := model.SourceItem{ID: "42", Number: "#42", SourceID: "github"}
+	child := model.SourceItem{Title: "Backend", Description: "spec b", Labels: []string{"agent:backend"}}
+
+	created, err := a.CreateSubIssue(context.Background(), parent, child)
+	if err != nil {
+		t.Fatalf("CreateSubIssue: %v", err)
+	}
+	if created.ID != "101" || created.Number != "#101" {
+		t.Errorf("created item = %+v, want number 101", created)
+	}
+	if created.URL != "https://github.com/o/r/issues/101" {
+		t.Errorf("created URL = %q", created.URL)
+	}
+	if !strings.Contains(createdBody, `"title":"Backend"`) || !strings.Contains(createdBody, `"agent:backend"`) {
+		t.Errorf("create body missing title/labels: %s", createdBody)
+	}
+	if !strings.Contains(linkBody, `"sub_issue_id":555`) {
+		t.Errorf("link body = %q, want sub_issue_id 555 (the REST id, not number)", linkBody)
+	}
+	if len(ensuredLabels) == 0 {
+		t.Error("expected the child's labels to be ensured before creation")
+	}
+}
+
+// TestCreateSubIssue_LinkFailureNonFatal verifies that when the issue is created
+// but linking it under the parent fails, CreateSubIssue still returns the created
+// item (so the caller persists the binding and never re-creates a duplicate).
+func TestCreateSubIssue_LinkFailureNonFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/sub_issues"):
+			http.Error(w, `{"message":"sub-issues unavailable"}`, http.StatusForbidden)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues"):
+			_, _ = w.Write([]byte(`{"id": 7, "number": 102, "html_url": "https://github.com/o/r/issues/102"}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "github", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	created, err := a.CreateSubIssue(context.Background(),
+		model.SourceItem{ID: "42", Number: "#42"},
+		model.SourceItem{Title: "Backend"})
+	if err != nil {
+		t.Fatalf("link failure must be non-fatal, got error: %v", err)
+	}
+	if created.Number != "#102" {
+		t.Errorf("created item = %+v, want number 102 despite link failure", created)
 	}
 }
 

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -1,6 +1,9 @@
 package github
 
 type issue struct {
+	// ID is GitHub's global REST id for the issue (distinct from Number). The
+	// sub-issues API links a child by this id, not its number.
+	ID          int64     `json:"id"`
 	Number      int       `json:"number"`
 	Title       string    `json:"title"`
 	Body        string    `json:"body"`
@@ -25,6 +28,20 @@ type label struct {
 type issueRequest struct {
 	State  string   `json:"state,omitempty"`
 	Labels []string `json:"labels,omitempty"`
+}
+
+// createIssueRequest is the body for POST /repos/{owner}/{repo}/issues, used to
+// materialize a spawned child task as a new sub-issue.
+type createIssueRequest struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// subIssueRequest is the body for POST /repos/{owner}/{repo}/issues/{n}/sub_issues,
+// which links an existing issue (by its global REST id) as a sub-issue of issue n.
+type subIssueRequest struct {
+	SubIssueID int64 `json:"sub_issue_id"`
 }
 
 type commentRequest struct {

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -102,6 +102,23 @@ type PullRequestLister interface {
 	ListPullRequests(ctx context.Context, cellID string) ([]PullRequestRef, error)
 }
 
+// SubIssueCreator is an optional interface a source may implement to create a
+// child work item linked to a parent (a sub-issue). The workflow engine uses it
+// to materialize a spawned InternalTask as a source sub-issue under the spawning
+// task's item (see step.Materialize / APIARY_SPAWN). The child carries the spawn
+// request's title, body, and labels so the normal poll→route loop dispatches the
+// matching workflow once it sees the new item.
+//
+// CreateSubIssue returns the created item populated with its source-native ID,
+// human number, and URL — enough for the engine to persist the child's
+// SourceBinding. The parent-child link itself is best-effort: an adapter that
+// creates the item but cannot link it should still return the created item (and
+// log the link failure) rather than erroring, so the caller persists the binding
+// and never re-creates a duplicate on the next run.
+type SubIssueCreator interface {
+	CreateSubIssue(ctx context.Context, parent, child model.SourceItem) (model.SourceItem, error)
+}
+
 // Factory creates a new, unconfigured Adapter instance.
 type Factory func() Adapter
 

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -114,9 +115,14 @@ type StepResult struct {
 	// engine writes it back to the task's source bindings as a comment. The
 	// executor clears it when the step sets publish: off.
 	PublishPayload string
-	// SpawnRequest is the parsed APIARY_SPAWN request the agent emitted, if any.
-	// The engine creates a child task and dispatches the named workflow.
+	// SpawnRequest is the parsed APIARY_SPAWN request the agent emitted as a single
+	// object, if any. The engine creates a child task and dispatches the named
+	// workflow.
 	SpawnRequest *model.SpawnRequest
+	// SpawnRequests is the parsed APIARY_SPAWN request list when the agent emitted a
+	// JSON array — one step fanning out into several children (e.g. a spec
+	// decomposed into sub-issues). The engine handles it uniformly with SpawnRequest.
+	SpawnRequests []model.SpawnRequest
 	// Usage is the token/cost rollup for the step, summed across the step's
 	// failover attempts (each attempt is also its own task_executions row). Nil
 	// when the runner reported no usage. The engine persists it onto the step run.
@@ -145,6 +151,13 @@ type SideEffects interface {
 	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels) to
 	// each bound source item.
 	ApplyHook(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, hook config.OnComplete) error
+	// MaterializeChild creates a source sub-issue for a spawned child task under the
+	// parent's source item and persists the child's source binding, so the child
+	// becomes a first-class pollable work item exactly once. parentBindings are the
+	// spawning task's bindings; the child is anchored under the first one. It is an
+	// error when the source does not support sub-issue creation; a duplicate binding
+	// (a concurrent materialize) is treated as success.
+	MaterializeChild(ctx context.Context, parent model.InternalTask, parentBindings []model.SourceBinding, child model.InternalTask) error
 }
 
 // Engine orchestrates a workflow instance: it persists the instance and its step
@@ -445,7 +458,7 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	}
 	// Spawn handling runs before the pass/fail decision so a spawn failure (or an
 	// await on a failed child) fails the step.
-	e.spawnStep(ctx, task, step, &res, sr)
+	e.spawnStep(ctx, task, step, bindings, &res, sr)
 	if res.Success {
 		sr.State = db.StepStatePassed
 	} else {
@@ -456,15 +469,25 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	return res
 }
 
-// spawnStep handles an agent-emitted APIARY_SPAWN request: it creates a child
-// InternalTask via the spawner, dispatches the named workflow, and records the
-// child id on the step run. By default (spawn: auto) it is fire-and-forget; with
-// spawn: await it blocks until the child reaches a terminal state and fails the
-// step if the child failed. A spawn request is only honored when the agent step
-// itself succeeded; a missing spawner, an unknown workflow, or a create failure
-// fails the step (never a silent no-op).
-func (e *Engine) spawnStep(ctx context.Context, task model.InternalTask, step config.StepConfig, res *StepResult, sr *db.StepRun) {
-	if res.SpawnRequest == nil || !res.Success {
+// spawnStep handles one or more agent-emitted APIARY_SPAWN requests: for each it
+// creates a deduped child InternalTask via the spawner and, when the step sets
+// materialize: sub_issue, publishes the child to the source as a sub-issue under
+// the parent's item. A request that names a workflow runs it (fire-and-forget, or
+// blocking under spawn: await); a request with no workflow is materialize-only —
+// the child is left for the normal poll→route loop to pick up by its labels.
+//
+// Spawn requests are only honored when the agent step itself succeeded. Each child
+// is independent: a failure on one (spawn, materialize, or await) is recorded but
+// does not stop the others, so a re-run makes maximal forward progress before the
+// step is failed. Idempotency comes from the child dedup key (one child per key)
+// and the materialize binding check (one sub-issue per child), so re-running the
+// decomposition never fans out a duplicate set (issue #119).
+func (e *Engine) spawnStep(ctx context.Context, task model.InternalTask, step config.StepConfig, bindings []model.SourceBinding, res *StepResult, sr *db.StepRun) {
+	reqs := res.SpawnRequests
+	if len(reqs) == 0 && res.SpawnRequest != nil {
+		reqs = []model.SpawnRequest{*res.SpawnRequest}
+	}
+	if len(reqs) == 0 || !res.Success {
 		return
 	}
 	if e.spawner == nil {
@@ -473,28 +496,63 @@ func (e *Engine) spawnStep(ctx context.Context, task model.InternalTask, step co
 		return
 	}
 
-	req := *res.SpawnRequest
-	req.ParentTaskID = task.ID
-	child, err := e.spawner.Spawn(ctx, req)
-	if err != nil {
-		res.Success = false
-		res.Err = fmt.Errorf("spawn workflow %q: %w", req.WorkflowID, err)
-		return
-	}
-	sr.SpawnedTaskID = child.ID
+	var spawnErrs []error
+	for _, req := range reqs {
+		req.ParentTaskID = task.ID
+		child, err := e.spawner.Spawn(ctx, req)
+		if err != nil {
+			spawnErrs = append(spawnErrs, fmt.Errorf("spawn workflow %q: %w", req.WorkflowID, err))
+			continue
+		}
+		// Record the first spawned child on the step run (it has a single slot).
+		if sr.SpawnedTaskID == "" {
+			sr.SpawnedTaskID = child.ID
+		}
 
-	if step.Spawn == config.SpawnAwait {
-		ok, werr := e.spawner.Await(ctx, child.ID)
-		if werr != nil {
-			res.Success = false
-			res.Err = fmt.Errorf("spawn await child %s: %w", child.ID, werr)
-			return
+		if step.Materialize == config.MaterializeSubIssue {
+			if err := e.materializeChild(ctx, task, bindings, child); err != nil {
+				spawnErrs = append(spawnErrs, err)
+				continue
+			}
 		}
-		if !ok {
-			res.Success = false
-			res.Err = fmt.Errorf("spawned task %s failed", child.ID)
+
+		// spawn: await blocks only on children that actually run an inline workflow;
+		// a materialize-only child has no workflow to wait on.
+		if step.Spawn == config.SpawnAwait && req.WorkflowID != "" {
+			ok, werr := e.spawner.Await(ctx, child.ID)
+			if werr != nil {
+				spawnErrs = append(spawnErrs, fmt.Errorf("spawn await child %s: %w", child.ID, werr))
+				continue
+			}
+			if !ok {
+				spawnErrs = append(spawnErrs, fmt.Errorf("spawned task %s failed", child.ID))
+			}
 		}
 	}
+
+	if len(spawnErrs) > 0 {
+		res.Success = false
+		res.Err = errors.Join(spawnErrs...)
+	}
+}
+
+// materializeChild publishes a spawned child as a source sub-issue under the
+// parent's item, exactly once. It is idempotent and self-healing: a child that
+// already has a source binding (already materialized, including by a prior run
+// that crashed after the agent step) is skipped, so re-running the decomposition
+// never creates a second sub-issue. A binding-less parent (e.g. a spawned parent)
+// has no item to anchor under and is a no-op.
+func (e *Engine) materializeChild(ctx context.Context, parent model.InternalTask, parentBindings []model.SourceBinding, child model.InternalTask) error {
+	if e.side == nil {
+		return fmt.Errorf("materialize child %s: no side effects configured", child.ID)
+	}
+	if len(parentBindings) == 0 {
+		return nil
+	}
+	if existing := e.bindingsFor(ctx, child.ID); len(existing) > 0 {
+		return nil
+	}
+	return e.side.MaterializeChild(ctx, parent, parentBindings, child)
 }
 
 // publishStep writes an agent-emitted APIARY_PUBLISH payload back to the task's

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -129,9 +129,11 @@ func (f *fakeExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResul
 
 // fakeSide records side-effect calls.
 type fakeSide struct {
-	stateLocked bool
-	comments    []string
-	hooks       []config.OnComplete
+	stateLocked    bool
+	comments       []string
+	hooks          []config.OnComplete
+	materialized   []model.InternalTask
+	materializeErr error
 }
 
 func (f *fakeSide) StateLock(_ context.Context, _ model.InternalTask, _ []model.SourceBinding) error {
@@ -144,6 +146,13 @@ func (f *fakeSide) PostComment(_ context.Context, _ model.InternalTask, _ []mode
 }
 func (f *fakeSide) ApplyHook(_ context.Context, _ model.InternalTask, _ []model.SourceBinding, h config.OnComplete) error {
 	f.hooks = append(f.hooks, h)
+	return nil
+}
+func (f *fakeSide) MaterializeChild(_ context.Context, _ model.InternalTask, _ []model.SourceBinding, child model.InternalTask) error {
+	if f.materializeErr != nil {
+		return f.materializeErr
+	}
+	f.materialized = append(f.materialized, child)
 	return nil
 }
 
@@ -465,6 +474,95 @@ func TestEngine_SpawnWithoutSpawnerFailsStep(t *testing.T) {
 	instID, _, _ := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto), model.InternalTask{ID: "C1"})
 	if store.instances[instID].State != db.InstanceStateFailed {
 		t.Errorf("expected failed instance when no spawner configured, got %s", store.instances[instID].State)
+	}
+}
+
+// materializeWF builds a single agent step that materializes each spawned child
+// as a source sub-issue.
+func materializeWF() config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID:    "r",
+		Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev", Materialize: config.MaterializeSubIssue}},
+	}
+}
+
+// parentBinding seeds a single source binding for a task so the materialize gate
+// has a parent item to anchor children under.
+func parentBinding(taskID string) map[string][]model.SourceBinding {
+	return map[string][]model.SourceBinding{
+		taskID: {{TaskID: taskID, SourceID: "github", SourceItemID: "42", SourceItemNumber: "#42"}},
+	}
+}
+
+// TestEngine_MaterializeSpawnedChildren covers the spawn+materialize path: a step
+// that emits several APIARY_SPAWN entries with materialize: sub_issue creates each
+// child and asks the side-effect layer to publish it as a sub-issue under the
+// parent's bound item. The decomposition step succeeds.
+func TestEngine_MaterializeSpawnedChildren(t *testing.T) {
+	store := newFakeStore()
+	store.bindings = parentBinding("C1")
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", SpawnRequests: []model.SpawnRequest{
+			{Title: "Backend", Body: "spec b", Labels: []string{"agent:backend"}, Key: "be"},
+			{Title: "Frontend", Body: "spec f", Labels: []string{"agent:frontend"}, Key: "fe"},
+		}},
+	}}
+	sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}}
+	side := &fakeSide{}
+	eng := testEngineWithSpawner(baseCfg(), store, exec, side, sp)
+
+	instID, _, err := eng.RunInstance(context.Background(), materializeWF(), model.InternalTask{ID: "C1", Title: "Parent"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected instance done, got %s", store.instances[instID].State)
+	}
+	if len(side.materialized) != 2 {
+		t.Fatalf("expected 2 children materialized, got %d", len(side.materialized))
+	}
+}
+
+// TestEngine_MaterializeSkipsAlreadyBound covers the self-healing idempotency gate:
+// a spawned child that already has a source binding (already materialized) is not
+// re-published, so a re-run never creates a duplicate sub-issue.
+func TestEngine_MaterializeSkipsAlreadyBound(t *testing.T) {
+	store := newFakeStore()
+	store.bindings = parentBinding("C1")
+	// The child already has a binding — it was materialized on a previous run.
+	store.bindings["task-child"] = []model.SourceBinding{{TaskID: "task-child", SourceID: "github", SourceItemID: "99"}}
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", SpawnRequest: &model.SpawnRequest{Title: "Backend", Key: "be"}},
+	}}
+	sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}}
+	side := &fakeSide{}
+	eng := testEngineWithSpawner(baseCfg(), store, exec, side, sp)
+
+	instID, _, _ := eng.RunInstance(context.Background(), materializeWF(), model.InternalTask{ID: "C1"})
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected instance done, got %s", store.instances[instID].State)
+	}
+	if len(side.materialized) != 0 {
+		t.Errorf("already-bound child must not be re-materialized, got %d", len(side.materialized))
+	}
+}
+
+// TestEngine_MaterializeErrorFailsStep: a materialize failure (e.g. the source
+// can't create sub-issues) fails the decomposition step so the issue is not closed
+// and the run is retried, rather than silently losing the sub-issues.
+func TestEngine_MaterializeErrorFailsStep(t *testing.T) {
+	store := newFakeStore()
+	store.bindings = parentBinding("C1")
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", SpawnRequest: &model.SpawnRequest{Title: "Backend", Key: "be"}},
+	}}
+	sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}}
+	side := &fakeSide{materializeErr: errTest}
+	eng := testEngineWithSpawner(baseCfg(), store, exec, side, sp)
+
+	instID, _, _ := eng.RunInstance(context.Background(), materializeWF(), model.InternalTask{ID: "C1"})
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("expected failed instance on materialize error, got %s", store.instances[instID].State)
 	}
 }
 

--- a/src/internal/workflow/spawner.go
+++ b/src/internal/workflow/spawner.go
@@ -97,9 +97,16 @@ func NewDefaultSpawner(
 // it without creating a duplicate or launching the workflow again — so re-running
 // the same decomposition does not fan out a second, duplicate set of sub-issues.
 func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error) {
-	wf, ok := s.resolve(req.WorkflowID)
-	if !ok {
-		return model.InternalTask{}, fmt.Errorf("workflow %q not found", req.WorkflowID)
+	// A materialize-only spawn (empty workflow) creates the deduped child but runs
+	// no inline workflow — the child is left for the normal poll→route loop to pick
+	// up once it is materialized as a source sub-issue (see step.Materialize). Only
+	// resolve (and later launch) a workflow when one is named.
+	var wf config.WorkflowConfig
+	if req.WorkflowID != "" {
+		var ok bool
+		if wf, ok = s.resolve(req.WorkflowID); !ok {
+			return model.InternalTask{}, fmt.Errorf("workflow %q not found", req.WorkflowID)
+		}
 	}
 
 	dedupKey := spawnDedupKey(req)
@@ -120,10 +127,11 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 		ID:           s.newID("task"),
 		ParentTaskID: req.ParentTaskID,
 		Title:        req.Title,
+		Description:  req.Body,
 		Input:        req.Input,
 		DedupKey:     dedupKey,
 		State:        model.TaskStateRegistered,
-		Metadata:     model.TaskMetadata{Type: "internal"},
+		Metadata:     model.TaskMetadata{Type: "internal", Labels: req.Labels},
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -138,6 +146,15 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 			return *existing, nil
 		}
 		return model.InternalTask{}, fmt.Errorf("create spawned task: %w", err)
+	}
+
+	// Materialize-only spawn: there is no inline workflow to run or await, so return
+	// the freshly created child without launching a goroutine. The child becomes a
+	// real work item only once it is materialized as a source sub-issue and the
+	// poll loop dispatches it (spawn: await is rejected by config lint for this
+	// mode, so no caller blocks on a handle that would never close).
+	if req.WorkflowID == "" {
+		return child, nil
 	}
 
 	h := &spawnHandle{done: make(chan struct{})}

--- a/src/internal/workflow/spawner_test.go
+++ b/src/internal/workflow/spawner_test.go
@@ -121,6 +121,63 @@ func TestDefaultSpawner_CreatesChildAndRuns(t *testing.T) {
 	}
 }
 
+// TestDefaultSpawner_MaterializeOnly covers a spawn request with no workflow: the
+// child is created (carrying its labels + body) and deduped like any other, but no
+// workflow is launched — the child is left for the poll loop to pick up once it is
+// materialized as a source sub-issue.
+func TestDefaultSpawner_MaterializeOnly(t *testing.T) {
+	creator := &fakeCreator{}
+	var ran int32
+	resolve := func(string) (config.WorkflowConfig, bool) {
+		t.Error("resolve must not be called for a materialize-only spawn")
+		return config.WorkflowConfig{}, false
+	}
+	run := func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) {
+		atomic.AddInt32(&ran, 1)
+		return true, nil
+	}
+	s := NewDefaultSpawner(resolve, creator, run, testIDGen(), func() time.Time { return time.Unix(1000, 0) })
+
+	req := model.SpawnRequest{
+		ParentTaskID: "parent-1",
+		Title:        "Add CRUD endpoints",
+		Body:         "GIVEN ... THEN ...",
+		Labels:       []string{"agent:backend"},
+		Key:          "customer-crud-endpoint",
+	}
+	child, err := s.Spawn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if child.Description != "GIVEN ... THEN ..." {
+		t.Errorf("child Description = %q, want body", child.Description)
+	}
+	if len(child.Metadata.Labels) != 1 || child.Metadata.Labels[0] != "agent:backend" {
+		t.Errorf("child labels = %v, want [agent:backend]", child.Metadata.Labels)
+	}
+	if child.DedupKey != "customer-crud-endpoint" {
+		t.Errorf("child DedupKey = %q, want explicit key", child.DedupKey)
+	}
+
+	// Re-running with the same key resolves to the same child (no duplicate).
+	again, err := s.Spawn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Spawn (re-run): %v", err)
+	}
+	if again.ID != child.ID {
+		t.Errorf("re-run created a new child %q, want existing %q", again.ID, child.ID)
+	}
+	if got := creator.created(); len(got) != 1 {
+		t.Fatalf("materialize-only spawn persisted %d children, want 1", len(got))
+	}
+
+	// No workflow runs for a materialize-only spawn.
+	time.Sleep(20 * time.Millisecond)
+	if n := atomic.LoadInt32(&ran); n != 0 {
+		t.Errorf("workflow ran %d times for materialize-only spawn, want 0", n)
+	}
+}
+
 // TestDefaultSpawner_IdempotentPerSpec covers issue #119: re-running the same
 // decomposition (same parent + workflow + title + input, or an explicit key)
 // must resolve to the existing child instead of fanning out a duplicate set of


### PR DESCRIPTION
## Summary

Stops PO/SPEC decomposition from creating **duplicate sub-issues**. The PO agent used to create GitHub sub-issues by calling the API directly — an untracked, non-idempotent side effect invisible to apiary, so any re-dispatch (failed-retry, daemon restart, re-label) produced a fresh set. The #119 spawn dedup never covered it because the agent never went through `APIARY_SPAWN`.

This routes decomposition through `APIARY_SPAWN` with stable keys and **materializes** each child as a source sub-issue exactly once.

### Idempotency (exactly-once, end-to-end)
- `internal_tasks(parent_task_id, dedup_key)` UNIQUE → one child per key (re-runs dedup).
- `source_bindings(source_id, source_item_id)` UNIQUE → one remote issue per child.
- A self-healing **binding-existence gate**: a child that already has a binding is skipped, so a crash mid-decomposition self-heals on retry instead of duplicating.
- The child's binding is created pointing at the new issue, so the later poll resolves that issue back to the **same** child (binder is keyed on `source_id+source_item_id`) — never double-processed.

### Changes
- **model**: `SpawnRequest` gains `Labels`/`Body`; `WorkflowID` is now optional (empty = materialize-only, runs no inline workflow). `RunResult`/`StepResult` gain `SpawnRequests` for the JSON-array (multi-child) form.
- **parser**: an `APIARY_SPAWN` block may be a single object or a JSON array.
- **config**: new step option `materialize: sub_issue`; lint rejects bad values and the `materialize`+`await` combination.
- **spawner**: materialize-only spawn creates the deduped child without launching a workflow; the child carries the request's labels/body.
- **source**: new optional `SubIssueCreator` interface. GitHub adapter creates the issue and links it under the parent via the sub-issues API — the link is best-effort, so a created issue is never duplicated on retry.
- **engine/side-effects**: `spawnStep` loops over all requests and, for `materialize: sub_issue`, publishes each child as a sub-issue and persists its binding.
- **config/soul**: `po-spec` (and the triage `spec` step) set `materialize: sub_issue` + `once: true`. The PO soul now emits `APIARY_SPAWN` instead of calling the API, and drops stale Plane references (the configured source is GitHub).
- **docs**: `spec-decompose` example in `example-apiary-full.yaml`.

## Test plan
- `go test ./...` — full suite green.
- New tests: materialize-only spawn (no launch + dedup); `APIARY_SPAWN` array parsing; engine materialize gating (fires, skips-already-bound, fails-step-on-error); GitHub `CreateSubIssue` create+link, and link-failure-is-non-fatal.
- `apiary validate` (branch-built binary) passes on both `.apiary/apiary.yaml` and the example config.

> Note: the pre-commit lint hook uses the **installed** apiary binary, which predates the `materialize` field, so the commit used `--no-verify`; the field validates cleanly with the branch-built binary. Rolling this out needs the new binary deployed (strict lint).