### PR TITLE
docs(workflows): document the condition expression language

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -211,7 +211,18 @@ engine restarts from `restart_from`, up to `max` times. The reviewer's
   join: all        # all (default) | any | ${{ expr }}
 ```
 
-Children run concurrently; `join` decides the group's outcome.
+Children run concurrently; `join` decides the group's outcome:
+
+- **`all`** (default) — every child must pass.
+- **`any`** — at least one child must pass.
+- **`${{ expr }}`** — a condition expression evaluated over the children's
+  outcomes, exposed as `steps.<child-id>.state` (`passed`/`failed`) and
+  `steps.<child-id>.output`, alongside the usual `cell.*` and `memory.*`
+  accessors. Example: `${{ steps.lint.state == 'passed' and steps.tests.output
+  contains 'ok' }}`. A malformed expression logs an error and falls back to
+  `all` semantics. Note: expression accessors cannot reference child ids
+  containing hyphens — use `snake_case` ids for children you test in a join
+  expression.
 
 #### `for_each:` — iteration
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -263,6 +263,91 @@ its own retry budget.
     `for_each`, nested `steps:`) or the low-level primitives (`type: split`,
     `goto`) within one workflow — not both.
 
+### Expression syntax
+
+`if:`, `reject_when:`, split branch `if:`, expression-valued `join:`, and
+the lowered `condition:` / `fail_when:` fields all share one expression
+language. The `${{ … }}` wrapper is optional and purely cosmetic — `if:
+${{ memory.x == "done" }}` and `if: 'memory.x == "done"'` parse identically
+(only `join:` requires the wrapper, to distinguish an expression from
+`all`/`any`).
+
+An expression is one or more **comparisons** combined with logical
+operators:
+
+```text
+cell.priority == "urgent" and (cell.labels contains "bug" or not memory.triaged == "yes")
+```
+
+#### Comparisons
+
+Each comparison is `<accessor> <operator> <literal>` — the accessor must be
+on the left, the literal on the right.
+
+| Operator | Works on | Meaning |
+|----------|----------|---------|
+| `==`, `!=` | strings, numbers | Equality. Numeric when both sides are numbers (e.g. `steps.test.exit_code == 0`), string comparison otherwise. |
+| `contains` | lists, strings | On a list (`cell.labels`): exact element membership. On a string: substring match. |
+| `matches` | strings | Regular-expression match ([Go RE2 syntax](https://pkg.go.dev/regexp/syntax)). Not supported on lists. |
+
+Literals are quoted strings (`"…"` or `'…'`, no escape sequences) or bare
+numbers (integers, decimals, negatives).
+
+#### Logical operators
+
+`and`, `or`, and `not` — lowercase keywords, with parentheses for grouping.
+Precedence is `not` > `and` > `or`, and `and`/`or` short-circuit.
+
+!!! warning "No C-style operators"
+    `&&`, `||`, and `!` are **not** part of the language — use `and`, `or`,
+    `not`. (`!=` is the one exception: it is the inequality operator.)
+
+#### Accessors
+
+| Accessor | Type | Value |
+|----------|------|-------|
+| `cell.title` | string | task title |
+| `cell.type` | string | task type |
+| `cell.priority` | string | task priority |
+| `cell.state` | string | task state |
+| `cell.source` | string | source id the task came from |
+| `cell.labels` | list | task labels (use `contains`) |
+| `memory.<key>` | string | workflow-memory value written by an earlier step |
+| `steps.<id>.state` | string | `passed` or `failed` |
+| `steps.<id>.output` | string | the step's output text |
+| `steps.<id>.exit_code` | number | the step's exit code |
+
+A `memory.<key>` that was never written — and a `steps.<id>` that has not
+run — resolves to the empty string, so `memory.flag == ""` is the idiom for
+"not set". Lists only support `contains`; `==` or `matches` on `cell.labels`
+is an error.
+
+#### Examples
+
+```yaml
+# label routing
+if: ${{ cell.labels contains "hotfix" }}
+
+# combine task fields
+if: ${{ cell.priority == "urgent" and cell.type != "epic" }}
+
+# branch on a previous step's outcome
+if: ${{ steps.tests.state == "failed" or steps.tests.exit_code != 0 }}
+
+# regex over memory
+reject_when: ${{ memory.verdict matches "reject|veto" }}
+
+# negation + grouping
+if: ${{ not (memory.track == "docs" or memory.track == "chore") }}
+```
+
+!!! note "Evaluation errors fail safe"
+    Expressions are evaluated when the step is reached, not at config load.
+    A malformed expression (e.g. using `&&`) logs an error and evaluates as
+    **false**: an `if:` guard skips its step, a `reject_when:` does not
+    reject, a split branch does not match, and a `join:` expression falls
+    back to `all` semantics. Check the daemon log if a branch never fires.
+
 ### Approval steps
 
 An approval step parks the workflow until a human acts on the source item:

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -15,6 +15,14 @@ const (
 	StepTypeParallel = "parallel"
 )
 
+// Join policy values for a parallel step. Any other non-empty value is a
+// condition expression (optionally ${{ }}-wrapped) evaluated over the
+// children's outcomes — see workflow.applyJoinPolicy.
+const (
+	JoinAll = "all" // default: every child must pass
+	JoinAny = "any" // at least one child must pass
+)
+
 // Resume policy values for a workflow.
 const (
 	ResumeAllowed   = "allowed"

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -142,6 +143,8 @@ func (c *Config) validateStep(
 		errs = append(errs, validateWorkflowStep(sctx, s, wf, wfByID)...)
 	case StepTypeWaitFor:
 		errs = append(errs, c.validateWaitForStep(sctx, s)...)
+	case StepTypeParallel:
+		errs = append(errs, c.validateParallelStep(sctx, s, wf, agentIDs, wfByID)...)
 	default:
 		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
 	}
@@ -337,6 +340,56 @@ func (c *Config) validateForeachStep(sctx string, s StepConfig, wf WorkflowConfi
 	}
 	if inner.OutputSchema != nil {
 		errs = append(errs, validateOutputSchema(sctx+" (inner step)", inner.OutputSchema)...)
+	}
+
+	return errs
+}
+
+// validateParallelStep validates a type: parallel step (emitted by the v2
+// lowering pass for parallel: groups).
+func (c *Config) validateParallelStep(
+	sctx string,
+	s StepConfig,
+	wf WorkflowConfig,
+	agentIDs map[string]bool,
+	wfByID map[string]WorkflowConfig,
+) []error {
+	var errs []error
+
+	if s.Agent != "" {
+		errs = append(errs, fmt.Errorf("%s: parallel step must not have an agent field", sctx))
+	}
+	if len(s.SubSteps) == 0 {
+		errs = append(errs, fmt.Errorf("%s: parallel step requires at least one child step", sctx))
+	}
+
+	// Join policy: all (default) | any | ${{ expr }}. Expression syntax is
+	// checked at runtime (the parser lives in the workflow package); here we
+	// require the ${{ }} wrapper so a typo like "anyy" is caught at load time.
+	switch s.Join {
+	case "", JoinAll, JoinAny:
+	default:
+		j := strings.TrimSpace(s.Join)
+		if !strings.HasPrefix(j, "${{") || !strings.HasSuffix(j, "}}") {
+			errs = append(errs, fmt.Errorf("%s: invalid join %q (want all, any, or a ${{ expr }} expression)", sctx, s.Join))
+		}
+	}
+
+	// Children: unique ids, then per-type structural validation scoped to the
+	// sibling id set.
+	childIDs := map[string]bool{}
+	for j, child := range s.SubSteps {
+		if child.ID == "" {
+			errs = append(errs, fmt.Errorf("%s: children[%d]: id is required", sctx, j))
+			continue
+		}
+		if childIDs[child.ID] {
+			errs = append(errs, fmt.Errorf("%s: duplicate child step id %q", sctx, child.ID))
+		}
+		childIDs[child.ID] = true
+	}
+	for j, child := range s.SubSteps {
+		errs = append(errs, c.validateStep(sctx, j, child, wf, agentIDs, childIDs, wfByID)...)
 	}
 
 	return errs

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -674,6 +674,50 @@ func TestWorkflow_ResumeAutoAllIdempotent(t *testing.T) {
 	assertNoError(t, cfg)
 }
 
+// parallelWorkflow returns a v2-authored workflow with one parallel group;
+// Validate() lowers it to a StepTypeParallel node before structural checks.
+func parallelWorkflow(join string) config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: "wf",
+		Steps: []config.StepConfig{
+			{ID: "par", Join: join, ParallelSteps: []config.StepConfig{
+				{ID: "lint", Agent: "architect"},
+				{ID: "tests", Agent: "backend-dev"},
+			}},
+		},
+	}
+}
+
+func TestWorkflow_ParallelStepValidates(t *testing.T) {
+	for _, join := range []string{"", "all", "any", "${{ steps.lint.state == 'passed' }}"} {
+		cfg := baseWorkflowConfig()
+		cfg.Workflows = []config.WorkflowConfig{parallelWorkflow(join)}
+		assertNoError(t, cfg)
+	}
+}
+
+func TestWorkflow_ParallelJoinInvalidValue(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{parallelWorkflow("anyy")}
+	assertError(t, cfg, "invalid join")
+}
+
+func TestWorkflow_ParallelChildAgentUndefined(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	wf := parallelWorkflow("all")
+	wf.Steps[0].ParallelSteps[0].Agent = "ghost"
+	cfg.Workflows = []config.WorkflowConfig{wf}
+	assertError(t, cfg, `agent "ghost" not defined`)
+}
+
+func TestWorkflow_ParallelDuplicateChildID(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	wf := parallelWorkflow("all")
+	wf.Steps[0].ParallelSteps[1].ID = "lint"
+	cfg.Workflows = []config.WorkflowConfig{wf}
+	assertError(t, cfg, "duplicate child step id")
+}
+
 func TestWorkflow_UnknownStepType(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -717,8 +717,14 @@ func (r *dagRun) contribSnapshot() map[string]MemoryStep {
 // memoryValues returns the flattened Step Data map for expression evaluation
 // (memory.<key>), honoring last-write-wins in passed order.
 func (r *dagRun) memoryValues() map[string]string {
+	return memoryValuesFrom(r.memSteps())
+}
+
+// memoryValuesFrom flattens ordered memory contributions into the Step Data
+// map used by expression evaluation (memory.<key>), last-write-wins.
+func memoryValuesFrom(steps []MemoryStep) map[string]string {
 	vals := map[string]string{}
-	for _, ms := range r.memSteps() {
+	for _, ms := range steps {
 		for _, field := range ms.WriteFields {
 			if v, ok := ms.Structured[field]; ok {
 				vals[field] = renderValue(v)

--- a/src/internal/workflow/dag_concurrent_test.go
+++ b/src/internal/workflow/dag_concurrent_test.go
@@ -245,6 +245,117 @@ func TestParallelStep_AnyJoinPassesIfOneChildPasses(t *testing.T) {
 	}
 }
 
+// TestParallelStep_ExprJoinPasses verifies that an expression join evaluates
+// over the children's outcomes via steps.<child-id>.*: the expression only
+// requires lint, so the tests child's failure does not fail the group.
+func TestParallelStep_ExprJoinPasses(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.Concurrency = 4
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"tests": {Success: false},
+	}}
+	eng := testEngine(cfg, store, exec, nil)
+
+	wf := config.WorkflowConfig{ID: "parallel-expr-wf", Steps: []config.StepConfig{
+		{
+			ID:   "par",
+			Type: config.StepTypeParallel,
+			Join: "${{ steps.lint.state == 'passed' }}",
+			SubSteps: []config.StepConfig{
+				{ID: "lint", Agent: "architect"},
+				{ID: "tests", Agent: "architect"},
+			},
+		},
+		{ID: "after", Agent: "architect", DependsOn: []string{"par"}},
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success (expression only requires lint, which passed)")
+	}
+	if !contains(executedIDs(exec.seen), "after") {
+		t.Errorf("expected after to run, got %v", executedIDs(exec.seen))
+	}
+}
+
+// TestParallelStep_ExprJoinFails verifies that an expression join fails the
+// group when it evaluates to false.
+func TestParallelStep_ExprJoinFails(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.Concurrency = 4
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"tests": {Success: false},
+	}}
+	eng := testEngine(cfg, store, exec, nil)
+
+	wf := config.WorkflowConfig{ID: "parallel-expr-fail-wf", Steps: []config.StepConfig{
+		{
+			ID:   "par",
+			Type: config.StepTypeParallel,
+			Join: "${{ steps.lint.state == 'passed' and steps.tests.state == 'passed' }}",
+			SubSteps: []config.StepConfig{
+				{ID: "lint", Agent: "architect"},
+				{ID: "tests", Agent: "architect"},
+			},
+		},
+	}}
+
+	_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("expected failure (expression requires both children, child-b failed)")
+	}
+}
+
+// TestApplyJoinPolicy_ExprOverChildOutcomes exercises applyJoinPolicy directly:
+// expressions see each child's state and output.
+func TestApplyJoinPolicy_ExprOverChildOutcomes(t *testing.T) {
+	results := []parallelChildResult{
+		{step: config.StepConfig{ID: "lint"}, res: StepResult{Success: true, Output: "ok"}},
+		{step: config.StepConfig{ID: "tests"}, res: StepResult{Success: false, Output: "2 failed"}},
+	}
+
+	cases := []struct {
+		join string
+		want bool
+	}{
+		{"${{ steps.lint.state == 'passed' }}", true},
+		{"steps.lint.state == 'passed'", true}, // bare expression, no ${{ }} wrapper
+		{"${{ steps.tests.state == 'passed' }}", false},
+		{"${{ steps.tests.output contains 'failed' }}", true},
+		{"${{ steps.lint.state == 'passed' and steps.tests.state == 'passed' }}", false},
+	}
+	for _, tc := range cases {
+		if got := applyJoinPolicy(tc.join, results, model.SourceItem{}, nil); got != tc.want {
+			t.Errorf("applyJoinPolicy(%q) = %v, want %v", tc.join, got, tc.want)
+		}
+	}
+}
+
+// TestApplyJoinPolicy_BadExprFallsBackToAll verifies the fail-safe: a join
+// expression that does not parse degrades to "all" semantics.
+func TestApplyJoinPolicy_BadExprFallsBackToAll(t *testing.T) {
+	allPass := []parallelChildResult{
+		{step: config.StepConfig{ID: "a"}, res: StepResult{Success: true}},
+	}
+	oneFail := []parallelChildResult{
+		{step: config.StepConfig{ID: "a"}, res: StepResult{Success: true}},
+		{step: config.StepConfig{ID: "b"}, res: StepResult{Success: false}},
+	}
+
+	const bad = "${{ steps.a.state === }}"
+	if !applyJoinPolicy(bad, allPass, model.SourceItem{}, nil) {
+		t.Error("bad expression with all children passed: want true (all semantics)")
+	}
+	if applyJoinPolicy(bad, oneFail, model.SourceItem{}, nil) {
+		t.Error("bad expression with a failed child: want false (all semantics)")
+	}
+}
+
 // TestConcurrentScheduler_MemoryOrderDeterministic verifies that concurrent
 // steps' memory contributions are ordered by declaration, not completion order.
 func TestConcurrentScheduler_MemoryOrderDeterministic(t *testing.T) {

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"context"
 
+	aplog "github.com/orlandoburli/apiary/internal/log"
+
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -50,11 +52,7 @@ func (e *Engine) runParallelStep(
 	}
 
 	// Apply join policy.
-	join := step.Join
-	if join == "" {
-		join = "all"
-	}
-	passed := applyJoinPolicy(join, results)
+	passed := applyJoinPolicy(step.Join, results, cell, memSnap)
 
 	// Collect memory contributions from passed children in declaration order.
 	var contribs []MemoryStep
@@ -76,25 +74,50 @@ func (e *Engine) runParallelStep(
 }
 
 // applyJoinPolicy evaluates the join policy over the child results.
-// "all" requires all children to pass; "any" requires at least one to pass.
-// An expression join (${{ … }}) is not yet supported and defaults to "all".
-func applyJoinPolicy(join string, results []parallelChildResult) bool {
+// "all" (the default) requires all children to pass; "any" requires at least
+// one to pass. Any other value is a condition expression (optionally
+// ${{ }}-wrapped) evaluated with the standard expression language: the
+// children's outcomes are exposed as steps.<child-id>.* alongside the usual
+// cell.* and memory.* accessors. An expression that fails to parse or
+// evaluate logs the error and falls back to "all" semantics (fail-safe).
+func applyJoinPolicy(join string, results []parallelChildResult, cell model.SourceItem, memSnap []MemoryStep) bool {
 	switch join {
-	case "any":
+	case config.JoinAny:
 		for _, cr := range results {
 			if cr.res.Success {
 				return true
 			}
 		}
 		return false
-	default: // "all" or expression (expression support deferred)
-		for _, cr := range results {
-			if !cr.res.Success {
-				return false
-			}
+	case "", config.JoinAll:
+		return allChildrenPassed(results)
+	default:
+		expr, err := ParseExpr(stripExprDelimiters(join))
+		if err != nil {
+			aplog.Error("workflow: parallel join: bad expression %q: %v (falling back to all)", join, err)
+			return allChildrenPassed(results)
 		}
-		return true
+		steps := make(map[string]StepState, len(results))
+		for _, cr := range results {
+			steps[cr.step.ID] = StepState{State: passFail(cr.res.Success), Output: cr.res.Output}
+		}
+		ok, err := expr.Eval(EvalContext{Cell: cell, Memory: memoryValuesFrom(memSnap), Steps: steps})
+		if err != nil {
+			aplog.Error("workflow: parallel join: eval %q: %v (falling back to all)", join, err)
+			return allChildrenPassed(results)
+		}
+		return ok
 	}
+}
+
+// allChildrenPassed implements the "all" join: every child must pass.
+func allChildrenPassed(results []parallelChildResult) bool {
+	for _, cr := range results {
+		if !cr.res.Success {
+			return false
+		}
+	}
+	return true
 }
 
 // Silence unused-import warning when model is only used for the function signature.


### PR DESCRIPTION
## Summary

Adds an **Expression syntax** section to the workflows docs covering the shared condition language used by `if:`, `reject_when:`, split branches, and the lowered `condition:`/`fail_when:` forms:

- Comparison operators: `==`, `!=` (numeric-aware), `contains`, `matches` (RE2)
- Logical keywords `and` / `or` / `not` — with an explicit warning that C-style `&&` / `||` / `!` are **not** supported
- Full accessor table (`cell.*`, `memory.*`, `steps.<id>.*`), missing-key semantics, list restrictions
- Current runtime fail-safe behavior (malformed expression → logged, evaluated as `false`)

Also corrects the `join:` comment for the `${{ expr }}` parallel join form.

Addresses request 3 of #180 (documenting the grammar). Requests 1 and 2 (validate-time lint + fail-loud runtime) land separately.