### PR TITLE
feat(db): prune old service_logs and task_logs rows

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -449,8 +449,8 @@ settings:
   # instances (rate-limited runs fail over and don't count). <=0 disables.
   max_attempts: 3
   # Log rotation: rotate apiary.log past this size (MB), keep this many
-  # rotated backups, and prune backups + per-task logs older than this many
-  # days. Negative values disable the corresponding behaviour.
+  # rotated backups, and prune backups + per-task logs + SQLite log rows
+  # older than this many days. Negative values disable each behaviour.
   log_max_size_mb: 50
   log_max_backups: 5
   log_max_age_days: 30

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,7 +217,7 @@ settings:
 | `max_attempts` | 3 | Stop re-dispatching a `(task, workflow)` after this many **consecutive failed** instances; `<=0` disables — see [resilience](resilience.md#re-dispatch-failure-cap) |
 | `log_max_size_mb` | 50 | Rotate `apiary.log` past this size (MB); negative disables rotation |
 | `log_max_backups` | 5 | Rotated files kept as `apiary.log.1` … `.N`, oldest dropped; negative keeps none |
-| `log_max_age_days` | 30 | Prune rotated backups **and** per-task logs (`logs/tasks/*.log`) older than this, at startup and after each rotation; negative disables |
+| `log_max_age_days` | 30 | Prune rotated backups, per-task logs (`logs/tasks/*.log`) **and** SQLite log rows (`service_logs`/`task_logs`) older than this; negative disables |
 
 ### Log rotation
 
@@ -227,8 +227,16 @@ unbounded, so rotation is on by default: when a write would push `apiary.log`
 past `log_max_size_mb`, the file is renamed to `apiary.log.1` (older backups
 shift up, the one past `log_max_backups` is dropped) and a fresh file is
 started. Backups and task-log files untouched for `log_max_age_days` are
-deleted. Task history shown in the dashboard lives in SQLite and is not
-affected by file pruning.
+deleted.
+
+The same log stream is persisted to SQLite for the dashboard (`service_logs`
+and `task_logs` in `apiary.db`), and those tables get the same retention: rows
+older than `log_max_age_days` are deleted at daemon startup and then daily,
+in small batches so log writes are never blocked for long. Older lines remain
+readable in the rotated log files. Deleting rows lets SQLite reuse the freed
+pages — the file stops growing but does not shrink; to compact a database
+that grew before retention existed, stop the daemon and run
+`sqlite3 .apiary/apiary.db 'VACUUM;'` once.
 
 ### Concurrency
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -438,7 +438,7 @@
         },
         "log_max_age_days": {
           "type": "integer",
-          "description": "Delete rotated backups and per-task log files older than this many days (checked at startup and after each rotation). Default 30; negative disables",
+          "description": "Delete rotated backups, per-task log files, and SQLite log rows (service_logs/task_logs) older than this many days. Files are checked at startup and after each rotation; DB rows at startup and then daily. Default 30; negative disables",
           "default": 30
         },
         "telemetry": {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -340,6 +340,18 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// instance would never be re-checked and its task would be stranded.
 	d.rehydrateParkedWaits(ctx)
 
+	// Prune old service_logs/task_logs rows once at startup and then daily,
+	// mirroring the file-side retention (settings.log_max_age_days). Without
+	// this the log tables dominate apiary.db on long-lived deployments.
+	if d.db != nil && d.cfg.Settings.LogMaxAgeDays > 0 {
+		maxAge := time.Duration(d.cfg.Settings.LogMaxAgeDays) * 24 * time.Hour
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.pruneLogsLoop(ctx, maxAge)
+		}()
+	}
+
 	for _, sc := range d.cfg.Sources {
 		sc := sc
 		adapter, ok := d.sources[sc.ID]
@@ -351,6 +363,31 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 			defer wg.Done()
 			d.pollLoop(ctx, sc, adapter)
 		}()
+	}
+}
+
+// pruneLogsLoop deletes DB log rows older than maxAge, at startup and then
+// once a day. Rows past the window stay readable in the rotated log files.
+func (d *Dispatcher) pruneLogsLoop(ctx context.Context, maxAge time.Duration) {
+	prune := func() {
+		n, err := d.db.PruneLogsBefore(ctx, time.Now().Add(-maxAge))
+		if err != nil {
+			aplog.Warn("prune log rows: %v", err)
+		} else if n > 0 {
+			aplog.Info("pruned %d log row(s) older than %dd", n, int(maxAge.Hours()/24))
+		}
+	}
+	prune()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			prune()
+		}
 	}
 }
 

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -406,6 +406,33 @@ func (c *Client) WriteServiceLog(ctx context.Context, level, message, component 
 	return err
 }
 
+// PruneLogsBefore deletes service_logs and task_logs rows older than cutoff.
+// Deletes run in batches so the single SQLite writer lock is never held long
+// while the dispatcher keeps streaming log writes. Returns rows deleted.
+// Lines past the retention window remain available in the rotated log files.
+func (c *Client) PruneLogsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	const batch = 5000
+	var total int64
+	for _, table := range []string{"service_logs", "task_logs"} {
+		stmt := fmt.Sprintf(`
+			DELETE FROM %s WHERE id IN (
+				SELECT id FROM %s WHERE timestamp < ? LIMIT %d
+			)`, table, table, batch)
+		for {
+			res, err := c.db.ExecContext(ctx, stmt, cutoff)
+			if err != nil {
+				return total, fmt.Errorf("prune %s: %w", table, err)
+			}
+			n, _ := res.RowsAffected()
+			total += n
+			if n < batch {
+				break
+			}
+		}
+	}
+	return total, nil
+}
+
 // Agent tracking
 
 func (c *Client) UpsertAgent(ctx context.Context, id, description string) error {

--- a/src/internal/db/prune_logs_test.go
+++ b/src/internal/db/prune_logs_test.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// PruneLogsBefore must delete service_logs and task_logs rows older than the
+// cutoff — including more rows than one delete batch — while keeping recent
+// ones, and report the total deleted.
+func TestPruneLogsBefore(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	old := time.Now().AddDate(0, 0, -40)
+
+	// 5001 old task_logs rows force a second delete batch (batch size 5000).
+	insert := func(stmt string, args ...any) {
+		t.Helper()
+		if _, err := c.db.ExecContext(ctx, stmt, args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	for i := 0; i < 5001; i++ {
+		insert(`INSERT INTO task_logs (task_id, level, message, timestamp) VALUES (?, ?, ?, ?)`,
+			"task-old", "INFO", fmt.Sprintf("old line %d", i), old)
+	}
+	insert(`INSERT INTO task_logs (task_id, level, message, timestamp) VALUES (?, ?, ?, ?)`,
+		"task-new", "INFO", "recent line", time.Now())
+	insert(`INSERT INTO service_logs (level, message, component, timestamp) VALUES (?, ?, ?, ?)`,
+		"INFO", "old service line", "dispatcher", old)
+	insert(`INSERT INTO service_logs (level, message, component, timestamp) VALUES (?, ?, ?, ?)`,
+		"INFO", "recent service line", "dispatcher", time.Now())
+
+	deleted, err := c.PruneLogsBefore(ctx, time.Now().AddDate(0, 0, -30))
+	if err != nil {
+		t.Fatalf("PruneLogsBefore: %v", err)
+	}
+	if deleted != 5002 {
+		t.Errorf("deleted = %d, want 5002", deleted)
+	}
+
+	count := func(table string) int {
+		t.Helper()
+		var n int
+		if err := c.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		return n
+	}
+	if n := count("task_logs"); n != 1 {
+		t.Errorf("task_logs rows = %d, want 1 (recent only)", n)
+	}
+	if n := count("service_logs"); n != 1 {
+		t.Errorf("service_logs rows = %d, want 1 (recent only)", n)
+	}
+
+	// Pruning again with nothing in range is a no-op.
+	deleted, err = c.PruneLogsBefore(ctx, time.Now().AddDate(0, 0, -30))
+	if err != nil {
+		t.Fatalf("PruneLogsBefore (2nd): %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("second prune deleted = %d, want 0", deleted)
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -201,6 +201,7 @@ CREATE INDEX IF NOT EXISTS idx_tasks_agent ON tasks(agent_id);
 CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
 CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_task_logs_task ON task_logs(task_id);
+CREATE INDEX IF NOT EXISTS idx_task_logs_timestamp ON task_logs(timestamp);
 CREATE INDEX IF NOT EXISTS idx_service_logs_timestamp ON service_logs(timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);


### PR DESCRIPTION
## Summary

Companion to #155: the same log stream that goes to `apiary.log` is persisted to SQLite for the dashboard, with no retention — a real deployment's `apiary.db` reached **146 MB, ~92% log rows** (`service_logs` 208k rows / 63 MB, `task_logs` 181k rows / 56 MB, plus ~18 MB of their indexes).

- **`db.PruneLogsBefore(cutoff)`**: deletes `service_logs` and `task_logs` rows older than the cutoff in batches of 5000 (`DELETE WHERE id IN (SELECT … LIMIT n)` loop), so the single SQLite writer lock is never held long while the dispatcher streams log writes.
- **New `idx_task_logs_timestamp`** — `task_logs` only had a `task_id` index, so age-based pruning would full-scan. Created via `CREATE INDEX IF NOT EXISTS`, existing DBs pick it up at startup.
- **`Dispatcher.Start` prune loop**: runs once at startup and then every 24h, gated on `settings.log_max_age_days > 0`. Reuses the retention knob from #155 — DB rows and files share the same window (default 30 days, negative disables). Plain age-based, including still-open tasks: older lines remain readable in the rotated log files.
- **No automatic `VACUUM`** — freed pages get reused so the DB stops growing; `docs/configuration.md` documents one-shot manual compaction for DBs that grew before retention existed.
- Docs/schema/example config updated to mention DB rows in `log_max_age_days`.

## Test plan

- New `TestPruneLogsBefore`: seeds 5001 old `task_logs` rows (forces a second batch) + old/new rows in both tables; asserts 5002 deleted, recent rows kept, second prune is a no-op.
- `go build`, `go vet`, full `go test ./...` pass locally (no Go CI in this repo).
- **Live verification**: ran `PruneLogsBefore` against a copy of the real 146 MB database — 285,473 rows deleted in 1.1 s (~19 ms per batch), exactly the rows older than the cutoff; the Go driver's timestamp format matches the stored text format.

Closes #157