### PR TITLE
fix(docs): widen logo viewBox so the tagline is not clipped

### DIFF
--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 35 400 130" width="400" height="130">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 35 520 130" width="520" height="130">
   <defs>
     <linearGradient id="gold" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#F5A623"/>


### PR DESCRIPTION
## Summary
- The logo tagline `HARNESS AGENT ORCHESTRATOR` overflowed the SVG viewBox (text runs to ~x510, canvas ended at x420), so it rendered clipped as "HARNESS AGENT ORCHES".
- Widened the canvas from 400 to 520 user units (`viewBox`/`width`), leaving a ~30px right margin.

## Test plan
- Rendered before/after PNGs with `rsvg-convert` and visually confirmed the full tagline now fits.
- README embeds the logo with an explicit `width="600"` and MkDocs scales the header logo by height, so both usages scale correctly with the new aspect ratio.