### PR TITLE
docs: bump pinned-version example to 0.3.0

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ as the original.
 !!! tip "Pin a version"
     Apiary is in public beta — config and adapter APIs may still change
     before `v1.0`. For anything you depend on, pin a release (e.g. the
-    `ghcr.io/orlandoburli/apiary:0.2.0` Docker tag) and read the
+    `ghcr.io/orlandoburli/apiary:0.3.0` Docker tag) and read the
     [release notes](https://github.com/orlandoburli/apiary/releases) before
     upgrading.
 


### PR DESCRIPTION
Prep for the v0.3.0 release: the "pin a version" tip in the installation guide now points at the 0.3.0 Docker tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)