### PR TITLE
fix(daemon): fingerprint-based cursor cost attribution for concurrent runs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,19 +315,20 @@ and the daemon keeps running (costs simply stop back-filling until refreshed).
 
 How it works, and the fine print:
 
-- Cursor's usage events carry no session or request id, so each event is
-  attributed to the one run whose `[started_at, completed_at]` window (±2min
-  skew) contains its timestamp.
-- **Overlapping concurrent cursor runs**: an event that falls inside two run
-  windows is attributed to *neither* (wrongly attributing money is worse than
-  undercounting). The affected runs keep a lower-bound cost and a warning is
-  logged. Runs that never resolve are abandoned after 10 sweeps.
+- One cursor-agent invocation produces exactly **one** usage event whose token
+  counts equal the CLI's reported usage digit for digit (verified live). So
+  attribution is **fingerprint-first**: an event whose token tuple exactly
+  matches a run's recorded usage belongs to that run — concurrent runs with
+  fully overlapping time windows are disambiguated reliably.
+- Runs without a usable fingerprint fall back to time-window matching
+  (`started_at..completed_at` ±2min): an event inside exactly one window is
+  attributed; an event inside several is attributed to *neither* (wrongly
+  attributing money is worse than undercounting), logged as ambiguous. Runs
+  that never resolve are abandoned after 10 sweeps.
 - **Interactive IDE usage is indistinguishable from CLI runs** (Cursor's
-  `isHeadless` flag is `false` for both — verified live), so if you actively
-  use the Cursor IDE on the same account while a run executes, its events can
-  land inside the run's window. The sweep cross-checks the attributed events'
-  token totals against the run's own counts and refuses to record a cost when
-  they exceed them by more than 50%.
+  `isHeadless` flag is `false` for both — verified live). Fingerprint matches
+  are immune to it; window-fallback attributions are cross-checked against the
+  run's own token counts and skipped when they exceed them by more than 50%.
 - The endpoint is **undocumented** and may change without notice — the whole
   feature is best-effort and degrades to "no cost recorded" on any failure.
 - Plan-included requests (`INCLUDED_IN_PRO` etc.) and errored/aborted requests

--- a/src/internal/cursorusage/match.go
+++ b/src/internal/cursorusage/match.go
@@ -2,66 +2,141 @@ package cursorusage
 
 import "time"
 
-// RunWindow is the wall-clock span of one finished run (one task_executions
-// row) awaiting cost attribution.
+// fingerprintSkew is the generous timestamp gate applied to fingerprint
+// matches: the event must land within the run's window widened by this much.
+// Exact token equality carries the matching weight; the gate only prevents a
+// (theoretical) identical-tuple event from another time being picked up.
+const fingerprintSkew = 15 * time.Minute
+
+// RunWindow is one finished run (one task_executions row) awaiting cost
+// attribution: its wall-clock span plus its token tuple as reported by the
+// CLI's final result event.
+//
+// Verified live: one cursor-agent invocation produces exactly ONE dashboard
+// usage event, whose tokenUsage equals the CLI's reported usage digit for
+// digit — so the tuple is a near-unique fingerprint of the run.
 type RunWindow struct {
 	ID    int64
 	Start time.Time
 	End   time.Time
+	// InputTokens is the full billed input (pure input + cache write + cache
+	// read), matching how apiary stores usage. OutputTokens, CacheWriteTokens
+	// and CacheReadTokens complete the fingerprint.
+	InputTokens      int
+	OutputTokens     int
+	CacheWriteTokens int
+	CacheReadTokens  int
+}
+
+// fingerprintMatch reports whether the event's token tuple equals the run's.
+func fingerprintMatch(ev UsageEvent, r RunWindow) bool {
+	tu := ev.TokenUsage
+	if tu == nil {
+		return false
+	}
+	return tu.InputTokens+tu.CacheWriteTokens+tu.CacheReadTokens == r.InputTokens &&
+		tu.OutputTokens == r.OutputTokens &&
+		tu.CacheWriteTokens == r.CacheWriteTokens &&
+		tu.CacheReadTokens == r.CacheReadTokens
+}
+
+func inWindow(t time.Time, r RunWindow, skew time.Duration) bool {
+	return !t.Before(r.Start.Add(-skew)) && !t.After(r.End.Add(skew))
 }
 
 // Attribution is the outcome of matching events to one run.
 type Attribution struct {
 	// CostUSD is the summed billed cost of all events attributed to the run.
 	CostUSD float64
-	// Events is how many events were attributed (including $0 not-charged ones).
+	// Events is how many events were attributed (normally exactly 1: one CLI
+	// invocation produces one usage event).
 	Events int
+	// Fingerprinted is true when the attribution came from an exact token-tuple
+	// match (self-validating). False means the weaker window fallback was used
+	// and the caller should sanity-check the totals.
+	Fingerprinted bool
 	// InputTokens/OutputTokens sum the attributed events' token counts so the
-	// caller can sanity-check against the run's own token totals.
+	// caller can sanity-check fallback attributions against the run's counts.
 	InputTokens  int
 	OutputTokens int
-	// Ambiguous counts events that fell inside this run's window but also inside
-	// another candidate's. They are attributed to no one, so when Ambiguous > 0
-	// CostUSD is a lower bound.
+	// Ambiguous counts events that could not be assigned because they fit more
+	// than one candidate run. When Ambiguous > 0, CostUSD is a lower bound.
 	Ambiguous int
 }
 
-// Attribute assigns usage events to runs by timestamp containment. An event
-// belongs to a run when its timestamp falls within [Start-skew, End+skew].
-// Events that match no run are dropped (other activity on the account); events
-// that match more than one run are counted as ambiguous on every candidate and
-// attributed to none — wrongly attributing money is worse than undercounting.
-// isHeadless is NOT consulted: cursor-agent CLI runs report false just like
-// IDE usage (verified live), so the flag cannot separate the two. Interactive
-// usage concurrent with a run on the same account is instead caught by the
-// caller's token-sum sanity check against the run's own counts.
+// Attribute assigns usage events to runs in two passes.
+//
+// Pass 1 — fingerprint: an event whose token tuple exactly equals a run's
+// recorded usage (and lands near its window) belongs to that run. Token
+// tuples are high-entropy, so this disambiguates even fully overlapping
+// concurrent runs. Runs whose CLI died before the final result event carry no
+// usage and are excluded upstream (total_tokens > 0).
+//
+// Pass 2 — window fallback for runs that pass 1 left empty, considering only
+// events pass 1 did not consume: an event inside exactly one such run's
+// window (±skew) is attributed; an event inside several is counted as
+// ambiguous on each and attributed to none — wrongly attributing money is
+// worse than undercounting. isHeadless is never consulted: cursor-agent CLI
+// runs report false, identical to interactive IDE usage (verified live).
 func Attribute(events []UsageEvent, runs []RunWindow, skew time.Duration) map[int64]*Attribution {
 	out := make(map[int64]*Attribution, len(runs))
 	for _, r := range runs {
 		out[r.ID] = &Attribution{}
 	}
-	for _, ev := range events {
+
+	addEvent := func(a *Attribution, ev UsageEvent) {
+		a.Events++
+		a.CostUSD += ev.CostUSD()
+		if ev.TokenUsage != nil {
+			a.InputTokens += ev.TokenUsage.InputTokens + ev.TokenUsage.CacheWriteTokens + ev.TokenUsage.CacheReadTokens
+			a.OutputTokens += ev.TokenUsage.OutputTokens
+		}
+	}
+
+	// Pass 1: fingerprint matches.
+	taken := make([]bool, len(events))
+	matched := make(map[int64]bool, len(runs))
+	for i, ev := range events {
+		t := ev.Time()
+		if t.IsZero() {
+			continue
+		}
+		var hits []RunWindow
+		for _, r := range runs {
+			if !matched[r.ID] && fingerprintMatch(ev, r) && inWindow(t, r, fingerprintSkew) {
+				hits = append(hits, r)
+			}
+		}
+		if len(hits) == 1 {
+			a := out[hits[0].ID]
+			addEvent(a, ev)
+			a.Fingerprinted = true
+			matched[hits[0].ID] = true
+			taken[i] = true
+		}
+		// >1 identical tuples in flight at once: leave for the window pass.
+	}
+
+	// Pass 2: window containment for whatever is left.
+	for i, ev := range events {
+		if taken[i] {
+			continue
+		}
 		t := ev.Time()
 		if t.IsZero() {
 			continue
 		}
 		var hits []int64
 		for _, r := range runs {
-			if !t.Before(r.Start.Add(-skew)) && !t.After(r.End.Add(skew)) {
+			if !matched[r.ID] && inWindow(t, r, skew) {
 				hits = append(hits, r.ID)
 			}
 		}
 		switch len(hits) {
 		case 0:
-			continue
+			// Someone else's activity (IDE usage, other accounts' runs): drop.
 		case 1:
-			a := out[hits[0]]
-			a.Events++
-			a.CostUSD += ev.CostUSD()
-			if ev.TokenUsage != nil {
-				a.InputTokens += ev.TokenUsage.InputTokens + ev.TokenUsage.CacheWriteTokens + ev.TokenUsage.CacheReadTokens
-				a.OutputTokens += ev.TokenUsage.OutputTokens
-			}
+			addEvent(out[hits[0]], ev)
 		default:
 			for _, id := range hits {
 				out[id].Ambiguous++

--- a/src/internal/cursorusage/match_test.go
+++ b/src/internal/cursorusage/match_test.go
@@ -41,6 +41,60 @@ func TestAttributeSingleRun(t *testing.T) {
 	}
 }
 
+// Two fully overlapping runs with distinct token tuples: the fingerprint pass
+// must attribute both events correctly even though every event lies inside
+// both windows (the case the window-only matcher gave up on).
+func TestAttributeFingerprintDisambiguatesOverlap(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	runs := []RunWindow{
+		{ID: 1, Start: base, End: base.Add(10 * time.Minute),
+			InputTokens: 30641, OutputTokens: 12, CacheWriteTokens: 29135, CacheReadTokens: 1500},
+		{ID: 2, Start: base.Add(time.Minute), End: base.Add(9 * time.Minute),
+			InputTokens: 105455, OutputTokens: 153, CacheWriteTokens: 0, CacheReadTokens: 75488},
+	}
+	ev1 := UsageEvent{
+		Timestamp:    ts(base.Add(5 * time.Minute)),
+		Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+		ChargedCents: 100,
+		TokenUsage:   &TokenUsage{InputTokens: 6, OutputTokens: 12, CacheWriteTokens: 29135, CacheReadTokens: 1500},
+	}
+	ev2 := UsageEvent{
+		Timestamp:    ts(base.Add(6 * time.Minute)),
+		Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+		ChargedCents: 572,
+		TokenUsage:   &TokenUsage{InputTokens: 29967, OutputTokens: 153, CacheWriteTokens: 0, CacheReadTokens: 75488},
+	}
+
+	got := Attribute([]UsageEvent{ev1, ev2}, runs, 2*time.Minute)
+	if a := got[1]; !a.Fingerprinted || a.Events != 1 || a.CostUSD != 1.00 || a.Ambiguous != 0 {
+		t.Errorf("run 1 = %+v, want fingerprinted $1.00", a)
+	}
+	if a := got[2]; !a.Fingerprinted || a.Events != 1 || a.CostUSD != 5.72 || a.Ambiguous != 0 {
+		t.Errorf("run 2 = %+v, want fingerprinted $5.72", a)
+	}
+}
+
+// Two OVERLAPPING runs with IDENTICAL token tuples (theoretical): the
+// fingerprint pass must not guess between them, and the window pass then
+// reports the events as ambiguous — nothing is attributed.
+func TestAttributeIdenticalTuplesStayAmbiguous(t *testing.T) {
+	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	runs := []RunWindow{
+		{ID: 1, Start: base, End: base.Add(10 * time.Minute), InputTokens: 100, OutputTokens: 10},
+		{ID: 2, Start: base.Add(time.Minute), End: base.Add(11 * time.Minute), InputTokens: 100, OutputTokens: 10},
+	}
+	mk := func(at time.Time) UsageEvent {
+		return UsageEvent{Timestamp: ts(at), Kind: "USAGE_EVENT_KIND_USAGE_BASED",
+			ChargedCents: 100, TokenUsage: &TokenUsage{InputTokens: 100, OutputTokens: 10}}
+	}
+	got := Attribute([]UsageEvent{mk(base.Add(2 * time.Minute)), mk(base.Add(3 * time.Minute))}, runs, 0)
+	for id, a := range got {
+		if a.Events != 0 || a.Ambiguous != 2 {
+			t.Errorf("run %d = %+v, want 0 events and 2 ambiguous (no guessing)", id, a)
+		}
+	}
+}
+
 func TestAttributeOverlapIsAmbiguous(t *testing.T) {
 	base := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	runs := []RunWindow{

--- a/src/internal/daemon/cursor_cost.go
+++ b/src/internal/daemon/cursor_cost.go
@@ -100,7 +100,11 @@ func (d *Dispatcher) backfillCursorCosts(ctx context.Context, fetcher cursorEven
 	first, last := pending[0].StartedAt, pending[0].CompletedAt
 	for _, r := range pending {
 		attempts[r.ID]++
-		windows = append(windows, cursorusage.RunWindow{ID: r.ID, Start: r.StartedAt, End: r.CompletedAt})
+		windows = append(windows, cursorusage.RunWindow{
+			ID: r.ID, Start: r.StartedAt, End: r.CompletedAt,
+			InputTokens: r.InputTokens, OutputTokens: r.OutputTokens,
+			CacheWriteTokens: r.CacheCreationTokens, CacheReadTokens: r.CacheReadTokens,
+		})
 		if r.StartedAt.Before(first) {
 			first = r.StartedAt
 		}
@@ -126,19 +130,21 @@ func (d *Dispatcher) backfillCursorCosts(ctx context.Context, fetcher cursorEven
 		if a.Ambiguous > 0 {
 			aplog.Warn("cursor cost: execution %d has %d ambiguous event(s) from overlapping runs; recorded $%.4f is a lower bound", r.ID, a.Ambiguous, a.CostUSD)
 		}
-		// Cursor's isHeadless flag cannot separate CLI runs from interactive IDE
-		// usage on the same account, so a user working in the Cursor IDE during a
-		// run would inflate the attributed events. The run's own token counts are
-		// the ground truth: when the attributed events' tokens far exceed them,
-		// pollution is more likely than a real match — skip rather than record
-		// money the run did not spend (retries are capped by attempts).
-		matched := a.InputTokens + a.OutputTokens
-		if matched > 0 && r.TotalTokens > 0 && matched > r.TotalTokens+r.TotalTokens/2 {
-			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; suspected interactive usage in the window, cost not recorded", r.ID, matched, r.TotalTokens)
-			continue
-		}
-		if matched > 0 && r.TotalTokens > 0 && matched*3 < r.TotalTokens {
-			aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; window match may be incomplete, recording lower bound", r.ID, matched, r.TotalTokens)
+		// A fingerprint match (exact token-tuple equality with the run's own
+		// usage) is self-validating. Window-fallback attributions are weaker:
+		// interactive IDE usage on the same account is indistinguishable from
+		// CLI events, so when the matched events' tokens far exceed the run's
+		// own counts, pollution is more likely than a real match — skip rather
+		// than record money the run did not spend (retries are capped).
+		if !a.Fingerprinted {
+			matched := a.InputTokens + a.OutputTokens
+			if matched > 0 && r.TotalTokens > 0 && matched > r.TotalTokens+r.TotalTokens/2 {
+				aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; suspected interactive usage in the window, cost not recorded", r.ID, matched, r.TotalTokens)
+				continue
+			}
+			if matched > 0 && r.TotalTokens > 0 && matched*3 < r.TotalTokens {
+				aplog.Warn("cursor cost: execution %d attributed events total %d tokens vs run's %d; window match may be incomplete, recording lower bound", r.ID, matched, r.TotalTokens)
+			}
 		}
 		if a.CostUSD <= 0 {
 			// All matched events were not charged (errored/included). Leave the row

--- a/src/internal/daemon/cursor_cost_test.go
+++ b/src/internal/daemon/cursor_cost_test.go
@@ -22,10 +22,14 @@ func (f *fakeFetcher) FetchEvents(ctx context.Context, start, end time.Time) ([]
 	return f.events, nil
 }
 
-// insertCursorExec creates a finished cursor-cli execution. Its window starts
-// at CreateExecution time (now) and ends at end; tests place events relative
-// to start.
+// insertCursorExec creates a finished cursor-cli execution with an 800/200
+// token tuple (1000 total). Its window starts at CreateExecution time (now)
+// and ends at end; tests place events relative to start.
 func insertCursorExec(t *testing.T, dbc *db.Client, ctx context.Context, instance, step string, end time.Time) (int64, time.Time) {
+	return insertCursorExecTokens(t, dbc, ctx, instance, step, end, 800, 200)
+}
+
+func insertCursorExecTokens(t *testing.T, dbc *db.Client, ctx context.Context, instance, step string, end time.Time, in, out int) (int64, time.Time) {
 	t.Helper()
 	exec, err := dbc.CreateExecution(ctx, "42", "engineer", "title", "42", "", "composer-2", "cursor-cli", 1)
 	if err != nil {
@@ -33,7 +37,9 @@ func insertCursorExec(t *testing.T, dbc *db.Client, ctx context.Context, instanc
 	}
 	exec.Status = "success"
 	exec.CompletedAt = &end
-	exec.TotalTokens = 1000
+	exec.InputTokens = in
+	exec.OutputTokens = out
+	exec.TotalTokens = in + out
 	if err := dbc.UpdateExecution(ctx, exec); err != nil {
 		t.Fatalf("finish execution: %v", err)
 	}
@@ -230,5 +236,50 @@ func TestBackfillCursorCostsOverlapStaysUnpriced(t *testing.T) {
 	}
 	if !got[idA] || !got[idB] {
 		t.Errorf("unpriced rows = %v, want both %d and %d still unpriced (ambiguous event)", got, idA, idB)
+	}
+}
+
+// The real-world shape that motivated fingerprint matching: concurrent cursor
+// runs with fully overlapping windows. Their events are inside both windows,
+// but distinct token tuples identify each run's event exactly — both get
+// priced where the window-only matcher attributed neither.
+func TestBackfillCursorCostsFingerprintResolvesOverlap(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer dbc.Close()
+
+	idA, startA := insertCursorExecTokens(t, dbc, ctx, "", "", time.Now().Add(10*time.Minute), 30641, 12)
+	idB, _ := insertCursorExecTokens(t, dbc, ctx, "", "", time.Now().Add(12*time.Minute), 105608, 153)
+
+	fetcher := &fakeFetcher{events: []cursorusage.UsageEvent{
+		{
+			Timestamp:    strconv.FormatInt(startA.Add(5*time.Minute).UnixMilli(), 10),
+			Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+			ChargedCents: 100,
+			TokenUsage:   &cursorusage.TokenUsage{InputTokens: 30641, OutputTokens: 12},
+		},
+		{
+			Timestamp:    strconv.FormatInt(startA.Add(6*time.Minute).UnixMilli(), 10),
+			Kind:         "USAGE_EVENT_KIND_USAGE_BASED",
+			ChargedCents: 572,
+			TokenUsage:   &cursorusage.TokenUsage{InputTokens: 105608, OutputTokens: 153},
+		},
+	}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	if err := d.backfillCursorCosts(ctx, fetcher, make(map[int64]int)); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	rows, err := dbc.ListUnpricedExecutions(ctx, "cursor-cli", time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == idA || r.ID == idB {
+			t.Errorf("execution %d still unpriced; want fingerprint attribution despite overlap", r.ID)
+		}
 	}
 }

--- a/src/internal/daemon/failover_test.go
+++ b/src/internal/daemon/failover_test.go
@@ -110,7 +110,7 @@ func TestPauseRunner(t *testing.T) {
 	}
 	// nil-map safe + zero reset defaults to ~5m out.
 	d.pauseRunner("claude", time.Time{})
-	if got := d.runnerPausedUntil("claude"); got.Before(time.Now().Add(4*time.Minute)) {
+	if got := d.runnerPausedUntil("claude"); got.Before(time.Now().Add(4 * time.Minute)) {
 		t.Errorf("zero reset should default ~5m out, got %v", got)
 	}
 	// Only extends, never shortens.

--- a/src/internal/daemon/parked_approval_concurrency_test.go
+++ b/src/internal/daemon/parked_approval_concurrency_test.go
@@ -29,9 +29,11 @@ func newApprovalAdapter() *approvalAdapter {
 	return &approvalAdapter{comments: map[string][]string{}, polls: map[string]int{}}
 }
 
-func (a *approvalAdapter) ID() string                                                  { return "src" }
-func (a *approvalAdapter) Connect(context.Context, map[string]any) error               { return nil }
-func (a *approvalAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) { return nil, nil }
+func (a *approvalAdapter) ID() string                                    { return "src" }
+func (a *approvalAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *approvalAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
 func (a *approvalAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
 	return nil
 }

--- a/src/internal/daemon/status.go
+++ b/src/internal/daemon/status.go
@@ -4,20 +4,20 @@ import "time"
 
 // StatusResponse is the JSON payload returned by GET /status on the IPC socket.
 type StatusResponse struct {
-	Version     string             `json:"version"`
-	ConfigFile  string             `json:"config_file"`
-	Uptime      string             `json:"uptime"`
-	Sources     []SourceStatus     `json:"sources"`
-	ActiveRuns  []ActiveRunStatus  `json:"active_runs"`
-	Concurrency ConcurrencyStatus  `json:"concurrency"`
+	Version     string            `json:"version"`
+	ConfigFile  string            `json:"config_file"`
+	Uptime      string            `json:"uptime"`
+	Sources     []SourceStatus    `json:"sources"`
+	ActiveRuns  []ActiveRunStatus `json:"active_runs"`
+	Concurrency ConcurrencyStatus `json:"concurrency"`
 }
 
 type SourceStatus struct {
-	ID         string `json:"id"`
-	Type       string `json:"type"`
-	LastPoll   string `json:"last_poll"`   // human-readable "Xs ago"
-	LastCount  int    `json:"last_count"`  // cells found in last poll
-	InFlight   int    `json:"in_flight"`   // cells currently being dispatched from this source
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	LastPoll  string `json:"last_poll"`  // human-readable "Xs ago"
+	LastCount int    `json:"last_count"` // cells found in last poll
+	InFlight  int    `json:"in_flight"`  // cells currently being dispatched from this source
 }
 
 type ActiveRunStatus struct {

--- a/src/internal/db/cursor_cost.go
+++ b/src/internal/db/cursor_cost.go
@@ -9,12 +9,20 @@ import (
 // on a runner that does not report cost (cursor-cli), consumed tokens, and has
 // cost_usd = 0.
 type UnpricedExecution struct {
-	ID                 int64
-	StartedAt          time.Time
-	CompletedAt        time.Time
-	TotalTokens        int
-	WorkflowInstanceID string
-	StepID             string
+	ID          int64
+	StartedAt   time.Time
+	CompletedAt time.Time
+	TotalTokens int
+	// The token tuple as reported by the CLI's final result event. One cursor
+	// invocation produces one dashboard usage event with this exact tuple, so
+	// it fingerprints the run during attribution. InputTokens is the full
+	// billed input (cache folded in), as stored everywhere else.
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+	WorkflowInstanceID  string
+	StepID              string
 }
 
 // ListUnpricedExecutions returns terminal executions of the given runner with
@@ -23,6 +31,7 @@ type UnpricedExecution struct {
 func (c *Client) ListUnpricedExecutions(ctx context.Context, runner string, since time.Time) ([]UnpricedExecution, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, started_at, completed_at, total_tokens,
+		       input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 		       COALESCE(workflow_instance_id, ''), COALESCE(step_id, '')
 		FROM task_executions
 		WHERE runner = ? AND status != 'running' AND cost_usd = 0
@@ -39,7 +48,9 @@ func (c *Client) ListUnpricedExecutions(ctx context.Context, runner string, sinc
 	var out []UnpricedExecution
 	for rows.Next() {
 		var u UnpricedExecution
-		if err := rows.Scan(&u.ID, &u.StartedAt, &u.CompletedAt, &u.TotalTokens, &u.WorkflowInstanceID, &u.StepID); err != nil {
+		if err := rows.Scan(&u.ID, &u.StartedAt, &u.CompletedAt, &u.TotalTokens,
+			&u.InputTokens, &u.OutputTokens, &u.CacheCreationTokens, &u.CacheReadTokens,
+			&u.WorkflowInstanceID, &u.StepID); err != nil {
 			return nil, err
 		}
 		out = append(out, u)


### PR DESCRIPTION
## Summary
First real deployment of cursor cost back-fill (v0.5.1) showed the window-only matcher giving up on most runs: with several cursor agents running concurrently, nearly every usage event fell inside multiple run windows — 5 of 7 runs stayed unpriced as "ambiguous", and the pollution guard misfired on a 6th.

**Key empirical finding** (verified live with single- and multi-turn cursor-agent runs): one CLI invocation produces exactly **one** dashboard usage event, whose `tokenUsage` equals the CLI result event's usage **digit for digit**. The token tuple is therefore a near-unique fingerprint of the run.

- Attribution is now two-pass: **fingerprint first** (exact tuple equality, gated by a generous ±15min timestamp window) — disambiguates fully overlapping concurrent runs; then the previous window-containment as fallback for runs without a usable fingerprint, with the same attribute-to-neither rule on ambiguity.
- The interactive-IDE pollution guard now applies **only to window-fallback attributions**: a fingerprint match is self-validating, and the old guard compared event sums against the run's final-request totals — wrongly rejecting legitimate matches.
- `ListUnpricedExecutions` returns the per-run token tuple to feed the matcher. No schema change, no config change.
- Docs updated to describe the fingerprint-first model.

## Test plan
- New matcher tests: fully-overlapping runs with distinct tuples both priced via fingerprints (the production failure case); identical tuples + overlapping windows stay ambiguous (no guessing).
- New daemon test: overlap resolved end-to-end through the sweep; pollution-guard and max-attempts tests updated for the tuple-carrying fixtures.
- `go test ./...` green, `go vet` clean.
- After merge + binary update on the daemon, executions 2–6 and 8 from the live log should back-fill on the next sweep (they're still within max_age and below the attempt cap).