### PR TITLE
feat(wait_for): add `kind: dependency` to gate a task on its upstream blockers (auto-resume)

### DIFF
--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -71,6 +71,12 @@ visible to the API user and logs a warning.
 - **No CI polling.** `wait_for` steps with `kind: ci` need a source that can
   see pull requests; Jira issues have no PR mapping, so host CI waits on a
   GitHub source instead.
+- **Dependency waits work.** `wait_for` steps with
+  [`kind: dependency`](workflows.md#wait_for-steps-waiting-on-blockers-kind-dependency)
+  read the inward side of the issue's `Blocks` links (*"is blocked by"*;
+  `blocker_link_type` overrides the link type). A blocker counts as satisfied
+  via its Done-category status — the `merged` condition never matches on Jira
+  (no PR visibility), so keep `done` in `satisfied_when`.
 
 ## State names in hooks
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -286,8 +286,9 @@ with their original timestamps and timeout intact.
 ### `wait_for` steps — waiting on CI
 
 A `wait_for` step parks the workflow until an external condition resolves.
-The supported kind is `ci`: wait for the checks on the pull request linked to
-this task.
+Two kinds are supported: `ci` waits for the checks on the pull request linked
+to this task; `dependency` waits for the task's upstream blockers (see the
+next section).
 
 ```yaml
 - id: implement
@@ -329,6 +330,52 @@ is present, it routes that failure exclusively — typically looping back to
 the implementation step so the agent rebases — with its own `max_retries`
 budget, separate from `on_fail`. Without `on_conflict`, a conflict falls
 through to `on_fail` like any other failure.
+
+### `wait_for` steps — waiting on blockers (`kind: dependency`)
+
+Triggers select a task by its own labels/state, so a task that is *blocked by*
+another (a Jira "is blocked by" link, a GitHub issue dependency) would
+otherwise start in parallel with its blocker. A `wait_for` step with
+`kind: dependency` parks the workflow until every blocker is satisfied, then
+auto-resumes — no labels to re-add, enforced by the engine regardless of agent
+behaviour:
+
+```yaml
+- id: await-blockers
+  type: wait_for
+  wait_for:
+    kind: dependency
+    satisfied_when: [merged, done]  # blocker OK when its PR merged OR status is Done-category
+    blocker_link_type: "Blocks"     # source-native relation; default: the source's blocking link
+    check_interval: 5m
+    max_duration: 168h              # optional; default: no deadline for this kind
+    on_timeout: hold                # hold (default) keeps it parked for a human; fail fails the step
+
+- id: implement
+  agent: engineer
+  prompt: "Blockers are resolved — implement the change."
+```
+
+How it works:
+
+- Placed as the first step, it suspends the instance (parked, restart-safe,
+  exactly like a CI wait) while any blocker is unsatisfied, re-checking every
+  poll cycle, and resumes the pipeline automatically once all are.
+- `satisfied_when` lists the conditions under which a blocker counts as
+  satisfied — `merged` (a pull request linked to the blocker is merged)
+  and/or `done` (the blocker's status is Done-category/closed). ANY listed
+  condition satisfies a blocker. Default: `[merged, done]`.
+- Blockers come from the source adapter: **Jira** reads the inward side of
+  the issue's `Blocks` links (*"is blocked by"*; `blocker_link_type`
+  overrides the link type); **GitHub** reads the issue dependencies API
+  (*"blocked by"*). A source without blocker support is rejected at config
+  validation.
+- Unlike `ci`, the default `max_duration` is *no deadline*, and at a
+  configured deadline the default `on_timeout: hold` keeps the instance
+  parked (a blocker may legitimately take days) — set `on_timeout: fail` to
+  fail the step instead.
+- Every check is recorded in the same poll history as CI waits, so the
+  dashboard shows which blockers are still pending.
 
 ### Sub-workflows
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -877,8 +877,8 @@
       "properties": {
         "kind": {
           "type": "string",
-          "description": "What to poll. Currently only 'ci' (CI status of the PR linked to the task)",
-          "enum": ["ci"],
+          "description": "What to poll: 'ci' (CI status of the PR linked to the task) or 'dependency' (the task's upstream blockers, e.g. Jira 'is blocked by' links — the step parks until every blocker is merged/Done, then auto-resumes)",
+          "enum": ["ci", "dependency"],
           "default": "ci"
         },
         "check_interval": {
@@ -888,17 +888,34 @@
         },
         "max_duration": {
           "type": "string",
-          "description": "Total timeout for polling (e.g., '2h'). Defaults to 2h",
+          "description": "Total timeout for polling (e.g., '2h'). Defaults to 2h for kind 'ci' and to no deadline for kind 'dependency'",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
         },
         "fail_if_not_passed": {
           "type": "boolean",
-          "description": "Reject the step if CI is not green",
+          "description": "Reject the step if CI is not green (kind 'ci' only)",
           "default": true
         },
         "remove_label": {
           "type": "string",
           "description": "Remove this label from the task before polling begins (resets stale labels from previous runs)"
+        },
+        "satisfied_when": {
+          "type": "array",
+          "description": "Kind 'dependency' only: conditions under which a blocker counts as satisfied — 'merged' (a linked PR merged) and/or 'done' (status is Done-category). A blocker is satisfied when ANY listed condition holds. Defaults to [merged, done]",
+          "items": {
+            "type": "string",
+            "enum": ["merged", "done"]
+          }
+        },
+        "blocker_link_type": {
+          "type": "string",
+          "description": "Kind 'dependency' only: the source-native relation that marks a blocker (e.g. Jira's 'Blocks' link type, read from its inward 'is blocked by' side). Empty uses the source's default blocking relation"
+        },
+        "on_timeout": {
+          "type": "string",
+          "description": "What happens when max_duration elapses: 'fail' fails the step, 'hold' keeps the instance parked for a human. Defaults to fail for kind 'ci' and hold for kind 'dependency'",
+          "enum": ["hold", "fail"]
         }
       }
     },

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
 
 	// Ensure the built-in adapters are registered before any command validates
 	// a config, even when the cli package is used without cmd/apiary.
@@ -11,4 +12,14 @@ import (
 
 func init() {
 	config.KnownAdapters = runner.Registered
+	// Evaluated at validation time, after the source adapters' init() registration
+	// (cmd/apiary imports them), so a fresh instance reflects the real capability.
+	config.SourceSupportsDependencyWait = func(sourceType string) bool {
+		a, ok := source.New(sourceType)
+		if !ok {
+			return false
+		}
+		_, ok = a.(source.BlockerLister)
+		return ok
+	}
 }

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -15,6 +15,14 @@ import (
 // the adapter check is skipped.
 var KnownAdapters func() []string
 
+// SourceSupportsDependencyWait reports whether a source type's adapter can
+// enumerate a task's upstream blockers (implements source.BlockerLister), which
+// a wait_for step with kind "dependency" requires. The cli package injects it
+// (config cannot import the source package without inverting the dependency
+// direction). When nil — configs built in code, isolated tests — the check is
+// skipped.
+var SourceSupportsDependencyWait func(sourceType string) bool
+
 // adapterCombos renders registered adapter names as the type/provider
 // combinations users write in apiary.yaml, mirroring the table in
 // docs/runners.md: "claude-cli" → `type: cli, provider: claude`; names

--- a/src/internal/config/wait_dependency_validate_test.go
+++ b/src/internal/config/wait_dependency_validate_test.go
@@ -1,0 +1,102 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// depWaitConfig returns a config with one workflow whose first step is a
+// wait_for with the given wait config.
+func depWaitConfig(wait *config.WaitForConfig) *config.Config {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "await", Type: config.StepTypeWaitFor, WaitFor: wait},
+			{ID: "impl", Agent: "architect", DependsOn: []string{"await"}},
+		}},
+	}
+	return cfg
+}
+
+func TestWaitFor_DependencyKindValid(t *testing.T) {
+	assertNoError(t, depWaitConfig(&config.WaitForConfig{
+		Kind:            "dependency",
+		SatisfiedWhen:   []string{"merged", "done"},
+		BlockerLinkType: "Blocks",
+		OnTimeout:       "hold",
+	}))
+}
+
+func TestWaitFor_UnknownKindRejected(t *testing.T) {
+	assertError(t, depWaitConfig(&config.WaitForConfig{Kind: "weather"}),
+		`kind "weather" not supported (valid: ci, dependency)`)
+}
+
+func TestWaitFor_SatisfiedWhenInvalidValue(t *testing.T) {
+	assertError(t, depWaitConfig(&config.WaitForConfig{
+		Kind: "dependency", SatisfiedWhen: []string{"closed"},
+	}), `satisfied_when value "closed" not supported`)
+}
+
+func TestWaitFor_SatisfiedWhenOnlyForDependency(t *testing.T) {
+	assertError(t, depWaitConfig(&config.WaitForConfig{
+		Kind: "ci", SatisfiedWhen: []string{"merged"},
+	}), `satisfied_when is only valid with kind "dependency"`)
+}
+
+func TestWaitFor_BlockerLinkTypeOnlyForDependency(t *testing.T) {
+	assertError(t, depWaitConfig(&config.WaitForConfig{
+		Kind: "ci", BlockerLinkType: "Blocks",
+	}), `blocker_link_type is only valid with kind "dependency"`)
+}
+
+func TestWaitFor_OnTimeoutInvalidValue(t *testing.T) {
+	assertError(t, depWaitConfig(&config.WaitForConfig{
+		Kind: "dependency", OnTimeout: "explode",
+	}), `invalid wait_for on_timeout "explode"`)
+}
+
+func TestWaitFor_DependencyRequiresCapableSource(t *testing.T) {
+	// The capability hook is injected by cli in production; simulate a config
+	// whose only source's adapter cannot list blockers.
+	prev := config.SourceSupportsDependencyWait
+	defer func() { config.SourceSupportsDependencyWait = prev }()
+
+	config.SourceSupportsDependencyWait = func(string) bool { return false }
+	assertError(t, depWaitConfig(&config.WaitForConfig{Kind: "dependency"}),
+		"no configured source supports it")
+
+	config.SourceSupportsDependencyWait = func(string) bool { return true }
+	assertNoError(t, depWaitConfig(&config.WaitForConfig{Kind: "dependency"}))
+}
+
+func TestWaitFor_DependencyDefaults(t *testing.T) {
+	dep := &config.WaitForConfig{Kind: "dependency"}
+	if d := dep.ParsedMaxDuration(); d != 0 {
+		t.Errorf("dependency default max_duration = %v, want 0 (no deadline)", d)
+	}
+	if a := dep.TimeoutAction(); a != config.OnTimeoutHold {
+		t.Errorf("dependency default on_timeout = %q, want hold", a)
+	}
+	if got := dep.EffectiveSatisfiedWhen(); len(got) != 2 || got[0] != "merged" || got[1] != "done" {
+		t.Errorf("default satisfied_when = %v, want [merged done]", got)
+	}
+
+	ci := &config.WaitForConfig{Kind: "ci"}
+	if d := ci.ParsedMaxDuration(); d != 2*time.Hour {
+		t.Errorf("ci default max_duration = %v, want 2h", d)
+	}
+	if a := ci.TimeoutAction(); a != config.OnTimeoutFail {
+		t.Errorf("ci default on_timeout = %q, want fail", a)
+	}
+
+	override := &config.WaitForConfig{Kind: "dependency", MaxDuration: "168h", OnTimeout: "fail"}
+	if d := override.ParsedMaxDuration(); d != 168*time.Hour {
+		t.Errorf("explicit max_duration = %v, want 168h", d)
+	}
+	if a := override.TimeoutAction(); a != config.OnTimeoutFail {
+		t.Errorf("explicit on_timeout = %q, want fail", a)
+	}
+}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -342,21 +342,68 @@ func (t ApprovalTrigger) IsEmpty() bool {
 	return t.CommentContains == "" && t.LabelAdded == "" && t.StateChanged == ""
 }
 
+// wait_for kinds: what external condition a wait_for step polls.
+const (
+	// WaitKindCI waits for the CI status of the PR linked to the task.
+	WaitKindCI = "ci"
+	// WaitKindDependency waits until every upstream blocker of the task (e.g. a
+	// Jira "is blocked by" link) is satisfied — merged and/or Done per
+	// satisfied_when — then auto-resumes the workflow.
+	WaitKindDependency = "dependency"
+)
+
+// on_timeout actions for a wait_for step whose max_duration elapses.
+const (
+	// OnTimeoutFail fails the step at the deadline (the CI default).
+	OnTimeoutFail = "fail"
+	// OnTimeoutHold keeps the instance parked past the deadline, leaving it for a
+	// human to resolve (the dependency default).
+	OnTimeoutHold = "hold"
+)
+
+// blocker satisfaction conditions accepted in satisfied_when.
+const (
+	// BlockerSatisfiedMerged accepts a blocker whose linked PR is merged.
+	BlockerSatisfiedMerged = "merged"
+	// BlockerSatisfiedDone accepts a blocker whose status is Done-category
+	// (resolved/closed).
+	BlockerSatisfiedDone = "done"
+)
+
 // WaitForConfig configures a wait_for step that suspends the workflow until an
 // external condition (e.g. CI status) resolves, re-checking each poll cycle until
 // the condition is met or a timeout occurs.
 type WaitForConfig struct {
-	// Kind specifies what to poll: "ci" for GitHub/GitLab CI status.
+	// Kind specifies what to poll: "ci" (default) for the CI status of the task's
+	// PR, or "dependency" for the task's upstream blockers (auto-resumes once
+	// every blocker is merged/Done).
 	Kind string `yaml:"kind,omitempty"`
 	// CheckInterval is how often to query the status (e.g., "30s"). Defaults to 1m.
 	CheckInterval string `yaml:"check_interval,omitempty"`
-	// MaxDuration is the total timeout for polling (e.g., "2h"). Defaults to 2h.
+	// MaxDuration is the total timeout for polling (e.g., "2h"). Defaults to 2h
+	// for kind: ci and to no deadline for kind: dependency (a blocker may take
+	// days to land).
 	MaxDuration string `yaml:"max_duration,omitempty"`
 	// FailIfNotPassed, when true, rejects the step if CI is not green. Defaults to true.
 	FailIfNotPassed *bool `yaml:"fail_if_not_passed,omitempty"`
 	// RemoveLabel, when set, removes this label from the task before polling begins.
 	// Used to reset stale labels from previous runs.
 	RemoveLabel string `yaml:"remove_label,omitempty"`
+
+	// ── kind: dependency only ─────────────────────────────────────
+	// SatisfiedWhen lists the conditions under which a blocker counts as
+	// satisfied: "merged" (a linked PR merged) and/or "done" (status is
+	// Done-category). A blocker is satisfied when ANY listed condition holds.
+	// Defaults to [merged, done].
+	SatisfiedWhen []string `yaml:"satisfied_when,omitempty"`
+	// BlockerLinkType is the source-native relation that marks a blocker (e.g.
+	// Jira's "Blocks" link type, read from its inward "is blocked by" side).
+	// Empty uses the source's default blocking relation.
+	BlockerLinkType string `yaml:"blocker_link_type,omitempty"`
+	// OnTimeout selects what happens when max_duration elapses: "fail" fails the
+	// step, "hold" keeps the instance parked for a human. Defaults to fail for
+	// kind: ci and hold for kind: dependency.
+	OnTimeout string `yaml:"on_timeout,omitempty"`
 }
 
 // ParsedCheckInterval returns the check interval duration, defaulting to 1 minute.
@@ -371,14 +418,21 @@ func (p *WaitForConfig) ParsedCheckInterval() time.Duration {
 	return d
 }
 
-// ParsedMaxDuration returns the maximum polling duration, defaulting to 2 hours.
+// ParsedMaxDuration returns the maximum polling duration. Unset/invalid values
+// default to 2 hours for kind: ci and to 0 (no deadline) for kind: dependency —
+// a blocker may legitimately take days, and the dependency default on_timeout
+// is hold anyway.
 func (p *WaitForConfig) ParsedMaxDuration() time.Duration {
+	fallback := 2 * time.Hour
+	if p != nil && p.Kind == WaitKindDependency {
+		fallback = 0
+	}
 	if p == nil || p.MaxDuration == "" {
-		return 2 * time.Hour
+		return fallback
 	}
 	d, _ := time.ParseDuration(p.MaxDuration)
 	if d <= 0 {
-		return 2 * time.Hour
+		return fallback
 	}
 	return d
 }
@@ -389,6 +443,27 @@ func (p *WaitForConfig) ShouldFailIfNotPassed() bool {
 		return true
 	}
 	return *p.FailIfNotPassed
+}
+
+// EffectiveSatisfiedWhen returns the blocker satisfaction conditions, defaulting
+// to [merged, done] — a blocker counts as satisfied when any condition holds.
+func (p *WaitForConfig) EffectiveSatisfiedWhen() []string {
+	if p == nil || len(p.SatisfiedWhen) == 0 {
+		return []string{BlockerSatisfiedMerged, BlockerSatisfiedDone}
+	}
+	return p.SatisfiedWhen
+}
+
+// TimeoutAction returns what happens when max_duration elapses, defaulting to
+// fail for kind: ci and hold for kind: dependency.
+func (p *WaitForConfig) TimeoutAction() string {
+	if p != nil && p.OnTimeout != "" {
+		return p.OnTimeout
+	}
+	if p != nil && p.Kind == WaitKindDependency {
+		return OnTimeoutHold
+	}
+	return OnTimeoutFail
 }
 
 // OutputSchema is the supported JSON Schema subset for structured step output.

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -141,7 +141,7 @@ func (c *Config) validateStep(
 	case StepTypeWorkflow:
 		errs = append(errs, validateWorkflowStep(sctx, s, wf, wfByID)...)
 	case StepTypeWaitFor:
-		errs = append(errs, validateWaitForStep(sctx, s)...)
+		errs = append(errs, c.validateWaitForStep(sctx, s)...)
 	default:
 		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
 	}
@@ -374,7 +374,7 @@ func validateWorkflowStep(sctx string, s StepConfig, parent WorkflowConfig, wfBy
 }
 
 // validateWaitForStep validates a type: wait_for step.
-func validateWaitForStep(sctx string, s StepConfig) []error {
+func (c *Config) validateWaitForStep(sctx string, s StepConfig) []error {
 	var errs []error
 
 	if s.Agent != "" {
@@ -389,10 +389,48 @@ func validateWaitForStep(sctx string, s StepConfig) []error {
 	cfg := s.WaitFor
 
 	// Validate kind
-	if cfg.Kind == "" {
+	switch cfg.Kind {
+	case "", WaitKindCI:
 		// Default is "ci", which is valid
-	} else if cfg.Kind != "ci" {
-		errs = append(errs, fmt.Errorf("%s: wait_for step kind %q not supported (currently only 'ci')", sctx, cfg.Kind))
+	case WaitKindDependency:
+		// A dependency wait needs a source whose adapter can enumerate a task's
+		// blockers. The capability check is injected by cli (config cannot import
+		// the source package); nil — configs built in code, isolated tests —
+		// skips it, mirroring KnownAdapters.
+		if SourceSupportsDependencyWait != nil && len(c.Sources) > 0 {
+			supported := false
+			for _, src := range c.Sources {
+				if SourceSupportsDependencyWait(src.Type) {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				errs = append(errs, fmt.Errorf("%s: wait_for kind \"dependency\" requires a source whose adapter can list a task's blockers, but no configured source supports it", sctx))
+			}
+		}
+	default:
+		errs = append(errs, fmt.Errorf("%s: wait_for step kind %q not supported (valid: ci, dependency)", sctx, cfg.Kind))
+	}
+
+	// dependency-only fields are rejected on other kinds.
+	if cfg.Kind != WaitKindDependency {
+		if len(cfg.SatisfiedWhen) > 0 {
+			errs = append(errs, fmt.Errorf("%s: wait_for satisfied_when is only valid with kind \"dependency\"", sctx))
+		}
+		if cfg.BlockerLinkType != "" {
+			errs = append(errs, fmt.Errorf("%s: wait_for blocker_link_type is only valid with kind \"dependency\"", sctx))
+		}
+	}
+	for _, cond := range cfg.SatisfiedWhen {
+		if cond != BlockerSatisfiedMerged && cond != BlockerSatisfiedDone {
+			errs = append(errs, fmt.Errorf("%s: wait_for satisfied_when value %q not supported (valid: merged, done)", sctx, cond))
+		}
+	}
+
+	// Validate on_timeout
+	if cfg.OnTimeout != "" && cfg.OnTimeout != OnTimeoutHold && cfg.OnTimeout != OnTimeoutFail {
+		errs = append(errs, fmt.Errorf("%s: invalid wait_for on_timeout %q (valid: hold, fail)", sctx, cfg.OnTimeout))
 	}
 
 	// Validate check_interval

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -42,6 +42,18 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			}
 			return poller.PollCIStatus(ctx, sourceItemID)
 		}))
+		// Wire up blocker listing for wait_for steps with kind: dependency.
+		opts = append(opts, workflow.WithDependencyChecker(func(ctx context.Context, sourceID, sourceItemID, linkType string) ([]source.BlockerRef, error) {
+			adapter, ok := d.sources[sourceID]
+			if !ok {
+				return nil, fmt.Errorf("source %q not found", sourceID)
+			}
+			lister, ok := adapter.(source.BlockerLister)
+			if !ok {
+				return nil, fmt.Errorf("source %q does not support blocker listing (wait_for kind: dependency)", sourceID)
+			}
+			return lister.ListBlockers(ctx, sourceItemID, linkType)
+		}))
 		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d}, opts...)
 	})
 	return d.engine

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -27,6 +27,7 @@ var (
 	_ source.TaskPoller      = (*Adapter)(nil)
 	_ source.CIStatusPoller  = (*Adapter)(nil)
 	_ source.SubIssueCreator = (*Adapter)(nil)
+	_ source.BlockerLister   = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -532,6 +533,75 @@ func (a *Adapter) ListPullRequests(ctx context.Context, cellID string) ([]source
 		})
 	}
 	return prs, nil
+}
+
+// ListBlockers enumerates the issues blocking the given one via GitHub's issue
+// dependencies API (GET .../issues/{n}/dependencies/blocked_by). linkType is
+// ignored — GitHub has a single "blocked by" relation. State is normalized to
+// "done" when the blocker is closed, otherwise its raw state. For an open
+// blocker, Merged reports whether any pull request cross-referenced from it is
+// merged (best-effort: a PR lookup failure leaves Merged false rather than
+// failing the whole check). Implements source.BlockerLister.
+func (a *Adapter) ListBlockers(ctx context.Context, cellID, _ string) ([]source.BlockerRef, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/dependencies/blocked_by", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("github: listing blockers of issue %s: %w", cellID, err)
+	}
+
+	var blocking []issue
+	if err := json.Unmarshal(body, &blocking); err != nil {
+		return nil, fmt.Errorf("github: decoding blockers of issue %s: %w", cellID, err)
+	}
+
+	blockers := make([]source.BlockerRef, 0, len(blocking))
+	for _, b := range blocking {
+		state := b.State
+		if state == "closed" {
+			state = "done"
+		}
+		ref := source.BlockerRef{
+			ID:     fmt.Sprintf("%d", b.Number),
+			Number: fmt.Sprintf("#%d", b.Number),
+			Title:  b.Title,
+			State:  state,
+		}
+		if state != "done" {
+			ref.Merged = a.blockerHasMergedPR(ctx, b.Number)
+		}
+		blockers = append(blockers, ref)
+	}
+	return blockers, nil
+}
+
+// blockerHasMergedPR reports whether any pull request cross-referenced from the
+// blocker issue is merged. Best-effort: any lookup failure returns false (the
+// dependency wait just keeps polling), so a transient API error cannot fail the
+// workflow step.
+func (a *Adapter) blockerHasMergedPR(ctx context.Context, issueNumber int) bool {
+	prs, err := a.ListPullRequests(ctx, fmt.Sprintf("%d", issueNumber))
+	if err != nil {
+		aplog.Debug("github: listing PRs of blocker #%d: %v", issueNumber, err)
+		return false
+	}
+	for _, ref := range prs {
+		prPath := fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, ref.Number)
+		body, err := a.client.get(ctx, prPath)
+		if err != nil {
+			aplog.Debug("github: fetching PR #%d of blocker #%d: %v", ref.Number, issueNumber, err)
+			continue
+		}
+		var pr struct {
+			Merged bool `json:"merged"`
+		}
+		if err := json.Unmarshal(body, &pr); err != nil {
+			continue
+		}
+		if pr.Merged {
+			return true
+		}
+	}
+	return false
 }
 
 // isAuthError reports whether a client error is a GitHub authorization failure

--- a/src/internal/source/github/listblockers_test.go
+++ b/src/internal/source/github/listblockers_test.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// blockersStub stands up a GitHub API stub for issue 42's dependencies plus the
+// blockers' timelines/PRs used by merged detection.
+func blockersStub(t *testing.T, routes map[string]string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for suffix, body := range routes {
+			if strings.HasSuffix(r.URL.Path, suffix) {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+}
+
+func TestListBlockers_ClosedIsDone(t *testing.T) {
+	a := blockersStub(t, map[string]string{
+		"/issues/42/dependencies/blocked_by": `[
+			{"id": 1, "number": 49, "title": "Register PAS purpose", "state": "closed"},
+			{"id": 2, "number": 50, "title": "Apigee product", "state": "open"}
+		]`,
+		"/issues/50/timeline": `[]`, // open blocker, no PR linked
+	})
+
+	blockers, err := a.ListBlockers(context.Background(), "42", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 2 {
+		t.Fatalf("got %d blockers, want 2: %+v", len(blockers), blockers)
+	}
+	if blockers[0].Number != "#49" || blockers[0].State != "done" {
+		t.Errorf("closed blocker = %+v, want state normalized to done", blockers[0])
+	}
+	if blockers[1].State != "open" || blockers[1].Merged {
+		t.Errorf("open blocker without PR = %+v, want open/unmerged", blockers[1])
+	}
+}
+
+func TestListBlockers_OpenBlockerWithMergedPR(t *testing.T) {
+	a := blockersStub(t, map[string]string{
+		"/issues/42/dependencies/blocked_by": `[
+			{"id": 2, "number": 50, "title": "Apigee product", "state": "open"}
+		]`,
+		"/issues/50/timeline": `[
+			{"event":"cross-referenced","source":{"type":"issue","issue":{"number":51,"pull_request":{"url":"https://api/pulls/51"}}}}
+		]`,
+		"/pulls/51": `{"number": 51, "merged": true}`,
+	})
+
+	blockers, err := a.ListBlockers(context.Background(), "42", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 1 || !blockers[0].Merged {
+		t.Fatalf("got %+v, want the open blocker marked Merged via its PR", blockers)
+	}
+}
+
+func TestListBlockers_NoBlockers(t *testing.T) {
+	a := blockersStub(t, map[string]string{
+		"/issues/42/dependencies/blocked_by": `[]`,
+	})
+
+	blockers, err := a.ListBlockers(context.Background(), "42", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 0 {
+		t.Errorf("got %+v, want none", blockers)
+	}
+}

--- a/src/internal/source/jira/adapter.go
+++ b/src/internal/source/jira/adapter.go
@@ -28,10 +28,11 @@ func init() {
 // capabilities used by the dispatcher and the workflow engine. CI status and
 // PR listing are PR-centric and have no Jira mapping, so they are omitted.
 var (
-	_ source.StateSetter  = (*Adapter)(nil)
-	_ source.LabelAdder   = (*Adapter)(nil)
-	_ source.LabelRemover = (*Adapter)(nil)
-	_ source.TaskPoller   = (*Adapter)(nil)
+	_ source.StateSetter   = (*Adapter)(nil)
+	_ source.LabelAdder    = (*Adapter)(nil)
+	_ source.LabelRemover  = (*Adapter)(nil)
+	_ source.TaskPoller    = (*Adapter)(nil)
+	_ source.BlockerLister = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -301,6 +302,53 @@ func (a *Adapter) PollTask(ctx context.Context, cellID string) (model.SourceItem
 		cell.Comments = comments
 	}
 	return cell, nil
+}
+
+// defaultBlockerLinkType is the stock Jira link type whose inward side reads
+// "is blocked by" — the relation a dependency wait gates on by default.
+const defaultBlockerLinkType = "Blocks"
+
+// ListBlockers enumerates the issues blocking the given one: the inward side
+// of its linkType issue links (default "Blocks", i.e. "is blocked by").
+// State is normalized to "done" when the blocker's status category is Done,
+// otherwise the raw status name. Merged is always false — Jira's core REST API
+// has no PR visibility, so dependency waits on Jira are satisfied via the
+// "done" condition. Implements source.BlockerLister.
+func (a *Adapter) ListBlockers(ctx context.Context, cellID, linkType string) ([]source.BlockerRef, error) {
+	if linkType == "" {
+		linkType = defaultBlockerLinkType
+	}
+
+	path := "/rest/api/3/issue/" + url.PathEscape(cellID)
+	data, err := a.client.get(ctx, path, url.Values{"fields": {"issuelinks"}})
+	if err != nil {
+		return nil, fmt.Errorf("jira: listing blockers of %s: %w", cellID, err)
+	}
+	var item issueLinks
+	if err := json.Unmarshal(data, &item); err != nil {
+		return nil, fmt.Errorf("jira: decoding issue links of %s: %w", cellID, err)
+	}
+
+	var blockers []source.BlockerRef
+	for _, link := range item.Fields.IssueLinks {
+		if link.InwardIssue == nil || !strings.EqualFold(link.Type.Name, linkType) {
+			continue
+		}
+		state := ""
+		if st := link.InwardIssue.Fields.Status; st != nil {
+			state = st.Name
+			if st.StatusCategory.Key == "done" {
+				state = "done"
+			}
+		}
+		blockers = append(blockers, source.BlockerRef{
+			ID:     link.InwardIssue.ID,
+			Number: link.InwardIssue.Key,
+			Title:  link.InwardIssue.Fields.Summary,
+			State:  state,
+		})
+	}
+	return blockers, nil
 }
 
 // fetchComments retrieves every comment on an issue, oldest first, flattening

--- a/src/internal/source/jira/listblockers_test.go
+++ b/src/internal/source/jira/listblockers_test.go
@@ -1,0 +1,112 @@
+package jira
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// issueLinksBody is GET /issue/10042?fields=issuelinks for an issue with one
+// open blocker (inward "Blocks"), one resolved blocker, one outward "Blocks"
+// link (an issue IT blocks — not a blocker), and one unrelated link type.
+const issueLinksBody = `{
+	"id": "10042", "key": "PSP-42",
+	"fields": {
+		"issuelinks": [
+			{
+				"type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+				"inwardIssue": {
+					"id": "10049", "key": "PSP-49",
+					"fields": {"summary": "Register PAS purpose", "status": {"name": "In Progress", "statusCategory": {"key": "indeterminate"}}}
+				}
+			},
+			{
+				"type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+				"inwardIssue": {
+					"id": "10050", "key": "PSP-50",
+					"fields": {"summary": "Apigee product", "status": {"name": "Concluído", "statusCategory": {"key": "done"}}}
+				}
+			},
+			{
+				"type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+				"outwardIssue": {
+					"id": "10060", "key": "PSP-60",
+					"fields": {"summary": "Downstream task", "status": {"name": "To Do", "statusCategory": {"key": "new"}}}
+				}
+			},
+			{
+				"type": {"name": "Relates", "inward": "relates to", "outward": "relates to"},
+				"inwardIssue": {
+					"id": "10070", "key": "PSP-70",
+					"fields": {"summary": "Related doc", "status": {"name": "To Do", "statusCategory": {"key": "new"}}}
+				}
+			}
+		]
+	}
+}`
+
+func blockersServer(t *testing.T, body string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/issue/10042") && r.URL.Query().Get("fields") == "issuelinks" {
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return newTestAdapter(srv.URL)
+}
+
+func TestListBlockers_InwardBlocksLinksOnly(t *testing.T) {
+	a := blockersServer(t, issueLinksBody)
+
+	blockers, err := a.ListBlockers(context.Background(), "10042", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 2 {
+		t.Fatalf("got %d blockers, want 2 (inward Blocks only): %+v", len(blockers), blockers)
+	}
+
+	open, done := blockers[0], blockers[1]
+	if open.ID != "10049" || open.Number != "PSP-49" || open.Title != "Register PAS purpose" {
+		t.Errorf("open blocker mapped wrong: %+v", open)
+	}
+	if open.State != "In Progress" {
+		t.Errorf("open blocker state = %q, want raw status name", open.State)
+	}
+	if done.State != "done" {
+		t.Errorf("Done-category blocker state = %q, want normalized \"done\"", done.State)
+	}
+	if open.Merged || done.Merged {
+		t.Error("jira blockers must never report Merged (no PR visibility)")
+	}
+}
+
+func TestListBlockers_CustomLinkType(t *testing.T) {
+	a := blockersServer(t, issueLinksBody)
+
+	// "Relates" as the blocking relation: only the inward Relates link matches.
+	blockers, err := a.ListBlockers(context.Background(), "10042", "Relates")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 1 || blockers[0].Number != "PSP-70" {
+		t.Fatalf("got %+v, want only PSP-70 for link type Relates", blockers)
+	}
+}
+
+func TestListBlockers_NoLinks(t *testing.T) {
+	a := blockersServer(t, `{"id": "10042", "key": "PSP-42", "fields": {"issuelinks": []}}`)
+
+	blockers, err := a.ListBlockers(context.Background(), "10042", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 0 {
+		t.Errorf("got %+v, want none", blockers)
+	}
+}

--- a/src/internal/source/jira/types.go
+++ b/src/internal/source/jira/types.go
@@ -39,6 +39,34 @@ type statusCategory struct {
 	Key string `json:"key"` // "new", "indeterminate", "done"
 }
 
+// issueLinks is the slice of GET /issue/{id}?fields=issuelinks we care about:
+// the issue's links, each carrying the link type and the OTHER side's issue —
+// inwardIssue when the other issue points at this one (for a "Blocks" link,
+// the inward side is "is blocked by", i.e. a blocker of this issue).
+type issueLinks struct {
+	Fields struct {
+		IssueLinks []issueLink `json:"issuelinks"`
+	} `json:"fields"`
+}
+
+type issueLink struct {
+	Type        issueLinkType `json:"type"`
+	InwardIssue *linkedIssue  `json:"inwardIssue"`
+}
+
+type issueLinkType struct {
+	Name string `json:"name"` // e.g. "Blocks"
+}
+
+type linkedIssue struct {
+	ID     string `json:"id"`
+	Key    string `json:"key"`
+	Fields struct {
+		Summary string        `json:"summary"`
+		Status  *statusEntity `json:"status"`
+	} `json:"fields"`
+}
+
 // transitionsResponse is the envelope of GET /issue/{id}/transitions.
 type transitionsResponse struct {
 	Transitions []transition `json:"transitions"`

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -102,6 +102,29 @@ type PullRequestLister interface {
 	ListPullRequests(ctx context.Context, cellID string) ([]PullRequestRef, error)
 }
 
+// BlockerRef is one upstream blocker of a source item — another work item that
+// must land before the blocked one may proceed (e.g. the other side of a Jira
+// "is blocked by" link). State and Merged carry the blocker's resolution
+// signals; the workflow engine decides satisfaction against the wait_for step's
+// satisfied_when conditions.
+type BlockerRef struct {
+	ID     string // source-native id of the blocking item
+	Number string // human-facing reference (e.g. "PSP-49", "#42")
+	Title  string // blocker summary, for poll-history/debug detail
+	State  string // normalized: "done" when resolved/closed, otherwise the source status
+	Merged bool   // true when a pull request linked to the blocker is merged
+}
+
+// BlockerLister is an optional interface a source may implement to enumerate a
+// task's upstream blockers. The workflow engine uses it for wait_for steps with
+// kind "dependency", which park the instance until every blocker is satisfied.
+// linkType selects the source-native blocking relation (e.g. Jira's "Blocks"
+// link type); empty means the source's default. Sources that do not implement
+// it cannot host dependency waits (rejected at config validation).
+type BlockerLister interface {
+	ListBlockers(ctx context.Context, cellID, linkType string) ([]BlockerRef, error)
+}
+
 // SubIssueCreator is an optional interface a source may implement to create a
 // child work item linked to a parent (a sub-issue). The workflow engine uses it
 // to materialize a spawned InternalTask as a source sub-issue under the spawning

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -200,16 +200,23 @@ type SideEffects interface {
 // It returns a CIStatus or an error if the check fails (transient or permanent).
 type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error)
 
+// DependencyChecker is called by wait_for steps with kind "dependency" to list
+// the task's upstream blockers. linkType is the step's blocker_link_type
+// (empty = the source's default blocking relation). It returns the blockers or
+// an error if the lookup fails (transient or permanent).
+type DependencyChecker func(ctx context.Context, sourceID, sourceItemID, linkType string) ([]source.BlockerRef, error)
+
 type Engine struct {
-	cfg       *config.Config
-	store     Store
-	exec      StepExecutor
-	side      SideEffects
-	mem       MemoryBuilder
-	memStore  MemoryStore
-	spawner   WorkflowSpawner
-	tracker   TaskTracker
-	ciChecker CIStatusChecker
+	cfg        *config.Config
+	store      Store
+	exec       StepExecutor
+	side       SideEffects
+	mem        MemoryBuilder
+	memStore   MemoryStore
+	spawner    WorkflowSpawner
+	tracker    TaskTracker
+	ciChecker  CIStatusChecker
+	depChecker DependencyChecker
 
 	now   func() time.Time
 	newID func(prefix string) string
@@ -252,6 +259,12 @@ func WithTaskTracker(t TaskTracker) Option { return func(e *Engine) { e.tracker 
 // WithCIStatusChecker sets the CI status checker used by wait_for steps.
 func WithCIStatusChecker(checker CIStatusChecker) Option {
 	return func(e *Engine) { e.ciChecker = checker }
+}
+
+// WithDependencyChecker sets the blocker lister used by wait_for steps with
+// kind "dependency".
+func WithDependencyChecker(checker DependencyChecker) Option {
+	return func(e *Engine) { e.depChecker = checker }
 }
 
 // NewEngine builds an Engine. cfg, store, and exec are required.

--- a/src/internal/workflow/wait_dependency_test.go
+++ b/src/internal/workflow/wait_dependency_test.go
@@ -1,0 +1,242 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// dependencyWorkflow: await-blockers (wait_for/dependency) → implement (agent).
+func dependencyWorkflow(wait *config.WaitForConfig) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "await-blockers", Type: config.StepTypeWaitFor, WaitFor: wait},
+		{ID: "implement", Agent: "backend-dev", DependsOn: []string{"await-blockers"}},
+	}}
+}
+
+// depWaitEngine builds a test engine with a controllable clock and blocker lister.
+func depWaitEngine(store Store, exec StepExecutor, clock *time.Time,
+	dep func() ([]source.BlockerRef, error)) *Engine {
+	var seq atomic.Int64
+	return NewEngine(baseCfg(), store, exec,
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return *clock }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+		WithDependencyChecker(func(_ context.Context, _, _, _ string) ([]source.BlockerRef, error) {
+			return dep()
+		}),
+	)
+}
+
+func TestDependencyWait_SuspendsWhileBlockerOpen(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "10049", Number: "PSP-49", State: "In Progress"}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	instID, success, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a dependency-parked instance should not report success")
+	}
+	if store.instances[instID].State != db.InstanceStateWaiting {
+		t.Errorf("instance state = %q, want waiting", store.instances[instID].State)
+	}
+	if contains(executedIDs(exec.seen), "implement") {
+		t.Error("implement must not run while a blocker is unsatisfied")
+	}
+	if pp := eng.ParkedWaits(); len(pp) != 1 || pp[0].Step.ID != "await-blockers" {
+		t.Fatalf("expected one parked wait for await-blockers, got %+v", pp)
+	}
+	// The unsatisfied check is recorded for audit, like a CI poll.
+	if len(store.ciPolls) == 0 || store.ciPolls[len(store.ciPolls)-1].Status != "pending" {
+		t.Errorf("expected a recorded pending poll, got %+v", store.ciPolls)
+	}
+}
+
+func TestDependencyWait_AutoResumesWhenBlockerDone(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	state := "In Progress"
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "10049", Number: "PSP-49", State: state}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+
+	// Blocker still open → stays parked.
+	eng.CheckParkedWaits(context.Background())
+	if store.instances[instID].State != db.InstanceStateWaiting {
+		t.Fatalf("expected still waiting, got %q", store.instances[instID].State)
+	}
+
+	// Blocker resolves → next check auto-resumes the workflow to done.
+	state = "done"
+	eng.CheckParkedWaits(context.Background())
+	if store.instances[instID].State != db.InstanceStateDone {
+		t.Errorf("expected done after blocker resolved, got %q", store.instances[instID].State)
+	}
+	if !contains(executedIDs(exec.seen), "implement") {
+		t.Error("implement should run once the blocker is satisfied")
+	}
+	if len(eng.ParkedWaits()) != 0 {
+		t.Error("instance should no longer be parked")
+	}
+}
+
+func TestDependencyWait_NoBlockersPassesImmediately(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	dep := func() ([]source.BlockerRef, error) { return nil, nil }
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	instID, success, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+	if !success || store.instances[instID].State != db.InstanceStateDone {
+		t.Fatalf("expected immediate success with no blockers, got success=%v state=%q", success, store.instances[instID].State)
+	}
+}
+
+func TestDependencyWait_SatisfiedWhenMergedOnly(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	// Blocker is Done-category but its PR is not merged: with satisfied_when
+	// restricted to merged, "done" must NOT satisfy it.
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "1", Number: "PSP-50", State: "done", Merged: false}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	wait := &config.WaitForConfig{Kind: "dependency", SatisfiedWhen: []string{"merged"}}
+	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(wait), model.InternalTask{ID: "c1"})
+	if store.instances[instID].State != db.InstanceStateWaiting {
+		t.Fatalf("done-but-unmerged blocker should keep waiting under satisfied_when [merged], got %q", store.instances[instID].State)
+	}
+}
+
+func TestDependencyWait_MergedSatisfiesDefaultConditions(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	// Open blocker with a merged PR: the default [merged, done] is an OR, so
+	// merged alone satisfies it.
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "1", Number: "PSP-50", State: "In Progress", Merged: true}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	instID, success, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+	if !success || store.instances[instID].State != db.InstanceStateDone {
+		t.Fatalf("merged blocker should satisfy the default conditions, got success=%v state=%q", success, store.instances[instID].State)
+	}
+}
+
+func TestDependencyWait_CheckerErrorKeepsWaiting(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	dep := func() ([]source.BlockerRef, error) { return nil, errors.New("jira down") }
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+	if store.instances[instID].State != db.InstanceStateWaiting {
+		t.Fatalf("a transient lookup error should park (retry next cycle), got %q", store.instances[instID].State)
+	}
+	if len(store.ciPolls) == 0 || store.ciPolls[len(store.ciPolls)-1].Status != "error" {
+		t.Errorf("expected a recorded error poll, got %+v", store.ciPolls)
+	}
+}
+
+func TestDependencyWait_TimeoutHoldStaysParked(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "1", Number: "PSP-49", State: "open"}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	// on_timeout defaults to hold for kind: dependency.
+	wait := &config.WaitForConfig{Kind: "dependency", MaxDuration: "1h"}
+	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(wait), model.InternalTask{ID: "c1"})
+
+	clock = clock.Add(2 * time.Hour)
+	eng.CheckParkedWaits(context.Background())
+	if store.instances[instID].State != db.InstanceStateWaiting {
+		t.Errorf("on_timeout hold should keep the instance parked, got %q", store.instances[instID].State)
+	}
+	if len(eng.ParkedWaits()) != 1 {
+		t.Error("instance should still be parked past the deadline under hold")
+	}
+}
+
+func TestDependencyWait_TimeoutFailFailsStep(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	dep := func() ([]source.BlockerRef, error) {
+		return []source.BlockerRef{{ID: "1", Number: "PSP-49", State: "open"}}, nil
+	}
+	eng := depWaitEngine(store, exec, &clock, dep)
+
+	wait := &config.WaitForConfig{Kind: "dependency", MaxDuration: "1h", OnTimeout: "fail"}
+	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(wait), model.InternalTask{ID: "c1"})
+
+	clock = clock.Add(2 * time.Hour)
+	eng.CheckParkedWaits(context.Background())
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("on_timeout fail should fail the instance at the deadline, got %q", store.instances[instID].State)
+	}
+}
+
+func TestDependencyWait_NoCheckerConfiguredFails(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	var seq atomic.Int64
+	eng := NewEngine(baseCfg(), store, exec,
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return clock }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+	)
+
+	instID, success, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
+	if success || store.instances[instID].State != db.InstanceStateFailed {
+		t.Fatalf("a dependency wait without a configured checker should fail, got success=%v state=%q", success, store.instances[instID].State)
+	}
+}
+
+func TestDependencyWait_LinkTypeReachesChecker(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	var gotLinkType string
+	var seq atomic.Int64
+	eng := NewEngine(baseCfg(), store, exec,
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return clock }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+		WithDependencyChecker(func(_ context.Context, _, _, linkType string) ([]source.BlockerRef, error) {
+			gotLinkType = linkType
+			return nil, nil
+		}),
+	)
+
+	wait := &config.WaitForConfig{Kind: "dependency", BlockerLinkType: "Depends"}
+	_, _, _ = eng.RunInstance(context.Background(), dependencyWorkflow(wait), model.InternalTask{ID: "c1"})
+	if gotLinkType != "Depends" {
+		t.Errorf("blocker_link_type = %q reached the checker, want \"Depends\"", gotLinkType)
+	}
+}

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/source"
 )
 
 // RunWaitStep performs ONE check of the external system (e.g. CI status) and
@@ -31,8 +32,10 @@ func (e *Engine) RunWaitStep(
 
 	cfg := step.WaitFor
 	switch cfg.Kind {
-	case "", "ci":
+	case "", config.WaitKindCI:
 		return e.checkCIWaitStep(ctx, instID, step, sourceID, sourceItemID, deadline)
+	case config.WaitKindDependency:
+		return e.checkDependencyWaitStep(ctx, instID, step, sourceID, sourceItemID, deadline)
 	default:
 		return StepResult{}, fmt.Errorf("wait_for step %q unsupported kind: %q", step.ID, cfg.Kind)
 	}
@@ -57,8 +60,15 @@ func (e *Engine) checkCIWaitStep(
 
 	cfg := step.WaitFor
 
-	// Timeout: give up waiting once past the deadline.
+	// Timeout: once past the deadline, fail the step — or, with on_timeout: hold,
+	// keep the instance parked for a human instead of giving up.
 	if !deadline.IsZero() && e.now().After(deadline) {
+		if cfg.TimeoutAction() == config.OnTimeoutHold {
+			aplog.Info("wait_for step %q: CI wait exceeded %v — holding (on_timeout: hold)", step.ID, cfg.ParsedMaxDuration())
+			e.recordCIPoll(ctx, instID, step.ID, "timeout", "",
+				fmt.Sprintf("CI did not complete within %v; holding for manual resolution", cfg.ParsedMaxDuration()))
+			return StepResult{Pending: true}, nil
+		}
 		aplog.Info("wait_for step %q: CI wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
 		e.recordCIPoll(ctx, instID, step.ID, "timeout", "",
 			fmt.Sprintf("CI did not complete within %v", cfg.ParsedMaxDuration()))
@@ -137,6 +147,130 @@ func (e *Engine) checkCIWaitStep(
 		aplog.Debug("wait_for step %q: CI status %q not yet conclusive", step.ID, status.Status)
 		return StepResult{Pending: true}, nil
 	}
+}
+
+// checkDependencyWaitStep performs a single blocker check for a wait_for step
+// with kind "dependency". Transient lookup errors and any still-unsatisfied
+// blocker both yield Pending (the instance stays parked and is re-checked next
+// poll cycle); all blockers satisfied — merged and/or Done, per satisfied_when —
+// is terminal success, auto-resuming the workflow. Past the deadline the step
+// honours on_timeout: hold keeps parking for a human (the default for this
+// kind), fail fails the step. Every check is recorded like a CI poll, so the
+// wait's history is auditable from the dashboard.
+func (e *Engine) checkDependencyWaitStep(
+	ctx context.Context,
+	instID string,
+	step config.StepConfig,
+	sourceID, sourceItemID string,
+	deadline time.Time,
+) (StepResult, error) {
+	if e.depChecker == nil {
+		return StepResult{
+			Success: false,
+			Err:     fmt.Errorf("dependency (blocker) polling not configured"),
+		}, nil
+	}
+
+	cfg := step.WaitFor
+
+	// Timeout: hold keeps the instance parked for a human; fail gives up.
+	if !deadline.IsZero() && e.now().After(deadline) {
+		if cfg.TimeoutAction() == config.OnTimeoutFail {
+			aplog.Info("wait_for step %q: dependency wait timed out after %v", step.ID, cfg.ParsedMaxDuration())
+			e.recordCIPoll(ctx, instID, step.ID, "timeout", "",
+				fmt.Sprintf("blockers not satisfied within %v", cfg.ParsedMaxDuration()))
+			return StepResult{
+				Success: false,
+				StructuredOutput: map[string]any{
+					"dependency_status": "timeout",
+					"reason":            fmt.Sprintf("blockers not satisfied within %v", cfg.ParsedMaxDuration()),
+				},
+			}, nil
+		}
+		aplog.Info("wait_for step %q: dependency wait exceeded %v — holding (on_timeout: hold)", step.ID, cfg.ParsedMaxDuration())
+		e.recordCIPoll(ctx, instID, step.ID, "timeout", "",
+			fmt.Sprintf("blockers not satisfied within %v; holding for manual resolution", cfg.ParsedMaxDuration()))
+		return StepResult{Pending: true}, nil
+	}
+
+	blockers, err := e.depChecker(ctx, sourceID, sourceItemID, cfg.BlockerLinkType)
+	if err != nil {
+		// WARN, not DEBUG: a persistent error (missing scope, wrong link type)
+		// would otherwise masquerade as an endless wait with no visible cause.
+		// Retried next cycle so it self-heals once the underlying problem is fixed.
+		aplog.Warn("wait_for step %q: blocker check failed (will retry next cycle): %v", step.ID, err)
+		e.recordCIPoll(ctx, instID, step.ID, "error", "", err.Error())
+		return StepResult{Pending: true}, nil
+	}
+
+	conditions := cfg.EffectiveSatisfiedWhen()
+	unsatisfied := make([]source.BlockerRef, 0, len(blockers))
+	for _, b := range blockers {
+		if !blockerSatisfied(b, conditions) {
+			unsatisfied = append(unsatisfied, b)
+		}
+	}
+
+	if len(unsatisfied) > 0 {
+		aplog.Debug("wait_for step %q: %d of %d blocker(s) still unsatisfied", step.ID, len(unsatisfied), len(blockers))
+		e.recordCIPoll(ctx, instID, step.ID, "pending", "", encodeBlockers(unsatisfied))
+		return StepResult{Pending: true}, nil
+	}
+
+	e.recordCIPoll(ctx, instID, step.ID, "passed", "", encodeBlockers(blockers))
+	return StepResult{
+		Success: true,
+		StructuredOutput: map[string]any{
+			"dependency_status": "satisfied",
+			"blockers":          blockersToMap(blockers),
+		},
+	}, nil
+}
+
+// blockerSatisfied reports whether one blocker meets ANY of the satisfied_when
+// conditions: "merged" — a PR linked to the blocker is merged; "done" — the
+// blocker's status is Done-category (resolved/closed).
+func blockerSatisfied(b source.BlockerRef, conditions []string) bool {
+	for _, cond := range conditions {
+		switch cond {
+		case config.BlockerSatisfiedMerged:
+			if b.Merged {
+				return true
+			}
+		case config.BlockerSatisfiedDone:
+			if b.State == "done" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// blockersToMap renders blockers as reference→state for structured step output.
+// A merged blocker reports "merged" so the output shows which condition held.
+func blockersToMap(blockers []source.BlockerRef) map[string]string {
+	m := make(map[string]string, len(blockers))
+	for _, b := range blockers {
+		state := b.State
+		if b.Merged {
+			state = "merged"
+		}
+		m[b.Number] = state
+	}
+	return m
+}
+
+// encodeBlockers renders blockers as compact JSON for the recorded poll's
+// detail column. Returns "" when there are none.
+func encodeBlockers(blockers []source.BlockerRef) string {
+	if len(blockers) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(blockersToMap(blockers))
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 func checksToMap(checks []struct {


### PR DESCRIPTION
## Summary

Implements #177: a first-class, restart-safe `wait_for` step kind — **`dependency`** — that suspends a workflow until the task's upstream blockers are merged/resolved, then **auto-resumes**. Replaces the interim judge-persona blocker gate (no auto-resume, prompt-dependent, burned `max_attempts`).

```yaml
- id: await-blockers
  type: wait_for
  wait_for:
    kind: dependency
    satisfied_when: [merged, done]   # blocker OK when its PR merged OR status is Done-category (OR semantics)
    blocker_link_type: "Blocks"      # source-native relation; default: the source's blocking link
    check_interval: 5m
    on_timeout: hold                 # hold (default for this kind) | fail
```

- **Config** — `WaitForConfig` gains `satisfied_when`, `blocker_link_type`, `on_timeout`. Kind-aware defaults: dependency waits default to **no deadline** + `on_timeout: hold` (a blocker may take days); `ci` keeps 2h + fail. The `ci` kind also honours `on_timeout: hold` now.
- **Engine** — `checkDependencyWaitStep` mirrors `checkCIWaitStep`: one cheap check per poll cycle; any unsatisfied blocker → `Pending` re-parks the instance (existing parked-wait machinery, so it survives daemon restarts); all satisfied → terminal success and the pipeline proceeds. Every check is recorded in the CI poll history (statuses `pending`/`passed`/`error`/`timeout` with a blockers→state JSON detail), auditable from the dashboard.
- **Source capability** — new optional `BlockerLister` interface (`ListBlockers(ctx, cellID, linkType) → []BlockerRef{ID, Number, Title, State, Merged}`), wired into the engine via `WithDependencyChecker` exactly like the CI checker.
- **Jira** — reads the inward side of the issue's `Blocks` links (*"is blocked by"*), `blocker_link_type` overrides the link type; `State` normalized to `done` on Done-category. `Merged` is always false (core REST has no PR visibility) — satisfaction comes from `done`.
- **GitHub** — reads the issue dependencies API (`…/dependencies/blocked_by`); closed → `done`, and an open blocker reports `Merged` when a cross-referenced PR is merged (best-effort).
- **Validation** — `kind: dependency` accepted; a config whose sources all lack `BlockerLister` is rejected at lint with a clear message (capability hook injected by `cli`, mirroring `KnownAdapters`); dependency-only fields are rejected on other kinds; `satisfied_when`/`on_timeout` values validated.
- **Schema + docs** — `schema/apiary.json` kind enum + new fields; `docs/workflows.md` gets a dedicated section with the example above; `docs/jira-source.md` capability note.

## Acceptance criteria (from #177)

- [x] `wait_for: { kind: dependency }` validates and runs; a source without `BlockerLister` is rejected at config-lint with a clear message
- [x] Step suspends (parked, restart-safe) while any blocker is unsatisfied and auto-resumes once all are merged/Done
- [x] `satisfied_when` supports `merged` and `done`; the Jira adapter reads inward `Blocks` links
- [x] `max_duration` / `on_timeout` honored (`hold` keeps parking; `fail` fails the step)
- [x] Poll history recorded/auditable like CI polls
- [x] `docs/workflows.md` + `schema/apiary.json` updated with an example

## Test plan

- `go test ./...` green; `go vet` clean (no Go CI in this repo — verified locally).
- New engine tests (`wait_dependency_test.go`): park while blocker open, auto-resume on done, merged-only and default OR semantics, checker error keeps waiting, timeout hold vs fail, missing checker fails, `blocker_link_type` threading.
- New config tests: kind/field validation, capability-hook rejection, kind-aware defaults.
- New adapter tests: Jira inward-`Blocks` filtering + custom link type + status normalization; GitHub `blocked_by` mapping + merged-PR detection.
- GitNexus impact on touched symbols (`RunWaitStep`, `ParsedMaxDuration`): LOW risk; `ci` behaviour unchanged (2h/fail defaults preserved).

Closes #177