### PR TITLE
fix(plane): make AddLabels merge from live labels, not the dispatch snapshot

### DIFF
--- a/src/internal/source/plane/adapter.go
+++ b/src/internal/source/plane/adapter.go
@@ -308,6 +308,11 @@ func (a *Adapter) SetState(ctx context.Context, cell model.SourceItem, stateName
 // work item's existing labels (Plane's PATCH replaces the set, so we must send
 // the full list) and auto-creates any label that doesn't yet exist in the
 // project. Names are matched case-insensitively.
+//
+// The existing labels are re-fetched from the API immediately before the
+// PATCH — never taken from cell.Labels, which is a snapshot from dispatch
+// time. An agent may have swapped labels while the run was executing, and
+// replaying the snapshot would silently revert those changes.
 func (a *Adapter) AddLabels(ctx context.Context, cell model.SourceItem, names []string) error {
 	if len(names) == 0 {
 		return nil
@@ -316,12 +321,19 @@ func (a *Adapter) AddLabels(ctx context.Context, cell model.SourceItem, names []
 		return err
 	}
 
-	idSet := make(map[string]struct{})
-	// Preserve the labels the item already has (cell.Labels are lowercased names).
-	for _, n := range cell.Labels {
-		if id, ok := a.labelNameToID[strings.ToLower(n)]; ok {
-			idSet[id] = struct{}{}
-		}
+	itemPath := a.workItemsBase() + "/" + cell.ID + "/"
+	data, err := a.client.get(ctx, itemPath, nil)
+	if err != nil {
+		return fmt.Errorf("plane: fetching current labels of %s: %w", cell.ID, err)
+	}
+	var current workItem
+	if err := json.Unmarshal(data, &current); err != nil {
+		return fmt.Errorf("plane: decoding work item %s: %w", cell.ID, err)
+	}
+
+	idSet := make(map[string]struct{}, len(current.Labels)+len(names))
+	for _, id := range current.Labels {
+		idSet[id] = struct{}{}
 	}
 	// Add the requested labels, creating any that are missing.
 	for _, n := range names {

--- a/src/internal/source/plane/adapter_test.go
+++ b/src/internal/source/plane/adapter_test.go
@@ -1,7 +1,11 @@
 package plane
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -163,6 +167,62 @@ func TestToCell_UnknownLabelSkipped(t *testing.T) {
 	if len(cell.Labels) != 1 || cell.Labels[0] != "known" {
 		t.Errorf("expected only known label, got %v", cell.Labels)
 	}
+}
+
+// ── AddLabels ─────────────────────────────────────────────────────────────────
+
+// TestAddLabels_MergesLiveLabelsNotSnapshot verifies that AddLabels re-fetches
+// the work item's CURRENT labels before the merge + PATCH, instead of replaying
+// cell.Labels (the dispatch-time snapshot) — which would revert labels an agent
+// swapped while the run was executing.
+func TestAddLabels_MergesLiveLabelsNotSnapshot(t *testing.T) {
+	var patchedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/workspaces/ws/projects/proj/work-items/item-1/":
+			// Live state: the agent already swapped l-spec → l-impl.
+			_, _ = w.Write([]byte(`{"id":"item-1","labels":["l-impl"]}`))
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/v1/workspaces/ws/projects/proj/work-items/item-1/":
+			b, _ := io.ReadAll(r.Body)
+			patchedBody = string(b)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{
+		id:         "plane",
+		workspace:  "ws",
+		project:    "proj",
+		client:     newClient(srv.URL, ""),
+		issuesPath: "work-items",
+		labelIDToName: map[string]string{
+			"l-spec": "workflow:spec",
+			"l-impl": "workflow:implementation",
+			"l-done": "po:done",
+		},
+		labelNameToID: map[string]string{
+			"workflow:spec":           "l-spec",
+			"workflow:implementation": "l-impl",
+			"po:done":                 "l-done",
+		},
+	}
+	a.metaOnce.Do(func() {}) // metadata already primed above
+
+	// Stale snapshot from dispatch time: still carries workflow:spec.
+	cell := model.SourceItem{ID: "item-1", Labels: []string{"workflow:spec"}}
+	if err := a.AddLabels(context.Background(), cell, []string{"po:done"}); err != nil {
+		t.Fatalf("AddLabels: %v", err)
+	}
+
+	if patchedBody == "" {
+		t.Fatal("expected PATCH to the work item")
+	}
+	mustContain(t, patchedBody, "l-impl")    // live label preserved
+	mustContain(t, patchedBody, "l-done")    // new label added
+	mustNotContain(t, patchedBody, "l-spec") // snapshot must not be replayed
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Same clobber bug fixed for the GitHub adapter in #186, in the Plane adapter: `AddLabels` rebuilt the label list from `cell.Labels` (the dispatch-time snapshot) and PATCHed the work item, replacing the entire set. Labels swapped by an agent mid-run (e.g. `workflow:spec` → `workflow:implementation`) were silently reverted when `on_complete` added its labels, orphaning the item.

## Fix

Plane's API has no additive label endpoint, so the GitHub fix (POST only the new labels) doesn't apply. Instead, `AddLabels` now re-fetches the work item's **current** labels immediately before merging in the new ones and PATCHing.

## Tests

- New `TestAddLabels_MergesLiveLabelsNotSnapshot` (httptest, same pattern as #186's test): live item carries `l-impl`, stale snapshot carries `workflow:spec`, adds `po:done` — asserts the PATCH body preserves the live label, includes the new one, and does not replay the snapshot.
- `go build ./...` and full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)