### PR TITLE
docs(memory): explain the memory system across README, concepts, and the apiary-guide skill

### DIFF
--- a/.claude/skills/apiary-guide/SKILL.md
+++ b/.claude/skills/apiary-guide/SKILL.md
@@ -335,6 +335,8 @@ settings:
   state_lock: true         # Add "in-progress" label on acknowledge
   result_comment: true     # Post agent output as comment
   max_attempts: 3          # Re-dispatch failure cap per (task, workflow); <=0 disables
+  memory:                  # Persistent agent memory — see "Agent Memory" section
+    enabled: false         # opt-in; default false
 ```
 
 ### Rate limits & resilience
@@ -356,6 +358,80 @@ runaway loop:
 - **Non-blocking dispatch.** A busy agent's `max_workers` slot is acquired inside
   the dispatch goroutine, so a saturated agent never stalls polling/dispatch for
   other sources or agents.
+
+## Agent Memory
+
+Persistent, tiered memory so agents stop relearning the same lessons
+(full reference: `docs/memory.md`). Three tiers:
+
+| Tier | Lifetime | Scope |
+|---|---|---|
+| Instance (built-in workflow memory) | One workflow instance | The instance's steps |
+| **Task** | Task terminal + `task_retention` (default 720h) | The task, its retries/fan-out, and spawned descendants (lineage) |
+| **Global** | Forever — human/agent curated | Daemon-wide: every agent and workflow of the project |
+
+Opt-in via `settings.memory.enabled: true`. Storage is plain markdown under
+`<data-dir>/memory/` (beside `apiary.db`): `MEMORY.md` index, `global/<slug>.md`
+one fact per file, `tasks/<task_id>.md` append-only notes. Hand-editable; the
+index self-heals. Gitignored by default.
+
+**Write — `APIARY_MEMORIZE` marker** (sibling of `APIARY_PUBLISH`/`APIARY_SPAWN`;
+single object or JSON array):
+
+```
+APIARY_MEMORIZE_BEGIN
+{"scope": "global", "name": "kebab-slug", "description": "one line for the index",
+ "content": "markdown body"}
+APIARY_MEMORIZE_END
+```
+
+- `scope: task` (default) appends a working note to the current task;
+  `scope: global` upserts a durable fact by `name` (same name = update).
+- `name` + `description` required for global only. Malformed blocks are
+  warnings — a memorize never fails the step.
+
+**Recall.** Each step prompt gets `[Long-term Memory]` (the index, not full
+bodies) and `[Task Memory]` (own + ancestor notes), capped by
+`settings.memory.max_inject_chars` (default 4000). Agents read full entries
+from `$APIARY_MEMORY_DIR/global/<name>.md` (env var set on every step).
+
+**Step controls** (mirror `publish: off`):
+
+```yaml
+steps:
+  - id: analyze
+    agent: analyzer
+    memory:
+      memorize: off        # drop APIARY_MEMORIZE from this step (default: auto)
+      recall: [task]       # inject only these tiers (default: both)
+      # read: false        # still suppresses the entire memory doc, recall included
+```
+
+**Curation:** `apiary memory path | list | show <name> | rm <name> | prune [--dry-run]`.
+Task notes are also pruned automatically by a daemon sweep; global entries never are.
+
+**Soul-file snippet** — teach agents the protocol by adding something like this
+to their soul file:
+
+```markdown
+## Memory
+
+You have persistent memory at $APIARY_MEMORY_DIR. Your prompt includes the
+long-term index and this task's notes — read a full entry from
+$APIARY_MEMORY_DIR/global/<name>.md before re-deriving anything it covers.
+
+When you learn something durable (a project gotcha, a tooling quirk, a
+convention), save it:
+
+APIARY_MEMORIZE_BEGIN
+{"scope": "global", "name": "short-kebab-slug", "description": "one-line summary",
+ "content": "the fact, with enough context to act on it cold"}
+APIARY_MEMORIZE_END
+
+For decisions and findings the NEXT step or a retry of THIS task needs, use
+{"content": "..."} alone (task scope, the default). Update a stale fact by
+re-emitting its name. NEVER memorize secrets, tokens, or credentials.
+```
 
 ## Dashboard
 
@@ -422,6 +498,7 @@ When an agent returns a response containing `APIARY-REVIEW: approve | request-ch
 | **Dispatcher** | Core loop that polls sources, routes Cells, dispatches to agents |
 | **inFlight** | Map of task IDs currently being processed — prevents double-dispatch |
 | **Soul file** | System prompt / persona definition for an agent |
+| **Agent memory** | Persistent markdown store (task notes + global facts) written via `APIARY_MEMORIZE`, recalled into step prompts |
 | **IPC Socket** | Unix socket (`apiary.sock`) for dashboard ↔ dispatcher communication |
 
 ## Agent Identity

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Most AI coding agents require a human to manually pick a task, paste context, an
 | **Agent** | A named LLM persona: runner + model + soul/skills, with optional fallbacks |
 | **Workflow** | A pipeline of steps, fired by a `trigger` that matches tasks; each step runs an agent |
 | **Task** | A unit of work flowing through the system (an issue or item from a Source) |
+| **Agent memory** | Opt-in persistent memory — task notes + durable global facts agents save via `APIARY_MEMORIZE` and recall on later runs |
 
 ## Quick Example
 
@@ -85,6 +86,7 @@ Apiary runs end-to-end today and ships with the safeguards that make unattended 
 - **Approval rehydration** — runs parked on a manual-approval gate survive a daemon restart.
 - **Scoped env vars** — set environment variables per agent, workflow, or step, merged with precedence.
 - **Schema-validated config** — `apiary.yaml` is validated against a JSON Schema, with live validation in the VS Code extension.
+- **Agent memory** — agents persist lessons (`APIARY_MEMORIZE`) as plain markdown: per-task working notes that survive retries and fan-out, plus a curated store of durable project facts recalled into every prompt.
 
 See [Rate Limits & Resilience](docs/resilience.md) for details.
 
@@ -99,6 +101,7 @@ See [Rate Limits & Resilience](docs/resilience.md) for details.
 | [Runners](docs/runners.md) | CLI and API execution engines, provider presets, MCP servers |
 | [Workflows](docs/workflows.md) | Triggers, steps, approval gates, CI waits, retry loops |
 | [Tasks & Fan-out](docs/tasks-and-fanout.md) | `APIARY_PUBLISH`, `APIARY_SPAWN`, task-level hooks |
+| [Agent Memory](docs/memory.md) | `APIARY_MEMORIZE`, task/global memory tiers, recall, curation |
 | [Rate Limits & Resilience](docs/resilience.md) | Failover chains and unattended-dispatch safeguards |
 | [CLI Reference](docs/cli.md) | Every command and flag |
 | [Dashboard](docs/dashboard.md) | The terminal UI, tab by tab |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -24,6 +24,7 @@ Task System ──► Apiary ──► Agent ──► LLM Model
 | **Workflow instance** | One execution of a workflow against one task — what `apiary instances` lists |
 | **Step run** | One step of an instance: an agent invocation, an approval gate, a CI wait, a split decision |
 | **Soul file** | A markdown file holding an agent's system prompt / persona |
+| **Agent memory** | Opt-in persistent memory: per-task working notes plus durable daemon-wide facts, written by agents via `APIARY_MEMORIZE` and recalled into step prompts — see [Agent Memory](memory.md) |
 
 ## Architecture
 
@@ -109,6 +110,7 @@ Everything is project-scoped, in a `.apiary/` directory next to your config:
   apiary.db      ← SQLite database (auto-created)
   apiary.sock    ← IPC socket between daemon and dashboard/CLI
   logs/          ← log files
+  memory/        ← agent memory (markdown; only when settings.memory is enabled)
 apiary.yaml      ← your config (default location)
 .env             ← auto-loaded environment variables (don't commit)
 ```

--- a/docs/tasks-and-fanout.md
+++ b/docs/tasks-and-fanout.md
@@ -28,13 +28,14 @@ and logs.
 
 ## Output markers
 
-Apiary scans agent output for three markers:
+Apiary scans agent output for these markers:
 
 | Marker | Purpose |
 |---|---|
 | `APIARY_OUTPUT: {…}` | [Structured output](workflows.md#agent-steps) validated against the step's schema |
 | `APIARY_PUBLISH_BEGIN … END` | Publish human-facing text back to the source item |
 | `APIARY_SPAWN_BEGIN … END` | Create a child task and run a named workflow on it |
+| `APIARY_MEMORIZE_BEGIN … END` | Save a task note or durable fact to [agent memory](memory.md) |
 
 Because they are plain text, they work identically across every runner — the
 agent does not need credentials or tracker-specific tooling.

--- a/openspec/changes/agent-memory/tasks.md
+++ b/openspec/changes/agent-memory/tasks.md
@@ -76,7 +76,7 @@ New package and config plumbing; nothing wired into execution yet.
 
 - [x] 5.3.1 New docs page `docs/memory.md` (tiers, marker protocol, config, curation) + mkdocs nav entry
 - [x] 5.3.2 Update `docs/workflows.md` memory section to name the instance tier and link out
-- [ ] 5.3.3 Update apiary-guide skill + example soul-file snippet teaching the memorize protocol and "no secrets" rule
+- [x] 5.3.3 Update apiary-guide skill + example soul-file snippet teaching the memorize protocol and "no secrets" rule
 - [x] 5.3.4 Best-effort secret-pattern warning on memorize content (`ghp_`, `xoxb-`, `AKIA`)
 - [x] 5.3.5 Gitignore guidance: add `**/.apiary/memory/` to this repo's `.gitignore` and to whatever `apiary init` emits; document the "commit it deliberately" alternative
 - [ ] 5.3.6 Archive change: move CHANGELOG entry from Ativas to Arquivadas


### PR DESCRIPTION
## Summary

Follow-up to #162 (agent memory, issue #160): the feature shipped with a full reference page (`docs/memory.md`) but the entry points readers actually hit first never mentioned it. This adds a proper explanation of the memory system everywhere it belongs:

- **README** — key-concepts row, a "What's in the beta" bullet, and a documentation-table entry pointing at the reference page
- **docs/concepts.md** — vocabulary entry + `memory/` in the "Where state lives" directory tree
- **docs/tasks-and-fanout.md** — `APIARY_MEMORIZE` added to the output-markers table beside `APIARY_PUBLISH` / `APIARY_SPAWN`
- **apiary-guide skill** — a complete "Agent Memory" section (tiers, marker protocol, recall, step controls, CLI curation) plus a ready-to-paste soul-file snippet teaching agents the memorize protocol and the no-secrets rule — checks off the last docs item (5.3.3) in `openspec/changes/agent-memory/tasks.md`

## Test plan

- Docs-only change; no Go code touched
- Verified all replaced anchors matched exactly once (scripted edits assert uniqueness)
- Links target existing pages (`docs/memory.md`, `memory.md` relative links within docs/)