### PR TITLE
Add Codex CLI runner support

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -18,6 +18,19 @@ runners:
         command: npx
         args: ["-y", "gitnexus@latest", "mcp"]
 
+  - id: codex
+    type: cli
+    provider: codex
+    models:
+      - gpt-5.5
+    # Uses the same checked-in skills through .agents/skills -> ../.claude/skills.
+    # GitNexus is exposed to Codex through ~/.codex/config.toml when this runner
+    # is configured by Apiary.
+    mcps:
+      - name: gitnexus
+        command: npx
+        args: ["-y", "gitnexus@latest", "mcp"]
+
 default_runner: claude
 
 # ── Sources ────────────────────────────────────────────────────────────────────

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -6,6 +6,7 @@ version: "1"
 #
 #   claude-cli    →  type: cli, provider: claude    (the `claude` binary)
 #   opencode-cli  →  type: cli, provider: opencode  (the `opencode` binary)
+#   codex-cli     →  type: cli, provider: codex     (the `codex` binary)
 #   cursor-cli    →  type: cli, provider: cursor    (the `agent` binary, Cursor CLI)
 #   opencode-api  →  type: opencode-api             (OpenCode HTTP API)
 #
@@ -21,8 +22,9 @@ runners:
     # Model Context Protocol servers exposed to every agent on this runner.
     # Each provider writes them into its own native MCP config: claude uses a
     # temp file + `--mcp-config`, cursor merges ~/.cursor/mcp.json + `--approve-mcps`,
-    # opencode merges the global opencode.json `mcp` block. Agent-level `mcps:`
-    # (see agents below) override these by name.
+    # opencode merges the global opencode.json `mcp` block, and codex merges
+    # ~/.codex/config.toml [mcp_servers.*] tables. Agent-level `mcps:` (see agents
+    # below) override these by name.
     mcps:
       - name: gitnexus
         command: npx
@@ -48,6 +50,13 @@ runners:
     # prompt_positional, turns_flag. See docs/runners.md#cli-engine-configuration.
     # config:
     #   command: /usr/local/bin/opencode
+
+  # Codex CLI — invokes the local `codex` binary as `codex exec --sandbox
+  # workspace-write …` with the prompt as a positional argument. Codex discovers
+  # repo skills from `.agents/skills`.
+  - id: codex-cli
+    type: cli
+    provider: codex
 
   # OpenCode API — calls the OpenCode HTTP API directly (OpenAI-compatible
   # chat completions). Requires an API key.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5580 symbols, 12587 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8314 symbols, 18979 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (5580 symbols, 12587 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8314 symbols, 18979 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Task-driven agent orchestration. Route work from any task system to the right AI agent and model.**
 
-Apiary is an open-source harness that connects project management tools (Jira, Plane, GitHub Issues, Linear) to AI agent runners and routes each task to the right agent profile and LLM model based on declarative rules.
+Apiary is an open-source harness that connects project management tools (Jira, Plane, GitHub Issues, Linear) to AI agent runners (Claude, OpenCode, Codex, Cursor) and routes each task to the right agent profile and LLM model based on declarative rules.
 
 ```
 Task System ──► Apiary ──► Agent ──► LLM Model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ version: "1"        # currently the only accepted value
 ## `runners`
 
 Runners define **how** agents execute — a CLI subprocess (`claude`,
-`opencode`, the Cursor `agent` CLI) or a direct API call. They have a
+`opencode`, `codex`, the Cursor `agent` CLI) or a direct API call. They have a
 [dedicated page](runners.md) covering each provider, the engine options,
 prompt delivery, MCP wiring, and API runners; this section is the short
 version.
@@ -52,6 +52,11 @@ runners:
     type: cli
     provider: opencode
 
+  # Codex CLI — requires the `codex` binary on PATH
+  - id: codex
+    type: cli
+    provider: codex
+
   # OpenCode API
   - id: opencode-api
     type: opencode-api
@@ -67,7 +72,7 @@ default_runner: claude    # used by agents that don't name a runner
 |---|---|
 | `id` | Unique runner identifier, referenced by `agents[].runner` and `agents[].fallbacks` |
 | `type` | `cli` (subprocess) or a self-contained adapter like `opencode-api` |
-| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `cursor` |
+| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `codex`, `cursor` |
 | `config` | Engine options — binary, flags, API key; see [Runners](runners.md#cli-engine-configuration) |
 | `models` | Models this runner supports (informational) |
 | `mcps` | [MCP servers](runners.md#mcp-servers) exposed to every agent on this runner |
@@ -79,6 +84,8 @@ default_runner: claude    # used by agents that don't name a runner
     conversation in the
     [task logs](dashboard.md#watching-the-live-conversation-debug-mode),
     plus accurate token and cost figures. `config` is only for overrides.
+    Codex runs as `codex exec --sandbox workspace-write` and reads repo skills
+    from `.agents/skills`.
 
 ## `sources`
 

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -25,7 +25,7 @@ so per-agent MCP servers and identity don't leak between them.
 |---|---|
 | `id` | Unique identifier, referenced by `agents[].runner` and `agents[].fallbacks` |
 | `type` | Execution engine: `cli` (subprocess) — or a self-contained adapter name like `opencode-api` |
-| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `cursor` |
+| `provider` | Which CLI the `cli` engine drives: `claude`, `opencode`, `codex`, `cursor` |
 | `config` | Engine options — see [CLI engine configuration](#cli-engine-configuration) |
 | `models` | Models this runner supports (informational) |
 | `mcps` | MCP servers exposed to every agent on this runner — see [MCP servers](#mcp-servers) |
@@ -38,6 +38,7 @@ registered adapters are:
 |---|---|---|
 | `claude-cli` | `type: cli`, `provider: claude` | the `claude` binary |
 | `opencode-cli` | `type: cli`, `provider: opencode` | the `opencode` binary |
+| `codex-cli` | `type: cli`, `provider: codex` | the `codex` binary |
 | `cursor-cli` | `type: cli`, `provider: cursor` | the `agent` binary (Cursor CLI) |
 | `opencode-api` | `type: opencode-api` | HTTP calls to the OpenCode API |
 
@@ -98,6 +99,23 @@ runners:
     provider: opencode
 ```
 
+#### Codex (`provider: codex`)
+
+Requires the OpenAI Codex CLI (`codex` binary) on `PATH`. The preset invokes
+`codex exec --sandbox workspace-write …` with the prompt as a positional
+argument.
+
+```yaml
+runners:
+  - id: codex
+    type: cli
+    provider: codex
+```
+
+Codex discovers repository skills from `.agents/skills`. If you already keep
+skills under `.claude/skills`, create `.agents/skills` as a symlink to reuse the
+same `SKILL.md` files without copying them.
+
 #### Cursor (`provider: cursor`)
 
 Requires the Cursor CLI (`agent` binary, from
@@ -122,14 +140,14 @@ runners:
 
 All `config` keys, with each provider's preset defaults:
 
-| Key | Description | claude | opencode | cursor |
-|---|---|---|---|---|
-| `command` | Binary to invoke (override to use a wrapper or absolute path) | `claude` | `opencode` | `agent` |
-| `args` | Extra argv appended after the preset's args | `--output-format stream-json --verbose` | `run` | `-p --output-format stream-json --force` |
-| `model_flag` | Flag used to pass the step's model | `--model` | `--model` | `--model` |
-| `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* |
-| `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` |
-| `turns_flag` | Flag used to pass a max-turns limit | — | — | — |
+| Key | Description | claude | opencode | codex | cursor |
+|---|---|---|---|---|---|
+| `command` | Binary to invoke (override to use a wrapper or absolute path) | `claude` | `opencode` | `codex` | `agent` |
+| `args` | Extra argv appended after the preset's args | `--output-format stream-json --verbose` | `run` | `exec --sandbox workspace-write` | `-p --output-format stream-json --force` |
+| `model_flag` | Flag used to pass the step's model | `--model` | `--model` | `--model` | `--model` |
+| `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* | *(positional)* |
+| `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` | `true` |
+| `turns_flag` | Flag used to pass a max-turns limit | — | — | — | — |
 
 Prompt delivery: via `prompt_flag` when set, as the last positional argument
 when `prompt_positional: true`, otherwise on **stdin**.
@@ -204,6 +222,7 @@ provider receives the merged list in its own native format:
 | claude | temp `.mcp.json` passed with `--mcp-config <path>` (trusted, no approval prompt, no workdir mutation) |
 | cursor | merged into `~/.cursor/mcp.json`, activated with `--approve-mcps` |
 | opencode | merged into the global `opencode.json` `mcp` block |
+| codex | merged into `~/.codex/config.toml` under Apiary-managed `[mcp_servers.*]` tables |
 
 The MCP configs are materialized once at daemon startup, not per run.
 

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -80,6 +80,17 @@ Runs the `opencode` binary as a subprocess.
 - **Setup:** `type: cli`, `provider: opencode` in `runners`
 - **Docs:** [Runners configuration](runners.md#opencode-provider-opencode)
 
+#### Codex CLI
+
+**Status:** ✅ Stable | **Provider:** `codex`
+
+Runs the OpenAI `codex` binary as a subprocess using `codex exec`.
+
+- **Requirements:** `codex` CLI installed and authenticated
+- **Skills:** Codex reads checked-in skills from `.agents/skills`
+- **Setup:** `type: cli`, `provider: codex` in `runners`
+- **Docs:** [Runners configuration](runners.md#codex-provider-codex)
+
 #### Cursor CLI
 
 **Status:** ✅ Stable | **Provider:** `cursor`
@@ -115,15 +126,15 @@ Direct API runner for Claude models via the Anthropic API is in development.
 
 ## Feature support matrix
 
-| Feature | GitHub | Plane | Jira | OpenCode API | Claude CLI | OpenCode CLI | Cursor CLI |
-|---------|--------|-------|------|---|---|---|---|
-| Polling | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| State transitions | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| Blocking relationships | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| Comment rendering | ✅ | ✅ | ✅ | — | N/A | N/A | N/A |
-| CI waits | ✅ | — | — | — | N/A | N/A | N/A |
-| Structured logs | — | — | — | ✅ | ✅ | ✅ | ✅ |
-| Exact cost tracking | — | — | — | ✅ | ✅ | — | — |
+| Feature | GitHub | Plane | Jira | OpenCode API | Claude CLI | OpenCode CLI | Codex CLI | Cursor CLI |
+|---------|--------|-------|------|---|---|---|---|---|
+| Polling | ✅ | ✅ | ✅ | — | N/A | N/A | N/A | N/A |
+| State transitions | ✅ | ✅ | ✅ | — | N/A | N/A | N/A | N/A |
+| Blocking relationships | ✅ | ✅ | ✅ | — | N/A | N/A | N/A | N/A |
+| Comment rendering | ✅ | ✅ | ✅ | — | N/A | N/A | N/A | N/A |
+| CI waits | ✅ | — | — | — | N/A | N/A | N/A | N/A |
+| Structured logs | — | — | — | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Exact cost tracking | — | — | — | ✅ | ✅ | — | — | — |
 
 ---
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -14,7 +14,7 @@
     },
     "runners": {
       "type": "array",
-      "description": "Runner definitions for agent execution. The adapter is resolved as '{provider}-{type}' (or just 'type' when provider is empty); registered adapters: claude-cli, opencode-cli, cursor-cli, opencode-api",
+      "description": "Runner definitions for agent execution. The adapter is resolved as '{provider}-{type}' (or just 'type' when provider is empty); registered adapters: claude-cli, opencode-cli, codex-cli, cursor-cli, opencode-api",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -27,12 +27,12 @@
           "type": {
             "type": "string",
             "description": "Execution engine: 'cli' (subprocess, combined with provider) or a self-contained adapter name like 'opencode-api'",
-            "enum": ["cli", "claude-cli", "opencode-cli", "cursor-cli", "opencode-api"]
+            "enum": ["cli", "claude-cli", "opencode-cli", "codex-cli", "cursor-cli", "opencode-api"]
           },
           "provider": {
             "type": "string",
             "description": "Which CLI the 'cli' engine drives. The adapter is resolved as '{provider}-{type}'; any unregistered combination fails at daemon startup with 'runner type not found'",
-            "enum": ["claude", "opencode", "cursor"]
+            "enum": ["claude", "opencode", "codex", "cursor"]
           },
           "config": {
             "type": "object",
@@ -41,11 +41,11 @@
             "properties": {
               "command": {
                 "type": "string",
-                "description": "Binary to invoke (override to use a wrapper or absolute path). Preset: claude / opencode / agent"
+                "description": "Binary to invoke (override to use a wrapper or absolute path). Preset: claude / opencode / codex / agent"
               },
               "args": {
                 "type": "array",
-                "description": "Extra argv appended after the preset's args on every run. Presets: claude '--output-format stream-json --verbose', opencode 'run', cursor '-p --output-format stream-json --force'",
+                "description": "Extra argv appended after the preset's args on every run. Presets: claude '--output-format stream-json --verbose', opencode 'run', codex 'exec --sandbox workspace-write', cursor '-p --output-format stream-json --force'",
                 "items": {
                   "type": "string"
                 }
@@ -60,7 +60,7 @@
               },
               "prompt_positional": {
                 "type": "boolean",
-                "description": "Pass the prompt as the last positional argument (preset: true for opencode and cursor)"
+                "description": "Pass the prompt as the last positional argument (preset: true for opencode, codex, and cursor)"
               },
               "turns_flag": {
                 "type": "string",
@@ -188,7 +188,7 @@
           },
           "model": {
             "type": "string",
-            "description": "Model name passed to the runner (e.g., 'claude-opus-4-8', 'claude-sonnet-4-6')"
+            "description": "Model name passed to the runner (e.g., 'claude-opus-4-8', 'claude-sonnet-4-6', 'gpt-5.5')"
           },
           "soul_file": {
             "type": "string",

--- a/src/internal/runner/execution/cli_mcp.go
+++ b/src/internal/runner/execution/cli_mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -21,6 +22,8 @@ import (
 //     format), activated with `--approve-mcps`.
 //   - opencode → merged into the global `~/.config/opencode/opencode.json` under
 //     the `mcp` key (local format); opencode auto-discovers it, so no run args.
+//   - codex    → merged into the user's global `~/.codex/config.toml`
+//     `[mcp_servers.*]` tables; codex auto-discovers it, so no run args.
 //
 // Called once from Configure (load time, sequential across agents) so the
 // global-config merges are race-free. Returns nil args when there are no servers
@@ -36,6 +39,8 @@ func (r *CliRunner) setupMCP() ([]string, error) {
 		return r.setupCursorMCP()
 	case "opencode":
 		return r.setupOpencodeMCP()
+	case "codex":
+		return r.setupCodexMCP()
 	default:
 		return nil, nil
 	}
@@ -114,6 +119,38 @@ func (r *CliRunner) setupOpencodeMCP() ([]string, error) {
 	return nil, nil
 }
 
+// setupCodexMCP merges the servers into ~/.codex/config.toml. Codex reads
+// [mcp_servers.<name>] tables from that file for CLI and IDE runs.
+func (r *CliRunner) setupCodexMCP() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("home dir: %w", err)
+	}
+	path := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, fmt.Errorf("create codex config dir: %w", err)
+	}
+
+	existing := ""
+	if data, err := os.ReadFile(path); err == nil {
+		existing = string(data)
+	}
+	updated := stripCodexManagedMCPBlock(existing)
+	block := codexManagedMCPBlock(r.mcps)
+	if strings.TrimSpace(updated) != "" {
+		updated = strings.TrimRight(updated, "\n") + "\n\n" + block
+	} else {
+		updated = block
+	}
+	if updated != "" && !strings.HasSuffix(updated, "\n") {
+		updated += "\n"
+	}
+	if err := os.WriteFile(path, []byte(updated), 0644); err != nil {
+		return nil, fmt.Errorf("write codex config: %w", err)
+	}
+	return nil, nil
+}
+
 // mcpServersObject builds the `mcpServers` map shared by the claude and cursor
 // formats: {name: {command, args?, env?}}.
 func mcpServersObject(mcps []model.MCPServer) map[string]any {
@@ -155,4 +192,71 @@ func mergeMCPServersFile(path string, mcps []model.MCPServer) error {
 		return err
 	}
 	return os.WriteFile(path, raw, 0644)
+}
+
+const (
+	codexManagedMCPStart = "# apiary:codex-mcp:start"
+	codexManagedMCPEnd   = "# apiary:codex-mcp:end"
+)
+
+func stripCodexManagedMCPBlock(s string) string {
+	start := strings.Index(s, codexManagedMCPStart)
+	if start < 0 {
+		return s
+	}
+	end := strings.Index(s[start:], codexManagedMCPEnd)
+	if end < 0 {
+		return s
+	}
+	end += start + len(codexManagedMCPEnd)
+	return strings.TrimRight(s[:start], "\n") + "\n" + strings.TrimLeft(s[end:], "\n")
+}
+
+func codexManagedMCPBlock(mcps []model.MCPServer) string {
+	var b strings.Builder
+	b.WriteString(codexManagedMCPStart)
+	b.WriteString("\n")
+	for i, m := range mcps {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "[mcp_servers.%s]\n", tomlBareKey(m.Name))
+		fmt.Fprintf(&b, "command = %q\n", m.Command)
+		if len(m.Args) > 0 {
+			b.WriteString("args = [")
+			for j, a := range m.Args {
+				if j > 0 {
+					b.WriteString(", ")
+				}
+				fmt.Fprintf(&b, "%q", a)
+			}
+			b.WriteString("]\n")
+		}
+		if len(m.Env) > 0 {
+			fmt.Fprintf(&b, "[mcp_servers.%s.env]\n", tomlBareKey(m.Name))
+			for k, v := range m.Env {
+				fmt.Fprintf(&b, "%s = %q\n", tomlBareKey(k), v)
+			}
+		}
+	}
+	b.WriteString(codexManagedMCPEnd)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func tomlBareKey(s string) string {
+	if s != "" {
+		ok := true
+		for _, r := range s {
+			if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' && r != '-' {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return s
+		}
+	}
+	raw, _ := json.Marshal(s)
+	return string(raw)
 }

--- a/src/internal/runner/execution/cli_mcp_test.go
+++ b/src/internal/runner/execution/cli_mcp_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -136,6 +137,51 @@ func TestSetupMCP_OpencodeMergesLocalFormat(t *testing.T) {
 	}
 	if gn.Env["GITNEXUS_REPO"] != "project-erp" {
 		t.Errorf("environment not mapped: %+v", gn.Env)
+	}
+}
+
+func TestSetupMCP_CodexMergesManagedConfigBlock(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	seed := "model = \"gpt-5.5\"\n\n# apiary:codex-mcp:start\n[mcp_servers.old]\ncommand = \"old\"\n# apiary:codex-mcp:end\n\nsandbox_mode = \"workspace-write\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &CliRunner{mcpFormat: "codex", mcps: []model.MCPServer{gitnexusMCP}}
+	args, err := r.setupMCP()
+	if err != nil {
+		t.Fatalf("setupMCP: %v", err)
+	}
+	if len(args) != 0 {
+		t.Fatalf("codex auto-discovers config; expected no run args, got %v", args)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read codex config: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`model = "gpt-5.5"`,
+		`sandbox_mode = "workspace-write"`,
+		`[mcp_servers.gitnexus]`,
+		`command = "npx"`,
+		`args = ["-y", "gitnexus@latest", "mcp"]`,
+		`[mcp_servers.gitnexus.env]`,
+		`GITNEXUS_REPO = "project-erp"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("codex config missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "[mcp_servers.old]") {
+		t.Errorf("old managed MCP block was not replaced:\n%s", text)
 	}
 }
 

--- a/src/internal/runner/providers/providers.go
+++ b/src/internal/runner/providers/providers.go
@@ -41,6 +41,16 @@ func init() {
 		"mcp_format":        "opencode",
 	}))
 
+	// Codex CLI — requires the `codex` binary from OpenAI's Codex CLI.
+	// Runs non-interactively with workspace-write sandboxing so implementation
+	// agents can edit the checked-out task workspace.
+	runner.Register("codex-cli", cliFactory("codex", map[string]any{
+		"args":              []any{"exec", "--sandbox", "workspace-write"},
+		"prompt_flag":       "",
+		"prompt_positional": true,
+		"mcp_format":        "codex",
+	}))
+
 	// Cursor agent CLI — requires the `agent` binary from https://cursor.com/install.
 	// Runs headlessly with stream-json output; --force auto-approves file changes.
 	runner.Register("cursor-cli", cliFactory("agent", map[string]any{

--- a/src/internal/runner/providers/providers_test.go
+++ b/src/internal/runner/providers/providers_test.go
@@ -83,3 +83,10 @@ func TestOpencodeCliPresetKeepsRunSubcommand(t *testing.T) {
 		t.Errorf("opencode-cli preset must start argv with `run`: %q", out)
 	}
 }
+
+func TestCodexCliPresetUsesExecWithWorkspaceWrite(t *testing.T) {
+	out := echoRun(t, "codex-cli", nil)
+	if !strings.HasPrefix(out, "exec --sandbox workspace-write ") {
+		t.Errorf("codex-cli preset must start argv with `exec --sandbox workspace-write`: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Codex CLI provider preset that runs `codex exec --sandbox workspace-write`
- wire Apiary MCP definitions into Codex `~/.codex/config.toml` managed blocks
- expose existing Claude skills to Codex through `.agents/skills` and document the runner

## Test plan
- `go test ./internal/runner/providers ./internal/runner/execution ./internal/config`
- `go test ./...`
- `/tmp/apiary-codex-runner-validate validate --config .apiary/apiary.yaml`

Closes #191