### PR TITLE
feat(source): add Codeberg/Forgejo source adapter

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -94,6 +94,21 @@ sources:
       states: [open]
       labels: [ai-ready]
 
+  - id: my-codeberg
+    type: codeberg
+    config:
+      repo: my-org/my-repo
+      # Codeberg / Forgejo / Gitea access token (Authorization: token <TOKEN>).
+      # Create one at https://codeberg.org/user/settings/applications
+      # Scopes: read:repository + write:issue (write:repository for CI/PR reads).
+      api_key: ${CODEBERG_TOKEN}
+      # Any self-hosted Forgejo/Gitea works by overriding the API base:
+      # base_url: https://git.example.org/api/v1
+    poll_interval: 120s
+    filters:
+      states: [open]
+      labels: [ai-ready]
+
   - id: my-jira
     type: jira
     config:

--- a/docs/codeberg-source.md
+++ b/docs/codeberg-source.md
@@ -1,0 +1,131 @@
+# Codeberg Source
+
+The `codeberg` source adapter polls issues from a [Codeberg](https://codeberg.org)
+repository — or **any self-hosted [Forgejo](https://forgejo.org) or Gitea
+instance** — and maps them to Apiary tasks for routing and dispatch. The Forgejo
+API closely mirrors GitHub's, so this adapter behaves like the
+[GitHub source](github-source.md) with a few platform differences noted below.
+
+Pull requests are **not** ingested: Forgejo's issues endpoint also returns PRs
+(a PR is an issue in the API), but the adapter skips them — PRs are
+implementation artifacts, not work items.
+
+## Configuration
+
+```yaml
+sources:
+  - id: my-codeberg
+    type: codeberg
+    config:
+      repo: my-org/my-repo
+      api_key: ${CODEBERG_TOKEN}
+      # base_url: https://git.example.org/api/v1   # any Forgejo/Gitea host
+    poll_interval: 120s
+    filters:
+      states: [open]
+      labels: [ai-ready]
+```
+
+### `config` fields
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `repo` | yes | — | Repository in `owner/repo` format |
+| `api_key` | no | — | Codeberg/Forgejo access token (see permissions below) |
+| `base_url` | no | `https://codeberg.org/api/v1` | API base for a self-hosted Forgejo/Gitea instance (include the `/api/v1` suffix) |
+
+### `filters`
+
+| Field | Description |
+|---|---|
+| `states` | Filter by issue state: `open` or `closed` |
+| `labels` | Only poll issues that have **all** of these labels |
+
+## What the adapter does
+
+| Operation | Forgejo API call | When |
+|---|---|---|
+| **Poll** | `GET /repos/{owner}/{repo}/issues?type=issues&state=open` | Every `poll_interval` |
+| **Acknowledge** | `POST /repos/{owner}/{repo}/issues/{index}/labels` (adds `in-progress`) | When `settings.state_lock: true` |
+| **WriteResult** | `POST /repos/{owner}/{repo}/issues/{index}/comments` | When `settings.result_comment: true` |
+| **SetState** | `PATCH /repos/{owner}/{repo}/issues/{index}` (sets `state`) | Via `workflow.on_complete.set_state` |
+| **AddLabels** | `POST /repos/{owner}/{repo}/issues/{index}/labels` (by label id) | Via `workflow.on_complete.add_labels` |
+| **RemoveLabels** | `DELETE /repos/{owner}/{repo}/issues/{index}/labels/{id}` (one per label) | Via `workflow.on_complete.remove_labels` |
+| **CI wait** | `GET /repos/{owner}/{repo}/commits/{sha}/status` | Via `wait_for` step, `kind: ci` |
+| **Dependency wait** | `GET /repos/{owner}/{repo}/issues/{index}/dependencies` | Via `wait_for` step, `kind: dependency` |
+
+## Differences from GitHub
+
+The Forgejo/Gitea API diverges from GitHub in ways the adapter handles transparently:
+
+- **Auth header** — Forgejo uses `Authorization: token <TOKEN>` (not `Bearer`).
+- **Labels are operated by id, not name.** The adapter lists the repo's labels,
+  creates any missing label (Forgejo requires a color — a neutral grey is used),
+  and applies labels by their numeric id.
+- **CI status comes from commit statuses, not check-runs.** Forgejo has no
+  check-runs API; Forgejo Actions and any external CI both report through commit
+  statuses, which the adapter aggregates into an overall verdict.
+- **Merge conflicts** are detected via the PR's boolean `mergeable` flag (Forgejo
+  has no GitHub-style `mergeable_state`). A conflict surfaces as the `conflict`
+  status so a `wait_for` step's `on_conflict` edge can hand the PR back to the
+  engineer.
+- **Blocking relationships** use Forgejo's native issue **dependencies** (the
+  issues a task depends on). Unlike Jira there is no link-type to configure.
+- **No sub-issues.** Forgejo has no parent/child issue API, so the `codeberg`
+  source cannot materialize spawned tasks as sub-issues (`materialize: sub_issue`).
+  Model parent/child with a dependency edge or a label convention instead.
+
+## Token permissions
+
+The `api_key` is a Codeberg/Forgejo access token, created at
+**Settings → Applications → Generate New Token**
+(`https://codeberg.org/user/settings/applications`).
+
+| Scope | Why |
+|---|---|
+| `read:repository` | Poll issues, read PR status for CI waits, list dependencies |
+| `write:issue` | Update state, add/remove labels, post comments |
+| `write:repository` | Required if agents open pull requests with this token |
+
+Without a token the adapter falls back to unauthenticated requests, which only
+see public repositories and are rate-limited — insufficient for regular polling.
+
+## Per-agent source identity (`source_token`, `source_email`, `source_name`)
+
+Like the GitHub source, each agent can use its own Forgejo account for issue
+operations and git commits:
+
+```yaml
+agents:
+  - id: engineer
+    model: claude-sonnet-4-6
+    source_token: ${CODEBERG_TOKEN_ENGINEER}
+    source_email: engineer@company.com
+    source_name: Engineer Bot
+```
+
+When `source_token` is set, the adapter's **write operations** (Acknowledge,
+WriteResult, SetState, AddLabels, RemoveLabels) use it instead of the
+source-level `api_key`. **Poll** always uses the source-level `api_key`.
+
+`source_email` / `source_name` are injected as `GIT_AUTHOR_*` / `GIT_COMMITTER_*`
+in the runner subprocess so commits carry the correct identity.
+
+## Environment variables
+
+Apiary auto-loads `.env` from the config directory:
+
+```bash
+# .env (next to apiary.yaml)
+CODEBERG_TOKEN=...
+CODEBERG_TOKEN_ENGINEER=...
+```
+
+## Setting up locally
+
+1. Create a token at `https://codeberg.org/user/settings/applications`.
+2. Set it in `.env` or export: `export CODEBERG_TOKEN=...`
+3. Run: `apiary run --config apiary.yaml`
+
+For a self-hosted Forgejo/Gitea instance, also set
+`config.base_url: https://your-host/api/v1`.

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -1,0 +1,182 @@
+# Supported Integrations
+
+Apiary works with multiple source systems (where work comes from) and runner providers (how agents execute).
+
+## Source Adapters
+
+Sources poll for tasks and write results back. Apiary reads issue status, comments, and metadata, then updates labels, states, and posts comments after agents complete work.
+
+### GitHub Issues
+
+**Status:** ✅ Stable | **Auth:** Personal access token
+
+Polls open issues from a GitHub repository. Apiary reads pull request status for CI waits, cross-references issues and PRs via the issue timeline, and writes back via commits and pull requests.
+
+- **Requirements:** Repository access via GitHub personal access token
+- **Blocking relationships:** Uses GitHub's `blocked_by` issue link type
+- **Comment rendering:** Markdown comments with embedded logs and cost summaries
+- **Setup:** See [GitHub Source configuration](github-source.md)
+
+### Plane
+
+**Status:** ✅ Stable | **Auth:** API key
+
+Polls issues from a Plane project. Supports custom states, labels, and relationships.
+
+- **Requirements:** Plane workspace with project access via API key
+- **Blocking relationships:** Uses Plane's native blocking link type
+- **Comment rendering:** Markdown comments
+- **Setup:** See [Plane Source configuration](plane-source.md)
+
+### Jira Cloud
+
+**Status:** ✅ Stable | **Auth:** API token
+
+Polls Jira Cloud via JQL search. Supports status transitions, blocking relationships, and labels.
+
+!!! note
+    Jira Server and Data Center are not supported — only Jira Cloud.
+
+- **Requirements:** Jira Cloud site with user access via API token
+- **Blocking relationships:** Uses Jira's `Blocks` link type (reads the inward "is blocked by" side)
+- **Comment rendering:** ADF (Atlassian Document Format) for rich formatting
+- **Setup:** See [Jira Source configuration](jira-source.md)
+
+### Linear
+
+**Status:** 🔄 Planned | **Auth:** API token
+
+Support for Linear is in development.
+
+---
+
+## Runners
+
+Runners define **how** agents execute: either as a CLI subprocess on your machine or via a direct API call.
+
+### CLI Runners
+
+CLI runners invoke the agent tool as a subprocess. The tool runs on your machine with full access to your credentials, so Apiary never handles auth secrets — they stay with the tool.
+
+#### Claude CLI
+
+**Status:** ✅ Stable | **Provider:** `claude`
+
+Runs the `claude` binary as a subprocess for each step.
+
+- **Requirements:** `claude` CLI installed and authenticated
+- **Structured parsing:** Apiary parses Claude's event stream into readable `[assistant]` / `[tool→ …]` logs
+- **Exact costs:** Token counts and costs come from Claude's structured response, not estimates
+- **Setup:** `type: cli`, `provider: claude` in `runners`
+- **Docs:** [Runners configuration](runners.md#claude-provider-claude)
+
+#### OpenCode CLI
+
+**Status:** ✅ Stable | **Provider:** `opencode`
+
+Runs the `opencode` binary as a subprocess.
+
+- **Requirements:** `opencode` CLI installed and authenticated
+- **Setup:** `type: cli`, `provider: opencode` in `runners`
+- **Docs:** [Runners configuration](runners.md#opencode-provider-opencode)
+
+#### Cursor CLI
+
+**Status:** ✅ Stable | **Provider:** `cursor`
+
+Runs the Cursor `agent` binary as a subprocess.
+
+- **Requirements:** `agent` binary on PATH (installed with Cursor)
+- **Setup:** `type: cli`, `provider: cursor` in `runners`
+- **Docs:** [Runners configuration](runners.md#cursor-provider-cursor)
+
+### API Runners
+
+API runners call a provider's API directly, without requiring the tool to be installed locally.
+
+#### OpenCode API
+
+**Status:** ✅ Stable | **Type:** `opencode-api`
+
+Calls the OpenCode Cloud API directly.
+
+- **Requirements:** OpenCode API key
+- **Setup:** `type: opencode-api` in `runners` with `config.api_key`
+- **Supported models:** `opencode-go/deepseek-v4-pro` and others
+- **Docs:** [Runners configuration](runners.md#opencode-api)
+
+### Anthropic API
+
+**Status:** 🔄 Planned
+
+Direct API runner for Claude models via the Anthropic API is in development.
+
+---
+
+## Feature support matrix
+
+| Feature | GitHub | Plane | Jira | OpenCode API | Claude CLI | OpenCode CLI | Cursor CLI |
+|---------|--------|-------|------|---|---|---|---|
+| Polling | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| State transitions | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| Blocking relationships | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| Comment rendering | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| CI waits | ✅ | — | — | — | N/A | N/A | N/A |
+| Structured logs | — | — | — | ✅ | ✅ | ✅ | ✅ |
+| Exact cost tracking | — | — | — | ✅ | ✅ | — | — |
+
+---
+
+## Using multiple adapters
+
+You can configure multiple sources and runners in the same `apiary.yaml`:
+
+```yaml
+sources:
+  - id: github-issues
+    type: github
+    config:
+      repo: my-org/my-repo
+      api_key: ${GITHUB_TOKEN}
+
+  - id: jira-backlog
+    type: jira
+    config:
+      base_url: https://company.atlassian.net
+      email: bot@company.com
+      api_token: ${JIRA_API_TOKEN}
+
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+
+  - id: opencode
+    type: opencode-api
+    config:
+      api_key: ${OPENCODE_API_KEY}
+
+agents:
+  - id: engineer
+    runner: claude
+    model: claude-sonnet-4-6
+
+  - id: fallback
+    runner: opencode
+    model: opencode-go/deepseek-v4-pro
+```
+
+Workflows can route to different agents, which run on different runners. Tasks from any source can be dispatched to any agent.
+
+---
+
+## Planned integrations
+
+| System | Type | Status |
+|--------|------|--------|
+| Linear | Source | 🔄 In development |
+| Anthropic API | Runner | 🔄 In development |
+| Mistral | Runner | 📝 Planned |
+| Ollama | Runner | 📝 Planned |
+
+Have a request? [Open an issue](https://github.com/orlandoburli/apiary/issues).

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -17,6 +17,22 @@ Polls open issues from a GitHub repository. Apiary reads pull request status for
 - **Comment rendering:** Markdown comments with embedded logs and cost summaries
 - **Setup:** See [GitHub Source configuration](github-source.md)
 
+### Codeberg / Forgejo / Gitea
+
+**Status:** ✅ Stable | **Auth:** Access token
+
+Polls open issues from a [Codeberg](https://codeberg.org) repository or any
+self-hosted Forgejo/Gitea instance (set `config.base_url`). Reads PR status for
+CI waits via commit statuses (Forgejo Actions or external CI), detects merge
+conflicts via the PR's `mergeable` flag, and uses native issue dependencies for
+blocking relationships.
+
+- **Requirements:** Repository access via a Codeberg/Forgejo access token
+- **Blocking relationships:** Uses Forgejo's native issue dependencies
+- **Comment rendering:** Markdown comments with embedded logs and cost summaries
+- **Limitations:** No sub-issue API (cannot `materialize: sub_issue`)
+- **Setup:** See [Codeberg Source configuration](codeberg-source.md)
+
 ### Plane
 
 **Status:** ✅ Stable | **Auth:** API key
@@ -41,6 +57,12 @@ Polls Jira Cloud via JQL search. Supports status transitions, blocking relations
 - **Blocking relationships:** Uses Jira's `Blocks` link type (reads the inward "is blocked by" side)
 - **Comment rendering:** ADF (Atlassian Document Format) for rich formatting
 - **Setup:** See [Jira Source configuration](jira-source.md)
+
+### GitLab
+
+**Status:** 🔄 Planned | **Auth:** Access token
+
+Support for GitLab issues, merge requests, and pipeline CI waits is in development.
 
 ### Linear
 
@@ -115,15 +137,16 @@ Direct API runner for Claude models via the Anthropic API is in development.
 
 ## Feature support matrix
 
-| Feature | GitHub | Plane | Jira | OpenCode API | Claude CLI | OpenCode CLI | Cursor CLI |
-|---------|--------|-------|------|---|---|---|---|
-| Polling | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| State transitions | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| Blocking relationships | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| Comment rendering | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| CI waits | ✅ | — | — | — | N/A | N/A | N/A |
-| Structured logs | — | — | — | ✅ | ✅ | ✅ | ✅ |
-| Exact cost tracking | — | — | — | ✅ | ✅ | — | — |
+| Feature | GitHub | Codeberg | Plane | Jira | OpenCode API | Claude CLI | OpenCode CLI | Cursor CLI |
+|---------|--------|----------|-------|------|---|---|---|---|
+| Polling | ✅ | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| State transitions | ✅ | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| Blocking relationships | ✅ | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| Comment rendering | ✅ | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
+| CI waits | ✅ | ✅ | — | — | — | N/A | N/A | N/A |
+| Sub-issues | ✅ | — | — | — | — | N/A | N/A | N/A |
+| Structured logs | — | — | — | — | ✅ | ✅ | ✅ | ✅ |
+| Exact cost tracking | — | — | — | — | ✅ | ✅ | — | — |
 
 ---
 
@@ -174,6 +197,7 @@ Workflows can route to different agents, which run on different runners. Tasks f
 
 | System | Type | Status |
 |--------|------|--------|
+| GitLab | Source | 🔄 In development |
 | Linear | Source | 🔄 In development |
 | Anthropic API | Runner | 🔄 In development |
 | Mistral | Runner | 📝 Planned |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Rate Limits & Resilience: resilience.md
   - Sources:
       - GitHub: github-source.md
+      - Codeberg: codeberg-source.md
       - Jira: jira-source.md
       - Plane: plane-source.md
   - Reference:

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Ativas
 
-_Nenhuma change ativa no momento._
+### git-forge-sources
+
+- **git-forge-sources** — Suporte a forges git além do GitHub. Fase 1 (este PR): novo source adapter `codeberg` para Codeberg e qualquer instância Forgejo/Gitea (via `base_url`): poll de issues, acknowledge, write-back, estados, labels (resolvidos/criados por id), approval polling, CI waits via commit statuses (sem check-runs), detecção de conflito via flag `mergeable`, e blockers via dependências nativas. Sem sub-issues (Forgejo não tem API). Enum do schema + config de exemplo + `docs/codeberg-source.md`. Fases seguintes (planejadas): GitLab (issues/MRs/pipelines), generalização das credenciais por-forge do agente, e E2E live.
 
 ## Arquivadas
 

--- a/openspec/changes/git-forge-sources/design.md
+++ b/openspec/changes/git-forge-sources/design.md
@@ -1,0 +1,97 @@
+# Design: Git Forge Sources
+
+## Where the seams already are
+
+Adding a forge is implementing `source.Adapter` (`src/internal/source/source.go`)
+plus the optional capability interfaces, registering a factory, and blank-importing
+the package in `cmd/apiary/main.go`. The dispatcher resolves `source.New(type)` per
+configured source; the workflow engine calls capability interfaces by type
+assertion, so a forge that implements `CIStatusPoller` can host `wait_for kind: ci`
+and one that implements `BlockerLister` can host `kind: dependency` — with no
+engine change. Config validation already gates dependency waits behind
+`config.SourceSupportsDependencyWait`, which instantiates the adapter and checks
+for `BlockerLister`.
+
+The GitHub adapter (`src/internal/source/github/`) is the structural template.
+
+## Forge primitive mapping
+
+| Concept | GitHub | Codeberg / Forgejo | GitLab |
+|---|---|---|---|
+| Auth header | `Authorization: Bearer` | `Authorization: token` | `PRIVATE-TOKEN` or Bearer |
+| API base | `api.github.com` | `{host}/api/v1` | `{host}/api/v4` |
+| List issues (excl. PRs) | `/issues` + skip `pull_request` | `/issues?type=issues` + skip | `/projects/{id}/issues` (issues only natively) |
+| Comment | issue comment | issue comment | issue **note** |
+| State change | `state` open/closed | `state` open/closed | `state_event` close/reopen |
+| Labels | by name | **by id** (resolve/create) | comma-separated names |
+| PR/MR for issue | timeline cross-ref | timeline (`ref_issue.pull_request`) | `/issues/{i}/related_merge_requests` |
+| Merge conflict | `mergeable_state == dirty` | `mergeable == false` | MR `has_conflicts == true` |
+| CI status | check-runs + commit status | **commit status only** | **pipelines** + jobs |
+| Blockers | `dependencies/blocked_by` | `/issues/{i}/dependencies` | issue links `blocks` (Premium) |
+| Sub-issues | native | **none** | epics / child issues |
+
+## Phase 1 — Codeberg/Forgejo (implemented here)
+
+Package `src/internal/source/codeberg/` — `adapter.go`, `client.go`, `types.go`,
+`adapter_test.go`. Capabilities: `StateSetter`, `LabelAdder`, `LabelRemover`,
+`TaskPoller`, `CIStatusPoller`, `PullRequestLister`, `BlockerLister`. **Not**
+`SubIssueCreator`.
+
+Key decisions, grounded in the verified Forgejo/Gitea API:
+
+- **Auth.** `Authorization: token <TOKEN>` — the universally supported PAT scheme
+  across Gitea/Forgejo versions. Per-agent override via `source.SourceTokenCtxKey`,
+  same as GitHub.
+- **Host-agnostic.** `base_url` defaults to `https://codeberg.org/api/v1`; any
+  Forgejo/Gitea host works by overriding it. The browser host is derived by
+  stripping the API suffix.
+- **Labels are ids, not names.** Forgejo's add/remove endpoints and create-issue
+  body work in numeric label ids (name support is version-gated). The adapter
+  caches the repo's labels (`name → id`, mutex-guarded), creates a missing label
+  (Forgejo requires a `color`; a neutral grey is used), and applies/removes by id.
+  `AddLabels` POSTs ids (Forgejo merges into the set); `RemoveLabels` issues one
+  DELETE per id and skips labels absent from the repo or the issue (404).
+- **CI = commit statuses.** Forgejo has no check-runs API; Forgejo Actions and
+  external CI both post commit statuses. `PollCIStatus` finds the PR via timeline,
+  reads `GET /commits/{sha}/status`, and aggregates per-context statuses
+  (`success`/`warning → passed`, `failure`/`error → failed`, `pending`,
+  `skipped`); an empty set is `pending` (CI not started).
+- **Conflict detection.** Forgejo exposes a boolean `mergeable` (no
+  `mergeable_state`). An unmerged PR with `mergeable == false` surfaces as
+  `conflict`. Forgejo computes mergeability lazily, so a freshly pushed PR can
+  report a stale value briefly — acceptable because the `wait_for` step's
+  `on_conflict` edge has its own retry budget.
+- **Blockers = native dependencies.** `GET /issues/{i}/dependencies` returns the
+  issues this one depends on. Closed → `done`; an open blocker's `Merged` is read
+  from its PR marker when it is itself a PR, else best-effort via its referenced
+  PRs.
+- **PR discovery is best-effort.** Forgejo's timeline schema is not guaranteed
+  stable; a cross-referencing PR appears as `ref_issue` with a non-null
+  `pull_request` marker. `findPRNumber` keeps the most recent match. (A future
+  hardening could fall back to listing open PRs and matching "Closes #N".)
+
+## Phase 2 — GitLab (planned, not in this PR)
+
+Package `src/internal/source/gitlab/`. Notable differences to handle: project-id
+resolution (numeric id or URL-encoded path), notes instead of comments,
+`state_event` for transitions, `related_merge_requests` for issue→MR (cleaner
+than timeline scraping), pipeline + job aggregation for CI, `has_conflicts` for
+conflict, and issue links for blockers — with a label-convention fallback when
+the link-type `blocks` relation is Premium-gated (log the downgrade, never fail).
+
+## Phase 3 — Agent credentials (planned, not in this PR)
+
+`agentIdentityEnv` in `src/internal/daemon/workflow.go` injects only
+`GITHUB_TOKEN`/`GH_TOKEN`. Generalize to emit the per-forge token env
+(`CODEBERG_TOKEN`, `GITLAB_TOKEN`/`CI_JOB_TOKEN`) and document the CLI/git-remote
+auth pattern per forge in agent souls. This is what makes agents actually open
+PRs/MRs against non-GitHub forges, versus Apiary merely reading their issues.
+
+## Testing
+
+Phase 1 ships table + `httptest` unit tests mirroring the github suite: field
+mapping, filters, PR skip on poll, label resolve-to-id (add + create), remove by
+id with skip-missing, CI conflict short-circuit, CI status aggregation, blocker
+state normalization, and a capability assertion that `codeberg` does **not**
+implement `SubIssueCreator`. Live E2E against a real Codeberg repo is Phase 4
+(needs an operator token).

--- a/openspec/changes/git-forge-sources/proposal.md
+++ b/openspec/changes/git-forge-sources/proposal.md
@@ -1,0 +1,67 @@
+# Proposal: Git Forge Sources (Codeberg, GitLab)
+
+## Why
+
+Apiary's source layer already supports three backends (GitHub, Jira, Plane)
+through a clean plugin abstraction: a `source.Adapter` interface plus opt-in
+capability interfaces (`CIStatusPoller`, `BlockerLister`, `PullRequestLister`,
+`SubIssueCreator`, `StateSetter`, `LabelAdder`/`Remover`, `TaskPoller`). The
+actual git operations (clone, branch, commit, push, open PR) are **already
+host-agnostic** — they run inside the agent subprocess, not in Apiary core.
+
+But the only *git forge* Apiary can drive end-to-end is **GitHub**. Teams on
+**Codeberg/Forgejo** (and self-hosted Gitea) or **GitLab** cannot use Apiary to
+triage issues, wait on CI, gate on blockers, or write results back — even though
+those platforms expose the same primitives (issues, comments, labels, states,
+pull/merge requests, CI status, issue dependencies).
+
+This change adds Codeberg/Forgejo and GitLab as first-class sources, proving the
+forge abstraction generalizes beyond GitHub and unlocking Apiary for the large
+population of teams not on github.com.
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Forges supported** | GitHub only | GitHub + Codeberg/Forgejo/Gitea + GitLab |
+| **`source.type` values** | `github`, `jira`, `plane` | + `codeberg`, `gitlab` |
+| **CI waits** | GitHub check-runs + commit status | + Forgejo commit statuses; + GitLab pipelines |
+| **Blockers** | GitHub `blocked_by`, Jira/Plane links | + Forgejo native dependencies; + GitLab issue links |
+| **Agent credentials** | `GITHUB_TOKEN`/`GH_TOKEN` only | source-type-aware token/CLI env (Phase 3) |
+| **Schema/docs** | github/plane (jira undocumented in schema) | enum + per-source docs for all forges |
+
+## Scope & Phasing
+
+The work ships incrementally; each phase is independently mergeable.
+
+- **Phase 1 — Codeberg/Forgejo source (this PR).** New `codeberg` adapter:
+  poll, acknowledge, write-back, state, labels, approval polling, CI waits
+  (commit statuses), conflict detection (`mergeable` flag), and native
+  dependency blockers. No sub-issues (Forgejo has none). Works against any
+  Forgejo/Gitea host via `base_url`. Schema enum, example config, and docs.
+- **Phase 2 — GitLab source.** New `gitlab` adapter: issues, notes, labels,
+  state events, merge requests via `related_merge_requests`, pipeline CI waits,
+  conflict detection (`has_conflicts`), and issue-link blockers (with a graceful
+  fallback when link-type relations require GitLab Premium).
+- **Phase 3 — Agent credential generalization.** Make the runner's identity env
+  source-type-aware so agents receive the right token env var and the right CLI
+  (`glab`/`tea`/raw git) per forge, not just `GITHUB_TOKEN`.
+- **Phase 4 — Live E2E.** Validate each adapter against a real Codeberg repo and
+  a real GitLab project (needs operator tokens).
+
+## New Concepts
+
+| Term | Description |
+|---|---|
+| **Forge** | A git hosting platform exposing issues + pull/merge requests + CI: GitHub, Codeberg/Forgejo, GitLab. |
+| **`codeberg` source** | A `source.Adapter` for Codeberg and any Forgejo/Gitea instance (`base_url` selects the host). |
+| **`gitlab` source** | A `source.Adapter` for gitlab.com and self-managed GitLab (Phase 2). |
+
+## Out of Scope
+
+- Bitbucket, Gitea-incompatible forks, and other forges.
+- Sub-issue materialization on forges without a native parent/child API
+  (Forgejo): spawned tasks still dispatch by label; they are just not linked as
+  sub-issues.
+- Changing the workflow engine, which already calls the capability interfaces
+  generically — no engine change is needed for new forges.

--- a/openspec/changes/git-forge-sources/tasks.md
+++ b/openspec/changes/git-forge-sources/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Git Forge Sources
+
+## Phase 1 — Codeberg / Forgejo source (this PR)
+
+- [x] 1.1 `codeberg` package: `types.go` (Forgejo issue/PR/label/status/timeline DTOs)
+- [x] 1.2 `client.go`: `Authorization: token` auth, per-agent token override, Link-header pagination, `base_url` for self-hosted hosts
+- [x] 1.3 `adapter.go`: core `Adapter` (Connect/Poll/Acknowledge/WriteResult/WebhookHandler), `type=issues` poll + PR skip
+- [x] 1.4 `StateSetter`, `LabelAdder`, `LabelRemover` — labels resolved/created by id (mutex-guarded cache)
+- [x] 1.5 `TaskPoller` — issue + comments for approval steps
+- [x] 1.6 `CIStatusPoller` — commit-status aggregation; `mergeable == false` → conflict
+- [x] 1.7 `PullRequestLister` + `BlockerLister` — timeline PR discovery; native `/dependencies` blockers
+- [x] 1.8 Register factory + blank-import in `cmd/apiary/main.go`
+- [x] 1.9 Unit tests (httptest) mirroring the github suite + capability assertions
+- [x] 1.10 Schema enum (`github`/`codeberg`/`jira`/`plane`), example config, `docs/codeberg-source.md`, integrations matrix, mkdocs nav
+- [x] 1.11 `go vet` + `gofmt` clean; full `go build ./...` and package tests green
+
+## Phase 2 — GitLab source (follow-up PR)
+
+- [ ] 2.1 `gitlab` package skeleton (client v4 API, `PRIVATE-TOKEN` auth, project-id resolution)
+- [ ] 2.2 Poll issues, notes (comments), labels, `state_event` transitions
+- [ ] 2.3 `PullRequestLister` via `related_merge_requests`; `CIStatusPoller` via pipelines + jobs
+- [ ] 2.4 Conflict via MR `has_conflicts`; `BlockerLister` via issue links with label-convention fallback (Premium gate)
+- [ ] 2.5 Register, schema enum, example config, `docs/gitlab-source.md`, matrix, nav
+- [ ] 2.6 Unit tests
+
+## Phase 3 — Agent credential generalization (follow-up PR)
+
+- [ ] 3.1 Make `agentIdentityEnv` source-type-aware (per-forge token env)
+- [ ] 3.2 Document per-forge CLI / git-remote auth in agent souls and docs
+
+## Phase 4 — Live E2E (follow-up)
+
+- [ ] 4.1 Codeberg E2E against a real repo (operator token)
+- [ ] 4.2 GitLab E2E against a real project (operator token)

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -117,7 +117,7 @@
     },
     "sources": {
       "type": "array",
-      "description": "Task sources (github, plane)",
+      "description": "Task sources (github, codeberg, gitlab, jira, plane)",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -130,11 +130,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "plane"]
+            "enum": ["github", "codeberg", "jira", "plane"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. plane: workspace, project, api_key, base_url",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. codeberg: repo, api_key, base_url (any Forgejo/Gitea host). jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/orlandoburli/apiary/internal/cli"
 
+	_ "github.com/orlandoburli/apiary/internal/source/codeberg"
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
 	_ "github.com/orlandoburli/apiary/internal/source/plane"

--- a/src/internal/source/codeberg/adapter.go
+++ b/src/internal/source/codeberg/adapter.go
@@ -1,0 +1,649 @@
+// Package codeberg implements a source.Adapter for Codeberg and any other
+// Forgejo/Gitea instance. The Forgejo REST API closely mirrors GitHub's, so the
+// shape follows the github adapter; the differences are concentrated here:
+// "Authorization: token" auth, label operations by id (not name), commit
+// statuses instead of check-runs, a bool Mergeable flag instead of
+// mergeable_state, native issue dependencies, and no sub-issue API.
+package codeberg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func init() {
+	source.Register("codeberg", func() source.Adapter { return &Adapter{} })
+}
+
+// Compile-time checks for the optional capabilities Codeberg supports. Note the
+// absence of source.SubIssueCreator: Forgejo/Gitea has no native parent/child
+// issue API, so spawned tasks cannot be materialized as sub-issues here.
+var (
+	_ source.StateSetter       = (*Adapter)(nil)
+	_ source.LabelAdder        = (*Adapter)(nil)
+	_ source.LabelRemover      = (*Adapter)(nil)
+	_ source.TaskPoller        = (*Adapter)(nil)
+	_ source.CIStatusPoller    = (*Adapter)(nil)
+	_ source.PullRequestLister = (*Adapter)(nil)
+	_ source.BlockerLister     = (*Adapter)(nil)
+)
+
+type Adapter struct {
+	id         string
+	client     *client
+	owner      string
+	repo       string
+	webBaseURL string
+
+	filterStates []string
+	filterLabels []string
+
+	// labelByName caches repo labels (lowercased name → id). Forgejo's label
+	// endpoints work in ids, so every add/remove resolves a name through here.
+	mu           sync.Mutex
+	labelByName  map[string]int64
+	labelsLoaded bool
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+func (a *Adapter) SetID(id string) { a.id = id }
+
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	repoStr, _ := cfg["repo"].(string)
+	if repoStr == "" {
+		return fmt.Errorf("codeberg: config.repo is required (e.g. \"owner/repo\")")
+	}
+	parts := strings.SplitN(repoStr, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("codeberg: config.repo %q must be in \"owner/repo\" format", repoStr)
+	}
+
+	apiKey, _ := cfg["api_key"].(string)
+	baseURL, _ := cfg["base_url"].(string)
+
+	a.owner = parts[0]
+	a.repo = parts[1]
+	a.client = newClient(baseURL, apiKey)
+	a.labelByName = map[string]int64{}
+
+	// Derive the browser host from the API base. Codeberg's API lives at
+	// codeberg.org/api/v1, so strip the /api/v1 suffix to reach the web host.
+	a.webBaseURL = deriveWebBaseURL(baseURL)
+
+	aplog.Info("codeberg: configured  repo=%s/%s  host=%s", a.owner, a.repo, a.webBaseURL)
+	return nil
+}
+
+// deriveWebBaseURL turns an API base URL into the browser-facing host root.
+func deriveWebBaseURL(baseURL string) string {
+	if baseURL == "" || baseURL == defaultBaseURL {
+		return "https://codeberg.org"
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return "https://codeberg.org"
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+func (a *Adapter) SetFilters(states, labels []string) {
+	for _, s := range states {
+		a.filterStates = append(a.filterStates, strings.ToLower(s))
+	}
+	for _, l := range labels {
+		a.filterLabels = append(a.filterLabels, strings.ToLower(l))
+	}
+}
+
+func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues", a.owner, a.repo)
+
+	state := "open"
+	if len(a.filterStates) > 0 {
+		state = a.filterStates[0]
+	}
+	// type=issues excludes pull requests server-side; the PullRequest guard
+	// below is a belt-and-suspenders check for older Forgejo versions.
+	params := url.Values{
+		"type":  {"issues"},
+		"state": {state},
+	}
+
+	issues, err := a.client.getAllIssues(ctx, path, params)
+	if err != nil {
+		return nil, fmt.Errorf("codeberg: polling issues: %w", err)
+	}
+
+	var cells []model.SourceItem
+	for _, item := range issues {
+		if item.PullRequest != nil {
+			aplog.Debug("  #%d (%q): pull request, skipping", item.Number, item.Title)
+			continue
+		}
+		if !a.matchesFilters(item) {
+			continue
+		}
+		cells = append(cells, a.toSourceItem(item))
+	}
+	return cells, nil
+}
+
+func (a *Adapter) matchesFilters(item issue) bool {
+	if len(a.filterStates) > 0 {
+		stateName := strings.ToLower(item.State)
+		if !containsAny(a.filterStates, stateName) {
+			aplog.Debug("  issue #%d (%q): state %q not in filter %v", item.Number, item.Title, stateName, a.filterStates)
+			return false
+		}
+	}
+	if len(a.filterLabels) > 0 {
+		itemLabels := make([]string, 0, len(item.Labels))
+		for _, l := range item.Labels {
+			itemLabels = append(itemLabels, strings.ToLower(l.Name))
+		}
+		for _, required := range a.filterLabels {
+			if !containsAny(itemLabels, required) {
+				aplog.Debug("  issue #%d (%q): missing required label %q (has: %v)", item.Number, item.Title, required, itemLabels)
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (a *Adapter) Acknowledge(ctx context.Context, cell model.SourceItem, action model.AckAction) error {
+	if action != model.AckActionInProgress {
+		return nil
+	}
+	if err := a.AddLabels(ctx, cell, []string{"in-progress"}); err != nil {
+		return fmt.Errorf("codeberg: acknowledging %s: %w", cell.ID, err)
+	}
+	return nil
+}
+
+func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result model.RunResult) error {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", a.owner, a.repo, cell.ID)
+	_, err := a.client.post(ctx, path, commentRequest{Body: formatComment(result)})
+	if err != nil {
+		return fmt.Errorf("codeberg: writing result to %s: %w", cell.ID, err)
+	}
+	return nil
+}
+
+func (a *Adapter) WebhookHandler() http.Handler { return nil }
+
+// PollTask fetches a single issue plus its comments for approval-step
+// evaluation. Implements source.TaskPoller.
+func (a *Adapter) PollTask(ctx context.Context, cellID string) (model.SourceItem, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return model.SourceItem{}, fmt.Errorf("codeberg: poll task %s: %w", cellID, err)
+	}
+	var item issue
+	if err := json.Unmarshal(body, &item); err != nil {
+		return model.SourceItem{}, fmt.Errorf("codeberg: decoding issue %s: %w", cellID, err)
+	}
+
+	cell := a.toSourceItem(item)
+	comments, err := a.fetchComments(ctx, cellID)
+	if err != nil {
+		aplog.Debug("codeberg: fetch comments for %s: %v", cellID, err)
+	} else {
+		cell.Comments = comments
+	}
+	return cell, nil
+}
+
+func (a *Adapter) fetchComments(ctx context.Context, issueNo string) ([]model.Comment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", a.owner, a.repo, issueNo)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	var raw []comment
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("codeberg: decoding comments for %s: %w", issueNo, err)
+	}
+	out := make([]model.Comment, 0, len(raw))
+	for _, c := range raw {
+		created, _ := time.Parse(time.RFC3339, c.CreatedAt)
+		out = append(out, model.Comment{ID: fmt.Sprintf("%d", c.ID), Body: c.Body, CreatedAt: created})
+	}
+	return out, nil
+}
+
+func (a *Adapter) SetState(ctx context.Context, cell model.SourceItem, stateName string) error {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s", a.owner, a.repo, cell.ID)
+	_, err := a.client.patch(ctx, path, editIssueRequest{State: stateName})
+	if err != nil {
+		return fmt.Errorf("codeberg: setting state %q on %s: %w", stateName, cell.ID, err)
+	}
+	return nil
+}
+
+// AddLabels resolves each label name to its id (creating the label if needed)
+// and POSTs them to the issue, which Forgejo merges into the existing set.
+// Implements source.LabelAdder.
+func (a *Adapter) AddLabels(ctx context.Context, cell model.SourceItem, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	ids, err := a.resolveLabelIDs(ctx, names, true)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/labels", a.owner, a.repo, cell.ID)
+	if _, err := a.client.post(ctx, path, issueLabelsRequest{Labels: ids}); err != nil {
+		return fmt.Errorf("codeberg: adding labels %v to %s: %w", names, cell.ID, err)
+	}
+	return nil
+}
+
+// RemoveLabels deletes the named labels from an issue, one DELETE per label by
+// its id so the rest are untouched. A label that does not exist on the repo (or
+// is already absent from the issue → 404) is skipped. Implements
+// source.LabelRemover.
+func (a *Adapter) RemoveLabels(ctx context.Context, cell model.SourceItem, names []string) error {
+	ids, err := a.resolveLabelIDs(ctx, names, false)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		path := fmt.Sprintf("/repos/%s/%s/issues/%s/labels/%d", a.owner, a.repo, cell.ID, id)
+		if _, err := a.client.delete(ctx, path); err != nil {
+			if strings.Contains(err.Error(), "status 404") {
+				continue // label already absent from the issue
+			}
+			return fmt.Errorf("codeberg: removing label id %d from %s: %w", id, cell.ID, err)
+		}
+	}
+	return nil
+}
+
+// PollCIStatus reports the CI status of the pull request linked to the issue.
+// Forgejo has no check-runs API, so it aggregates the combined commit status of
+// the PR's head commit (where Forgejo Actions and external CI both report).
+// Implements source.CIStatusPoller.
+func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CIStatus, error) {
+	prNumber, err := a.findPRNumber(ctx, cellID)
+	if err != nil {
+		if isAuthError(err) {
+			return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: cannot read PRs for issue %s — the configured token likely lacks repository read access: %w", cellID, err)
+		}
+		return source.CIStatus{Status: "pending"}, nil // no timeline access; keep waiting
+	}
+	if prNumber == 0 {
+		return source.CIStatus{Status: "pending"}, nil // no PR yet
+	}
+
+	prBody, err := a.client.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, prNumber))
+	if err != nil {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: fetching PR #%d for issue %s: %w", prNumber, cellID, err)
+	}
+	var pr pullRequest
+	if err := json.Unmarshal(prBody, &pr); err != nil {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: decoding PR %d: %w", prNumber, err)
+	}
+
+	// An unmerged PR that Forgejo reports as not mergeable has conflicts and can
+	// never merge until rebased/resolved, so waiting for CI on it is pointless —
+	// surface the conflict so the wait_for step hands it back to the engineer.
+	if !pr.Merged && !pr.Mergeable {
+		aplog.Info("codeberg: PR #%d for %s is not mergeable (conflict)", pr.Number, cellID)
+		return source.CIStatus{Status: "conflict", URL: prWebURL(pr, a.webBaseURL, a.owner, a.repo)}, nil
+	}
+
+	headSHA := pr.Head.SHA
+	if headSHA == "" {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: PR #%d has no head SHA", prNumber)
+	}
+
+	statusBody, err := a.client.get(ctx, fmt.Sprintf("/repos/%s/%s/commits/%s/status", a.owner, a.repo, headSHA))
+	if err != nil {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: fetching status for %s: %w", headSHA, err)
+	}
+	var combined combinedStatus
+	if err := json.Unmarshal(statusBody, &combined); err != nil {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("codeberg: decoding commit status: %w", err)
+	}
+
+	// Aggregate every per-context status. No statuses at all means CI has not
+	// started yet → pending (never report passed on an empty set).
+	anyFail, anyPending, anySignal := false, false, false
+	checks := make([]struct {
+		Name   string
+		Status string
+	}, 0, len(combined.Statuses))
+	for _, st := range combined.Statuses {
+		anySignal = true
+		norm := normalizeStatus(st.Status)
+		switch norm {
+		case "failed":
+			anyFail = true
+		case "pending":
+			anyPending = true
+		}
+		checks = append(checks, struct {
+			Name   string
+			Status string
+		}{Name: st.Context, Status: norm})
+	}
+
+	overall := "pending"
+	switch {
+	case anyFail:
+		overall = "failed"
+	case anyPending:
+		overall = "pending"
+	case anySignal:
+		overall = "passed"
+	}
+	return source.CIStatus{Status: overall, URL: prWebURL(pr, a.webBaseURL, a.owner, a.repo), Checks: checks}, nil
+}
+
+// ListPullRequests returns every pull request that references the issue, oldest
+// first, derived from the issue timeline. Implements source.PullRequestLister.
+func (a *Adapter) ListPullRequests(ctx context.Context, cellID string) ([]source.PullRequestRef, error) {
+	timeline, err := a.fetchTimeline(ctx, cellID)
+	if err != nil {
+		return nil, err
+	}
+	var prs []source.PullRequestRef
+	seen := make(map[int]bool)
+	for _, e := range timeline {
+		if e.RefIssue == nil || e.RefIssue.PullRequest == nil {
+			continue
+		}
+		n := e.RefIssue.Number
+		if n == 0 || seen[n] {
+			continue
+		}
+		seen[n] = true
+		prs = append(prs, source.PullRequestRef{
+			Number: n,
+			URL:    fmt.Sprintf("%s/%s/%s/pulls/%d", a.webBaseURL, a.owner, a.repo, n),
+		})
+	}
+	return prs, nil
+}
+
+// ListBlockers enumerates the issues blocking the given one via Forgejo's
+// dependencies endpoint (the issues this one depends on). linkType is ignored —
+// Forgejo has a single dependency relation. State is normalized to "done" when
+// the blocker is closed; for an open blocker, Merged reports whether the blocker
+// is a merged PR or has a merged PR cross-referenced from it (best-effort).
+// Implements source.BlockerLister.
+func (a *Adapter) ListBlockers(ctx context.Context, cellID, _ string) ([]source.BlockerRef, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/dependencies", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("codeberg: listing blockers of issue %s: %w", cellID, err)
+	}
+	var blocking []issue
+	if err := json.Unmarshal(body, &blocking); err != nil {
+		return nil, fmt.Errorf("codeberg: decoding blockers of issue %s: %w", cellID, err)
+	}
+
+	blockers := make([]source.BlockerRef, 0, len(blocking))
+	for _, b := range blocking {
+		state := b.State
+		if state == "closed" {
+			state = "done"
+		}
+		ref := source.BlockerRef{
+			ID:     fmt.Sprintf("%d", b.Number),
+			Number: fmt.Sprintf("#%d", b.Number),
+			Title:  b.Title,
+			State:  state,
+		}
+		switch {
+		case b.PullRequest != nil:
+			ref.Merged = b.PullRequest.Merged
+		case state != "done":
+			ref.Merged = a.blockerHasMergedPR(ctx, b.Number)
+		}
+		blockers = append(blockers, ref)
+	}
+	return blockers, nil
+}
+
+// blockerHasMergedPR reports whether any PR referenced from the blocker issue is
+// merged. Best-effort: any lookup failure returns false so a transient API error
+// cannot fail the dependency wait.
+func (a *Adapter) blockerHasMergedPR(ctx context.Context, issueNumber int) bool {
+	prs, err := a.ListPullRequests(ctx, fmt.Sprintf("%d", issueNumber))
+	if err != nil {
+		aplog.Debug("codeberg: listing PRs of blocker #%d: %v", issueNumber, err)
+		return false
+	}
+	for _, ref := range prs {
+		body, err := a.client.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, ref.Number))
+		if err != nil {
+			aplog.Debug("codeberg: fetching PR #%d of blocker #%d: %v", ref.Number, issueNumber, err)
+			continue
+		}
+		var pr struct {
+			Merged bool `json:"merged"`
+		}
+		if err := json.Unmarshal(body, &pr); err != nil {
+			continue
+		}
+		if pr.Merged {
+			return true
+		}
+	}
+	return false
+}
+
+// findPRNumber returns the most recent pull request referencing the issue, or 0
+// when none is found. It scans the issue timeline (best-effort — Forgejo's
+// timeline schema is not guaranteed stable) and keeps the last match so a
+// reopened/replacement PR wins over an earlier closed one.
+func (a *Adapter) findPRNumber(ctx context.Context, cellID string) (int, error) {
+	timeline, err := a.fetchTimeline(ctx, cellID)
+	if err != nil {
+		return 0, err
+	}
+	var prNumber int
+	for _, e := range timeline {
+		if e.RefIssue != nil && e.RefIssue.PullRequest != nil && e.RefIssue.Number != 0 {
+			prNumber = e.RefIssue.Number
+		}
+	}
+	return prNumber, nil
+}
+
+func (a *Adapter) fetchTimeline(ctx context.Context, cellID string) ([]timelineComment, error) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/timeline", a.owner, a.repo, cellID)
+	body, err := a.client.get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("codeberg: fetching timeline for issue %s: %w", cellID, err)
+	}
+	var timeline []timelineComment
+	if err := json.Unmarshal(body, &timeline); err != nil {
+		return nil, fmt.Errorf("codeberg: decoding timeline for issue %s: %w", cellID, err)
+	}
+	return timeline, nil
+}
+
+// resolveLabelIDs maps label names to repo label ids. When create is true,
+// missing labels are created; when false, missing labels are skipped (used by
+// RemoveLabels, which has nothing to delete for a label that never existed).
+func (a *Adapter) resolveLabelIDs(ctx context.Context, names []string, create bool) ([]int64, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if err := a.ensureLabelsLoadedLocked(ctx); err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, 0, len(names))
+	for _, name := range names {
+		key := strings.ToLower(name)
+		if id, ok := a.labelByName[key]; ok {
+			ids = append(ids, id)
+			continue
+		}
+		if !create {
+			continue
+		}
+		id, err := a.createLabelLocked(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+// ensureLabelsLoadedLocked populates the label cache once. Caller holds a.mu.
+func (a *Adapter) ensureLabelsLoadedLocked(ctx context.Context) error {
+	if a.labelsLoaded {
+		return nil
+	}
+	body, err := a.client.get(ctx, fmt.Sprintf("/repos/%s/%s/labels?limit=%d", a.owner, a.repo, perPage))
+	if err != nil {
+		return fmt.Errorf("codeberg: listing labels: %w", err)
+	}
+	var labels []label
+	if err := json.Unmarshal(body, &labels); err != nil {
+		return fmt.Errorf("codeberg: decoding labels: %w", err)
+	}
+	for _, l := range labels {
+		a.labelByName[strings.ToLower(l.Name)] = l.ID
+	}
+	a.labelsLoaded = true
+	return nil
+}
+
+// createLabelLocked creates a repo label (Forgejo requires a color) and caches
+// its id. Caller holds a.mu. A concurrent/duplicate create (409/422) falls back
+// to a cache refresh so the existing label's id is returned.
+func (a *Adapter) createLabelLocked(ctx context.Context, name string) (int64, error) {
+	body, err := a.client.post(ctx, fmt.Sprintf("/repos/%s/%s/labels", a.owner, a.repo),
+		createLabelRequest{Name: name, Color: defaultLabelColor})
+	if err != nil {
+		if strings.Contains(err.Error(), "status 409") || strings.Contains(err.Error(), "status 422") {
+			a.labelsLoaded = false
+			if rerr := a.ensureLabelsLoadedLocked(ctx); rerr != nil {
+				return 0, rerr
+			}
+			if id, ok := a.labelByName[strings.ToLower(name)]; ok {
+				return id, nil
+			}
+		}
+		return 0, fmt.Errorf("codeberg: creating label %q: %w", name, err)
+	}
+	var created label
+	if err := json.Unmarshal(body, &created); err != nil {
+		return 0, fmt.Errorf("codeberg: decoding created label %q: %w", name, err)
+	}
+	a.labelByName[strings.ToLower(created.Name)] = created.ID
+	return created.ID, nil
+}
+
+const defaultLabelColor = "#ededed"
+
+func (a *Adapter) toSourceItem(item issue) model.SourceItem {
+	labels := make([]string, 0, len(item.Labels))
+	for _, l := range item.Labels {
+		labels = append(labels, strings.ToLower(l.Name))
+	}
+	createdAt, _ := time.Parse(time.RFC3339, item.CreatedAt)
+	updatedAt, _ := time.Parse(time.RFC3339, item.UpdatedAt)
+
+	return model.SourceItem{
+		ID:          fmt.Sprintf("%d", item.Number),
+		SourceID:    a.ID(),
+		Number:      fmt.Sprintf("#%d", item.Number),
+		Title:       item.Title,
+		Description: item.Body,
+		Labels:      labels,
+		Type:        "issue",
+		State:       item.State,
+		URL:         item.HTMLURL,
+		CreatedAt:   createdAt,
+		UpdatedAt:   updatedAt,
+	}
+}
+
+// prWebURL prefers the PR's own html_url and falls back to constructing the
+// Forgejo PR web path (/{owner}/{repo}/pulls/{n}) from the host.
+func prWebURL(pr pullRequest, webBaseURL, owner, repo string) string {
+	if pr.HTMLURL != "" {
+		return pr.HTMLURL
+	}
+	return fmt.Sprintf("%s/%s/%s/pulls/%d", webBaseURL, owner, repo, pr.Number)
+}
+
+// normalizeStatus maps Forgejo commit-status states to Apiary's check vocabulary.
+// Forgejo's set is wider than GitHub's: "warning" is a non-blocking pass and
+// "skipped" is reported as skipped.
+func normalizeStatus(s string) string {
+	switch s {
+	case "success", "warning":
+		return "passed"
+	case "failure", "error":
+		return "failed"
+	case "pending":
+		return "pending"
+	case "skipped":
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
+
+// isAuthError reports whether a client error is an authorization failure (401/403)
+// — a permanent permission problem, not a transient blip to retry past.
+func isAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "status 401") || strings.Contains(msg, "status 403")
+}
+
+func formatComment(result model.RunResult) string {
+	var b strings.Builder
+	if result.Success {
+		b.WriteString("✓ **Apiary run complete**")
+	} else {
+		b.WriteString("✗ **Apiary run failed**")
+	}
+	fmt.Fprintf(&b, " · worker: `%s`", result.WorkerID)
+	fmt.Fprintf(&b, " · duration: %s", result.Duration.Round(time.Second))
+
+	if result.Output != "" {
+		b.WriteString("\n\n```\n")
+		b.WriteString(result.Output)
+		b.WriteString("\n```")
+	}
+	if result.Error != nil {
+		fmt.Fprintf(&b, "\n\n**Error:** `%s`", result.Error.Error())
+	}
+	return b.String()
+}
+
+func containsAny(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/source/codeberg/adapter_test.go
+++ b/src/internal/source/codeberg/adapter_test.go
@@ -1,0 +1,300 @@
+package codeberg
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func TestToSourceItem_MapsFields(t *testing.T) {
+	a := &Adapter{id: "cb-test"}
+	item := issue{
+		Number:    42,
+		Title:     "Fix login bug",
+		Body:      "Users cannot log in",
+		State:     "open",
+		Labels:    []label{{ID: 1, Name: "Bug"}, {ID: 2, Name: "backend"}},
+		HTMLURL:   "https://codeberg.org/o/r/issues/42",
+		CreatedAt: "2025-01-01T10:00:00Z",
+		UpdatedAt: "2025-06-15T12:00:00Z",
+	}
+	cell := a.toSourceItem(item)
+
+	if cell.ID != "42" || cell.Number != "#42" {
+		t.Errorf("ID/Number = %q/%q, want 42/#42", cell.ID, cell.Number)
+	}
+	if cell.SourceID != "cb-test" {
+		t.Errorf("SourceID = %q", cell.SourceID)
+	}
+	if cell.Type != "issue" {
+		t.Errorf("Type = %q, want issue", cell.Type)
+	}
+	if len(cell.Labels) != 2 || cell.Labels[0] != "bug" || cell.Labels[1] != "backend" {
+		t.Errorf("Labels = %v, want lowercased [bug backend]", cell.Labels)
+	}
+	if cell.CreatedAt.IsZero() || cell.UpdatedAt.IsZero() {
+		t.Error("timestamps should not be zero")
+	}
+}
+
+func TestMatchesFilters(t *testing.T) {
+	if !(&Adapter{}).matchesFilters(issue{Number: 1, State: "open"}) {
+		t.Error("no filters should match")
+	}
+	if (&Adapter{filterStates: []string{"closed"}}).matchesFilters(issue{State: "open"}) {
+		t.Error("open should not match state filter [closed]")
+	}
+	a := &Adapter{filterLabels: []string{"bug", "backend"}}
+	if !a.matchesFilters(issue{Labels: []label{{Name: "bug"}, {Name: "backend"}, {Name: "x"}}}) {
+		t.Error("all required labels present should match")
+	}
+	if a.matchesFilters(issue{Labels: []label{{Name: "bug"}}}) {
+		t.Error("missing a required label should not match")
+	}
+}
+
+func TestDeriveWebBaseURL(t *testing.T) {
+	cases := map[string]string{
+		"":                                   "https://codeberg.org",
+		defaultBaseURL:                       "https://codeberg.org",
+		"https://git.example.org/api/v1":     "https://git.example.org",
+		"https://forge.internal:3000/api/v1": "https://forge.internal:3000",
+	}
+	for in, want := range cases {
+		if got := deriveWebBaseURL(in); got != want {
+			t.Errorf("deriveWebBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeStatus(t *testing.T) {
+	cases := map[string]string{
+		"success": "passed", "warning": "passed",
+		"failure": "failed", "error": "failed",
+		"pending": "pending", "skipped": "skipped", "weird": "unknown",
+	}
+	for in, want := range cases {
+		if got := normalizeStatus(in); got != want {
+			t.Errorf("normalizeStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatComment(t *testing.T) {
+	ok := formatComment(model.RunResult{WorkerID: "eng", Success: true, Output: "done it", Duration: 90 * time.Second})
+	mustContain(t, ok, "✓")
+	mustContain(t, ok, "eng")
+	mustContain(t, ok, "done it")
+	mustNotContain(t, ok, "✗")
+
+	fail := formatComment(model.RunResult{WorkerID: "eng", Success: false, Error: fmt.Errorf("boom"), Duration: time.Second})
+	mustContain(t, fail, "✗")
+	mustContain(t, fail, "boom")
+}
+
+// TestPoll_SkipsPullRequests verifies a PR returned by the /issues endpoint is
+// not ingested as a task — only plain issues become SourceItems.
+func TestPoll_SkipsPullRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("type") != "issues" {
+			t.Errorf("expected type=issues query, got %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[
+			{"number": 1, "title": "Real issue", "state": "open"},
+			{"number": 2, "title": "A PR", "state": "open", "pull_request": {"merged": false}}
+		]`))
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "1" {
+		t.Fatalf("got %+v, want only issue #1", items)
+	}
+}
+
+// TestAddLabels_ResolvesNamesToIDs verifies the adapter lists labels, creates a
+// missing one (with a color), and POSTs label ids — not names — to the issue.
+func TestAddLabels_ResolvesNamesToIDs(t *testing.T) {
+	var postedLabels, createBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/labels"):
+			_, _ = w.Write([]byte(`[{"id": 10, "name": "in-progress", "color": "ededed"}]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/repos/o/r/labels"):
+			b, _ := io.ReadAll(r.Body)
+			createBody = string(b)
+			_, _ = w.Write([]byte(`{"id": 20, "name": "agent:engineer", "color": "ededed"}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/issues/42/labels"):
+			b, _ := io.ReadAll(r.Body)
+			postedLabels = string(b)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", client: newClient(srv.URL, ""), labelByName: map[string]int64{}}
+	cell := model.SourceItem{ID: "42"}
+	if err := a.AddLabels(context.Background(), cell, []string{"in-progress", "agent:engineer"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+	// in-progress (10) resolved from the listing, agent:engineer (20) created.
+	if !strings.Contains(postedLabels, "10") || !strings.Contains(postedLabels, "20") {
+		t.Errorf("posted labels = %q, want ids 10 and 20", postedLabels)
+	}
+	if !strings.Contains(createBody, `"agent:engineer"`) || !strings.Contains(createBody, `"color"`) {
+		t.Errorf("create body = %q, want name + required color", createBody)
+	}
+}
+
+// TestRemoveLabels_DeletesByID verifies labels are resolved to ids and removed
+// one DELETE per id, and that a name absent from the repo is silently skipped.
+func TestRemoveLabels_DeletesByID(t *testing.T) {
+	var deleted []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/labels"):
+			_, _ = w.Write([]byte(`[{"id": 10, "name": "in-progress"}, {"id": 11, "name": "agent:engineer"}]`))
+		case r.Method == http.MethodDelete:
+			i := strings.LastIndex(r.URL.Path, "/labels/")
+			deleted = append(deleted, r.URL.Path[i+len("/labels/"):])
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", client: newClient(srv.URL, ""), labelByName: map[string]int64{}}
+	cell := model.SourceItem{ID: "42"}
+	// "never-existed" is not on the repo and must be skipped, not error.
+	if err := a.RemoveLabels(context.Background(), cell, []string{"in-progress", "never-existed", "agent:engineer"}); err != nil {
+		t.Fatalf("RemoveLabels: %v", err)
+	}
+	if len(deleted) != 2 || deleted[0] != "10" || deleted[1] != "11" {
+		t.Errorf("deleted ids = %v, want [10 11]", deleted)
+	}
+}
+
+// TestPollCIStatus_Conflict verifies an unmerged, non-mergeable PR surfaces as a
+// conflict without fetching commit status.
+func TestPollCIStatus_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/timeline"):
+			_, _ = w.Write([]byte(`[{"type":"comment_ref","ref_issue":{"number":7,"pull_request":{"merged":false}}}]`))
+		case strings.Contains(r.URL.Path, "/pulls/7"):
+			_, _ = w.Write([]byte(`{"number":7,"mergeable":false,"merged":false,"html_url":"https://codeberg.org/o/r/pulls/7","head":{"sha":"abc"}}`))
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", webBaseURL: "https://codeberg.org", client: newClient(srv.URL, "")}
+	st, err := a.PollCIStatus(context.Background(), "5")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if st.Status != "conflict" {
+		t.Errorf("status = %q, want conflict", st.Status)
+	}
+}
+
+// TestPollCIStatus_AggregatesStatuses verifies commit statuses aggregate to an
+// overall verdict and that a failing context wins.
+func TestPollCIStatus_AggregatesStatuses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/timeline"):
+			_, _ = w.Write([]byte(`[{"ref_issue":{"number":7,"pull_request":{"merged":false}}}]`))
+		case strings.Contains(r.URL.Path, "/pulls/7"):
+			_, _ = w.Write([]byte(`{"number":7,"mergeable":true,"merged":false,"head":{"sha":"abc"}}`))
+		case strings.Contains(r.URL.Path, "/commits/abc/status"):
+			_, _ = w.Write([]byte(`{"state":"failure","total_count":2,"statuses":[{"context":"lint","status":"success"},{"context":"test","status":"failure"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", webBaseURL: "https://codeberg.org", client: newClient(srv.URL, "")}
+	st, err := a.PollCIStatus(context.Background(), "5")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if st.Status != "failed" {
+		t.Errorf("status = %q, want failed", st.Status)
+	}
+	if len(st.Checks) != 2 {
+		t.Errorf("checks = %d, want 2", len(st.Checks))
+	}
+}
+
+// TestListBlockers_NormalizesState verifies closed blockers become "done" and a
+// blocker that is itself a merged PR reports Merged.
+func TestListBlockers_NormalizesState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"number": 3, "title": "closed dep", "state": "closed"},
+			{"number": 4, "title": "open PR dep", "state": "open", "pull_request": {"merged": true}}
+		]`))
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "cb", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	blockers, err := a.ListBlockers(context.Background(), "9", "")
+	if err != nil {
+		t.Fatalf("ListBlockers: %v", err)
+	}
+	if len(blockers) != 2 {
+		t.Fatalf("got %d blockers, want 2", len(blockers))
+	}
+	if blockers[0].State != "done" {
+		t.Errorf("closed blocker state = %q, want done", blockers[0].State)
+	}
+	if !blockers[1].Merged {
+		t.Errorf("merged-PR blocker should report Merged=true")
+	}
+}
+
+func TestImplementsCapabilities(t *testing.T) {
+	var a any = &Adapter{}
+	if _, ok := a.(source.SubIssueCreator); ok {
+		t.Error("Codeberg must NOT implement SubIssueCreator (Forgejo has no sub-issue API)")
+	}
+	if _, ok := a.(source.CIStatusPoller); !ok {
+		t.Error("Codeberg should implement CIStatusPoller")
+	}
+	if _, ok := a.(source.BlockerLister); !ok {
+		t.Error("Codeberg should implement BlockerLister")
+	}
+}
+
+func mustContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if !strings.Contains(s, sub) {
+		t.Errorf("expected %q to contain %q", s, sub)
+	}
+}
+
+func mustNotContain(t *testing.T, s, sub string) {
+	t.Helper()
+	if strings.Contains(s, sub) {
+		t.Errorf("expected %q NOT to contain %q", s, sub)
+	}
+}

--- a/src/internal/source/codeberg/client.go
+++ b/src/internal/source/codeberg/client.go
@@ -1,0 +1,180 @@
+package codeberg
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// defaultBaseURL is Codeberg's API root. Any self-hosted Forgejo/Gitea instance
+// works by overriding config.base_url (e.g. https://git.example.org/api/v1).
+const defaultBaseURL = "https://codeberg.org/api/v1"
+
+// perPage is Forgejo's max page size for list endpoints.
+const perPage = 50
+
+type client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func newClient(baseURL, apiKey string) *client {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return &client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		httpClient: &http.Client{},
+	}
+}
+
+func (c *client) newRequest(ctx context.Context, method, path string, body []byte) (*http.Request, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	token := c.apiKey
+	if t, ok := ctx.Value(source.SourceTokenCtxKey).(string); ok && t != "" {
+		token = t
+	}
+	// Forgejo/Gitea's canonical PAT scheme is "Authorization: token <TOKEN>"
+	// (the literal word "token" is kept for historical reasons and is the most
+	// universally supported form across versions).
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}
+
+func (c *client) do(ctx context.Context, req *http.Request) ([]byte, error) {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	aplog.Debug("codeberg: %s %s → %d", req.Method, req.URL, resp.StatusCode)
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("codeberg API %s: status %d: %s", req.Method, resp.StatusCode, body)
+	}
+	return body, nil
+}
+
+func (c *client) get(ctx context.Context, path string) ([]byte, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
+func (c *client) post(ctx context.Context, path string, payload any) ([]byte, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.newRequest(ctx, http.MethodPost, path, data)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
+func (c *client) patch(ctx context.Context, path string, payload any) ([]byte, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.newRequest(ctx, http.MethodPatch, path, data)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
+func (c *client) delete(ctx context.Context, path string) ([]byte, error) {
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req)
+}
+
+// getAllIssues pages through a list endpoint following the RFC 5988 Link header
+// (Forgejo sets rel="next" like GitHub). per_page is capped at Forgejo's max.
+func (c *client) getAllIssues(ctx context.Context, path string, params url.Values) ([]issue, error) {
+	var all []issue
+	page := 1
+
+	for {
+		p := url.Values{}
+		for k, v := range params {
+			p[k] = v
+		}
+		p.Set("limit", strconv.Itoa(perPage))
+		p.Set("page", strconv.Itoa(page))
+
+		req, err := c.newRequest(ctx, http.MethodGet, path+"?"+p.Encode(), nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		aplog.Debug("codeberg: GET %s → %d", req.URL, resp.StatusCode)
+
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("codeberg API: status %d: %s", resp.StatusCode, body)
+		}
+
+		var issues []issue
+		if err := json.Unmarshal(body, &issues); err != nil {
+			return nil, fmt.Errorf("codeberg: decoding issues: %w", err)
+		}
+		all = append(all, issues...)
+
+		if !hasNextPage(resp.Header.Get("Link")) {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
+var linkNextRe = regexp.MustCompile(`<[^>]+>;\s*rel="([^"]+)"`)
+
+func hasNextPage(link string) bool {
+	for _, part := range strings.Split(link, ",") {
+		part = strings.TrimSpace(part)
+		m := linkNextRe.FindStringSubmatch(part)
+		if len(m) == 2 && m[1] == "next" {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/source/codeberg/types.go
+++ b/src/internal/source/codeberg/types.go
@@ -1,0 +1,107 @@
+package codeberg
+
+// issue is a Forgejo/Gitea issue. The /issues endpoint returns pull requests too
+// (a PR is an issue in the API); PullRequest is non-nil for those.
+type issue struct {
+	ID          int64            `json:"id"`
+	Number      int              `json:"number"`
+	Title       string           `json:"title"`
+	Body        string           `json:"body"`
+	State       string           `json:"state"`
+	Labels      []label          `json:"labels"`
+	HTMLURL     string           `json:"html_url"`
+	CreatedAt   string           `json:"created_at"`
+	UpdatedAt   string           `json:"updated_at"`
+	PullRequest *pullRequestMeta `json:"pull_request,omitempty"`
+}
+
+// pullRequestMeta is the marker Forgejo attaches to an issue object that is
+// actually a pull request. Merged lets ListBlockers read a blocker's merge state
+// without a second round-trip when the blocker is itself a PR.
+type pullRequestMeta struct {
+	Merged  bool   `json:"merged"`
+	HTMLURL string `json:"html_url"`
+}
+
+type label struct {
+	ID    int64  `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+// editIssueRequest patches an issue. Forgejo's EditIssueOption.state is a
+// *string, so it is omitted unless set.
+type editIssueRequest struct {
+	State string `json:"state,omitempty"`
+}
+
+// createIssueRequest is the body for POST /repos/{o}/{r}/issues. Forgejo's
+// CreateIssueOption.labels is []int64 (ids only) — unlike the add-labels
+// endpoint, which also accepts names. We always work in ids.
+type createIssueRequest struct {
+	Title  string  `json:"title"`
+	Body   string  `json:"body,omitempty"`
+	Labels []int64 `json:"labels,omitempty"`
+}
+
+// issueLabelsRequest adds labels to an issue. Recent Forgejo accepts ids or
+// names; we always send ids for cross-version safety (older versions reject
+// names with a JSON unmarshal error).
+type issueLabelsRequest struct {
+	Labels []int64 `json:"labels"`
+}
+
+// createLabelRequest creates a repo label. Forgejo requires both name and color.
+type createLabelRequest struct {
+	Name  string `json:"name"`
+	Color string `json:"color"`
+}
+
+type commentRequest struct {
+	Body string `json:"body"`
+}
+
+// comment is a Forgejo issue comment, fetched by PollTask for approval steps.
+type comment struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
+}
+
+// pullRequest carries the merge-conflict and head-SHA signals for CI waits.
+// Forgejo exposes Mergeable as a bool (there is no GitHub-style mergeable_state
+// string): Mergeable == false on an unmerged PR means it has conflicts and can
+// never merge. Forgejo computes mergeability lazily, so a freshly pushed PR can
+// report a stale value for a moment — the wait_for step's on_conflict edge
+// (own retry budget) absorbs that.
+type pullRequest struct {
+	Number    int    `json:"number"`
+	HTMLURL   string `json:"html_url"`
+	Mergeable bool   `json:"mergeable"`
+	Merged    bool   `json:"merged"`
+	Head      struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+// combinedStatus is Forgejo's combined commit status. Forgejo has no GitHub-style
+// check-runs API: Forgejo Actions and any external CI both report through these
+// commit statuses, so the combined endpoint is the single CI signal. Note the
+// top-level field is "state" while each entry's field is "status".
+type combinedStatus struct {
+	State      string `json:"state"`
+	TotalCount int    `json:"total_count"`
+	Statuses   []struct {
+		Context   string `json:"context"`
+		Status    string `json:"status"`
+		TargetURL string `json:"target_url"`
+	} `json:"statuses"`
+}
+
+// timelineComment is one entry of an issue's timeline. A pull request that
+// references the issue surfaces as RefIssue with its PullRequest marker set —
+// Forgejo has no separate ref_pull_request field because a PR is an issue.
+type timelineComment struct {
+	Type     string `json:"type"`
+	RefIssue *issue `json:"ref_issue"`
+}


### PR DESCRIPTION
## Summary

Phase 1 of the **git-forge-sources** OpenSpec change: extend Apiary beyond GitHub to other git forges, starting with **Codeberg** (and any self-hosted Forgejo/Gitea instance via `base_url`).

The Forgejo/Gitea REST API closely mirrors GitHub's, so the new `codeberg` adapter follows the github adapter's structure. The platform differences are concentrated in the new package:

- **Auth** via `Authorization: token <TOKEN>` (not Bearer), with per-agent token override.
- **Labels by id** — Forgejo's label endpoints work in numeric ids, so the adapter caches the repo's labels, creates any missing label (Forgejo requires a color), and applies/removes by id.
- **CI waits via commit statuses** — Forgejo has no check-runs API; Forgejo Actions and external CI both post commit statuses, which the adapter aggregates.
- **Merge-conflict detection** via the PR's boolean `mergeable` flag (no GitHub-style `mergeable_state`) → surfaces as the `conflict` status for `on_conflict`.
- **Blockers** via Forgejo's native issue **dependencies**.
- **No sub-issues** — Forgejo has no parent/child API, so `codeberg` intentionally does **not** implement `SubIssueCreator`.

Capabilities implemented: core `Adapter`, `StateSetter`, `LabelAdder`, `LabelRemover`, `TaskPoller`, `CIStatusPoller`, `PullRequestLister`, `BlockerLister`.

Wire-up: register factory + blank import in `cmd/apiary`, schema `type` enum (also adds the previously-missing `jira`), example config, `docs/codeberg-source.md`, integrations matrix + mkdocs nav.

Tracked under `openspec/changes/git-forge-sources/` — follow-up phases: GitLab source, per-forge agent credential generalization, and live E2E.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` + `gofmt` clean
- [x] `go test ./internal/source/codeberg/...` — unit tests (httptest) covering field mapping, filters, PR-skip on poll, label resolve-to-id (add + create), remove-by-id with skip-missing, CI conflict short-circuit, CI status aggregation, blocker state normalization, and a capability assertion that `codeberg` does not implement `SubIssueCreator`
- [ ] Live E2E against a real Codeberg repo (Phase 4 — needs operator token)