### PR TITLE
fix(config): make example configs runnable and regenerate the JSON schema from the Go structs

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -1,7 +1,16 @@
 version: "1"
 
 # ── Runners ────────────────────────────────────────────────────────────────────
-# Define how agents will execute (CLI, API, custom gateway, etc.)
+# Define how agents will execute. The adapter is resolved as "{provider}-{type}"
+# (or just "type" when provider is empty). Registered adapters:
+#
+#   claude-cli    →  type: cli, provider: claude    (the `claude` binary)
+#   opencode-cli  →  type: cli, provider: opencode  (the `opencode` binary)
+#   cursor-cli    →  type: cli, provider: cursor    (the `agent` binary, Cursor CLI)
+#   opencode-api  →  type: opencode-api             (OpenCode HTTP API)
+#
+# Any other combination fails at daemon startup with "runner type not found".
+# See docs/runners.md for the full reference.
 runners:
   # Claude CLI runner (local development, no API keys needed)
   - id: claude-cli
@@ -21,66 +30,36 @@ runners:
         # env:                       # optional; ${VAR} refs are expanded at load
         #   GITNEXUS_TOKEN: ${GITNEXUS_TOKEN}
 
-  # Claude API runner (Anthropic API with full model access) — requires provider
-  - id: claude-api
+  # Cursor agent CLI — requires the `agent` binary from https://cursor.com/install.
+  # The preset runs it headlessly (`-p --output-format stream-json --force`) and
+  # passes the prompt positionally; no config needed.
+  - id: cursor-cli
     type: cli
-    provider: anthropic
-    config:
-      provider: anthropic
-      base_url: https://api.anthropic.com/v1
-      api_key: ${ANTHROPIC_API_KEY}
-      # Optional: model name mappings if needed
-      # models:
-      #   claude-opus-4-8: claude-4-20250514
-      #   claude-sonnet-4-6: claude-3-5-sonnet-20241022
+    provider: cursor
 
-  # ── OpenCode runners ────────────────────────────────────────────────────────
-  # OpenCode has two subscription tiers (Go and Zen), each available in two
-  # execution modes (CLI and API). Choose the combination that fits your setup.
-  #
-  #   CLI mode:   invokes the opencode binary as a subprocess.
-  #               Requires opencode installed on the host.
-  #
-  #   API mode:   calls the opencode HTTP API directly.
-  #               Requires an API key from the respective subscription.
-  #
-  # OpenCode Go — CLI mode (uses the local opencode binary with Go subscription)
-  - id: opencode-go-cli
+  # OpenCode CLI — invokes the local `opencode` binary (`opencode run …` with the
+  # prompt as a positional argument). The binary authenticates as whatever account
+  # is logged in; Apiary never handles credentials for CLI runners.
+  - id: opencode-cli
     type: cli
     provider: opencode
-    config:
-      mode: cli
-      subscription: go
-      binary: opencode
-      agent: backend-dev
-      model_flag: --model
-      prompt_flag: --prompt
-      turns_flag: --max-turns
-      agent_flag: --agent
+    # All `config` keys are optional — the provider preset covers them. Available
+    # keys: command (binary override), args, model_flag, prompt_flag,
+    # prompt_positional, turns_flag. See docs/runners.md#cli-engine-configuration.
+    # config:
+    #   command: /usr/local/bin/opencode
 
-  # OpenCode Go — API mode (calls the Go API directly)
-  - id: opencode-go-api
+  # OpenCode API — calls the OpenCode HTTP API directly (OpenAI-compatible
+  # chat completions). Requires an API key.
+  - id: opencode-api
     type: opencode-api
     config:
-      subscription: go
-      api_key: ${OPENCODE_GO_API_KEY}
+      api_key: ${OPENCODE_API_KEY}
+      # base_url: https://api.opencode.ai/v1   # optional; /chat/completions appended
+      # endpoint: https://...                  # full URL override (wins over base_url)
     models:
       - opencode-go/deepseek-v4-pro
       - opencode-go/minimax-m3
-
-  # OpenCode Zen — CLI mode (uses the local opencode binary with Zen subscription)
-  - id: opencode-zen-cli
-    type: cli
-    provider: opencode
-    config:
-      binary: opencode
-
-  # OpenCode Zen — API mode (calls the Zen API directly)
-  - id: opencode-zen-api
-    type: opencode-api
-    config:
-      subscription: zen
-      api_key: ${OPENCODE_ZEN_API_KEY}
 
 # Default runner used by agents if not overridden
 default_runner: claude-cli
@@ -150,8 +129,8 @@ agents:
     # limit, retry on these runners (in order) until one isn't rate-limited.
     # `runner` must be defined above; `model` is optional (omitted = its default).
     fallbacks:
-      - {runner: opencode-go-cli}
-      - {runner: opencode-zen-cli}
+      - {runner: opencode-cli, model: opencode-go/deepseek-v4-pro}
+      - {runner: cursor-cli}
     # Agent-scope MCP servers are layered over the runner's `mcps:` (override by
     # name, new names appended). Use this to give one agent an extra tool.
     # mcps:
@@ -187,32 +166,18 @@ agents:
     source_email: qa@company.com
 
   # === OpenCode-based agents ===
-  - id: agent-go-cli
-    description: "OpenCode Go — runs tasks via the opencode CLI"
+  - id: agent-opencode-cli
+    description: "OpenCode — runs tasks via the opencode CLI"
     soul_file: .apiary/souls/engineer.md
-    runner: opencode-go-cli
+    runner: opencode-cli
     model: opencode-go/deepseek-v4-flash
     skills: [git-workflow, gitnexus-codebase]
 
-  - id: agent-go-api
-    description: "OpenCode Go — runs tasks via the Go API"
+  - id: agent-opencode-api
+    description: "OpenCode — runs tasks via the OpenCode API"
     soul_file: .apiary/souls/engineer.md
-    runner: opencode-go-api
+    runner: opencode-api
     model: opencode-go/deepseek-v4-pro
-    skills: [git-workflow, gitnexus-codebase]
-
-  - id: agent-zen-cli
-    description: "OpenCode Zen — runs tasks via the opencode CLI"
-    soul_file: .apiary/souls/engineer.md
-    runner: opencode-zen-cli
-    model: opencode/gpt-5.5
-    skills: [git-workflow, gitnexus-codebase]
-
-  - id: agent-zen-api
-    description: "OpenCode Zen — runs tasks via the Zen API"
-    soul_file: .apiary/souls/engineer.md
-    runner: opencode-zen-api
-    model: opencode/gpt-5.4
     skills: [git-workflow, gitnexus-codebase]
 
 # ── Workflows ──────────────────────────────────────────────────────────────────
@@ -414,7 +379,6 @@ settings:
   concurrency: 2
   log_level: info
   state_lock: true
-  result_comment: true
   # Stop re-dispatching a (task, workflow) after this many consecutive failed
   # instances (rate-limited runs fail over and don't count). <=0 disables.
   max_attempts: 3

--- a/.apiary/example-with-recovery.yaml
+++ b/.apiary/example-with-recovery.yaml
@@ -1,13 +1,11 @@
-version: "1.0"
+version: "1"
 
 runners:
   - id: claude-cli
     type: cli
+    provider: claude
     config:
-      command: claude
-      model_flag: --model
-      prompt_flag: --input-text
-      turns_flag: --turns
+      args: ["--output-format", "stream-json", "--verbose"]
 
 default_runner: claude-cli
 
@@ -15,9 +13,10 @@ sources:
   - id: project-erp
     type: plane
     config:
-      workspace_id: ${PLANE_WORKSPACE_ID}
-      project_id: ${PLANE_PROJECT_ID}
-      api_token: ${PLANE_API_TOKEN}
+      workspace: my-workspace
+      project: ${PLANE_PROJECT_ID}
+      api_key: ${PLANE_API_KEY}
+      base_url: https://plane.example.com
     poll_interval: 60s
     filters:
       states: [backlog, todo]
@@ -66,5 +65,4 @@ settings:
   concurrency: 4
   log_level: info
   state_lock: true
-  result_comment: true
 

--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -129,4 +129,3 @@ workflows:
 settings:
   concurrency: 2
   state_lock: true
-  result_comment: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ agents:
 
     # Rate-limit failover chain — see Rate limits & resilience
     fallbacks:
-      - {runner: opencode-go-cli, model: opencode-go/deepseek-v4-pro}
+      - {runner: opencode, model: opencode-go/deepseek-v4-pro}
 
     # Agent-scope environment variables
     env:

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -26,7 +26,7 @@ agents:
     runner: claude
     model: claude-sonnet-4-6
     fallbacks:
-      - {runner: opencode-go-cli, model: opencode-go/deepseek-v4-pro}
+      - {runner: opencode, model: opencode-go/deepseek-v4-pro}
       - {runner: cursor, model: composer-2.5-fast}
 ```
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -2,19 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://apiary.orlandoburli.com.br/schema/apiary.json",
   "title": "Apiary Configuration Schema",
-  "description": "JSON Schema for apiary.yaml workflow configuration files",
+  "description": "JSON Schema for apiary.yaml workflow configuration files. Mirrors the Go structs in src/internal/config (config.go, workflow.go).",
   "type": "object",
   "additionalProperties": false,
   "required": ["version"],
   "properties": {
     "version": {
       "type": "string",
-      "description": "Configuration schema version (e.g., '1.0')",
-      "default": "1.0"
+      "description": "Configuration schema version (currently '1')",
+      "default": "1"
     },
     "runners": {
       "type": "array",
-      "description": "Runner definitions for agent execution",
+      "description": "Runner definitions for agent execution. The adapter is resolved as '{provider}-{type}' (or just 'type' when provider is empty); registered adapters: claude-cli, opencode-cli, cursor-cli, opencode-api",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -22,39 +22,102 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique runner identifier"
+            "description": "Unique runner identifier, referenced by agents[].runner and agents[].fallbacks"
           },
           "type": {
             "type": "string",
-            "description": "Execution mode: 'cli' or 'api'",
-            "enum": ["cli", "api"]
+            "description": "Execution engine: 'cli' (subprocess, combined with provider) or a self-contained adapter name like 'opencode-api'",
+            "enum": ["cli", "claude-cli", "opencode-cli", "cursor-cli", "opencode-api"]
           },
           "provider": {
             "type": "string",
-            "description": "Runner provider/adapter (e.g., 'claude', 'opencode', 'cursor')"
+            "description": "Which CLI the 'cli' engine drives. The adapter is resolved as '{provider}-{type}'; any unregistered combination fails at daemon startup with 'runner type not found'",
+            "enum": ["claude", "opencode", "cursor"]
           },
           "config": {
             "type": "object",
-            "description": "Runner-specific configuration",
-            "additionalProperties": true
+            "description": "Engine options. CLI engine keys: command, args, model_flag, prompt_flag, prompt_positional, turns_flag (provider presets cover them; override only when needed). API engine keys: api_key, base_url, endpoint",
+            "additionalProperties": true,
+            "properties": {
+              "command": {
+                "type": "string",
+                "description": "Binary to invoke (override to use a wrapper or absolute path). Preset: claude / opencode / agent"
+              },
+              "args": {
+                "type": "array",
+                "description": "Extra argv prepended to every run (e.g. ['--output-format', 'stream-json', '--verbose'] for claude)",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "model_flag": {
+                "type": "string",
+                "description": "Flag used to pass the step's model (preset: --model)"
+              },
+              "prompt_flag": {
+                "type": "string",
+                "description": "Flag used to pass the prompt; empty with prompt_positional false delivers the prompt on stdin"
+              },
+              "prompt_positional": {
+                "type": "boolean",
+                "description": "Pass the prompt as the last positional argument (preset: true for opencode and cursor)"
+              },
+              "turns_flag": {
+                "type": "string",
+                "description": "Flag used to pass a max-turns limit"
+              },
+              "api_key": {
+                "type": "string",
+                "description": "API runners: sent as 'Authorization: Bearer <key>'"
+              },
+              "base_url": {
+                "type": "string",
+                "description": "API runners: override the API base; /chat/completions is appended"
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "API runners: full URL override (takes precedence over base_url)"
+              }
+            }
           },
           "models": {
             "type": "array",
-            "description": "Supported models for this runner",
+            "description": "Models this runner supports (informational)",
             "items": {
               "type": "string"
             }
+          },
+          "mcps": {
+            "type": "array",
+            "description": "MCP servers exposed to every agent on this runner. Agent-scope mcps are layered on top, overriding by name",
+            "items": {
+              "$ref": "#/definitions/MCPServer"
+            }
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "cli"
+                }
+              }
+            },
+            "then": {
+              "required": ["provider"]
+            }
+          }
+        ]
       }
     },
     "default_runner": {
       "type": "string",
-      "description": "Default runner ID to use when not specified"
+      "description": "Default runner ID used by agents that don't name a runner"
     },
     "sources": {
       "type": "array",
-      "description": "Task sources (GitHub, Jira, Linear, etc.)",
+      "description": "Task sources (github, plane)",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -62,21 +125,22 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique source identifier"
+            "description": "Unique source identifier, referenced by trigger.match.source"
           },
           "type": {
             "type": "string",
-            "description": "Source type (e.g., 'github', 'jira', 'linear')"
+            "description": "Source adapter type",
+            "enum": ["github", "plane"]
           },
           "config": {
             "type": "object",
-            "description": "Source-specific configuration",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. plane: workspace, project, api_key, base_url",
             "additionalProperties": true
           },
           "poll_interval": {
             "type": "string",
-            "description": "Polling interval (e.g., '5m', '30s'). Defaults to 60s",
-            "pattern": "^[0-9]+(s|m|h)$"
+            "description": "Polling interval (e.g., '30s', '2m'). Defaults to 60s",
+            "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
           },
           "filters": {
             "type": "object",
@@ -85,21 +149,21 @@
             "properties": {
               "states": {
                 "type": "array",
-                "description": "Filter by task states",
+                "description": "Only ingest items in these states",
                 "items": {
                   "type": "string"
                 }
               },
               "labels": {
                 "type": "array",
-                "description": "Filter by labels (tasks must have any of these)",
+                "description": "Only ingest items carrying these labels",
                 "items": {
                   "type": "string"
                 }
               },
               "jql": {
                 "type": "string",
-                "description": "Jira Query Language filter (for Jira sources)"
+                "description": "Query-language filter (reserved)"
               }
             }
           }
@@ -124,7 +188,7 @@
           },
           "model": {
             "type": "string",
-            "description": "LLM model ID (e.g., 'claude-opus-4-8', 'claude-sonnet-4-6')"
+            "description": "Model name passed to the runner (e.g., 'claude-opus-4-8', 'claude-sonnet-4-6')"
           },
           "soul_file": {
             "type": "string",
@@ -132,7 +196,7 @@
           },
           "skills": {
             "type": "array",
-            "description": "Available skills for this agent",
+            "description": "Skill names injected into the agent's prompt",
             "items": {
               "type": "string"
             }
@@ -148,21 +212,35 @@
           },
           "source_token": {
             "type": "string",
-            "description": "Auth token environment variable for the source"
+            "description": "Per-agent source auth token; write operations (comments, labels, state changes) use this identity"
           },
           "source_email": {
             "type": "string",
-            "description": "Email for source authentication"
+            "description": "Git author email exported to the runner environment"
           },
           "source_name": {
             "type": "string",
-            "description": "Display name for the source"
+            "description": "Git author name exported to the runner environment"
           },
           "env": {
             "type": "object",
-            "description": "Agent-scope environment variables for the agent subprocess. Lowest-precedence explicit scope (overridden by workflow.env and step.env), applied above the identity overlay (git + source_token).",
+            "description": "Agent-scope environment variables for the agent subprocess. Lowest-precedence explicit scope (overridden by workflow.env and step.env), applied above the identity overlay (git + source_token)",
             "additionalProperties": {
               "type": "string"
+            }
+          },
+          "fallbacks": {
+            "type": "array",
+            "description": "Ordered rate-limit failover chain: alternative {runner, model} pairs tried when the primary runner is rejected by a provider rate limit",
+            "items": {
+              "$ref": "#/definitions/FallbackConfig"
+            }
+          },
+          "mcps": {
+            "type": "array",
+            "description": "Agent-scope MCP servers, layered over the runner's mcps (same name overrides, new names are appended)",
+            "items": {
+              "$ref": "#/definitions/MCPServer"
             }
           }
         }
@@ -170,7 +248,7 @@
     },
     "workers": {
       "type": "array",
-      "description": "Worker definitions for task execution",
+      "description": "Worker definitions for task execution (legacy)",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -220,13 +298,13 @@
               "timeout": {
                 "type": "string",
                 "description": "Execution timeout (e.g., '30m', '1h'). Defaults to 30m",
-                "pattern": "^[0-9]+(s|m|h)$"
+                "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
               }
             }
           },
           "runner_config": {
             "type": "object",
-            "description": "Runner-specific configuration",
+            "description": "Runner-specific configuration passed to Runner.Configure()",
             "additionalProperties": true
           }
         }
@@ -250,18 +328,18 @@
           },
           "resume": {
             "type": "string",
-            "description": "Resume policy for failed instances",
+            "description": "Resume policy for failed/interrupted instances",
             "enum": ["allowed", "forbidden", "auto"],
             "default": "allowed"
           },
           "result_comment": {
             "type": "string",
-            "description": "Result comment mode (deprecated, use APIARY_PUBLISH instead)",
+            "description": "Result comment mode (deprecated, use the APIARY_PUBLISH marker in agent output instead)",
             "enum": ["on_complete", "per_step", "off"]
           },
           "trigger": {
             "type": "object",
-            "description": "Task trigger configuration",
+            "description": "Selects which tasks start this workflow. Omit for named child workflows started via APIARY_SPAWN",
             "additionalProperties": false,
             "properties": {
               "priority": {
@@ -270,7 +348,12 @@
               },
               "exclusive": {
                 "type": "boolean",
-                "description": "Stop trigger evaluation after this trigger matches",
+                "description": "Stop trigger evaluation after this trigger matches: no lower-priority trigger is considered",
+                "default": false
+              },
+              "once": {
+                "type": "boolean",
+                "description": "Run this workflow at most once per task: once it has a completed instance for the task, later polls do not re-dispatch it. Failed runs stay eligible for retry up to settings.max_attempts",
                 "default": false
               },
               "match": {
@@ -280,7 +363,7 @@
           },
           "steps": {
             "type": "array",
-            "description": "Workflow steps",
+            "description": "Workflow steps (implicit sequential ordering)",
             "items": {
               "$ref": "#/definitions/StepConfig"
             }
@@ -293,7 +376,7 @@
           },
           "env": {
             "type": "object",
-            "description": "Workflow-scope environment variables applied to every step of this workflow. Overrides agent.env; overridden by step.env.",
+            "description": "Workflow-scope environment variables applied to every step of this workflow. Overrides agent.env; overridden by step.env",
             "additionalProperties": {
               "type": "string"
             }
@@ -310,7 +393,7 @@
           "type": "integer",
           "description": "Maximum concurrent workflow instances",
           "minimum": 1,
-          "default": 4
+          "default": 2
         },
         "log_level": {
           "type": "string",
@@ -320,18 +403,23 @@
         },
         "state_lock": {
           "type": "boolean",
-          "description": "Enable distributed state locking",
+          "description": "Move a task to an in-progress state while an agent works on it",
           "default": false
         },
         "result_comment": {
           "type": "boolean",
-          "description": "Enable result comments (deprecated)",
+          "description": "Post agent results as comments (deprecated, use the APIARY_PUBLISH marker in agent output instead)",
           "default": false
         },
         "task_timeout": {
           "type": "string",
           "description": "Default task timeout (e.g., '2h'). Defaults to 120m",
-          "pattern": "^[0-9]+(s|m|h)$"
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "max_attempts": {
+          "type": "integer",
+          "description": "Stop re-dispatching a (task, workflow) pair after this many consecutive failed instances (rate-limited runs fail over and don't count). Default 3; negative disables",
+          "default": 3
         },
         "telemetry": {
           "type": "object",
@@ -354,7 +442,7 @@
     },
     "tasks": {
       "type": "object",
-      "description": "Top-level task configuration hooks (fire once per InternalTask)",
+      "description": "Top-level task completion hooks. Fire once per InternalTask when the LAST of its fanned-out workflows reaches a terminal state: on_complete when all succeeded, on_fail when any failed",
       "additionalProperties": false,
       "properties": {
         "on_complete": {
@@ -367,9 +455,55 @@
     }
   },
   "definitions": {
+    "MCPServer": {
+      "type": "object",
+      "description": "A Model Context Protocol server launched over stdio and exposed to the CLI tool",
+      "additionalProperties": false,
+      "required": ["name", "command"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Server key the agent sees (e.g., 'gitnexus')"
+        },
+        "command": {
+          "type": "string",
+          "description": "Executable launched over stdio (e.g., 'npx')"
+        },
+        "args": {
+          "type": "array",
+          "description": "Command arguments (e.g., ['-y', 'gitnexus@latest', 'mcp'])",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment overlay for the server subprocess; ${VAR} references are expanded at config load",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FallbackConfig": {
+      "type": "object",
+      "description": "One entry in an agent's rate-limit failover chain",
+      "additionalProperties": false,
+      "required": ["runner"],
+      "properties": {
+        "runner": {
+          "type": "string",
+          "description": "Runner ID to fail over to (must be defined in runners)"
+        },
+        "model": {
+          "type": "string",
+          "description": "Model to use on that runner (empty uses the runner's default)"
+        }
+      }
+    },
     "RouteMatch": {
       "type": "object",
-      "description": "Task matching rules for routing/triggering",
+      "description": "Task matching rules for triggering",
       "additionalProperties": false,
       "properties": {
         "source": {
@@ -403,27 +537,27 @@
         },
         "states": {
           "type": "array",
-          "description": "Match tasks in these states",
+          "description": "Match tasks in these states (case-insensitive)",
           "items": {
             "type": "string"
           }
         },
         "exclude_labels": {
           "type": "array",
-          "description": "Reject tasks carrying any of these labels",
+          "description": "Reject tasks carrying any of these labels (case-insensitive)",
           "items": {
             "type": "string"
           }
         },
         "exclude_label_prefix": {
           "type": "string",
-          "description": "Reject tasks with labels starting with this prefix"
+          "description": "Reject tasks with any label starting with this prefix (case-insensitive), e.g. 'agent:'"
         }
       }
     },
     "OnComplete": {
       "type": "object",
-      "description": "Actions to take on workflow/task completion",
+      "description": "Source-side actions applied on workflow/task completion or failure",
       "additionalProperties": false,
       "properties": {
         "set_state": {
@@ -436,22 +570,12 @@
           "items": {
             "type": "string"
           }
-        },
-        "assign_from_output": {
-          "type": "boolean",
-          "description": "Parse APIARY-ASSIGN directive from agent output (removed, use APIARY_PUBLISH instead)",
-          "default": false
-        },
-        "assign_label_prefix": {
-          "type": "string",
-          "description": "Label prefix for AssignFromOutput (removed)",
-          "default": "agent:"
         }
       }
     },
     "StepConfig": {
       "type": "object",
-      "description": "A workflow step (agent, split, approval, foreach, or sub-workflow)",
+      "description": "A workflow step. Type selects the active fields: agent (default), split, approval, foreach, workflow, or wait_for. v2 authoring fields (if, reject_when, on_reject, steps, parallel, join, for_each, max, output) are lowered to the DAG IR before execution",
       "additionalProperties": false,
       "required": ["id"],
       "properties": {
@@ -461,8 +585,8 @@
         },
         "type": {
           "type": "string",
-          "description": "Step type",
-          "enum": ["agent", "split", "approval", "foreach", "workflow", "parallel"],
+          "description": "Step type (default: agent)",
+          "enum": ["agent", "split", "approval", "foreach", "workflow", "wait_for"],
           "default": "agent"
         },
         "name": {
@@ -471,15 +595,15 @@
         },
         "condition": {
           "type": "string",
-          "description": "DAG IR condition expression (e.g., 'memory.track == \"implement\"'). Skip step if false"
+          "description": "DAG IR condition expression (e.g., 'memory.track == \"implement\"'). Skip step if false. Prefer the v2 'if:' field when authoring"
         },
         "fail_when": {
           "type": "string",
-          "description": "DAG IR expression that triggers step failure if true. Re-evaluates after agent runs"
+          "description": "DAG IR expression evaluated after the agent runs; true → logical rejection. Prefer the v2 'reject_when:' field when authoring"
         },
         "seq_depends_on": {
           "type": "array",
-          "description": "Step IDs that must complete before this step (v2 explicit sequencing)",
+          "description": "Step IDs that must complete before this step (explicit sequencing)",
           "items": {
             "type": "string"
           }
@@ -490,7 +614,7 @@
         },
         "model": {
           "type": "string",
-          "description": "Override agent's model for this step (for type=agent)"
+          "description": "Override the agent's model for this step (for type=agent)"
         },
         "prompt": {
           "type": "string",
@@ -498,7 +622,7 @@
         },
         "summary_prompt": {
           "type": "string",
-          "description": "Prompt to summarize agent output (for type=agent)"
+          "description": "Prompt asking the agent for a short summary recorded on the step (for type=agent)"
         },
         "idempotent": {
           "type": "boolean",
@@ -507,6 +631,10 @@
         },
         "output_schema": {
           "$ref": "#/definitions/OutputSchema"
+        },
+        "output": {
+          "$ref": "#/definitions/OutputSchema",
+          "description": "v2 alias for output_schema"
         },
         "on_missing_output": {
           "type": "string",
@@ -519,19 +647,19 @@
         },
         "publish": {
           "type": "string",
-          "description": "Control APIARY_PUBLISH write-back to source bindings (for type=agent)",
+          "description": "Whether an APIARY_PUBLISH payload emitted by this step's agent is written back to the task's source bindings (for type=agent)",
           "enum": ["auto", "off"],
           "default": "auto"
         },
         "spawn": {
           "type": "string",
-          "description": "Control APIARY_SPAWN request handling (for type=agent)",
+          "description": "How an APIARY_SPAWN request emitted by this step's agent is handled: auto (fire-and-forget) or await (block until the spawned task is terminal; child failure fails the step)",
           "enum": ["auto", "await"],
           "default": "auto"
         },
         "env": {
           "type": "object",
-          "description": "Step-scope environment variables. Highest-precedence explicit scope: overrides workflow.env and agent.env for the same key.",
+          "description": "Step-scope environment variables. Highest-precedence explicit scope: overrides workflow.env and agent.env for the same key",
           "additionalProperties": {
             "type": "string"
           }
@@ -542,6 +670,10 @@
         "on_fail": {
           "$ref": "#/definitions/StepOutcome"
         },
+        "on_conflict": {
+          "$ref": "#/definitions/StepOutcome",
+          "description": "Merge-conflict edge of a wait_for/ci step (goto + max_retries). When the step fails because the PR has merge conflicts, this route governs the loop-back exclusively, with its own retry budget separate from on_fail. Only valid on a wait_for step"
+        },
         "multi": {
           "type": "boolean",
           "description": "Execute branches in parallel (for type=split)",
@@ -549,7 +681,7 @@
         },
         "branches": {
           "type": "array",
-          "description": "Split branches (for type=split)",
+          "description": "Conditional edges (for type=split)",
           "items": {
             "$ref": "#/definitions/SplitBranch"
           }
@@ -566,12 +698,16 @@
         },
         "timeout": {
           "type": "string",
-          "description": "Approval timeout (for type=approval)",
-          "pattern": "^[0-9]+(s|m|h)$"
+          "description": "Approval timeout (for type=approval), e.g. '48h'",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "wait_for": {
+          "$ref": "#/definitions/WaitForConfig",
+          "description": "Configuration for a wait_for step (required for type=wait_for)"
         },
         "items": {
           "type": "string",
-          "description": "DAG IR expression yielding items array (for type=foreach)"
+          "description": "DAG IR expression yielding the items array (for type=foreach). Prefer the v2 'for_each:' field when authoring"
         },
         "as": {
           "type": "string",
@@ -584,7 +720,7 @@
         },
         "max_items": {
           "type": "integer",
-          "description": "Maximum items to iterate (for type=foreach)",
+          "description": "Maximum items to iterate (for type=foreach). Prefer the v2 'max:' field when authoring",
           "minimum": 1
         },
         "fail_fast": {
@@ -599,22 +735,151 @@
         "workflow": {
           "type": "string",
           "description": "Sub-workflow ID (for type=workflow)"
+        },
+        "if": {
+          "type": "string",
+          "description": "v2 guard expression (e.g., \"${{ memory.complexity == 'high' }}\"). When false the step is skipped. Lowers to condition"
+        },
+        "reject_when": {
+          "type": "string",
+          "description": "v2 rejection gate expression evaluated against memory plus this step's fresh structured output. Lowers to fail_when"
+        },
+        "on_reject": {
+          "$ref": "#/definitions/OnRejectConfig"
+        },
+        "steps": {
+          "type": "array",
+          "description": "v2 sequential group of child steps, inlined into the parent during lowering",
+          "items": {
+            "$ref": "#/definitions/StepConfig"
+          }
+        },
+        "parallel": {
+          "type": "array",
+          "description": "v2 concurrent child steps",
+          "items": {
+            "$ref": "#/definitions/StepConfig"
+          }
+        },
+        "join": {
+          "type": "string",
+          "description": "Parallel join policy: all (default), any, or a '${{ expr }}' expression"
+        },
+        "for_each": {
+          "type": "string",
+          "description": "v2 fan-out expression (e.g., '${{ design.tasks }}'). Lowers to items + foreach"
+        },
+        "max": {
+          "type": "integer",
+          "description": "v2 loop cap. Lowers to max_items",
+          "minimum": 1
+        }
+      }
+    },
+    "WaitForConfig": {
+      "type": "object",
+      "description": "Configures a wait_for step that suspends the workflow until an external condition resolves, re-checking each poll cycle until it is met or times out",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "What to poll. Currently only 'ci' (CI status of the PR linked to the task)",
+          "enum": ["ci"],
+          "default": "ci"
+        },
+        "check_interval": {
+          "type": "string",
+          "description": "How often to query the status (e.g., '30s'). Defaults to 1m",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "max_duration": {
+          "type": "string",
+          "description": "Total timeout for polling (e.g., '2h'). Defaults to 2h",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "fail_if_not_passed": {
+          "type": "boolean",
+          "description": "Reject the step if CI is not green",
+          "default": true
+        },
+        "remove_label": {
+          "type": "string",
+          "description": "Remove this label from the task before polling begins (resets stale labels from previous runs)"
         }
       }
     },
     "OutputSchema": {
       "type": "object",
-      "description": "JSON Schema for validating agent output",
-      "additionalProperties": true
+      "description": "Supported JSON Schema subset for structured step output (type must be 'object')",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["object"]
+        },
+        "properties": {
+          "type": "object",
+          "description": "Property name → field schema",
+          "additionalProperties": {
+            "$ref": "#/definitions/SchemaField"
+          }
+        },
+        "required": {
+          "type": "array",
+          "description": "Required property names",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SchemaField": {
+      "type": "object",
+      "description": "One property within an OutputSchema. items for arrays; properties/required for nested objects",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "array", "object"]
+        },
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "items": {
+          "$ref": "#/definitions/SchemaField"
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SchemaField"
+          }
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "MemoryConfig": {
       "type": "object",
-      "description": "Memory persistence for agent state",
+      "description": "How a step interacts with the workflow memory object",
       "additionalProperties": false,
       "properties": {
-        "persist": {
+        "read": {
+          "type": "boolean",
+          "description": "Inject the workflow memory document into this step (default true; only an explicit false disables it)",
+          "default": true
+        },
+        "write": {
           "type": "array",
-          "description": "Fields to persist from agent output",
+          "description": "output_schema field names this step persists to workflow memory",
           "items": {
             "type": "string"
           }
@@ -623,75 +888,85 @@
     },
     "StepNext": {
       "type": "object",
-      "description": "Actions on step success",
+      "description": "Explicit success edge of an agent step",
       "additionalProperties": false,
       "properties": {
-        "goto": {
+        "next": {
           "type": "string",
-          "description": "Jump to this step on success"
+          "description": "Step ID to jump to on success"
         }
       }
     },
     "StepOutcome": {
       "type": "object",
-      "description": "Actions on step failure",
+      "description": "Failure edge of a step (loop-back with a retry budget)",
       "additionalProperties": false,
       "properties": {
         "goto": {
           "type": "string",
-          "description": "Jump to this step (e.g., retry loop) on failure"
+          "description": "Step ID to jump to (e.g., a retry loop) on failure"
         },
-        "set_state": {
-          "type": "string",
-          "description": "Set task state on failure"
-        },
-        "add_labels": {
-          "type": "array",
-          "description": "Add labels on failure",
-          "items": {
-            "type": "string"
-          }
+        "max_retries": {
+          "type": "integer",
+          "description": "Maximum loop-back cycles through this edge",
+          "minimum": 1
         }
       }
     },
     "SplitBranch": {
       "type": "object",
-      "description": "A conditional branch in a split step",
+      "description": "One conditional edge of a split step. A branch is the fallback when else is true or if is empty",
       "additionalProperties": false,
-      "required": ["id", "step"],
+      "required": ["goto"],
       "properties": {
-        "id": {
+        "if": {
           "type": "string",
-          "description": "Unique branch identifier"
+          "description": "DAG IR condition to take this branch (e.g., 'memory.agent == \"po\"')"
         },
-        "condition": {
+        "else": {
+          "type": "boolean",
+          "description": "Mark this branch as the catch-all/else branch",
+          "default": false
+        },
+        "goto": {
           "type": "string",
-          "description": "DAG IR condition to take this branch"
-        },
-        "step": {
-          "$ref": "#/definitions/StepConfig",
-          "description": "Step to execute in this branch"
+          "description": "Step ID to jump to when this branch is taken"
         }
       }
     },
     "ApprovalTrigger": {
       "type": "object",
-      "description": "Condition for approving/aborting",
+      "description": "Resume/abort condition for an approval step. Any single populated field that matches the live task is sufficient (OR semantics)",
       "additionalProperties": false,
       "properties": {
-        "labels": {
-          "type": "array",
-          "description": "Trigger when any of these labels are added",
-          "items": {
-            "type": "string"
-          }
+        "comment_contains": {
+          "type": "string",
+          "description": "Trigger when a new comment contains this substring"
         },
-        "states": {
-          "type": "array",
-          "description": "Trigger when task enters any of these states",
-          "items": {
-            "type": "string"
-          }
+        "label_added": {
+          "type": "string",
+          "description": "Trigger when this label is added to the task"
+        },
+        "state_changed": {
+          "type": "string",
+          "description": "Trigger when the task enters this state"
+        }
+      }
+    },
+    "OnRejectConfig": {
+      "type": "object",
+      "description": "v2 loop-back spec for reject_when gates. Lowers to on_fail (goto + max_retries)",
+      "additionalProperties": false,
+      "required": ["restart_from"],
+      "properties": {
+        "restart_from": {
+          "type": "string",
+          "description": "Earlier sibling step to restart from when rejected"
+        },
+        "max": {
+          "type": "integer",
+          "description": "Maximum rejection+restart cycles",
+          "minimum": 1
         }
       }
     }


### PR DESCRIPTION
## Summary

- **`.apiary/example-apiary-full.yaml`**: remove the `claude-api` runner — `type: cli, provider: anthropic` resolves to adapter `anthropic-cli` (adapters resolve as `{provider}-{type}`, see `config.AdapterName`), which is not registered in `runner/providers`, so the daemon fails at startup with `runner type not found`. Replaced with a `cursor-cli` runner. Collapse the four opencode runners into `opencode-cli` + `opencode-api` and drop config keys no non-test code consumes (`mode`, `subscription`, `binary`, `agent`, `agent_flag`) — `CliRunner.Configure` reads only `command`/`args`/`model_flag`/`prompt_flag`/`prompt_positional`/`turns_flag`; the binary-override key is `command`. Document the adapter-resolution rule inline.
- **`.apiary/example-with-recovery.yaml`**: the runner had `type: cli` with **no provider**, which resolves to unregistered adapter `cli` (same startup failure), plus invented claude flags (`--input-text`, `--turns`) and Plane source keys the adapter never reads (`workspace_id`/`project_id`/`api_token`). Fixed to `provider: claude` with the recommended stream-json args and the real Plane keys (`workspace`/`project`/`api_key`/`base_url`).
- Remove deprecated `settings.result_comment` from all three examples (it warns on every load; APIARY_PUBLISH is the replacement).
- **`schema/apiary.json`**: regenerated from the Go structs (`config.go`, `workflow.go`). Adds the missing `wait_for` step type + block, `on_conflict`, `agents[].fallbacks`, `agents[].mcps`, `runners[].mcps`, `trigger.once`, `settings.max_attempts`, and the v2 authoring fields (`if`, `reject_when`, `on_reject`, nested `steps`, `parallel`, `join`, `for_each`, `max`, `output`). Fixes definitions that didn't match the structs at all: `StepNext` (`next`, not `goto`), `StepOutcome` (`goto` + `max_retries`), `SplitBranch` (`if`/`else`/`goto`), `MemoryConfig` (`read`/`write`), `ApprovalTrigger` (`comment_contains`/`label_added`/`state_changed`), `OutputSchema`/`SchemaField`. Constrains `runners[].type`/`provider` to the registered adapters (requires `provider` when `type: cli`) and drops the removed `assign_from_output` directives that lint now hard-errors.
- **Docs**: `configuration.md` / `resilience.md` fallback snippets renamed `opencode-go-cli` → `opencode` to match the cleaned example and the runner ids used on the Runners page.

## Test plan

- `apiary validate --config <file>` passes for all three examples (built from this branch).
- A one-off check that every example runner's `AdapterName()` is registered in `runner/providers` passes (this is the daemon-startup path that used to fail).
- All three examples validate against the regenerated schema with ajv (draft-07, same as yaml-language-server / the VS Code setup in `docs/SCHEMA_SETUP.md`).
- Negative test: the **old** `example-apiary-full.yaml` is rejected by the new schema exactly at `runners/1/provider` (`anthropic`).
- The repo's live `.apiary/apiary.yaml` still validates against the new schema.