### PR TITLE
feat(logging): include human-facing source reference in task log labels

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1157,7 +1157,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	for _, cell := range cells {
 		cell := cell
 		if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
-			aplog.Debug("cell %s: already in-flight, skipping", cell.ID)
+			aplog.Debug("cell %s: already in-flight, skipping", cell.LogLabel())
 			continue
 		}
 		task, persisted := d.bindItem(ctx, cell)
@@ -1172,7 +1172,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			matches = d.dropCappedMatches(ctx, task, matches)
 		}
 		if len(matches) == 0 {
-			aplog.Debug("cell %s (%q): no matching route, skipping", cell.ID, cell.Title)
+			aplog.Debug("cell %s (%q): no matching route, skipping", cell.LogLabel(), cell.Title)
 			d.inFlight.Delete(cell.ID)
 			continue
 		}
@@ -1243,7 +1243,7 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 			defer d.activeRuns.Delete(runID)
 
 			aplog.Info("dispatching cell %s (%q) → workflow %s [agent %s]",
-				cell.ID, cell.Title, match.Route.ID, match.Route.Agent)
+				cell.LogLabel(), cell.Title, match.Route.ID, match.Route.Agent)
 
 			result := d.dispatch(ctx, cell, adapter, task, match)
 			if !result.Success && onFail != nil {
@@ -1296,10 +1296,10 @@ func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task 
 	}
 	task, err := d.binder.Bind(ctx, cell)
 	if err != nil {
-		aplog.Error("bind source item %s (%q): %v", cell.ID, cell.Title, err)
+		aplog.Error("bind source item %s (%q): %v", cell.LogLabel(), cell.Title, err)
 		return transientTask(cell), false
 	}
-	aplog.Debug("bound source item %s → task %s [%s]", cell.ID, task.ID, task.State)
+	aplog.Debug("bound source item %s → task %s [%s]", cell.LogLabel(), task.ID, task.State)
 	return task, true
 }
 

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -193,17 +193,17 @@ func (t dbTaskTracker) SetTaskState(ctx context.Context, taskID string, state mo
 // instances and step runs).
 func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem, task model.InternalTask, match router.Match) model.RunResult {
 	if d.db == nil {
-		aplog.Error("cell %s: workflow dispatch requires a run-history database", cell.ID)
+		aplog.Error("cell %s: workflow dispatch requires a run-history database", cell.LogLabel())
 		return model.RunResult{Success: false}
 	}
 
 	wf := d.resolveWorkflow(match)
 	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
 	if err != nil {
-		aplog.Error("cell %s: workflow run failed: %v", cell.ID, err)
+		aplog.Error("cell %s: workflow run failed: %v", cell.LogLabel(), err)
 		return model.RunResult{Success: false, WorkerID: match.Route.Agent}
 	}
-	aplog.Info("cell %s: workflow instance %s started (success=%v; may be awaiting approval)", cell.ID, instID, success)
+	aplog.Info("cell %s: workflow instance %s started (success=%v; may be awaiting approval)", cell.LogLabel(), instID, success)
 	return model.RunResult{Success: success, WorkerID: match.Route.Agent}
 }
 
@@ -376,6 +376,10 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 
 	if x.d.logger != nil {
 		cellID := req.Cell.ID
+		// DB logs stay keyed by the cell id; the console/file mirror carries the
+		// human-facing reference too (e.g. Jira's "CDT-123") so a task is
+		// recognizable in the stream.
+		label := req.Cell.LogLabel()
 		rr.LogSink = func(e model.LogEntry) {
 			switch e.Level {
 			case "error":
@@ -385,7 +389,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 			default:
 				x.d.logger.TaskDebug(ctx, cellID, e.Message)
 			}
-			aplog.Info("[%s] %s", cellID, e.Message)
+			aplog.Info("[%s] %s", label, e.Message)
 		}
 	}
 
@@ -410,7 +414,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 	for i, c := range candidates {
 		last := i == len(candidates)-1
 		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
-			aplog.Info("[%s] runner %q paused by rate limit, skipping to fallback", req.Cell.ID, c.runnerType)
+			aplog.Info("[%s] runner %q paused by rate limit, skipping to fallback", req.Cell.LogLabel(), c.runnerType)
 			continue
 		}
 
@@ -453,7 +457,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		if out.RateLimited {
 			x.d.pauseRunner(c.runnerType, out.RateLimitResetsAt)
 			if !last {
-				aplog.Info("[%s] runner %q rate-limited, failing over to next runner", req.Cell.ID, c.runnerType)
+				aplog.Info("[%s] runner %q rate-limited, failing over to next runner", req.Cell.LogLabel(), c.runnerType)
 				continue
 			}
 		}
@@ -521,7 +525,7 @@ func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRe
 	exec, err := x.d.db.CreateExecution(ctx, req.Cell.ID, req.Step.Agent, req.Cell.Title,
 		req.Cell.Number, req.Cell.URL, model, runnerType, attempt)
 	if err != nil {
-		aplog.Error("cell %s: create execution record: %v", req.Cell.ID, err)
+		aplog.Error("cell %s: create execution record: %v", req.Cell.LogLabel(), err)
 		return nil
 	}
 	if req.InstanceID != "" {

--- a/src/internal/model/source_item.go
+++ b/src/internal/model/source_item.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // SourceItem is a normalized, source-system-agnostic view of a single item
 // returned by a source adapter's Poll. It lives only within the binding layer:
@@ -26,6 +29,18 @@ type SourceItem struct {
 	// approval steps), not by Poll. It holds comments relevant to evaluating an
 	// approval condition.
 	Comments []Comment
+}
+
+// LogLabel returns the identifier used to tag this item's log lines: the
+// source-native id plus the human-facing reference when that adds information
+// the id alone doesn't carry (e.g. Jira's "CDT-123" next to its numeric id).
+// For sources where the reference is just the id itself (GitHub's "#42"), the
+// id alone is returned.
+func (s SourceItem) LogLabel() string {
+	if s.Number == "" || strings.TrimPrefix(s.Number, "#") == s.ID {
+		return s.ID
+	}
+	return s.ID + " " + s.Number
 }
 
 // Comment is a single comment on a source task, used to evaluate approval-step

--- a/src/internal/model/source_item_test.go
+++ b/src/internal/model/source_item_test.go
@@ -1,0 +1,24 @@
+package model
+
+import "testing"
+
+func TestSourceItemLogLabel(t *testing.T) {
+	cases := []struct {
+		name   string
+		item   SourceItem
+		expect string
+	}{
+		{"jira key differs from id", SourceItem{ID: "10234", Number: "CDT-123"}, "10234 CDT-123"},
+		{"github number is the id", SourceItem{ID: "42", Number: "#42"}, "42"},
+		{"plane uuid with project key", SourceItem{ID: "9b1c-uuid", Number: "PSP-398"}, "9b1c-uuid PSP-398"},
+		{"plane uuid without project identifier", SourceItem{ID: "9b1c-uuid", Number: "#7"}, "9b1c-uuid #7"},
+		{"no number", SourceItem{ID: "42"}, "42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.item.LogLabel(); got != tc.expect {
+				t.Errorf("LogLabel() = %q, want %q", got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `SourceItem.LogLabel()`: returns the source-native id plus the human-facing reference (`Number`) when it adds information — e.g. Jira `10234 CDT-123`, Plane `<uuid> PSP-398`. For GitHub, where `#42` is just the id, the id alone is returned (no `42 #42` redundancy).
- Use the label in the per-task agent log stream mirror (`[10234 CDT-123] <message>`), rate-limit failover lines, dispatch/bind lines, and workflow start/failure lines in `daemon/workflow.go` and `daemon/dispatcher.go`.
- DB task logs remain keyed by the cell id (`task_logs.task_id` unchanged); the dashboard already shows the human reference via `source_bindings.source_item_number`.

## Test plan
- New unit test `TestSourceItemLogLabel` covering Jira, GitHub, Plane (with/without project identifier), and empty-Number cases.
- `go build ./...`, `go vet ./...`, full `go test ./...` pass locally (no Go CI in this repo).