### PR TITLE
feat(settings): enforce shared git hooks on agent checkouts

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -477,6 +477,15 @@ settings:
     # max_age: 72h                   # how far back to back-fill
     # team_id: 0                     # REQUIRED for team-billed accounts (authInfo.teamId in ~/.cursor/cli-config.json)
     # user_id: 0                     # filter to your own events on team accounts (authInfo.userId)
+  # Git hook enforcement (opt-in): at startup the daemon points core.hooksPath
+  # of every repo matched by `repos` at `dir`, so e.g. a pre-push hook running
+  # the project's local lint/tests physically blocks agents from pushing
+  # untested code — soul-file rules alone are advisory. Scripts in `dir` are
+  # made executable automatically; non-git matches are skipped.
+  # git_hooks:
+  #   dir: .apiary/hooks
+  #   repos:
+  #     - ../myproject--*            # the agents' per-role checkouts
 
 # ── Task completion hook (internal-task-model) ───────────────────────────────────
 # Fires once per InternalTask, when the LAST of its fanned-out workflows reaches a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,35 @@ pages — the file stops growing but does not shrink; to compact a database
 that grew before retention existed, stop the daemon and run
 `sqlite3 .apiary/apiary.db 'VACUUM;'` once.
 
+### Git hook enforcement (`git_hooks`)
+
+Prompt-level rules like "always run the tests before pushing" are advisory —
+under a long run an agent will eventually skip them, and the cost shows up
+later as CI-failure retry loops. `git_hooks` makes the rule mechanical: at
+startup the daemon points `core.hooksPath` of every repo matched by `repos`
+at the shared `dir`, so a `pre-push` script there (running the project's
+local lint/tests, or refusing pushes from a branch behind `main`) physically
+rejects the push with a non-zero exit, whatever the agent decided.
+
+```yaml
+settings:
+  git_hooks:
+    dir: .apiary/hooks        # holds pre-push, pre-commit, ... scripts
+    repos:
+      - ../myproject--*       # the agents' per-role checkouts (glob)
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `dir` | — | Directory with the hook scripts; absolute, `~`-prefixed, or relative to the daemon working directory. Scripts are made executable automatically |
+| `repos` | — | Glob patterns of git checkouts to enforce on. Matches without a `.git` are skipped silently; both fields are required together |
+
+Enforcement is re-applied on every daemon start, so newly-cloned checkouts
+matching the glob pick the hooks up on the next restart. Hooks live in one
+shared directory — editing a script updates every repo at once. Note that
+`core.hooksPath` replaces the per-repo `.git/hooks` directory entirely for
+the configured repos.
+
 ### Cursor cost back-fill (`cursor_cost`)
 
 The Cursor agent CLI streams token counts but **no dollar cost** — unlike the

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -524,6 +524,24 @@
               "default": 0
             }
           }
+        },
+        "git_hooks": {
+          "type": "object",
+          "description": "Enforce a shared git hooks directory on the agents' repo checkouts. At startup the daemon sets core.hooksPath of every repo matched by 'repos' to 'dir' (and marks the scripts executable), so hooks like a pre-push running local lint/tests mechanically gate agent pushes — prompt rules alone are advisory. Both keys are required together",
+          "additionalProperties": false,
+          "required": ["dir", "repos"],
+          "properties": {
+            "dir": {
+              "type": "string",
+              "description": "Directory holding the hook scripts (pre-push, pre-commit, ...); absolute, ~-prefixed, or relative to the daemon working directory"
+            },
+            "repos": {
+              "type": "array",
+              "description": "Glob patterns of git checkouts to enforce the hooks on (e.g. \"../myproject--*\"). Matches that are not git repos are skipped",
+              "items": { "type": "string" },
+              "minItems": 1
+            }
+          }
         }
       }
     },

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -224,6 +224,28 @@ type Settings struct {
 	Memory        MemorySettings     `yaml:"memory"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
+	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
+}
+
+// GitHooksSettings makes the daemon enforce a shared git hooks directory on
+// the agents' local repo checkouts. At startup the daemon points
+// core.hooksPath of every repo matched by Repos at Dir, so hooks placed there
+// (e.g. a pre-push script that runs the project's lint/tests) physically gate
+// what agents can push — prompt-level rules alone are advisory and get
+// skipped under pressure. Hook scripts are made executable automatically.
+type GitHooksSettings struct {
+	// Dir is the directory holding the hook scripts (pre-push, pre-commit, …),
+	// absolute, ~-prefixed, or relative to the daemon working directory.
+	Dir string `yaml:"dir"`
+	// Repos are glob patterns (absolute, ~-prefixed, or relative to the daemon
+	// working directory) of git checkouts to enforce the hooks on, e.g.
+	// "../project-erp--*". Non-git matches are skipped silently.
+	Repos []string `yaml:"repos"`
+}
+
+// Enabled reports whether git hook enforcement is configured.
+func (g GitHooksSettings) Enabled() bool {
+	return g.Dir != "" && len(g.Repos) > 0
 }
 
 // CursorCostSettings configures the cursor-cli cost back-fill. The Cursor

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -185,6 +185,22 @@ func (c *Config) Validate() []error {
 		errs = append(errs, fmt.Errorf("settings.memory.max_entry_bytes must be >= 0"))
 	}
 
+	// settings.git_hooks: dir and repos only make sense together — one without
+	// the other is a config mistake, not a partial setup.
+	if g := c.Settings.GitHooks; g.Dir != "" || len(g.Repos) > 0 {
+		if g.Dir == "" {
+			errs = append(errs, fmt.Errorf("settings.git_hooks: dir is required when repos is set"))
+		}
+		if len(g.Repos) == 0 {
+			errs = append(errs, fmt.Errorf("settings.git_hooks: repos is required when dir is set"))
+		}
+		for i, r := range g.Repos {
+			if strings.TrimSpace(r) == "" {
+				errs = append(errs, fmt.Errorf("settings.git_hooks.repos[%d]: pattern must not be empty", i))
+			}
+		}
+	}
+
 	// Validate v2-specific authoring rules before lowering (while v2 fields are
 	// still present on the raw StepConfig nodes).
 	errs = append(errs, c.validateV2Workflows()...)

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -181,3 +181,42 @@ func containsStr(s, sub string) bool {
 			return false
 		}())
 }
+
+func TestValidate_GitHooksPairing(t *testing.T) {
+	base := func() *config.Config {
+		return &config.Config{
+			Version: "1",
+			Sources: []config.SourceConfig{{ID: "src-1", Type: "plane"}},
+			Agents:  []config.AgentConfig{{ID: "a-1", Model: "claude-sonnet-4-6"}},
+			Workflows: []config.WorkflowConfig{{
+				ID:      "wf-1",
+				Trigger: &config.TriggerConfig{Priority: 1, Match: config.RouteMatch{Source: "src-1"}},
+				Steps:   []config.StepConfig{{ID: "run", Agent: "a-1"}},
+			}},
+		}
+	}
+
+	cfg := base()
+	cfg.Settings.GitHooks = config.GitHooksSettings{Dir: ".apiary/hooks", Repos: []string{"../proj--*"}}
+	if errs := cfg.Validate(); len(errs) != 0 {
+		t.Errorf("valid git_hooks rejected: %v", errs)
+	}
+
+	cfg = base()
+	cfg.Settings.GitHooks = config.GitHooksSettings{Repos: []string{"../proj--*"}}
+	if errs := cfg.Validate(); len(errs) != 1 {
+		t.Errorf("repos without dir: expected 1 error, got: %v", errs)
+	}
+
+	cfg = base()
+	cfg.Settings.GitHooks = config.GitHooksSettings{Dir: ".apiary/hooks"}
+	if errs := cfg.Validate(); len(errs) != 1 {
+		t.Errorf("dir without repos: expected 1 error, got: %v", errs)
+	}
+
+	cfg = base()
+	cfg.Settings.GitHooks = config.GitHooksSettings{Dir: ".apiary/hooks", Repos: []string{"  "}}
+	if errs := cfg.Validate(); len(errs) != 1 {
+		t.Errorf("blank repo pattern: expected 1 error, got: %v", errs)
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -319,6 +319,11 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 // Start launches one poll goroutine per source.
 // Cancel ctx to initiate a graceful shutdown; then call wg.Wait().
 func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
+	// Enforce the shared git hooks directory on the agents' repo checkouts
+	// (settings.git_hooks) before the first dispatch, so pre-push hooks gate
+	// agent pushes from the very first run.
+	installGitHooks(d.cfg.Settings.GitHooks)
+
 	// A fresh process owns no in-flight runs: clear any executions left in the
 	// 'running' state by a previously-killed dispatcher so the dashboard's
 	// agent status reflects real, live claude processes rather than orphans.

--- a/src/internal/daemon/githooks.go
+++ b/src/internal/daemon/githooks.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+// installGitHooks enforces settings.git_hooks on the agents' repo checkouts:
+// it points core.hooksPath of every git repo matched by the configured globs
+// at the shared hooks directory, and marks the hook scripts executable. This
+// runs at daemon startup so a pre-push hook (running the project's local
+// lint/tests) gates agent pushes mechanically — soul-file rules alone are
+// advisory and agents skip them under pressure, which shows up as CI-failure
+// retry loops.
+//
+// Best-effort by design: a repo that fails to configure is logged and skipped
+// so one broken checkout cannot keep the daemon from starting.
+func installGitHooks(gh config.GitHooksSettings) {
+	if !gh.Enabled() {
+		return
+	}
+
+	hooksDir, err := absPath(gh.Dir)
+	if err != nil {
+		aplog.Warn("git_hooks: resolving dir %q: %v", gh.Dir, err)
+		return
+	}
+	info, err := os.Stat(hooksDir)
+	if err != nil || !info.IsDir() {
+		aplog.Warn("git_hooks: dir %q is not a directory (hooks not installed)", hooksDir)
+		return
+	}
+
+	// Hook scripts must be executable or git silently ignores them.
+	entries, _ := os.ReadDir(hooksDir)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p := filepath.Join(hooksDir, e.Name())
+		if fi, err := os.Stat(p); err == nil && fi.Mode()&0o111 == 0 {
+			if err := os.Chmod(p, fi.Mode()|0o755); err != nil {
+				aplog.Warn("git_hooks: chmod +x %s: %v", p, err)
+			}
+		}
+	}
+
+	installed := 0
+	for _, pattern := range gh.Repos {
+		pat, err := absPath(pattern)
+		if err != nil {
+			aplog.Warn("git_hooks: resolving pattern %q: %v", pattern, err)
+			continue
+		}
+		matches, err := filepath.Glob(pat)
+		if err != nil {
+			aplog.Warn("git_hooks: bad glob %q: %v", pattern, err)
+			continue
+		}
+		if len(matches) == 0 {
+			aplog.Warn("git_hooks: pattern %q matched no paths", pattern)
+			continue
+		}
+		for _, repo := range matches {
+			// .git may be a directory (clone) or a file (linked worktree).
+			if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
+				continue
+			}
+			cmd := exec.Command("git", "-C", repo, "config", "core.hooksPath", hooksDir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				aplog.Warn("git_hooks: %s: git config core.hooksPath: %v (%s)", repo, err, strings.TrimSpace(string(out)))
+				continue
+			}
+			installed++
+		}
+	}
+	aplog.Info("git_hooks: core.hooksPath -> %s enforced on %d repo(s)", hooksDir, installed)
+}
+
+// absPath expands a leading ~ and makes the path absolute relative to the
+// daemon working directory (the same convention soul_file paths follow).
+func absPath(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expanding ~: %w", err)
+		}
+		p = filepath.Join(home, strings.TrimPrefix(p, "~"))
+	}
+	return filepath.Abs(p)
+}

--- a/src/internal/daemon/githooks_test.go
+++ b/src/internal/daemon/githooks_test.go
@@ -1,0 +1,89 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v (%s)", err, out)
+	}
+}
+
+func hooksPath(t *testing.T, repo string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repo, "config", "core.hooksPath").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestInstallGitHooks(t *testing.T) {
+	base := t.TempDir()
+	hooks := filepath.Join(base, "hooks")
+	if err := os.MkdirAll(hooks, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Hook script written without the executable bit: install must chmod it.
+	hookFile := filepath.Join(hooks, "pre-push")
+	if err := os.WriteFile(hookFile, []byte("#!/bin/sh\nexit 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repoA := filepath.Join(base, "erp--feat")
+	repoB := filepath.Join(base, "erp--fix")
+	gitInit(t, repoA)
+	gitInit(t, repoB)
+	// A matching path that is not a git repo must be skipped without error.
+	if err := os.MkdirAll(filepath.Join(base, "erp--notgit"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	installGitHooks(config.GitHooksSettings{
+		Dir:   hooks,
+		Repos: []string{filepath.Join(base, "erp--*")},
+	})
+
+	for _, repo := range []string{repoA, repoB} {
+		if got := hooksPath(t, repo); got != hooks {
+			t.Errorf("%s: core.hooksPath = %q, want %q", repo, got, hooks)
+		}
+	}
+	if got := hooksPath(t, filepath.Join(base, "erp--notgit")); got != "" {
+		t.Errorf("non-git dir unexpectedly configured: %q", got)
+	}
+	fi, err := os.Stat(hookFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&0o111 == 0 {
+		t.Errorf("hook script not made executable: mode %v", fi.Mode())
+	}
+}
+
+func TestInstallGitHooksDisabledOrMissingDir(t *testing.T) {
+	// Not configured: must be a no-op.
+	installGitHooks(config.GitHooksSettings{})
+
+	// Configured but dir missing: must log-and-return, not panic.
+	repo := filepath.Join(t.TempDir(), "repo")
+	gitInit(t, repo)
+	installGitHooks(config.GitHooksSettings{
+		Dir:   filepath.Join(t.TempDir(), "nope"),
+		Repos: []string{repo},
+	})
+	if got := hooksPath(t, repo); got != "" {
+		t.Errorf("hooksPath set despite missing hooks dir: %q", got)
+	}
+}


### PR DESCRIPTION
## Why

Analysis of project-erp's live data showed `implementation` workflows average **145 min end-to-end with only 30 min of agent work** — the rest is CI-failure retry loops. Roughly half those CI failures (lint, unit tests) would have been caught locally, and the engineer soul already mandates local tests before push in three places. Prompt rules are advisory; agents skip them under pressure.

## What

New opt-in `settings.git_hooks` makes the rule mechanical:

```yaml
settings:
  git_hooks:
    dir: .apiary/hooks     # pre-push, pre-commit, ... scripts
    repos:
      - ../myproject--*    # the agents' per-role checkouts
```

At daemon startup, `core.hooksPath` of every git repo matched by `repos` is pointed at `dir` (scripts chmod +x'd), so a `pre-push` hook running the project's scoped lint/tests physically rejects untested pushes with a non-zero exit — whatever the agent decided.

- `config`: `Settings.GitHooks {dir, repos}` + pairing validation (`dir`/`repos` required together, no blank patterns)
- `daemon`: `installGitHooks()` wired at the top of `Dispatcher.Start` — best-effort, one broken checkout never blocks startup; non-git glob matches skipped
- mirrors: `schema/apiary.json`, `.apiary/example-apiary-full.yaml`, `docs/configuration.md`

## Tests

`go test ./...` green; new coverage: installer (multi-repo glob, non-git skip, chmod), disabled/missing-dir no-op, validate pairing rules.