### PR TITLE
fix(github): make AddLabels additive so it can't revert mid-run label changes

### DIFF
--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -266,30 +266,28 @@ func (a *Adapter) SetState(ctx context.Context, cell model.SourceItem, stateName
 	return nil
 }
 
+// AddLabels appends the named labels to an issue via the additive
+// POST /issues/{n}/labels endpoint, leaving every other label untouched.
+// It must NOT send the full label set (PATCH with labels replaces it): the
+// dispatched cell's label snapshot goes stale while a run executes, and an
+// agent may legitimately swap labels mid-run — replaying the snapshot here
+// would silently revert that. Implements source.LabelAdder.
 func (a *Adapter) AddLabels(ctx context.Context, cell model.SourceItem, names []string) error {
 	if len(names) == 0 {
 		return nil
 	}
 
-	idSet := make(map[string]struct{})
-	for _, n := range cell.Labels {
-		idSet[strings.ToLower(n)] = struct{}{}
-	}
+	labelList := make([]string, 0, len(names))
 	for _, n := range names {
 		if err := a.ensureLabel(ctx, n); err != nil {
 			return err
 		}
-		idSet[strings.ToLower(n)] = struct{}{}
-	}
-
-	labelList := make([]string, 0, len(idSet))
-	for n := range idSet {
 		labelList = append(labelList, n)
 	}
 
 	issueNo := cell.ID
-	path := fmt.Sprintf("/repos/%s/%s/issues/%s", a.owner, a.repo, issueNo)
-	_, err := a.client.patch(ctx, path, issueRequest{Labels: labelList})
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/labels", a.owner, a.repo, issueNo)
+	_, err := a.client.post(ctx, path, labelListRequest{Labels: labelList})
 	if err != nil {
 		return fmt.Errorf("github: adding labels %v to %s: %w", names, cell.ID, err)
 	}

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -334,3 +334,49 @@ func TestPoll_SkipsPullRequests(t *testing.T) {
 		t.Errorf("Type = %q, want %q", items[0].Type, "issue")
 	}
 }
+
+// TestAddLabels_AppendsWithoutReplacing verifies that AddLabels uses the
+// additive POST /issues/{n}/labels endpoint sending ONLY the new labels —
+// never a PATCH replaying the cell's (possibly stale) label snapshot, which
+// would revert labels an agent swapped while the run was executing.
+func TestAddLabels_AppendsWithoutReplacing(t *testing.T) {
+	var issuePatched bool
+	var postedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/labels":
+			// ensureLabel: label already exists.
+			http.Error(w, `{"message":"already_exists"}`, http.StatusUnprocessableEntity)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/issues/42/labels":
+			b, _ := io.ReadAll(r.Body)
+			postedBody = string(b)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPatch:
+			issuePatched = true
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	// Stale snapshot: the agent already swapped workflow:spec → workflow:implementation
+	// on the live issue; the snapshot must not leak into the request.
+	cell := model.SourceItem{ID: "42", Labels: []string{"workflow:spec"}}
+	if err := a.AddLabels(context.Background(), cell, []string{"po:done"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+	if issuePatched {
+		t.Error("AddLabels must not PATCH the issue (label replace) — additive POST only")
+	}
+	if postedBody == "" {
+		t.Fatal("expected POST to /issues/42/labels")
+	}
+	if !strings.Contains(postedBody, "po:done") {
+		t.Errorf("posted body missing new label: %s", postedBody)
+	}
+	if strings.Contains(postedBody, "workflow:spec") {
+		t.Errorf("posted body must not replay the snapshot labels: %s", postedBody)
+	}
+}


### PR DESCRIPTION
## Problema

`AddLabels` do adapter GitHub montava a lista final a partir de `cell.Labels` — o snapshot de labels do momento do **dispatch** — e fazia `PATCH /issues/{n}` com o campo `labels`, que **substitui o conjunto inteiro**.

Qualquer label alterada pelo agente durante a run era revertida quando o `on_complete`/`on_fail` aplicava `add_labels`. Caso real: no pipeline do project-erp, o PO troca `workflow:spec` → `workflow:implementation` (demanda atômica) e, segundos depois, o engine restaurava `workflow:spec` ao adicionar `po:done` — a issue ficava órfã para sempre (nenhum workflow volta a casar com ela).

## Fix

Usar o endpoint aditivo `POST /repos/{owner}/{repo}/issues/{n}/labels` enviando **apenas** as labels novas. `RemoveLabels` já era atômico (um DELETE por label); agora o Add também é.

## Testes

- Novo `TestAddLabels_AppendsWithoutReplacing`: garante POST aditivo, sem PATCH, e que o snapshot não vaza no payload.
- `go test ./...` verde, `go vet` limpo.

## Follow-up (fora deste PR)

O adapter Plane tem o mesmo padrão de snapshot, mas a API do Plane só tem PATCH replace — o fix lá é re-buscar as labels atuais antes do merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)