### PR TITLE
feat(memory): persistent tiered agent memory via APIARY_MEMORIZE

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -454,6 +454,17 @@ settings:
   log_max_size_mb: 50
   log_max_backups: 5
   log_max_age_days: 30
+  # Persistent agent memory (opt-in): agents save durable facts and per-task
+  # working notes via the APIARY_MEMORIZE marker, stored as markdown under
+  # <data-dir>/memory (next to apiary.db). The MEMORY.md index plus the task's
+  # notes are injected into every step prompt (budget-capped); agents read full
+  # entries from $APIARY_MEMORY_DIR. Curate with `apiary memory list|show|rm|prune`.
+  memory:
+    enabled: false
+    # path: /custom/memory/root      # default: <data-dir>/memory
+    # max_inject_chars: 4000         # prompt budget for the recall sections
+    # max_entry_bytes: 16384         # cap on a single memorized fact
+    # task_retention: 720h           # prune task notes this long after the task ends
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ apiary.yaml.local
 **/.apiary/apiary.db-*
 **/.apiary/apiary.sock
 **/.apiary/logs/
+**/.apiary/memory/
 
 # editor
 .DS_Store

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,151 @@
+# Agent Memory
+
+Apiary agents are stateless between executions by default. The only built-in
+context is the [workflow memory](workflows.md#workflow-memory) document — and it
+dies with the workflow instance.
+
+**Agent memory** adds two persistent tiers on top, written by agents themselves
+through an output marker and stored as plain markdown files you can read, edit,
+and delete by hand:
+
+| Tier | What it holds | Lifetime | Scope |
+|---|---|---|---|
+| Instance (built-in) | Step data + handoff summaries | One workflow instance | The instance |
+| **Task** | Working notes: decisions, findings, what was already tried | Until the task is terminal + retention | The task, its retries and fan-out instances, and its spawned descendants |
+| **Global** | Durable facts: project gotchas, tooling quirks, conventions | Forever (curated) | The whole daemon — every agent, source, and workflow |
+
+Memory is **opt-in**:
+
+```yaml
+settings:
+  memory:
+    enabled: true
+    # path: /custom/root         # default: <data-dir>/memory, beside apiary.db
+    # max_inject_chars: 4000     # prompt budget for the recall sections
+    # max_entry_bytes: 16384     # cap on a single memorized fact
+    # task_retention: 720h       # prune task notes this long after the task ends
+```
+
+With memory disabled (the default) nothing is persisted or injected, and any
+`APIARY_MEMORIZE` markers agents emit are stripped from output and dropped.
+
+## Writing memory — `APIARY_MEMORIZE`
+
+An agent saves a memory by emitting a marker block in its step output, exactly
+like `APIARY_PUBLISH` and `APIARY_SPAWN`. The block carries one JSON object or
+an array of them:
+
+```
+APIARY_MEMORIZE_BEGIN
+{
+  "scope": "global",
+  "name": "erp-precommit-stale-binary",
+  "description": "pre-commit lint fails when the apiary binary is stale",
+  "content": "When the local binary predates the config schema, pre-commit lint\nhard-errors. Rebuild the binary, or commit with --no-verify and note it in the PR."
+}
+APIARY_MEMORIZE_END
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `scope` | no | `task` (default) or `global` |
+| `name` | global only | kebab-case slug — the upsert key and the entry's filename |
+| `description` | global only | one line, shown in the injected index |
+| `content` | yes | markdown body |
+
+- **Global** requests upsert `global/<name>.md`: re-emitting the same `name`
+  updates the fact (the original `created` timestamp is kept).
+- **Task** requests append a timestamped, provenance-stamped note to the task's
+  notes file. A retry re-emitting identical content is deduplicated.
+- A malformed block, a rejected name, or oversized content is a **warning** in
+  the daemon log — a memorize can never fail a step.
+
+To suppress writes for a sensitive step (mirroring `publish: off`):
+
+```yaml
+steps:
+  - id: untrusted-analysis
+    agent: analyzer
+    memory:
+      memorize: off        # drop APIARY_MEMORIZE requests from this step
+      recall: [task]       # inject task notes only, no global index
+```
+
+## Recall — what agents see
+
+When memory is enabled, every agent step's prompt is prefixed with two sections
+(ahead of the workflow memory document, on the same channel):
+
+```
+[Long-term Memory]
+Persistent memory lives at $APIARY_MEMORY_DIR. The index is below; read the full
+entry from $APIARY_MEMORY_DIR/global/<name>.md when one looks relevant. ...
+- erp-precommit-stale-binary — pre-commit lint fails when the apiary binary is stale
+- ci-duration — CI takes ~12 minutes on this project
+
+[Task Memory]
+- 2026-06-10T14:02:11Z [triage/analyze] (triage) Root cause is in the ADF renderer
+- 2026-06-10T14:31:09Z [engineer/implement] (engineer) Chose lipgloss; tests in markdown_test.go
+```
+
+Key properties:
+
+- **The index is injected, not full entries.** Agents read full files from
+  `$APIARY_MEMORY_DIR` (set for every step), so the prompt budget stays flat as
+  memory grows. Both sections together are capped by
+  `settings.memory.max_inject_chars` — task notes drop oldest-first, the index
+  truncates with an explicit `(… N more entries)` marker.
+- **Task memory follows lineage.** A task spawned via `APIARY_SPAWN` sees its
+  own notes first, then its parent's, then its grandparent's — so a child
+  inherits the context its ancestors collected.
+- `memory: {read: false}` on a step suppresses everything, recall included;
+  `memory.recall: [task]` / `[global]` filters tiers.
+
+## On-disk layout
+
+```
+.apiary/                     # the project data dir, beside apiary.yaml
+  memory/
+    MEMORY.md                # global index — one line per entry, regenerated on write
+    global/
+      erp-precommit-stale-binary.md
+    tasks/
+      01JXKQ8Z3F.md          # working notes for one task (append-only)
+```
+
+Each global entry is frontmatter + markdown body, recording provenance (agent,
+task, workflow, created/updated). The files are the source of truth: edit or
+delete them freely — `MEMORY.md` is derived and self-heals on the next write.
+
+By default the memory root is runtime state; gitignore it like `apiary.db`
+(`**/.apiary/memory/`). Because entries are plain markdown, a team can instead
+point `settings.memory.path` at a committed directory to version and share
+memory deliberately.
+
+## Lifecycle and curation
+
+- **Task notes** are pruned by a daemon sweep (at startup, then every 6 hours)
+  once the task has been terminal longer than `task_retention` — unless a
+  spawned descendant is still running. Unknown task IDs (after a DB reset) are
+  pruned by file age.
+- **Global entries are never auto-pruned.** Curate them via the CLI or your editor:
+
+```bash
+apiary memory path               # print the memory root
+apiary memory list               # index view: name, description, updated, agent
+apiary memory show <name>        # print one entry
+apiary memory rm <name>          # delete one entry
+apiary memory prune [--dry-run]  # run the task-notes sweep on demand
+```
+
+## Security notes
+
+- **Recalled memory is untrusted agent output.** It is injected as inert
+  context; markers are only ever parsed out of live step output, so a memory
+  entry containing `APIARY_SPAWN_BEGIN…` cannot trigger anything by being
+  recalled.
+- **Global means daemon-wide.** Every agent served by the daemon can read every
+  global entry. The store is project-scoped (it lives in the project's data
+  dir), so different projects never share memory.
+- **Don't memorize secrets.** Instruct agents (in soul files) to never store
+  credentials or tokens in memory.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -137,6 +137,11 @@ by persisting structured-output fields (`memory.write: [field, …]`), and
 every later step reads it automatically — the document is injected into the
 agent's context unless the step opts out with `memory: {read: false}`.
 
+This is the *instance* tier: it dies with the workflow instance. For memory
+that survives across instances — per-task working notes and durable
+daemon-wide facts written via `APIARY_MEMORIZE` — see
+[Agent Memory](memory.md).
+
 Memory also drives all control-flow expressions:
 
 ```yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Runners: runners.md
       - Workflows: workflows.md
       - Tasks & Fan-out: tasks-and-fanout.md
+      - Agent Memory: memory.md
       - Rate Limits & Resilience: resilience.md
   - Sources:
       - GitHub: github-source.md

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Ativas
 
+### agent-memory
+
+Memória persistente em camadas para agentes: tier global (fatos duráveis, daemon-wide) + tier de task (notas de trabalho que sobrevivem a instâncias e seguem a linhagem via `parent_task_id`), gravadas pelo marker `APIARY_MEMORIZE` e armazenadas como markdown em disco (`<data-dir>/memory`, índice `MEMORY.md`). Recall injetado no `SystemPrepend` (índice + notas, com budget) e leitura direta via `APIARY_MEMORY_DIR`; curadoria via `apiary memory` CLI. Opt-in (`settings.memory.enabled: false` por padrão).
+
 ### binary-distribution
 
 Publicação dos binários por release: GoReleaser dirigido por push de tag `v*` produz archives + checksums (GitHub Releases), Homebrew tap, Scoop bucket, winget, pacotes Linux (`.deb`/`.rpm` + AUR) e imagem OCI multi-arch (`ghcr.io`). Assinatura/notarização (macOS/Windows) fica fora do escopo v1. Restrição dominante: `mattn/go-sqlite3` exige cgo, então cross-compile precisa de toolchains C.

--- a/openspec/changes/agent-memory/design.md
+++ b/openspec/changes/agent-memory/design.md
@@ -1,0 +1,215 @@
+# Design: Agent Memory
+
+## Architecture Overview
+
+A new `internal/memory` package owns the on-disk store. The runner's structured-output parser gains one more marker; the engine gains one more settle-time handler (sibling of `publishStep` / `spawnStep`); the daemon injects rendered recall sections into the existing `SystemPrepend` channel and exposes the store path via env.
+
+```mermaid
+flowchart TB
+    subgraph RUNNER["Runner — execution"]
+        OUT["Agent output"]
+        EX["extractStructured()<br/>structured.go"]
+        RR["RunResult<br/>+ MemorizeRequests<br/>+ MemorizeError"]
+    end
+
+    subgraph ENGINE["WorkflowEngine"]
+        ST["step settle"]
+        MZ["memorizeStep()<br/>sibling of publishStep/spawnStep"]
+    end
+
+    subgraph MEMPKG["internal/memory"]
+        STORE["Store<br/>mutex · atomic writes"]
+        IDX["MEMORY.md index"]
+        GLB["global/&lt;slug&gt;.md"]
+        TSK["tasks/&lt;task_id&gt;.md"]
+        REN["RenderRecall(taskID, tiers, budget)"]
+        PRUNE["Prune(retention)"]
+    end
+
+    subgraph DAEMON["Daemon"]
+        EXEC["ExecuteStep()<br/>workflow.go"]
+        ENV["stepEnv()<br/>APIARY_MEMORY_DIR"]
+        SWEEP["startup + periodic sweep"]
+        CLI["apiary memory<br/>list · show · rm · prune · path"]
+    end
+
+    OUT --> EX --> RR --> ST --> MZ --> STORE
+    STORE --> IDX
+    STORE --> GLB
+    STORE --> TSK
+    EXEC -->|"SystemPrepend = recall + instance doc"| REN
+    REN --> STORE
+    EXEC --> ENV
+    SWEEP --> PRUNE
+    CLI --> STORE
+```
+
+---
+
+## Components and Integration Points
+
+### 1. Marker parsing — `src/internal/runner/execution/structured.go`
+
+Add to the existing constant block (`structured.go:14-22`):
+
+```go
+memorizeBegin = "APIARY_MEMORIZE_BEGIN"
+memorizeEnd   = "APIARY_MEMORIZE_END"
+```
+
+`extractStructured()` (`structured.go:31`) gains a fourth block extraction, identical in shape to the spawn block: content between markers parsed as one JSON object or an array of objects; marker lines stripped from the visible output. `applyStructured()` (`structured.go:176`) maps the payloads onto `RunResult`:
+
+```go
+// model
+type MemorizeRequest struct {
+    Scope       string `json:"scope"`       // "task" (default) | "global"
+    Name        string `json:"name"`        // slug; required for global
+    Description string `json:"description"` // required for global
+    Content     string `json:"content"`     // required
+}
+
+// RunResult additions
+MemorizeRequests []model.MemorizeRequest
+MemorizeError    string // malformed JSON — step warning, never failure
+```
+
+Parsing happens unconditionally (markers must be stripped from output even when memory is disabled, so they never leak into `APIARY_PUBLISH`-adjacent text or source comments); persistence is gated later by config.
+
+### 2. Store — new package `src/internal/memory`
+
+```go
+type Store struct {
+    root string
+    mu   sync.Mutex // single daemon process; serialize all writes
+}
+
+func Open(root string) (*Store, error)            // mkdir -p root, global/, tasks/
+
+// Writes (called from engine settle)
+func (s *Store) UpsertGlobal(e Entry) error        // write global/<name>.md, regen MEMORY.md
+func (s *Store) AppendTaskNote(taskID string, n Note) error // skip if hash == last note hash
+
+// Recall (called from daemon ExecuteStep)
+func (s *Store) RenderRecall(taskIDs []string, tiers []string, budget int) (string, error)
+
+// Lifecycle
+func (s *Store) Prune(terminalBefore func(taskID string) (bool, time.Time)) (int, error)
+func (s *Store) RebuildIndex() error               // regen MEMORY.md from global/*.md frontmatter
+
+// Curation (CLI)
+func (s *Store) List() ([]EntryMeta, error)
+func (s *Store) Read(name string) (Entry, error)
+func (s *Store) Delete(name string) error
+```
+
+Implementation notes:
+
+- **Atomic writes**: write to `<file>.tmp` in the same directory, then `os.Rename`. The index is always regenerated after a global write inside the same lock.
+- **Slug validation**: `^[a-z0-9][a-z0-9-]{1,63}$`. Reject anything else (path-traversal guard — the name becomes a filename). `task_id` path components come from internal ULIDs, not agent input.
+- **Entry size**: reject `Content` larger than `settings.memory.max_entry_bytes` (default 16 KiB) with a step warning.
+- **Frontmatter**: minimal hand-rolled `key: value` block (name, description, created, updated, agent, task, workflow) — no new YAML dependency needed beyond what config already uses; reuse `gopkg.in/yaml.v3`.
+- **Self-healing index**: `MEMORY.md` is derived state. Operators may delete or hand-edit entry files; `RebuildIndex` runs at daemon start and after every write.
+- **Task note format**: one bullet per note — `- <RFC3339> [<workflow>/<step>] <content>` — multi-line content indented under the bullet.
+
+### 3. Engine — `src/internal/workflow/engine.go`
+
+A `memorizeStep()` handler runs in the same settle path as `spawnStep()` (engine.go:461) and `publishStep()` (engine.go:563), before publish so a step that both memorizes and publishes persists knowledge even if write-back fails:
+
+1. No-op if memory disabled or `step.memory.memorize == "off"` (requests dropped, debug log).
+2. For each request: validate scope/name/size → `UpsertGlobal` or `AppendTaskNote(task.ID, …)` with provenance from the step context.
+3. `MemorizeError` or per-request validation failures append to step warnings (same surfacing as `SpawnError`); the step result state is untouched.
+
+The engine needs access to the `*memory.Store`; it is constructed in the daemon and passed in like the task store (capability-style, matching how `TaskTracker` was wired).
+
+### 4. Recall injection — `src/internal/daemon/workflow.go`
+
+`ExecuteStep()` (workflow.go:345) currently sets `SystemPrepend: req.MemoryDoc` (workflow.go:362). Change:
+
+```go
+prepend := req.MemoryDoc
+if memEnabled && step.Memory.ReadEnabled() {
+    recall, _ := store.RenderRecall(lineage(req.TaskID), step.Memory.RecallTiers(), cfg.MaxInjectChars)
+    prepend = recall + "\n" + prepend
+}
+```
+
+- `lineage()` resolves the task's ancestor chain via the existing `GetTaskAncestors` store method (added in internal-task-model Phase 9), self first, root last.
+- `RenderRecall` emits `[Long-term Memory]` (protocol line + index, truncated with an explicit `(… N more entries — read MEMORY.md)` marker) and `[Task Memory]` (own notes first, then ancestors', oldest dropped first under budget). Either section is omitted when its tier is excluded or empty.
+- Render failures degrade to the instance doc alone (log warning, never block dispatch).
+
+`buildPrompt()` (`runner/execution/cli.go:525`) is untouched — recall rides the existing `SystemPrepend` field.
+
+### 5. Env — `src/internal/daemon/workflow.go:748`
+
+`stepEnv()` identity base gains `APIARY_MEMORY_DIR=<memory root>` when memory is enabled. Explicit agent/workflow/step `env` can still override it (existing precedence: STEP > WORKFLOW > AGENT > base). Runners execute on the same host as the daemon, so the path is directly readable; if remote runners land later, recall injection still works (it's in-prompt) and only direct file reads degrade.
+
+### 6. Config — `src/internal/config/config.go`
+
+```go
+type MemorySettings struct {
+    Enabled        bool   `yaml:"enabled"`
+    Path           string `yaml:"path"`             // default <data-dir>/memory
+    MaxInjectChars int    `yaml:"max_inject_chars"` // default 4000
+    MaxEntryBytes  int    `yaml:"max_entry_bytes"`  // default 16384
+    TaskRetention  string `yaml:"task_retention"`   // duration, default "720h"
+}
+// Settings gains: Memory MemorySettings `yaml:"memory"`
+```
+
+Step-level (`src/internal/config/workflow.go:263`):
+
+```go
+type MemoryConfig struct {
+    Read     *bool    `yaml:"read"`     // existing
+    Write    []string `yaml:"write"`    // existing
+    Recall   []string `yaml:"recall"`   // new: subset of {task, global}; default both
+    Memorize string   `yaml:"memorize"` // new: "auto" (default) | "off"
+}
+```
+
+Lint (`src/internal/config/lint.go`): strict decode already rejects unknown fields; add value checks (recall enum, memorize enum, retention parses as duration, max_* positive). Mirror the struct changes into `schema/apiary.json` and the `.apiary/example-*.yaml` files (per the PR #149 convention).
+
+### 7. Pruning sweep — daemon
+
+At `Start()` (next to `ReconcileOrphanWorkflowInstances`) and then every 6 h: for each `tasks/<id>.md`, look the task up; delete the file when the task is terminal and `updated_at + task_retention < now`, **unless** any descendant task is non-terminal (children inherit ancestor notes, so the chain stays readable while work is in flight). Unknown task IDs (DB reset) are deleted after the same retention based on file mtime.
+
+### 8. CLI — `apiary memory`
+
+| Command | Behavior |
+|---|---|
+| `apiary memory path` | Print the memory root |
+| `apiary memory list` | Index view: name, description, updated, provenance agent |
+| `apiary memory show <name>` | Print the entry (frontmatter + body) |
+| `apiary memory rm <name>` | Delete entry + regen index |
+| `apiary memory prune [--dry-run]` | Run the task-notes sweep on demand |
+
+The CLI opens the store read/write directly (same process model as other `apiary` commands against the data dir); `RebuildIndex` on open makes concurrent daemon writes safe to interleave at the file level since all writes are atomic renames. Cross-process write races are accepted as benign for v1 (worst case: index one write stale, healed on next write).
+
+---
+
+## Security Notes
+
+- **Recalled memory is untrusted model output.** It is injected as inert context inside clearly-delimited sections; the engine never parses markers out of recalled content (markers are only extracted from live step output). A memory entry containing `APIARY_SPAWN_BEGIN…` therefore cannot trigger spawns by being recalled.
+- **Path safety.** Global entry filenames derive solely from the validated slug; task filenames from internal ULIDs. No agent-controlled string is joined into a path without validation.
+- **Cross-project leakage is accepted by design** (global scope was chosen deliberately): any agent can read any global entry. Operators handling multi-tenant setups should treat the memory root as shared context — per-agent/per-project partitioning is a future change (provenance frontmatter already records enough to partition later).
+- **Secrets.** Soul files / docs should instruct agents not to memorize credentials. v1 adds a best-effort lint: warn (don't block) when content matches common token patterns (`ghp_`, `xoxb-`, `AKIA…`).
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| Memory disabled, agent emits marker | Marker stripped from output, request dropped silently |
+| Malformed JSON in block | `MemorizeError` → step warning; step state unaffected |
+| `global` without `name`/`description` | Request rejected with step warning |
+| Duplicate task note (retry re-emits) | Content hash equals last note → skipped |
+| Two steps memorize same global name concurrently | Store mutex serializes; last write wins; both recorded in `updated` |
+| Index/entry drift (hand edits) | `RebuildIndex` at daemon start and on every write |
+| Budget exceeded | Task notes drop oldest-first; index truncates with explicit count marker |
+| Task with no notes / empty store | Sections omitted entirely — zero prompt overhead |
+
+## Alternatives Considered
+
+- **SQLite storage** — queryable and transactional, but the chosen requirement is human-readable, hand-editable files; the index file recovers the "queryable summary" property. Provenance frontmatter keeps a later DB migration mechanical.
+- **Mounted memory directory as the write path** — agents editing files directly would bypass validation, size caps, and provenance stamping, and `WorkingDir` handling differs per runner. The marker keeps writes runner-agnostic and engine-mediated; reads remain direct (env var) since they are side-effect-free.
+- **Per-agent scoping in v1** — rejected for now (decision: global store). Provenance fields make partitioning an additive follow-up.
+- **Embedding/semantic recall** — out of scope; index-line recall plus agent-driven file reads is the v1 retrieval model.

--- a/openspec/changes/agent-memory/proposal.md
+++ b/openspec/changes/agent-memory/proposal.md
@@ -1,0 +1,212 @@
+# Proposal: Agent Memory
+
+## Why
+
+Apiary agents are stateless between executions. The only memory that exists today is the **instance memory document** (`MemoryBuilder`, `step.memory.read/write`): structured fields and handoff summaries accumulated across the steps of a *single workflow instance*, injected as `SystemPrepend` and discarded when the instance reaches a terminal state.
+
+This creates three compounding problems as agents take on longer-running and recurring work:
+
+1. **Agents relearn the same lessons forever.** An engineer agent that discovers "this repo's pre-commit hook needs `--no-verify` when the binary is stale" or "CI takes ~12 minutes on this project" loses that knowledge the moment the instance ends. The next task pays the same exploration cost — every time.
+
+2. **Work on the same task is amnesiac across instances.** A task that fans out to multiple workflows, retries after a failure, or spawns children via `APIARY_SPAWN` produces several workflow instances — none of which can see what the others learned or decided. A retry repeats the failed approach; a spawned child re-derives context its parent already collected (the `input` payload helps, but is fixed at spawn time and write-once).
+
+3. **There is no curation surface.** Operators cannot inspect, correct, or prune what agents "know". Knowledge lives only in transient prompts and step outputs scattered across `step_runs` rows.
+
+The fix is a **tiered, persistent memory system**: a daemon-wide long-term store of durable facts, plus per-task working memory that survives across instances and follows task lineage — both written by agents through a new `APIARY_MEMORIZE` output marker and stored as human-readable markdown files on disk.
+
+---
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Memory lifetime** | One workflow instance | Three tiers: instance (unchanged), task (across instances + lineage), global (forever) |
+| **Memory storage** | In-memory, rebuilt per step | Markdown files under a memory root on disk |
+| **Write path** | `step.memory.write` (declared fields only) | Plus agent-driven `APIARY_MEMORIZE` marker (like `APIARY_PUBLISH` / `APIARY_SPAWN`) |
+| **Recall** | Instance doc via `SystemPrepend` | Plus task notes + global index injected; full entries readable via `APIARY_MEMORY_DIR` |
+| **Curation** | None | `apiary memory` CLI (list, show, rm, prune) + plain files editable by hand |
+| **Spawned children context** | Fixed `input` payload at spawn time | Plus inherited task memory from ancestor chain |
+
+---
+
+## New Concepts
+
+| Term | Description |
+|---|---|
+| **Memory tier** | Where a memory lives and how long: `instance` (existing, unchanged), `task`, `global`. |
+| **Task memory** | Append-only working notes attached to an `InternalTask`. Visible to every workflow instance of that task **and of its descendants** (via `parent_task_id` lineage). Pruned after the task is terminal + retention period. |
+| **Long-term (global) memory** | One daemon-wide store of durable facts, shared by all agents, sources, and projects. One markdown file per fact, upserted by slug. Never auto-pruned — curated by humans or by agents updating entries. |
+| **`APIARY_MEMORIZE` marker** | Agent-emitted block (single JSON object or array, mirroring `APIARY_SPAWN`) instructing the engine to persist a memory to a tier. |
+| **Memory root** | The on-disk directory holding all persistent memory. Defaults to `<data-dir>/memory` — i.e. `.apiary/memory/` beside the config file, next to `apiary.db` (per `config.DataDir`, the single source of truth for project state). Configurable via `settings.memory.path`. Because the data dir is project-scoped, "global" means **daemon-wide**: shared across all agents, sources, and workflows served by that daemon, but naturally isolated between projects. |
+| **Memory index** | `MEMORY.md` at the memory root — one line per global entry (name + description). This index, not the full entries, is what gets injected into prompts; agents read full entries from disk when needed. |
+| **Memory provenance** | Frontmatter on every entry recording which agent, task, and workflow wrote it, and when. Enables future per-agent/per-project partitioning without changing the store. |
+
+---
+
+## What Stays
+
+- **Instance memory** — `MemoryBuilder`, the `[Cell]` / `[Step Data]` / `[Summaries]` document, `step.memory.read` and `step.memory.write` are all unchanged. The persistent tiers compose with it; they do not replace it.
+- **Markers** — `APIARY_OUTPUT`, `APIARY_SUMMARY`, `APIARY_PUBLISH`, `APIARY_SPAWN` unchanged. `APIARY_MEMORIZE` is a sibling, parsed by the same `extractStructured` pass.
+- **Engine, router, sources, runners** — no behavioral change for configs that don't enable memory. The feature is **opt-in** (`settings.memory.enabled: false` by default in v1).
+- **InternalTask model** — no schema change to `internal_tasks`; task memory is keyed by task ID on disk, and lineage reads reuse the existing ancestor chain (`GetTaskAncestors`).
+
+---
+
+## Core Behaviors
+
+### 1. Writing memory — `APIARY_MEMORIZE`
+
+An agent emits the marker in its step output. Single object or JSON array (same convention as `APIARY_SPAWN`):
+
+```
+APIARY_MEMORIZE_BEGIN
+{
+  "scope": "global",
+  "name": "erp-precommit-stale-binary",
+  "description": "project-erp pre-commit lint fails when the apiary binary is stale",
+  "content": "When the local apiary binary predates the config schema, pre-commit lint hard-errors.\nFix: rebuild the binary or commit with --no-verify and note it in the PR."
+}
+APIARY_MEMORIZE_END
+```
+
+Fields:
+
+- `scope` — `"task"` (default) or `"global"`.
+- `name` — kebab-case slug. **Required for `global`** (it is the upsert key); ignored for `task`.
+- `description` — one line, shown in the index. Required for `global`.
+- `content` — markdown body. Required.
+
+Engine handling, after step completion (alongside `publishStep` / `spawnStep`):
+
+- **`global`**: upsert `global/<name>.md` (same name = overwrite body, bump `updated`, keep `created`), regenerate `MEMORY.md` index.
+- **`task`**: append a timestamped, provenance-stamped note to `tasks/<task_id>.md`. Identical consecutive content (hash match) is skipped to keep retries from duplicating notes.
+- Malformed JSON sets a `MemorizeError` surfaced as a step warning (mirrors `SpawnError`) — it never fails the step.
+- If memory is disabled, the marker is stripped from output and silently ignored (same posture as `APIARY_PUBLISH` on a task with no bindings).
+
+### 2. Recall — what gets injected
+
+When memory is enabled, the daemon prepends two sections to the existing instance memory document (same `SystemPrepend` channel, before `[Cell]`):
+
+```
+[Long-term Memory]
+You have a persistent memory at $APIARY_MEMORY_DIR. Index below; read full
+entries from global/<name>.md when relevant. To save a durable fact, emit
+APIARY_MEMORIZE (see protocol).
+- erp-precommit-stale-binary — project-erp pre-commit lint fails when the binary is stale
+- ci-duration-erp — project-erp CI takes ~12min; poll accordingly
+
+[Task Memory]
+- 2026-06-10T14:02 [triage/analyze] Root cause is in the ADF table renderer; fix belongs in markdown.go
+- 2026-06-10T14:31 [engineer/implement] Chose lipgloss table over manual padding; tests in markdown_test.go
+```
+
+- The **index** is injected, not full global entries — agents read full files from `APIARY_MEMORY_DIR` (env var set for every step when enabled). This keeps the prompt budget flat as memory grows.
+- **Task memory** for a task includes its own notes plus its ancestors' (walk `parent_task_id` up), so spawned children inherit working context.
+- Both sections are size-capped (`settings.memory.max_inject_chars`, default 4000 — same default as the instance doc cap): task notes drop oldest-first, the global index truncates with an explicit `(… N more entries — read MEMORY.md)` line.
+- `step.memory.read: false` continues to suppress the entire memory document, persistent sections included. A new `step.memory.recall` list allows finer opt-out per tier.
+
+### 3. Lifecycle and curation
+
+- **Task memory** is pruned by a daemon sweep: notes whose task has been terminal (done/failed) longer than `settings.memory.task_retention` (default `720h` = 30 days) are deleted. Notes of ancestors are retained while any descendant is non-terminal.
+- **Global memory** is never auto-pruned. Curation paths:
+  - Files are plain markdown — operators edit or delete them directly; the index is regenerated from frontmatter on the next write (self-healing).
+  - `apiary memory list | show <name> | rm <name> | prune [--dry-run] | path` for inspection and cleanup.
+  - Agents can update entries by re-emitting the same `name`, and a curation workflow (e.g. a periodic consolidation agent) can be built with existing primitives — out of scope for v1.
+
+### 4. Suppression
+
+Mirroring `publish: off`:
+
+```yaml
+steps:
+  - id: untrusted-analysis
+    agent: analyzer
+    memory:
+      memorize: off        # marker stripped and ignored for this step
+      recall: [task]       # inject task notes only; no global index
+```
+
+Defaults: `memorize: auto`, `recall: [task, global]`.
+
+---
+
+## New Config Schema
+
+```yaml
+# top-level in apiary.yaml
+settings:
+  memory:
+    enabled: true                 # default false (opt-in in v1)
+    path: ~/.apiary/memory        # default: <data-dir>/memory
+    max_inject_chars: 4000        # per-prompt budget for the two persistent sections
+    max_entry_bytes: 16384        # cap on a single APIARY_MEMORIZE content
+    task_retention: 720h          # prune task notes this long after task is terminal
+```
+
+```yaml
+# per step (extends existing memory block)
+steps:
+  - id: implement
+    agent: engineer
+    memory:
+      read: true                  # existing — gates the whole memory doc
+      write: ["pr_url"]           # existing — instance-tier declared fields
+      recall: [task, global]      # new — which persistent tiers to inject
+      memorize: auto              # new — auto | off
+```
+
+Config lint validates the block strictly (unknown fields rejected, `recall` values restricted to `task`/`global`, durations parsed).
+
+---
+
+## On-disk Layout
+
+```
+.apiary/                     # config.DataDir — beside apiary.yaml, same dir as apiary.db
+  memory/                    # memory root (override: settings.memory.path)
+    MEMORY.md                # global index — one line per entry, regenerated on write
+    global/
+      erp-precommit-stale-binary.md
+      ci-duration-erp.md
+    tasks/
+      01JXKQ8Z3F.md          # working notes for task 01JXKQ8Z3F (append-only)
+```
+
+Versioning: by default memory is runtime state and should be gitignored like `apiary.db` (`**/.apiary/memory/`). Because entries are plain markdown, a team can deliberately point `settings.memory.path` at a committed directory to version and share long-term memory — supported, but not the default posture.
+
+Entry file format:
+
+```markdown
+---
+name: erp-precommit-stale-binary
+description: project-erp pre-commit lint fails when the apiary binary is stale
+created: 2026-06-10T14:02:11Z
+updated: 2026-06-10T14:02:11Z
+agent: engineer
+task: 01JXKQ8Z3F
+workflow: engineer-workflow
+---
+
+When the local apiary binary predates the config schema, pre-commit lint hard-errors.
+Fix: rebuild the binary or commit with --no-verify and note it in the PR.
+```
+
+---
+
+## Concrete Use Case: ERP Project Workflows
+
+1. **Triage** runs on issue #2140. The analyze step discovers the bug lives in the Jira ADF renderer and emits a `task`-scoped memorize. It routes to the engineer workflow.
+2. **Engineer** workflow starts as a *different workflow instance on the same task* — its first step already sees `[Task Memory]` with triage's note and skips re-investigation.
+3. Mid-implementation the agent hits the stale-binary pre-commit failure, burns 10 minutes diagnosing it, and emits a `global` memorize.
+4. The step's CI wait fails; **retry** instance starts — task notes tell it exactly what was already tried and decided.
+5. A week later, a different agent on a different task hits pre-commit. Its prompt's `[Long-term Memory]` index shows `erp-precommit-stale-binary`; it reads the entry from `$APIARY_MEMORY_DIR/global/` and resolves it in seconds.
+6. The operator runs `apiary memory list`, spots a stale entry from before a tooling change, and deletes the file.
+
+---
+
+## Migration Notes
+
+- Purely additive. With `settings.memory.enabled: false` (default), behavior is byte-for-byte identical to today; `APIARY_MEMORIZE` blocks are stripped from output (so prompts that mention the protocol don't leak markers into publishes) but nothing is persisted.
+- No database schema changes. The memory root is created lazily on first write.
+- Existing `step.memory.read` / `step.memory.write` semantics are unchanged; the new `recall` / `memorize` keys are optional with backward-compatible defaults.
+- Memory content is **agent-generated and untrusted**: it is injected with explicit section delimiters and never interpreted by the engine (no markers are parsed out of recalled memory). Documented in the security notes of `design.md`.

--- a/openspec/changes/agent-memory/tasks.md
+++ b/openspec/changes/agent-memory/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Agent Memory
+
+Implementation follows 5 phases. Each phase produces a shippable state and must pass `go test ./...` before the next begins. Read `proposal.md` and `design.md` before starting.
+
+**Key references:**
+- `design.md` — store API, integration points with file:line anchors, security notes, edge cases
+- `proposal.md` — behavioral spec, marker protocol, config schema, on-disk layout
+
+---
+
+## Phase 1 — Store & Config Foundation
+
+New package and config plumbing; nothing wired into execution yet.
+
+### 1.1 Memory store
+
+- [x] 1.1.1 Create `src/internal/memory/store.go`: `Store`, `Open`, `Entry`/`EntryMeta`/`Note` types, slug validation regex, atomic write helper (tmp + rename)
+- [x] 1.1.2 Implement `UpsertGlobal` (frontmatter render, create-vs-update `created`/`updated` handling) and index regeneration into `MEMORY.md`
+- [x] 1.1.3 Implement `AppendTaskNote` with last-note content-hash dedup
+- [x] 1.1.4 Implement `RebuildIndex` (parse `global/*.md` frontmatter; tolerate hand-edited/broken files by skipping with a warning)
+- [x] 1.1.5 Implement `List` / `Read` / `Delete`
+- [x] 1.1.6 Unit tests: round-trip, upsert semantics, slug rejection (traversal attempts), size cap, dedup, index self-healing after manual file deletion
+
+### 1.2 Config
+
+- [x] 1.2.1 Add `MemorySettings` to `Settings` in `src/internal/config/config.go` with defaults (enabled=false, path=`<data-dir>/memory`, max_inject_chars=4000, max_entry_bytes=16384, task_retention=720h)
+- [x] 1.2.2 Extend `MemoryConfig` in `src/internal/config/workflow.go` with `Recall []string` and `Memorize string`; default helpers (`RecallTiers()`, `MemorizeEnabled()`)
+- [x] 1.2.3 Lint: recall enum (`task`/`global`), memorize enum (`auto`/`off`), retention duration parse, positive size caps
+- [x] 1.2.4 Regenerate `schema/apiary.json` and update `.apiary/example-*.yaml` mirrors
+- [x] 1.2.5 Unit tests: lint accept/reject cases; defaults applied
+
+---
+
+## Phase 2 — Marker Parsing
+
+- [x] 2.1 Add `APIARY_MEMORIZE_BEGIN/END` constants and block extraction in `src/internal/runner/execution/structured.go` (object-or-array, mirroring spawn)
+- [x] 2.2 Add `model.MemorizeRequest`; extend `RunResult` with `MemorizeRequests` / `MemorizeError`; wire in `applyStructured`
+- [x] 2.3 Markers always stripped from visible output, even when memory is disabled
+- [x] 2.4 Unit tests in `structured_test.go`: single object, array, malformed JSON → `MemorizeError`, marker stripping, defaults (`scope` omitted → `task`)
+
+---
+
+## Phase 3 — Engine Write Path
+
+- [x] 3.1 Construct `*memory.Store` in daemon startup when enabled; pass to engine (capability-style, like `TaskTracker`)
+- [x] 3.2 Implement `memorizeStep()` in `src/internal/workflow/engine.go` settle path, ordered before `publishStep`; gate on enabled + `memory.memorize`
+- [x] 3.3 Validation failures and `MemorizeError` surface as step warnings; provenance (agent, task, workflow, step) stamped from step context
+- [x] 3.4 Tests: end-to-end engine test — step output with marker → file on disk with correct frontmatter; disabled → no file; `memorize: off` → no file; oversized content → warning, no file
+
+---
+
+## Phase 4 — Recall & Env
+
+- [x] 4.1 Implement `RenderRecall` in the store: `[Long-term Memory]` (protocol line + index, truncation marker) and `[Task Memory]` (self + ancestors via `GetTaskAncestors`, oldest-dropped budget)
+- [x] 4.2 Prepend recall to `req.MemoryDoc` in `ExecuteStep` (`src/internal/daemon/workflow.go`); degrade to instance doc on store error
+- [x] 4.3 Respect `step.memory.read=false` (suppresses everything) and `step.memory.recall` tier filtering
+- [x] 4.4 Add `APIARY_MEMORY_DIR` to `stepEnv()` identity base when enabled
+- [x] 4.5 Tests: budget truncation, ancestor inheritance order, empty-store zero-overhead, env var presence/override precedence
+
+---
+
+## Phase 5 — Lifecycle, CLI & Docs
+
+### 5.1 Pruning
+
+- [x] 5.1.1 Implement `Prune` (terminal + retention, descendant-aware keep, mtime fallback for unknown task IDs)
+- [x] 5.1.2 Wire sweep at daemon `Start()` (next to startup reconcile) + 6h ticker
+- [x] 5.1.3 Tests: terminal-old pruned, in-flight descendant retained, unknown-id mtime path
+
+### 5.2 CLI
+
+- [x] 5.2.1 `apiary memory path|list|show|rm|prune [--dry-run]` subcommands
+- [x] 5.2.2 `RebuildIndex` on CLI store open; human-readable list output
+
+### 5.3 Docs & rollout
+
+- [x] 5.3.1 New docs page `docs/memory.md` (tiers, marker protocol, config, curation) + mkdocs nav entry
+- [x] 5.3.2 Update `docs/workflows.md` memory section to name the instance tier and link out
+- [ ] 5.3.3 Update apiary-guide skill + example soul-file snippet teaching the memorize protocol and "no secrets" rule
+- [x] 5.3.4 Best-effort secret-pattern warning on memorize content (`ghp_`, `xoxb-`, `AKIA`)
+- [x] 5.3.5 Gitignore guidance: add `**/.apiary/memory/` to this repo's `.gitignore` and to whatever `apiary init` emits; document the "commit it deliberately" alternative
+- [ ] 5.3.6 Archive change: move CHANGELOG entry from Ativas to Arquivadas

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -441,6 +441,37 @@
           "description": "Delete rotated backups, per-task log files, and SQLite log rows (service_logs/task_logs) older than this many days. Files are checked at startup and after each rotation; DB rows at startup and then daily. Default 30; negative disables",
           "default": 30
         },
+        "memory": {
+          "type": "object",
+          "description": "Persistent agent memory: per-task working notes plus daemon-wide durable facts, written via the APIARY_MEMORIZE marker and stored as markdown files under the memory root. Disabled by default",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable the persistent memory store",
+              "default": false
+            },
+            "path": {
+              "type": "string",
+              "description": "Memory root directory. Empty means <data-dir>/memory — the .apiary/ folder beside the config file, next to apiary.db"
+            },
+            "max_inject_chars": {
+              "type": "integer",
+              "description": "Budget for the recall sections ([Long-term Memory] index + [Task Memory] notes) injected into each step prompt",
+              "default": 4000
+            },
+            "max_entry_bytes": {
+              "type": "integer",
+              "description": "Cap on a single APIARY_MEMORIZE content",
+              "default": 16384
+            },
+            "task_retention": {
+              "type": "string",
+              "description": "How long task notes are kept after the task reaches a terminal state, as a Go duration. Global entries are never auto-pruned",
+              "default": "720h"
+            }
+          }
+        },
         "telemetry": {
           "type": "object",
           "description": "Telemetry configuration",
@@ -889,12 +920,12 @@
     },
     "MemoryConfig": {
       "type": "object",
-      "description": "How a step interacts with the workflow memory object",
+      "description": "How a step interacts with the workflow memory object and the persistent memory store (settings.memory)",
       "additionalProperties": false,
       "properties": {
         "read": {
           "type": "boolean",
-          "description": "Inject the workflow memory document into this step (default true; only an explicit false disables it)",
+          "description": "Inject the workflow memory document into this step (default true; only an explicit false disables it). Gates the persistent recall sections too",
           "default": true
         },
         "write": {
@@ -903,6 +934,20 @@
           "items": {
             "type": "string"
           }
+        },
+        "recall": {
+          "type": "array",
+          "description": "Persistent memory tiers injected into this step's prompt. Empty/omitted means both. Only meaningful when settings.memory.enabled is true",
+          "items": {
+            "type": "string",
+            "enum": ["task", "global"]
+          }
+        },
+        "memorize": {
+          "type": "string",
+          "description": "How APIARY_MEMORIZE requests emitted by this step's agent are handled: auto (default, persist) or off (drop)",
+          "enum": ["auto", "off"],
+          "default": "auto"
         }
       }
     },

--- a/src/internal/cli/memory_cmd.go
+++ b/src/internal/cli/memory_cmd.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/memory"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func newMemoryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "memory",
+		Short: "Inspect and curate the persistent agent memory",
+		Long: "Inspect and curate the persistent agent memory store (settings.memory): the\n" +
+			"global tier (durable facts written via APIARY_MEMORIZE) and the task tier\n" +
+			"(per-task working notes). Entries are plain markdown — they can also be\n" +
+			"edited or deleted by hand; the MEMORY.md index self-heals on the next write.",
+	}
+	cmd.AddCommand(
+		newMemoryPathCmd(),
+		newMemoryListCmd(),
+		newMemoryShowCmd(),
+		newMemoryRmCmd(),
+		newMemoryPruneCmd(),
+	)
+	return cmd
+}
+
+// memoryRoot resolves the memory root the same way the daemon does:
+// settings.memory.path when set, else <data-dir>/memory.
+func memoryRoot() string {
+	if cfg, err := config.Load(configFile); err == nil && cfg.Settings.Memory.Path != "" {
+		return cfg.Settings.Memory.Path
+	}
+	return filepath.Join(config.DataDir(configFile), "memory")
+}
+
+// openMemoryStore opens the store at the resolved root. Open also rebuilds the
+// index, healing any drift from hand edits.
+func openMemoryStore() (*memory.Store, error) {
+	return memory.Open(memoryRoot())
+}
+
+func newMemoryPathCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print the memory root directory",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println(memoryRoot())
+			return nil
+		},
+	}
+}
+
+func newMemoryListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List global memory entries",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := openMemoryStore()
+			if err != nil {
+				return err
+			}
+			metas, err := store.List()
+			if err != nil {
+				return err
+			}
+			notes, _ := store.ListTaskNotes()
+			if len(metas) == 0 {
+				fmt.Println(instMuted.Render("No global memory entries."))
+			}
+			for _, m := range metas {
+				line := fmt.Sprintf("%-32s %s", m.Name, m.Description)
+				meta := ""
+				if m.Agent != "" {
+					meta = " (" + m.Agent
+					if !m.Updated.IsZero() {
+						meta += ", " + m.Updated.Local().Format("2006-01-02")
+					}
+					meta += ")"
+				} else if !m.Updated.IsZero() {
+					meta = " (" + m.Updated.Local().Format("2006-01-02") + ")"
+				}
+				fmt.Println(line + instMuted.Render(meta))
+			}
+			fmt.Println(instMuted.Render(fmt.Sprintf("%d global entr(ies), %d task note file(s) at %s", len(metas), len(notes), store.Root())))
+			return nil
+		},
+	}
+}
+
+func newMemoryShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Print one global memory entry (frontmatter + body)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := openMemoryStore()
+			if err != nil {
+				return err
+			}
+			data, err := os.ReadFile(filepath.Join(store.Root(), "global", args[0]+".md"))
+			if err != nil {
+				return fmt.Errorf("entry %q not found", args[0])
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	}
+}
+
+func newMemoryRmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Delete one global memory entry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := openMemoryStore()
+			if err != nil {
+				return err
+			}
+			if err := store.Delete(args[0]); err != nil {
+				return err
+			}
+			fmt.Println(instOK.Render("✓ Deleted ") + args[0])
+			return nil
+		},
+	}
+}
+
+func newMemoryPruneCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Prune task notes past the retention window",
+		Long: "Delete task-memory note files whose task has been terminal (done/failed)\n" +
+			"longer than settings.memory.task_retention (default 720h). Notes whose task\n" +
+			"is unknown (e.g. after a database reset) are pruned by file age instead.\n" +
+			"Global entries are never pruned by this command — use rm.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runMemoryPrune(dryRun)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "report what would be pruned without deleting")
+	return cmd
+}
+
+func runMemoryPrune(dryRun bool) error {
+	store, err := openMemoryStore()
+	if err != nil {
+		return err
+	}
+	retention := 720 * time.Hour
+	if cfg, err := config.Load(configFile); err == nil {
+		retention = cfg.Settings.Memory.TaskRetentionDuration()
+	}
+
+	// Task states come from the project DB when it exists; without one, fall
+	// back to file age for every note file.
+	var dbClient *db.Client
+	ctx := context.Background()
+	if _, err := os.Stat(getDBPath()); err == nil {
+		if c, err := db.New(ctx, getDBPath()); err == nil {
+			dbClient = c
+			defer dbClient.Close()
+		}
+	}
+
+	notes, err := store.ListTaskNotes()
+	if err != nil {
+		return err
+	}
+	cutoff := time.Now().Add(-retention)
+	pruned := 0
+	for _, tn := range notes {
+		prune := false
+		if dbClient != nil {
+			if task, err := dbClient.InternalTasks().GetTask(ctx, tn.TaskID); err == nil && task != nil {
+				terminal := task.State == model.TaskStateDone || task.State == model.TaskStateFailed
+				prune = terminal && task.UpdatedAt.Before(cutoff)
+			} else {
+				prune = tn.ModTime.Before(cutoff)
+			}
+		} else {
+			prune = tn.ModTime.Before(cutoff)
+		}
+		if !prune {
+			continue
+		}
+		if dryRun {
+			fmt.Println(instMuted.Render("would prune ") + tn.TaskID)
+			pruned++
+			continue
+		}
+		if err := store.DeleteTaskNotes(tn.TaskID); err != nil {
+			fmt.Println(instErr.Render("prune "+tn.TaskID+": ") + err.Error())
+			continue
+		}
+		pruned++
+	}
+	verb := "Pruned"
+	if dryRun {
+		verb = "Would prune"
+	}
+	fmt.Println(instOK.Render(fmt.Sprintf("✓ %s %d task note file(s).", verb, pruned)))
+	return nil
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -58,6 +58,7 @@ func init() {
 		newRestartCmd(),
 		newDeleteCmd(),
 		newUpdateCmd(),
+		newMemoryCmd(),
 	)
 }
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -213,10 +213,42 @@ type Settings struct {
 	MaxAttempts int `yaml:"max_attempts"`
 	// Log rotation for the shared apiary.log file and retention for rotated
 	// backups and per-task log files. 0 means default; negative disables.
-	LogMaxSizeMB  int       `yaml:"log_max_size_mb"`  // rotate apiary.log past this size; default 50
-	LogMaxBackups int       `yaml:"log_max_backups"`  // rotated files to keep; default 5
-	LogMaxAgeDays int       `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
-	Telemetry     Telemetry `yaml:"telemetry"`
+	LogMaxSizeMB  int            `yaml:"log_max_size_mb"`  // rotate apiary.log past this size; default 50
+	LogMaxBackups int            `yaml:"log_max_backups"`  // rotated files to keep; default 5
+	LogMaxAgeDays int            `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
+	Memory        MemorySettings `yaml:"memory"`
+	Telemetry     Telemetry      `yaml:"telemetry"`
+}
+
+// MemorySettings configures the persistent agent memory store (the task and
+// global tiers written via APIARY_MEMORIZE). Disabled by default: with
+// Enabled false nothing is persisted or injected, and emitted markers are
+// stripped from output and dropped.
+type MemorySettings struct {
+	Enabled bool `yaml:"enabled"`
+	// Path is the memory root directory. Empty means <data-dir>/memory — the
+	// .apiary/ folder beside the config file, next to apiary.db.
+	Path string `yaml:"path"`
+	// MaxInjectChars bounds the recall sections ([Long-term Memory] index +
+	// [Task Memory] notes) injected into each step prompt. Default 4000.
+	MaxInjectChars int `yaml:"max_inject_chars"`
+	// MaxEntryBytes caps a single APIARY_MEMORIZE content. Default 16384.
+	MaxEntryBytes int `yaml:"max_entry_bytes"`
+	// TaskRetention is how long a task's notes are kept after the task reaches a
+	// terminal state (duration string). Default "720h" (30 days).
+	TaskRetention string `yaml:"task_retention"`
+}
+
+// TaskRetentionDuration returns the parsed retention window (default 720h).
+func (m MemorySettings) TaskRetentionDuration() time.Duration {
+	if m.TaskRetention == "" {
+		return 720 * time.Hour
+	}
+	d, err := time.ParseDuration(m.TaskRetention)
+	if err != nil {
+		return 720 * time.Hour
+	}
+	return d
 }
 
 func (s *Settings) TaskTimeoutDuration() time.Duration {
@@ -488,6 +520,12 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Settings.LogMaxAgeDays == 0 {
 		cfg.Settings.LogMaxAgeDays = 30
+	}
+	if cfg.Settings.Memory.MaxInjectChars == 0 {
+		cfg.Settings.Memory.MaxInjectChars = 4000
+	}
+	if cfg.Settings.Memory.MaxEntryBytes == 0 {
+		cfg.Settings.Memory.MaxEntryBytes = 16384
 	}
 	warnDeprecatedResultComment(&cfg)
 	return &cfg, nil

--- a/src/internal/config/memory_validate_test.go
+++ b/src/internal/config/memory_validate_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func memValidCfg() *Config {
+	return &Config{
+		Version: "1.0",
+		Agents:  []AgentConfig{{ID: "dev", Model: "claude-sonnet-4-6"}},
+		Workflows: []WorkflowConfig{{
+			ID:    "wf",
+			Steps: []StepConfig{{ID: "run", Agent: "dev"}},
+		}},
+	}
+}
+
+func errorsContain(errs []error, want string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Error(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidate_MemorySettings(t *testing.T) {
+	cfg := memValidCfg()
+	cfg.Settings.Memory = MemorySettings{Enabled: true, TaskRetention: "720h", MaxInjectChars: 4000}
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Fatalf("valid memory settings rejected: %v", errs)
+	}
+
+	cfg = memValidCfg()
+	cfg.Settings.Memory.TaskRetention = "not-a-duration"
+	if errs := cfg.Validate(); !errorsContain(errs, "task_retention") {
+		t.Fatalf("invalid retention accepted: %v", errs)
+	}
+
+	cfg = memValidCfg()
+	cfg.Settings.Memory.MaxInjectChars = -1
+	if errs := cfg.Validate(); !errorsContain(errs, "max_inject_chars") {
+		t.Fatalf("negative max_inject_chars accepted: %v", errs)
+	}
+}
+
+func TestValidate_StepMemoryEnums(t *testing.T) {
+	cfg := memValidCfg()
+	cfg.Workflows[0].Steps[0].Memory = &MemoryConfig{Recall: []string{"task", "global"}, Memorize: "auto"}
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Fatalf("valid step memory rejected: %v", errs)
+	}
+
+	cfg = memValidCfg()
+	cfg.Workflows[0].Steps[0].Memory = &MemoryConfig{Recall: []string{"everything"}}
+	if errs := cfg.Validate(); !errorsContain(errs, "memory.recall") {
+		t.Fatalf("invalid recall tier accepted: %v", errs)
+	}
+
+	cfg = memValidCfg()
+	cfg.Workflows[0].Steps[0].Memory = &MemoryConfig{Memorize: "maybe"}
+	if errs := cfg.Validate(); !errorsContain(errs, "memory.memorize") {
+		t.Fatalf("invalid memorize accepted: %v", errs)
+	}
+}
+
+func TestStepMemoryDefaults(t *testing.T) {
+	s := StepConfig{}
+	if !s.MemorizeEnabled() {
+		t.Error("memorize must default to enabled")
+	}
+	tiers := s.MemoryRecallTiers()
+	if len(tiers) != 2 || tiers[0] != MemoryTierTask || tiers[1] != MemoryTierGlobal {
+		t.Errorf("recall must default to both tiers, got %v", tiers)
+	}
+	s.Memory = &MemoryConfig{Memorize: MemorizeOff, Recall: []string{"global"}}
+	if s.MemorizeEnabled() {
+		t.Error("memorize: off must disable")
+	}
+	if got := s.MemoryRecallTiers(); len(got) != 1 || got[0] != "global" {
+		t.Errorf("recall filter not honored: %v", got)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -153,6 +154,19 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("workers[%d]: duplicate id %q", i, w.ID))
 		}
 		workerIDs[w.ID] = true
+	}
+
+	// settings.memory value checks (the block itself is optional).
+	if m := c.Settings.Memory; m.TaskRetention != "" {
+		if _, err := time.ParseDuration(m.TaskRetention); err != nil {
+			errs = append(errs, fmt.Errorf("settings.memory.task_retention %q: invalid duration: %w", m.TaskRetention, err))
+		}
+	}
+	if c.Settings.Memory.MaxInjectChars < 0 {
+		errs = append(errs, fmt.Errorf("settings.memory.max_inject_chars must be >= 0"))
+	}
+	if c.Settings.Memory.MaxEntryBytes < 0 {
+		errs = append(errs, fmt.Errorf("settings.memory.max_entry_bytes must be >= 0"))
 	}
 
 	// Validate v2-specific authoring rules before lowering (while v2 fields are

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -247,6 +247,22 @@ func (s StepConfig) MemoryWriteFields() []string {
 	return s.Memory.Write
 }
 
+// MemorizeEnabled reports whether APIARY_MEMORIZE requests emitted by this
+// step's agent should be persisted. Defaults to true; only an explicit
+// `memory.memorize: off` disables it.
+func (s StepConfig) MemorizeEnabled() bool {
+	return s.Memory == nil || s.Memory.Memorize != MemorizeOff
+}
+
+// MemoryRecallTiers returns the persistent memory tiers to inject into this
+// step's prompt. An unset/empty `memory.recall` means both tiers.
+func (s StepConfig) MemoryRecallTiers() []string {
+	if s.Memory == nil || len(s.Memory.Recall) == 0 {
+		return []string{MemoryTierTask, MemoryTierGlobal}
+	}
+	return s.Memory.Recall
+}
+
 // ParsedTimeout returns the approval-step timeout, or 0 when unset/invalid
 // (meaning no timeout).
 func (s StepConfig) ParsedTimeout() time.Duration {
@@ -260,12 +276,33 @@ func (s StepConfig) ParsedTimeout() time.Duration {
 	return d
 }
 
-// MemoryConfig controls how a step interacts with the workflow memory object.
+// Memorize handling for a step's APIARY_MEMORIZE requests.
+const (
+	MemorizeAuto = "auto" // default: persist requests the agent emits
+	MemorizeOff  = "off"  // drop requests, even if the agent emits them
+)
+
+// Persistent memory tiers a step may recall (step.memory.recall values).
+const (
+	MemoryTierTask   = "task"
+	MemoryTierGlobal = "global"
+)
+
+// MemoryConfig controls how a step interacts with the workflow memory object
+// (the per-instance document) and the persistent memory store (the task and
+// global tiers).
 type MemoryConfig struct {
 	// Read is a pointer so an explicit `read: false` is distinguishable from an
 	// unset value (which defaults to true). Use StepConfig.MemoryReadEnabled().
+	// It gates the entire memory document, persistent recall sections included.
 	Read  *bool    `yaml:"read,omitempty"`
 	Write []string `yaml:"write,omitempty"`
+	// Recall lists the persistent tiers injected into this step's prompt: any
+	// subset of "task" and "global". Empty means both. Use
+	// StepConfig.MemoryRecallTiers().
+	Recall []string `yaml:"recall,omitempty"`
+	// Memorize controls the step's APIARY_MEMORIZE handling: auto (default) | off.
+	Memorize string `yaml:"memorize,omitempty"`
 }
 
 // StepNext is the explicit success edge of an agent step (on_pass.next).

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -203,6 +203,22 @@ func (c *Config) validateAgentStep(sctx string, s StepConfig, agentIDs, stepIDs 
 		errs = append(errs, fmt.Errorf("%s: materialize: sub_issue is incompatible with spawn: await", sctx))
 	}
 
+	// memory.memorize and memory.recall take closed enums.
+	if s.Memory != nil {
+		switch s.Memory.Memorize {
+		case "", MemorizeAuto, MemorizeOff:
+		default:
+			errs = append(errs, fmt.Errorf("%s: invalid memory.memorize %q (want auto|off)", sctx, s.Memory.Memorize))
+		}
+		for _, tier := range s.Memory.Recall {
+			switch tier {
+			case MemoryTierTask, MemoryTierGlobal:
+			default:
+				errs = append(errs, fmt.Errorf("%s: invalid memory.recall tier %q (want task|global)", sctx, tier))
+			}
+		}
+	}
+
 	// memory.write requires output_schema with matching top-level fields.
 	if w := s.MemoryWriteFields(); len(w) > 0 {
 		if s.OutputSchema == nil {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -22,6 +22,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/logging"
+	"github.com/orlandoburli/apiary/internal/memory"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
@@ -61,6 +62,12 @@ type Dispatcher struct {
 
 	db     *db.Client
 	logger *logging.Logger
+
+	// memStore is the persistent agent memory store (settings.memory). nil when
+	// memory is disabled; memDir is its root, exported to agent subprocesses as
+	// APIARY_MEMORY_DIR.
+	memStore *memory.Store
+	memDir   string
 
 	// binder records each polled SourceItem as an InternalTask + SourceBinding.
 	// nil when no DB is configured (tests / dry-run without persistence).
@@ -136,25 +143,42 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 	}
 
 	d := &Dispatcher{
-		cfg:         cfg,
-		configFile:  configFile,
-		startedAt:   time.Now(),
-		router:      r,
+		cfg:             cfg,
+		configFile:      configFile,
+		startedAt:       time.Now(),
+		router:          r,
 		sources:         make(map[string]source.Adapter),
 		runners:         make(map[string]runnerimpl.Runner),
 		agentRunner:     make(map[string]string),
 		agentFallbacks:  make(map[string][]runnerCandidate),
 		rateLimitPaused: make(map[string]time.Time),
-		db:          dbClient,
-		logger:      logger,
-		sem:         make(chan struct{}, 1), // poll: one at a time
-		agentSem:    make(map[string]chan struct{}),
-		stats:       make(map[string]*sourceStat),
+		db:              dbClient,
+		logger:          logger,
+		sem:             make(chan struct{}, 1), // poll: one at a time
+		agentSem:        make(map[string]chan struct{}),
+		stats:           make(map[string]*sourceStat),
 	}
 
 	// The binder persists InternalTasks + SourceBindings; it needs the DB.
 	if dbClient != nil {
 		d.binder = source.NewSourceBinder(dbClient)
+	}
+
+	// Persistent agent memory (settings.memory). The root defaults to
+	// <data-dir>/memory, beside apiary.db.
+	if cfg.Settings.Memory.Enabled {
+		root := cfg.Settings.Memory.Path
+		if root == "" {
+			root = filepath.Join(config.DataDir(configFile), "memory")
+		}
+		store, err := memory.Open(root)
+		if err != nil {
+			return nil, fmt.Errorf("memory store: %w", err)
+		}
+		store.MaxEntryBytes = cfg.Settings.Memory.MaxEntryBytes
+		d.memStore = store
+		d.memDir = root
+		aplog.Info("agent memory enabled at %s", root)
 	}
 
 	// Per-agent concurrency: each agent gets its own semaphore so that
@@ -352,6 +376,17 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		}()
 	}
 
+	// Prune task-memory notes whose task has been terminal longer than the
+	// retention window (settings.memory.task_retention), at startup and then
+	// every 6 hours. Global entries are never auto-pruned.
+	if d.memStore != nil && d.db != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.pruneMemoryLoop(ctx)
+		}()
+	}
+
 	for _, sc := range d.cfg.Sources {
 		sc := sc
 		adapter, ok := d.sources[sc.ID]
@@ -389,6 +424,89 @@ func (d *Dispatcher) pruneLogsLoop(ctx context.Context, maxAge time.Duration) {
 			prune()
 		}
 	}
+}
+
+// pruneMemoryLoop deletes task-memory note files whose task has been terminal
+// (done/failed) longer than settings.memory.task_retention, at startup and then
+// every 6 hours. A task is kept while any descendant is still non-terminal —
+// spawned children inherit their ancestors' notes, so the chain must stay
+// readable while work is in flight. Notes whose task ID is unknown (e.g. after
+// a DB reset) fall back to the file's mtime against the same retention window.
+func (d *Dispatcher) pruneMemoryLoop(ctx context.Context) {
+	d.pruneTaskMemoryOnce(ctx)
+
+	ticker := time.NewTicker(6 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.pruneTaskMemoryOnce(ctx)
+		}
+	}
+}
+
+// pruneTaskMemoryOnce runs one retention sweep over the task-memory note files
+// and returns how many were deleted.
+func (d *Dispatcher) pruneTaskMemoryOnce(ctx context.Context) int {
+	retention := d.cfg.Settings.Memory.TaskRetentionDuration()
+	notes, err := d.memStore.ListTaskNotes()
+	if err != nil {
+		aplog.Warn("prune task memory: %v", err)
+		return 0
+	}
+	pruned := 0
+	cutoff := time.Now().Add(-retention)
+	for _, tn := range notes {
+		task, err := d.db.InternalTasks().GetTask(ctx, tn.TaskID)
+		if err != nil || task == nil {
+			// Unknown task (DB reset / hand-created file): mtime fallback.
+			if tn.ModTime.Before(cutoff) {
+				if d.memStore.DeleteTaskNotes(tn.TaskID) == nil {
+					pruned++
+				}
+			}
+			continue
+		}
+		terminal := task.State == model.TaskStateDone || task.State == model.TaskStateFailed
+		if !terminal || task.UpdatedAt.After(cutoff) {
+			continue
+		}
+		if d.hasLiveDescendant(ctx, tn.TaskID, 0) {
+			continue
+		}
+		if err := d.memStore.DeleteTaskNotes(tn.TaskID); err != nil {
+			aplog.Warn("prune task memory %s: %v", tn.TaskID, err)
+		} else {
+			pruned++
+		}
+	}
+	if pruned > 0 {
+		aplog.Info("pruned %d task memory file(s) past the %s retention", pruned, retention)
+	}
+	return pruned
+}
+
+// hasLiveDescendant reports whether any spawned descendant of the task is still
+// non-terminal. Depth-capped as cheap insurance against an accidental cycle.
+func (d *Dispatcher) hasLiveDescendant(ctx context.Context, taskID string, depth int) bool {
+	if depth > 32 {
+		return false
+	}
+	children, err := d.db.InternalTasks().ListChildTasks(ctx, taskID)
+	if err != nil {
+		return true // unsure — keep the notes
+	}
+	for _, c := range children {
+		if c.State != model.TaskStateDone && c.State != model.TaskStateFailed {
+			return true
+		}
+		if d.hasLiveDescendant(ctx, c.ID, depth+1) {
+			return true
+		}
+	}
+	return false
 }
 
 // DryRun polls every source once, routes cells, and prints what would be

--- a/src/internal/daemon/memory_prune_test.go
+++ b/src/internal/daemon/memory_prune_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/memory"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestPruneTaskMemoryOnce(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "prune.db"))
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer dbc.Close()
+
+	ms, err := memory.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.Open: %v", err)
+	}
+
+	d := &Dispatcher{
+		db:       dbc,
+		memStore: ms,
+		cfg: &config.Config{Settings: config.Settings{
+			Memory: config.MemorySettings{Enabled: true, TaskRetention: "1ms"},
+		}},
+	}
+
+	tasks := dbc.InternalTasks()
+	mk := func(id string, state model.TaskState, parent string) {
+		t.Helper()
+		task := &model.InternalTask{ID: id, ParentTaskID: parent, Title: id, State: state}
+		if err := tasks.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := tasks.UpdateTaskState(ctx, id, state); err != nil {
+			t.Fatalf("state %s: %v", id, err)
+		}
+	}
+	mk("done-old", model.TaskStateDone, "")
+	mk("still-running", model.TaskStateRunning, "")
+	mk("done-with-live-child", model.TaskStateDone, "")
+	mk("live-child", model.TaskStateRunning, "done-with-live-child")
+
+	for _, id := range []string{"done-old", "still-running", "done-with-live-child", "unknown-task"} {
+		if err := ms.AppendTaskNote(id, memory.Note{Content: "note for " + id}); err != nil {
+			t.Fatalf("note %s: %v", id, err)
+		}
+	}
+
+	// Let every UpdatedAt and file mtime fall past the 1ms retention window.
+	time.Sleep(20 * time.Millisecond)
+
+	pruned := d.pruneTaskMemoryOnce(ctx)
+	if pruned != 2 {
+		t.Fatalf("expected 2 pruned (done-old + unknown-task), got %d", pruned)
+	}
+	if ms.TaskNoteContent("done-old") != "" {
+		t.Error("done-old notes should be pruned (terminal past retention)")
+	}
+	if ms.TaskNoteContent("unknown-task") != "" {
+		t.Error("unknown-task notes should be pruned (mtime fallback)")
+	}
+	if ms.TaskNoteContent("still-running") == "" {
+		t.Error("still-running notes must be retained (non-terminal)")
+	}
+	if ms.TaskNoteContent("done-with-live-child") == "" {
+		t.Error("done-with-live-child notes must be retained (live descendant)")
+	}
+}
+
+func TestWithMemoryDir(t *testing.T) {
+	env := withMemoryDir(map[string]string{"A": "1"}, "/mem/root")
+	if env["APIARY_MEMORY_DIR"] != "/mem/root" {
+		t.Fatalf("memory dir not injected: %v", env)
+	}
+	// An explicit value at any env scope wins.
+	env = withMemoryDir(map[string]string{"APIARY_MEMORY_DIR": "/custom"}, "/mem/root")
+	if env["APIARY_MEMORY_DIR"] != "/custom" {
+		t.Fatalf("explicit env must win: %v", env)
+	}
+	// Disabled memory ("" dir) leaves env untouched.
+	env = withMemoryDir(map[string]string{}, "")
+	if _, ok := env["APIARY_MEMORY_DIR"]; ok {
+		t.Fatal("disabled memory must not set the env var")
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -27,6 +27,9 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 				workflow.WithTaskTracker(dbTaskTracker{db: d.db}),
 			)
 		}
+		if d.memStore != nil {
+			opts = append(opts, workflow.WithMemoryStore(d.memStore))
+		}
 		// Wire up CI status polling for wait_for steps.
 		opts = append(opts, workflow.WithCIStatusChecker(func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error) {
 			adapter, ok := d.sources[sourceID]
@@ -354,6 +357,8 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		ctx = context.WithValue(ctx, source.SourceTokenCtxKey, req.Agent.SourceToken)
 	}
 
+	env := withMemoryDir(stepEnv(req.Agent, req.WorkflowEnv, req.Step.Env), x.d.memDir)
+
 	rr := model.RunRequest{
 		Cell:               req.Cell,
 		WorkerID:           req.Step.Agent,
@@ -365,7 +370,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		StepID:             req.Step.ID,
 		WorkflowInstanceID: req.InstanceID,
 		WorkingDir:         "/",
-		Env:                stepEnv(req.Agent, req.WorkflowEnv, req.Step.Env),
+		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
 	}
 
@@ -462,6 +467,15 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		publishPayload = ""
 	}
 
+	// memory.memorize: off mirrors publish: off — requests (and any parse error)
+	// are dropped before the engine ever sees them.
+	memorizeRequests := res.MemorizeRequests
+	memorizeError := res.MemorizeError
+	if !req.Step.MemorizeEnabled() {
+		memorizeRequests = nil
+		memorizeError = nil
+	}
+
 	var usage *model.Usage
 	if anyUsage {
 		u := summedUsage
@@ -469,9 +483,12 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 	}
 
 	// A malformed APIARY_SPAWN block is a step-level error so the workflow fails
-	// with a descriptive message rather than silently dropping the request.
+	// with a descriptive message rather than silently dropping the request. The
+	// step's memorize requests still travel — persisted knowledge should survive
+	// an unrelated spawn failure.
 	if res.SpawnError != nil {
-		return workflow.StepResult{Success: false, Output: res.Output, Usage: usage, InputPrompt: res.InputPrompt, Err: res.SpawnError}
+		return workflow.StepResult{Success: false, Output: res.Output, Usage: usage, InputPrompt: res.InputPrompt,
+			MemorizeRequests: memorizeRequests, MemorizeError: memorizeError, Err: res.SpawnError}
 	}
 
 	return workflow.StepResult{
@@ -482,6 +499,8 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		PublishPayload:   publishPayload,
 		SpawnRequest:     res.SpawnRequest,
 		SpawnRequests:    res.SpawnRequests,
+		MemorizeRequests: memorizeRequests,
+		MemorizeError:    memorizeError,
 		Usage:            usage,
 		InputPrompt:      res.InputPrompt,
 		Err:              res.Error,
@@ -755,6 +774,20 @@ func stepEnv(agent config.AgentConfig, wfEnv, stepEnv map[string]string) map[str
 	}
 	for k, v := range stepEnv {
 		env[k] = v
+	}
+	return env
+}
+
+// withMemoryDir exposes the memory root to the agent subprocess as
+// APIARY_MEMORY_DIR, so it can read full memory entries directly (recall only
+// injects the index). Part of the identity base: an explicit env value already
+// present (any scope) wins. A "" dir (memory disabled) leaves env untouched.
+func withMemoryDir(env map[string]string, dir string) map[string]string {
+	if dir == "" {
+		return env
+	}
+	if _, ok := env["APIARY_MEMORY_DIR"]; !ok {
+		env["APIARY_MEMORY_DIR"] = dir
 	}
 	return env
 }

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -297,6 +297,13 @@ func (s *InternalTaskStore) ListChildTasks(ctx context.Context, parentTaskID str
 	return out, rows.Err()
 }
 
+// GetTaskAncestors is a Client-level convenience so the workflow engine can
+// resolve a task's lineage (for task-memory recall) through the same Store it
+// already holds, mirroring ListBindingsByTask.
+func (c *Client) GetTaskAncestors(ctx context.Context, id string) ([]model.InternalTask, error) {
+	return c.InternalTasks().GetTaskAncestors(ctx, id)
+}
+
 // GetTaskAncestors returns the task's lineage from root to the task itself
 // (root first, the task last), walking parent_task_id via a recursive CTE. The
 // depth cap (32) is cheap insurance against an accidental cycle. For a root task

--- a/src/internal/memory/store.go
+++ b/src/internal/memory/store.go
@@ -1,0 +1,611 @@
+// Package memory implements the persistent agent memory store: a directory of
+// plain markdown files holding daemon-wide durable facts (the global tier) and
+// per-task working notes (the task tier). Agents write to it through the
+// APIARY_MEMORIZE marker (handled by the workflow engine) and read from it via
+// the recall sections injected into their prompts plus direct file reads
+// (APIARY_MEMORY_DIR). The files are deliberately human-readable and
+// hand-editable; MEMORY.md is derived state, regenerated from entry frontmatter
+// on every write and on open, so manual edits and deletions self-heal.
+package memory
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// IndexFile is the global index at the memory root: one line per entry.
+	IndexFile = "MEMORY.md"
+	// globalDir holds one markdown file per durable fact, named by slug.
+	globalDir = "global"
+	// tasksDir holds one append-only notes file per InternalTask, named by task ID.
+	tasksDir = "tasks"
+
+	// DefaultMaxEntryBytes caps a single global entry's content.
+	DefaultMaxEntryBytes = 16384
+
+	// lastHashPrefix marks the trailing line of a task-notes file recording the
+	// hash of the most recent note, so a retry re-emitting identical content is
+	// detected and skipped without parsing bullets back out of markdown.
+	lastHashPrefix = "<!-- last-note-hash: "
+	lastHashSuffix = " -->"
+)
+
+// Memory tiers, mirroring config.MemoryTierTask / MemoryTierGlobal (the config
+// package cannot be imported here without inverting the dependency direction).
+const (
+	TierTask   = "task"
+	TierGlobal = "global"
+)
+
+// slugRe validates global entry names. The name becomes a filename, so this is
+// also the path-traversal guard: lowercase kebab-case only, 2–64 chars.
+var slugRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,63}$`)
+
+// taskIDRe validates task-note file keys. Task IDs are internal (ULID-style),
+// never agent-authored, but the store still refuses anything that could not be
+// a plain filename.
+var taskIDRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// Entry is one durable global fact: a markdown body plus the provenance
+// frontmatter recording who wrote it and when.
+type Entry struct {
+	Name        string
+	Description string
+	Content     string
+	Agent       string
+	Task        string
+	Workflow    string
+	Created     time.Time
+	Updated     time.Time
+}
+
+// EntryMeta is the index view of an Entry (no body).
+type EntryMeta struct {
+	Name        string
+	Description string
+	Agent       string
+	Updated     time.Time
+}
+
+// Note is one task-tier working note, appended to the task's notes file with
+// provenance and a timestamp.
+type Note struct {
+	Content  string
+	Agent    string
+	Workflow string
+	Step     string
+	At       time.Time
+}
+
+// TaskNotes identifies one task-notes file for lifecycle sweeps.
+type TaskNotes struct {
+	TaskID  string
+	ModTime time.Time
+}
+
+// Store is the on-disk memory store rooted at a single directory. All writes
+// are serialized by an internal mutex (one daemon process owns the root) and
+// performed atomically (temp file + rename), so readers — including humans and
+// agent subprocesses — never observe a half-written file.
+type Store struct {
+	root string
+	// MaxEntryBytes caps a single entry/note content. Zero means
+	// DefaultMaxEntryBytes.
+	MaxEntryBytes int
+
+	mu  sync.Mutex
+	now func() time.Time
+}
+
+// Open prepares the memory root (creating it and its subdirectories when
+// missing) and rebuilds the index from the entries on disk, healing any drift
+// from hand edits since the last write.
+func Open(root string) (*Store, error) {
+	for _, dir := range []string{root, filepath.Join(root, globalDir), filepath.Join(root, tasksDir)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("memory: create %s: %w", dir, err)
+		}
+	}
+	s := &Store{root: root, now: time.Now}
+	if err := s.RebuildIndex(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Root returns the memory root directory.
+func (s *Store) Root() string { return s.root }
+
+func (s *Store) maxEntryBytes() int {
+	if s.MaxEntryBytes > 0 {
+		return s.MaxEntryBytes
+	}
+	return DefaultMaxEntryBytes
+}
+
+// ValidSlug reports whether name is acceptable as a global entry name.
+func ValidSlug(name string) bool { return slugRe.MatchString(name) }
+
+// UpsertGlobal writes (or overwrites) one global entry and regenerates the
+// index. An existing entry keeps its original Created timestamp; everything
+// else — body, description, provenance, Updated — is replaced. Same name means
+// same fact: agents update knowledge by re-emitting the slug.
+func (s *Store) UpsertGlobal(e Entry) error {
+	if !ValidSlug(e.Name) {
+		return fmt.Errorf("memory: invalid entry name %q (want kebab-case slug, 2-64 chars)", e.Name)
+	}
+	if strings.TrimSpace(e.Description) == "" {
+		return fmt.Errorf("memory: entry %q: description is required", e.Name)
+	}
+	if strings.TrimSpace(e.Content) == "" {
+		return fmt.Errorf("memory: entry %q: content is required", e.Name)
+	}
+	if len(e.Content) > s.maxEntryBytes() {
+		return fmt.Errorf("memory: entry %q: content is %d bytes (max %d)", e.Name, len(e.Content), s.maxEntryBytes())
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.root, globalDir, e.Name+".md")
+	now := s.now().UTC()
+	e.Updated = now
+	e.Created = now
+	if prev, err := readEntryFile(path); err == nil {
+		if !prev.Created.IsZero() {
+			e.Created = prev.Created
+		}
+	}
+	if err := atomicWrite(path, renderEntry(e)); err != nil {
+		return fmt.Errorf("memory: write entry %q: %w", e.Name, err)
+	}
+	return s.rebuildIndexLocked()
+}
+
+// AppendTaskNote appends one working note to the task's notes file. A note
+// whose content matches the previous note exactly (by hash) is skipped, so a
+// retried step re-emitting the same APIARY_MEMORIZE block does not duplicate
+// the file.
+func (s *Store) AppendTaskNote(taskID string, n Note) error {
+	if !taskIDRe.MatchString(taskID) {
+		return fmt.Errorf("memory: invalid task id %q", taskID)
+	}
+	if strings.TrimSpace(n.Content) == "" {
+		return fmt.Errorf("memory: task %s: note content is required", taskID)
+	}
+	if len(n.Content) > s.maxEntryBytes() {
+		return fmt.Errorf("memory: task %s: note is %d bytes (max %d)", taskID, len(n.Content), s.maxEntryBytes())
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := filepath.Join(s.root, tasksDir, taskID+".md")
+	existing, _ := os.ReadFile(path)
+	body, lastHash := splitLastHash(string(existing))
+
+	sum := sha256.Sum256([]byte(n.Content))
+	hash := hex.EncodeToString(sum[:8])
+	if hash == lastHash {
+		return nil // identical to the previous note (e.g. a retry) — skip
+	}
+
+	at := n.At
+	if at.IsZero() {
+		at = s.now()
+	}
+	var b strings.Builder
+	b.WriteString(body)
+	if body == "" {
+		fmt.Fprintf(&b, "# Task Memory — %s\n\n", taskID)
+	}
+	prov := strings.Trim(strings.Join(nonEmpty(n.Workflow, n.Step), "/"), "/")
+	if prov != "" {
+		prov = " [" + prov + "]"
+	}
+	if n.Agent != "" {
+		prov += " (" + n.Agent + ")"
+	}
+	lines := strings.Split(strings.TrimRight(n.Content, "\n"), "\n")
+	fmt.Fprintf(&b, "- %s%s %s\n", at.UTC().Format(time.RFC3339), prov, lines[0])
+	for _, line := range lines[1:] {
+		b.WriteString("  " + line + "\n")
+	}
+	b.WriteString(lastHashPrefix + hash + lastHashSuffix + "\n")
+
+	if err := atomicWrite(path, b.String()); err != nil {
+		return fmt.Errorf("memory: append task note %s: %w", taskID, err)
+	}
+	return nil
+}
+
+// TaskNoteContent returns the rendered notes for one task ("" when none).
+func (s *Store) TaskNoteContent(taskID string) string {
+	if !taskIDRe.MatchString(taskID) {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(s.root, tasksDir, taskID+".md"))
+	if err != nil {
+		return ""
+	}
+	body, _ := splitLastHash(string(data))
+	// Drop the heading line; recall renders its own section header.
+	lines := strings.Split(strings.TrimSpace(body), "\n")
+	if len(lines) > 0 && strings.HasPrefix(lines[0], "# ") {
+		lines = lines[1:]
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// List returns the index view of every global entry, sorted by name.
+func (s *Store) List() ([]EntryMeta, error) {
+	entries, err := s.readAllEntries()
+	if err != nil {
+		return nil, err
+	}
+	metas := make([]EntryMeta, 0, len(entries))
+	for _, e := range entries {
+		metas = append(metas, EntryMeta{Name: e.Name, Description: e.Description, Agent: e.Agent, Updated: e.Updated})
+	}
+	return metas, nil
+}
+
+// Read returns one global entry by name.
+func (s *Store) Read(name string) (Entry, error) {
+	if !ValidSlug(name) {
+		return Entry{}, fmt.Errorf("memory: invalid entry name %q", name)
+	}
+	return readEntryFile(filepath.Join(s.root, globalDir, name+".md"))
+}
+
+// Delete removes one global entry and regenerates the index.
+func (s *Store) Delete(name string) error {
+	if !ValidSlug(name) {
+		return fmt.Errorf("memory: invalid entry name %q", name)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.Remove(filepath.Join(s.root, globalDir, name+".md")); err != nil {
+		return fmt.Errorf("memory: delete entry %q: %w", name, err)
+	}
+	return s.rebuildIndexLocked()
+}
+
+// ListTaskNotes returns every task-notes file with its mtime, for the
+// retention sweep.
+func (s *Store) ListTaskNotes() ([]TaskNotes, error) {
+	dirEntries, err := os.ReadDir(filepath.Join(s.root, tasksDir))
+	if err != nil {
+		return nil, fmt.Errorf("memory: list task notes: %w", err)
+	}
+	var out []TaskNotes
+	for _, de := range dirEntries {
+		name, ok := strings.CutSuffix(de.Name(), ".md")
+		if !ok || de.IsDir() {
+			continue
+		}
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, TaskNotes{TaskID: name, ModTime: info.ModTime()})
+	}
+	return out, nil
+}
+
+// DeleteTaskNotes removes one task's notes file (no-op when absent).
+func (s *Store) DeleteTaskNotes(taskID string) error {
+	if !taskIDRe.MatchString(taskID) {
+		return fmt.Errorf("memory: invalid task id %q", taskID)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := os.Remove(filepath.Join(s.root, tasksDir, taskID+".md"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// RebuildIndex regenerates MEMORY.md from the frontmatter of every entry under
+// global/. Entries with unparsable frontmatter are skipped (the file itself is
+// untouched); a hand-deleted entry simply disappears from the index.
+func (s *Store) RebuildIndex() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rebuildIndexLocked()
+}
+
+func (s *Store) rebuildIndexLocked() error {
+	entries, err := s.readAllEntries()
+	if err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("# Apiary Memory Index\n\n")
+	if len(entries) == 0 {
+		b.WriteString("(no entries yet)\n")
+	}
+	for _, e := range entries {
+		fmt.Fprintf(&b, "- %s — %s\n", e.Name, e.Description)
+	}
+	if err := atomicWrite(filepath.Join(s.root, IndexFile), b.String()); err != nil {
+		return fmt.Errorf("memory: write index: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) readAllEntries() ([]Entry, error) {
+	dirEntries, err := os.ReadDir(filepath.Join(s.root, globalDir))
+	if err != nil {
+		return nil, fmt.Errorf("memory: list entries: %w", err)
+	}
+	var out []Entry
+	for _, de := range dirEntries {
+		name, ok := strings.CutSuffix(de.Name(), ".md")
+		if !ok || de.IsDir() {
+			continue
+		}
+		e, err := readEntryFile(filepath.Join(s.root, globalDir, de.Name()))
+		if err != nil {
+			continue // hand-edited beyond recognition; skip from the index
+		}
+		if e.Name == "" {
+			e.Name = name
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// RenderRecall renders the prompt sections for the requested tiers: the
+// long-term index (never full bodies — agents read those from disk) and the
+// task notes for the given lineage (self first, then ancestors). The combined
+// output is bounded by budget: task notes drop oldest-first, then ancestor
+// files entirely; the index truncates with an explicit count marker. Empty
+// tiers produce no output at all, so a fresh store adds zero prompt overhead.
+func (s *Store) RenderRecall(taskIDs []string, tiers []string, budget int) string {
+	if budget <= 0 {
+		budget = 4000
+	}
+	wantTask, wantGlobal := false, false
+	for _, t := range tiers {
+		switch t {
+		case TierTask:
+			wantTask = true
+		case TierGlobal:
+			wantGlobal = true
+		}
+	}
+
+	var global string
+	if wantGlobal {
+		global = s.renderGlobalIndex(budget / 2)
+	}
+	var task string
+	if wantTask {
+		remaining := budget - len(global)
+		if remaining > 0 {
+			task = s.renderTaskNotes(taskIDs, remaining)
+		}
+	}
+
+	switch {
+	case global == "" && task == "":
+		return ""
+	case global == "":
+		return task
+	case task == "":
+		return global
+	default:
+		return global + "\n" + task
+	}
+}
+
+func (s *Store) renderGlobalIndex(budget int) string {
+	metas, err := s.List()
+	if err != nil || len(metas) == 0 {
+		return ""
+	}
+	header := "[Long-term Memory]\n" +
+		"Persistent memory lives at $APIARY_MEMORY_DIR. The index is below; read the full\n" +
+		"entry from $APIARY_MEMORY_DIR/global/<name>.md when one looks relevant. To save a\n" +
+		"durable fact for future tasks, emit an APIARY_MEMORIZE block (scope \"global\",\n" +
+		"kebab-case name, one-line description, markdown content). Never memorize secrets.\n"
+	var b strings.Builder
+	b.WriteString(header)
+	shown := 0
+	for _, m := range metas {
+		line := fmt.Sprintf("- %s — %s\n", m.Name, m.Description)
+		if b.Len()+len(line) > budget {
+			break
+		}
+		b.WriteString(line)
+		shown++
+	}
+	if shown < len(metas) {
+		fmt.Fprintf(&b, "(… %d more entries — read %s)\n", len(metas)-shown, IndexFile)
+	}
+	return b.String()
+}
+
+func (s *Store) renderTaskNotes(taskIDs []string, budget int) string {
+	type block struct {
+		id    string
+		notes string
+	}
+	var blocks []block
+	for _, id := range taskIDs {
+		if notes := s.TaskNoteContent(id); notes != "" {
+			blocks = append(blocks, block{id, notes})
+		}
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+
+	render := func(bs []block) string {
+		var b strings.Builder
+		b.WriteString("[Task Memory]\n")
+		for i, blk := range bs {
+			if i > 0 {
+				fmt.Fprintf(&b, "(from parent task %s)\n", blk.id)
+			}
+			b.WriteString(blk.notes + "\n")
+		}
+		return b.String()
+	}
+
+	// Drop ancestors' blocks last-first (self is index 0 and is kept longest),
+	// then trim the self block's oldest lines if it alone is still over budget.
+	for keep := len(blocks); keep >= 1; keep-- {
+		out := render(blocks[:keep])
+		if len(out) <= budget {
+			return out
+		}
+	}
+	lines := strings.Split(blocks[0].notes, "\n")
+	for len(lines) > 1 {
+		lines = lines[1:] // oldest notes are at the top
+		out := render([]block{{blocks[0].id, strings.Join(lines, "\n")}})
+		if len(out) <= budget {
+			return out
+		}
+	}
+	return ""
+}
+
+// ── file format helpers ──────────────────────────────────────────────
+
+// renderEntry serializes an Entry as frontmatter + body. The frontmatter is a
+// minimal key/value block (no nested YAML), parsed back by parseEntry.
+func renderEntry(e Entry) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	writeFM(&b, "name", e.Name)
+	writeFM(&b, "description", oneLine(e.Description))
+	writeFM(&b, "created", e.Created.UTC().Format(time.RFC3339))
+	writeFM(&b, "updated", e.Updated.UTC().Format(time.RFC3339))
+	writeFM(&b, "agent", e.Agent)
+	writeFM(&b, "task", e.Task)
+	writeFM(&b, "workflow", e.Workflow)
+	b.WriteString("---\n\n")
+	b.WriteString(strings.TrimRight(e.Content, "\n") + "\n")
+	return b.String()
+}
+
+func writeFM(b *strings.Builder, key, value string) {
+	if value == "" {
+		return
+	}
+	fmt.Fprintf(b, "%s: %s\n", key, value)
+}
+
+func readEntryFile(path string) (Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Entry{}, err
+	}
+	return parseEntry(string(data))
+}
+
+func parseEntry(raw string) (Entry, error) {
+	rest, ok := strings.CutPrefix(raw, "---\n")
+	if !ok {
+		return Entry{}, fmt.Errorf("memory: entry has no frontmatter")
+	}
+	fm, body, ok := strings.Cut(rest, "\n---")
+	if !ok {
+		return Entry{}, fmt.Errorf("memory: entry frontmatter is unterminated")
+	}
+	var e Entry
+	for _, line := range strings.Split(fm, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		switch strings.TrimSpace(key) {
+		case "name":
+			e.Name = value
+		case "description":
+			e.Description = value
+		case "agent":
+			e.Agent = value
+		case "task":
+			e.Task = value
+		case "workflow":
+			e.Workflow = value
+		case "created":
+			e.Created, _ = time.Parse(time.RFC3339, value)
+		case "updated":
+			e.Updated, _ = time.Parse(time.RFC3339, value)
+		}
+	}
+	e.Content = strings.TrimSpace(strings.TrimPrefix(body, "\n"))
+	return e, nil
+}
+
+// splitLastHash separates a task-notes file into its body and the trailing
+// last-note-hash marker ("" when absent).
+func splitLastHash(raw string) (body, hash string) {
+	trimmed := strings.TrimRight(raw, "\n")
+	idx := strings.LastIndex(trimmed, lastHashPrefix)
+	if idx < 0 {
+		return raw, ""
+	}
+	line := trimmed[idx:]
+	if !strings.HasSuffix(line, lastHashSuffix) || strings.Contains(line, "\n") {
+		return raw, ""
+	}
+	hash = strings.TrimSuffix(strings.TrimPrefix(line, lastHashPrefix), lastHashSuffix)
+	return trimmed[:idx], hash
+}
+
+// atomicWrite writes content to path via a temp file + rename in the same
+// directory, so concurrent readers never see a partial file.
+func atomicWrite(path, content string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func nonEmpty(vals ...string) []string {
+	out := vals[:0]
+	for _, v := range vals {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/src/internal/memory/store_test.go
+++ b/src/internal/memory/store_test.go
@@ -1,0 +1,238 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.now = func() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) }
+	return s
+}
+
+func TestUpsertGlobal_RoundTrip(t *testing.T) {
+	s := testStore(t)
+	in := Entry{
+		Name:        "ci-duration",
+		Description: "CI takes ~12 minutes",
+		Content:     "Poll with a 12m budget.\nSecond line.",
+		Agent:       "engineer",
+		Task:        "01ABC",
+		Workflow:    "engineer-workflow",
+	}
+	if err := s.UpsertGlobal(in); err != nil {
+		t.Fatalf("UpsertGlobal: %v", err)
+	}
+	got, err := s.Read("ci-duration")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Description != in.Description || got.Content != in.Content ||
+		got.Agent != in.Agent || got.Task != in.Task || got.Workflow != in.Workflow {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.Created.IsZero() || got.Updated.IsZero() {
+		t.Fatalf("timestamps not set: %+v", got)
+	}
+
+	idx, err := os.ReadFile(filepath.Join(s.Root(), IndexFile))
+	if err != nil {
+		t.Fatalf("read index: %v", err)
+	}
+	if !strings.Contains(string(idx), "ci-duration — CI takes ~12 minutes") {
+		t.Fatalf("index missing entry: %s", idx)
+	}
+}
+
+func TestUpsertGlobal_UpdateKeepsCreated(t *testing.T) {
+	s := testStore(t)
+	if err := s.UpsertGlobal(Entry{Name: "fact", Description: "v1", Content: "one"}); err != nil {
+		t.Fatal(err)
+	}
+	created := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return created.Add(48 * time.Hour) }
+	if err := s.UpsertGlobal(Entry{Name: "fact", Description: "v2", Content: "two"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Read("fact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Content != "two" || got.Description != "v2" {
+		t.Fatalf("update not applied: %+v", got)
+	}
+	if !got.Created.Equal(created) {
+		t.Fatalf("created not preserved: %v", got.Created)
+	}
+	if !got.Updated.After(got.Created) {
+		t.Fatalf("updated not bumped: %v", got.Updated)
+	}
+}
+
+func TestUpsertGlobal_Validation(t *testing.T) {
+	s := testStore(t)
+	cases := []Entry{
+		{Name: "../escape", Description: "d", Content: "c"},
+		{Name: "Has Spaces", Description: "d", Content: "c"},
+		{Name: "ok-name", Description: "", Content: "c"},
+		{Name: "ok-name", Description: "d", Content: ""},
+		{Name: "ok-name", Description: "d", Content: strings.Repeat("x", DefaultMaxEntryBytes+1)},
+	}
+	for i, e := range cases {
+		if err := s.UpsertGlobal(e); err == nil {
+			t.Fatalf("case %d: expected error for %+v", i, e)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(s.Root(), "global", "ok-name.md")); !os.IsNotExist(err) {
+		t.Fatalf("rejected entry was written")
+	}
+}
+
+func TestAppendTaskNote_DedupAndOrder(t *testing.T) {
+	s := testStore(t)
+	n := Note{Content: "root cause is in adf.go", Agent: "triage", Workflow: "triage", Step: "analyze"}
+	if err := s.AppendTaskNote("01TASK", n); err != nil {
+		t.Fatal(err)
+	}
+	// Identical content again (a retry) — skipped.
+	if err := s.AppendTaskNote("01TASK", n); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendTaskNote("01TASK", Note{Content: "fix lives in markdown.go", Agent: "engineer"}); err != nil {
+		t.Fatal(err)
+	}
+
+	notes := s.TaskNoteContent("01TASK")
+	if strings.Count(notes, "root cause is in adf.go") != 1 {
+		t.Fatalf("dedup failed:\n%s", notes)
+	}
+	first := strings.Index(notes, "root cause")
+	second := strings.Index(notes, "fix lives")
+	if first < 0 || second < 0 || first > second {
+		t.Fatalf("notes out of order:\n%s", notes)
+	}
+	if strings.Contains(notes, lastHashPrefix) {
+		t.Fatalf("hash marker leaked into content:\n%s", notes)
+	}
+}
+
+func TestRebuildIndex_SelfHealsAfterManualDelete(t *testing.T) {
+	s := testStore(t)
+	for _, n := range []string{"alpha", "beta"} {
+		if err := s.UpsertGlobal(Entry{Name: n, Description: n + " fact", Content: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Operator deletes a file by hand; index is stale until the next write/open.
+	if err := os.Remove(filepath.Join(s.Root(), "global", "alpha.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RebuildIndex(); err != nil {
+		t.Fatal(err)
+	}
+	idx, _ := os.ReadFile(filepath.Join(s.Root(), IndexFile))
+	if strings.Contains(string(idx), "alpha") || !strings.Contains(string(idx), "beta") {
+		t.Fatalf("index not healed: %s", idx)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	s := testStore(t)
+	if err := s.UpsertGlobal(Entry{Name: "gone", Description: "d", Content: "c"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("gone"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Read("gone"); err == nil {
+		t.Fatal("entry still readable after delete")
+	}
+	idx, _ := os.ReadFile(filepath.Join(s.Root(), IndexFile))
+	if strings.Contains(string(idx), "gone") {
+		t.Fatalf("index still lists deleted entry: %s", idx)
+	}
+}
+
+func TestRenderRecall_SectionsAndTiers(t *testing.T) {
+	s := testStore(t)
+	if err := s.UpsertGlobal(Entry{Name: "fact-a", Description: "alpha fact", Content: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendTaskNote("01SELF", Note{Content: "decided X"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendTaskNote("01PARENT", Note{Content: "collected Y"}); err != nil {
+		t.Fatal(err)
+	}
+
+	out := s.RenderRecall([]string{"01SELF", "01PARENT"}, []string{TierTask, TierGlobal}, 4000)
+	for _, want := range []string{"[Long-term Memory]", "fact-a — alpha fact", "[Task Memory]", "decided X", "from parent task 01PARENT", "collected Y"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("recall missing %q:\n%s", want, out)
+		}
+	}
+
+	// Tier filtering: task only.
+	out = s.RenderRecall([]string{"01SELF"}, []string{TierTask}, 4000)
+	if strings.Contains(out, "[Long-term Memory]") || !strings.Contains(out, "[Task Memory]") {
+		t.Fatalf("tier filter failed:\n%s", out)
+	}
+
+	// Empty store / unknown task → zero overhead.
+	empty := testStore(t)
+	if got := empty.RenderRecall([]string{"none"}, []string{TierTask, TierGlobal}, 4000); got != "" {
+		t.Fatalf("expected empty recall, got:\n%s", got)
+	}
+}
+
+func TestRenderRecall_BudgetTruncation(t *testing.T) {
+	s := testStore(t)
+	for _, n := range []string{"aaa-one", "bbb-two", "ccc-three", "ddd-four"} {
+		if err := s.UpsertGlobal(Entry{Name: n, Description: strings.Repeat("d", 80), Content: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := s.RenderRecall(nil, []string{TierGlobal}, 700)
+	if !strings.Contains(out, "more entries") {
+		t.Fatalf("expected truncation marker:\n%s", out)
+	}
+
+	// Task notes drop oldest-first under budget.
+	for i := 0; i < 30; i++ {
+		if err := s.AppendTaskNote("01BIG", Note{Content: strings.Repeat("n", 50) + string(rune('a'+i))}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out = s.RenderRecall([]string{"01BIG"}, []string{TierTask}, 400)
+	if out == "" {
+		t.Fatal("expected truncated task notes, got empty")
+	}
+	if len(out) > 400 {
+		t.Fatalf("over budget: %d", len(out))
+	}
+}
+
+func TestListTaskNotesAndDelete(t *testing.T) {
+	s := testStore(t)
+	if err := s.AppendTaskNote("01A", Note{Content: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	notes, err := s.ListTaskNotes()
+	if err != nil || len(notes) != 1 || notes[0].TaskID != "01A" {
+		t.Fatalf("ListTaskNotes: %v %v", notes, err)
+	}
+	if err := s.DeleteTaskNotes("01A"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteTaskNotes("01A"); err != nil {
+		t.Fatalf("delete absent should be no-op: %v", err)
+	}
+}

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -97,6 +97,14 @@ type RunResult struct {
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error
+	// MemorizeRequests are the parsed APIARY_MEMORIZE_BEGIN/END requests (a single
+	// object or a JSON array). The markers are stripped from Output. The workflow
+	// engine persists each request to the memory store when memory is enabled.
+	MemorizeRequests []MemorizeRequest
+	// MemorizeError is set when an APIARY_MEMORIZE block was present but its body
+	// was not valid JSON. Unlike SpawnError it never fails the step — the engine
+	// surfaces it as a warning and the run's outcome is untouched.
+	MemorizeError error
 
 	// RateLimited is true when the provider rejected the run because of a
 	// usage/rate limit (e.g. Claude's 5-hour session limit). Such a run does no

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -97,3 +97,25 @@ type SpawnRequest struct {
 	// materialized (the spec / acceptance criteria for the downstream agent).
 	Body string `json:"body,omitempty"`
 }
+
+// Memorize scopes — which memory tier an APIARY_MEMORIZE request targets.
+const (
+	// MemorizeScopeTask appends a working note to the current task's memory,
+	// visible to every workflow instance of the task and its descendants.
+	MemorizeScopeTask = "task"
+	// MemorizeScopeGlobal upserts a durable daemon-wide fact by name.
+	MemorizeScopeGlobal = "global"
+)
+
+// MemorizeRequest is one agent-emitted APIARY_MEMORIZE_BEGIN/END payload (the
+// block carries a single object or a JSON array of them, mirroring
+// APIARY_SPAWN). Scope defaults to "task" when empty. Name and Description are
+// required for the global scope: Name is the upsert key (kebab-case slug, it
+// becomes the entry's filename) and Description is the one-liner shown in the
+// injected memory index.
+type MemorizeRequest struct {
+	Scope       string `json:"scope,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Content     string `json:"content"`
+}

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -12,31 +12,36 @@ import (
 // summary from an agent's raw stdout. Runners strip these from the visible
 // Output and surface the parsed values on RunResult.
 const (
-	apiaryOutputPrefix = "APIARY_OUTPUT:"
-	summaryStartMarker = "APIARY_SUMMARY_START"
-	summaryEndMarker   = "APIARY_SUMMARY_END"
-	publishStartMarker = "APIARY_PUBLISH_BEGIN"
-	publishEndMarker   = "APIARY_PUBLISH_END"
-	spawnStartMarker   = "APIARY_SPAWN_BEGIN"
-	spawnEndMarker     = "APIARY_SPAWN_END"
+	apiaryOutputPrefix  = "APIARY_OUTPUT:"
+	summaryStartMarker  = "APIARY_SUMMARY_START"
+	summaryEndMarker    = "APIARY_SUMMARY_END"
+	publishStartMarker  = "APIARY_PUBLISH_BEGIN"
+	publishEndMarker    = "APIARY_PUBLISH_END"
+	spawnStartMarker    = "APIARY_SPAWN_BEGIN"
+	spawnEndMarker      = "APIARY_SPAWN_END"
+	memorizeStartMarker = "APIARY_MEMORIZE_BEGIN"
+	memorizeEndMarker   = "APIARY_MEMORIZE_END"
 )
 
 // extractStructured scans an agent's raw output for the APIARY_OUTPUT: sentinel,
-// the APIARY_SUMMARY_START/END block, the APIARY_PUBLISH_BEGIN/END block, and the
-// APIARY_SPAWN_BEGIN/END block. It returns the cleaned output (with those lines
-// removed), the parsed structured object (nil when absent or unparseable), the
-// summary text, the publish payload, and the raw spawn payload (all empty when
-// absent). The last valid APIARY_OUTPUT line wins; block payloads are taken
-// verbatim between their markers.
-func extractStructured(output string) (cleaned string, structured map[string]any, summary, publish, spawn string) {
+// the APIARY_SUMMARY_START/END block, the APIARY_PUBLISH_BEGIN/END block, the
+// APIARY_SPAWN_BEGIN/END block, and the APIARY_MEMORIZE_BEGIN/END block. It
+// returns the cleaned output (with those lines removed), the parsed structured
+// object (nil when absent or unparseable), the summary text, the publish
+// payload, and the raw spawn and memorize payloads (all empty when absent). The
+// last valid APIARY_OUTPUT line wins; block payloads are taken verbatim between
+// their markers.
+func extractStructured(output string) (cleaned string, structured map[string]any, summary, publish, spawn, memorize string) {
 	lines := strings.Split(output, "\n")
 	kept := make([]string, 0, len(lines))
 	var summaryLines []string
 	var publishLines []string
 	var spawnLines []string
+	var memorizeLines []string
 	inSummary := false
 	inPublish := false
 	inSpawn := false
+	inMemorize := false
 
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -53,12 +58,18 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 			inSpawn = true
 		case trimmed == spawnEndMarker:
 			inSpawn = false
+		case trimmed == memorizeStartMarker:
+			inMemorize = true
+		case trimmed == memorizeEndMarker:
+			inMemorize = false
 		case inSummary:
 			summaryLines = append(summaryLines, line)
 		case inPublish:
 			publishLines = append(publishLines, line)
 		case inSpawn:
 			spawnLines = append(spawnLines, line)
+		case inMemorize:
+			memorizeLines = append(memorizeLines, line)
 		default:
 			// The APIARY_OUTPUT: sentinel may arrive bare, or wrapped by an
 			// agent in markdown — inline backticks, code fences, or list /
@@ -79,7 +90,8 @@ func extractStructured(output string) (cleaned string, structured map[string]any
 	summary = strings.TrimSpace(strings.Join(summaryLines, "\n"))
 	publish = strings.TrimSpace(strings.Join(publishLines, "\n"))
 	spawn = strings.TrimSpace(strings.Join(spawnLines, "\n"))
-	return cleaned, structured, summary, publish, spawn
+	memorize = strings.TrimSpace(strings.Join(memorizeLines, "\n"))
+	return cleaned, structured, summary, publish, spawn, memorize
 }
 
 // outputSentinelJSON reports whether a trimmed line carries an APIARY_OUTPUT:
@@ -169,16 +181,36 @@ func balancedJSON(s string) string {
 }
 
 // applyStructured post-processes a RunResult's Output, moving any structured
-// output, summary, publish payload, and spawn request into their dedicated
-// fields. Safe to call for plain runs: when no sentinels are present, Output is
-// unchanged and the new fields stay nil/empty. A malformed APIARY_SPAWN block
-// (invalid JSON) is surfaced via RunResult.SpawnError so the engine fails the step.
+// output, summary, publish payload, spawn request, and memorize request into
+// their dedicated fields. Safe to call for plain runs: when no sentinels are
+// present, Output is unchanged and the new fields stay nil/empty. A malformed
+// APIARY_SPAWN block (invalid JSON) is surfaced via RunResult.SpawnError so the
+// engine fails the step; a malformed APIARY_MEMORIZE block is surfaced via
+// RunResult.MemorizeError, which only ever becomes a warning.
 func applyStructured(result *model.RunResult) {
-	cleaned, structured, summary, publish, spawn := extractStructured(result.Output)
+	cleaned, structured, summary, publish, spawn, memorize := extractStructured(result.Output)
 	result.Output = cleaned
 	result.StructuredOutput = structured
 	result.Summary = summary
 	result.PublishPayload = publish
+	if memorize != "" {
+		// Like APIARY_SPAWN, the block may carry a single object or a JSON array.
+		if strings.HasPrefix(memorize, "[") {
+			var reqs []model.MemorizeRequest
+			if err := json.Unmarshal([]byte(memorize), &reqs); err != nil {
+				result.MemorizeError = fmt.Errorf("APIARY_MEMORIZE: invalid JSON array: %w", err)
+			} else {
+				result.MemorizeRequests = reqs
+			}
+		} else {
+			var req model.MemorizeRequest
+			if err := json.Unmarshal([]byte(memorize), &req); err != nil {
+				result.MemorizeError = fmt.Errorf("APIARY_MEMORIZE: invalid JSON: %w", err)
+			} else {
+				result.MemorizeRequests = []model.MemorizeRequest{req}
+			}
+		}
+	}
 	if spawn != "" {
 		// The block may carry a single object (one child) or a JSON array (a
 		// decomposition fanning out into several). A leading '[' selects the array

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -18,7 +18,7 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 		`APIARY_OUTPUT: {"complexity":"high","action":"implement"}`,
 	}, "\n")
 
-	cleaned, structured, summary, _, _ := extractStructured(raw)
+	cleaned, structured, summary, _, _, _ := extractStructured(raw)
 
 	if strings.Contains(cleaned, "APIARY_OUTPUT") || strings.Contains(cleaned, "APIARY_SUMMARY") {
 		t.Errorf("cleaned output still contains sentinels:\n%s", cleaned)
@@ -39,7 +39,7 @@ func TestExtractStructured_OutputAndSummary(t *testing.T) {
 
 func TestExtractStructured_NoSentinels(t *testing.T) {
 	raw := "Just a normal agent response.\nNothing structured here."
-	cleaned, structured, summary, publish, _ := extractStructured(raw)
+	cleaned, structured, summary, publish, _, _ := extractStructured(raw)
 	if publish != "" {
 		t.Errorf("expected empty publish, got: %q", publish)
 	}
@@ -60,7 +60,7 @@ func TestExtractStructured_LastOutputWins(t *testing.T) {
 		"some text",
 		`APIARY_OUTPUT: {"v":2}`,
 	}, "\n")
-	_, structured, _, _, _ := extractStructured(raw)
+	_, structured, _, _, _, _ := extractStructured(raw)
 	if structured == nil || structured["v"] != float64(2) {
 		t.Errorf("expected last APIARY_OUTPUT to win, got: %#v", structured)
 	}
@@ -71,7 +71,7 @@ func TestExtractStructured_BareLineRegression(t *testing.T) {
 		"real output",
 		`APIARY_OUTPUT: {"review_verdict":"rejected","reason":"missing tests"}`,
 	}, "\n")
-	cleaned, structured, _, _, _ := extractStructured(raw)
+	cleaned, structured, _, _, _, _ := extractStructured(raw)
 	if structured == nil {
 		t.Fatal("expected structured output for bare sentinel, got nil")
 	}
@@ -91,7 +91,7 @@ func TestExtractStructured_InlineBacktickWrapped(t *testing.T) {
 		"Here is my verdict:",
 		"`APIARY_OUTPUT: {\"review_verdict\": \"rejected\", \"reason\": \"flaky test\"}`",
 	}, "\n")
-	cleaned, structured, _, _, _ := extractStructured(raw)
+	cleaned, structured, _, _, _, _ := extractStructured(raw)
 	if structured == nil {
 		t.Fatal("expected structured output for backtick-wrapped sentinel, got nil")
 	}
@@ -116,7 +116,7 @@ func TestExtractStructured_FencedCodeBlock(t *testing.T) {
 		`APIARY_OUTPUT: {"review_verdict":"approved"}`,
 		"```",
 	}, "\n")
-	_, structured, _, _, _ := extractStructured(raw)
+	_, structured, _, _, _, _ := extractStructured(raw)
 	if structured == nil {
 		t.Fatal("expected structured output inside fenced block, got nil")
 	}
@@ -131,7 +131,7 @@ func TestExtractStructured_WrappedLastWins(t *testing.T) {
 		"some reconsideration",
 		"`APIARY_OUTPUT: {\"review_verdict\": \"rejected\"}`",
 	}, "\n")
-	_, structured, _, _, _ := extractStructured(raw)
+	_, structured, _, _, _, _ := extractStructured(raw)
 	if structured == nil {
 		t.Fatal("expected structured output, got nil")
 	}
@@ -142,7 +142,7 @@ func TestExtractStructured_WrappedLastWins(t *testing.T) {
 
 func TestExtractStructured_ProseMentionNotStripped(t *testing.T) {
 	raw := "I will now emit APIARY_OUTPUT: with the final verdict."
-	cleaned, structured, _, _, _ := extractStructured(raw)
+	cleaned, structured, _, _, _, _ := extractStructured(raw)
 	if structured != nil {
 		t.Errorf("prose mention should not parse as structured, got: %#v", structured)
 	}
@@ -153,7 +153,7 @@ func TestExtractStructured_ProseMentionNotStripped(t *testing.T) {
 
 func TestExtractStructured_InvalidJSONStrippedButNil(t *testing.T) {
 	raw := "real output\nAPIARY_OUTPUT: {not valid json}"
-	cleaned, structured, _, _, _ := extractStructured(raw)
+	cleaned, structured, _, _, _, _ := extractStructured(raw)
 	if structured != nil {
 		t.Errorf("expected nil structured for invalid JSON, got: %#v", structured)
 	}
@@ -175,7 +175,7 @@ func TestExtractStructured_PublishBlock(t *testing.T) {
 		"Trailing line.",
 	}, "\n")
 
-	cleaned, structured, summary, publish, _ := extractStructured(raw)
+	cleaned, structured, summary, publish, _, _ := extractStructured(raw)
 
 	if structured != nil || summary != "" {
 		t.Errorf("expected no structured/summary, got %#v / %q", structured, summary)
@@ -325,5 +325,63 @@ func TestBuildPrompt_NoWorkflowFieldsUnchanged(t *testing.T) {
 	}
 	if !strings.HasPrefix(prompt, "Task: Plain task") {
 		t.Errorf("plain prompt should start with the task line, got:\n%s", prompt)
+	}
+}
+
+func TestApplyStructured_MemorizeBlock(t *testing.T) {
+	result := model.RunResult{Output: "done\n" +
+		"APIARY_MEMORIZE_BEGIN\n" +
+		`{"scope":"global","name":"ci-duration","description":"CI takes 12m","content":"plan accordingly"}` + "\n" +
+		"APIARY_MEMORIZE_END\n"}
+	applyStructured(&result)
+
+	if result.MemorizeError != nil {
+		t.Fatalf("unexpected error: %v", result.MemorizeError)
+	}
+	if len(result.MemorizeRequests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(result.MemorizeRequests))
+	}
+	req := result.MemorizeRequests[0]
+	if req.Scope != "global" || req.Name != "ci-duration" || req.Content != "plan accordingly" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+	if strings.Contains(result.Output, "APIARY_MEMORIZE") {
+		t.Fatalf("markers not stripped: %q", result.Output)
+	}
+	if result.Output != "done" {
+		t.Fatalf("unexpected cleaned output: %q", result.Output)
+	}
+}
+
+func TestApplyStructured_MemorizeArrayAndDefaults(t *testing.T) {
+	result := model.RunResult{Output: "APIARY_MEMORIZE_BEGIN\n" +
+		`[{"content":"task note, no scope"},{"scope":"global","name":"x-y","description":"d","content":"c"}]` + "\n" +
+		"APIARY_MEMORIZE_END"}
+	applyStructured(&result)
+
+	if result.MemorizeError != nil {
+		t.Fatalf("unexpected error: %v", result.MemorizeError)
+	}
+	if len(result.MemorizeRequests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(result.MemorizeRequests))
+	}
+	if result.MemorizeRequests[0].Scope != "" {
+		t.Fatalf("scope should stay empty (task default applied later): %+v", result.MemorizeRequests[0])
+	}
+}
+
+func TestApplyStructured_MemorizeInvalidJSON(t *testing.T) {
+	result := model.RunResult{Output: "ok\nAPIARY_MEMORIZE_BEGIN\nnot json\nAPIARY_MEMORIZE_END"}
+	applyStructured(&result)
+
+	if result.MemorizeError == nil {
+		t.Fatal("expected MemorizeError")
+	}
+	if len(result.MemorizeRequests) != 0 {
+		t.Fatalf("no requests expected, got %v", result.MemorizeRequests)
+	}
+	// The block is stripped even when malformed, so it never leaks downstream.
+	if strings.Contains(result.Output, "APIARY_MEMORIZE") || strings.Contains(result.Output, "not json") {
+		t.Fatalf("block not stripped: %q", result.Output)
 	}
 }

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -68,6 +68,10 @@ type dagRun struct {
 // execution view (cell) is projected from the task + its primary binding. seed
 // is inherited memory for a sub-workflow child; depth tracks nesting.
 func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) *dagRun {
+	// Memory provenance: parallel/foreach worker paths only carry the instance
+	// ID, so memorizeStep resolves the workflow ID through this map. Removed on
+	// terminal settle; parked instances keep their mapping for the resume path.
+	e.instWF.Store(instID, wf.ID)
 	r := &dagRun{
 		instID:          instID,
 		wf:              wf,

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
 	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/memory"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/source"
 )
@@ -123,6 +124,15 @@ type StepResult struct {
 	// JSON array — one step fanning out into several children (e.g. a spec
 	// decomposed into sub-issues). The engine handles it uniformly with SpawnRequest.
 	SpawnRequests []model.SpawnRequest
+	// MemorizeRequests are the agent's APIARY_MEMORIZE requests. The engine
+	// persists each to the memory store (task notes or global entries) when a
+	// store is wired and the step has not set memory.memorize: off (the executor
+	// clears them in that case, mirroring publish: off).
+	MemorizeRequests []model.MemorizeRequest
+	// MemorizeError is set when an APIARY_MEMORIZE block was present but
+	// malformed. Unlike SpawnError it is only ever surfaced as a warning — a
+	// failed memorize never fails the step.
+	MemorizeError error
 	// Usage is the token/cost rollup for the step, summed across the step's
 	// failover attempts (each attempt is also its own task_executions row). Nil
 	// when the runner reported no usage. The engine persists it onto the step run.
@@ -137,6 +147,28 @@ type StepResult struct {
 // The engine owns persistence, memory, and hooks; the executor owns execution.
 type StepExecutor interface {
 	ExecuteStep(ctx context.Context, req StepRequest) StepResult
+}
+
+// MemoryStore is the persistent agent memory the engine writes APIARY_MEMORIZE
+// requests to and reads recall sections from. *memory.Store satisfies it; nil
+// disables persistent memory entirely (the per-instance memory document is
+// unaffected).
+type MemoryStore interface {
+	// UpsertGlobal writes one durable daemon-wide fact (same name = update).
+	UpsertGlobal(e memory.Entry) error
+	// AppendTaskNote appends one working note to a task's notes file.
+	AppendTaskNote(taskID string, n memory.Note) error
+	// RenderRecall renders the prompt sections for the given task lineage (self
+	// first) and tiers, bounded by budget. "" when there is nothing to recall.
+	RenderRecall(taskIDs []string, tiers []string, budget int) string
+}
+
+// ancestorLister is the optional capability the engine uses to resolve a task's
+// ancestor chain for task-memory recall (spawned children inherit their
+// ancestors' notes). *db.Client satisfies it; fake stores that omit it limit
+// recall to the task's own notes.
+type ancestorLister interface {
+	GetTaskAncestors(ctx context.Context, id string) ([]model.InternalTask, error)
 }
 
 // SideEffects applies source-facing actions for an InternalTask. Each action
@@ -174,6 +206,7 @@ type Engine struct {
 	exec      StepExecutor
 	side      SideEffects
 	mem       MemoryBuilder
+	memStore  MemoryStore
 	spawner   WorkflowSpawner
 	tracker   TaskTracker
 	ciChecker CIStatusChecker
@@ -183,6 +216,11 @@ type Engine struct {
 
 	mu     sync.Mutex         // guards parked
 	parked map[string]*dagRun // instances suspended at an approval step, by id
+
+	// instWF maps a live instance ID to its workflow ID, for memory provenance in
+	// code paths (parallel / foreach workers) that do not carry the dagRun.
+	// Entries are added in initDAG and removed when the instance settles terminal.
+	instWF sync.Map
 }
 
 // Option customizes an Engine.
@@ -199,6 +237,10 @@ func WithIDGen(gen func(prefix string) string) Option { return func(e *Engine) {
 
 // WithMemoryBuilder overrides the memory builder.
 func WithMemoryBuilder(b MemoryBuilder) Option { return func(e *Engine) { e.mem = b } }
+
+// WithMemoryStore wires the persistent agent memory store (APIARY_MEMORIZE
+// write path + recall injection). Nil disables persistent memory.
+func WithMemoryStore(s MemoryStore) Option { return func(e *Engine) { e.memStore = s } }
 
 // WithSpawner sets the APIARY_SPAWN handler used to create child tasks.
 func WithSpawner(s WorkflowSpawner) Option { return func(e *Engine) { e.spawner = s } }
@@ -338,6 +380,7 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 	e.mu.Lock()
 	delete(e.parked, r.instID)
 	e.mu.Unlock()
+	e.instWF.Delete(r.instID)
 	e.applyCompletion(ctx, r, failed)
 	e.completeTask(ctx, r, failed)
 	return !failed
@@ -419,6 +462,12 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	memDoc := ""
 	if step.MemoryReadEnabled() {
 		memDoc = e.mem.Build(cell, memSteps)
+		// Persistent recall ([Long-term Memory] + [Task Memory]) rides ahead of the
+		// per-instance document on the same SystemPrepend channel. memory.read: false
+		// suppresses everything; memory.recall filters tiers.
+		if recall := e.renderRecall(ctx, task, step); recall != "" {
+			memDoc = recall + "\n" + memDoc
+		}
 	}
 
 	var ag config.AgentConfig
@@ -464,9 +513,120 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	} else {
 		sr.State = db.StepStateFailed
 	}
+	// Memorize runs before publish so knowledge is persisted even when the
+	// source write-back fails; neither outcome affects the step state.
+	e.memorizeStep(instID, task, step, res)
 	e.publishStep(ctx, task, bindings, res, sr)
 	_ = e.store.UpdateStepRun(ctx, sr)
 	return res
+}
+
+// secretPattern returns the name of the first common credential pattern found
+// in s, or "" when none match. Heuristic by design (see memorizeStep).
+func secretPattern(s string) string {
+	for _, p := range []struct{ name, marker string }{
+		{"GitHub token", "ghp_"},
+		{"GitHub fine-grained token", "github_pat_"},
+		{"Slack token", "xoxb-"},
+		{"Slack user token", "xoxp-"},
+		{"AWS access key", "AKIA"},
+		{"private key", "-----BEGIN"},
+	} {
+		if strings.Contains(s, p.marker) {
+			return p.name
+		}
+	}
+	return ""
+}
+
+// renderRecall renders the persistent-memory sections for one step's prompt:
+// the global index and the task notes of the task plus its ancestors (so
+// spawned children inherit working context). Best-effort — a store or lineage
+// failure degrades to no recall, never blocks the step.
+func (e *Engine) renderRecall(ctx context.Context, task model.InternalTask, step config.StepConfig) string {
+	if e.memStore == nil {
+		return ""
+	}
+	lineage := []string{}
+	if task.ID != "" {
+		lineage = append(lineage, task.ID)
+		if al, ok := e.store.(ancestorLister); ok {
+			// GetTaskAncestors returns root first, self last; recall wants nearest
+			// context first (self, parent, grandparent, …) so reverse, skipping self.
+			if ancestors, err := al.GetTaskAncestors(ctx, task.ID); err == nil {
+				for i := len(ancestors) - 1; i >= 0; i-- {
+					if ancestors[i].ID != task.ID {
+						lineage = append(lineage, ancestors[i].ID)
+					}
+				}
+			}
+		}
+	}
+	return e.memStore.RenderRecall(lineage, step.MemoryRecallTiers(), e.cfg.Settings.Memory.MaxInjectChars)
+}
+
+// memorizeStep persists the step's APIARY_MEMORIZE requests: global-scope
+// requests upsert durable entries, task-scope requests (the default) append
+// working notes to the task. Every failure — malformed block, validation,
+// store error — is a warning only; a memorize can never fail a step. The
+// executor has already dropped the requests when the step set
+// memory.memorize: off.
+func (e *Engine) memorizeStep(instID string, task model.InternalTask, step config.StepConfig, res StepResult) {
+	if res.MemorizeError != nil {
+		aplog.Warn("step %q: %v (block ignored)", step.ID, res.MemorizeError)
+	}
+	if e.memStore == nil || len(res.MemorizeRequests) == 0 {
+		if len(res.MemorizeRequests) > 0 {
+			aplog.Debug("step %q: %d APIARY_MEMORIZE request(s) dropped (memory disabled)", step.ID, len(res.MemorizeRequests))
+		}
+		return
+	}
+
+	wfID := ""
+	if v, ok := e.instWF.Load(instID); ok {
+		wfID, _ = v.(string)
+	}
+	for _, req := range res.MemorizeRequests {
+		// Best-effort guard: memory files are plain text read by every agent, so
+		// flag content that looks like a credential. Warn-only — patterns are
+		// heuristic and a false positive must not lose a legitimate fact.
+		if pat := secretPattern(req.Content); pat != "" {
+			aplog.Warn("step %q: APIARY_MEMORIZE content matches a credential pattern (%s) — memory is not a secret store", step.ID, pat)
+		}
+		scope := req.Scope
+		if scope == "" {
+			scope = model.MemorizeScopeTask
+		}
+		var err error
+		switch scope {
+		case model.MemorizeScopeGlobal:
+			err = e.memStore.UpsertGlobal(memory.Entry{
+				Name:        req.Name,
+				Description: req.Description,
+				Content:     req.Content,
+				Agent:       step.Agent,
+				Task:        task.ID,
+				Workflow:    wfID,
+			})
+		case model.MemorizeScopeTask:
+			if task.ID == "" {
+				err = fmt.Errorf("task-scope memorize on a transient task with no id")
+				break
+			}
+			err = e.memStore.AppendTaskNote(task.ID, memory.Note{
+				Content:  req.Content,
+				Agent:    step.Agent,
+				Workflow: wfID,
+				Step:     step.ID,
+				At:       e.now(),
+			})
+		default:
+			err = fmt.Errorf("unknown scope %q (want task|global)", scope)
+		}
+		if err != nil {
+			aplog.Warn("step %q: APIARY_MEMORIZE: %v", step.ID, err)
+		}
+	}
 }
 
 // spawnStep handles one or more agent-emitted APIARY_SPAWN requests: for each it

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -38,6 +38,7 @@ type fakeStore struct {
 	stepOrder []string
 	bindings  map[string][]model.SourceBinding // task id → bindings (for bindingLister)
 	ciPolls   []db.CIPollCheck                 // recorded wait_for CI polls (for ciPollRecorder)
+	ancestors map[string][]model.InternalTask  // task id → lineage (for ancestorLister)
 }
 
 func newFakeStore() *fakeStore {
@@ -67,6 +68,14 @@ func (f *fakeStore) pollStatuses() []string {
 		out[i] = p.Status
 	}
 	return out
+}
+
+// GetTaskAncestors satisfies ancestorLister so the engine resolves a task's
+// lineage (root first, self last) the same way the production *db.Client does.
+func (f *fakeStore) GetTaskAncestors(_ context.Context, id string) ([]model.InternalTask, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ancestors[id], nil
 }
 
 // ListBindingsByTask satisfies bindingLister so the engine resolves a task's

--- a/src/internal/workflow/memorize_test.go
+++ b/src/internal/workflow/memorize_test.go
@@ -1,0 +1,228 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/memory"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// memEngine builds a test engine wired to a real memory.Store in a temp dir.
+func memEngine(t *testing.T, cfg *config.Config, store Store, exec StepExecutor) (*Engine, *memory.Store) {
+	t.Helper()
+	ms, err := memory.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.Open: %v", err)
+	}
+	e := testEngine(cfg, store, exec, &fakeSide{})
+	WithMemoryStore(ms)(e)
+	return e, ms
+}
+
+func memCfg() *config.Config {
+	cfg := baseCfg()
+	cfg.Settings.Memory = config.MemorySettings{Enabled: true, MaxInjectChars: 4000, MaxEntryBytes: 16384}
+	return cfg
+}
+
+func TestEngine_MemorizeGlobalAndTask(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done", MemorizeRequests: []model.MemorizeRequest{
+			{Scope: "global", Name: "ci-duration", Description: "CI takes 12m", Content: "plan accordingly"},
+			{Content: "decided to use lipgloss"}, // scope defaults to task
+		}},
+	}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	wf := config.WorkflowConfig{ID: "engineer", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	task := model.InternalTask{ID: "01TASK", Title: "Fix bug"}
+	if _, ok, err := e.RunInstance(context.Background(), wf, task); err != nil || !ok {
+		t.Fatalf("RunInstance: ok=%v err=%v", ok, err)
+	}
+
+	entry, err := ms.Read("ci-duration")
+	if err != nil {
+		t.Fatalf("global entry not written: %v", err)
+	}
+	if entry.Agent != "backend-dev" || entry.Task != "01TASK" || entry.Workflow != "engineer" {
+		t.Fatalf("provenance wrong: %+v", entry)
+	}
+	notes := ms.TaskNoteContent("01TASK")
+	if !strings.Contains(notes, "decided to use lipgloss") {
+		t.Fatalf("task note not written:\n%s", notes)
+	}
+	if !strings.Contains(notes, "[engineer/run]") || !strings.Contains(notes, "(backend-dev)") {
+		t.Fatalf("note provenance missing:\n%s", notes)
+	}
+}
+
+func TestEngine_MemorizeInvalidNeverFailsStep(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done", MemorizeRequests: []model.MemorizeRequest{
+			{Scope: "global", Content: "no name or description"}, // rejected by the store
+			{Scope: "nonsense", Content: "bad scope"},            // rejected by the engine
+		}},
+	}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	_, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01T"})
+	if err != nil || !ok {
+		t.Fatalf("invalid memorize must not fail the step: ok=%v err=%v", ok, err)
+	}
+	if metas, _ := ms.List(); len(metas) != 0 {
+		t.Fatalf("rejected requests were persisted: %v", metas)
+	}
+}
+
+func TestEngine_MemorizeDisabledIsNoop(t *testing.T) {
+	cfg := baseCfg() // memory disabled — engine has no store wired
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, MemorizeRequests: []model.MemorizeRequest{{Content: "note"}}},
+	}}
+	e := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	if _, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01T"}); err != nil || !ok {
+		t.Fatalf("RunInstance: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestEngine_RecallInjectedIntoMemoryDoc(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true}}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	if err := ms.UpsertGlobal(memory.Entry{Name: "known-fact", Description: "a durable fact", Content: "details"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.AppendTaskNote("01TASK", memory.Note{Content: "earlier instance decided X"}); err != nil {
+		t.Fatal(err)
+	}
+
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	if _, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01TASK", Title: "T"}); err != nil || !ok {
+		t.Fatalf("RunInstance: ok=%v err=%v", ok, err)
+	}
+
+	doc := exec.seen[0].MemoryDoc
+	for _, want := range []string{"[Long-term Memory]", "known-fact — a durable fact", "[Task Memory]", "earlier instance decided X", "=== Workflow Memory ==="} {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("memory doc missing %q:\n%s", want, doc)
+		}
+	}
+	// Recall rides ahead of the per-instance document.
+	if strings.Index(doc, "[Long-term Memory]") > strings.Index(doc, "=== Workflow Memory ===") {
+		t.Fatalf("recall not prepended:\n%s", doc)
+	}
+}
+
+func TestEngine_RecallRespectsTierFilterAndReadOff(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"a": {Success: true}, "b": {Success: true}}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	if err := ms.UpsertGlobal(memory.Entry{Name: "known-fact", Description: "d", Content: "c"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.AppendTaskNote("01TASK", memory.Note{Content: "task context"}); err != nil {
+		t.Fatal(err)
+	}
+
+	off := false
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{
+		{ID: "a", Agent: "backend-dev", Memory: &config.MemoryConfig{Recall: []string{"task"}}},
+		{ID: "b", Agent: "backend-dev", Memory: &config.MemoryConfig{Read: &off}},
+	}}
+	if _, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01TASK"}); err != nil || !ok {
+		t.Fatalf("RunInstance: ok=%v err=%v", ok, err)
+	}
+
+	docA := exec.seen[0].MemoryDoc
+	if strings.Contains(docA, "[Long-term Memory]") || !strings.Contains(docA, "task context") {
+		t.Fatalf("recall tier filter failed:\n%s", docA)
+	}
+	docB := exec.seen[1].MemoryDoc
+	if docB != "" {
+		t.Fatalf("memory.read: false must suppress everything, got:\n%s", docB)
+	}
+}
+
+func TestEngine_RecallInheritsAncestorNotes(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	store.ancestors = map[string][]model.InternalTask{
+		// GetTaskAncestors order: root first, self last.
+		"01CHILD": {{ID: "01ROOT"}, {ID: "01PARENT"}, {ID: "01CHILD"}},
+	}
+	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true}}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	if err := ms.AppendTaskNote("01PARENT", memory.Note{Content: "parent collected logs"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.AppendTaskNote("01CHILD", memory.Note{Content: "child started"}); err != nil {
+		t.Fatal(err)
+	}
+
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	if _, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01CHILD"}); err != nil || !ok {
+		t.Fatalf("RunInstance: ok=%v err=%v", ok, err)
+	}
+
+	doc := exec.seen[0].MemoryDoc
+	if !strings.Contains(doc, "parent collected logs") || !strings.Contains(doc, "from parent task 01PARENT") {
+		t.Fatalf("ancestor notes not inherited:\n%s", doc)
+	}
+	// Self notes come before the parent's.
+	if strings.Index(doc, "child started") > strings.Index(doc, "parent collected logs") {
+		t.Fatalf("self notes must lead:\n%s", doc)
+	}
+}
+
+func TestEngine_MemorizeRetryDedups(t *testing.T) {
+	cfg := memCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, MemorizeRequests: []model.MemorizeRequest{{Content: "same note"}}},
+	}}
+	e, ms := memEngine(t, cfg, store, exec)
+
+	wf := config.WorkflowConfig{ID: "r", Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev"}}}
+	for i := 0; i < 2; i++ { // a re-dispatched instance re-emits the same note
+		if _, ok, err := e.RunInstance(context.Background(), wf, model.InternalTask{ID: "01T"}); err != nil || !ok {
+			t.Fatalf("run %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if n := strings.Count(ms.TaskNoteContent("01T"), "same note"); n != 1 {
+		t.Fatalf("expected 1 note after retry, found %d", n)
+	}
+}
+
+// TestMemoryStoreSatisfiedByRealStore pins the interface compatibility.
+func TestMemoryStoreSatisfiedByRealStore(t *testing.T) {
+	var _ MemoryStore = (*memory.Store)(nil)
+	// And the entry files land where APIARY_MEMORY_DIR points.
+	ms, err := memory.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ms.UpsertGlobal(memory.Entry{Name: "loc", Description: "d", Content: "c"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(ms.Root(), "global", "loc.md")); err != nil {
+		t.Fatalf("entry not on disk: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements OpenSpec change **`agent-memory`** (proposal, design, and tasks included in this PR under `openspec/changes/agent-memory/`).

Closes #160

Agents are stateless between executions today — the instance memory document dies with the workflow instance. This adds two persistent tiers, written by agents through a new `APIARY_MEMORIZE` output marker and stored as plain markdown the operator can read, edit, and delete by hand:

- **Task memory** — append-only working notes on an `InternalTask`, visible across retries, fan-out instances, and spawned descendants (lineage via `parent_task_id` / `GetTaskAncestors`). Pruned by a daemon sweep after terminal + `task_retention` (default 30d), kept while any descendant is live.
- **Global memory** — daemon-wide durable facts, one file per slug, upserted on re-emit (original `created` preserved). Never auto-pruned; curated via `apiary memory list|show|rm|prune` or by hand (the `MEMORY.md` index self-heals).

Mechanics:

- `APIARY_MEMORIZE_BEGIN/END` (single object or JSON array, mirroring `APIARY_SPAWN`) parsed in `extractStructured`; malformed blocks become warnings — a memorize can never fail a step. Markers are stripped from output even when memory is disabled.
- Engine `memorizeStep` (sibling of `publishStep`/`spawnStep`, ordered before publish) persists with provenance (agent, task, workflow) and a best-effort credential-pattern warning.
- Recall: `[Long-term Memory]` (index only — never full bodies) + `[Task Memory]` (self first, then ancestors) injected ahead of the instance memory doc on the existing `SystemPrepend` channel, capped by `settings.memory.max_inject_chars` (task notes drop oldest-first; the index truncates with an explicit count). Agents read full entries via `APIARY_MEMORY_DIR` (new identity-base env var; explicit env scopes win).
- **Opt-in**: `settings.memory.enabled: false` by default — zero behavior change when disabled. No DB schema changes; the store is `<data-dir>/memory` beside `apiary.db` (override: `settings.memory.path`), gitignored like the rest of the runtime state.
- Step controls: `memory.recall: [task|global]` and `memory.memorize: auto|off` (mirrors `publish: off`); `memory.read: false` still suppresses everything. Validated by config lint; `schema/apiary.json` + `.apiary/example-apiary-full.yaml` mirrored.
- Docs: new `docs/memory.md` (+ nav) and a cross-link from the workflow-memory section.

Out of scope (tracked in tasks.md): apiary-guide skill refresh (5.3.3 — the skill is stale beyond this feature) and archiving the OpenSpec change (5.3.6, on merge of follow-ups).

## Test plan

- `go test ./...` green locally (no Go CI in this repo)
- New suites: `internal/memory` (round-trip, upsert/created-preserved, slug & size validation incl. path traversal, note dedup, index self-heal, recall budget truncation), `internal/workflow/memorize_test.go` (write path with provenance, invalid-never-fails, disabled no-op, recall injection/tier filter/read-off, ancestor inheritance, retry dedup, real-store interface pin), `internal/runner/execution` (marker object/array/malformed/stripping), `internal/config` (settings + step enum validation, defaults), `internal/daemon` (retention sweep incl. live-descendant retention and mtime fallback, env var precedence)
- Manual: built the binary; `apiary validate` accepts the new config and rejects bad enums; `apiary memory --help`/subcommands work