### PR TITLE
feat(workflow): support remove_labels in on_complete / on_fail hooks

### DIFF
--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -121,6 +121,8 @@ workflows:
     on_complete:
       set_state: in_review
       add_labels: [reviewed]
+      # Clear the trigger label so the item is not matched again on the next poll.
+      remove_labels: [ai-ready]
     on_fail:
       add_labels: [needs-attention]
 

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -44,6 +44,7 @@ sources:
 | **WriteResult** | `POST /repos/{owner}/{repo}/issues/{number}/comments` | When `settings.result_comment: true` |
 | **SetState** | `PATCH /repos/{owner}/{repo}/issues/{number}` (sets `state`) | Via `workflow.on_complete.set_state` |
 | **AddLabels** | `PATCH /repos/{owner}/{repo}/issues/{number}` (replaces labels) | Via `workflow.on_complete.add_labels` |
+| **RemoveLabels** | `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name}` (one per label) | Via `workflow.on_complete.remove_labels` |
 
 GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
 them out during polling — only plain issues become cells (always
@@ -94,6 +95,7 @@ source-level `api_key`:
 - **WriteResult** — posts comment with run output
 - **SetState** — closes/re-opens issue via `on_complete.set_state`
 - **AddLabels** — adds labels via `on_complete.add_labels`
+- **RemoveLabels** — removes labels via `on_complete.remove_labels`
 
 **Poll** always uses the source-level `api_key` — one account reads all issues.
 
@@ -153,6 +155,7 @@ below live under `trigger.match`.
 |---|---|---|
 | `set_state` | `string` | Transition the task to this state after a successful run |
 | `add_labels` | `[string]` | Add these labels to the task after a successful run |
+| `remove_labels` | `[string]` | Remove these labels after a successful run — e.g. clear the trigger label so the item is not matched again |
 
 ### Example: trigger by label
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -348,9 +348,15 @@ apply to the task's source item:
 on_complete:
   set_state: in review
   add_labels: [reviewed]
+  remove_labels: [create-spec]
 on_fail:
   add_labels: [needs-attention]
 ```
+
+`remove_labels` strips labels from the source item — typically the label that
+triggered the workflow, so a label-driven trigger fires once and the item
+stops matching on the next poll. Removals run after `add_labels`, and sources
+that don't support label removal skip the directive.
 
 A workflow can also override the global result-comment behavior:
 `result_comment: on_complete | per_step | off`.

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -590,6 +590,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "remove_labels": {
+          "type": "array",
+          "description": "Remove these labels from the task, e.g. to clear a label-driven trigger so the item is not matched again. Applied after add_labels",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -177,6 +177,11 @@ type RouteMatch struct {
 type OnComplete struct {
 	SetState  string   `yaml:"set_state"`
 	AddLabels []string `yaml:"add_labels"`
+	// RemoveLabels strips labels from the source item, so a label-driven trigger
+	// (e.g. `labels: [create-spec]`) can clear its own trigger label on
+	// completion instead of matching again on every poll. Removals are applied
+	// after AddLabels; a label listed in both ends up removed.
+	RemoveLabels []string `yaml:"remove_labels"`
 	// AssignFromOutput parses the agent's output for an `APIARY-ASSIGN: <agent>`
 	// directive and adds the corresponding `<prefix><agent>` label, so a
 	// classifier agent can route a task to the agent it picked.
@@ -191,8 +196,8 @@ type OnComplete struct {
 // terminal state — as opposed to the per-workflow on_complete/on_fail hooks
 // which fire once per workflow instance. OnComplete applies when every instance
 // succeeded; OnFail applies when any instance failed. Both follow the same rules
-// as per-workflow hooks (set_state, add_labels; the removed assign_* directives
-// are rejected by lint).
+// as per-workflow hooks (set_state, add_labels, remove_labels; the removed
+// assign_* directives are rejected by lint).
 type TasksConfig struct {
 	OnComplete *OnComplete `yaml:"on_complete"`
 	OnFail     *OnComplete `yaml:"on_fail"`

--- a/src/internal/config/workflow_parse_test.go
+++ b/src/internal/config/workflow_parse_test.go
@@ -83,6 +83,7 @@ workflows:
         timeout: 48h
     on_complete:
       set_state: in_review
+      remove_labels: [ai-ready]
     on_fail:
       set_state: blocked
       add_labels: [workflow-failed]
@@ -185,6 +186,9 @@ workflows:
 	// on_complete / on_fail hooks
 	if wf.OnComplete == nil || wf.OnComplete.SetState != "in_review" {
 		t.Errorf("on_complete parsed incorrectly: %+v", wf.OnComplete)
+	}
+	if wf.OnComplete == nil || len(wf.OnComplete.RemoveLabels) != 1 || wf.OnComplete.RemoveLabels[0] != "ai-ready" {
+		t.Errorf("on_complete.remove_labels parsed incorrectly: %+v", wf.OnComplete)
 	}
 	if wf.OnFail == nil || wf.OnFail.SetState != "blocked" || len(wf.OnFail.AddLabels) != 1 {
 		t.Errorf("on_fail parsed incorrectly: %+v", wf.OnFail)

--- a/src/internal/daemon/apply_hook_test.go
+++ b/src/internal/daemon/apply_hook_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// fakeHookSource implements Adapter plus the optional LabelAdder, LabelRemover,
+// and StateSetter interfaces ApplyHook fans out to, recording the order of the
+// label operations.
+type fakeHookSource struct {
+	ops      []string
+	added    []string
+	removed  []string
+	stateSet string
+}
+
+func (f *fakeHookSource) ID() string                                    { return "fake" }
+func (f *fakeHookSource) Connect(context.Context, map[string]any) error { return nil }
+func (f *fakeHookSource) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (f *fakeHookSource) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (f *fakeHookSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (f *fakeHookSource) WebhookHandler() http.Handler { return nil }
+func (f *fakeHookSource) AddLabels(_ context.Context, _ model.SourceItem, labels []string) error {
+	f.ops = append(f.ops, "add")
+	f.added = append(f.added, labels...)
+	return nil
+}
+func (f *fakeHookSource) RemoveLabels(_ context.Context, _ model.SourceItem, labels []string) error {
+	f.ops = append(f.ops, "remove")
+	f.removed = append(f.removed, labels...)
+	return nil
+}
+func (f *fakeHookSource) SetState(_ context.Context, _ model.SourceItem, state string) error {
+	f.stateSet = state
+	return nil
+}
+
+// fakeBareSource implements only the base Adapter interface, so every optional
+// hook capability must be skipped without error.
+type fakeBareSource struct{}
+
+func (f *fakeBareSource) ID() string                                    { return "bare" }
+func (f *fakeBareSource) Connect(context.Context, map[string]any) error { return nil }
+func (f *fakeBareSource) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (f *fakeBareSource) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (f *fakeBareSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (f *fakeBareSource) WebhookHandler() http.Handler { return nil }
+
+func TestApplyHook_RemovesLabelsAfterAdditions(t *testing.T) {
+	fake := &fakeHookSource{}
+	d := &Dispatcher{sources: map[string]source.Adapter{"fake": fake}}
+
+	task := model.InternalTask{ID: "T-1", Title: "Spec"}
+	bindings := []model.SourceBinding{{SourceID: "fake", SourceItemID: "ISSUE-1"}}
+	hook := config.OnComplete{
+		SetState:     "done",
+		AddLabels:    []string{"ai-spec-done"},
+		RemoveLabels: []string{"create-spec"},
+	}
+
+	if err := (&wfSideEffects{d: d}).ApplyHook(context.Background(), task, bindings, hook); err != nil {
+		t.Fatalf("ApplyHook: %v", err)
+	}
+
+	if len(fake.added) != 1 || fake.added[0] != "ai-spec-done" {
+		t.Errorf("added labels = %v, want [ai-spec-done]", fake.added)
+	}
+	if len(fake.removed) != 1 || fake.removed[0] != "create-spec" {
+		t.Errorf("removed labels = %v, want [create-spec]", fake.removed)
+	}
+	if fake.stateSet != "done" {
+		t.Errorf("state set = %q, want done", fake.stateSet)
+	}
+	// A label listed in both add_labels and remove_labels must end up removed.
+	if len(fake.ops) != 2 || fake.ops[0] != "add" || fake.ops[1] != "remove" {
+		t.Errorf("op order = %v, want [add remove]", fake.ops)
+	}
+}
+
+func TestApplyHook_SkipsSourcesWithoutLabelRemover(t *testing.T) {
+	d := &Dispatcher{sources: map[string]source.Adapter{"bare": &fakeBareSource{}}}
+
+	task := model.InternalTask{ID: "T-2", Title: "Spec"}
+	bindings := []model.SourceBinding{{SourceID: "bare", SourceItemID: "ISSUE-2"}}
+	hook := config.OnComplete{RemoveLabels: []string{"create-spec"}}
+
+	if err := (&wfSideEffects{d: d}).ApplyHook(context.Background(), task, bindings, hook); err != nil {
+		t.Fatalf("ApplyHook on a source without LabelRemover must be a no-op, got: %v", err)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -614,6 +614,14 @@ func (s *wfSideEffects) ApplyHook(ctx context.Context, task model.InternalTask, 
 				}
 			}
 		}
+		// Removals run after additions so a label in both lists ends up removed.
+		if len(hook.RemoveLabels) > 0 {
+			if lr, ok := adapter.(source.LabelRemover); ok {
+				if err := lr.RemoveLabels(ctx, item, hook.RemoveLabels); err != nil {
+					aplog.Error("item %s: remove labels %v: %v", item.ID, hook.RemoveLabels, err)
+				}
+			}
+		}
 		if hook.SetState != "" {
 			if ss, ok := adapter.(source.StateSetter); ok {
 				if err := ss.SetState(ctx, item, hook.SetState); err != nil {

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -148,8 +148,8 @@ type SideEffects interface {
 	StateLock(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding) error
 	// PostComment posts a comment (result_comment) on each bound source item.
 	PostComment(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, comment string) error
-	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels) to
-	// each bound source item.
+	// ApplyHook applies an on_complete/on_fail hook (set_state, add_labels,
+	// remove_labels) to each bound source item.
 	ApplyHook(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, hook config.OnComplete) error
 	// MaterializeChild creates a source sub-issue for a spawned child task under the
 	// parent's source item and persists the child's source binding, so the child


### PR DESCRIPTION
## Summary
- Add `remove_labels` to `config.OnComplete`, so per-workflow `on_complete`/`on_fail` and the top-level `tasks:` hooks can strip labels from the source item — typically the label that triggered the workflow, so a label-driven trigger fires once and the item stops matching on the next poll.
- Apply it in `wfSideEffects.ApplyHook` via the existing `source.LabelRemover` capability (Jira and GitHub adapters already implement it; sources without it skip the directive, same as `add_labels`).
- Removals run after additions, so a label listed in both `add_labels` and `remove_labels` ends up removed.
- Mirror the field into `schema/apiary.json`, document it in `docs/workflows.md` and `docs/github-source.md`, and showcase it in `.apiary/example-workflow.yaml`.

Closes #158

## Test plan
- `go build ./...`, `go vet ./...`, full `go test ./...` — all pass.
- New `TestApplyHook_RemovesLabelsAfterAdditions` asserts labels are removed via `LabelRemover`, state is set, and removal runs after addition; `TestApplyHook_SkipsSourcesWithoutLabelRemover` asserts a source without the capability is a clean no-op.
- Extended `TestWorkflowYAMLParsing` to parse `on_complete.remove_labels`.
- Built the binary and ran `apiary validate` against the issue's example config (workflow hook + `tasks:` hook) and both `.apiary/example-*.yaml` — all valid.