### PR TITLE
fix(tasks): scope failure aggregation to the current dispatch generation

### DIFF
--- a/src/internal/db/generation_test.go
+++ b/src/internal/db/generation_test.go
@@ -1,0 +1,329 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// taskGeneration reads a task's dispatch generation. The column is SQL-only
+// (not surfaced on model.InternalTask), so tests query it directly.
+func taskGeneration(t *testing.T, c *Client, id string) int {
+	t.Helper()
+	var g int
+	if err := c.db.QueryRowContext(context.Background(),
+		`SELECT generation FROM internal_tasks WHERE id = ?`, id).Scan(&g); err != nil {
+		t.Fatalf("read task generation: %v", err)
+	}
+	return g
+}
+
+func instanceGeneration(t *testing.T, c *Client, id string) int {
+	t.Helper()
+	var g int
+	if err := c.db.QueryRowContext(context.Background(),
+		`SELECT task_generation FROM workflow_instances WHERE id = ?`, id).Scan(&g); err != nil {
+		t.Fatalf("read instance generation: %v", err)
+	}
+	return g
+}
+
+// TestInternalTask_IncrementBumpsGenerationOnReopen locks in when the dispatch
+// generation advances: only when a positive increment reopens a task from a
+// terminal state. Mid-round increments (registered/running) must not bump, or
+// same-round siblings would land in different generations.
+func TestInternalTask_IncrementBumpsGenerationOnReopen(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if g := taskGeneration(t, c, task.ID); g != 0 {
+		t.Fatalf("fresh task generation = %d, want 0", g)
+	}
+
+	// Increment while registered: no bump.
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 2); err != nil {
+		t.Fatalf("increment (registered): %v", err)
+	}
+	if g := taskGeneration(t, c, task.ID); g != 0 {
+		t.Errorf("increment while registered bumped generation to %d, want 0", g)
+	}
+
+	// Increment while running: no bump.
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateRunning); err != nil {
+		t.Fatalf("set running: %v", err)
+	}
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment (running): %v", err)
+	}
+	if g := taskGeneration(t, c, task.ID); g != 0 {
+		t.Errorf("increment while running bumped generation to %d, want 0", g)
+	}
+
+	// Reopen from done: bump.
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateDone); err != nil {
+		t.Fatalf("set done: %v", err)
+	}
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment (done): %v", err)
+	}
+	if g := taskGeneration(t, c, task.ID); g != 1 {
+		t.Errorf("reopen from done: generation = %d, want 1", g)
+	}
+	got, _ := store.GetTask(ctx, task.ID)
+	if got.State != model.TaskStateRunning {
+		t.Errorf("reopen from done: state = %q, want running", got.State)
+	}
+
+	// Reopen from failed: bump again.
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateFailed); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment (failed): %v", err)
+	}
+	if g := taskGeneration(t, c, task.ID); g != 2 {
+		t.Errorf("reopen from failed: generation = %d, want 2", g)
+	}
+}
+
+func TestCreateWorkflowInstance_StampsTaskGeneration(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	task := &model.InternalTask{Title: "t", State: model.TaskStateDone}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Reopen once so the task sits at generation 1.
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "i1", WorkflowID: "impl", CellID: "1", TaskID: task.ID, State: InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	if g := instanceGeneration(t, c, "i1"); g != 1 {
+		t.Errorf("instance generation = %d, want the task's current generation 1", g)
+	}
+
+	// Transient/unknown task ids stamp generation 0.
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "i2", WorkflowID: "impl", CellID: "2", TaskID: "not-a-task", State: InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("create transient instance: %v", err)
+	}
+	if g := instanceGeneration(t, c, "i2"); g != 0 {
+		t.Errorf("transient instance generation = %d, want 0", g)
+	}
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "i3", WorkflowID: "impl", CellID: "3", State: InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("create task-less instance: %v", err)
+	}
+	if g := instanceGeneration(t, c, "i3"); g != 0 {
+		t.Errorf("task-less instance generation = %d, want 0", g)
+	}
+}
+
+// TestHasFailedInstance_GenerationScoped is the core of the stuck-failed-task
+// fix: a failed instance from an earlier round must stop counting once a
+// re-dispatch reopens the task under a new generation, while failures within
+// the current round still fail the task.
+func TestHasFailedInstance_GenerationScoped(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	has := func() bool {
+		ok, err := c.HasFailedInstance(ctx, task.ID)
+		if err != nil {
+			t.Fatalf("has failed instance: %v", err)
+		}
+		return ok
+	}
+
+	if has() {
+		t.Fatal("no instances yet: want false")
+	}
+
+	// Round 0 failure counts.
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "g0-fail", WorkflowID: "impl", CellID: "1", TaskID: task.ID, State: InstanceStateFailed,
+	}); err != nil {
+		t.Fatalf("create g0 instance: %v", err)
+	}
+	if !has() {
+		t.Fatal("current-generation failure: want true")
+	}
+
+	// Task settles failed, then a re-dispatch reopens it → new generation.
+	// The stale failure no longer counts.
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateFailed); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if has() {
+		t.Fatal("previous-generation failure still counted after reopen: want false")
+	}
+
+	// A failure in the new round counts again.
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "g1-fail", WorkflowID: "impl-10x", CellID: "1", TaskID: task.ID, State: InstanceStateFailed,
+	}); err != nil {
+		t.Fatalf("create g1 instance: %v", err)
+	}
+	if !has() {
+		t.Fatal("new-generation failure: want true")
+	}
+}
+
+// TestCountConsecutiveFailedInstances_AcrossGenerations locks in that the
+// re-dispatch failure cap (settings.max_attempts) is NOT generation-scoped:
+// every re-dispatch bumps the generation, so a scoped count would never exceed
+// one and the cap would never fire. Only a later success resets it.
+func TestCountConsecutiveFailedInstances_AcrossGenerations(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	task := &model.InternalTask{Title: "t"}
+	if err := store.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	fail := func(id string) {
+		if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+			ID: id, WorkflowID: "impl", CellID: "1", TaskID: task.ID, State: InstanceStateFailed,
+		}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	fail("f1") // generation 0
+	if err := store.UpdateTaskState(ctx, task.ID, model.TaskStateFailed); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if _, err := store.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	fail("f2") // generation 1
+
+	n, err := c.CountConsecutiveFailedInstances(ctx, task.ID, "impl")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("consecutive failures across generations = %d, want 2", n)
+	}
+}
+
+// TestRepairSupersededFailedTasks covers the one-shot migration repair for
+// databases written by builds that aggregated failures across the task's whole
+// history: settled 'failed' tasks whose newest terminal top-level instance is
+// done are flipped to 'done'; everything else is left alone.
+func TestRepairSupersededFailedTasks(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+
+	mkTask := func(title string) *model.InternalTask {
+		t.Helper()
+		task := &model.InternalTask{Title: title, State: model.TaskStateFailed}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create task %s: %v", title, err)
+		}
+		return task
+	}
+	mkInst := func(id, taskID, state, parent string) {
+		t.Helper()
+		if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+			ID: id, WorkflowID: "impl", CellID: "1", TaskID: taskID,
+			State: state, ParentInstanceID: parent,
+		}); err != nil {
+			t.Fatalf("create instance %s: %v", id, err)
+		}
+	}
+	state := func(id string) model.TaskState {
+		t.Helper()
+		got, err := store.GetTask(ctx, id)
+		if err != nil || got == nil {
+			t.Fatalf("get task %s: %v (%v)", id, err, got)
+		}
+		return got.State
+	}
+
+	// (i) failed task whose newest terminal instance is done → flipped.
+	superseded := mkTask("superseded")
+	mkInst("s-old-fail", superseded.ID, InstanceStateFailed, "")
+	mkInst("s-new-done", superseded.ID, InstanceStateDone, "")
+
+	// (ii) failed task whose newest terminal instance is failed → untouched.
+	stillFailed := mkTask("still-failed")
+	mkInst("r-old-done", stillFailed.ID, InstanceStateDone, "")
+	mkInst("r-new-fail", stillFailed.ID, InstanceStateFailed, "")
+
+	// (iii) task with outstanding workflows → untouched even with a newest done.
+	inFlight := mkTask("in-flight")
+	if _, err := store.IncrementOutstanding(ctx, inFlight.ID, 1); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	// Reopen flipped it to running; put it back to failed with the counter held.
+	if err := store.UpdateTaskState(ctx, inFlight.ID, model.TaskStateFailed); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	mkInst("p-done", inFlight.ID, InstanceStateDone, "")
+
+	// (iv) genuine single failure → untouched.
+	genuine := mkTask("genuine")
+	mkInst("g-fail", genuine.ID, InstanceStateFailed, "")
+
+	// (v) done sub-workflow child under a failed top-level parent → untouched:
+	// child rows are inserted before the parent settles, so by-rowid ordering
+	// must not read the done child as "newest terminal".
+	childDone := mkTask("child-done")
+	mkInst("c-parent-fail", childDone.ID, InstanceStateFailed, "")
+	mkInst("c-child-done", childDone.ID, InstanceStateDone, "c-parent-fail")
+
+	if err := repairSupersededFailedTasks(ctx, c.db); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+
+	if s := state(superseded.ID); s != model.TaskStateDone {
+		t.Errorf("superseded task = %q, want done", s)
+	}
+	if s := state(stillFailed.ID); s != model.TaskStateFailed {
+		t.Errorf("still-failed task = %q, want failed", s)
+	}
+	if s := state(inFlight.ID); s != model.TaskStateFailed {
+		t.Errorf("in-flight task = %q, want failed (outstanding > 0)", s)
+	}
+	if s := state(genuine.ID); s != model.TaskStateFailed {
+		t.Errorf("genuine failure = %q, want failed", s)
+	}
+	if s := state(childDone.ID); s != model.TaskStateFailed {
+		t.Errorf("done-child-under-failed-parent = %q, want failed", s)
+	}
+
+	// Idempotent: a second run changes nothing.
+	if err := repairSupersededFailedTasks(ctx, c.db); err != nil {
+		t.Fatalf("repair (second run): %v", err)
+	}
+	if s := state(superseded.ID); s != model.TaskStateDone {
+		t.Errorf("superseded task after re-run = %q, want done", s)
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -281,6 +281,12 @@ var migrations = []string{
 	// child per (parent, dedup_key); NULL/empty keys (source-bound tasks) are exempt.
 	`ALTER TABLE internal_tasks ADD COLUMN dedup_key TEXT`,
 	`CREATE UNIQUE INDEX IF NOT EXISTS idx_internal_tasks_dedup ON internal_tasks(parent_task_id, dedup_key) WHERE dedup_key IS NOT NULL AND dedup_key != ''`,
+	// Dispatch generations: reopening a settled task (re-dispatch/escalation)
+	// starts a new round, and task settlement aggregates failures only within
+	// the current round. Without this, one failed instance kept the task failed
+	// forever, even after a later round completed successfully.
+	`ALTER TABLE internal_tasks ADD COLUMN generation INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE workflow_instances ADD COLUMN task_generation INTEGER NOT NULL DEFAULT 0`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).
@@ -299,7 +305,36 @@ func InitSchema(ctx context.Context, db *sql.DB) error {
 	if err := normalizeLegacyTimestamps(ctx, db); err != nil {
 		return fmt.Errorf("normalize legacy timestamps: %w", err)
 	}
+	if err := repairSupersededFailedTasks(ctx, db); err != nil {
+		return fmt.Errorf("repair superseded failed tasks: %w", err)
+	}
 	return nil
+}
+
+// repairSupersededFailedTasks corrects tasks stranded in 'failed' by builds
+// that aggregated failed instances across the task's whole history: a failed
+// instance kept failing the task even after a later re-dispatch or escalation
+// completed successfully. A task qualifies when it is settled (no outstanding
+// workflows) and its newest terminal top-level instance is done — the last
+// round of work actually succeeded. Sub-workflow child instances are excluded
+// because they are inserted before their parent settles, so by-rowid ordering
+// would misread a done child under a failed parent. Idempotent: flipped rows
+// stop matching.
+func repairSupersededFailedTasks(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET state = 'done', updated_at = ?
+		WHERE state = 'failed'
+		  AND COALESCE(outstanding_workflows, 0) = 0
+		  AND (
+		    SELECT wi.state FROM workflow_instances wi
+		    WHERE wi.task_id = internal_tasks.id
+		      AND (wi.parent_instance_id IS NULL OR wi.parent_instance_id = '')
+		      AND wi.state IN ('done','failed')
+		    ORDER BY wi.rowid DESC LIMIT 1
+		  ) = 'done'
+	`, time.Now())
+	return err
 }
 
 // legacyTimestampColumns lists every TIMESTAMP column written from a time.Time.

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -168,14 +168,20 @@ func (s *InternalTaskStore) UpdateTaskMetadata(ctx context.Context, id, title, d
 // instance is still running/waiting in the detail view. completeTask sets the real
 // terminal state again once the new stage settles. The literals mirror
 // model.TaskState ('done'/'failed'/'running').
+//
+// Reopening also bumps the task's generation: instances dispatched from here on
+// belong to a new round, so HasFailedInstance stops counting earlier rounds'
+// failures and a successful re-dispatch/escalation can settle the task as done.
+// Both CASEs read the pre-update state, so the bump and the flip agree.
 func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string, delta int) (int, error) {
 	if _, err := s.db.ExecContext(ctx, `
 		UPDATE internal_tasks
 		SET outstanding_workflows = outstanding_workflows + ?,
+		    generation = CASE WHEN ? > 0 AND state IN ('done','failed') THEN generation + 1 ELSE generation END,
 		    state = CASE WHEN ? > 0 AND state IN ('done','failed') THEN 'running' ELSE state END,
 		    updated_at = ?
 		WHERE id = ?
-	`, delta, delta, time.Now(), id); err != nil {
+	`, delta, delta, delta, time.Now(), id); err != nil {
 		return 0, err
 	}
 	return s.outstanding(ctx, id)

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -91,7 +91,10 @@ type StepRun struct {
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
-// the ID (the engine generates it) so persistence stays deterministic.
+// the ID (the engine generates it) so persistence stays deterministic. The row
+// is stamped with the owning task's current dispatch generation (0 for
+// transient/unknown task ids), which scopes failure aggregation to the round
+// the instance was dispatched in.
 func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInstance) error {
 	now := time.Now()
 	if inst.CreatedAt.IsZero() {
@@ -100,10 +103,12 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 	inst.UpdatedAt = now
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO workflow_instances
-		  (id, workflow_id, task_id, cell_id, source_id, state, parent_instance_id, resumed_from, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		  (id, workflow_id, task_id, cell_id, source_id, state, parent_instance_id, resumed_from,
+		   task_generation, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+		        COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0), ?, ?)
 	`, inst.ID, inst.WorkflowID, nullStr(inst.TaskID), inst.CellID, nullStr(inst.SourceID), inst.State,
-		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.CreatedAt, inst.UpdatedAt)
+		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.TaskID, inst.CreatedAt, inst.UpdatedAt)
 	return err
 }
 
@@ -129,14 +134,21 @@ func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowI
 	return inst, err
 }
 
-// HasFailedInstance reports whether any workflow instance bound to the given task
-// is in the failed state. The engine calls it when a task's last outstanding
-// workflow settles, to choose between the tasks: on_complete and on_fail hooks.
+// HasFailedInstance reports whether any workflow instance from the task's
+// current dispatch generation is in the failed state. The engine calls it when
+// a task's last outstanding workflow settles, to choose between the tasks:
+// on_complete and on_fail hooks. Scoping to the current generation keeps
+// any-fail semantics within a round (a failed sibling in a parallel fan-out
+// still fails the task) while letting a later successful re-dispatch or
+// escalation settle the task as done instead of being poisoned by earlier
+// rounds' failures.
 func (c *Client) HasFailedInstance(ctx context.Context, taskID string) (bool, error) {
 	var n int
 	err := c.db.QueryRowContext(ctx, `
-		SELECT COUNT(*) FROM workflow_instances WHERE task_id = ? AND state = ?
-	`, taskID, InstanceStateFailed).Scan(&n)
+		SELECT COUNT(*) FROM workflow_instances
+		WHERE task_id = ? AND state = ?
+		  AND task_generation = COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0)
+	`, taskID, InstanceStateFailed, taskID).Scan(&n)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -405,8 +405,11 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 // tasks: on_complete/on_fail hook to every source binding. It is a no-op when no
 // TaskTracker is wired (the pre-Phase-8 default) or for a binding-less transient
 // task with no id. The aggregate outcome is failed if THIS instance failed or any
-// sibling instance of the task did (HasFailedInstance also covers this instance,
-// whose terminal state was just persisted above).
+// sibling instance from the task's current dispatch generation did
+// (HasFailedInstance also covers this instance, whose terminal state was just
+// persisted above). Failures from earlier generations don't count: a re-dispatch
+// or escalation reopens the task under a new generation, so its success settles
+// the task as done even though older failed instances remain in the DB.
 func (e *Engine) completeTask(ctx context.Context, r *dagRun, failed bool) {
 	if e.tracker == nil || r.task.ID == "" {
 		return

--- a/src/internal/workflow/task_generation_test.go
+++ b/src/internal/workflow/task_generation_test.go
@@ -1,0 +1,209 @@
+package workflow
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// dbTracker adapts *db.Client to TaskTracker exactly like the daemon's
+// dbTaskTracker, so these tests exercise the real generation-scoped
+// HasFailedInstance query instead of the fakeTracker's boolean flag.
+type dbTracker struct{ c *db.Client }
+
+func (t dbTracker) DecrementOutstanding(ctx context.Context, taskID string) (int, error) {
+	return t.c.InternalTasks().DecrementOutstanding(ctx, taskID)
+}
+func (t dbTracker) HasFailedInstance(ctx context.Context, taskID string) (bool, error) {
+	return t.c.HasFailedInstance(ctx, taskID)
+}
+func (t dbTracker) SetTaskState(ctx context.Context, taskID string, state model.TaskState) error {
+	return t.c.InternalTasks().UpdateTaskState(ctx, taskID, state)
+}
+
+// generationTestEnv wires an engine to a real SQLite db.Client (Store and
+// TaskTracker both) with the tasks: completion hook configured.
+func generationTestEnv(t *testing.T) (*db.Client, *Engine, *fakeExecutor, *fakeSide) {
+	t.Helper()
+	client, err := db.New(context.Background(), filepath.Join(t.TempDir(), "wf.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	exec := &fakeExecutor{results: map[string]StepResult{}}
+	side := &fakeSide{}
+	eng := trackerEngine(taskHookCfg(), client, exec, side, dbTracker{client})
+	return client, eng, exec, side
+}
+
+func createTask(t *testing.T, client *db.Client, title string) model.InternalTask {
+	t.Helper()
+	task := &model.InternalTask{Title: title}
+	if err := client.InternalTasks().CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	return *task
+}
+
+func scriptStep(exec *fakeExecutor, stepID string, res StepResult) {
+	exec.mu.Lock()
+	exec.results[stepID] = res
+	exec.mu.Unlock()
+}
+
+func taskState(t *testing.T, client *db.Client, id string) model.TaskState {
+	t.Helper()
+	got, err := client.InternalTasks().GetTask(context.Background(), id)
+	if err != nil || got == nil {
+		t.Fatalf("get task: %v (%v)", err, got)
+	}
+	return got.State
+}
+
+func lastHook(t *testing.T, side *fakeSide) config.OnComplete {
+	t.Helper()
+	if len(side.hooks) == 0 {
+		t.Fatal("no tasks: hook fired")
+	}
+	return side.hooks[len(side.hooks)-1]
+}
+
+// TestEngine_RedispatchAfterFailureMarksTaskDone is the production reproducer
+// for the stuck-failed-task bug: a workflow fails and settles the task as
+// failed; a later re-dispatch of the same workflow (fanOut-style
+// IncrementOutstanding reopen) succeeds. The task must settle done — before
+// generation scoping, the round-one failed instance kept it failed forever.
+func TestEngine_RedispatchAfterFailureMarksTaskDone(t *testing.T) {
+	ctx := context.Background()
+	client, eng, exec, side := generationTestEnv(t)
+	task := createTask(t, client, "t")
+	tasks := client.InternalTasks()
+
+	// Round 1: dispatch fails.
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment round 1: %v", err)
+	}
+	scriptStep(exec, "a", StepResult{Success: false, Output: "boom"})
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("impl", "a"), task); err != nil {
+		t.Fatalf("RunInstance round 1: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateFailed {
+		t.Fatalf("after round 1: task = %q, want failed", s)
+	}
+
+	// Round 2: re-dispatch of the same workflow succeeds.
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment round 2: %v", err)
+	}
+	scriptStep(exec, "a", StepResult{Success: true, Output: "ok"})
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("impl", "a"), task); err != nil {
+		t.Fatalf("RunInstance round 2: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateDone {
+		t.Errorf("after successful re-dispatch: task = %q, want done", s)
+	}
+	if h := lastHook(t, side); h.SetState != "all_done" {
+		t.Errorf("last tasks: hook = %q, want on_complete (all_done)", h.SetState)
+	}
+}
+
+// TestEngine_EscalationWorkflowMarksTaskDone covers the cross-workflow round:
+// the first workflow fails, an escalation route dispatches a DIFFERENT workflow
+// that succeeds (project-erp's implementation → implementation-10x chain). The
+// task settles done even though the first workflow's newest instance is still
+// failed.
+func TestEngine_EscalationWorkflowMarksTaskDone(t *testing.T) {
+	ctx := context.Background()
+	client, eng, exec, side := generationTestEnv(t)
+	task := createTask(t, client, "t")
+	tasks := client.InternalTasks()
+
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment round 1: %v", err)
+	}
+	scriptStep(exec, "a", StepResult{Success: false, Output: "boom"})
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("impl", "a"), task); err != nil {
+		t.Fatalf("RunInstance impl: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateFailed {
+		t.Fatalf("after impl failure: task = %q, want failed", s)
+	}
+
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment round 2: %v", err)
+	}
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("impl-10x", "b"), task); err != nil {
+		t.Fatalf("RunInstance impl-10x: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateDone {
+		t.Errorf("after escalation success: task = %q, want done", s)
+	}
+	if h := lastHook(t, side); h.SetState != "all_done" {
+		t.Errorf("last tasks: hook = %q, want on_complete (all_done)", h.SetState)
+	}
+}
+
+// TestEngine_SameRoundSiblingFailureFailsTask locks in that generation scoping
+// does NOT weaken any-fail semantics within a round: two workflows fan out
+// together, one fails, the other succeeds — the task is failed.
+func TestEngine_SameRoundSiblingFailureFailsTask(t *testing.T) {
+	ctx := context.Background()
+	client, eng, exec, side := generationTestEnv(t)
+	task := createTask(t, client, "t")
+
+	if _, err := client.InternalTasks().IncrementOutstanding(ctx, task.ID, 2); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	scriptStep(exec, "a", StepResult{Success: false, Output: "boom"})
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("wf-a", "a"), task); err != nil {
+		t.Fatalf("RunInstance wf-a: %v", err)
+	}
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("wf-b", "b"), task); err != nil {
+		t.Fatalf("RunInstance wf-b: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateFailed {
+		t.Errorf("sibling failure in same round: task = %q, want failed", s)
+	}
+	if h := lastHook(t, side); h.SetState != "all_failed" {
+		t.Errorf("last tasks: hook = %q, want on_fail (all_failed)", h.SetState)
+	}
+}
+
+// TestEngine_Stage2FailureAfterStage1SuccessFailsTask covers multi-stage
+// pipelines: stage 1 settles the task done, the next stage's dispatch reopens
+// it (bumping the generation), and a stage-2 failure must fail the task — the
+// new round's outcome wins in both directions.
+func TestEngine_Stage2FailureAfterStage1SuccessFailsTask(t *testing.T) {
+	ctx := context.Background()
+	client, eng, exec, side := generationTestEnv(t)
+	task := createTask(t, client, "t")
+	tasks := client.InternalTasks()
+
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment stage 1: %v", err)
+	}
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("triage", "a"), task); err != nil {
+		t.Fatalf("RunInstance triage: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateDone {
+		t.Fatalf("after stage 1: task = %q, want done", s)
+	}
+
+	if _, err := tasks.IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatalf("increment stage 2: %v", err)
+	}
+	scriptStep(exec, "b", StepResult{Success: false, Output: "boom"})
+	if _, _, err := eng.RunInstance(ctx, oneStepWF("impl", "b"), task); err != nil {
+		t.Fatalf("RunInstance impl: %v", err)
+	}
+	if s := taskState(t, client, task.ID); s != model.TaskStateFailed {
+		t.Errorf("after stage-2 failure: task = %q, want failed", s)
+	}
+	if h := lastHook(t, side); h.SetState != "all_failed" {
+		t.Errorf("last tasks: hook = %q, want on_fail (all_failed)", h.SetState)
+	}
+}


### PR DESCRIPTION
## Problem

Tasks stuck in **failed** even though the work actually completed. In project-erp, 36+ of the failed tasks had a later workflow instance that finished `done` — all steps passed, PRs merged.

Root cause: when a task's last outstanding instance settles, `completeTask` asks `HasFailedInstance`, which counted failed instances for the task **forever**. The typical production sequence:

1. `implementation` fails → task `failed`, `on_fail` escalates via label
2. `implementation-10x` is dispatched (`IncrementOutstanding` reopens the task) and finishes `done`
3. `completeTask` runs, still sees the old failed rows → task set back to `failed`

No path ever corrected the state afterwards.

## Fix: dispatch generations

- `internal_tasks.generation` + `workflow_instances.task_generation` (idempotent ALTERs in the migration list)
- `IncrementOutstanding` bumps the generation when it reopens a settled task — each re-dispatch/escalation/pipeline stage is a new round
- `CreateWorkflowInstance` stamps rows with the task's current generation (subselect, `COALESCE 0` for transient/unknown task ids)
- `HasFailedInstance` only counts failures from the current generation: a failed sibling in a parallel fan-out still fails the task, but a later successful round settles the task `done` and fires `tasks: on_complete`
- `CountConsecutiveFailedInstances` deliberately stays unscoped — every re-dispatch bumps the generation, so a scoped count could never reach the `settings.max_attempts` cap

## Repair for existing databases

`InitSchema` gains `repairSupersededFailedTasks`: settled `failed` tasks whose newest terminal **top-level** instance is `done` are flipped to `done` on the next daemon start. Idempotent; child (sub-workflow) rows are excluded from "newest terminal" since they're inserted before their parent settles. It does **not** re-fire `on_complete` hooks (no surprise GitHub writes).

## Verification

- New reproducer `TestEngine_RedispatchAfterFailureMarksTaskDone` fails on pre-fix code with exactly the production symptom; escalation, same-round-sibling-failure, stage-2-failure, generation-bump, stamping, cap and repair tests all added — `go test ./...` green
- Ran the real migration against a copy of the project-erp DB: 23 tasks flipped failed→done (49→26); the remaining 26 are genuinely failed (no successful instance, or the newest round failed). Second open confirmed idempotency.

## Rollout

Restart the project-erp daemon with the new binary — the migration heals the stuck tasks on first open.