### PR TITLE
feat(source): add Jira Cloud source adapter

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -115,6 +115,28 @@ sources:
       states: [open]
       labels: [ai-ready]
 
+  - id: my-jira
+    type: jira
+    config:
+      # Jira Cloud site URL (Server/Data Center is not supported).
+      base_url: https://yoursite.atlassian.net
+      # Atlassian account email + API token (Basic auth).
+      # Create a token at https://id.atlassian.com/manage-profile/security/api-tokens
+      email: bot@example.com
+      api_token: ${JIRA_API_TOKEN}
+      # Optional project key to scope polling.
+      project: ERP
+      # Optional status Acknowledge transitions issues to on dispatch.
+      # Without it, the first transition into Jira's "In Progress" category is used.
+      started_state: In Progress
+    poll_interval: 120s
+    filters:
+      # Primary filter: any JQL clause, ANDed into every poll.
+      jql: 'labels = apiary AND statusCategory != Done'
+      # Secondary client-side filters (status / label names).
+      states: [to do, in progress]
+      labels: [apiary]
+
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:
   # === Claude-based agents (original design) ===

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -124,8 +124,8 @@ sources:
       # Create a token at https://id.atlassian.com/manage-profile/security/api-tokens
       email: bot@example.com
       api_token: ${JIRA_API_TOKEN}
-      # Optional project key to scope polling.
-      project: ERP
+      # Optional project key (or list of keys) to scope polling.
+      project: ERP            # or: project: [ERP, OPS]
       # Optional status Acknowledge transitions issues to on dispatch.
       # Without it, the first transition into Jira's "In Progress" category is used.
       started_state: In Progress

--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -1,0 +1,111 @@
+# Jira Source
+
+The `jira` source adapter polls issues from a **Jira Cloud** site via JQL
+search and maps them to Apiary tasks. Jira Server / Data Center is not
+supported (the adapter relies on Cloud-only API endpoints and auth).
+
+## Configuration
+
+```yaml
+sources:
+  - id: my-jira
+    type: jira
+    config:
+      base_url: https://yoursite.atlassian.net
+      email: bot@example.com
+      api_token: ${JIRA_API_TOKEN}
+      project: ERP                    # optional
+      started_state: In Progress      # optional
+    poll_interval: 120s
+    filters:
+      jql: 'labels = apiary AND statusCategory != Done'
+      states: [to do, in progress]
+      labels: [apiary]
+```
+
+### `config` fields
+
+| Field | Required | Description |
+|---|---|---|
+| `base_url` | yes | Jira Cloud site URL (`https://<site>.atlassian.net`) |
+| `email` | yes | Atlassian account email for Basic auth |
+| `api_token` | yes | API token — create one at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) |
+| `project` | no | Project key (e.g. `ERP`) to scope polling; recommended |
+| `started_state` | no | Status name Acknowledge transitions issues to on dispatch |
+
+If neither `project` nor `filters.jql` is set, the adapter polls every issue
+visible to the API user and logs a warning.
+
+### `filters`
+
+| Field | Description |
+|---|---|
+| `jql` | Any JQL clause, ANDed into every poll's search — the primary filter for Jira sources |
+| `states` | Only ingest issues in these statuses (matched by status **name**, case-insensitive, client-side) |
+| `labels` | Only ingest issues carrying all of these labels (client-side) |
+
+## Behavior
+
+- **JQL search.** Polling uses the enhanced `/rest/api/3/search/jql`
+  endpoint, combining `project`, your `filters.jql`, and an incremental
+  `updated >=` cut-off. Bare JQL datetimes are interpreted in the API user's
+  profile timezone, which the adapter resolves once from `/myself` (falling
+  back to UTC — a small overlap window plus client-side filtering keeps
+  results exact either way).
+- **Human references.** Issues are tracked by their immutable numeric id but
+  displayed with the issue key (e.g. `ERP-42`) in the dashboard's `#` column;
+  item URLs open the issue in the Jira web UI (`o` in the dashboard).
+- **Acknowledge transitions the issue.** On dispatch the issue moves to
+  `started_state` if configured, otherwise to the first transition whose
+  target sits in Jira's *In Progress* status category — so the board reflects
+  pickup, like the Plane adapter.
+- **Comments are rich text.** Run results are posted as native Jira (ADF)
+  comments: status line, detected PR link, output as a code block. Issue
+  descriptions and comments are flattened to plain text for agents and
+  approval matching.
+- **Approvals work.** The adapter implements per-task polling, so approval
+  steps can match human Jira comments, labels, or statuses.
+- **Labels.** Adding/removing labels uses Jira's atomic update verbs; labels
+  are created implicitly. Jira labels cannot contain spaces — names with
+  whitespace are rewritten with `-` (e.g. `needs review` → `needs-review`).
+- **No CI polling.** `wait_for` steps with `kind: ci` need a source that can
+  see pull requests; Jira issues have no PR mapping, so host CI waits on a
+  GitHub source instead.
+
+## State names in hooks
+
+`set_state` and `started_state` values are matched against the target status
+of the issue's *available transitions* (case-insensitive; the transition's
+own name works as a fallback), so hooks read naturally:
+
+```yaml
+workflows:
+  - id: implement
+    trigger:
+      priority: 10
+      match:
+        source: my-jira
+        labels: [agent:engineer]
+    steps:
+      - id: run
+        agent: engineer
+    on_complete:
+      set_state: in review
+```
+
+Jira only offers transitions that are valid from the issue's current status.
+If the target status is unreachable, the adapter fails with an error listing
+the transitions that *were* available — fix the Jira workflow or pick a
+reachable status.
+
+## Per-agent identity
+
+An agent's `source_token` override can carry either just an API token (the
+source's `email` is reused) or a full `email:api_token` pair to post
+comments and transitions as a different Atlassian account.
+
+## Rate limits
+
+Jira Cloud rate-limits per user and answers `429` with a `Retry-After`
+header, which the adapter honours with exponential backoff. With several
+Jira sources or short intervals, keep `poll_interval: 60s` or higher.

--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -30,7 +30,7 @@ sources:
 | `base_url` | yes | Jira Cloud site URL (`https://<site>.atlassian.net`) |
 | `email` | yes | Atlassian account email for Basic auth |
 | `api_token` | yes | API token — create one at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) |
-| `project` | no | Project key (e.g. `ERP`) to scope polling; recommended |
+| `project` | no | Project key (e.g. `ERP`) or list of keys (`[ERP, OPS]`) to scope polling; recommended |
 | `started_state` | no | Status name Acknowledge transitions issues to on dispatch |
 
 If neither `project` nor `filters.jql` is set, the adapter polls every issue

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Rate Limits & Resilience: resilience.md
   - Sources:
       - GitHub: github-source.md
+      - Jira: jira-source.md
       - Plane: plane-source.md
   - Reference:
       - CLI: cli.md

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -3,8 +3,9 @@ package main
 import (
 	"github.com/orlandoburli/apiary/internal/cli"
 
-	_ "github.com/orlandoburli/apiary/internal/source/plane"
 	_ "github.com/orlandoburli/apiary/internal/source/github"
+	_ "github.com/orlandoburli/apiary/internal/source/jira"
+	_ "github.com/orlandoburli/apiary/internal/source/plane"
 
 	_ "github.com/orlandoburli/apiary/internal/runner/providers"
 )

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -188,6 +188,11 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		}); ok {
 			fs.SetFilters(sc.Filters.States, sc.Filters.Labels)
 		}
+		if js, ok := adapter.(interface {
+			SetJQL(jql string)
+		}); ok {
+			js.SetJQL(sc.Filters.JQL)
+		}
 		d.sources[sc.ID] = adapter
 		d.stats[sc.ID] = &sourceStat{}
 	}

--- a/src/internal/source/jira/adapter.go
+++ b/src/internal/source/jira/adapter.go
@@ -39,8 +39,8 @@ type Adapter struct {
 	client  *client
 	baseURL string // site URL, serves both the REST API and /browse links
 
-	project      string // optional project key (e.g. "ERP") to scope polling
-	startedState string // optional status name Acknowledge transitions to
+	projects     []string // optional project key(s) (e.g. "ERP") to scope polling
+	startedState string   // optional status name Acknowledge transitions to
 
 	// Bare JQL datetimes are interpreted in the API user's profile timezone,
 	// so it is resolved once (lazily) from /myself before the first search.
@@ -77,13 +77,41 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 		return fmt.Errorf("jira: config.api_token is required (create one at https://id.atlassian.com/manage-profile/security/api-tokens)")
 	}
 
-	a.project, _ = cfg["project"].(string)
+	a.projects, err = parseProjects(cfg["project"])
+	if err != nil {
+		return err
+	}
 	a.startedState, _ = cfg["started_state"].(string)
 	a.baseURL = baseURL
 	a.client = newClient(baseURL, email, apiToken)
 
-	aplog.Info("jira: configured  site=%s  project=%q", baseURL, a.project)
+	aplog.Info("jira: configured  site=%s  projects=%q", baseURL, a.projects)
 	return nil
+}
+
+// parseProjects accepts config.project as a single key or a list of keys.
+func parseProjects(v any) ([]string, error) {
+	switch p := v.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if p = strings.TrimSpace(p); p != "" {
+			return []string{p}, nil
+		}
+		return nil, nil
+	case []any:
+		var keys []string
+		for _, e := range p {
+			s, ok := e.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				return nil, fmt.Errorf("jira: config.project list must contain only non-empty strings, got %v", e)
+			}
+			keys = append(keys, strings.TrimSpace(s))
+		}
+		return keys, nil
+	default:
+		return nil, fmt.Errorf("jira: config.project must be a project key or a list of keys, got %T", v)
+	}
 }
 
 // SetFilters stores the states/labels filter config (applied client-side).
@@ -126,10 +154,18 @@ func (a *Adapter) userLocation(ctx context.Context) *time.Location {
 // minute granularity and are interpreted in the API user's profile timezone,
 // so `since` is converted to loc and padded back by two minutes; Poll
 // re-applies the exact cut-off client-side (the binder dedups any overlap).
-func buildJQL(project, userJQL string, since time.Time, loc *time.Location) string {
+func buildJQL(projects []string, userJQL string, since time.Time, loc *time.Location) string {
 	var clauses []string
-	if project != "" {
-		clauses = append(clauses, fmt.Sprintf("project = %q", project))
+	switch len(projects) {
+	case 0:
+	case 1:
+		clauses = append(clauses, fmt.Sprintf("project = %q", projects[0]))
+	default:
+		quoted := make([]string, len(projects))
+		for i, p := range projects {
+			quoted[i] = fmt.Sprintf("%q", p)
+		}
+		clauses = append(clauses, fmt.Sprintf("project in (%s)", strings.Join(quoted, ", ")))
 	}
 	if q := strings.TrimSpace(userJQL); q != "" {
 		clauses = append(clauses, "("+q+")")
@@ -145,12 +181,12 @@ func buildJQL(project, userJQL string, since time.Time, loc *time.Location) stri
 }
 
 func (a *Adapter) Poll(ctx context.Context, since time.Time) ([]model.SourceItem, error) {
-	if a.project == "" && a.jql == "" && !a.warnedNoScope {
+	if len(a.projects) == 0 && a.jql == "" && !a.warnedNoScope {
 		aplog.Info("jira: neither config.project nor filters.jql is set — polling every issue visible to the API user")
 		a.warnedNoScope = true
 	}
 
-	jql := buildJQL(a.project, a.jql, since, a.userLocation(ctx))
+	jql := buildJQL(a.projects, a.jql, since, a.userLocation(ctx))
 	issues, err := a.client.searchAll(ctx, jql)
 	if err != nil {
 		return nil, fmt.Errorf("jira: polling issues: %w", err)

--- a/src/internal/source/jira/adapter.go
+++ b/src/internal/source/jira/adapter.go
@@ -1,0 +1,500 @@
+// Package jira provides a Jira Cloud source adapter that polls issues via
+// JQL search and maps them to Apiary source items. Cloud only: Basic auth
+// with account email + API token against https://<site>.atlassian.net.
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func init() {
+	source.Register("jira", func() source.Adapter { return &Adapter{} })
+}
+
+// Compile-time checks: the Jira adapter supports the optional source
+// capabilities used by the dispatcher and the workflow engine. CI status and
+// PR listing are PR-centric and have no Jira mapping, so they are omitted.
+var (
+	_ source.StateSetter  = (*Adapter)(nil)
+	_ source.LabelAdder   = (*Adapter)(nil)
+	_ source.LabelRemover = (*Adapter)(nil)
+	_ source.TaskPoller   = (*Adapter)(nil)
+)
+
+type Adapter struct {
+	id      string
+	client  *client
+	baseURL string // site URL, serves both the REST API and /browse links
+
+	project      string // optional project key (e.g. "ERP") to scope polling
+	startedState string // optional status name Acknowledge transitions to
+
+	// Bare JQL datetimes are interpreted in the API user's profile timezone,
+	// so it is resolved once (lazily) from /myself before the first search.
+	tzOnce sync.Once
+	loc    *time.Location
+
+	warnedNoScope bool
+
+	filterStates []string
+	filterLabels []string
+	jql          string
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+func (a *Adapter) SetID(id string) { a.id = id }
+
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	baseURL, _ := cfg["base_url"].(string)
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return fmt.Errorf("jira: config.base_url is required (e.g. \"https://yoursite.atlassian.net\")")
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("jira: config.base_url %q must be an absolute http(s) URL", baseURL)
+	}
+	email, _ := cfg["email"].(string)
+	if email == "" {
+		return fmt.Errorf("jira: config.email is required (Atlassian account email)")
+	}
+	apiToken, _ := cfg["api_token"].(string)
+	if apiToken == "" {
+		return fmt.Errorf("jira: config.api_token is required (create one at https://id.atlassian.com/manage-profile/security/api-tokens)")
+	}
+
+	a.project, _ = cfg["project"].(string)
+	a.startedState, _ = cfg["started_state"].(string)
+	a.baseURL = baseURL
+	a.client = newClient(baseURL, email, apiToken)
+
+	aplog.Info("jira: configured  site=%s  project=%q", baseURL, a.project)
+	return nil
+}
+
+// SetFilters stores the states/labels filter config (applied client-side).
+func (a *Adapter) SetFilters(states, labels []string) {
+	for _, s := range states {
+		a.filterStates = append(a.filterStates, strings.ToLower(s))
+	}
+	for _, l := range labels {
+		a.filterLabels = append(a.filterLabels, strings.ToLower(l))
+	}
+}
+
+// SetJQL stores the filters.jql clause, ANDed into every search.
+func (a *Adapter) SetJQL(jql string) { a.jql = strings.TrimSpace(jql) }
+
+// userLocation resolves the API user's profile timezone exactly once. On any
+// failure it falls back to UTC — safe because the JQL `updated >=` clause is
+// only a volume reducer; Poll re-applies the precise cut-off client-side.
+func (a *Adapter) userLocation(ctx context.Context) *time.Location {
+	a.tzOnce.Do(func() {
+		a.loc = time.UTC
+		data, err := a.client.get(ctx, "/rest/api/3/myself", nil)
+		if err != nil {
+			aplog.Debug("jira: timezone lookup failed, JQL datetimes use UTC: %v", err)
+			return
+		}
+		var me myself
+		if err := json.Unmarshal(data, &me); err != nil || me.TimeZone == "" {
+			return
+		}
+		if loc, err := time.LoadLocation(me.TimeZone); err == nil {
+			a.loc = loc
+			aplog.Debug("jira: JQL datetimes use API user timezone %s", me.TimeZone)
+		}
+	})
+	return a.loc
+}
+
+// buildJQL composes the server-side search filter. Bare JQL datetimes have
+// minute granularity and are interpreted in the API user's profile timezone,
+// so `since` is converted to loc and padded back by two minutes; Poll
+// re-applies the exact cut-off client-side (the binder dedups any overlap).
+func buildJQL(project, userJQL string, since time.Time, loc *time.Location) string {
+	var clauses []string
+	if project != "" {
+		clauses = append(clauses, fmt.Sprintf("project = %q", project))
+	}
+	if q := strings.TrimSpace(userJQL); q != "" {
+		clauses = append(clauses, "("+q+")")
+	}
+	if !since.IsZero() {
+		t := since.In(loc).Add(-2 * time.Minute)
+		clauses = append(clauses, fmt.Sprintf("updated >= %q", t.Format("2006/01/02 15:04")))
+	}
+	if len(clauses) == 0 {
+		return "ORDER BY updated ASC"
+	}
+	return strings.Join(clauses, " AND ") + " ORDER BY updated ASC"
+}
+
+func (a *Adapter) Poll(ctx context.Context, since time.Time) ([]model.SourceItem, error) {
+	if a.project == "" && a.jql == "" && !a.warnedNoScope {
+		aplog.Info("jira: neither config.project nor filters.jql is set — polling every issue visible to the API user")
+		a.warnedNoScope = true
+	}
+
+	jql := buildJQL(a.project, a.jql, since, a.userLocation(ctx))
+	issues, err := a.client.searchAll(ctx, jql)
+	if err != nil {
+		return nil, fmt.Errorf("jira: polling issues: %w", err)
+	}
+
+	var cells []model.SourceItem
+	for _, item := range issues {
+		if !a.matchesFilters(item) {
+			continue
+		}
+		cell := a.toSourceItem(item)
+		if !since.IsZero() && !cell.UpdatedAt.After(since) {
+			continue
+		}
+		cells = append(cells, cell)
+	}
+	return cells, nil
+}
+
+func (a *Adapter) matchesFilters(item issue) bool {
+	if len(a.filterStates) > 0 {
+		stateName := ""
+		if item.Fields.Status != nil {
+			stateName = strings.ToLower(item.Fields.Status.Name)
+		}
+		if !containsAny(a.filterStates, stateName) {
+			aplog.Debug("  issue %s (%q): state %q not in filter %v", item.Key, item.Fields.Summary, stateName, a.filterStates)
+			return false
+		}
+	}
+	if len(a.filterLabels) > 0 {
+		itemLabels := make([]string, 0, len(item.Fields.Labels))
+		for _, l := range item.Fields.Labels {
+			itemLabels = append(itemLabels, strings.ToLower(l))
+		}
+		for _, required := range a.filterLabels {
+			if !containsAny(itemLabels, required) {
+				aplog.Debug("  issue %s (%q): missing required label %q (has: %v)", item.Key, item.Fields.Summary, required, itemLabels)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Acknowledge transitions the issue into work when it is dispatched: to the
+// configured started_state if set, otherwise to the first transition whose
+// target is in Jira's "In Progress" category (statusCategory "indeterminate").
+func (a *Adapter) Acknowledge(ctx context.Context, cell model.SourceItem, action model.AckAction) error {
+	if action != model.AckActionInProgress {
+		return nil
+	}
+	if a.startedState != "" {
+		if err := a.transitionTo(ctx, cell.ID, a.startedState); err != nil {
+			return fmt.Errorf("jira: acknowledging %s: %w", cell.ID, err)
+		}
+		return nil
+	}
+
+	transitions, err := a.listTransitions(ctx, cell.ID)
+	if err != nil {
+		return fmt.Errorf("jira: acknowledging %s: %w", cell.ID, err)
+	}
+	for _, t := range transitions {
+		if t.To.StatusCategory.Key == "indeterminate" {
+			if err := a.applyTransition(ctx, cell.ID, t.ID); err != nil {
+				return fmt.Errorf("jira: acknowledging %s: %w", cell.ID, err)
+			}
+			return nil
+		}
+	}
+
+	// No in-progress transition available: if the issue already sits in an
+	// in-progress status this is a no-op, otherwise the workflow has no way in.
+	current, err := a.currentStatus(ctx, cell.ID)
+	if err == nil && current.StatusCategory.Key == "indeterminate" {
+		return nil
+	}
+	return fmt.Errorf("jira: acknowledging %s: no transition to an in-progress status (available: %s) — set config.started_state or adjust the Jira workflow",
+		cell.ID, availableTargets(transitions))
+}
+
+func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result model.RunResult) error {
+	path := "/rest/api/3/issue/" + url.PathEscape(cell.ID) + "/comment"
+	if _, err := a.client.post(ctx, path, commentCreateRequest{Body: formatComment(result)}); err != nil {
+		return fmt.Errorf("jira: writing result to %s: %w", cell.ID, err)
+	}
+	return nil
+}
+
+func (a *Adapter) WebhookHandler() http.Handler { return nil }
+
+// PollTask fetches the current state of a single issue plus its comments, for
+// the workflow engine to evaluate approval-step conditions. Implements
+// source.TaskPoller.
+func (a *Adapter) PollTask(ctx context.Context, cellID string) (model.SourceItem, error) {
+	path := "/rest/api/3/issue/" + url.PathEscape(cellID)
+	data, err := a.client.get(ctx, path, url.Values{"fields": {searchFields}})
+	if err != nil {
+		return model.SourceItem{}, fmt.Errorf("jira: poll task %s: %w", cellID, err)
+	}
+	var item issue
+	if err := json.Unmarshal(data, &item); err != nil {
+		return model.SourceItem{}, fmt.Errorf("jira: decoding issue %s: %w", cellID, err)
+	}
+
+	cell := a.toSourceItem(item)
+	comments, err := a.fetchComments(ctx, cellID)
+	if err != nil {
+		aplog.Debug("jira: fetch comments for %s: %v", cellID, err)
+	} else {
+		cell.Comments = comments
+	}
+	return cell, nil
+}
+
+// fetchComments retrieves every comment on an issue, oldest first, flattening
+// the ADF bodies to plain text.
+func (a *Adapter) fetchComments(ctx context.Context, cellID string) ([]model.Comment, error) {
+	var out []model.Comment
+	startAt := 0
+
+	for {
+		params := url.Values{
+			"startAt":    {strconv.Itoa(startAt)},
+			"maxResults": {"100"},
+			"orderBy":    {"created"},
+		}
+		path := "/rest/api/3/issue/" + url.PathEscape(cellID) + "/comment"
+		data, err := a.client.get(ctx, path, params)
+		if err != nil {
+			return nil, err
+		}
+		var pg commentPage
+		if err := json.Unmarshal(data, &pg); err != nil {
+			return nil, fmt.Errorf("jira: decoding comments for %s: %w", cellID, err)
+		}
+		for _, c := range pg.Comments {
+			out = append(out, model.Comment{
+				ID:        c.ID,
+				Body:      adfToText(c.Body),
+				CreatedAt: parseJiraTime(c.Created),
+			})
+		}
+		startAt += len(pg.Comments)
+		if len(pg.Comments) == 0 || startAt >= pg.Total {
+			return out, nil
+		}
+	}
+}
+
+// SetState transitions the issue to the named status. Implements
+// source.StateSetter.
+func (a *Adapter) SetState(ctx context.Context, cell model.SourceItem, stateName string) error {
+	if err := a.transitionTo(ctx, cell.ID, stateName); err != nil {
+		return fmt.Errorf("jira: setting state %q on %s: %w", stateName, cell.ID, err)
+	}
+	return nil
+}
+
+// transitionTo moves an issue to the named status via the transitions API.
+// Jira only exposes transitions valid from the issue's current status, so a
+// missing match is either "already there" (success) or a workflow gap (error
+// listing what was available, to make misconfiguration debuggable).
+func (a *Adapter) transitionTo(ctx context.Context, cellID, target string) error {
+	transitions, err := a.listTransitions(ctx, cellID)
+	if err != nil {
+		return err
+	}
+	if t, ok := matchTransition(transitions, target); ok {
+		return a.applyTransition(ctx, cellID, t.ID)
+	}
+
+	current, err := a.currentStatus(ctx, cellID)
+	if err == nil && strings.EqualFold(current.Name, target) {
+		return nil
+	}
+	return fmt.Errorf("no transition to state %q from current status %q (available: %s)",
+		target, current.Name, availableTargets(transitions))
+}
+
+func (a *Adapter) listTransitions(ctx context.Context, cellID string) ([]transition, error) {
+	path := "/rest/api/3/issue/" + url.PathEscape(cellID) + "/transitions"
+	data, err := a.client.get(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp transitionsResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("jira: decoding transitions for %s: %w", cellID, err)
+	}
+	return resp.Transitions, nil
+}
+
+func (a *Adapter) applyTransition(ctx context.Context, cellID, transitionID_ string) error {
+	path := "/rest/api/3/issue/" + url.PathEscape(cellID) + "/transitions"
+	_, err := a.client.post(ctx, path, transitionRequest{Transition: transitionID{ID: transitionID_}})
+	return err
+}
+
+func (a *Adapter) currentStatus(ctx context.Context, cellID string) (statusEntity, error) {
+	path := "/rest/api/3/issue/" + url.PathEscape(cellID)
+	data, err := a.client.get(ctx, path, url.Values{"fields": {"status"}})
+	if err != nil {
+		return statusEntity{}, err
+	}
+	var item issue
+	if err := json.Unmarshal(data, &item); err != nil {
+		return statusEntity{}, fmt.Errorf("jira: decoding issue %s: %w", cellID, err)
+	}
+	if item.Fields.Status == nil {
+		return statusEntity{}, fmt.Errorf("jira: issue %s has no status", cellID)
+	}
+	return *item.Fields.Status, nil
+}
+
+// matchTransition finds the transition whose target status matches, falling
+// back to the transition's own name. Both are case-insensitive.
+func matchTransition(transitions []transition, target string) (transition, bool) {
+	for _, t := range transitions {
+		if strings.EqualFold(t.To.Name, target) {
+			return t, true
+		}
+	}
+	for _, t := range transitions {
+		if strings.EqualFold(t.Name, target) {
+			return t, true
+		}
+	}
+	return transition{}, false
+}
+
+func availableTargets(transitions []transition) string {
+	if len(transitions) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(transitions))
+	for _, t := range transitions {
+		names = append(names, t.To.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// AddLabels adds the named labels to the issue with Jira's atomic update
+// verbs. Labels are free-form in Jira (created implicitly), but may not
+// contain whitespace — offending names are rewritten with "-". Implements
+// source.LabelAdder.
+func (a *Adapter) AddLabels(ctx context.Context, cell model.SourceItem, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	ops := make([]labelOp, 0, len(names))
+	for _, n := range names {
+		ops = append(ops, labelOp{Add: sanitizeLabel(n)})
+	}
+	path := "/rest/api/3/issue/" + url.PathEscape(cell.ID)
+	if _, err := a.client.put(ctx, path, labelsUpdateRequest{Update: labelsUpdate{Labels: ops}}); err != nil {
+		return fmt.Errorf("jira: adding labels %v to %s: %w", names, cell.ID, err)
+	}
+	return nil
+}
+
+// RemoveLabels removes the named labels from the issue; removing an absent
+// label is a server-side no-op. Implements source.LabelRemover.
+func (a *Adapter) RemoveLabels(ctx context.Context, cell model.SourceItem, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	ops := make([]labelOp, 0, len(names))
+	for _, n := range names {
+		ops = append(ops, labelOp{Remove: sanitizeLabel(n)})
+	}
+	path := "/rest/api/3/issue/" + url.PathEscape(cell.ID)
+	if _, err := a.client.put(ctx, path, labelsUpdateRequest{Update: labelsUpdate{Labels: ops}}); err != nil {
+		return fmt.Errorf("jira: removing labels %v from %s: %w", names, cell.ID, err)
+	}
+	return nil
+}
+
+var labelWhitespaceRe = regexp.MustCompile(`\s+`)
+
+// sanitizeLabel rewrites whitespace to "-": Jira rejects the whole update
+// when any label contains spaces.
+func sanitizeLabel(name string) string {
+	clean := labelWhitespaceRe.ReplaceAllString(strings.TrimSpace(name), "-")
+	if clean != name {
+		aplog.Debug("jira: label %q rewritten to %q (Jira labels cannot contain whitespace)", name, clean)
+	}
+	return clean
+}
+
+// jiraTimeLayout is Jira's timestamp format: RFC3339-like but with a colonless
+// zone offset, so time.RFC3339 fails to parse it.
+const jiraTimeLayout = "2006-01-02T15:04:05.000-0700"
+
+func parseJiraTime(s string) time.Time {
+	if t, err := time.Parse(jiraTimeLayout, s); err == nil {
+		return t
+	}
+	t, _ := time.Parse(time.RFC3339, s)
+	return t
+}
+
+func (a *Adapter) toSourceItem(item issue) model.SourceItem {
+	labels := make([]string, 0, len(item.Fields.Labels))
+	for _, l := range item.Fields.Labels {
+		labels = append(labels, strings.ToLower(l))
+	}
+
+	var state, priority, issueType string
+	if item.Fields.Status != nil {
+		state = item.Fields.Status.Name
+	}
+	if item.Fields.Priority != nil {
+		priority = strings.ToLower(item.Fields.Priority.Name)
+	}
+	if item.Fields.IssueType != nil {
+		issueType = strings.ToLower(item.Fields.IssueType.Name)
+	}
+
+	return model.SourceItem{
+		// The numeric id is the binding identity: issue keys change when an
+		// issue moves projects, ids never do. Every /issue/{idOrKey} endpoint
+		// accepts the id, so write-backs receive it transparently.
+		ID:          item.ID,
+		SourceID:    a.ID(),
+		Number:      item.Key,
+		Title:       item.Fields.Summary,
+		Description: adfToText(item.Fields.Description),
+		Labels:      labels,
+		Type:        issueType,
+		Priority:    priority,
+		State:       state,
+		URL:         a.baseURL + "/browse/" + item.Key,
+		CreatedAt:   parseJiraTime(item.Fields.Created),
+		UpdatedAt:   parseJiraTime(item.Fields.Updated),
+	}
+}
+
+func containsAny(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/source/jira/adapter_test.go
+++ b/src/internal/source/jira/adapter_test.go
@@ -18,25 +18,30 @@ func TestBuildJQL(t *testing.T) {
 	since := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name            string
-		project, userQL string
-		since           time.Time
-		want            string
+		name     string
+		projects []string
+		userQL   string
+		since    time.Time
+		want     string
 	}{
 		{
 			name: "empty", want: "ORDER BY updated ASC",
 		},
 		{
-			name: "project only", project: "ERP",
+			name: "project only", projects: []string{"ERP"},
 			want: `project = "ERP" ORDER BY updated ASC`,
 		},
 		{
-			name: "project and user jql parenthesized", project: "ERP", userQL: "labels = apiary",
+			name: "multiple projects use IN", projects: []string{"ERP", "OPS"},
+			want: `project in ("ERP", "OPS") ORDER BY updated ASC`,
+		},
+		{
+			name: "project and user jql parenthesized", projects: []string{"ERP"}, userQL: "labels = apiary",
 			want: `project = "ERP" AND (labels = apiary) ORDER BY updated ASC`,
 		},
 		{
 			// 12:00 UTC = 09:00 UTC-3, minus the 2-minute slack = 08:58.
-			name: "since converted to user tz with slack", project: "ERP", since: since,
+			name: "since converted to user tz with slack", projects: []string{"ERP"}, since: since,
 			want: `project = "ERP" AND updated >= "2026/06/10 08:58" ORDER BY updated ASC`,
 		},
 		{
@@ -46,7 +51,7 @@ func TestBuildJQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildJQL(tt.project, tt.userQL, tt.since, loc); got != tt.want {
+			if got := buildJQL(tt.projects, tt.userQL, tt.since, loc); got != tt.want {
 				t.Errorf("got  %s\nwant %s", got, tt.want)
 			}
 		})
@@ -110,7 +115,7 @@ func TestPoll_PaginatesAndMaps(t *testing.T) {
 	defer srv.Close()
 
 	a := newTestAdapter(srv.URL)
-	a.project = "ERP"
+	a.projects = []string{"ERP"}
 
 	cells, err := a.Poll(context.Background(), time.Time{})
 	if err != nil {
@@ -375,8 +380,40 @@ func TestConnect_Validation(t *testing.T) {
 	if a.baseURL != "https://x.atlassian.net" {
 		t.Errorf("trailing slash not trimmed: %q", a.baseURL)
 	}
-	if a.project != "ERP" || a.startedState != "In Progress" {
+	if len(a.projects) != 1 || a.projects[0] != "ERP" || a.startedState != "In Progress" {
 		t.Errorf("optional fields not stored: %+v", a)
+	}
+}
+
+func TestConnect_ProjectList(t *testing.T) {
+	base := map[string]any{"base_url": "https://x.atlassian.net", "email": "e@x.com", "api_token": "t"}
+
+	a := &Adapter{}
+	cfg := map[string]any{"project": []any{"ERP", "OPS"}}
+	for k, v := range base {
+		cfg[k] = v
+	}
+	if err := a.Connect(context.Background(), cfg); err != nil {
+		t.Fatalf("project list rejected: %v", err)
+	}
+	if len(a.projects) != 2 || a.projects[0] != "ERP" || a.projects[1] != "OPS" {
+		t.Errorf("project list not stored: %v", a.projects)
+	}
+
+	bad := map[string]any{"project": []any{"ERP", 7}}
+	for k, v := range base {
+		bad[k] = v
+	}
+	if err := (&Adapter{}).Connect(context.Background(), bad); err == nil || !strings.Contains(err.Error(), "non-empty strings") {
+		t.Errorf("expected error for non-string project entry, got %v", err)
+	}
+
+	notList := map[string]any{"project": 42}
+	for k, v := range base {
+		notList[k] = v
+	}
+	if err := (&Adapter{}).Connect(context.Background(), notList); err == nil || !strings.Contains(err.Error(), "config.project") {
+		t.Errorf("expected error for non-string project, got %v", err)
 	}
 }
 

--- a/src/internal/source/jira/adapter_test.go
+++ b/src/internal/source/jira/adapter_test.go
@@ -1,0 +1,416 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestBuildJQL(t *testing.T) {
+	loc := time.FixedZone("UTC-3", -3*60*60)
+	since := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		project, userQL string
+		since           time.Time
+		want            string
+	}{
+		{
+			name: "empty", want: "ORDER BY updated ASC",
+		},
+		{
+			name: "project only", project: "ERP",
+			want: `project = "ERP" ORDER BY updated ASC`,
+		},
+		{
+			name: "project and user jql parenthesized", project: "ERP", userQL: "labels = apiary",
+			want: `project = "ERP" AND (labels = apiary) ORDER BY updated ASC`,
+		},
+		{
+			// 12:00 UTC = 09:00 UTC-3, minus the 2-minute slack = 08:58.
+			name: "since converted to user tz with slack", project: "ERP", since: since,
+			want: `project = "ERP" AND updated >= "2026/06/10 08:58" ORDER BY updated ASC`,
+		},
+		{
+			name: "user jql only", userQL: "statusCategory != Done",
+			want: `(statusCategory != Done) ORDER BY updated ASC`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildJQL(tt.project, tt.userQL, tt.since, loc); got != tt.want {
+				t.Errorf("got  %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
+const issuePageOne = `{
+	"issues": [{
+		"id": "10001", "key": "ERP-1",
+		"fields": {
+			"summary": "Add login",
+			"description": {"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"the spec"}]}]},
+			"status": {"name": "To Do", "statusCategory": {"key": "new"}},
+			"priority": {"name": "High"},
+			"issuetype": {"name": "Story"},
+			"labels": ["Apiary", "backend"],
+			"created": "2026-06-01T10:00:00.000-0300",
+			"updated": "2026-06-09T15:30:00.000-0300"
+		}
+	}],
+	"nextPageToken": "tok-2"
+}`
+
+const issuePageTwo = `{
+	"issues": [{
+		"id": "10002", "key": "ERP-2",
+		"fields": {
+			"summary": "Fix logout",
+			"description": null,
+			"status": {"name": "In Progress", "statusCategory": {"key": "indeterminate"}},
+			"priority": null,
+			"issuetype": {"name": "Bug"},
+			"labels": [],
+			"created": "2026-06-02T10:00:00.000-0300",
+			"updated": "2026-06-09T16:00:00.000-0300"
+		}
+	}]
+}`
+
+func newTestAdapter(srvURL string) *Adapter {
+	return &Adapter{id: "jira-test", baseURL: srvURL, client: newClient(srvURL, "bot@example.com", "tok")}
+}
+
+func TestPoll_PaginatesAndMaps(t *testing.T) {
+	var jqls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			_, _ = w.Write([]byte(`{"timeZone": "UTC"}`))
+		case "/rest/api/3/search/jql":
+			jqls = append(jqls, r.URL.Query().Get("jql"))
+			if r.URL.Query().Get("nextPageToken") == "tok-2" {
+				_, _ = w.Write([]byte(issuePageTwo))
+			} else {
+				_, _ = w.Write([]byte(issuePageOne))
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	a.project = "ERP"
+
+	cells, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(cells) != 2 {
+		t.Fatalf("expected 2 cells across pages, got %d", len(cells))
+	}
+	if len(jqls) != 2 || !strings.Contains(jqls[0], `project = "ERP"`) {
+		t.Errorf("expected 2 search calls with project clause, got %v", jqls)
+	}
+
+	c := cells[0]
+	if c.ID != "10001" || c.Number != "ERP-1" || c.Title != "Add login" {
+		t.Errorf("identity mapping wrong: %+v", c)
+	}
+	if c.Description != "the spec" {
+		t.Errorf("ADF description not flattened: %q", c.Description)
+	}
+	if c.State != "To Do" || c.Priority != "high" || c.Type != "story" {
+		t.Errorf("state/priority/type mapping wrong: %+v", c)
+	}
+	if len(c.Labels) != 2 || c.Labels[0] != "apiary" {
+		t.Errorf("labels not lowercased: %v", c.Labels)
+	}
+	if c.URL != srv.URL+"/browse/ERP-1" {
+		t.Errorf("URL wrong: %s", c.URL)
+	}
+	// 15:30 -0300 = 18:30 UTC; the colonless offset must parse.
+	if !c.UpdatedAt.Equal(time.Date(2026, 6, 9, 18, 30, 0, 0, time.UTC)) {
+		t.Errorf("UpdatedAt wrong (jira timestamp layout not parsed?): %v", c.UpdatedAt)
+	}
+
+	if cells[1].Priority != "" || cells[1].Description != "" {
+		t.Errorf("nil priority/description must map to empty: %+v", cells[1])
+	}
+}
+
+func TestPoll_ClientSideFiltersAndSinceCut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rest/api/3/myself":
+			_, _ = w.Write([]byte(`{"timeZone": "UTC"}`))
+		case "/rest/api/3/search/jql":
+			page := strings.Replace(issuePageOne, `"nextPageToken": "tok-2"`, `"nextPageToken": ""`, 1)
+			_, _ = w.Write([]byte(page))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	a.SetFilters([]string{"In Progress"}, nil)
+	cells, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(cells) != 0 {
+		t.Errorf("state filter should drop the To Do issue, got %d cells", len(cells))
+	}
+
+	a2 := newTestAdapter(srv.URL)
+	a2.SetFilters(nil, []string{"apiary"})
+	since := time.Date(2026, 6, 9, 19, 0, 0, 0, time.UTC) // after the issue's 18:30 UTC update
+	cells, err = a2.Poll(context.Background(), since)
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(cells) != 0 {
+		t.Errorf("since cut should drop the stale issue, got %d cells", len(cells))
+	}
+}
+
+const transitionsBody = `{"transitions": [
+	{"id": "11", "name": "Start work", "to": {"name": "In Progress", "statusCategory": {"key": "indeterminate"}}},
+	{"id": "21", "name": "Finish", "to": {"name": "Done", "statusCategory": {"key": "done"}}}
+]}`
+
+// transitionServer serves the transitions list and captures the POSTed
+// transition id; the issue endpoint reports the given current status.
+func transitionServer(t *testing.T, currentStatus, categoryKey string, posted *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(transitionsBody))
+		case strings.HasSuffix(r.URL.Path, "/transitions") && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var req transitionRequest
+			_ = json.Unmarshal(body, &req)
+			*posted = req.Transition.ID
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(r.URL.Path, "/issue/10001"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "10001", "key": "ERP-1",
+				"fields": map[string]any{
+					"status": map[string]any{"name": currentStatus, "statusCategory": map[string]any{"key": categoryKey}},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestSetState_MatchesTargetCaseInsensitively(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "To Do", "new", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	if err := a.SetState(context.Background(), model.SourceItem{ID: "10001"}, "done"); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+	if posted != "21" {
+		t.Errorf("expected transition 21 posted, got %q", posted)
+	}
+}
+
+func TestSetState_FallsBackToTransitionName(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "To Do", "new", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	if err := a.SetState(context.Background(), model.SourceItem{ID: "10001"}, "start work"); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+	if posted != "11" {
+		t.Errorf("expected transition 11 posted, got %q", posted)
+	}
+}
+
+func TestSetState_AlreadyInTargetIsNoop(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "Blocked", "indeterminate", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	if err := a.SetState(context.Background(), model.SourceItem{ID: "10001"}, "blocked"); err != nil {
+		t.Fatalf("expected no-op success when already in target state: %v", err)
+	}
+	if posted != "" {
+		t.Errorf("no transition should be posted, got %q", posted)
+	}
+}
+
+func TestSetState_UnreachableListsAvailable(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "To Do", "new", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	err := a.SetState(context.Background(), model.SourceItem{ID: "10001"}, "Archived")
+	if err == nil {
+		t.Fatal("expected error for unreachable state")
+	}
+	if !strings.Contains(err.Error(), "In Progress, Done") {
+		t.Errorf("error should list available targets: %v", err)
+	}
+}
+
+func TestAcknowledge_UsesConfiguredStartedState(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "To Do", "new", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	a.startedState = "In Progress"
+	if err := a.Acknowledge(context.Background(), model.SourceItem{ID: "10001"}, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if posted != "11" {
+		t.Errorf("expected transition 11 posted, got %q", posted)
+	}
+}
+
+func TestAcknowledge_FallsBackToIndeterminateCategory(t *testing.T) {
+	var posted string
+	srv := transitionServer(t, "To Do", "new", &posted)
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	if err := a.Acknowledge(context.Background(), model.SourceItem{ID: "10001"}, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if posted != "11" {
+		t.Errorf("expected the indeterminate-category transition 11, got %q", posted)
+	}
+}
+
+func TestAcknowledge_OtherActionsAreNoops(t *testing.T) {
+	a := newTestAdapter("http://unused.invalid")
+	if err := a.Acknowledge(context.Background(), model.SourceItem{ID: "10001"}, model.AckActionSkip); err != nil {
+		t.Errorf("skip action must be a no-op: %v", err)
+	}
+}
+
+func TestAddAndRemoveLabels_AtomicVerbsAndSanitization(t *testing.T) {
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.HasSuffix(r.URL.Path, "/issue/10001") {
+			b, _ := io.ReadAll(r.Body)
+			bodies = append(bodies, string(b))
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	cell := model.SourceItem{ID: "10001"}
+
+	if err := a.AddLabels(context.Background(), cell, []string{"agent:engineer", "needs review"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+	if err := a.RemoveLabels(context.Background(), cell, []string{"in-progress"}); err != nil {
+		t.Fatalf("RemoveLabels: %v", err)
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 PUTs, got %d", len(bodies))
+	}
+	if !strings.Contains(bodies[0], `{"add":"agent:engineer"}`) || !strings.Contains(bodies[0], `{"add":"needs-review"}`) {
+		t.Errorf("add body wrong (space not sanitized?): %s", bodies[0])
+	}
+	if !strings.Contains(bodies[1], `{"remove":"in-progress"}`) {
+		t.Errorf("remove body wrong: %s", bodies[1])
+	}
+}
+
+func TestConnect_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  map[string]any
+		want string
+	}{
+		{"missing base_url", map[string]any{"email": "e@x.com", "api_token": "t"}, "base_url"},
+		{"relative base_url", map[string]any{"base_url": "yoursite.atlassian.net", "email": "e@x.com", "api_token": "t"}, "http(s)"},
+		{"missing email", map[string]any{"base_url": "https://x.atlassian.net", "api_token": "t"}, "email"},
+		{"missing api_token", map[string]any{"base_url": "https://x.atlassian.net", "email": "e@x.com"}, "api_token"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := (&Adapter{}).Connect(context.Background(), tt.cfg)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("expected error mentioning %q, got %v", tt.want, err)
+			}
+		})
+	}
+
+	ok := map[string]any{
+		"base_url": "https://x.atlassian.net/", "email": "e@x.com", "api_token": "t",
+		"project": "ERP", "started_state": "In Progress",
+	}
+	a := &Adapter{}
+	if err := a.Connect(context.Background(), ok); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+	if a.baseURL != "https://x.atlassian.net" {
+		t.Errorf("trailing slash not trimmed: %q", a.baseURL)
+	}
+	if a.project != "ERP" || a.startedState != "In Progress" {
+		t.Errorf("optional fields not stored: %+v", a)
+	}
+}
+
+func TestClient_RetriesOn429(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "e@x.com", "t")
+	if _, err := c.get(context.Background(), "/rest/api/3/myself", nil); err != nil {
+		t.Fatalf("expected retry to succeed: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls (429 then 200), got %d", calls)
+	}
+}
+
+func TestSearchAll_StopsOnRepeatedToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Always hand back the same token: the guard must terminate the loop.
+		_, _ = w.Write([]byte(`{"issues": [], "nextPageToken": "same"}`))
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "e@x.com", "t")
+	if _, err := c.searchAll(context.Background(), "project = X"); err != nil {
+		t.Fatalf("repeated token must terminate cleanly: %v", err)
+	}
+}

--- a/src/internal/source/jira/adf.go
+++ b/src/internal/source/jira/adf.go
@@ -1,0 +1,167 @@
+package jira
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// adfNode is a single Atlassian Document Format node. Jira Cloud's v3 API
+// represents rich text (descriptions, comments) as a tree of these.
+type adfNode struct {
+	Type    string         `json:"type"`
+	Version int            `json:"version,omitempty"`
+	Text    string         `json:"text,omitempty"`
+	Content []adfNode      `json:"content,omitempty"`
+	Marks   []adfMark      `json:"marks,omitempty"`
+	Attrs   map[string]any `json:"attrs,omitempty"`
+}
+
+type adfMark struct {
+	Type  string         `json:"type"`
+	Attrs map[string]any `json:"attrs,omitempty"`
+}
+
+// adfBlockNodes get a trailing newline when flattened to plain text.
+var adfBlockNodes = map[string]bool{
+	"paragraph":  true,
+	"heading":    true,
+	"codeBlock":  true,
+	"blockquote": true,
+	"listItem":   true,
+	"tableRow":   true,
+	"rule":       true,
+}
+
+// adfToText flattens an ADF document into plain text. It is tolerant of
+// null/empty input, plain-string bodies, and unknown node types (which are
+// recursed into so their text content is not lost).
+func adfToText(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var n adfNode
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	flattenADF(&b, n)
+	return strings.TrimSpace(b.String())
+}
+
+func flattenADF(b *strings.Builder, n adfNode) {
+	switch n.Type {
+	case "text":
+		b.WriteString(n.Text)
+	case "hardBreak":
+		b.WriteString("\n")
+	case "mention", "emoji":
+		if t, ok := n.Attrs["text"].(string); ok {
+			b.WriteString(t)
+		}
+	case "inlineCard":
+		if u, ok := n.Attrs["url"].(string); ok {
+			b.WriteString(u)
+		}
+	default:
+		for _, c := range n.Content {
+			flattenADF(b, c)
+		}
+		if adfBlockNodes[n.Type] {
+			b.WriteString("\n")
+		}
+	}
+}
+
+// --- minimal ADF builders for WriteResult comments ---
+//
+// ADF rejects empty text nodes, so builders are only called with non-empty
+// strings (callers guard).
+
+func adfDoc(content ...adfNode) adfNode {
+	return adfNode{Type: "doc", Version: 1, Content: content}
+}
+
+func adfParagraph(content ...adfNode) adfNode {
+	return adfNode{Type: "paragraph", Content: content}
+}
+
+func adfText(s string, marks ...string) adfNode {
+	n := adfNode{Type: "text", Text: s}
+	for _, m := range marks {
+		n.Marks = append(n.Marks, adfMark{Type: m})
+	}
+	return n
+}
+
+func adfLink(url string) adfNode {
+	return adfNode{
+		Type:  "text",
+		Text:  url,
+		Marks: []adfMark{{Type: "link", Attrs: map[string]any{"href": url}}},
+	}
+}
+
+func adfCodeBlock(s string) adfNode {
+	return adfNode{Type: "codeBlock", Content: []adfNode{{Type: "text", Text: s}}}
+}
+
+// formatComment renders a run result as an ADF document, mirroring the layout
+// the other adapters post: status line, optional PR link, output, error.
+func formatComment(result model.RunResult) adfNode {
+	worker := result.WorkerID
+	if worker == "" {
+		worker = "unknown"
+	}
+	head := []adfNode{}
+	if result.Success {
+		head = append(head, adfText("✓ "), adfText("Apiary run complete", "strong"))
+	} else {
+		head = append(head, adfText("✗ "), adfText("Apiary run failed", "strong"))
+	}
+	head = append(head,
+		adfText(" · worker: "),
+		adfText(worker, "code"),
+		adfText(fmt.Sprintf(" · duration: %s", result.Duration.Round(time.Second))),
+	)
+
+	blocks := []adfNode{adfParagraph(head...)}
+
+	if prURL := extractPRURL(result.Output); prURL != "" {
+		blocks = append(blocks, adfParagraph(adfText("🔗 Pull Request: ", "strong"), adfLink(prURL)))
+	}
+	if result.Output != "" {
+		blocks = append(blocks, adfCodeBlock(result.Output))
+	}
+	if result.Error != nil && result.Error.Error() != "" {
+		blocks = append(blocks, adfParagraph(adfText("Error: ", "strong"), adfText(result.Error.Error(), "code")))
+	}
+	return adfDoc(blocks...)
+}
+
+var prURLRe = regexp.MustCompile(`https://github\.com/[^/\s]+/[^/\s]+/pull/\d+`)
+
+func extractPRURL(output string) string {
+	if output == "" {
+		return ""
+	}
+	if match := prURLRe.FindString(output); match != "" {
+		return match
+	}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "github.com") && strings.Contains(line, "/pull/") {
+			return line
+		}
+	}
+	return ""
+}

--- a/src/internal/source/jira/adf_test.go
+++ b/src/internal/source/jira/adf_test.go
@@ -1,0 +1,142 @@
+package jira
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestADFToText_EmptyAndNull(t *testing.T) {
+	if got := adfToText(nil); got != "" {
+		t.Errorf("nil: got %q", got)
+	}
+	if got := adfToText(json.RawMessage("null")); got != "" {
+		t.Errorf("null: got %q", got)
+	}
+}
+
+func TestADFToText_PlainString(t *testing.T) {
+	if got := adfToText(json.RawMessage(`"just text"`)); got != "just text" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestADFToText_ParagraphsAndHardBreak(t *testing.T) {
+	doc := `{"type":"doc","version":1,"content":[
+		{"type":"paragraph","content":[
+			{"type":"text","text":"line one"},
+			{"type":"hardBreak"},
+			{"type":"text","text":"line two"}
+		]},
+		{"type":"paragraph","content":[{"type":"text","text":"second para"}]}
+	]}`
+	got := adfToText(json.RawMessage(doc))
+	want := "line one\nline two\nsecond para"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestADFToText_CodeBlockAndList(t *testing.T) {
+	doc := `{"type":"doc","version":1,"content":[
+		{"type":"codeBlock","content":[{"type":"text","text":"go test ./..."}]},
+		{"type":"bulletList","content":[
+			{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"first"}]}]},
+			{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"second"}]}]}
+		]}
+	]}`
+	got := adfToText(json.RawMessage(doc))
+	for _, want := range []string{"go test ./...", "first", "second"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestADFToText_MentionAndInlineCard(t *testing.T) {
+	doc := `{"type":"doc","version":1,"content":[{"type":"paragraph","content":[
+		{"type":"mention","attrs":{"id":"abc","text":"@Orlando"}},
+		{"type":"text","text":" see "},
+		{"type":"inlineCard","attrs":{"url":"https://example.com/spec"}}
+	]}]}`
+	got := adfToText(json.RawMessage(doc))
+	want := "@Orlando see https://example.com/spec"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestADFToText_UnknownNodeRecursed(t *testing.T) {
+	doc := `{"type":"doc","version":1,"content":[
+		{"type":"futureWidget","content":[{"type":"text","text":"survives"}]}
+	]}`
+	if got := adfToText(json.RawMessage(doc)); got != "survives" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFormatComment_Success(t *testing.T) {
+	result := model.RunResult{
+		WorkerID: "engineer",
+		Success:  true,
+		Output:   "all done\nhttps://github.com/o/r/pull/7",
+		Duration: 90 * time.Second,
+	}
+	data, err := json.Marshal(formatComment(result))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		`"type":"doc"`, `"version":1,`,
+		"Apiary run complete", "engineer", "1m30s",
+		`"type":"codeBlock"`,
+		"https://github.com/o/r/pull/7", `"type":"link"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %s in %s", want, s)
+		}
+	}
+}
+
+func TestFormatComment_FailureWithError(t *testing.T) {
+	result := model.RunResult{
+		WorkerID: "qa",
+		Success:  false,
+		Error:    errors.New("exit status 1"),
+	}
+	data, err := json.Marshal(formatComment(result))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "Apiary run failed") || !strings.Contains(s, "exit status 1") {
+		t.Errorf("failure layout wrong: %s", s)
+	}
+	if strings.Contains(s, "codeBlock") {
+		t.Error("empty output must not produce a codeBlock (ADF rejects empty text nodes)")
+	}
+}
+
+func TestFormatComment_EscapesSpecialChars(t *testing.T) {
+	result := model.RunResult{
+		WorkerID: "w",
+		Success:  true,
+		Output:   `quotes " and <pre> tags`,
+	}
+	data, err := json.Marshal(formatComment(result))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundTrip adfNode
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if got := adfToText(data); !strings.Contains(got, `quotes " and <pre> tags`) {
+		t.Errorf("output not preserved verbatim: %q", got)
+	}
+}

--- a/src/internal/source/jira/client.go
+++ b/src/internal/source/jira/client.go
@@ -1,0 +1,192 @@
+package jira
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+const (
+	maxRetries     = 5
+	baseBackoff    = time.Second
+	maxSearchPages = 50
+)
+
+type client struct {
+	baseURL    string
+	email      string
+	apiToken   string
+	httpClient *http.Client
+}
+
+func newClient(baseURL, email, apiToken string) *client {
+	return &client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		email:      email,
+		apiToken:   apiToken,
+		httpClient: &http.Client{},
+	}
+}
+
+// credentials returns the Basic-auth pair for a request. A per-agent override
+// from source.SourceTokenCtxKey replaces the API token; when the override
+// contains ":" it is treated as "email:api_token" and replaces both (Jira
+// Cloud Basic auth always needs the account email alongside the token).
+func (c *client) credentials(ctx context.Context) (email, token string) {
+	email, token = c.email, c.apiToken
+	if t, ok := ctx.Value(source.SourceTokenCtxKey).(string); ok && t != "" {
+		if e, tok, found := strings.Cut(t, ":"); found {
+			email, token = e, tok
+		} else {
+			token = t
+		}
+	}
+	return email, token
+}
+
+func (c *client) get(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	return c.doWithRetry(ctx, http.MethodGet, path, nil)
+}
+
+func (c *client) post(ctx context.Context, path string, payload any) ([]byte, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return c.doWithRetry(ctx, http.MethodPost, path, data)
+}
+
+func (c *client) put(ctx context.Context, path string, payload any) ([]byte, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return c.doWithRetry(ctx, http.MethodPut, path, data)
+}
+
+// doWithRetry executes the request, retrying on 429 with exponential backoff.
+// It honours the Retry-After header when present. Error responses include the
+// body so Jira's errorMessages (e.g. JQL syntax errors) stay visible.
+func (c *client) doWithRetry(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		var bodyReader io.Reader
+		if body != nil {
+			bodyReader = bytes.NewReader(body)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+		if err != nil {
+			return nil, err
+		}
+		email, token := c.credentials(ctx)
+		req.SetBasicAuth(email, token)
+		req.Header.Set("Accept", "application/json")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		aplog.Debug("jira: %s %s → %d", method, req.URL.Path, resp.StatusCode)
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			wait := retryAfter(resp, attempt)
+			lastErr = fmt.Errorf("rate limited")
+			aplog.Info("jira: rate limited — waiting %s before retry %d/%d",
+				wait.Round(time.Millisecond), attempt+1, maxRetries)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("jira API %s %s: status %d: %s", method, req.URL.Path, resp.StatusCode, respBody)
+		}
+		return respBody, nil
+	}
+
+	return nil, fmt.Errorf("jira API %s %s: exceeded %d retries: %w", method, path, maxRetries, lastErr)
+}
+
+// retryAfter returns how long to wait before the next attempt.
+// Uses the Retry-After header if present, otherwise exponential backoff.
+func retryAfter(resp *http.Response, attempt int) time.Duration {
+	if h := resp.Header.Get("Retry-After"); h != "" {
+		if secs, err := strconv.Atoi(h); err == nil {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	// exponential backoff: 1s, 2s, 4s, 8s, …
+	return baseBackoff * (1 << attempt)
+}
+
+// searchFields is every issue field Poll/PollTask need; user-identifying
+// fields (assignee, reporter) are deliberately not requested.
+const searchFields = "summary,description,status,labels,priority,issuetype,created,updated"
+
+// searchAll pages through GET /rest/api/3/search/jql. The legacy
+// /rest/api/3/search endpoint was removed from Jira Cloud in 2025 and returns
+// 410 Gone — do not "simplify" back to it. Pagination is an opaque
+// nextPageToken; the loop is additionally guarded against a server that
+// repeats a token or never stops handing them out.
+func (c *client) searchAll(ctx context.Context, jql string) ([]issue, error) {
+	var all []issue
+	token := ""
+
+	for page := 0; page < maxSearchPages; page++ {
+		params := url.Values{
+			"jql":        {jql},
+			"maxResults": {"100"},
+			"fields":     {searchFields},
+		}
+		if token != "" {
+			params.Set("nextPageToken", token)
+		}
+
+		data, err := c.get(ctx, "/rest/api/3/search/jql", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var pg searchResponse
+		if err := json.Unmarshal(data, &pg); err != nil {
+			return nil, fmt.Errorf("jira: decoding search page: %w", err)
+		}
+
+		all = append(all, pg.Issues...)
+
+		if pg.NextPageToken == "" || pg.NextPageToken == token {
+			return all, nil
+		}
+		token = pg.NextPageToken
+	}
+
+	return nil, fmt.Errorf("jira: search pagination exceeded %d pages — narrow filters.jql", maxSearchPages)
+}

--- a/src/internal/source/jira/polltask_test.go
+++ b/src/internal/source/jira/polltask_test.go
@@ -1,0 +1,103 @@
+package jira
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const issueBody = `{
+	"id": "10001", "key": "ERP-1",
+	"fields": {
+		"summary": "Add login",
+		"description": null,
+		"status": {"name": "In Review", "statusCategory": {"key": "indeterminate"}},
+		"labels": ["apiary"],
+		"created": "2026-06-01T10:00:00.000-0300",
+		"updated": "2026-06-09T15:30:00.000-0300"
+	}
+}`
+
+func adfComment(id int, text string) string {
+	return fmt.Sprintf(`{
+		"id": "%d",
+		"body": {"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"%s"}]}]},
+		"created": "2026-06-0%dT10:00:00.000-0300"
+	}`, id, text, id)
+}
+
+func TestPollTask_FetchesIssueAndPaginatedComments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/issue/10001/comment"):
+			if r.URL.Query().Get("startAt") == "0" {
+				_, _ = fmt.Fprintf(w, `{"comments": [%s, %s], "total": 3}`,
+					adfComment(1, "needs work"), adfComment(2, "fixed"))
+			} else {
+				_, _ = fmt.Fprintf(w, `{"comments": [%s], "total": 3}`,
+					adfComment(3, "looks good, approve"))
+			}
+		case strings.HasSuffix(r.URL.Path, "/issue/10001"):
+			_, _ = w.Write([]byte(issueBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	cell, err := a.PollTask(context.Background(), "10001")
+	if err != nil {
+		t.Fatalf("PollTask: %v", err)
+	}
+	if cell.ID != "10001" || cell.Number != "ERP-1" || cell.State != "In Review" {
+		t.Errorf("issue fields wrong: %+v", cell)
+	}
+	if len(cell.Comments) != 3 {
+		t.Fatalf("expected 3 comments across pages, got %d", len(cell.Comments))
+	}
+	if cell.Comments[2].Body != "looks good, approve" {
+		t.Errorf("ADF comment body not flattened: %q", cell.Comments[2].Body)
+	}
+	if cell.Comments[0].CreatedAt.IsZero() {
+		t.Error("comment created not parsed")
+	}
+}
+
+func TestPollTask_CommentFailureIsNonFatal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/comment"):
+			http.Error(w, "boom", http.StatusInternalServerError)
+		case strings.HasSuffix(r.URL.Path, "/issue/10001"):
+			_, _ = w.Write([]byte(issueBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	cell, err := a.PollTask(context.Background(), "10001")
+	if err != nil {
+		t.Fatalf("comment failure must not fail PollTask: %v", err)
+	}
+	if len(cell.Comments) != 0 {
+		t.Errorf("expected no comments, got %d", len(cell.Comments))
+	}
+}
+
+func TestPollTask_IssueErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(srv.URL)
+	if _, err := a.PollTask(context.Background(), "999"); err == nil {
+		t.Error("expected error when issue fetch fails")
+	}
+}

--- a/src/internal/source/jira/types.go
+++ b/src/internal/source/jira/types.go
@@ -1,0 +1,95 @@
+package jira
+
+import "encoding/json"
+
+// searchResponse is the envelope of GET /rest/api/3/search/jql. The enhanced
+// endpoint paginates with an opaque token and carries no total count.
+type searchResponse struct {
+	Issues        []issue `json:"issues"`
+	NextPageToken string  `json:"nextPageToken"`
+}
+
+type issue struct {
+	ID     string      `json:"id"`  // immutable numeric id, e.g. "10042"
+	Key    string      `json:"key"` // human-facing key, e.g. "ERP-42"
+	Fields issueFields `json:"fields"`
+}
+
+type issueFields struct {
+	Summary     string          `json:"summary"`
+	Description json.RawMessage `json:"description"` // ADF document, or null
+	Status      *statusEntity   `json:"status"`
+	Priority    *namedEntity    `json:"priority"`
+	IssueType   *namedEntity    `json:"issuetype"`
+	Labels      []string        `json:"labels"`
+	Created     string          `json:"created"`
+	Updated     string          `json:"updated"`
+}
+
+type namedEntity struct {
+	Name string `json:"name"`
+}
+
+type statusEntity struct {
+	Name           string         `json:"name"`
+	StatusCategory statusCategory `json:"statusCategory"`
+}
+
+type statusCategory struct {
+	Key string `json:"key"` // "new", "indeterminate", "done"
+}
+
+// transitionsResponse is the envelope of GET /issue/{id}/transitions.
+type transitionsResponse struct {
+	Transitions []transition `json:"transitions"`
+}
+
+type transition struct {
+	ID   string       `json:"id"`
+	Name string       `json:"name"`
+	To   statusEntity `json:"to"`
+}
+
+type transitionRequest struct {
+	Transition transitionID `json:"transition"`
+}
+
+type transitionID struct {
+	ID string `json:"id"`
+}
+
+// commentPage is the envelope of GET /issue/{id}/comment (offset pagination).
+type commentPage struct {
+	Comments []comment `json:"comments"`
+	Total    int       `json:"total"`
+}
+
+type comment struct {
+	ID      string          `json:"id"`
+	Body    json.RawMessage `json:"body"` // ADF document
+	Created string          `json:"created"`
+}
+
+type commentCreateRequest struct {
+	Body adfNode `json:"body"`
+}
+
+// labelsUpdateRequest is the PUT /issue/{id} body using Jira's atomic update
+// verbs, so labels are added/removed without a read-modify-write cycle.
+type labelsUpdateRequest struct {
+	Update labelsUpdate `json:"update"`
+}
+
+type labelsUpdate struct {
+	Labels []labelOp `json:"labels"`
+}
+
+type labelOp struct {
+	Add    string `json:"add,omitempty"`
+	Remove string `json:"remove,omitempty"`
+}
+
+// myself is the slice of GET /rest/api/3/myself we care about.
+type myself struct {
+	TimeZone string `json:"timeZone"`
+}


### PR DESCRIPTION
## Summary
- New `jira` source adapter (Jira Cloud only): polls issues via the enhanced JQL search endpoint (`/rest/api/3/search/jql`, `nextPageToken` pagination — the legacy `/search` returns 410 Gone on Cloud), Basic auth with account email + API token.
- Capabilities: `StateSetter` + `Acknowledge` via the transitions API (configurable `started_state`, falling back to the first *In Progress*-category transition), `LabelAdder`/`LabelRemover` with atomic update verbs (whitespace in label names sanitized to `-`), and `TaskPoller` with paginated comments so approval steps work. CI polling / PR listing are intentionally omitted (PR-centric, no Jira mapping).
- Rich text both ways: run results are posted as native ADF comments (status line, detected PR link, output code block); issue descriptions and comments are flattened from ADF to plain text for agents and approval matching.
- Incremental polling converts `since` to the API user's profile timezone (lazy `/myself` lookup) with a 2-minute slack, and re-applies the exact cut-off client-side. 429s retry honoring `Retry-After`.
- `filters.jql` (already in the config schema) now reaches adapters via a new duck-typed `SetJQL` probe in the dispatcher — additive, existing adapters untouched.
- Docs: new `docs/jira-source.md` mirroring the Plane page, mkdocs nav entry, and a jira block in `.apiary/example-apiary-full.yaml`.

## Test plan
- `go build ./... && go test ./...` green (new unit tests cover JQL building incl. timezone slack, search pagination + repeated-token guard, SourceItem mapping incl. Jira's colonless timestamp offset, transitions matching/no-op/unreachable error, Acknowledge paths, label verbs + sanitization, Connect validation, 429 retry, ADF flatten/build, PollTask comment pagination + non-fatal comment failure).
- `apiary validate` passes on the updated full example config.
- E2E against a real Jira Cloud sandbox pending (poll → ack transition → ADF result comment → labels → approval round-trip); will run before merging.