### PR TITLE
fix(workflow): consume already_done — inject output_schema instruction into prompts, last-write-wins resume memory

### DIFF
--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -11,6 +11,7 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/runner/execution"
 	"github.com/orlandoburli/apiary/internal/source"
 	"github.com/orlandoburli/apiary/internal/workflow"
 )
@@ -378,6 +379,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		MaxTurns:           req.Agent.MaxTurns,
 		SystemPrepend:      req.MemoryDoc,
 		SystemAppend:       composeSystemAppend(req.Prompt, readSoulFile(req.Agent, req.Cell.ID)),
+		OutputInstruction:  execution.OutputSchemaInstruction(req.Step.OutputSchema),
 		SummaryPrompt:      req.Step.SummaryPrompt,
 		StepID:             req.Step.ID,
 		WorkflowInstanceID: req.InstanceID,

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -17,6 +17,11 @@ type RunRequest struct {
 	// details and SystemAppend. In workflow mode it carries the formatted
 	// workflow memory document. Empty for plain routes.
 	SystemPrepend string
+	// OutputInstruction, when set, is the pre-rendered prompt block that teaches
+	// the agent to emit its step's structured output via the APIARY_OUTPUT:
+	// sentinel (derived from the step's output_schema). Appended verbatim to the
+	// composed prompt. Empty for steps without a schema and for plain routes.
+	OutputInstruction string
 	// SummaryPrompt, when set, instructs the agent to emit a short handoff
 	// summary delimited by APIARY_SUMMARY_START/END markers, extracted into
 	// RunResult.Summary. Empty for plain routes.

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -551,6 +551,9 @@ func buildPrompt(req model.RunRequest) string {
 		b.WriteString(req.SystemAppend)
 		b.WriteString("\n")
 	}
+	if req.OutputInstruction != "" {
+		b.WriteString(req.OutputInstruction)
+	}
 	if req.SummaryPrompt != "" {
 		b.WriteString(summaryInstruction(req.SummaryPrompt))
 	}

--- a/src/internal/runner/execution/structured.go
+++ b/src/internal/runner/execution/structured.go
@@ -3,8 +3,10 @@ package execution
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -230,6 +232,78 @@ func applyStructured(result *model.RunResult) {
 				result.SpawnRequest = &req
 			}
 		}
+	}
+}
+
+// OutputSchemaInstruction renders the prompt block that teaches an agent how to
+// satisfy a step's output_schema: one bare APIARY_OUTPUT: line with the declared
+// fields. Without it only agents whose soul file happens to document the sentinel
+// ever emit structured output — every other agent answers in prose, the step
+// passes with no structured output (on_missing_output=warn default), and every
+// workflow condition keyed on those fields silently misroutes. Returns "" for a
+// nil schema (plain steps and legacy routes).
+func OutputSchemaInstruction(schema *config.OutputSchema) string {
+	if schema == nil || len(schema.Properties) == 0 {
+		return ""
+	}
+	required := map[string]bool{}
+	for _, f := range schema.Required {
+		required[f] = true
+	}
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	// Required fields first, then alphabetical — deterministic output.
+	sort.Slice(names, func(i, j int) bool {
+		if required[names[i]] != required[names[j]] {
+			return required[names[i]]
+		}
+		return names[i] < names[j]
+	})
+
+	var example []string
+	var fields []string
+	for _, name := range names {
+		f := schema.Properties[name]
+		example = append(example, fmt.Sprintf("%q: %s", name, exampleValue(f)))
+		desc := f.Type
+		if len(f.Enum) > 0 {
+			desc = fmt.Sprintf("%s, one of: %s", f.Type, strings.Join(f.Enum, " | "))
+		}
+		if required[name] {
+			desc += ", required"
+		}
+		fields = append(fields, fmt.Sprintf("- %s (%s)", name, desc))
+	}
+
+	var b strings.Builder
+	b.WriteString("\n---\n")
+	b.WriteString("When you finish, report your structured result by writing EXACTLY one line, bare at the start of a line (no code fence, no backticks, no bold):\n")
+	fmt.Fprintf(&b, "%s {%s}\n", apiaryOutputPrefix, strings.Join(example, ", "))
+	b.WriteString("Fields:\n")
+	b.WriteString(strings.Join(fields, "\n"))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// exampleValue renders a JSON placeholder for one schema field, used in the
+// APIARY_OUTPUT example line.
+func exampleValue(f config.SchemaField) string {
+	if len(f.Enum) > 0 {
+		return fmt.Sprintf("%q", strings.Join(f.Enum, "|"))
+	}
+	switch f.Type {
+	case "integer", "number":
+		return "0"
+	case "boolean":
+		return "true"
+	case "array":
+		return "[...]"
+	case "object":
+		return "{...}"
+	default:
+		return `"..."`
 	}
 }
 

--- a/src/internal/runner/execution/structured_test.go
+++ b/src/internal/runner/execution/structured_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -383,5 +384,44 @@ func TestApplyStructured_MemorizeInvalidJSON(t *testing.T) {
 	// The block is stripped even when malformed, so it never leaks downstream.
 	if strings.Contains(result.Output, "APIARY_MEMORIZE") || strings.Contains(result.Output, "not json") {
 		t.Fatalf("block not stripped: %q", result.Output)
+	}
+}
+
+func TestOutputSchemaInstruction(t *testing.T) {
+	schema := &config.OutputSchema{Type: "object",
+		Properties: map[string]config.SchemaField{
+			"action": {Type: "string", Enum: []string{"pr_opened", "already_done"}},
+			"reason": {Type: "string"},
+		},
+		Required: []string{"action"}}
+
+	got := OutputSchemaInstruction(schema)
+	for _, want := range []string{
+		"APIARY_OUTPUT:",
+		`"action": "pr_opened|already_done"`,
+		"- action (string, one of: pr_opened | already_done, required)",
+		"- reason (string)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("instruction missing %q:\n%s", want, got)
+		}
+	}
+	// Required fields come before optional ones in the example line.
+	if strings.Index(got, `"action"`) > strings.Index(got, `"reason"`) {
+		t.Errorf("required field should precede optional in example:\n%s", got)
+	}
+	if OutputSchemaInstruction(nil) != "" {
+		t.Error("nil schema must render no instruction")
+	}
+}
+
+func TestBuildPrompt_IncludesOutputInstruction(t *testing.T) {
+	req := model.RunRequest{
+		Cell:              model.SourceItem{Title: "issue"},
+		OutputInstruction: "\n---\nAPIARY_OUTPUT: {\"action\": \"...\"}\n",
+	}
+	got := buildPrompt(req)
+	if !strings.Contains(got, `APIARY_OUTPUT: {"action": "..."}`) {
+		t.Errorf("prompt missing output instruction:\n%s", got)
 	}
 }

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -326,6 +326,13 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			res.Success = false
 			aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", r.wf.ID, step.ID)
 		}
+		// Default warn policy: the step still passes, but say so loudly — every
+		// condition keyed on the missing fields will now evaluate against "".
+		if res.Success && step.OutputSchema != nil &&
+			step.OnMissingOutput != config.OnMissingOutputIgnore &&
+			len(res.StructuredOutput) == 0 {
+			aplog.Error("workflow %s: step %q declared output_schema but emitted no APIARY_OUTPUT — conditions reading its fields will see empty values", r.wf.ID, step.ID)
+		}
 
 		// fail_when — evaluate on the scheduler goroutine after the agent runs.
 		// An expression that cannot be parsed or evaluated fails the step —

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -81,13 +81,18 @@ func (e *Engine) restoreCachedSteps(r *dagRun, priorSteps []db.StepRun) []db.Ste
 
 		r.state[step.ID] = stPassed
 		r.stepStates[step.ID] = StepState{State: stPassed, Output: sr.Output}
+		// Last passed run wins: an on_fail.goto / restart_from loop re-runs a step,
+		// and downstream conditions must see the newest attempt's output. Keeping
+		// the first run's memory here made a restored `if` read stale fields (e.g.
+		// an implement re-run that emitted already_done was invisible after a
+		// rehydrate, so the noop exit never fired and the issue looped).
+		r.contrib[step.ID] = MemoryStep{
+			StepID:      step.ID,
+			WriteFields: step.MemoryWriteFields(),
+			Structured:  structured,
+			Summary:     sr.Summary,
+		}
 		if !seen[step.ID] {
-			r.contrib[step.ID] = MemoryStep{
-				StepID:      step.ID,
-				WriteFields: step.MemoryWriteFields(),
-				Structured:  structured,
-				Summary:     sr.Summary,
-			}
 			r.passedOrder = append(r.passedOrder, step.ID)
 			seen[step.ID] = true
 		}

--- a/src/internal/workflow/resume_test.go
+++ b/src/internal/workflow/resume_test.go
@@ -163,3 +163,63 @@ func TestResume_ReevaluatesSplit(t *testing.T) {
 		t.Errorf("plan should be cached, not re-run: %v", ids)
 	}
 }
+
+// alreadyDoneWF mirrors the shape of project-erp's implementation workflow
+// (issue #2967 loop): implement writes `action` to memory; check-ci is gated on
+// action != already_done and close-noop on action == already_done.
+func alreadyDoneWF() config.WorkflowConfig {
+	actionSchema := &config.OutputSchema{Type: "object",
+		Properties: map[string]config.SchemaField{
+			"action": {Type: "string", Enum: []string{"pr_opened", "already_done"}}},
+		Required: []string{"action"}}
+	return config.WorkflowConfig{ID: "implementation", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "engineer",
+			OutputSchema: actionSchema,
+			Memory:       &config.MemoryConfig{Write: []string{"action"}}},
+		{ID: "checkci", Agent: "engineer", DependsOn: []string{"implement"},
+			Condition: `memory.action != "already_done"`},
+		{ID: "closenoop", Agent: "engineer", DependsOn: []string{"implement"},
+			Condition: `memory.action == "already_done"`},
+	}}
+}
+
+// A step re-run by a restart_from/goto loop persists a second passed run. On
+// resume/rehydrate the LATEST passed run's structured output must win —
+// restoring the first run's memory made `if` conditions read the stale value,
+// so an implement re-run that emitted already_done was invisible and the
+// workflow looped instead of taking the noop exit (project-erp #2967).
+func TestRestoreCachedSteps_LastPassedRunWins(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID := "wf_resume_lastwins"
+	prior := []db.StepRun{
+		{ID: "sr-impl-1", WorkflowInstanceID: instID, StepID: "implement",
+			State: db.StepStatePassed, StructuredOutput: `{"action":"pr_opened"}`},
+		{ID: "sr-ci-1", WorkflowInstanceID: instID, StepID: "checkci",
+			State: db.StepStateFailed},
+		{ID: "sr-impl-2", WorkflowInstanceID: instID, StepID: "implement",
+			State: db.StepStatePassed, StructuredOutput: `{"action":"already_done"}`},
+	}
+
+	success, err := eng.ResumeInstance(context.Background(), instID, alreadyDoneWF(), model.InternalTask{ID: "c1"}, prior)
+	if err != nil {
+		t.Fatalf("ResumeInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected resume to succeed")
+	}
+
+	ids := executedIDs(exec.seen)
+	if contains(ids, "implement") {
+		t.Errorf("implement is cached and must not re-run: %v", ids)
+	}
+	if contains(ids, "checkci") {
+		t.Errorf("checkci must be condition-skipped — latest implement run said already_done: %v", ids)
+	}
+	if !contains(ids, "closenoop") {
+		t.Errorf("closenoop must run so the noop exit closes the task: %v", ids)
+	}
+}


### PR DESCRIPTION
## Problem

project-erp issue #2967 was re-dispatched **7 times** after the implement step emitted `action: already_done` — the engine never took the `close-noop` exit, so the issue was never closed. The agent eventually commented on the loop itself.

## Root cause (confirmed against the live daemon DB + logs)

Every `implement` step run had **empty `structured_output`** (while `review`/`qa` captured theirs fine). Chain:

1. Nothing ever told the agent HOW to satisfy a step's `output_schema`. The prompt carried the step `prompt:` + soul file only; agents whose soul doesn't document `APIARY_OUTPUT` (engineer, engineer-10x) answered in prose (`**action: already_done**`), which the sentinel extractor rightly ignores.
2. `on_missing_output` defaults to `warn`, but the warn path logged **nothing** — the step passed silently with no structured output.
3. Every `if: implement.action != "already_done"` then evaluated against `""` → true → `check-ci` ran, found a conflicting cross-referenced PR (#2986, `mergeable_state=dirty`), and `on_conflict: goto implement` looped until retries exhausted → `on_fail` escalated to `implementation-10x` → same loop again. `close-noop` (`== "already_done"`) never fired.
4. Secondary bug: `restoreCachedSteps` kept the **first** passed run of a re-run step, so after a rehydrate/resume the conditions read the stale first attempt (`pr_opened`) instead of the loop-back re-run (`already_done`).

## Fix

- **Prompt injection**: `buildPrompt` now appends an `APIARY_OUTPUT:` instruction rendered from the step's `output_schema` (bare-line rule, example JSON, required-first field list with enum values). Agents no longer depend on soul files duplicating the sentinel contract.
- **Loud warn**: a schema step that passes with no structured output now logs an explicit error under the default `warn` policy.
- **Resume memory**: `restoreCachedSteps` is last-write-wins — the latest passed run's structured output feeds the restored memory.

## Tests

- `TestRestoreCachedSteps_LastPassedRunWins` mirrors the #2967 shape (implement re-run says `already_done` → `check-ci` condition-skipped, `close-noop` runs). Verified it **fails** on the pre-fix code with exactly the production symptom.
- `TestOutputSchemaInstruction` / `TestBuildPrompt_IncludesOutputInstruction` cover the rendering and wiring.
- Full `go build ./... && go vet ./... && go test ./...` green.