### PR TITLE
feat(logging): rotate apiary.log and prune old per-task logs

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -448,6 +448,12 @@ settings:
   # Stop re-dispatching a (task, workflow) after this many consecutive failed
   # instances (rate-limited runs fail over and don't count). <=0 disables.
   max_attempts: 3
+  # Log rotation: rotate apiary.log past this size (MB), keep this many
+  # rotated backups, and prune backups + per-task logs older than this many
+  # days. Negative values disable the corresponding behaviour.
+  log_max_size_mb: 50
+  log_max_backups: 5
+  log_max_age_days: 30
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,6 +202,9 @@ settings:
   result_comment: true
   task_timeout: 30m
   max_attempts: 3
+  log_max_size_mb: 50
+  log_max_backups: 5
+  log_max_age_days: 30
 ```
 
 | Field | Default | Description |
@@ -212,6 +215,20 @@ settings:
 | `result_comment` | `false` | Post the agent's final output back as a comment |
 | `task_timeout` | `30m` | Default per-run timeout (e.g. `2h`) |
 | `max_attempts` | 3 | Stop re-dispatching a `(task, workflow)` after this many **consecutive failed** instances; `<=0` disables — see [resilience](resilience.md#re-dispatch-failure-cap) |
+| `log_max_size_mb` | 50 | Rotate `apiary.log` past this size (MB); negative disables rotation |
+| `log_max_backups` | 5 | Rotated files kept as `apiary.log.1` … `.N`, oldest dropped; negative keeps none |
+| `log_max_age_days` | 30 | Prune rotated backups **and** per-task logs (`logs/tasks/*.log`) older than this, at startup and after each rotation; negative disables |
+
+### Log rotation
+
+The daemon writes its service log to `<config-dir>/.apiary/logs/apiary.log`
+and one file per task under `logs/tasks/`. Without limits these grow
+unbounded, so rotation is on by default: when a write would push `apiary.log`
+past `log_max_size_mb`, the file is renamed to `apiary.log.1` (older backups
+shift up, the one past `log_max_backups` is dropped) and a fresh file is
+started. Backups and task-log files untouched for `log_max_age_days` are
+deleted. Task history shown in the dashboard lives in SQLite and is not
+affected by file pruning.
 
 ### Concurrency
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -426,6 +426,21 @@
           "description": "Stop re-dispatching a (task, workflow) pair after this many consecutive failed instances (rate-limited runs fail over and don't count). Default 3; negative disables",
           "default": 3
         },
+        "log_max_size_mb": {
+          "type": "integer",
+          "description": "Rotate apiary.log when it grows past this size in MB. Default 50; negative disables rotation",
+          "default": 50
+        },
+        "log_max_backups": {
+          "type": "integer",
+          "description": "Rotated log files to keep (apiary.log.1 .. .N, oldest dropped). Default 5; negative keeps none",
+          "default": 5
+        },
+        "log_max_age_days": {
+          "type": "integer",
+          "description": "Delete rotated backups and per-task log files older than this many days (checked at startup and after each rotation). Default 30; negative disables",
+          "default": 30
+        },
         "telemetry": {
           "type": "object",
           "description": "Telemetry configuration",

--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -73,7 +73,12 @@ func newRunCmd() *cobra.Command {
 				logLevel = logging.LevelDebug
 				aplog.Enable(true)
 			}
-			logger, err := logging.New(logDir, dbClient, logLevel)
+			rotation := logging.Rotation{
+				MaxSizeMB:  cfg.Settings.LogMaxSizeMB,
+				MaxBackups: cfg.Settings.LogMaxBackups,
+				MaxAgeDays: cfg.Settings.LogMaxAgeDays,
+			}
+			logger, err := logging.New(logDir, dbClient, logLevel, rotation)
 			if err != nil {
 				return fmt.Errorf("initializing logger: %w", err)
 			}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -210,8 +210,13 @@ type Settings struct {
 	// runs are recorded as success (they fail over), so they do not count. This
 	// is an internal backstop independent of source-side labels — it stops
 	// runaway loops even for workflows with no on_fail. Default 3; <=0 disables.
-	MaxAttempts int       `yaml:"max_attempts"`
-	Telemetry   Telemetry `yaml:"telemetry"`
+	MaxAttempts int `yaml:"max_attempts"`
+	// Log rotation for the shared apiary.log file and retention for rotated
+	// backups and per-task log files. 0 means default; negative disables.
+	LogMaxSizeMB  int       `yaml:"log_max_size_mb"`  // rotate apiary.log past this size; default 50
+	LogMaxBackups int       `yaml:"log_max_backups"`  // rotated files to keep; default 5
+	LogMaxAgeDays int       `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
+	Telemetry     Telemetry `yaml:"telemetry"`
 }
 
 func (s *Settings) TaskTimeoutDuration() time.Duration {
@@ -474,6 +479,15 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Settings.MaxAttempts == 0 {
 		cfg.Settings.MaxAttempts = 3
+	}
+	if cfg.Settings.LogMaxSizeMB == 0 {
+		cfg.Settings.LogMaxSizeMB = 50
+	}
+	if cfg.Settings.LogMaxBackups == 0 {
+		cfg.Settings.LogMaxBackups = 5
+	}
+	if cfg.Settings.LogMaxAgeDays == 0 {
+		cfg.Settings.LogMaxAgeDays = 30
 	}
 	warnDeprecatedResultComment(&cfg)
 	return &cfg, nil

--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -45,18 +45,35 @@ type LogEntry struct {
 	Timestamp time.Time
 }
 
+// Rotation controls size-based rotation of the shared apiary.log file and
+// age-based pruning of rotated backups and per-task log files. Values <= 0
+// disable the corresponding behaviour.
+type Rotation struct {
+	MaxSizeMB  int // rotate apiary.log past this size; <=0 disables rotation
+	MaxBackups int // rotated files to keep (apiary.log.1 .. .N); <=0 keeps none
+	MaxAgeDays int // delete backups and task logs older than this; <=0 disables
+}
+
+// DefaultRotation mirrors the defaults config.Load applies when the settings
+// are absent from apiary.yaml.
+func DefaultRotation() Rotation {
+	return Rotation{MaxSizeMB: 50, MaxBackups: 5, MaxAgeDays: 30}
+}
+
 // Logger writes to file and optional SQLite.
 type Logger struct {
-	file   io.WriteCloser
+	file   *os.File
+	size   int64
 	db     *db.Client
 	mu     sync.Mutex
 	level  Level
 	logDir string
+	rot    Rotation
 }
 
 // New creates a logger that writes to a log file in logDir.
 // If db is provided, logs also go to SQLite.
-func New(logDir string, dbClient *db.Client, level Level) (*Logger, error) {
+func New(logDir string, dbClient *db.Client, level Level, rot Rotation) (*Logger, error) {
 	if logDir != "" {
 		if err := os.MkdirAll(logDir, 0755); err != nil {
 			return nil, fmt.Errorf("create log dir: %w", err)
@@ -69,12 +86,21 @@ func New(logDir string, dbClient *db.Client, level Level) (*Logger, error) {
 		return nil, fmt.Errorf("open log file: %w", err)
 	}
 
-	return &Logger{
+	var size int64
+	if fi, err := f.Stat(); err == nil {
+		size = fi.Size()
+	}
+
+	l := &Logger{
 		file:   f,
+		size:   size,
 		db:     dbClient,
 		level:  level,
 		logDir: logDir,
-	}, nil
+		rot:    rot,
+	}
+	l.pruneOldLogs()
+	return l, nil
 }
 
 func (l *Logger) Close() error {
@@ -153,7 +179,7 @@ func (l *Logger) log(ctx context.Context, level Level, msg, component, taskID st
 		if component != "" {
 			line = fmt.Sprintf("[%s] [%s] [%s] %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"), level, component, msg)
 		}
-		l.file.Write([]byte(line))
+		l.writeLine(line)
 	}
 
 	// Write to database
@@ -162,6 +188,68 @@ func (l *Logger) log(ctx context.Context, level Level, msg, component, taskID st
 			l.db.WriteTaskLog(ctx, taskID, string(level), msg)
 		} else {
 			l.db.WriteServiceLog(ctx, string(level), msg, component)
+		}
+	}
+}
+
+// writeLine appends a line to apiary.log, rotating first when the write would
+// push the file past the configured size limit. Caller must hold l.mu.
+func (l *Logger) writeLine(line string) {
+	if l.rot.MaxSizeMB > 0 && l.size > 0 && l.size+int64(len(line)) > int64(l.rot.MaxSizeMB)*1024*1024 {
+		l.rotate()
+	}
+	n, _ := l.file.Write([]byte(line))
+	l.size += int64(n)
+}
+
+// rotate closes apiary.log, shifts existing backups up one slot
+// (apiary.log.1 -> apiary.log.2, ..., dropping the oldest), and reopens a
+// fresh file. With MaxBackups <= 0 the current file is simply removed.
+// Caller must hold l.mu.
+func (l *Logger) rotate() {
+	logFile := filepath.Join(l.logDir, "apiary.log")
+
+	l.file.Close()
+
+	if l.rot.MaxBackups > 0 {
+		for i := l.rot.MaxBackups - 1; i >= 1; i-- {
+			src := fmt.Sprintf("%s.%d", logFile, i)
+			dst := fmt.Sprintf("%s.%d", logFile, i+1)
+			os.Remove(dst) // os.Rename does not overwrite on Windows
+			os.Rename(src, dst)
+		}
+		os.Remove(logFile + ".1")
+		os.Rename(logFile, logFile+".1")
+	} else {
+		os.Remove(logFile)
+	}
+
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		// Leave size past the limit so the next write retries the rotation
+		// (and the reopen) instead of silently giving up for good.
+		return
+	}
+	l.file = f
+	l.size = 0
+	l.pruneOldLogs()
+}
+
+// pruneOldLogs deletes rotated backups (apiary.log.N) and per-task log files
+// older than the retention window. Files touched within the window — including
+// logs of still-running tasks — are left alone. Pruning is best-effort
+// housekeeping, so errors are ignored.
+func (l *Logger) pruneOldLogs() {
+	if l.rot.MaxAgeDays <= 0 || l.logDir == "" {
+		return
+	}
+	cutoff := time.Now().AddDate(0, 0, -l.rot.MaxAgeDays)
+
+	backups, _ := filepath.Glob(filepath.Join(l.logDir, "apiary.log.*"))
+	taskLogs, _ := filepath.Glob(filepath.Join(l.logDir, "tasks", "*.log"))
+	for _, path := range append(backups, taskLogs...) {
+		if fi, err := os.Stat(path); err == nil && fi.ModTime().Before(cutoff) {
+			os.Remove(path)
 		}
 	}
 }

--- a/src/internal/logging/logger_test.go
+++ b/src/internal/logging/logger_test.go
@@ -2,8 +2,12 @@ package logging
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/orlandoburli/apiary/internal/db"
 )
@@ -20,7 +24,7 @@ func TestLog_TaskDebugPersistsBelowThreshold(t *testing.T) {
 	}
 	defer dbClient.Close()
 
-	logger, err := New(t.TempDir(), dbClient, LevelInfo)
+	logger, err := New(t.TempDir(), dbClient, LevelInfo, DefaultRotation())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -53,5 +57,107 @@ func TestLog_TaskDebugPersistsBelowThreshold(t *testing.T) {
 		if l.Message == "service debug line" {
 			t.Errorf("service DEBUG log should have been dropped below threshold")
 		}
+	}
+}
+
+// A write that would push apiary.log past the size limit must rotate the file
+// into a .1 backup and start a fresh one, shifting older backups up a slot and
+// dropping the oldest beyond MaxBackups.
+func TestRotate_SizeLimitShiftsBackups(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// 1 MB limit, keep 2 backups, no age pruning.
+	logger, err := New(dir, nil, LevelInfo, Rotation{MaxSizeMB: 1, MaxBackups: 2, MaxAgeDays: -1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer logger.Close()
+
+	// Each INFO line is ~1 KB of payload; ~3.2 MB total forces >= 2 rotations.
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 3200; i++ {
+		logger.Info(ctx, fmt.Sprintf("%05d %s", i, payload), "test")
+	}
+
+	logPath := filepath.Join(dir, "apiary.log")
+	limit := int64(1 * 1024 * 1024)
+
+	fi, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("apiary.log missing after rotation: %v", err)
+	}
+	if fi.Size() > limit+2048 {
+		t.Errorf("apiary.log size = %d, want <= ~%d", fi.Size(), limit)
+	}
+	for _, backup := range []string{"apiary.log.1", "apiary.log.2"} {
+		if _, err := os.Stat(filepath.Join(dir, backup)); err != nil {
+			t.Errorf("expected backup %s: %v", backup, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "apiary.log.3")); err == nil {
+		t.Errorf("apiary.log.3 exists, want at most MaxBackups=2 backups")
+	}
+}
+
+// With MaxSizeMB <= 0 rotation is disabled: the file keeps growing and no
+// backups appear.
+func TestRotate_DisabledKeepsSingleFile(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	logger, err := New(dir, nil, LevelInfo, Rotation{MaxSizeMB: -1, MaxBackups: 2, MaxAgeDays: -1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer logger.Close()
+
+	payload := strings.Repeat("x", 1024)
+	for i := 0; i < 100; i++ {
+		logger.Info(ctx, payload, "test")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "apiary.log.1")); err == nil {
+		t.Errorf("rotation disabled but apiary.log.1 was created")
+	}
+}
+
+// Startup must prune rotated backups and per-task logs older than MaxAgeDays,
+// while keeping recent files.
+func TestNew_PrunesOldBackupsAndTaskLogs(t *testing.T) {
+	dir := t.TempDir()
+	taskDir := filepath.Join(dir, "tasks")
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		t.Fatalf("mkdir tasks: %v", err)
+	}
+
+	old := time.Now().AddDate(0, 0, -40)
+	files := map[string]time.Time{
+		filepath.Join(dir, "apiary.log.1"):     old,
+		filepath.Join(taskDir, "old-task.log"): old,
+		filepath.Join(taskDir, "new-task.log"): time.Now(),
+	}
+	for path, mtime := range files {
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatalf("chtimes %s: %v", path, err)
+		}
+	}
+
+	logger, err := New(dir, nil, LevelInfo, Rotation{MaxSizeMB: 50, MaxBackups: 5, MaxAgeDays: 30})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer logger.Close()
+
+	for _, gone := range []string{filepath.Join(dir, "apiary.log.1"), filepath.Join(taskDir, "old-task.log")} {
+		if _, err := os.Stat(gone); err == nil {
+			t.Errorf("%s should have been pruned", gone)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(taskDir, "new-task.log")); err != nil {
+		t.Errorf("recent task log was pruned: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- **Size-based rotation of `apiary.log`**: when a write would push the file past `settings.log_max_size_mb` (default 50), backups shift up (`apiary.log.1` … `.N`, capped by `settings.log_max_backups`, default 5, oldest dropped) and a fresh file is opened. Rotation state is tracked in-process (size counter seeded from `stat` at startup), so no extra syscalls per write.
- **Age-based pruning**: rotated backups and per-task log files (`logs/tasks/*.log`) older than `settings.log_max_age_days` (default 30) are deleted at daemon startup and after each rotation. Dashboard task history lives in SQLite and is unaffected.
- **Config**: three new optional `settings:` keys following the existing `max_attempts` convention (0 = default applied in `config.Load`, negative = disabled). Mirrored into `schema/apiary.json`, `.apiary/example-apiary-full.yaml`, and `docs/configuration.md`.
- No new dependencies — rotation is ~60 lines in `internal/logging`.

## Test plan

- New tests in `internal/logging`: rotation shifts backups and respects `MaxBackups` (3.2 MB through a 1 MB limit), disabled rotation keeps a single file, startup pruning removes >30-day-old backups/task logs while keeping recent ones.
- `go vet ./...` and full `go test ./...` pass locally (no Go CI in this repo).
- `apiary validate` (built from this branch) passes on `.apiary/example-apiary-full.yaml`; `schema/apiary.json` parses as valid JSON.

Closes #154