### PR TITLE
feat(runner): bake stream-json args into the claude-cli provider preset

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -12,12 +12,12 @@ version: "1"
 # Any other combination fails at daemon startup with "runner type not found".
 # See docs/runners.md for the full reference.
 runners:
-  # Claude CLI runner (local development, no API keys needed)
+  # Claude CLI runner (local development, no API keys needed). The preset runs
+  # `claude --output-format stream-json --verbose` so Apiary can parse usage,
+  # results, and rate-limit events; no config needed.
   - id: claude-cli
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
     # Model Context Protocol servers exposed to every agent on this runner.
     # Each provider writes them into its own native MCP config: claude uses a
     # temp file + `--mcp-config`, cursor merges ~/.cursor/mcp.json + `--approve-mcps`,

--- a/.apiary/example-with-recovery.yaml
+++ b/.apiary/example-with-recovery.yaml
@@ -4,8 +4,6 @@ runners:
   - id: claude-cli
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 
 default_runner: claude-cli
 

--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -21,8 +21,6 @@ runners:
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
     models: [claude-opus-4-8, claude-sonnet-4-6]
 
 default_runner: claude

--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ runners:
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 
 sources:
   - id: main-repo

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,8 +46,6 @@ runners:
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 
   # OpenCode CLI — requires the `opencode` binary on PATH
   - id: opencode
@@ -74,12 +72,13 @@ default_runner: claude    # used by agents that don't name a runner
 | `models` | Models this runner supports (informational) |
 | `mcps` | [MCP servers](runners.md#mcp-servers) exposed to every agent on this runner |
 
-!!! tip "Recommended Claude CLI args"
-    `args: ["--output-format", "stream-json", "--verbose"]` makes the Claude
-    CLI emit structured events, which Apiary parses into the readable
-    `[assistant]` / `[tool→ …]` conversation in the
+!!! tip "Presets cover the CLI flags"
+    Each provider preset already passes the right flags — the Claude preset
+    runs `claude --output-format stream-json --verbose`, so Apiary parses the
+    structured events into the readable `[assistant]` / `[tool→ …]`
+    conversation in the
     [task logs](dashboard.md#watching-the-live-conversation-debug-mode),
-    plus accurate token and cost figures. Without it you get raw text output.
+    plus accurate token and cost figures. `config` is only for overrides.
 
 ## `sources`
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -170,22 +170,19 @@ dashboard refreshes every couple of seconds). You'll see, in order:
 These are `DEBUG`-level lines (shown in grey). Without `--debug` they are not
 recorded, keeping normal runs lightweight.
 
-To get the rich `[assistant]` / `[tool→ …]` breakdown from the Claude CLI, the
-runner must ask Claude for structured events. In your runner config:
+The rich `[assistant]` / `[tool→ …]` breakdown comes from Claude's structured
+event stream — the claude provider preset already requests it
+(`--output-format stream-json --verbose`), so a plain runner is enough:
 
 ```yaml
 runners:
   - id: claude-cli
     type: cli
-    config:
-      command: claude
-      model_flag: --model
-      prompt_flag: -p
-      args: ["--output-format", "stream-json", "--verbose"]
+    provider: claude
 ```
 
-Apiary parses those events into the readable lines above. Any other CLI (or
-Claude without those args) still streams — you just see its raw output instead.
+Apiary parses those events into the readable lines above. A CLI without
+structured output still streams — you just see its raw output instead.
 
 ### Agents
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,13 +30,11 @@ version: "1"
 
 runners:
   # How agents execute — here, the local `claude` CLI as a subprocess.
-  # The args ask Claude for structured events, so the dashboard can show
+  # The preset asks Claude for structured events, so the dashboard can show
   # the live conversation (messages, tool calls, cost).
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 
 sources:
   # Where work comes from — GitHub issues carrying the `ai-ready` label.

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -9,8 +9,6 @@ runners:
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 
 default_runner: claude
 
@@ -64,8 +62,9 @@ the daemon's environment plus the
 
 ### Providers
 
-Each provider preconfigures the engine — binary name, how the prompt and
-model are passed, and the MCP format. You usually only add `args`.
+Each provider preconfigures the engine — binary name, default args, how the
+prompt and model are passed, and the MCP format. `config` is only for
+overrides; a bare `provider:` line is a fully working runner.
 
 #### Claude (`provider: claude`)
 
@@ -76,11 +75,9 @@ runners:
   - id: claude
     type: cli
     provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
 ```
 
-The `args` shown are strongly recommended: with `stream-json`, Apiary parses
+The preset runs `claude --output-format stream-json --verbose`: Apiary parses
 Claude's structured event stream into
 
 - readable `[assistant]` / `[tool→ …]` / `[tool← result]` lines in the
@@ -88,9 +85,6 @@ Claude's structured event stream into
 - exact token counts and `cost_usd` per run (reported, not estimated),
 - `rate_limit_event` detection, which drives
   [failover](resilience.md#provider-rate-limits-failover).
-
-Without them the agent still runs — you just see raw text output and lose
-usage/rate-limit parsing.
 
 #### OpenCode (`provider: opencode`)
 
@@ -125,7 +119,7 @@ All `config` keys, with each provider's preset defaults:
 | Key | Description | claude | opencode | cursor |
 |---|---|---|---|---|
 | `command` | Binary to invoke (override to use a wrapper or absolute path) | `claude` | `opencode` | `agent` |
-| `args` | Extra argv prepended to every run | — | `run` | `-p --output-format stream-json --force` |
+| `args` | Extra argv appended after the preset's args | `--output-format stream-json --verbose` | `run` | `-p --output-format stream-json --force` |
 | `model_flag` | Flag used to pass the step's model | `--model` | `--model` | `--model` |
 | `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* |
 | `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` |

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -45,7 +45,7 @@
               },
               "args": {
                 "type": "array",
-                "description": "Extra argv prepended to every run (e.g. ['--output-format', 'stream-json', '--verbose'] for claude)",
+                "description": "Extra argv appended after the preset's args on every run. Presets: claude '--output-format stream-json --verbose', opencode 'run', cursor '-p --output-format stream-json --force'",
                 "items": {
                   "type": "string"
                 }

--- a/src/internal/runner/providers/providers.go
+++ b/src/internal/runner/providers/providers.go
@@ -23,7 +23,11 @@ func init() {
 
 	// mcp_format selects how the CLI runner serialises MCP servers into the
 	// provider's native config (see execution.CliRunner.setupMCP).
+	// stream-json output is required for usage accounting, final-result
+	// extraction, and rate-limit detection (see execution/cli.go); user `args`
+	// are appended after these, and claude tolerates repeated flags (last wins).
 	runner.Register("claude-cli", cliFactory("claude", map[string]any{
+		"args":       []any{"--output-format", "stream-json", "--verbose"},
 		"mcp_format": "claude",
 	}))
 

--- a/src/internal/runner/providers/providers_test.go
+++ b/src/internal/runner/providers/providers_test.go
@@ -1,0 +1,60 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/runner"
+)
+
+// echoRun instantiates a registered provider, swaps its command for `echo`,
+// and returns the argv line the provider would have executed.
+func echoRun(t *testing.T, providerID string, userConfig map[string]any) string {
+	t.Helper()
+	r, ok := runner.New(providerID)
+	if !ok {
+		t.Fatalf("provider %q not registered", providerID)
+	}
+	cfg := map[string]any{"command": "echo"}
+	for k, v := range userConfig {
+		cfg[k] = v
+	}
+	if err := r.Configure(cfg); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	res, err := r.Run(context.Background(), model.RunRequest{
+		Cell:     model.SourceItem{Title: "ping"},
+		WorkerID: "test",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	return res.Output
+}
+
+func TestClaudeCliPresetIncludesStreamJSONArgs(t *testing.T) {
+	out := echoRun(t, "claude-cli", nil)
+	if !strings.Contains(out, "--output-format stream-json --verbose") {
+		t.Errorf("claude-cli preset args missing from argv: %q", out)
+	}
+	if !strings.Contains(out, "-p ") {
+		t.Errorf("claude-cli prompt flag missing from argv: %q", out)
+	}
+}
+
+func TestClaudeCliUserArgsAppendAfterPreset(t *testing.T) {
+	out := echoRun(t, "claude-cli", map[string]any{"args": []any{"--add-dir", "/tmp"}})
+	want := "--output-format stream-json --verbose --add-dir /tmp"
+	if !strings.Contains(out, want) {
+		t.Errorf("user args not appended after preset args: %q", out)
+	}
+}
+
+func TestOpencodeCliPresetKeepsRunSubcommand(t *testing.T) {
+	out := echoRun(t, "opencode-cli", nil)
+	if !strings.HasPrefix(out, "run ") {
+		t.Errorf("opencode-cli preset must start argv with `run`: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- The `claude-cli` provider preset now includes `--output-format stream-json --verbose` by default, the same way `cursor-cli` already ships its own headless args. Usage accounting, final-result extraction, and rate-limit detection (the failover trigger) all depend on stream-json output, so a bare `provider: claude` runner previously ran silently degraded unless every config copied the same three args.
- User `config.args` keep their append-after-preset semantics; existing configs that still carry the old args keep working (claude tolerates repeated flags, last wins).
- Example configs, README, docs (runners/configuration/quickstart/dashboard), and the JSON schema drop the now-redundant `config:` blocks and document the preset defaults + append semantics.
- New `providers_test.go` exercises the presets end-to-end (command swapped for `echo`): claude preset argv, user-args append order, and opencode's `run` subcommand.

## Test plan
- `go build ./...` and `go test ./...` pass locally (no Go CI in this repo).
- `apiary validate` (built from this branch) passes on all three `.apiary/example-*.yaml`.