### PR TITLE
fix(workflows): lint condition expressions at validate; fail loudly on eval errors

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,8 @@ apiary status [--watch]    # --watch refreshes every 2 seconds
 ### `apiary validate`
 
 Validate `apiary.yaml` — schema, reference integrity (agents → runners,
-steps → agents, goto targets), and workflow graph rules.
+steps → agents, goto targets), workflow graph rules, and condition expression
+syntax (`if:`, `reject_when:`, split branches, `${{ }}` joins).
 
 ```sh
 apiary validate [--connectivity]    # --connectivity also tests each source

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -219,10 +219,10 @@ Children run concurrently; `join` decides the group's outcome:
   outcomes, exposed as `steps.<child-id>.state` (`passed`/`failed`) and
   `steps.<child-id>.output`, alongside the usual `cell.*` and `memory.*`
   accessors. Example: `${{ steps.lint.state == 'passed' and steps.tests.output
-  contains 'ok' }}`. A malformed expression logs an error and falls back to
-  `all` semantics. Note: expression accessors cannot reference child ids
-  containing hyphens — use `snake_case` ids for children you test in a join
-  expression.
+  contains 'ok' }}`. A malformed expression fails `apiary validate`; an
+  expression that cannot be evaluated at runtime fails the parallel step.
+  Note: expression accessors cannot reference child ids containing hyphens —
+  use `snake_case` ids for children you test in a join expression.
 
 #### `for_each:` — iteration
 
@@ -341,12 +341,14 @@ reject_when: ${{ memory.verdict matches "reject|veto" }}
 if: ${{ not (memory.track == "docs" or memory.track == "chore") }}
 ```
 
-!!! note "Evaluation errors fail safe"
-    Expressions are evaluated when the step is reached, not at config load.
-    A malformed expression (e.g. using `&&`) logs an error and evaluates as
-    **false**: an `if:` guard skips its step, a `reject_when:` does not
-    reject, a split branch does not match, and a `join:` expression falls
-    back to `all` semantics. Check the daemon log if a branch never fires.
+!!! note "Malformed expressions fail loudly"
+    Every expression is statically parsed by `apiary validate` (and at daemon
+    config load): a syntax slip like `&&` instead of `and` is rejected
+    pre-flight with a pointer to the supported operator. If an expression
+    still cannot be evaluated at runtime (e.g. an invalid regex operand or an
+    unknown accessor field), the step **fails** — triggering its `on_fail`
+    handling — rather than being silently treated as false. A branch can
+    therefore never be dropped without an error signal.
 
 ### Approval steps
 

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -4,6 +4,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/workflow"
 
 	// Ensure the built-in adapters are registered before any command validates
 	// a config, even when the cli package is used without cmd/apiary.
@@ -12,6 +13,7 @@ import (
 
 func init() {
 	config.KnownAdapters = runner.Registered
+	config.LintExpr = workflow.LintExpr
 	// Evaluated at validation time, after the source adapters' init() registration
 	// (cmd/apiary imports them), so a fresh instance reflects the real capability.
 	config.SourceSupportsDependencyWait = func(sourceType string) bool {

--- a/src/internal/cli/expr_lint_wiring_test.go
+++ b/src/internal/cli/expr_lint_wiring_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// TestLintExprWiring verifies the end-to-end #180 repro: with the cli wiring
+// in place (init() injects the real workflow parser), a config whose `if:`
+// uses C-style && fails Validate with a pointer to the supported operator —
+// it must not pass validation and silently skip at runtime.
+func TestLintExprWiring(t *testing.T) {
+	if config.LintExpr == nil {
+		t.Fatal("config.LintExpr not wired by cli init()")
+	}
+
+	c := &config.Config{
+		Version: "1",
+		Agents:  []config.AgentConfig{{ID: "engineer", Model: "m"}},
+		Workflows: []config.WorkflowConfig{{
+			ID: "w",
+			Steps: []config.StepConfig{
+				{ID: "judge", Agent: "engineer"},
+				{ID: "standard-track", Agent: "engineer",
+					If: `${{ memory.engineer_track != "100x" && memory.engineer_track != "decomposed" }}`},
+			},
+		}},
+	}
+
+	errs := c.Validate()
+	var hit bool
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "use 'and'") {
+			hit = true
+		}
+	}
+	if !hit {
+		t.Errorf("expected a validation error suggesting 'and' for '&&', got: %v", errs)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -15,6 +15,14 @@ import (
 // the adapter check is skipped.
 var KnownAdapters func() []string
 
+// LintExpr statically parses a workflow condition expression (lowered
+// condition:/fail_when:, split branch if:, parallel ${{ }} join) and returns
+// a syntax error, accepting an optional ${{ }} wrapper. The cli package
+// injects it (config cannot import the workflow package's parser without
+// inverting the dependency direction). When nil — configs built in code,
+// isolated tests — expression lint is skipped.
+var LintExpr func(expr string) error
+
 // SourceSupportsDependencyWait reports whether a source type's adapter can
 // enumerate a task's upstream blockers (implements source.BlockerLister), which
 // a wait_for step with kind "dependency" requires. The cli package injects it

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -149,6 +149,10 @@ func (c *Config) validateStep(
 		errs = append(errs, fmt.Errorf("%s: unknown step type %q", sctx, s.Type))
 	}
 
+	// Expression syntax applies to any step type (condition/fail_when survive
+	// lowering on every step), so lint here rather than in a per-type validator.
+	errs = append(errs, lintStepExprs(sctx, s)...)
+
 	// on_conflict applies to any step type, so validate it here rather than in a
 	// per-type validator. It is only meaningful on a wait_for step (the sole
 	// producer of a conflict) and otherwise mirrors on_fail (goto + max_retries).
@@ -250,6 +254,40 @@ func (c *Config) validateAgentStep(sctx string, s StepConfig, agentIDs, stepIDs 
 		}
 	}
 
+	return errs
+}
+
+// lintStepExprs statically parses every condition expression a step can carry
+// (lowered condition:/fail_when:, split branch if:, foreach inner step) so a
+// malformed expression — e.g. C-style `&&` instead of `and` — fails validate
+// instead of surfacing as a silent skip at runtime (#180). LintExpr is
+// injected by the cli package; when nil the check is skipped.
+func lintStepExprs(sctx string, s StepConfig) []error {
+	if LintExpr == nil {
+		return nil
+	}
+	var errs []error
+	if s.Condition != "" {
+		if err := LintExpr(s.Condition); err != nil {
+			errs = append(errs, fmt.Errorf("%s: condition (if:) %q: %w", sctx, s.Condition, err))
+		}
+	}
+	if s.FailWhen != "" {
+		if err := LintExpr(s.FailWhen); err != nil {
+			errs = append(errs, fmt.Errorf("%s: fail_when (reject_when:) %q: %w", sctx, s.FailWhen, err))
+		}
+	}
+	for j, b := range s.Branches {
+		if b.If == "" {
+			continue
+		}
+		if err := LintExpr(b.If); err != nil {
+			errs = append(errs, fmt.Errorf("%s: branches[%d] if %q: %w", sctx, j, b.If, err))
+		}
+	}
+	if s.Step != nil {
+		errs = append(errs, lintStepExprs(sctx+" (inner step)", *s.Step)...)
+	}
 	return errs
 }
 
@@ -363,15 +401,19 @@ func (c *Config) validateParallelStep(
 		errs = append(errs, fmt.Errorf("%s: parallel step requires at least one child step", sctx))
 	}
 
-	// Join policy: all (default) | any | ${{ expr }}. Expression syntax is
-	// checked at runtime (the parser lives in the workflow package); here we
-	// require the ${{ }} wrapper so a typo like "anyy" is caught at load time.
+	// Join policy: all (default) | any | ${{ expr }}. The ${{ }} wrapper is
+	// required so a typo like "anyy" is caught at load time; the expression
+	// body is parsed via LintExpr (injected by the cli package, skipped when nil).
 	switch s.Join {
 	case "", JoinAll, JoinAny:
 	default:
 		j := strings.TrimSpace(s.Join)
 		if !strings.HasPrefix(j, "${{") || !strings.HasSuffix(j, "}}") {
 			errs = append(errs, fmt.Errorf("%s: invalid join %q (want all, any, or a ${{ expr }} expression)", sctx, s.Join))
+		} else if LintExpr != nil {
+			if err := LintExpr(j); err != nil {
+				errs = append(errs, fmt.Errorf("%s: join %q: %w", sctx, s.Join, err))
+			}
 		}
 	}
 

--- a/src/internal/config/workflow_validate_lint_test.go
+++ b/src/internal/config/workflow_validate_lint_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// stubLintExpr installs a stand-in for the workflow package's parser (the real
+// one is injected by the cli package): it rejects C-style operators, which is
+// the failure mode from #180.
+func stubLintExpr(t *testing.T) {
+	t.Helper()
+	prev := LintExpr
+	LintExpr = func(expr string) error {
+		if strings.Contains(expr, "&&") || strings.Contains(expr, "||") {
+			return fmt.Errorf("unsupported operator")
+		}
+		return nil
+	}
+	t.Cleanup(func() { LintExpr = prev })
+}
+
+// TestValidate_LintsV2IfExpression runs the full Validate() pipeline so the v2
+// `if:` is lowered to `condition:` before the lint sees it.
+func TestValidate_LintsV2IfExpression(t *testing.T) {
+	stubLintExpr(t)
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "classify", Agent: "a"},
+			{ID: "impl", Agent: "a", If: `${{ classify.track != "100x" && classify.track != "decomposed" }}`},
+		},
+	}}
+	errs := c.Validate()
+	if !anyError(errs, "condition") {
+		t.Errorf("expected a condition lint error, got: %v", errs)
+	}
+}
+
+func TestValidate_LintsFailWhen(t *testing.T) {
+	stubLintExpr(t)
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "review", Agent: "a", FailWhen: `memory.verdict == "rejected" || memory.verdict == "needs_work"`},
+		},
+	}}
+	errs := c.Validate()
+	if !anyError(errs, "fail_when") {
+		t.Errorf("expected a fail_when lint error, got: %v", errs)
+	}
+}
+
+func TestValidate_LintsSplitBranchIf(t *testing.T) {
+	stubLintExpr(t)
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "plan", Agent: "a"},
+			{ID: "route", Type: StepTypeSplit, DependsOn: []string{"plan"}, Branches: []SplitBranch{
+				{If: `memory.level == "high" && memory.size == "xl"`, Goto: "senior"},
+				{Else: true, Goto: "junior"},
+			}},
+			{ID: "senior", Agent: "a"},
+			{ID: "junior", Agent: "a"},
+		},
+	}}
+	errs := c.Validate()
+	if !anyError(errs, "branches[0]") {
+		t.Errorf("expected a branch lint error, got: %v", errs)
+	}
+}
+
+func TestValidate_LintsParallelJoin(t *testing.T) {
+	stubLintExpr(t)
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "par", Type: StepTypeParallel,
+				Join: `${{ steps.lint.state == 'passed' && steps.tests.state == 'passed' }}`,
+				SubSteps: []StepConfig{
+					{ID: "lint", Agent: "a"},
+					{ID: "tests", Agent: "a"},
+				}},
+		},
+	}}
+	errs := c.Validate()
+	if !anyError(errs, "join") {
+		t.Errorf("expected a join lint error, got: %v", errs)
+	}
+}
+
+// TestValidate_LintSkippedWhenNil mirrors the KnownAdapters contract: configs
+// built in code (LintExpr == nil) skip the expression lint.
+func TestValidate_LintSkippedWhenNil(t *testing.T) {
+	prev := LintExpr
+	LintExpr = nil
+	t.Cleanup(func() { LintExpr = prev })
+
+	c := minimalConfig()
+	c.Workflows = []WorkflowConfig{{
+		ID: "w",
+		Steps: []StepConfig{
+			{ID: "impl", Agent: "a", Condition: `memory.a != "x" && memory.b != "y"`},
+		},
+	}}
+	if errs := c.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors with LintExpr nil, got: %v", errs)
+	}
+}

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -151,9 +152,23 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			step := r.byID[id]
 
 			// Per-step condition: evaluate on scheduler goroutine (reads dagRun).
+			// An expression that cannot be parsed or evaluated fails the step
+			// (routed through resultCh so on_fail applies) — silently treating it
+			// as false would skip the branch with no error signal (#180).
 			if step.Condition != "" {
 				evalCtx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
-				if e.conditionFalse(step.Condition, evalCtx) {
+				condOK, condErr := e.evalExpr(step.Condition, evalCtx)
+				if condErr != nil {
+					aplog.Error("workflow %s: step %q condition eval error %q: %v (failing step)", r.wf.ID, id, step.Condition, condErr)
+					r.state[id] = stRunning
+					inFlight++
+					resultCh <- workerResult{stepID: id, step: step, res: StepResult{
+						Success: false,
+						Output:  fmt.Sprintf("condition eval error %q: %v", step.Condition, condErr),
+					}}
+					continue
+				}
+				if !condOK {
 					r.markCondSkipped(id)
 					aplog.Debug("workflow %s: step %q skipped (condition false)", r.wf.ID, id)
 					continue
@@ -161,8 +176,18 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			}
 
 			// Split: synchronous, no I/O — apply inline on scheduler goroutine.
+			// A branch expression that cannot be evaluated fails the split step
+			// (routed through resultCh so on_fail applies) — see #180.
 			if step.StepType() == config.StepTypeSplit {
-				e.runSplitStep(r, step)
+				if err := e.runSplitStep(r, step); err != nil {
+					aplog.Error("workflow %s: split %q condition eval error: %v (failing step)", r.wf.ID, id, err)
+					r.state[id] = stRunning
+					inFlight++
+					resultCh <- workerResult{stepID: id, step: step, res: StepResult{
+						Success: false,
+						Output:  fmt.Sprintf("split condition eval error: %v", err),
+					}}
+				}
 				continue
 			}
 
@@ -303,13 +328,22 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		}
 
 		// fail_when — evaluate on the scheduler goroutine after the agent runs.
+		// An expression that cannot be parsed or evaluated fails the step —
+		// silently treating it as "not rejected" would pass a result the gate
+		// was supposed to inspect (#180).
 		if res.Success && step.FailWhen != "" {
 			transientMem := r.memoryValues()
 			for field, val := range res.StructuredOutput {
 				transientMem[field] = renderValue(val)
 			}
 			evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates}
-			if e.conditionTrue(step.FailWhen, evalCtx) {
+			rejected, fwErr := e.evalExpr(step.FailWhen, evalCtx)
+			switch {
+			case fwErr != nil:
+				res.Success = false
+				res.Output = fmt.Sprintf("fail_when eval error %q: %v", step.FailWhen, fwErr)
+				aplog.Error("workflow %s: step %q fail_when eval error %q: %v (failing step)", r.wf.ID, step.ID, step.FailWhen, fwErr)
+			case rejected:
 				res.Success = false
 				aplog.Info("workflow %s: step %q rejected (fail_when matched)", r.wf.ID, step.ID)
 			}
@@ -603,8 +637,10 @@ func (r *dagRun) markCondSkipped(id string) {
 }
 
 // runSplitStep evaluates a split's branches and activates the chosen target(s),
-// skipping the rest.
-func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) bool {
+// skipping the rest. A branch expression that cannot be parsed or evaluated
+// returns an error before any state is mutated — the caller fails the split
+// step rather than silently routing as if the branch didn't match (#180).
+func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) error {
 	ctx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
 
 	chosen := map[string]bool{}
@@ -613,13 +649,11 @@ func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) bool {
 		if !match {
 			expr, err := ParseExpr(b.If)
 			if err != nil {
-				aplog.Error("workflow %s: split %q: bad condition %q: %v", r.wf.ID, step.ID, b.If, err)
-				continue
+				return fmt.Errorf("branch %q: %w", b.If, err)
 			}
 			ok, err := expr.Eval(ctx)
 			if err != nil {
-				aplog.Error("workflow %s: split %q: eval %q: %v", r.wf.ID, step.ID, b.If, err)
-				continue
+				return fmt.Errorf("branch %q: %w", b.If, err)
 			}
 			match = ok
 		}
@@ -648,7 +682,7 @@ func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) bool {
 			r.markSkipped(b.Goto)
 		}
 	}
-	return false
+	return nil
 }
 
 // resetLoop resets the goto target and all its transitive dependents back to
@@ -739,28 +773,6 @@ func passFail(success bool) string {
 		return stPassed
 	}
 	return stFailed
-}
-
-// conditionFalse reports whether expr evaluates to false (or fails to parse/eval).
-// Used for per-step condition checks: false → skip the step.
-func (e *Engine) conditionFalse(expr string, ctx EvalContext) bool {
-	result, err := e.evalExpr(expr, ctx)
-	if err != nil {
-		aplog.Error("workflow: condition eval error %q: %v (treating as false → skip)", expr, err)
-		return true
-	}
-	return !result
-}
-
-// conditionTrue reports whether expr evaluates to true.
-// Used for fail_when: true → logical rejection.
-func (e *Engine) conditionTrue(expr string, ctx EvalContext) bool {
-	result, err := e.evalExpr(expr, ctx)
-	if err != nil {
-		aplog.Error("workflow: fail_when eval error %q: %v (treating as false → not rejected)", expr, err)
-		return false
-	}
-	return result
 }
 
 // evalExpr parses and evaluates a condition expression. Strips optional ${{ }}

--- a/src/internal/workflow/dag_concurrent_test.go
+++ b/src/internal/workflow/dag_concurrent_test.go
@@ -330,29 +330,28 @@ func TestApplyJoinPolicy_ExprOverChildOutcomes(t *testing.T) {
 		{"${{ steps.lint.state == 'passed' and steps.tests.state == 'passed' }}", false},
 	}
 	for _, tc := range cases {
-		if got := applyJoinPolicy(tc.join, results, model.SourceItem{}, nil); got != tc.want {
+		got, err := applyJoinPolicy(tc.join, results, model.SourceItem{}, nil)
+		if err != nil {
+			t.Errorf("applyJoinPolicy(%q): unexpected error: %v", tc.join, err)
+			continue
+		}
+		if got != tc.want {
 			t.Errorf("applyJoinPolicy(%q) = %v, want %v", tc.join, got, tc.want)
 		}
 	}
 }
 
-// TestApplyJoinPolicy_BadExprFallsBackToAll verifies the fail-safe: a join
-// expression that does not parse degrades to "all" semantics.
-func TestApplyJoinPolicy_BadExprFallsBackToAll(t *testing.T) {
+// TestApplyJoinPolicy_BadExprErrors verifies that a join expression that does
+// not parse returns an error (the caller fails the parallel step) instead of
+// silently falling back to "all" semantics (#180).
+func TestApplyJoinPolicy_BadExprErrors(t *testing.T) {
 	allPass := []parallelChildResult{
 		{step: config.StepConfig{ID: "a"}, res: StepResult{Success: true}},
 	}
-	oneFail := []parallelChildResult{
-		{step: config.StepConfig{ID: "a"}, res: StepResult{Success: true}},
-		{step: config.StepConfig{ID: "b"}, res: StepResult{Success: false}},
-	}
 
 	const bad = "${{ steps.a.state === }}"
-	if !applyJoinPolicy(bad, allPass, model.SourceItem{}, nil) {
-		t.Error("bad expression with all children passed: want true (all semantics)")
-	}
-	if applyJoinPolicy(bad, oneFail, model.SourceItem{}, nil) {
-		t.Error("bad expression with a failed child: want false (all semantics)")
+	if _, err := applyJoinPolicy(bad, allPass, model.SourceItem{}, nil); err == nil {
+		t.Error("bad expression: want a parse error, got nil")
 	}
 }
 

--- a/src/internal/workflow/dag_expr_fail_loud_test.go
+++ b/src/internal/workflow/dag_expr_fail_loud_test.go
@@ -1,0 +1,130 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// These tests pin the fail-loud contract from #180: a condition expression
+// that cannot be parsed or evaluated fails the step (and the instance), it is
+// never silently coerced to false → skip.
+
+func TestDAG_ConditionEvalErrorFailsStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "cond-err-wf", Steps: []config.StepConfig{
+		{ID: "classify", Agent: "architect"},
+		{
+			ID: "implement", Agent: "backend-dev", DependsOn: []string{"classify"},
+			// C-style && does not parse — the exact slip from #180.
+			Condition: `memory.track != "100x" && memory.track != "decomposed"`,
+		},
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure (condition eval error must fail the step, not skip it)")
+	}
+	if contains(executedIDs(exec.seen), "implement") {
+		t.Errorf("implement must not run when its condition cannot be evaluated, got %v", executedIDs(exec.seen))
+	}
+}
+
+// TestDAG_ConditionEvalErrorTriggersOnFail verifies the eval error is routed
+// through the normal failure path, so step-level on_fail.goto applies.
+func TestDAG_ConditionEvalErrorTriggersOnFail(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "cond-err-onfail-wf", Steps: []config.StepConfig{
+		{ID: "classify", Agent: "architect"},
+		{
+			ID: "implement", Agent: "backend-dev", DependsOn: []string{"classify"},
+			Condition: `memory.track != "100x" && memory.track != "decomposed"`,
+			OnFail:    &config.StepOutcome{Goto: "classify", MaxRetries: 1},
+		},
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure after on_fail retries are exhausted")
+	}
+	// classify runs once, then re-runs once via on_fail.goto before the retry
+	// budget is exhausted by the deterministic eval error.
+	runs := 0
+	for _, id := range executedIDs(exec.seen) {
+		if id == "classify" {
+			runs++
+		}
+	}
+	if runs != 2 {
+		t.Errorf("expected classify to run twice (initial + on_fail loop), ran %d times", runs)
+	}
+}
+
+func TestDAG_FailWhenEvalErrorFailsStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "failwhen-err-wf", Steps: []config.StepConfig{
+		{
+			ID: "review", Agent: "architect",
+			FailWhen: `memory.verdict == "rejected" || memory.verdict == "needs_work"`,
+		},
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure (fail_when eval error must fail the step, not pass it)")
+	}
+}
+
+func TestDAG_SplitBranchEvalErrorFailsSplit(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "split-err-wf", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect"},
+		{ID: "route", Type: config.StepTypeSplit, DependsOn: []string{"plan"}, Branches: []config.SplitBranch{
+			{If: `memory.level == "high" && memory.size == "xl"`, Goto: "senior"},
+			{Else: true, Goto: "junior"},
+		}},
+		{ID: "senior", Agent: "architect"},
+		{ID: "junior", Agent: "backend-dev"},
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure (split branch eval error must fail the split, not route as no-match)")
+	}
+	ids := executedIDs(exec.seen)
+	if contains(ids, "senior") || contains(ids, "junior") {
+		t.Errorf("no branch target may run when a branch condition cannot be evaluated, got %v", ids)
+	}
+}

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
 
@@ -51,8 +52,14 @@ func (e *Engine) runParallelStep(
 		results[cr.idx] = cr
 	}
 
-	// Apply join policy.
-	passed := applyJoinPolicy(step.Join, results, cell, memSnap)
+	// Apply join policy. A join expression that cannot be parsed or evaluated
+	// fails the parallel step — silently falling back to "all" would let an
+	// unintended join policy decide the outcome (#180).
+	passed, joinErr := applyJoinPolicy(step.Join, results, cell, memSnap)
+	if joinErr != nil {
+		aplog.Error("workflow: parallel %q join eval error %q: %v (failing step)", step.ID, step.Join, joinErr)
+		return StepResult{Success: false, Output: fmt.Sprintf("join eval error %q: %v", step.Join, joinErr)}, nil
+	}
 
 	// Collect memory contributions from passed children in declaration order.
 	var contribs []MemoryStep
@@ -79,34 +86,28 @@ func (e *Engine) runParallelStep(
 // ${{ }}-wrapped) evaluated with the standard expression language: the
 // children's outcomes are exposed as steps.<child-id>.* alongside the usual
 // cell.* and memory.* accessors. An expression that fails to parse or
-// evaluate logs the error and falls back to "all" semantics (fail-safe).
-func applyJoinPolicy(join string, results []parallelChildResult, cell model.SourceItem, memSnap []MemoryStep) bool {
+// evaluate returns an error — the caller fails the parallel step (#180).
+func applyJoinPolicy(join string, results []parallelChildResult, cell model.SourceItem, memSnap []MemoryStep) (bool, error) {
 	switch join {
 	case config.JoinAny:
 		for _, cr := range results {
 			if cr.res.Success {
-				return true
+				return true, nil
 			}
 		}
-		return false
+		return false, nil
 	case "", config.JoinAll:
-		return allChildrenPassed(results)
+		return allChildrenPassed(results), nil
 	default:
 		expr, err := ParseExpr(stripExprDelimiters(join))
 		if err != nil {
-			aplog.Error("workflow: parallel join: bad expression %q: %v (falling back to all)", join, err)
-			return allChildrenPassed(results)
+			return false, err
 		}
 		steps := make(map[string]StepState, len(results))
 		for _, cr := range results {
 			steps[cr.step.ID] = StepState{State: passFail(cr.res.Success), Output: cr.res.Output}
 		}
-		ok, err := expr.Eval(EvalContext{Cell: cell, Memory: memoryValuesFrom(memSnap), Steps: steps})
-		if err != nil {
-			aplog.Error("workflow: parallel join: eval %q: %v (falling back to all)", join, err)
-			return allChildrenPassed(results)
-		}
-		return ok
+		return expr.Eval(EvalContext{Cell: cell, Memory: memoryValuesFrom(memSnap), Steps: steps})
 	}
 }
 

--- a/src/internal/workflow/expr.go
+++ b/src/internal/workflow/expr.go
@@ -52,6 +52,15 @@ func (e *Expr) Eval(ctx EvalContext) (bool, error) {
 	return e.root.eval(ctx)
 }
 
+// LintExpr statically parses a condition expression, accepting the optional
+// ${{ }} wrapper kept by the v2 lowering pass. It is injected into
+// config.LintExpr by the cli package so `apiary validate` rejects malformed
+// expressions pre-flight instead of discovering them at runtime (#180).
+func LintExpr(src string) error {
+	_, err := ParseExpr(stripExprDelimiters(src))
+	return err
+}
+
 // String returns the original source.
 func (e *Expr) String() string { return e.src }
 
@@ -105,8 +114,12 @@ func lex(s string) ([]token, error) {
 				toks = append(toks, token{tNeq, "!="})
 				i += 2
 			} else {
-				return nil, fmt.Errorf("unexpected '!' (did you mean '!='?) at position %d", i)
+				return nil, fmt.Errorf("unsupported operator '!' at position %d — use 'not' (or '!=' for inequality)", i)
 			}
+		case c == '&':
+			return nil, fmt.Errorf("unsupported operator '&&' at position %d — use 'and' (C-style operators are not supported)", i)
+		case c == '|':
+			return nil, fmt.Errorf("unsupported operator '||' at position %d — use 'or' (C-style operators are not supported)", i)
 		case c == '"' || c == '\'':
 			quote := c
 			j := i + 1
@@ -127,6 +140,8 @@ func lex(s string) ([]token, error) {
 			}
 			toks = append(toks, token{tNumber, s[i:j]})
 			i = j
+		case c == '-':
+			return nil, fmt.Errorf("unexpected '-' at position %d — identifiers cannot contain '-' (hyphenated step ids cannot be referenced in expressions)", i)
 		case isIdentStart(c):
 			j := i + 1
 			for j < len(s) && isIdentChar(s[j]) {

--- a/src/internal/workflow/expr_lint_test.go
+++ b/src/internal/workflow/expr_lint_test.go
@@ -1,0 +1,51 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestExpr_CStyleOperatorHints verifies that the lexer points authors at the
+// supported keyword operators when it meets C-style ones (#180).
+func TestExpr_CStyleOperatorHints(t *testing.T) {
+	cases := []struct{ src, hint string }{
+		{`memory.a != "x" && memory.b != "y"`, "use 'and'"},
+		{`memory.a == "x" || memory.b == "y"`, "use 'or'"},
+		{`! cell.title == "x"`, "use 'not'"},
+		{`steps.my-step.state == "passed"`, "hyphenated"},
+	}
+	for _, tc := range cases {
+		_, err := ParseExpr(tc.src)
+		if err == nil {
+			t.Errorf("expected parse error for %q, got nil", tc.src)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.hint) {
+			t.Errorf("error for %q should mention %q, got: %v", tc.src, tc.hint, err)
+		}
+	}
+}
+
+// TestLintExpr verifies the static lint entry point wired into config.LintExpr.
+func TestLintExpr(t *testing.T) {
+	good := []string{
+		`${{ memory.track != "100x" and memory.track != "decomposed" }}`,
+		`memory.a == "x"`, // bare expression, no ${{ }} wrapper
+		`${{ steps.lint.state == 'passed' or steps.tests.state == 'passed' }}`,
+	}
+	for _, src := range good {
+		if err := LintExpr(src); err != nil {
+			t.Errorf("LintExpr(%q): unexpected error: %v", src, err)
+		}
+	}
+	bad := []string{
+		`${{ memory.track != "100x" && memory.track != "decomposed" }}`,
+		`memory.a == "x" || memory.b == "y"`,
+		`${{ memory.a == }}`,
+	}
+	for _, src := range bad {
+		if err := LintExpr(src); err == nil {
+			t.Errorf("LintExpr(%q): expected error, got nil", src)
+		}
+	}
+}


### PR DESCRIPTION
Closes #180.

A one-character syntax slip (`&&` instead of `and`) previously passed `apiary validate` cleanly and was coerced to `false` at runtime — the step (or a whole branch) was silently skipped, the workflow completed `done`, `on_fail` never fired, and the only trace was a single dispatcher log line.

## Request 1 — `validate` lints expression syntax

- New `config.LintExpr` hook (same injection pattern as `KnownAdapters`; config cannot import the workflow parser without a cycle), wired in `cli.init()`.
- `validateStep` statically parses every expression in the lowered IR: `condition:` (lowered `if:`), `fail_when:` (lowered `reject_when:`), split branch `if:`, foreach inner step expressions, and the body of a `${{ }}` parallel `join:`.
- The repro from the issue now fails pre-flight:

  ```
  workflows[0] "w": step "standard-track": condition (if:) "...": unsupported operator '&&' at position 32 — use 'and' (C-style operators are not supported)
  ```

- The lexer also gained targeted hints for `||` → `or`, bare `!` → `not`, and the hyphenated-identifier limitation.

## Request 2 — runtime eval errors fail loudly

`error → false → skip` is gone in all four evaluation sites:

| site | before | after |
|------|--------|-------|
| `condition:` | error → skip step | fails the step, routed through the result channel so `on_fail`/goto and terminal handling apply |
| `fail_when:` | error → not rejected | fails the step |
| split branch | error → branch no-match | fails the split step before any routing |
| parallel `join:` expr | error → fall back to `all` | fails the parallel step |

A failed instance reaches the task `on_fail` aggregate hook, so the `ai-needs-attention` label now fires for unevaluable conditions.

## Request 3 — docs

Grammar documentation landed in #181; this PR rewrites its "evaluation errors fail safe" note for the new fail-loud contract and mentions expression lint under `apiary validate` in the CLI reference.

## Tests

- `expr_lint_test.go` — operator hints + `LintExpr` entry point
- `workflow_validate_lint_test.go` — lint plumbing for condition / fail_when / branch / join, and the nil-hook skip contract
- `expr_lint_wiring_test.go` (cli) — end-to-end #180 repro: full `Validate()` with the real parser rejects `&&` with the `use 'and'` hint
- `dag_expr_fail_loud_test.go` — engine: condition error fails (not skips) and triggers `on_fail.goto`; fail_when error fails; split branch error fails without routing
- Updated `TestApplyJoinPolicy_*` to the new `(bool, error)` contract

Full `go test ./...` green.

## Compatibility note

A config that previously "worked" while silently dropping a branch will now fail `apiary validate` / daemon config load — that is the point of the issue, but existing deployed configs with latent syntax errors will surface on upgrade.