### PR TITLE
fix(config): validate runner adapter names against the registered adapters

### DIFF
--- a/docs/runners.md
+++ b/docs/runners.md
@@ -43,7 +43,8 @@ registered adapters are:
 | `cursor-cli` | `type: cli`, `provider: cursor` | the `agent` binary (Cursor CLI) |
 | `opencode-api` | `type: opencode-api` | HTTP calls to the OpenCode API |
 
-Any other combination fails at startup with `runner type not found`.
+Any other combination is rejected by `apiary validate` (and by the daemon's
+config check at startup) with an error listing the valid combinations.
 
 ## CLI runners
 

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/runner"
+
+	// Ensure the built-in adapters are registered before any command validates
+	// a config, even when the cli package is used without cmd/apiary.
+	_ "github.com/orlandoburli/apiary/internal/runner/providers"
+)
+
+func init() {
+	config.KnownAdapters = runner.Registered
+}

--- a/src/internal/config/adapter_validate_test.go
+++ b/src/internal/config/adapter_validate_test.go
@@ -1,0 +1,113 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/runner"
+	_ "github.com/orlandoburli/apiary/internal/runner/providers"
+)
+
+// withKnownAdapters points config.KnownAdapters at the real runner registry
+// for the duration of the test, mirroring the wiring done by the cli package.
+func withKnownAdapters(t *testing.T) {
+	t.Helper()
+	prev := config.KnownAdapters
+	config.KnownAdapters = runner.Registered
+	t.Cleanup(func() { config.KnownAdapters = prev })
+}
+
+func runnerConfigFor(adapter string) config.RunnerConfig {
+	rc := config.RunnerConfig{ID: "r-1"}
+	if p, ok := strings.CutSuffix(adapter, "-cli"); ok && p != "" {
+		rc.Type = "cli"
+		rc.Provider = p
+	} else {
+		rc.Type = adapter
+	}
+	return rc
+}
+
+func TestValidate_RunnerAdapter_RegisteredCombosPass(t *testing.T) {
+	withKnownAdapters(t)
+
+	adapters := runner.Registered()
+	if len(adapters) == 0 {
+		t.Fatal("no adapters registered — providers import missing?")
+	}
+	for _, adapter := range adapters {
+		t.Run(adapter, func(t *testing.T) {
+			rc := runnerConfigFor(adapter)
+			if got := rc.AdapterName(); got != adapter {
+				t.Fatalf("test setup: AdapterName() = %q, want %q", got, adapter)
+			}
+			cfg := &config.Config{
+				Version: "1",
+				Runners: []config.RunnerConfig{rc},
+			}
+			if errs := cfg.Validate(); len(errs) != 0 {
+				t.Errorf("expected no errors for adapter %q, got: %v", adapter, errs)
+			}
+		})
+	}
+}
+
+func TestValidate_RunnerAdapter_UnknownProvider(t *testing.T) {
+	withKnownAdapters(t)
+
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "r-1", Type: "cli", Provider: "anthropic"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %v", len(errs), errs)
+	}
+	msg := errs[0].Error()
+	for _, want := range []string{`"anthropic-cli"`, "valid combinations", "provider: claude", "type: opencode-api"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestValidate_RunnerAdapter_BareCliType(t *testing.T) {
+	withKnownAdapters(t)
+
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "r-1", Type: "cli"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %v", len(errs), errs)
+	}
+	msg := errs[0].Error()
+	if !strings.Contains(msg, `type "cli"`) || !strings.Contains(msg, "valid combinations") {
+		t.Errorf("unexpected error message: %s", msg)
+	}
+	if strings.Contains(msg, "provider") && strings.Contains(msg, `provider ""`) {
+		t.Errorf("error message should omit the empty provider: %s", msg)
+	}
+}
+
+func TestValidate_RunnerAdapter_SkippedWithoutHook(t *testing.T) {
+	prev := config.KnownAdapters
+	config.KnownAdapters = nil
+	t.Cleanup(func() { config.KnownAdapters = prev })
+
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "r-1", Type: "cli", Provider: "anthropic"},
+		},
+	}
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Errorf("expected adapter check to be skipped without hook, got: %v", errs)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -3,9 +3,32 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
+
+// KnownAdapters reports the registered runner adapter names. The cli package
+// injects it (config cannot import the runner package without inverting the
+// dependency direction). When nil — configs built in code, isolated tests —
+// the adapter check is skipped.
+var KnownAdapters func() []string
+
+// adapterCombos renders registered adapter names as the type/provider
+// combinations users write in apiary.yaml, mirroring the table in
+// docs/runners.md: "claude-cli" → `type: cli, provider: claude`; names
+// without the -cli suffix are self-contained, e.g. `type: opencode-api`.
+func adapterCombos(names []string) string {
+	combos := make([]string, 0, len(names))
+	for _, n := range names {
+		if p, ok := strings.CutSuffix(n, "-cli"); ok && p != "" {
+			combos = append(combos, fmt.Sprintf("`type: cli, provider: %s` (%s)", p, n))
+		} else {
+			combos = append(combos, fmt.Sprintf("`type: %s`", n))
+		}
+	}
+	return strings.Join(combos, ", ")
+}
 
 // validateMCPs checks that each MCP server has a name and command, and that
 // names are unique within the scope. `scope` is a human label for error
@@ -36,6 +59,15 @@ func (c *Config) Validate() []error {
 		errs = append(errs, fmt.Errorf("version is required"))
 	}
 
+	var adapters []string
+	if KnownAdapters != nil {
+		adapters = KnownAdapters()
+	}
+	adapterSet := map[string]bool{}
+	for _, a := range adapters {
+		adapterSet[a] = true
+	}
+
 	runnerIDs := map[string]bool{}
 	for i, r := range c.Runners {
 		if r.ID == "" {
@@ -43,6 +75,13 @@ func (c *Config) Validate() []error {
 		}
 		if r.Type == "" {
 			errs = append(errs, fmt.Errorf("runners[%d] %q: type is required", i, r.ID))
+		} else if KnownAdapters != nil && !adapterSet[r.AdapterName()] {
+			where := fmt.Sprintf("type %q", r.Type)
+			if r.Provider != "" {
+				where = fmt.Sprintf("type %q, provider %q", r.Type, r.Provider)
+			}
+			errs = append(errs, fmt.Errorf("runners[%d] %q: no adapter registered for %s (resolves to %q); valid combinations: %s",
+				i, r.ID, where, r.AdapterName(), adapterCombos(adapters)))
 		}
 		if runnerIDs[r.ID] {
 			errs = append(errs, fmt.Errorf("runners[%d]: duplicate id %q", i, r.ID))

--- a/src/internal/runner/runner.go
+++ b/src/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"sort"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -37,3 +38,12 @@ func New(id string) (Runner, bool) {
 	return f(), true
 }
 
+// Registered returns the sorted list of registered adapter names.
+func Registered() []string {
+	names := make([]string, 0, len(factories))
+	for id := range factories {
+		names = append(names, id)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary
- `apiary validate` did not check that each runner's resolved adapter name (`{provider}-{type}`, or bare `type`) is actually registered, so a config like `type: cli, provider: anthropic` passed validation but the daemon failed at startup with `runner type not found`.
- `runner`: new `Registered()` helper returning the sorted list of registered adapter names.
- `config`: `Validate` now checks each `runners[].AdapterName()` against an injected `KnownAdapters` hook. The hook keeps the dependency direction intact (config does not import runner); when nil (configs built in code, isolated tests) the check is skipped. The error message lists the valid combinations derived from the registry, mirroring the table in `docs/runners.md`:
  ```
  runners[0] "main": no adapter registered for type "cli", provider "anthropic" (resolves to "anthropic-cli"); valid combinations: `type: cli, provider: claude` (claude-cli), `type: cli, provider: cursor` (cursor-cli), `type: opencode-api`, `type: cli, provider: opencode` (opencode-cli)
  ```
- `cli`: wires `config.KnownAdapters = runner.Registered` (with a blank import of `runner/providers`), so the check covers both `apiary validate` and the daemon pre-flight in `apiary run`.
- Docs: `runners.md` no longer claims bad combinations only fail at startup.

## Test plan
- New unit tests in `config_test`: one passing config per registered adapter (driven off `runner.Registered()`), failing cases for `provider: anthropic` and bare `type: cli`, and a hook-unset case verifying the check is skipped.
- `go build ./...` and full `go test ./...` pass locally (no Go CI in this repo).
- Manual: built the binary, confirmed `apiary validate` rejects `provider: anthropic` with the combination list and accepts `provider: claude`.