### PR TITLE
fix(github): PollCIStatus escolhe o PR aberto da issue, não um cross-ref fechado

### DIFF
--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -345,30 +345,61 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 			return source.CIStatus{Status: "pending"}, nil
 		}
 
-		// Find the cross-reference event pointing to a PR
-		var prNumber int
-		for _, event := range timeline {
+		// Collect every cross-referenced PR, most recent first. Any PR that merely
+		// MENTIONS the issue shows up here (including closed PRs from sibling
+		// issues), so we can't just take the first hit: an issue's real PR must be
+		// picked among the candidates, preferring OPEN PRs and, among those, the
+		// most recently referenced one. Only when no candidate is open do we fall
+		// back to the most recent one regardless of state (e.g. polling right
+		// after a merge).
+		var candidates []int
+		seen := map[int]bool{}
+		for i := len(timeline) - 1; i >= 0; i-- {
+			event := timeline[i]
 			if event.Event == "cross-referenced" && event.Source.Type == "issue" && event.Source.Issue.PullRequest.URL != "" {
-				prNumber = event.Source.Issue.Number
-				break
+				if n := event.Source.Issue.Number; !seen[n] {
+					seen[n] = true
+					candidates = append(candidates, n)
+				}
 			}
 		}
 
-		if prNumber == 0 {
+		if len(candidates) == 0 {
 			return source.CIStatus{Status: "pending"}, nil // No PR found yet; still pending
 		}
 
-		// Fetch the PR details. A failure here is NOT "pending": we found a real PR
-		// but can't read it. Surface it as an error so the caller logs it instead of
-		// masking a permanent problem (e.g. a token lacking Pull requests: Read,
-		// which returns 403) as an endless wait.
-		prPath = fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, prNumber)
-		prBody, err = a.client.get(ctx, prPath)
-		if err != nil {
-			if isAuthError(err) {
-				return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: cannot read PR #%d for issue %s — the configured token likely lacks 'Pull requests: Read' (and 'Contents: Read'): %w", prNumber, cellID, err)
+		// Fetch candidate PRs until an open one is found. A fetch failure is NOT
+		// "pending": we found a real PR but can't read it. Surface it as an error
+		// so the caller logs it instead of masking a permanent problem (e.g. a
+		// token lacking Pull requests: Read, which returns 403) as an endless wait.
+		var fallbackBody []byte
+		prBody = nil
+		for _, prNumber := range candidates {
+			prPath = fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, prNumber)
+			body, err := a.client.get(ctx, prPath)
+			if err != nil {
+				if isAuthError(err) {
+					return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: cannot read PR #%d for issue %s — the configured token likely lacks 'Pull requests: Read' (and 'Contents: Read'): %w", prNumber, cellID, err)
+				}
+				return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: fetching PR #%d for issue %s: %w", prNumber, cellID, err)
 			}
-			return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: fetching PR #%d for issue %s: %w", prNumber, cellID, err)
+			var candidate pullRequest
+			if err := json.Unmarshal(body, &candidate); err != nil {
+				continue
+			}
+			if candidate.State == "open" {
+				prBody = body
+				break
+			}
+			if fallbackBody == nil {
+				fallbackBody = body
+			}
+		}
+		if prBody == nil {
+			prBody = fallbackBody
+		}
+		if prBody == nil {
+			return source.CIStatus{Status: "pending"}, nil
 		}
 	}
 

--- a/src/internal/source/github/pollci_test.go
+++ b/src/internal/source/github/pollci_test.go
@@ -176,6 +176,50 @@ func TestPollCIStatus_NoSignalsYet(t *testing.T) {
 	}
 }
 
+// The regression behind the 2026-07-05 needs-human cascade: the issue timeline
+// cross-references BOTH a stale CLOSED PR with conflicts (from a sibling issue
+// that merely mentioned this one) and the issue's real OPEN PR. The poller must
+// pick the open PR — not short-circuit on the closed dirty one.
+func TestPollCIStatus_PrefersOpenPROverStaleClosedOne(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/pulls/1958"):
+			http.NotFound(w, r)
+		case strings.HasSuffix(r.URL.Path, "/issues/1958/timeline"):
+			// Chronological order: the real PR (1961) referenced first, then the
+			// stale closed one (1960) referenced later (= most recent).
+			_, _ = w.Write([]byte(`[
+				{"event":"cross-referenced","source":{"type":"issue",
+					"issue":{"number":1961,"pull_request":{"url":"https://api/pulls/1961"}}}},
+				{"event":"cross-referenced","source":{"type":"issue",
+					"issue":{"number":1960,"pull_request":{"url":"https://api/pulls/1960"}}}}]`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/1960"):
+			_, _ = w.Write([]byte(`{"number":1960,"state":"closed","html_url":"https://gh/pr/1960","head":{"sha":"stale"},"mergeable":false,"mergeable_state":"dirty"}`))
+		case strings.HasSuffix(r.URL.Path, "/pulls/1961"):
+			_, _ = w.Write([]byte(`{"number":1961,"state":"open","html_url":"https://gh/pr/1961","head":{"sha":"abc"},"mergeable":true,"mergeable_state":"clean"}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/status"):
+			_, _ = w.Write([]byte(`{"state":"pending","total_count":0,"statuses":[]}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}`))
+		case strings.Contains(r.URL.Path, "/commits/stale/"):
+			t.Errorf("CI polled on the stale closed PR's head %q — the open PR should have been picked", r.URL.Path)
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+
+	got, err := a.PollCIStatus(context.Background(), "1958")
+	if err != nil {
+		t.Fatalf("PollCIStatus: %v", err)
+	}
+	if got.Status != "passed" {
+		t.Errorf("status = %q, want passed (from the OPEN PR #1961, not conflict from closed #1960)", got.Status)
+	}
+}
+
 // Legacy commit statuses (non-Actions CI) still work and are aggregated with checks.
 func TestPollCIStatus_LegacyStatusesGreen(t *testing.T) {
 	a := ciServer(t,

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -73,6 +73,7 @@ type labelCreateRequest struct {
 // mergeable_state == "dirty".
 type pullRequest struct {
 	Number         int    `json:"number"`
+	State          string `json:"state"`
 	HTMLURL        string `json:"html_url"`
 	Mergeable      *bool  `json:"mergeable"`
 	MergeableState string `json:"mergeable_state"`


### PR DESCRIPTION
## Summary
- `PollCIStatus` pegava o **primeiro** PR cross-referenciado na timeline da issue — incluindo PRs **fechados** de issues irmãs que apenas mencionavam a issue. Um PR stale `dirty` fazia o `check-ci` abortar como "conflict", exaurir os retries e falhar o workflow (cascata `needs-human` de 2026-07-05 no project-erp: #2874–#2877 escalados com PRs reais verdes e mergeáveis).
- Agora coleta todos os candidatos (mais recente primeiro) e **prefere PR aberto**; sem nenhum aberto, cai no candidato mais recente (ex.: polling logo após merge).

## Test plan
- Novo `TestPollCIStatus_PrefersOpenPROverStaleClosedOne` reproduz o cenário (PR fechado dirty referenciado depois do PR aberto limpo).
- `go build ./... && go test ./...` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)