### PR TITLE
docs: stamp the latest release version into the site at build time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,8 @@ on:
       - DEVELOPMENT.md
       - docs/**
       - mkdocs.yml
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -44,6 +46,22 @@ jobs:
           sed -i 's|COMMERCIAL.md|https://github.com/orlandoburli/apiary/blob/main/COMMERCIAL.md|g' docs/index.md
           sed -i 's|\([^!]\)(openspec/|\1(https://github.com/orlandoburli/apiary/tree/main/openspec/|g' docs/index.md
           sed -i 's|openspec/specs/plugin-api/spec.md|https://github.com/orlandoburli/apiary/blob/main/openspec/specs/plugin-api/spec.md|g' docs/development.md
+
+      - name: Stamp latest release version into docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Rewrite any pinned-version example (e.g. ghcr.io/orlandoburli/apiary:0.3.0)
+          # to the latest published release, so the site never shows a stale version.
+          # The markdown keeps a real version so it also reads fine on GitHub.
+          LATEST=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name | sed 's/^v//') || true
+          if [ -n "$LATEST" ]; then
+            echo "latest release: $LATEST"
+            find docs -name '*.md' -exec \
+              sed -i -E "s|(ghcr\.io/orlandoburli/apiary:)[0-9]+\.[0-9]+\.[0-9]+|\1${LATEST}|g" {} +
+          else
+            echo "could not resolve latest release — keeping versions as committed"
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ as the original.
 !!! tip "Pin a version"
     Apiary is in public beta — config and adapter APIs may still change
     before `v1.0`. For anything you depend on, pin a release (e.g. the
-    `ghcr.io/orlandoburli/apiary:0.3.0` Docker tag) and read the
+    `ghcr.io/orlandoburli/apiary:0.4.0` Docker tag) and read the
     [release notes](https://github.com/orlandoburli/apiary/releases) before
     upgrading.
 


### PR DESCRIPTION
## Summary
- The Pages workflow now resolves the latest published release via the GitHub API and rewrites any pinned-version example (`ghcr.io/orlandoburli/apiary:X.Y.Z`) in the docs before `mkdocs build`, so the published site never shows a stale release number. If the API call fails, the build keeps the committed version instead of failing.
- The docs site also redeploys on every `release: published` event, so a new tag refreshes the site without a docs commit (previously only `docs/**` pushes to main triggered a deploy — see #146 for the manual bump this replaces).
- Bumped the committed example in `docs/installation.md` from 0.3.0 to 0.4.0 so the markdown reads current on GitHub itself.

## Test plan
- Dry-ran the resolve + sed locally: `gh api .../releases/latest` → `0.4.0`, and the rewrite produced `ghcr.io/orlandoburli/apiary:0.4.0` in installation.md.
- Workflow YAML parses cleanly.
- After merge: the docs-path trigger will deploy, and the site's installation page should show 0.4.0.