### PR TITLE
docs: add a dedicated Runners page; correct stale runner config in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ See [Rate Limits & Resilience](docs/resilience.md) for details.
 | [Installation](docs/installation.md) | Homebrew, Scoop, Docker, deb/rpm, direct download |
 | [Quickstart](docs/quickstart.md) | From install to your first autonomously handled issue |
 | [Concepts](docs/concepts.md) | Vocabulary, architecture, lifecycle of a task |
-| [Configuration](docs/configuration.md) | Every field of `apiary.yaml` — runners, sources, agents, settings |
+| [Configuration](docs/configuration.md) | Every field of `apiary.yaml` — sources, agents, settings |
+| [Runners](docs/runners.md) | CLI and API execution engines, provider presets, MCP servers |
 | [Workflows](docs/workflows.md) | Triggers, steps, approval gates, CI waits, retry loops |
 | [Tasks & Fan-out](docs/tasks-and-fanout.md) | `APIARY_PUBLISH`, `APIARY_SPAWN`, task-level hooks |
 | [Rate Limits & Resilience](docs/resilience.md) | Failover chains and unattended-dispatch safeguards |
@@ -169,22 +170,17 @@ Apiary supports a `cli` runner adapter that invokes agent CLI tools (such as `op
 runners:
   - id: opencode
     type: cli
-    provider: opencode
-    config:
-      binary: opencode        # CLI binary on your PATH
-      model_flag: "--model"   # flag used to pass the model
+    provider: opencode        # presets: binary, prompt passing, MCP format
 
 agents:
   - id: my-agent
     runner: opencode          # references the runner above
     model: opencode-go/deepseek-v4-pro
-    config:
-      working_dir: /my/repo   # where the agent runs
 ```
 
 **Important:** Apiary never handles, stores, intercepts, or transmits authentication credentials of any kind. CLI tools manage their own authentication independently. The `cli` runner simply invokes the binary — it has no knowledge of how the tool authenticates.
 
-This runner is intended for **personal use on your own machine**, where you have already set up and authenticated the CLI tool yourself. For shared or team deployments, use an API-key-based runner instead (see roadmap).
+This runner is intended for **personal use on your own machine**, where you have already set up and authenticated the CLI tool yourself. For shared or team deployments, use an API-key-based runner instead. See [Runners](docs/runners.md) for all providers and engine options.
 
 ## Dashboard
 

--- a/docs/apiary-guide.md
+++ b/docs/apiary-guide.md
@@ -8,6 +8,8 @@ This page has been split into focused sections:
   of a task.
 - **[Configuration](configuration.md)** — every field of `apiary.yaml`:
   runners, sources, agents, settings, environment variables.
+- **[Runners](runners.md)** — CLI and API execution engines, provider
+  presets, MCP servers.
 - **[Workflows](workflows.md)** — triggers, steps, structured outputs,
   approval gates, CI waits, retry loops.
 - **[Tasks & Fan-out](tasks-and-fanout.md)** — `APIARY_PUBLISH`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,11 @@ version: "1"        # currently the only accepted value
 
 ## `runners`
 
-Runners define **how** agents execute. Each runner pairs an execution `type`
-(`cli` for a subprocess, `api` for a direct HTTP call) with a `provider`
-adapter.
+Runners define **how** agents execute — a CLI subprocess (`claude`,
+`opencode`, the Cursor `agent` CLI) or a direct API call. They have a
+[dedicated page](runners.md) covering each provider, the engine options,
+prompt delivery, MCP wiring, and API runners; this section is the short
+version.
 
 ```yaml
 runners:
@@ -47,34 +49,18 @@ runners:
     config:
       args: ["--output-format", "stream-json", "--verbose"]
 
-  # Anthropic API
-  - id: claude-api
-    type: cli
-    provider: anthropic
-    config:
-      provider: anthropic
-      base_url: https://api.anthropic.com/v1
-      api_key: ${ANTHROPIC_API_KEY}
-
   # OpenCode CLI — requires the `opencode` binary on PATH
-  - id: opencode-go-cli
+  - id: opencode
     type: cli
     provider: opencode
-    config:
-      mode: cli
-      subscription: go
-      binary: opencode
-      agent: backend-dev
 
   # OpenCode API
-  - id: opencode-go-api
+  - id: opencode-api
     type: opencode-api
     config:
-      subscription: go
-      api_key: ${OPENCODE_GO_API_KEY}
+      api_key: ${OPENCODE_API_KEY}
     models:
       - opencode-go/deepseek-v4-pro
-      - opencode-go/minimax-m3
 
 default_runner: claude    # used by agents that don't name a runner
 ```
@@ -82,11 +68,11 @@ default_runner: claude    # used by agents that don't name a runner
 | Field | Description |
 |---|---|
 | `id` | Unique runner identifier, referenced by `agents[].runner` and `agents[].fallbacks` |
-| `type` | `cli` (subprocess) or `api` |
-| `provider` | Adapter: `claude`, `anthropic`, `opencode`, `cursor`, … |
-| `config` | Provider-specific settings (binary, flags, base URL, API key) |
-| `models` | Models this runner supports (informational / for API runners) |
-| `mcps` | MCP servers exposed to every agent on this runner — see below |
+| `type` | `cli` (subprocess) or a self-contained adapter like `opencode-api` |
+| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `cursor` |
+| `config` | Engine options — binary, flags, API key; see [Runners](runners.md#cli-engine-configuration) |
+| `models` | Models this runner supports (informational) |
+| `mcps` | [MCP servers](runners.md#mcp-servers) exposed to every agent on this runner |
 
 !!! tip "Recommended Claude CLI args"
     `args: ["--output-format", "stream-json", "--verbose"]` makes the Claude
@@ -94,53 +80,6 @@ default_runner: claude    # used by agents that don't name a runner
     `[assistant]` / `[tool→ …]` conversation in the
     [task logs](dashboard.md#watching-the-live-conversation-debug-mode),
     plus accurate token and cost figures. Without it you get raw text output.
-
-### CLI provider flags
-
-For generic CLI providers, the flag names used to pass parameters are
-configurable (defaults shown):
-
-| Config field | Default |
-|---|---|
-| `model_flag` | `--model` |
-| `prompt_flag` | `--prompt` |
-| `turns_flag` | `--max-turns` |
-| `agent_flag` | `--agent` |
-
-The OpenCode CLI uses a `run` subcommand with a positional prompt
-(`prompt_positional: true` is its default).
-
-### MCP servers (`mcps`)
-
-Runners (and individual agents) can expose
-[Model Context Protocol](https://modelcontextprotocol.io) servers to the CLI
-agents they launch. Each provider injects them into its own native MCP
-config: `claude` via a temp file + `--mcp-config`, `cursor` by merging
-`~/.cursor/mcp.json`, `opencode` by merging the global `opencode.json`.
-
-```yaml
-runners:
-  - id: claude
-    type: cli
-    provider: claude
-    mcps:
-      - name: gitnexus
-        command: npx
-        args: ["-y", "gitnexus@latest", "mcp"]
-        # env:                          # optional; ${VAR} expanded at load
-        #   GITNEXUS_TOKEN: ${GITNEXUS_TOKEN}
-
-agents:
-  - id: qa
-    runner: claude
-    model: claude-sonnet-4-6
-    # Agent-scope MCPs are layered over the runner's: same name overrides,
-    # new names are appended. Use this to give one agent an extra tool.
-    mcps:
-      - name: playwright
-        command: npx
-        args: ["-y", "@playwright/mcp@latest"]
-```
 
 ## `sources`
 
@@ -231,7 +170,7 @@ agents:
 | `source_token` | no | Source API token for this agent's write operations — see [Agent identity](#agent-identity) |
 | `source_email` / `source_name` | no | Git author identity exported to the runner environment |
 | `fallbacks` | no | Ordered `{runner, model}` list for [rate-limit failover](resilience.md#provider-rate-limits-failover); `model` optional (empty = that runner's default) |
-| `mcps` | no | Agent-scope [MCP servers](#mcp-servers-mcps), layered over the runner's |
+| `mcps` | no | Agent-scope [MCP servers](runners.md#mcp-servers), layered over the runner's |
 | `env` | no | Agent-scope environment variables — see [Environment variables](#environment-variables) |
 
 Which tasks reach an agent is decided by a

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -1,0 +1,236 @@
+# Runners
+
+A runner defines **how** agents execute. Agents decide *what* to do (model,
+persona, skills); the runner is the engine that actually launches the LLM —
+either as a **CLI subprocess** on the host or as a direct **API call**.
+
+```yaml
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+    config:
+      args: ["--output-format", "stream-json", "--verbose"]
+
+default_runner: claude
+
+agents:
+  - id: engineer
+    runner: claude            # ← references the runner above
+    model: claude-sonnet-4-6
+```
+
+Several agents can share one runner — each gets its own configured instance,
+so per-agent MCP servers and identity don't leak between them.
+
+| Field | Description |
+|---|---|
+| `id` | Unique identifier, referenced by `agents[].runner` and `agents[].fallbacks` |
+| `type` | Execution engine: `cli` (subprocess) — or a self-contained adapter name like `opencode-api` |
+| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `cursor` |
+| `config` | Engine options — see [CLI engine configuration](#cli-engine-configuration) |
+| `models` | Models this runner supports (informational) |
+| `mcps` | MCP servers exposed to every agent on this runner — see [MCP servers](#mcp-servers) |
+
+**How `type` and `provider` resolve.** Apiary picks the adapter by combining
+them as `{provider}-{type}` (or just `type` when `provider` is empty). The
+registered adapters are:
+
+| Adapter | YAML | Launches |
+|---|---|---|
+| `claude-cli` | `type: cli`, `provider: claude` | the `claude` binary |
+| `opencode-cli` | `type: cli`, `provider: opencode` | the `opencode` binary |
+| `cursor-cli` | `type: cli`, `provider: cursor` | the `agent` binary (Cursor CLI) |
+| `opencode-api` | `type: opencode-api` | HTTP calls to the OpenCode API |
+
+Any other combination fails at startup with `runner type not found`.
+
+## CLI runners
+
+A `cli` runner invokes the agent tool as a subprocess for each step, streams
+its stdout/stderr into the task logs, tracks its PID and heartbeats, and
+enforces the run timeout (`settings.task_timeout`). The subprocess inherits
+the daemon's environment plus the
+[env overlay](configuration.md#environment-variables) and the agent's
+[git/source identity](configuration.md#agent-identity).
+
+!!! note "Credentials stay with the tool"
+    Apiary never handles, stores, or transmits provider credentials for CLI
+    runners. The `claude` / `opencode` / `agent` binaries authenticate exactly
+    as they do when you run them by hand — Apiary just invokes them. This is
+    what makes the `cli` type a good fit for personal machines where the
+    tools are already logged in.
+
+### Providers
+
+Each provider preconfigures the engine — binary name, how the prompt and
+model are passed, and the MCP format. You usually only add `args`.
+
+#### Claude (`provider: claude`)
+
+Requires the `claude` binary on `PATH`.
+
+```yaml
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+    config:
+      args: ["--output-format", "stream-json", "--verbose"]
+```
+
+The `args` shown are strongly recommended: with `stream-json`, Apiary parses
+Claude's structured event stream into
+
+- readable `[assistant]` / `[tool→ …]` / `[tool← result]` lines in the
+  [task logs](dashboard.md#watching-the-live-conversation-debug-mode),
+- exact token counts and `cost_usd` per run (reported, not estimated),
+- `rate_limit_event` detection, which drives
+  [failover](resilience.md#provider-rate-limits-failover).
+
+Without them the agent still runs — you just see raw text output and lose
+usage/rate-limit parsing.
+
+#### OpenCode (`provider: opencode`)
+
+Requires the `opencode` binary on `PATH`. The preset invokes
+`opencode run …` with the prompt as a positional argument.
+
+```yaml
+runners:
+  - id: opencode
+    type: cli
+    provider: opencode
+```
+
+#### Cursor (`provider: cursor`)
+
+Requires the Cursor CLI (`agent` binary, from
+[cursor.com/install](https://cursor.com/install)). The preset runs it
+headlessly: `agent -p --output-format stream-json --force` (with `--force`
+auto-approving file changes) and passes the prompt positionally.
+
+```yaml
+runners:
+  - id: cursor
+    type: cli
+    provider: cursor
+```
+
+### CLI engine configuration
+
+All `config` keys, with each provider's preset defaults:
+
+| Key | Description | claude | opencode | cursor |
+|---|---|---|---|---|
+| `command` | Binary to invoke (override to use a wrapper or absolute path) | `claude` | `opencode` | `agent` |
+| `args` | Extra argv prepended to every run | — | `run` | `-p --output-format stream-json --force` |
+| `model_flag` | Flag used to pass the step's model | `--model` | `--model` | `--model` |
+| `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* |
+| `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` |
+| `turns_flag` | Flag used to pass a max-turns limit | — | — | — |
+
+Prompt delivery: via `prompt_flag` when set, as the last positional argument
+when `prompt_positional: true`, otherwise on **stdin**.
+
+## API runners
+
+API runners skip the subprocess and POST to a chat-completions endpoint
+directly. The built-in adapter is `opencode-api`:
+
+```yaml
+runners:
+  - id: opencode-api
+    type: opencode-api
+    config:
+      api_key: ${OPENCODE_API_KEY}
+      # base_url: https://api.opencode.ai/v1   # optional override
+    models:
+      - opencode-go/deepseek-v4-pro
+      - opencode-go/minimax-m3
+```
+
+| Key | Description |
+|---|---|
+| `api_key` | Sent as `Authorization: Bearer <key>` |
+| `base_url` | Override the API base; `/chat/completions` is appended |
+| `endpoint` | Full URL override (takes precedence over `base_url`) |
+
+The request/response shape is OpenAI-compatible chat completions. API runners
+are the right choice for shared or headless deployments where no
+pre-authenticated CLI tool exists on the host.
+
+!!! warning
+    An API runner sends the task prompt to the provider directly. CLI tools
+    that do their own context-gathering (file reads, shell, MCP) are far more
+    capable for implementation work — prefer `cli` runners for coding agents
+    and API runners for lightweight classification or as fallback capacity.
+
+## MCP servers
+
+Runners (and individual agents) can expose
+[Model Context Protocol](https://modelcontextprotocol.io) servers to the CLI
+tools they launch:
+
+```yaml
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+    mcps:
+      - name: gitnexus
+        command: npx
+        args: ["-y", "gitnexus@latest", "mcp"]
+        # env:                       # optional; ${VAR} expanded at load
+        #   GITNEXUS_TOKEN: ${GITNEXUS_TOKEN}
+
+agents:
+  - id: qa
+    runner: claude
+    model: claude-sonnet-4-6
+    mcps:                            # agent-scope: merged over the runner's
+      - name: playwright
+        command: npx
+        args: ["-y", "@playwright/mcp@latest"]
+```
+
+Runner-level `mcps` apply to every agent on the runner; agent-level `mcps`
+are layered on top — same `name` overrides, new names are appended. Each
+provider receives the merged list in its own native format:
+
+| Provider | Mechanism |
+|---|---|
+| claude | temp `.mcp.json` passed with `--mcp-config <path>` (trusted, no approval prompt, no workdir mutation) |
+| cursor | merged into `~/.cursor/mcp.json`, activated with `--approve-mcps` |
+| opencode | merged into the global `opencode.json` `mcp` block |
+
+The MCP configs are materialized once at daemon startup, not per run.
+
+## Fallbacks: runners as failover capacity
+
+An agent's `fallbacks` chain lists alternative `{runner, model}` pairs to try
+when its primary runner is rejected by a provider rate limit:
+
+```yaml
+agents:
+  - id: engineer
+    runner: claude
+    model: claude-sonnet-4-6
+    fallbacks:
+      - {runner: opencode, model: opencode-go/deepseek-v4-pro}
+      - {runner: cursor, model: composer-2.5-fast}
+```
+
+Every entry must reference a defined runner; `model` is optional (empty uses
+that runner's default). Fallback adapters are instantiated and configured at
+startup — including their MCP setup — so failover never pays an
+initialization cost on the hot path. The full behavior is described in
+[Rate Limits & Resilience](resilience.md#provider-rate-limits-failover).
+
+## Adding a provider
+
+Runner adapters are small: a provider registers a factory that preconfigures
+one of the generic engines (subprocess or HTTP). See the
+[Plugin API spec](https://github.com/orlandoburli/apiary/blob/main/openspec/specs/plugin-api/spec.md)
+and `src/internal/runner/providers/` for the current registrations —
+contributions are welcome.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - Guide:
       - Concepts: concepts.md
       - Configuration: configuration.md
+      - Runners: runners.md
       - Workflows: workflows.md
       - Tasks & Fan-out: tasks-and-fanout.md
       - Rate Limits & Resilience: resilience.md


### PR DESCRIPTION
## Summary

- **New [Runners] page** under Guide → after Configuration, documenting runners end to end, verified against the code (`src/internal/runner/providers/providers.go`, `execution/cli.go`, `execution/api.go`, `execution/cli_mcp.go`, `config.AdapterName`):
  - how `type` + `provider` resolve to an adapter, and the four registered adapters (`claude-cli`, `opencode-cli`, `cursor-cli`, `opencode-api`)
  - per-provider presets (binary, args, prompt delivery) and the full CLI engine config-key table
  - what the recommended Claude `stream-json` args actually buy (readable logs, exact usage/cost, rate-limit detection)
  - API runner configuration (`api_key`/`base_url`/`endpoint`, OpenAI-compatible shape) and when to prefer CLI vs API
  - MCP server wiring per provider (claude `--mcp-config` temp file, cursor `~/.cursor/mcp.json` + `--approve-mcps`, opencode global `opencode.json`), runner-level vs agent-level merge
  - fallbacks as pre-instantiated failover capacity
- **Corrects stale config shapes** that the code does not support, previously shown in `configuration.md` and the README (inherited from `.apiary/example-apiary-full.yaml`):
  - the `provider: anthropic` runner — adapter key "anthropic-cli" is **not registered**, so that example fails at daemon startup with "runner type not found"
  - opencode `mode`/`subscription`/`binary`/`agent`/`agent_flag` keys — not consumed anywhere; the binary override key is `command`
  - README's `agents[].config.working_dir` — `AgentConfig` has no `config` field
- `configuration.md`'s runners section is now a short summary linking to the new page; README gets a Runners row in the docs table.

Note: the example YAML and `schema/apiary.json` still carry the stale shapes — flagged as a separate follow-up task.

## Test plan

- `mkdocs build --strict` passes with the CI copy/sed steps replicated (zero warnings)
- All new cross-page anchors verified against the built HTML
- Every config key documented was traced to a consuming `Configure`/factory call in non-test code