### PR TITLE
fix(daemon): cursor cost back-fill on team accounts; drop unreliable isHeadless filter

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -475,6 +475,8 @@ settings:
     # session_token: ${CURSOR_SESSION_TOKEN}  # default: CURSOR_SESSION_TOKEN env var
     # interval: 5m                   # sweep cadence
     # max_age: 72h                   # how far back to back-fill
+    # team_id: 0                     # REQUIRED for team-billed accounts (authInfo.teamId in ~/.cursor/cli-config.json)
+    # user_id: 0                     # filter to your own events on team accounts (authInfo.userId)
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,32 +258,50 @@ settings:
 | Field | Default | Description |
 |---|---|---|
 | `enabled` | `false` | Enable the back-fill sweep (runs at startup, then every `interval`) |
-| `session_token` | — | `WorkosCursorSessionToken` cookie from a logged-in cursor.com browser session; empty falls back to the `CURSOR_SESSION_TOKEN` env var |
+| `session_token` | — | `WorkosCursorSessionToken` cookie value; empty falls back to the `CURSOR_SESSION_TOKEN` env var |
 | `interval` | `5m` | Time between sweeps (minimum `1m`) |
 | `max_age` | `72h` | Unpriced executions older than this are left alone |
+| `team_id` | `0` | **Required for team-billed accounts** (the usual per-usage setup) — without it the API returns no events. `0` = personal account |
+| `user_id` | `0` | On team accounts, filter to your own events so teammates' activity cannot pollute attribution. Strongly recommended with `team_id` |
 
-To get the token: log into [cursor.com/dashboard](https://cursor.com/dashboard),
-open DevTools (F12) → Application → Cookies → `https://cursor.com`, and copy
-the `WorkosCursorSessionToken` value into your `.env`:
+#### Getting the token
+
+The easiest source is the machine where the Cursor CLI is logged in — the
+CLI keeps a long-lived session token in the OS keychain, and its account ids
+in `~/.cursor/cli-config.json`:
 
 ```bash
-CURSOR_SESSION_TOKEN=user_XXXX%3A%3AeyJhbGci...
+# macOS — build the cookie value from the CLI's stored session
+TOKEN=$(security find-generic-password -s cursor-access-token -w)
+AUTH_ID=$(python3 -c "import json;print(json.load(open('$HOME/.cursor/cli-config.json'))['authInfo']['authId'].split('|')[1])")
+echo "CURSOR_SESSION_TOKEN=${AUTH_ID}%3A%3A${TOKEN}" >> .env
+
+# team_id / user_id for apiary.yaml:
+python3 -c "import json;a=json.load(open('$HOME/.cursor/cli-config.json'))['authInfo'];print('team_id:',a.get('teamId',0));print('user_id:',a.get('userId',0))"
 ```
 
-The token is valid for about 60 days; when it expires the sweep logs an auth
-warning and the daemon keeps running (costs simply stop back-filling until
-you refresh it).
+Browser alternative: log into [cursor.com/dashboard](https://cursor.com/dashboard)
+**with the same account the CLI uses**, open DevTools (F12) → Application →
+Cookies → `https://cursor.com`, and copy the `WorkosCursorSessionToken` value.
+(The cookie is HttpOnly — a console `document.cookie` snippet cannot read it.)
+Browser cookies last ~60 days; when one expires the sweep logs an auth warning
+and the daemon keeps running (costs simply stop back-filling until refreshed).
 
 How it works, and the fine print:
 
 - Cursor's usage events carry no session or request id, so each event is
   attributed to the one run whose `[started_at, completed_at]` window (±2min
-  skew) contains its timestamp. Events explicitly marked as interactive IDE
-  usage (`isHeadless: false`) are ignored.
+  skew) contains its timestamp.
 - **Overlapping concurrent cursor runs**: an event that falls inside two run
   windows is attributed to *neither* (wrongly attributing money is worse than
   undercounting). The affected runs keep a lower-bound cost and a warning is
   logged. Runs that never resolve are abandoned after 10 sweeps.
+- **Interactive IDE usage is indistinguishable from CLI runs** (Cursor's
+  `isHeadless` flag is `false` for both — verified live), so if you actively
+  use the Cursor IDE on the same account while a run executes, its events can
+  land inside the run's window. The sweep cross-checks the attributed events'
+  token totals against the run's own counts and refuses to record a cost when
+  they exceed them by more than 50%.
 - The endpoint is **undocumented** and may change without notice — the whole
   feature is best-effort and degrades to "no cost recorded" on any failure.
 - Plan-included requests (`INCLUDED_IN_PRO` etc.) and errored/aborted requests

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -512,6 +512,16 @@
               "type": "string",
               "description": "How far back unpriced executions are considered, as a Go duration",
               "default": "72h"
+            },
+            "team_id": {
+              "type": "integer",
+              "description": "Cursor team id when the account bills through a team (the usual per-usage setup) — without it the API returns no events. 0 means a personal account. Find it in ~/.cursor/cli-config.json under authInfo.teamId",
+              "default": 0
+            },
+            "user_id": {
+              "type": "integer",
+              "description": "Filter team queries to this member's events so teammates' activity cannot pollute attribution. Strongly recommended whenever team_id is set (authInfo.userId in the same file)",
+              "default": 0
             }
           }
         }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -245,6 +245,15 @@ type CursorCostSettings struct {
 	// MaxAge is how far back unpriced executions are considered (duration
 	// string). Default "72h".
 	MaxAge string `yaml:"max_age"`
+	// TeamID scopes the dashboard query to a team account. Required when the
+	// Cursor account bills through a team (the usual per-usage setup) — without
+	// it the API silently returns no events. 0 means a personal account. Find it
+	// in ~/.cursor/cli-config.json under authInfo.teamId.
+	TeamID int `yaml:"team_id"`
+	// UserID filters team queries to this member's events so teammates'
+	// activity cannot pollute time-window attribution. Strongly recommended
+	// whenever TeamID is set (authInfo.userId in the same file). 0 omits it.
+	UserID int `yaml:"user_id"`
 }
 
 // IntervalDuration returns the parsed sweep interval (default 5m, floor 1m).

--- a/src/internal/cursorusage/client.go
+++ b/src/internal/cursorusage/client.go
@@ -36,6 +36,13 @@ type Client struct {
 	Token   string
 	BaseURL string
 	HTTP    *http.Client
+	// TeamID scopes the query to a team account. Personal accounts use 0.
+	// Accounts whose usage is billed through a team (the common per-usage
+	// setup) MUST pass their team id or the API returns no events.
+	TeamID int
+	// UserID filters team queries to one member's events, so teammates'
+	// activity does not pollute time-window attribution. Omitted when 0.
+	UserID int
 }
 
 // TokenUsage is the per-event token breakdown. Field names mirror the API's
@@ -65,9 +72,10 @@ type UsageEvent struct {
 	// CursorTokenFee is Cursor's markup in fractional cents.
 	CursorTokenFee float64 `json:"cursorTokenFee"`
 	IsChargeable   bool    `json:"isChargeable"`
-	// IsHeadless is true for headless/background-agent calls (the cursor-agent
-	// CLI). A pointer so that older events that predate the field are
-	// distinguishable from an explicit false (interactive IDE usage).
+	// IsHeadless marks Cursor's hosted background-agent product. Verified live:
+	// cursor-agent CLI runs report false, same as interactive IDE usage, so this
+	// CANNOT distinguish apiary runs from IDE activity and is kept for
+	// observability only.
 	IsHeadless *bool `json:"isHeadless"`
 	// ChargedCents is the amount actually billed in fractional cents
 	// (≈ TokenUsage.TotalCents + CursorTokenFee). Newer schema; may be absent.
@@ -106,6 +114,7 @@ func (e UsageEvent) CostUSD() float64 {
 
 type eventsRequest struct {
 	TeamID    int    `json:"teamId"`
+	UserID    int    `json:"userId,omitempty"`
 	StartDate string `json:"startDate"`
 	EndDate   string `json:"endDate"`
 	Page      int    `json:"page"`
@@ -132,7 +141,8 @@ func (c *Client) FetchEvents(ctx context.Context, start, end time.Time) ([]Usage
 	var all []UsageEvent
 	for page := 1; page <= maxPages; page++ {
 		body, err := json.Marshal(eventsRequest{
-			TeamID:    0,
+			TeamID:    c.TeamID,
+			UserID:    c.UserID,
 			StartDate: strconv.FormatInt(start.UnixMilli(), 10),
 			EndDate:   strconv.FormatInt(end.UnixMilli(), 10),
 			Page:      page,

--- a/src/internal/cursorusage/client_test.go
+++ b/src/internal/cursorusage/client_test.go
@@ -48,7 +48,7 @@ func TestFetchEvents(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := &Client{Token: "user_123%3A%3Ajwt", BaseURL: srv.URL}
+	c := &Client{Token: "user_123%3A%3Ajwt", BaseURL: srv.URL, TeamID: 11303557, UserID: 207112194}
 	events, err := c.FetchEvents(context.Background(), time.UnixMilli(1765357200000), time.UnixMilli(1765364400000))
 	if err != nil {
 		t.Fatalf("FetchEvents: %v", err)
@@ -59,8 +59,8 @@ func TestFetchEvents(t *testing.T) {
 	if gotCookie != "user_123%3A%3Ajwt" {
 		t.Errorf("cookie = %q, want token passed through", gotCookie)
 	}
-	if gotBody["teamId"] != float64(0) || gotBody["pageSize"] != float64(100) {
-		t.Errorf("body = %v, want teamId 0 and pageSize 100", gotBody)
+	if gotBody["teamId"] != float64(11303557) || gotBody["userId"] != float64(207112194) || gotBody["pageSize"] != float64(100) {
+		t.Errorf("body = %v, want configured teamId/userId and pageSize 100", gotBody)
 	}
 	if gotBody["startDate"] != "1765357200000" {
 		t.Errorf("startDate = %v, want stringified epoch ms", gotBody["startDate"])
@@ -111,6 +111,28 @@ func TestFetchEventsPagination(t *testing.T) {
 	}
 	if pages != 2 || len(events) != pageSize+3 {
 		t.Errorf("pages = %d, events = %d; want 2 pages, %d events", pages, len(events), pageSize+3)
+	}
+}
+
+// Personal accounts (TeamID 0) must omit userId so the request matches what
+// the dashboard itself sends.
+func TestFetchEventsPersonalAccountBody(t *testing.T) {
+	var gotRaw map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotRaw)
+		fmt.Fprint(w, `{"usageEventsDisplay":[]}`)
+	}))
+	defer srv.Close()
+
+	c := &Client{Token: "t", BaseURL: srv.URL}
+	if _, err := c.FetchEvents(context.Background(), time.Now().Add(-time.Hour), time.Now()); err != nil {
+		t.Fatalf("FetchEvents: %v", err)
+	}
+	if gotRaw["teamId"] != float64(0) {
+		t.Errorf("teamId = %v, want 0", gotRaw["teamId"])
+	}
+	if _, present := gotRaw["userId"]; present {
+		t.Errorf("userId present in body = %v, want omitted when 0", gotRaw["userId"])
 	}
 }
 

--- a/src/internal/cursorusage/match.go
+++ b/src/internal/cursorusage/match.go
@@ -31,17 +31,16 @@ type Attribution struct {
 // Events that match no run are dropped (other activity on the account); events
 // that match more than one run are counted as ambiguous on every candidate and
 // attributed to none — wrongly attributing money is worse than undercounting.
-// Events explicitly marked as interactive IDE usage (isHeadless == false) are
-// ignored; events without the flag (older schema) are kept.
+// isHeadless is NOT consulted: cursor-agent CLI runs report false just like
+// IDE usage (verified live), so the flag cannot separate the two. Interactive
+// usage concurrent with a run on the same account is instead caught by the
+// caller's token-sum sanity check against the run's own counts.
 func Attribute(events []UsageEvent, runs []RunWindow, skew time.Duration) map[int64]*Attribution {
 	out := make(map[int64]*Attribution, len(runs))
 	for _, r := range runs {
 		out[r.ID] = &Attribution{}
 	}
 	for _, ev := range events {
-		if ev.IsHeadless != nil && !*ev.IsHeadless {
-			continue
-		}
 		t := ev.Time()
 		if t.IsZero() {
 			continue

--- a/src/internal/cursorusage/match_test.go
+++ b/src/internal/cursorusage/match_test.go
@@ -62,21 +62,20 @@ func TestAttributeOverlapIsAmbiguous(t *testing.T) {
 	}
 }
 
-func TestAttributeSkipsInteractiveEvents(t *testing.T) {
+// cursor-agent CLI events report isHeadless=false just like IDE usage
+// (verified live against a real CLI run), so the flag must NOT exclude
+// events from attribution.
+func TestAttributeKeepsHeadlessFalseEvents(t *testing.T) {
 	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	run := RunWindow{ID: 1, Start: base, End: base.Add(10 * time.Minute)}
 
-	headless, ide := true, false
-	evHeadless := chargedEvent(base.Add(time.Minute), 100)
-	evHeadless.IsHeadless = &headless
-	evIDE := chargedEvent(base.Add(2*time.Minute), 500)
-	evIDE.IsHeadless = &ide
-	evLegacy := chargedEvent(base.Add(3*time.Minute), 50) // no flag: kept
+	notHeadless := false
+	ev := chargedEvent(base.Add(time.Minute), 100)
+	ev.IsHeadless = &notHeadless
 
-	got := Attribute([]UsageEvent{evHeadless, evIDE, evLegacy}, []RunWindow{run}, 0)
-	a := got[1]
-	if a.Events != 2 || a.CostUSD != 1.50 {
-		t.Errorf("attribution = %+v, want IDE event excluded (2 events, $1.50)", a)
+	got := Attribute([]UsageEvent{ev}, []RunWindow{run}, 0)
+	if got[1].Events != 1 || got[1].CostUSD != 1.00 {
+		t.Errorf("attribution = %+v, want isHeadless=false event attributed (CLI runs report false)", got[1])
 	}
 }
 

--- a/src/internal/daemon/cursor_cost.go
+++ b/src/internal/daemon/cursor_cost.go
@@ -43,7 +43,7 @@ func (d *Dispatcher) cursorCostLoop(ctx context.Context) {
 		aplog.Warn("cursor_cost enabled but no session token (settings.cursor_cost.session_token or CURSOR_SESSION_TOKEN); back-fill disabled")
 		return
 	}
-	client := &cursorusage.Client{Token: token}
+	client := &cursorusage.Client{Token: token, TeamID: cc.TeamID, UserID: cc.UserID}
 	attempts := make(map[int64]int)
 
 	sweep := func() {
@@ -126,9 +126,19 @@ func (d *Dispatcher) backfillCursorCosts(ctx context.Context, fetcher cursorEven
 		if a.Ambiguous > 0 {
 			aplog.Warn("cursor cost: execution %d has %d ambiguous event(s) from overlapping runs; recorded $%.4f is a lower bound", r.ID, a.Ambiguous, a.CostUSD)
 		}
+		// Cursor's isHeadless flag cannot separate CLI runs from interactive IDE
+		// usage on the same account, so a user working in the Cursor IDE during a
+		// run would inflate the attributed events. The run's own token counts are
+		// the ground truth: when the attributed events' tokens far exceed them,
+		// pollution is more likely than a real match — skip rather than record
+		// money the run did not spend (retries are capped by attempts).
 		matched := a.InputTokens + a.OutputTokens
-		if matched > 0 && r.TotalTokens > 0 && (matched > r.TotalTokens*3 || matched*3 < r.TotalTokens) {
-			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; window match may be off", r.ID, matched, r.TotalTokens)
+		if matched > 0 && r.TotalTokens > 0 && matched > r.TotalTokens+r.TotalTokens/2 {
+			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; suspected interactive usage in the window, cost not recorded", r.ID, matched, r.TotalTokens)
+			continue
+		}
+		if matched > 0 && r.TotalTokens > 0 && matched*3 < r.TotalTokens {
+			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; window match may be incomplete, recording lower bound", r.ID, matched, r.TotalTokens)
 		}
 		if a.CostUSD <= 0 {
 			// All matched events were not charged (errored/included). Leave the row

--- a/src/internal/daemon/cursor_cost_test.go
+++ b/src/internal/daemon/cursor_cost_test.go
@@ -157,6 +157,46 @@ func TestBackfillCursorCostsGivesUpAfterMaxAttempts(t *testing.T) {
 	}
 }
 
+// Interactive IDE usage on the same Cursor account is indistinguishable from
+// CLI events (isHeadless is false for both), so when the attributed events
+// carry far more tokens than the run itself reported, the sweep must refuse
+// to record the inflated amount.
+func TestBackfillCursorCostsSkipsSuspectedPollution(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer dbc.Close()
+
+	// Run reports 1000 tokens; attributed events total 5000 — pollution.
+	id, start := insertCursorExec(t, dbc, ctx, "", "", time.Now().Add(10*time.Minute))
+	fetcher := &fakeFetcher{events: []cursorusage.UsageEvent{{
+		Timestamp:    strconv.FormatInt(start.Add(2*time.Minute).UnixMilli(), 10),
+		Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+		ChargedCents: 500,
+		TokenUsage:   &cursorusage.TokenUsage{InputTokens: 4000, OutputTokens: 1000},
+	}}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	if err := d.backfillCursorCosts(ctx, fetcher, make(map[int64]int)); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	rows, err := dbc.ListUnpricedExecutions(ctx, "cursor-cli", time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("execution %d was priced despite token mismatch; want skipped (suspected IDE pollution)", id)
+	}
+}
+
 func TestBackfillCursorCostsOverlapStaysUnpriced(t *testing.T) {
 	ctx := context.Background()
 	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))


### PR DESCRIPTION
## Summary
Live validation of #169 against a real per-usage Cursor account (team-billed) exposed two flaws:

- **`teamId` was hardcoded to 0** — team-billed accounts (the usual per-usage setup) silently get zero events. New `settings.cursor_cost.team_id` / `user_id` knobs; `user_id` scopes team queries to the member's own events so teammates' usage cannot pollute time-window attribution. Both discoverable in `~/.cursor/cli-config.json` (`authInfo.teamId` / `authInfo.userId`).
- **`isHeadless` cannot identify CLI runs** — a real `cursor-agent` CLI run's usage event reports `isHeadless: false`, identical to interactive IDE events (verified live; the flag marks Cursor's hosted background-agent product, not headless CLIs). The v1 attribution filter would have dropped every event. Removed. Replacement guard: the sweep cross-checks attributed token totals against the run's own token counts and **skips recording** when they exceed them by >50% (suspected concurrent IDE usage on the same account), preferring undercounting over inflated costs.
- Docs now describe the far easier token path: the CLI stores a long-lived session token in the OS keychain (`security find-generic-password -s cursor-access-token -w`) — no DevTools digging; includes a copy-paste snippet that builds `CURSOR_SESSION_TOKEN` and prints `team_id`/`user_id`.

## Test plan
- Live E2E: ran a minimal `cursor-agent` call on a team-billed per-usage account; its dashboard event appeared with exact token-count match (29710/32/5352), `isHeadless: false`, and `chargedCents = totalCents + cursorTokenFee` as implemented. Team query (`teamId`+`userId`) returns the events; `teamId: 0` returns none.
- `go test ./...` green — updated client body assertions (team/user, userId omitted when 0), replaced the headless-exclusion matcher test with a keeps-headless-false test, new daemon pollution-guard test.
- `apiary validate` passes on the updated example config.