### PR TITLE
feat(runner): wire agent max_turns through to runners

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,7 @@ agents:
 | `soul_file` | no | Path to the agent's system prompt / persona file |
 | `skills` | no | Skill names injected into the agent's context |
 | `max_workers` | no | Per-agent concurrency cap (default 1) — see [concurrency](#concurrency) |
+| `max_turns` | no | Max agent turns per step run (default 0 = unlimited). CLI runners pass it as the provider's turns flag (e.g. claude's `--max-turns`); 0 omits the flag |
 | `source_token` | no | Source API token for this agent's write operations — see [Agent identity](#agent-identity) |
 | `source_email` / `source_name` | no | Git author identity exported to the runner environment |
 | `fallbacks` | no | Ordered `{runner, model}` list for [rate-limit failover](resilience.md#provider-rate-limits-failover); `model` optional (empty = that runner's default) |

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -210,6 +210,11 @@
             "description": "Maximum concurrent workers for this agent",
             "minimum": 1
           },
+          "max_turns": {
+            "type": "integer",
+            "description": "Maximum agent turns per step run. 0 (default) = unlimited: CLI runners omit the provider's turns flag",
+            "minimum": 0
+          },
           "source_token": {
             "type": "string",
             "description": "Per-agent source auth token; write operations (comments, labels, state changes) use this identity"

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -42,7 +42,6 @@ func (s SourceConfig) ParsedPollInterval() (time.Duration, error) {
 	return time.ParseDuration(s.PollInterval)
 }
 
-
 type SourceFilters struct {
 	States []string `yaml:"states"`
 	Labels []string `yaml:"labels"`
@@ -79,9 +78,13 @@ type AgentConfig struct {
 	Skills      []string `yaml:"skills,omitempty"`
 	Runner      string   `yaml:"runner,omitempty"`
 	MaxWorkers  int      `yaml:"max_workers,omitempty"`
-	SourceToken string   `yaml:"source_token,omitempty"`
-	SourceEmail string   `yaml:"source_email,omitempty"`
-	SourceName  string   `yaml:"source_name,omitempty"`
+	// MaxTurns caps the number of agent turns per step run. 0 (the default)
+	// means unlimited: CLI runners omit the provider's turns flag entirely, so
+	// long-running coding tasks are never cut short unless explicitly capped.
+	MaxTurns    int    `yaml:"max_turns,omitempty"`
+	SourceToken string `yaml:"source_token,omitempty"`
+	SourceEmail string `yaml:"source_email,omitempty"`
+	SourceName  string `yaml:"source_name,omitempty"`
 	// Env is the agent-scope environment overlay applied to every step that runs
 	// this agent, in any workflow. It is the lowest-precedence explicit env scope
 	// (below workflow.env and step.env), layered on top of the identity overlay.

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -358,7 +358,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		Cell:               req.Cell,
 		WorkerID:           req.Step.Agent,
 		Model:              req.Model,
-		MaxTurns:           15,
+		MaxTurns:           req.Agent.MaxTurns,
 		SystemPrepend:      req.MemoryDoc,
 		SystemAppend:       composeSystemAppend(req.Prompt, readSoulFile(req.Agent, req.Cell.ID)),
 		SummaryPrompt:      req.Step.SummaryPrompt,

--- a/src/internal/runner/execution/api.go
+++ b/src/internal/runner/execution/api.go
@@ -62,7 +62,14 @@ func (r *ApiRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		parseResp = defaultParseResponse
 	}
 
-	raw, err := buildBody(prompt, req.Model, req.MaxTurns*4096)
+	// MaxTurns sizes the response token budget here: a turn cap has no direct
+	// equivalent for a single-shot HTTP call. 0 means uncapped upstream, so
+	// fall back to the budget the old hardcoded 15-turn default produced.
+	maxTokens := req.MaxTurns * 4096
+	if maxTokens <= 0 {
+		maxTokens = 15 * 4096
+	}
+	raw, err := buildBody(prompt, req.Model, maxTokens)
 	if err != nil {
 		return model.RunResult{}, fmt.Errorf("api runner: build body: %w", err)
 	}

--- a/src/internal/runner/providers/providers.go
+++ b/src/internal/runner/providers/providers.go
@@ -26,9 +26,12 @@ func init() {
 	// stream-json output is required for usage accounting, final-result
 	// extraction, and rate-limit detection (see execution/cli.go); user `args`
 	// are appended after these, and claude tolerates repeated flags (last wins).
+	// turns_flag is only emitted when the agent sets max_turns > 0 (see
+	// execution.CliRunner.Run), so runs stay uncapped by default.
 	runner.Register("claude-cli", cliFactory("claude", map[string]any{
 		"args":       []any{"--output-format", "stream-json", "--verbose"},
 		"mcp_format": "claude",
+		"turns_flag": "--max-turns",
 	}))
 
 	runner.Register("opencode-cli", cliFactory("opencode", map[string]any{

--- a/src/internal/runner/providers/providers_test.go
+++ b/src/internal/runner/providers/providers_test.go
@@ -13,6 +13,16 @@ import (
 // and returns the argv line the provider would have executed.
 func echoRun(t *testing.T, providerID string, userConfig map[string]any) string {
 	t.Helper()
+	return echoRunReq(t, providerID, userConfig, model.RunRequest{
+		Cell:     model.SourceItem{Title: "ping"},
+		WorkerID: "test",
+	})
+}
+
+// echoRunReq is echoRun with a caller-supplied RunRequest, for asserting how
+// request fields (e.g. MaxTurns) surface in the provider's argv.
+func echoRunReq(t *testing.T, providerID string, userConfig map[string]any, req model.RunRequest) string {
+	t.Helper()
 	r, ok := runner.New(providerID)
 	if !ok {
 		t.Fatalf("provider %q not registered", providerID)
@@ -24,10 +34,7 @@ func echoRun(t *testing.T, providerID string, userConfig map[string]any) string 
 	if err := r.Configure(cfg); err != nil {
 		t.Fatalf("configure: %v", err)
 	}
-	res, err := r.Run(context.Background(), model.RunRequest{
-		Cell:     model.SourceItem{Title: "ping"},
-		WorkerID: "test",
-	})
+	res, err := r.Run(context.Background(), req)
 	if err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -49,6 +56,24 @@ func TestClaudeCliUserArgsAppendAfterPreset(t *testing.T) {
 	want := "--output-format stream-json --verbose --add-dir /tmp"
 	if !strings.Contains(out, want) {
 		t.Errorf("user args not appended after preset args: %q", out)
+	}
+}
+
+func TestClaudeCliMaxTurnsEmitsFlag(t *testing.T) {
+	out := echoRunReq(t, "claude-cli", nil, model.RunRequest{
+		Cell:     model.SourceItem{Title: "ping"},
+		WorkerID: "test",
+		MaxTurns: 30,
+	})
+	if !strings.Contains(out, "--max-turns 30") {
+		t.Errorf("max_turns > 0 must emit --max-turns in argv: %q", out)
+	}
+}
+
+func TestClaudeCliZeroMaxTurnsOmitsFlag(t *testing.T) {
+	out := echoRun(t, "claude-cli", nil)
+	if strings.Contains(out, "--max-turns") {
+		t.Errorf("max_turns 0 must omit --max-turns from argv (uncapped): %q", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

The max-turns plumbing was dead end-to-end:

1. `WorkerRunConfig.MaxTurns` (yaml `max_turns` under legacy `workers[].config`) was parsed but never copied into a `model.RunRequest` — setting it did nothing.
2. The workflow executor hardcoded `MaxTurns: 15` (`src/internal/daemon/workflow.go`).
3. No provider preset set `turns_flag`, and `CliRunner.Run` only emits the flag when it's non-empty — so the hardcoded 15 was a silent no-op for every CLI runner. Only the API runner used it, as an arbitrary `15*4096` token budget.

Naively adding `turns_flag` to the claude preset without first fixing the source of the value would have suddenly capped every workflow step at 15 turns — apiary agents routinely run 30+ minute coding tasks.

## Change

- **`agents[].max_turns`** (new field, default **0 = unlimited**): caps agent turns per step run. The workflow executor passes it through instead of the hardcoded 15.
- **claude-cli preset** now sets `turns_flag: --max-turns`. `CliRunner` already omits the flag when `MaxTurns` is 0, so default behavior is unchanged (uncapped). opencode-cli/cursor-cli have no equivalent flag and stay unset.
- **ApiRunner** keeps its previous effective token budget (`15*4096`) when `MaxTurns` is 0, so API runs don't send `max_tokens: 0`.
- Schema (`schema/apiary.json`) and `docs/configuration.md` document the new agent field.

## Behavior matrix

| Config | Before | After |
|---|---|---|
| no `max_turns` (default) | CLI: uncapped (15 was no-op); API: 61440 tokens | identical |
| `agents[].max_turns: 30` | impossible (field didn't exist) | claude-cli gets `--max-turns 30`; API gets 122880 tokens |

## Testing

- `go build ./... && go test ./...` green locally (no Go CI).
- New tests: `TestClaudeCliMaxTurnsEmitsFlag` (flag emitted when set) and `TestClaudeCliZeroMaxTurnsOmitsFlag` (default stays uncapped).
- GitNexus impact analysis on `wfStepExecutor.ExecuteStep`, `CliRunner.Run`, `ApiRunner.Run`: all LOW risk.