### PR TITLE
feat(daemon): back-fill cursor-cli run costs from the Cursor dashboard API

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -465,6 +465,16 @@ settings:
     # max_inject_chars: 4000         # prompt budget for the recall sections
     # max_entry_bytes: 16384         # cap on a single memorized fact
     # task_retention: 720h           # prune task notes this long after the task ends
+  # Cursor cost back-fill (opt-in): the Cursor agent CLI streams token counts
+  # but no dollar cost, so cursor-cli runs record $0.00. On usage-based Cursor
+  # plans the daemon can recover real billed amounts from the cursor.com
+  # dashboard API and back-fill cost_usd on finished executions. Needs the
+  # WorkosCursorSessionToken browser cookie (valid ~60 days) in .env.
+  cursor_cost:
+    enabled: false
+    # session_token: ${CURSOR_SESSION_TOKEN}  # default: CURSOR_SESSION_TOKEN env var
+    # interval: 5m                   # sweep cadence
+    # max_age: 72h                   # how far back to back-fill
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,57 @@ pages — the file stops growing but does not shrink; to compact a database
 that grew before retention existed, stop the daemon and run
 `sqlite3 .apiary/apiary.db 'VACUUM;'` once.
 
+### Cursor cost back-fill (`cursor_cost`)
+
+The Cursor agent CLI streams token counts but **no dollar cost** — unlike the
+Claude CLI's `total_cost_usd`, cursor runs always record `$0.00`. If your
+Cursor plan is usage-based, the daemon can recover the real billed amounts
+from the same private API the [cursor.com dashboard](https://cursor.com/dashboard)
+usage tab uses, and back-fill `cost_usd` on finished `cursor-cli` executions:
+
+```yaml
+settings:
+  cursor_cost:
+    enabled: true
+    session_token: ${CURSOR_SESSION_TOKEN}  # from .env beside apiary.yaml
+    interval: 5m   # sweep cadence (default)
+    max_age: 72h   # how far back to back-fill (default)
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable the back-fill sweep (runs at startup, then every `interval`) |
+| `session_token` | — | `WorkosCursorSessionToken` cookie from a logged-in cursor.com browser session; empty falls back to the `CURSOR_SESSION_TOKEN` env var |
+| `interval` | `5m` | Time between sweeps (minimum `1m`) |
+| `max_age` | `72h` | Unpriced executions older than this are left alone |
+
+To get the token: log into [cursor.com/dashboard](https://cursor.com/dashboard),
+open DevTools (F12) → Application → Cookies → `https://cursor.com`, and copy
+the `WorkosCursorSessionToken` value into your `.env`:
+
+```bash
+CURSOR_SESSION_TOKEN=user_XXXX%3A%3AeyJhbGci...
+```
+
+The token is valid for about 60 days; when it expires the sweep logs an auth
+warning and the daemon keeps running (costs simply stop back-filling until
+you refresh it).
+
+How it works, and the fine print:
+
+- Cursor's usage events carry no session or request id, so each event is
+  attributed to the one run whose `[started_at, completed_at]` window (±2min
+  skew) contains its timestamp. Events explicitly marked as interactive IDE
+  usage (`isHeadless: false`) are ignored.
+- **Overlapping concurrent cursor runs**: an event that falls inside two run
+  windows is attributed to *neither* (wrongly attributing money is worse than
+  undercounting). The affected runs keep a lower-bound cost and a warning is
+  logged. Runs that never resolve are abandoned after 10 sweeps.
+- The endpoint is **undocumented** and may change without notice — the whole
+  feature is best-effort and degrades to "no cost recorded" on any failure.
+- Plan-included requests (`INCLUDED_IN_PRO` etc.) and errored/aborted requests
+  are counted as $0, which is the real marginal charge.
+
 ### Concurrency
 
 Each agent has its own semaphore sized by its `max_workers` (default 1), so

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -112,6 +112,12 @@ runners:
     provider: cursor
 ```
 
+!!! note "Cost reporting"
+    The Cursor CLI streams token counts but no dollar cost, so cursor runs
+    show `$0.00` out of the box. On usage-based Cursor plans the daemon can
+    back-fill real billed amounts from the Cursor dashboard API — see
+    [`settings.cursor_cost`](configuration.md#cursor-cost-back-fill-cursor_cost).
+
 ### CLI engine configuration
 
 All `config` keys, with each provider's preset defaults:

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -488,6 +488,32 @@
               "format": "uri"
             }
           }
+        },
+        "cursor_cost": {
+          "type": "object",
+          "description": "Back-fill cost_usd on finished cursor-cli executions from Cursor's dashboard usage API (cookie auth). The Cursor agent CLI streams token counts but no dollar cost, so when enabled the daemon periodically matches dashboard usage events to run time windows and records the billed amount. Best-effort: the endpoint is undocumented, and events overlapping concurrent cursor runs are left unattributed (recorded cost is a lower bound). Disabled by default",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable the cursor-cli cost back-fill sweep",
+              "default": false
+            },
+            "session_token": {
+              "type": "string",
+              "description": "WorkosCursorSessionToken cookie value from a logged-in cursor.com browser session (valid ~60 days). Usually \"${CURSOR_SESSION_TOKEN}\" resolved from the .env file beside apiary.yaml; empty falls back to the CURSOR_SESSION_TOKEN environment variable"
+            },
+            "interval": {
+              "type": "string",
+              "description": "Time between back-fill sweeps, as a Go duration (minimum 1m)",
+              "default": "5m"
+            },
+            "max_age": {
+              "type": "string",
+              "description": "How far back unpriced executions are considered, as a Go duration",
+              "default": "72h"
+            }
+          }
         }
       }
     },

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -218,11 +218,54 @@ type Settings struct {
 	MaxAttempts int `yaml:"max_attempts"`
 	// Log rotation for the shared apiary.log file and retention for rotated
 	// backups and per-task log files. 0 means default; negative disables.
-	LogMaxSizeMB  int            `yaml:"log_max_size_mb"`  // rotate apiary.log past this size; default 50
-	LogMaxBackups int            `yaml:"log_max_backups"`  // rotated files to keep; default 5
-	LogMaxAgeDays int            `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
-	Memory        MemorySettings `yaml:"memory"`
-	Telemetry     Telemetry      `yaml:"telemetry"`
+	LogMaxSizeMB  int                `yaml:"log_max_size_mb"`  // rotate apiary.log past this size; default 50
+	LogMaxBackups int                `yaml:"log_max_backups"`  // rotated files to keep; default 5
+	LogMaxAgeDays int                `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
+	Memory        MemorySettings     `yaml:"memory"`
+	Telemetry     Telemetry          `yaml:"telemetry"`
+	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
+}
+
+// CursorCostSettings configures the cursor-cli cost back-fill. The Cursor
+// agent CLI reports token counts but no dollar cost in its stream output, so
+// when enabled the daemon periodically queries Cursor's dashboard usage API
+// (cookie auth) and back-fills cost_usd on finished cursor-cli executions by
+// matching usage events to run time windows. Best-effort: the endpoint is
+// undocumented, and overlapping concurrent cursor runs leave ambiguous events
+// unattributed (cost becomes a lower bound). Disabled by default.
+type CursorCostSettings struct {
+	Enabled bool `yaml:"enabled"`
+	// SessionToken is the WorkosCursorSessionToken cookie from a logged-in
+	// cursor.com browser session (valid ~60 days). Usually set as
+	// "${CURSOR_SESSION_TOKEN}" resolved from the .env file beside apiary.yaml.
+	// Empty falls back to the CURSOR_SESSION_TOKEN environment variable.
+	SessionToken string `yaml:"session_token"`
+	// Interval between back-fill sweeps (duration string). Default "5m".
+	Interval string `yaml:"interval"`
+	// MaxAge is how far back unpriced executions are considered (duration
+	// string). Default "72h".
+	MaxAge string `yaml:"max_age"`
+}
+
+// IntervalDuration returns the parsed sweep interval (default 5m, floor 1m).
+func (c CursorCostSettings) IntervalDuration() time.Duration {
+	d, err := time.ParseDuration(c.Interval)
+	if err != nil || d <= 0 {
+		return 5 * time.Minute
+	}
+	if d < time.Minute {
+		return time.Minute
+	}
+	return d
+}
+
+// MaxAgeDuration returns the parsed back-fill window (default 72h).
+func (c CursorCostSettings) MaxAgeDuration() time.Duration {
+	d, err := time.ParseDuration(c.MaxAge)
+	if err != nil || d <= 0 {
+		return 72 * time.Hour
+	}
+	return d
 }
 
 // MemorySettings configures the persistent agent memory store (the task and

--- a/src/internal/cursorusage/client.go
+++ b/src/internal/cursorusage/client.go
@@ -1,0 +1,188 @@
+// Package cursorusage fetches per-request usage events from Cursor's dashboard
+// API and attributes their cost to apiary runs. The Cursor agent CLI does not
+// report cost in its stream output (only token counts), so dollar amounts must
+// be recovered after the fact from the same endpoint the cursor.com usage tab
+// uses, authenticated with the user's WorkosCursorSessionToken browser cookie.
+//
+// The endpoint is undocumented and may change without notice; everything in
+// this package is best-effort and must degrade to "no cost recorded" on any
+// failure.
+package cursorusage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultBaseURL is the Cursor dashboard host. Overridable for tests.
+const DefaultBaseURL = "https://cursor.com"
+
+// maxPages bounds pagination per fetch so a huge window cannot loop forever.
+const maxPages = 20
+
+const pageSize = 100
+
+// Client calls Cursor's private dashboard API with cookie auth.
+type Client struct {
+	// Token is the WorkosCursorSessionToken cookie value, copied from a logged-in
+	// cursor.com browser session (F12 → Application → Cookies). Lasts ~60 days.
+	Token   string
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// TokenUsage is the per-event token breakdown. Field names mirror the API's
+// protobuf-es camelCase JSON. TotalCents is the model cost in fractional cents
+// and may be absent.
+type TokenUsage struct {
+	InputTokens      int     `json:"inputTokens"`
+	OutputTokens     int     `json:"outputTokens"`
+	CacheWriteTokens int     `json:"cacheWriteTokens"`
+	CacheReadTokens  int     `json:"cacheReadTokens"`
+	TotalCents       float64 `json:"totalCents"`
+}
+
+// UsageEvent is one model request as reported by the dashboard. There is no
+// session or request id — correlation to a run is by timestamp window only.
+type UsageEvent struct {
+	// Timestamp is UTC epoch milliseconds serialized as a string.
+	Timestamp string `json:"timestamp"`
+	Model     string `json:"model"`
+	// Kind is a USAGE_EVENT_KIND_* enum name, e.g. USAGE_EVENT_KIND_USAGE_BASED
+	// or USAGE_EVENT_KIND_ERRORED_NOT_CHARGED.
+	Kind             string      `json:"kind"`
+	MaxMode          bool        `json:"maxMode"`
+	UsageBasedCosts  string      `json:"usageBasedCosts"`
+	IsTokenBasedCall bool        `json:"isTokenBasedCall"`
+	TokenUsage       *TokenUsage `json:"tokenUsage"`
+	// CursorTokenFee is Cursor's markup in fractional cents.
+	CursorTokenFee float64 `json:"cursorTokenFee"`
+	IsChargeable   bool    `json:"isChargeable"`
+	// IsHeadless is true for headless/background-agent calls (the cursor-agent
+	// CLI). A pointer so that older events that predate the field are
+	// distinguishable from an explicit false (interactive IDE usage).
+	IsHeadless *bool `json:"isHeadless"`
+	// ChargedCents is the amount actually billed in fractional cents
+	// (≈ TokenUsage.TotalCents + CursorTokenFee). Newer schema; may be absent.
+	ChargedCents float64 `json:"chargedCents"`
+}
+
+// Time parses the event's epoch-millisecond timestamp. Zero time on garbage.
+func (e UsageEvent) Time() time.Time {
+	ms, err := strconv.ParseInt(e.Timestamp, 10, 64)
+	if err != nil || ms <= 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(ms)
+}
+
+// CostUSD returns the event's billed cost in dollars, preferring the newer
+// chargedCents field, then totalCents + markup, then the "$x.xx" display
+// string. Not-charged events return 0 regardless of any stale cost fields.
+func (e UsageEvent) CostUSD() float64 {
+	if strings.HasSuffix(e.Kind, "_NOT_CHARGED") {
+		return 0
+	}
+	if e.ChargedCents > 0 {
+		return e.ChargedCents / 100
+	}
+	if e.TokenUsage != nil && e.TokenUsage.TotalCents > 0 {
+		return (e.TokenUsage.TotalCents + e.CursorTokenFee) / 100
+	}
+	if s := strings.TrimPrefix(e.UsageBasedCosts, "$"); s != e.UsageBasedCosts {
+		if v, err := strconv.ParseFloat(strings.ReplaceAll(s, ",", ""), 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+type eventsRequest struct {
+	TeamID    int    `json:"teamId"`
+	StartDate string `json:"startDate"`
+	EndDate   string `json:"endDate"`
+	Page      int    `json:"page"`
+	PageSize  int    `json:"pageSize"`
+}
+
+type eventsResponse struct {
+	TotalUsageEventsCount int          `json:"totalUsageEventsCount"`
+	UsageEventsDisplay    []UsageEvent `json:"usageEventsDisplay"`
+}
+
+// FetchEvents returns all usage events with timestamps in [start, end],
+// walking pages newest-first until the window is exhausted.
+func (c *Client) FetchEvents(ctx context.Context, start, end time.Time) ([]UsageEvent, error) {
+	base := c.BaseURL
+	if base == "" {
+		base = DefaultBaseURL
+	}
+	httpc := c.HTTP
+	if httpc == nil {
+		httpc = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	var all []UsageEvent
+	for page := 1; page <= maxPages; page++ {
+		body, err := json.Marshal(eventsRequest{
+			TeamID:    0,
+			StartDate: strconv.FormatInt(start.UnixMilli(), 10),
+			EndDate:   strconv.FormatInt(end.UnixMilli(), 10),
+			Page:      page,
+			PageSize:  pageSize,
+		})
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			base+"/api/dashboard/get-filtered-usage-events", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		// Without a cursor.com Origin the API rejects the call with
+		// "Invalid origin for state-changing request".
+		req.Header.Set("Origin", "https://cursor.com")
+		req.Header.Set("Referer", "https://cursor.com/dashboard?tab=usage")
+		req.AddCookie(&http.Cookie{Name: "WorkosCursorSessionToken", Value: c.Token})
+
+		resp, err := httpc.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		data, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("cursor dashboard auth failed (%d): session token expired or invalid", resp.StatusCode)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("cursor dashboard returned %d: %s", resp.StatusCode, truncate(string(data), 200))
+		}
+		var er eventsResponse
+		if err := json.Unmarshal(data, &er); err != nil {
+			return nil, fmt.Errorf("cursor dashboard response: %w", err)
+		}
+		all = append(all, er.UsageEventsDisplay...)
+		if len(er.UsageEventsDisplay) < pageSize {
+			break
+		}
+	}
+	return all, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/src/internal/cursorusage/client_test.go
+++ b/src/internal/cursorusage/client_test.go
@@ -1,0 +1,148 @@
+package cursorusage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Fixture mirrors live get-filtered-usage-events responses: protobuf-es
+// camelCase keys, stringified timestamps, costs in fractional cents on
+// chargedCents/totalCents and a "$x.xx" display string.
+const eventJSON = `{
+	"timestamp": "1765360800000",
+	"model": "claude-4.5-sonnet",
+	"kind": "USAGE_EVENT_KIND_USAGE_BASED",
+	"maxMode": false,
+	"requestsCosts": 30.4,
+	"usageBasedCosts": "$1.21",
+	"isTokenBasedCall": true,
+	"tokenUsage": {
+		"inputTokens": 3,
+		"outputTokens": 20525,
+		"cacheWriteTokens": 112151,
+		"cacheReadTokens": 0,
+		"totalCents": 121.41
+	},
+	"cursorTokenFee": 3.32,
+	"isChargeable": true,
+	"isHeadless": true,
+	"chargedCents": 124.73
+}`
+
+func TestFetchEvents(t *testing.T) {
+	var gotOrigin, gotCookie string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOrigin = r.Header.Get("Origin")
+		if c, err := r.Cookie("WorkosCursorSessionToken"); err == nil {
+			gotCookie = c.Value
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		fmt.Fprintf(w, `{"totalUsageEventsCount":1,"usageEventsDisplay":[%s]}`, eventJSON)
+	}))
+	defer srv.Close()
+
+	c := &Client{Token: "user_123%3A%3Ajwt", BaseURL: srv.URL}
+	events, err := c.FetchEvents(context.Background(), time.UnixMilli(1765357200000), time.UnixMilli(1765364400000))
+	if err != nil {
+		t.Fatalf("FetchEvents: %v", err)
+	}
+	if gotOrigin != "https://cursor.com" {
+		t.Errorf("Origin = %q, want https://cursor.com (API rejects other origins)", gotOrigin)
+	}
+	if gotCookie != "user_123%3A%3Ajwt" {
+		t.Errorf("cookie = %q, want token passed through", gotCookie)
+	}
+	if gotBody["teamId"] != float64(0) || gotBody["pageSize"] != float64(100) {
+		t.Errorf("body = %v, want teamId 0 and pageSize 100", gotBody)
+	}
+	if gotBody["startDate"] != "1765357200000" {
+		t.Errorf("startDate = %v, want stringified epoch ms", gotBody["startDate"])
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	ev := events[0]
+	if ev.Model != "claude-4.5-sonnet" || ev.Kind != "USAGE_EVENT_KIND_USAGE_BASED" {
+		t.Errorf("event = %+v", ev)
+	}
+	if ev.TokenUsage == nil || ev.TokenUsage.CacheWriteTokens != 112151 {
+		t.Errorf("tokenUsage = %+v, want cacheWriteTokens 112151", ev.TokenUsage)
+	}
+	if ev.IsHeadless == nil || !*ev.IsHeadless {
+		t.Errorf("isHeadless = %v, want true", ev.IsHeadless)
+	}
+	if got := ev.Time(); !got.Equal(time.UnixMilli(1765360800000)) {
+		t.Errorf("Time() = %v", got)
+	}
+}
+
+func TestFetchEventsPagination(t *testing.T) {
+	pages := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		pages++
+		n := pageSize
+		if body["page"] == float64(2) {
+			n = 3 // short page ends the walk
+		}
+		evs := make([]json.RawMessage, n)
+		for i := range evs {
+			evs[i] = json.RawMessage(eventJSON)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"totalUsageEventsCount": pageSize + 3,
+			"usageEventsDisplay":    evs,
+		})
+	}))
+	defer srv.Close()
+
+	c := &Client{Token: "t", BaseURL: srv.URL}
+	events, err := c.FetchEvents(context.Background(), time.Now().Add(-time.Hour), time.Now())
+	if err != nil {
+		t.Fatalf("FetchEvents: %v", err)
+	}
+	if pages != 2 || len(events) != pageSize+3 {
+		t.Errorf("pages = %d, events = %d; want 2 pages, %d events", pages, len(events), pageSize+3)
+	}
+}
+
+func TestFetchEventsAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := &Client{Token: "expired", BaseURL: srv.URL}
+	if _, err := c.FetchEvents(context.Background(), time.Now().Add(-time.Hour), time.Now()); err == nil {
+		t.Fatal("want auth error, got nil")
+	}
+}
+
+func TestCostUSD(t *testing.T) {
+	headless := true
+	cases := []struct {
+		name string
+		ev   UsageEvent
+		want float64
+	}{
+		{"chargedCents preferred", UsageEvent{Kind: "USAGE_EVENT_KIND_USAGE_BASED", ChargedCents: 124.73, TokenUsage: &TokenUsage{TotalCents: 121.41}, CursorTokenFee: 3.32, IsHeadless: &headless}, 1.2473},
+		{"totalCents plus fee fallback", UsageEvent{Kind: "USAGE_EVENT_KIND_USAGE_BASED", TokenUsage: &TokenUsage{TotalCents: 121.41}, CursorTokenFee: 3.32}, 1.2473},
+		{"display string fallback", UsageEvent{Kind: "USAGE_EVENT_KIND_USAGE_BASED", UsageBasedCosts: "$1.21"}, 1.21},
+		{"dash display is free", UsageEvent{Kind: "USAGE_EVENT_KIND_INCLUDED_IN_PRO", UsageBasedCosts: "-"}, 0},
+		{"errored never charged", UsageEvent{Kind: "USAGE_EVENT_KIND_ERRORED_NOT_CHARGED", ChargedCents: 50}, 0},
+		{"aborted never charged", UsageEvent{Kind: "USAGE_EVENT_KIND_ABORTED_NOT_CHARGED", UsageBasedCosts: "$0.50"}, 0},
+	}
+	for _, tc := range cases {
+		if got := tc.ev.CostUSD(); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("%s: CostUSD = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/src/internal/cursorusage/match.go
+++ b/src/internal/cursorusage/match.go
@@ -1,0 +1,73 @@
+package cursorusage
+
+import "time"
+
+// RunWindow is the wall-clock span of one finished run (one task_executions
+// row) awaiting cost attribution.
+type RunWindow struct {
+	ID    int64
+	Start time.Time
+	End   time.Time
+}
+
+// Attribution is the outcome of matching events to one run.
+type Attribution struct {
+	// CostUSD is the summed billed cost of all events attributed to the run.
+	CostUSD float64
+	// Events is how many events were attributed (including $0 not-charged ones).
+	Events int
+	// InputTokens/OutputTokens sum the attributed events' token counts so the
+	// caller can sanity-check against the run's own token totals.
+	InputTokens  int
+	OutputTokens int
+	// Ambiguous counts events that fell inside this run's window but also inside
+	// another candidate's. They are attributed to no one, so when Ambiguous > 0
+	// CostUSD is a lower bound.
+	Ambiguous int
+}
+
+// Attribute assigns usage events to runs by timestamp containment. An event
+// belongs to a run when its timestamp falls within [Start-skew, End+skew].
+// Events that match no run are dropped (other activity on the account); events
+// that match more than one run are counted as ambiguous on every candidate and
+// attributed to none — wrongly attributing money is worse than undercounting.
+// Events explicitly marked as interactive IDE usage (isHeadless == false) are
+// ignored; events without the flag (older schema) are kept.
+func Attribute(events []UsageEvent, runs []RunWindow, skew time.Duration) map[int64]*Attribution {
+	out := make(map[int64]*Attribution, len(runs))
+	for _, r := range runs {
+		out[r.ID] = &Attribution{}
+	}
+	for _, ev := range events {
+		if ev.IsHeadless != nil && !*ev.IsHeadless {
+			continue
+		}
+		t := ev.Time()
+		if t.IsZero() {
+			continue
+		}
+		var hits []int64
+		for _, r := range runs {
+			if !t.Before(r.Start.Add(-skew)) && !t.After(r.End.Add(skew)) {
+				hits = append(hits, r.ID)
+			}
+		}
+		switch len(hits) {
+		case 0:
+			continue
+		case 1:
+			a := out[hits[0]]
+			a.Events++
+			a.CostUSD += ev.CostUSD()
+			if ev.TokenUsage != nil {
+				a.InputTokens += ev.TokenUsage.InputTokens + ev.TokenUsage.CacheWriteTokens + ev.TokenUsage.CacheReadTokens
+				a.OutputTokens += ev.TokenUsage.OutputTokens
+			}
+		default:
+			for _, id := range hits {
+				out[id].Ambiguous++
+			}
+		}
+	}
+	return out
+}

--- a/src/internal/cursorusage/match_test.go
+++ b/src/internal/cursorusage/match_test.go
@@ -1,0 +1,93 @@
+package cursorusage
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func ts(t time.Time) string { return strconv.FormatInt(t.UnixMilli(), 10) }
+
+func chargedEvent(at time.Time, cents float64) UsageEvent {
+	return UsageEvent{
+		Timestamp:    ts(at),
+		Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+		ChargedCents: cents,
+		TokenUsage:   &TokenUsage{InputTokens: 10, OutputTokens: 5},
+	}
+}
+
+func TestAttributeSingleRun(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	run := RunWindow{ID: 1, Start: base, End: base.Add(10 * time.Minute)}
+
+	events := []UsageEvent{
+		chargedEvent(base.Add(time.Minute), 100),      // inside
+		chargedEvent(base.Add(5*time.Minute), 50),     // inside
+		chargedEvent(base.Add(11*time.Minute), 25),    // inside via skew
+		chargedEvent(base.Add(30*time.Minute), 99999), // outside: dropped
+	}
+
+	got := Attribute(events, []RunWindow{run}, 2*time.Minute)
+	a := got[1]
+	if a.Events != 3 || a.Ambiguous != 0 {
+		t.Fatalf("attribution = %+v, want 3 events, 0 ambiguous", a)
+	}
+	if a.CostUSD != 1.75 {
+		t.Errorf("CostUSD = %v, want 1.75", a.CostUSD)
+	}
+	if a.InputTokens != 30 || a.OutputTokens != 15 {
+		t.Errorf("tokens = %d/%d, want 30/15", a.InputTokens, a.OutputTokens)
+	}
+}
+
+func TestAttributeOverlapIsAmbiguous(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	runs := []RunWindow{
+		{ID: 1, Start: base, End: base.Add(10 * time.Minute)},
+		{ID: 2, Start: base.Add(5 * time.Minute), End: base.Add(15 * time.Minute)},
+	}
+	events := []UsageEvent{
+		chargedEvent(base.Add(2*time.Minute), 100),  // only run 1
+		chargedEvent(base.Add(7*time.Minute), 200),  // overlap: ambiguous
+		chargedEvent(base.Add(14*time.Minute), 300), // only run 2
+	}
+
+	got := Attribute(events, runs, 0)
+	if got[1].Events != 1 || got[1].CostUSD != 1.00 || got[1].Ambiguous != 1 {
+		t.Errorf("run 1 = %+v, want 1 event $1.00 with 1 ambiguous", got[1])
+	}
+	if got[2].Events != 1 || got[2].CostUSD != 3.00 || got[2].Ambiguous != 1 {
+		t.Errorf("run 2 = %+v, want 1 event $3.00 with 1 ambiguous", got[2])
+	}
+}
+
+func TestAttributeSkipsInteractiveEvents(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	run := RunWindow{ID: 1, Start: base, End: base.Add(10 * time.Minute)}
+
+	headless, ide := true, false
+	evHeadless := chargedEvent(base.Add(time.Minute), 100)
+	evHeadless.IsHeadless = &headless
+	evIDE := chargedEvent(base.Add(2*time.Minute), 500)
+	evIDE.IsHeadless = &ide
+	evLegacy := chargedEvent(base.Add(3*time.Minute), 50) // no flag: kept
+
+	got := Attribute([]UsageEvent{evHeadless, evIDE, evLegacy}, []RunWindow{run}, 0)
+	a := got[1]
+	if a.Events != 2 || a.CostUSD != 1.50 {
+		t.Errorf("attribution = %+v, want IDE event excluded (2 events, $1.50)", a)
+	}
+}
+
+func TestAttributeIgnoresGarbageTimestamps(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	run := RunWindow{ID: 1, Start: base, End: base.Add(10 * time.Minute)}
+	ev := chargedEvent(base.Add(time.Minute), 100)
+	ev.Timestamp = "not-a-number"
+
+	got := Attribute([]UsageEvent{ev}, []RunWindow{run}, 0)
+	if got[1].Events != 0 {
+		t.Errorf("attribution = %+v, want garbage timestamp dropped", got[1])
+	}
+}

--- a/src/internal/daemon/cursor_cost.go
+++ b/src/internal/daemon/cursor_cost.go
@@ -1,0 +1,149 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/cursorusage"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+// cursorCostRunner is the runner type whose executions need a cost back-fill:
+// the Cursor agent CLI streams token counts but no dollar cost.
+const cursorCostRunner = "cursor-cli"
+
+// cursorCostSkew widens each run's [started_at, completed_at] window when
+// matching dashboard events, absorbing clock drift between the local machine
+// and Cursor's billing timestamps.
+const cursorCostSkew = 2 * time.Minute
+
+// cursorCostMaxAttempts caps how many sweeps may retry one execution before it
+// is abandoned (events never appeared, or stay ambiguous). In-memory: a daemon
+// restart re-arms abandoned rows, which is harmless — the sweep is idempotent
+// and bounded by settings.cursor_cost.max_age.
+const cursorCostMaxAttempts = 10
+
+// cursorEventFetcher is the slice of cursorusage.Client the sweep needs;
+// narrowed for tests.
+type cursorEventFetcher interface {
+	FetchEvents(ctx context.Context, start, end time.Time) ([]cursorusage.UsageEvent, error)
+}
+
+// cursorCostLoop periodically back-fills cost_usd on finished cursor-cli
+// executions from Cursor's dashboard usage API. Runs once at startup and then
+// every settings.cursor_cost.interval until ctx is cancelled.
+func (d *Dispatcher) cursorCostLoop(ctx context.Context) {
+	cc := d.cfg.Settings.CursorCost
+	token := cc.SessionToken
+	if token == "" {
+		token = os.Getenv("CURSOR_SESSION_TOKEN")
+	}
+	if token == "" {
+		aplog.Warn("cursor_cost enabled but no session token (settings.cursor_cost.session_token or CURSOR_SESSION_TOKEN); back-fill disabled")
+		return
+	}
+	client := &cursorusage.Client{Token: token}
+	attempts := make(map[int64]int)
+
+	sweep := func() {
+		if err := d.backfillCursorCosts(ctx, client, attempts); err != nil {
+			aplog.Warn("cursor cost back-fill: %v", err)
+		}
+	}
+	sweep()
+
+	ticker := time.NewTicker(cc.IntervalDuration())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}
+
+// backfillCursorCosts runs one sweep: list unpriced cursor-cli executions,
+// fetch the dashboard events spanning their windows in one call, attribute
+// events to runs by time window, and write back the resolved costs. attempts
+// tracks per-execution retries across sweeps so rows whose events never
+// resolve are eventually abandoned.
+func (d *Dispatcher) backfillCursorCosts(ctx context.Context, fetcher cursorEventFetcher, attempts map[int64]int) error {
+	since := time.Now().Add(-d.cfg.Settings.CursorCost.MaxAgeDuration())
+	rows, err := d.db.ListUnpricedExecutions(ctx, cursorCostRunner, since)
+	if err != nil {
+		return err
+	}
+	// Drop rows that exhausted their retries; forget attempt counts for rows
+	// that no longer come back (resolved or aged out).
+	live := make(map[int64]bool, len(rows))
+	pending := rows[:0]
+	for _, r := range rows {
+		live[r.ID] = true
+		if attempts[r.ID] >= cursorCostMaxAttempts {
+			continue
+		}
+		pending = append(pending, r)
+	}
+	for id := range attempts {
+		if !live[id] {
+			delete(attempts, id)
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+
+	windows := make([]cursorusage.RunWindow, 0, len(pending))
+	first, last := pending[0].StartedAt, pending[0].CompletedAt
+	for _, r := range pending {
+		attempts[r.ID]++
+		windows = append(windows, cursorusage.RunWindow{ID: r.ID, Start: r.StartedAt, End: r.CompletedAt})
+		if r.StartedAt.Before(first) {
+			first = r.StartedAt
+		}
+		if r.CompletedAt.After(last) {
+			last = r.CompletedAt
+		}
+	}
+
+	events, err := fetcher.FetchEvents(ctx, first.Add(-cursorCostSkew), last.Add(cursorCostSkew))
+	if err != nil {
+		return err
+	}
+
+	attributed := cursorusage.Attribute(events, windows, cursorCostSkew)
+	for _, r := range pending {
+		a := attributed[r.ID]
+		if a == nil || a.Events == 0 {
+			if a != nil && a.Ambiguous > 0 {
+				aplog.Warn("cursor cost: execution %d overlaps another cursor run; %d event(s) ambiguous, cost not attributed", r.ID, a.Ambiguous)
+			}
+			continue
+		}
+		if a.Ambiguous > 0 {
+			aplog.Warn("cursor cost: execution %d has %d ambiguous event(s) from overlapping runs; recorded $%.4f is a lower bound", r.ID, a.Ambiguous, a.CostUSD)
+		}
+		matched := a.InputTokens + a.OutputTokens
+		if matched > 0 && r.TotalTokens > 0 && (matched > r.TotalTokens*3 || matched*3 < r.TotalTokens) {
+			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; window match may be off", r.ID, matched, r.TotalTokens)
+		}
+		if a.CostUSD <= 0 {
+			// All matched events were not charged (errored/included). Leave the row
+			// at 0; retries are capped by attempts.
+			continue
+		}
+		if err := d.db.SetExecutionCost(ctx, r.ID, a.CostUSD); err != nil {
+			aplog.Warn("cursor cost: update execution %d: %v", r.ID, err)
+			continue
+		}
+		if err := d.db.RefreshStepRunCost(ctx, r.WorkflowInstanceID, r.StepID); err != nil {
+			aplog.Warn("cursor cost: refresh step run for execution %d: %v", r.ID, err)
+		}
+		delete(attempts, r.ID)
+		aplog.Info("cursor cost: execution %d back-filled $%.4f from %d usage event(s)", r.ID, a.CostUSD, a.Events)
+	}
+	return nil
+}

--- a/src/internal/daemon/cursor_cost_test.go
+++ b/src/internal/daemon/cursor_cost_test.go
@@ -1,0 +1,194 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/cursorusage"
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+type fakeFetcher struct {
+	events []cursorusage.UsageEvent
+	calls  int
+}
+
+func (f *fakeFetcher) FetchEvents(ctx context.Context, start, end time.Time) ([]cursorusage.UsageEvent, error) {
+	f.calls++
+	return f.events, nil
+}
+
+// insertCursorExec creates a finished cursor-cli execution. Its window starts
+// at CreateExecution time (now) and ends at end; tests place events relative
+// to start.
+func insertCursorExec(t *testing.T, dbc *db.Client, ctx context.Context, instance, step string, end time.Time) (int64, time.Time) {
+	t.Helper()
+	exec, err := dbc.CreateExecution(ctx, "42", "engineer", "title", "42", "", "composer-2", "cursor-cli", 1)
+	if err != nil {
+		t.Fatalf("create execution: %v", err)
+	}
+	exec.Status = "success"
+	exec.CompletedAt = &end
+	exec.TotalTokens = 1000
+	if err := dbc.UpdateExecution(ctx, exec); err != nil {
+		t.Fatalf("finish execution: %v", err)
+	}
+	if instance != "" {
+		if err := dbc.SetStepLink(ctx, exec.ID, instance, step); err != nil {
+			t.Fatalf("set step link: %v", err)
+		}
+	}
+	return exec.ID, *exec.StartedAt
+}
+
+func execCost(t *testing.T, dbc *db.Client, ctx context.Context, id int64) float64 {
+	t.Helper()
+	execs, err := dbc.ListUnpricedExecutions(ctx, "cursor-cli", time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, e := range execs {
+		if e.ID == id {
+			return 0 // still unpriced
+		}
+	}
+	// Priced (or filtered out): read the rollup through GetStepUsage-free path —
+	// use ListUnpricedExecutions absence as "non-zero" signal plus exact value
+	// via the dashboard usage helper below.
+	usage, err := dbc.GetInstanceStepUsage(ctx, "wf_1")
+	if err != nil {
+		t.Fatalf("instance usage: %v", err)
+	}
+	if u, ok := usage["implement"]; ok {
+		return u.CostUSD
+	}
+	return -1
+}
+
+func TestBackfillCursorCosts(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer dbc.Close()
+
+	execID, start := insertCursorExec(t, dbc, ctx, "wf_1", "implement", time.Now().Add(10*time.Minute))
+	sr := &db.StepRun{ID: "sr_1", WorkflowInstanceID: "wf_1", StepID: "implement", State: "passed"}
+	if err := dbc.CreateStepRun(ctx, sr); err != nil {
+		t.Fatalf("create step_run: %v", err)
+	}
+
+	fetcher := &fakeFetcher{events: []cursorusage.UsageEvent{
+		{
+			Timestamp:    strconv.FormatInt(start.Add(2*time.Minute).UnixMilli(), 10),
+			Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+			ChargedCents: 124.73,
+			TokenUsage:   &cursorusage.TokenUsage{InputTokens: 800, OutputTokens: 200},
+		},
+		{
+			Timestamp:    strconv.FormatInt(start.Add(40*time.Minute).UnixMilli(), 10),
+			Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+			ChargedCents: 99999, // outside the run window: unrelated activity
+		},
+	}}
+
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	attempts := make(map[int64]int)
+	if err := d.backfillCursorCosts(ctx, fetcher, attempts); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	if got := execCost(t, dbc, ctx, execID); got != 1.2473 {
+		t.Errorf("execution cost = %v, want 1.2473", got)
+	}
+	srs, err := dbc.ListStepRuns(ctx, "wf_1")
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if len(srs) != 1 || srs[0].CostUSD != 1.2473 {
+		t.Errorf("step_run cost = %+v, want 1.2473 (refreshed from executions)", srs)
+	}
+
+	// Resolved rows must not be re-fetched on the next sweep.
+	if err := d.backfillCursorCosts(ctx, fetcher, attempts); err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if fetcher.calls != 1 {
+		t.Errorf("fetcher calls = %d, want 1 (nothing pending after back-fill)", fetcher.calls)
+	}
+	if len(attempts) != 0 {
+		t.Errorf("attempts map = %v, want empty after resolution", attempts)
+	}
+}
+
+func TestBackfillCursorCostsGivesUpAfterMaxAttempts(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer dbc.Close()
+
+	insertCursorExec(t, dbc, ctx, "", "", time.Now().Add(10*time.Minute))
+
+	// No events ever match (e.g. billing data never appeared).
+	fetcher := &fakeFetcher{}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	attempts := make(map[int64]int)
+	for i := 0; i < cursorCostMaxAttempts; i++ {
+		if err := d.backfillCursorCosts(ctx, fetcher, attempts); err != nil {
+			t.Fatalf("sweep %d: %v", i, err)
+		}
+	}
+	if fetcher.calls != cursorCostMaxAttempts {
+		t.Fatalf("fetcher calls = %d, want %d", fetcher.calls, cursorCostMaxAttempts)
+	}
+	// The row exhausted its retries: further sweeps must skip the fetch.
+	if err := d.backfillCursorCosts(ctx, fetcher, attempts); err != nil {
+		t.Fatalf("post-exhaustion sweep: %v", err)
+	}
+	if fetcher.calls != cursorCostMaxAttempts {
+		t.Errorf("fetcher calls = %d after exhaustion, want unchanged %d", fetcher.calls, cursorCostMaxAttempts)
+	}
+}
+
+func TestBackfillCursorCostsOverlapStaysUnpriced(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer dbc.Close()
+
+	// Two runs with overlapping windows.
+	idA, startA := insertCursorExec(t, dbc, ctx, "", "", time.Now().Add(10*time.Minute))
+	idB, _ := insertCursorExec(t, dbc, ctx, "", "", time.Now().Add(15*time.Minute))
+
+	// The only event falls in both windows: must not be attributed to either.
+	fetcher := &fakeFetcher{events: []cursorusage.UsageEvent{{
+		Timestamp:    strconv.FormatInt(startA.Add(7*time.Minute).UnixMilli(), 10),
+		Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+		ChargedCents: 100,
+	}}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	if err := d.backfillCursorCosts(ctx, fetcher, make(map[int64]int)); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	rows, err := dbc.ListUnpricedExecutions(ctx, "cursor-cli", time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := map[int64]bool{}
+	for _, r := range rows {
+		got[r.ID] = true
+	}
+	if !got[idA] || !got[idB] {
+		t.Errorf("unpriced rows = %v, want both %d and %d still unpriced (ambiguous event)", got, idA, idB)
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -387,6 +387,17 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		}()
 	}
 
+	// Back-fill cost_usd on finished cursor-cli executions from Cursor's
+	// dashboard usage API (settings.cursor_cost), at startup and then every
+	// sweep interval. The Cursor agent CLI streams token counts but no cost.
+	if d.db != nil && d.cfg.Settings.CursorCost.Enabled {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.cursorCostLoop(ctx)
+		}()
+	}
+
 	for _, sc := range d.cfg.Sources {
 		sc := sc
 		adapter, ok := d.sources[sc.ID]

--- a/src/internal/db/cursor_cost.go
+++ b/src/internal/db/cursor_cost.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"time"
+)
+
+// UnpricedExecution is a finished execution awaiting a cost back-fill: it ran
+// on a runner that does not report cost (cursor-cli), consumed tokens, and has
+// cost_usd = 0.
+type UnpricedExecution struct {
+	ID                 int64
+	StartedAt          time.Time
+	CompletedAt        time.Time
+	TotalTokens        int
+	WorkflowInstanceID string
+	StepID             string
+}
+
+// ListUnpricedExecutions returns terminal executions of the given runner with
+// zero cost and non-zero token usage, completed since the given time. Ordered
+// oldest-first so back-fill progress is stable across sweeps.
+func (c *Client) ListUnpricedExecutions(ctx context.Context, runner string, since time.Time) ([]UnpricedExecution, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, started_at, completed_at, total_tokens,
+		       COALESCE(workflow_instance_id, ''), COALESCE(step_id, '')
+		FROM task_executions
+		WHERE runner = ? AND status != 'running' AND cost_usd = 0
+		  AND total_tokens > 0
+		  AND started_at IS NOT NULL AND completed_at IS NOT NULL
+		  AND completed_at >= ?
+		ORDER BY completed_at ASC
+	`, runner, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []UnpricedExecution
+	for rows.Next() {
+		var u UnpricedExecution
+		if err := rows.Scan(&u.ID, &u.StartedAt, &u.CompletedAt, &u.TotalTokens, &u.WorkflowInstanceID, &u.StepID); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// SetExecutionCost back-fills cost_usd on one execution without touching any
+// other column (the row may be re-read concurrently by dashboards).
+func (c *Client) SetExecutionCost(ctx context.Context, execID int64, costUSD float64) error {
+	_, err := c.db.ExecContext(ctx, `
+		UPDATE task_executions SET cost_usd = ? WHERE id = ?
+	`, costUSD, execID)
+	return err
+}
+
+// RefreshStepRunCost re-derives a step run's cost_usd as the sum of its linked
+// executions (a step may have several attempts via failover), so instance
+// detail views stay consistent after an execution-level cost back-fill.
+func (c *Client) RefreshStepRunCost(ctx context.Context, instanceID, stepID string) error {
+	if instanceID == "" || stepID == "" {
+		return nil
+	}
+	_, err := c.db.ExecContext(ctx, `
+		UPDATE step_runs
+		SET cost_usd = (
+			SELECT COALESCE(SUM(cost_usd), 0) FROM task_executions
+			WHERE workflow_instance_id = ? AND step_id = ?
+		)
+		WHERE workflow_instance_id = ? AND step_id = ?
+	`, instanceID, stepID, instanceID, stepID)
+	return err
+}

--- a/src/internal/db/cursor_cost_test.go
+++ b/src/internal/db/cursor_cost_test.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestListUnpricedExecutions(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	ins := func(runner, status string, total int, cost float64, completed any) int64 {
+		t.Helper()
+		res, err := c.db.ExecContext(ctx, `
+			INSERT INTO task_executions
+			  (task_id, agent_id, workflow_instance_id, step_id, runner, status,
+			   total_tokens, cost_usd, started_at, completed_at, created_at)
+			VALUES ('42', 'engineer', 'wf_1', 'implement', ?, ?, ?, ?, ?, ?, ?)`,
+			runner, status, total, cost, base, completed, base)
+		if err != nil {
+			t.Fatalf("insert exec: %v", err)
+		}
+		id, _ := res.LastInsertId()
+		return id
+	}
+
+	want := ins("cursor-cli", "success", 1000, 0, base.Add(5*time.Minute))
+	ins("cursor-cli", "failed", 500, 0, base.Add(6*time.Minute)) // failed still billed
+	ins("cursor-cli", "running", 100, 0, nil)                    // in flight: skip
+	ins("cursor-cli", "success", 0, 0, base.Add(5*time.Minute))  // no tokens: skip
+	ins("cursor-cli", "success", 900, 0.5, base.Add(5*time.Minute))
+	ins("claude-cli", "success", 900, 0, base.Add(5*time.Minute))
+	ins("cursor-cli", "success", 800, 0, base.Add(-100*time.Hour)) // too old
+
+	rows, err := c.ListUnpricedExecutions(ctx, "cursor-cli", base.Add(-72*time.Hour))
+	if err != nil {
+		t.Fatalf("ListUnpricedExecutions: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2 (success + failed unpriced cursor rows)", len(rows))
+	}
+	if rows[0].ID != want {
+		t.Errorf("rows[0].ID = %d, want %d (oldest completed first)", rows[0].ID, want)
+	}
+	if rows[0].TotalTokens != 1000 || rows[0].WorkflowInstanceID != "wf_1" || rows[0].StepID != "implement" {
+		t.Errorf("row = %+v", rows[0])
+	}
+	if rows[0].StartedAt.IsZero() || rows[0].CompletedAt.IsZero() {
+		t.Errorf("timestamps not scanned: %+v", rows[0])
+	}
+}
+
+func TestSetExecutionCostAndRefreshStepRun(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	res, err := c.db.ExecContext(ctx, `
+		INSERT INTO task_executions
+		  (task_id, agent_id, workflow_instance_id, step_id, runner, status,
+		   total_tokens, cost_usd, started_at, completed_at, created_at)
+		VALUES ('42', 'engineer', 'wf_1', 'implement', 'cursor-cli', 'success',
+		   1000, 0, ?, ?, ?)`, base, base.Add(5*time.Minute), base)
+	if err != nil {
+		t.Fatalf("insert exec: %v", err)
+	}
+	execID, _ := res.LastInsertId()
+	// A second attempt on the same step already carries cost (failover mix).
+	_, err = c.db.ExecContext(ctx, `
+		INSERT INTO task_executions
+		  (task_id, agent_id, workflow_instance_id, step_id, runner, status,
+		   total_tokens, cost_usd, started_at, completed_at, created_at)
+		VALUES ('42', 'engineer', 'wf_1', 'implement', 'claude-cli', 'success',
+		   500, 0.30, ?, ?, ?)`, base, base.Add(8*time.Minute), base)
+	if err != nil {
+		t.Fatalf("insert exec 2: %v", err)
+	}
+	_, err = c.db.ExecContext(ctx, `
+		INSERT INTO step_runs (id, workflow_instance_id, step_id, state, cost_usd, started_at)
+		VALUES ('sr_1', 'wf_1', 'implement', 'passed', 0.30, ?)`, base)
+	if err != nil {
+		t.Fatalf("insert step_run: %v", err)
+	}
+
+	if err := c.SetExecutionCost(ctx, execID, 1.25); err != nil {
+		t.Fatalf("SetExecutionCost: %v", err)
+	}
+	var cost float64
+	var status string
+	if err := c.db.QueryRowContext(ctx, `SELECT cost_usd, status FROM task_executions WHERE id = ?`, execID).Scan(&cost, &status); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if cost != 1.25 || status != "success" {
+		t.Errorf("execution = $%v/%s, want $1.25 with status untouched", cost, status)
+	}
+
+	if err := c.RefreshStepRunCost(ctx, "wf_1", "implement"); err != nil {
+		t.Fatalf("RefreshStepRunCost: %v", err)
+	}
+	var srCost float64
+	if err := c.db.QueryRowContext(ctx, `SELECT cost_usd FROM step_runs WHERE id = 'sr_1'`).Scan(&srCost); err != nil {
+		t.Fatalf("read step_run: %v", err)
+	}
+	if srCost != 1.55 {
+		t.Errorf("step_run cost = %v, want 1.55 (sum of both attempts)", srCost)
+	}
+
+	// Legacy executions without a step link must be a no-op, not an error.
+	if err := c.RefreshStepRunCost(ctx, "", ""); err != nil {
+		t.Fatalf("RefreshStepRunCost empty link: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- The Cursor agent CLI streams token counts but no dollar cost in its `stream-json` output, so `cursor-cli` executions always recorded `cost_usd = 0`. On usage-based Cursor plans the billed amounts are recoverable from the same private endpoint the cursor.com dashboard usage tab uses (`POST /api/dashboard/get-filtered-usage-events`, `WorkosCursorSessionToken` cookie auth).
- New package `internal/cursorusage`: API client (pagination, mandatory `Origin` header, cents→USD with `chargedCents` → `totalCents + fee` → display-string fallbacks, `*_NOT_CHARGED` kinds always $0) and a time-window attribution matcher.
- New opt-in `settings.cursor_cost` block (`enabled`, `session_token`, `interval` default 5m, `max_age` default 72h). Token falls back to the `CURSOR_SESSION_TOKEN` env var (auto-loaded from `.env` beside `apiary.yaml`).
- Daemon sweep loop (startup + every interval, same pattern as `pruneLogsLoop`): lists terminal `cursor-cli` executions with zero cost and non-zero tokens, fetches events spanning their windows in one call, attributes each event to the single run whose `started_at..completed_at` window (±2min skew) contains its timestamp, then back-fills `task_executions.cost_usd` and re-derives the linked `step_runs` rollup. No schema migration — `cost_usd` columns already exist.
- Correctness over coverage: events flagged `isHeadless: false` (interactive IDE usage) are ignored; an event inside two overlapping run windows is attributed to **neither** (lower-bound cost + logged warning); rows that never resolve are abandoned after 10 sweeps; token totals of attributed events are sanity-checked against the run's own counts.
- Best-effort by design: the endpoint is undocumented, so auth expiry or schema drift degrade to costs simply not back-filling (warning logged, daemon unaffected).
- Docs: `settings.cursor_cost` reference + token how-to in configuration.md, note in runners.md cursor section, schema/apiary.json mirror, commented block in `.apiary/example-apiary-full.yaml`.

## Test plan
- `go test ./...` green (new: client fixture/pagination/auth-error tests, attribution matcher tests incl. overlap ambiguity and `isHeadless` filtering, DB list/set/refresh tests, daemon sweep tests incl. retry exhaustion and overlap no-attribution).
- `apiary validate` passes on both example configs with the new block.
- Live E2E pending: requires a real `WorkosCursorSessionToken` (usage-based plan) — will be validated on the live daemon after merge.