### PR TITLE
fix(docs): recolor favicon with brand gold so it is visible on light tabs

### DIFF
--- a/docs/icon.svg
+++ b/docs/icon.svg
@@ -1,14 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 110" width="110" height="110">
+  <defs>
+    <linearGradient id="gold" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#F5A623"/>
+      <stop offset="100%" stop-color="#D4841A"/>
+    </linearGradient>
+    <linearGradient id="goldLight" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#F9C96A"/>
+      <stop offset="100%" stop-color="#F5A623"/>
+    </linearGradient>
+  </defs>
   <!-- Outer hexagon -->
   <polygon points="55,5 97.5,30 97.5,80 55,105 12.5,80 12.5,30"
-           fill="none" stroke="#FFFFFF" stroke-width="5" stroke-linejoin="round" opacity="0.9"/>
+           fill="none" stroke="url(#gold)" stroke-width="7" stroke-linejoin="round"/>
   <!-- Top cell -->
   <polygon points="55,28 62,34 62,46 55,52 48,46 48,34"
-           fill="#FFFFFF" opacity="0.85"/>
+           fill="url(#goldLight)"/>
   <!-- Bottom-left cell -->
   <polygon points="35,56 42,62 42,74 35,80 28,74 28,62"
-           fill="#FFFFFF" opacity="0.85"/>
+           fill="url(#goldLight)"/>
   <!-- Bottom-right cell -->
   <polygon points="75,56 82,62 82,74 75,80 68,74 68,62"
-           fill="#FFFFFF" opacity="0.85"/>
+           fill="url(#goldLight)"/>
 </svg>


### PR DESCRIPTION
## Summary
- The favicon (`docs/icon.svg`) was drawn entirely in white on a transparent background, making it nearly invisible on light browser tabs — and the docs theme uses `primary: white`.
- Recolored the hexagon outline and honeycomb cells with the same gold gradients used in `docs/logo.svg`, and bumped the stroke from 5 to 7 for legibility at 16px.

## Test plan
- Rendered the icon at 128/32/16px on white and dark backgrounds with `rsvg-convert`/ImageMagick and visually confirmed it is clearly visible on both.
- Checked `tools/vscode-apiary/icon.svg` — it already uses gold and is unaffected.