### PR TITLE
Switch runtime config to Codex

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -2,22 +2,6 @@ version: "1"
 
 # ── Runners ────────────────────────────────────────────────────────────────────
 runners:
-  - id: claude
-    type: cli
-    provider: claude
-    config:
-      args: ["--output-format", "stream-json", "--verbose"]
-    models:
-      - claude-opus-4-8
-      - claude-sonnet-4-6
-      - claude-haiku-4-5
-    # GitNexus code-intelligence MCP — exposed to every agent on this runner.
-    # `mcp` serves all repos already indexed via `gitnexus analyze`.
-    mcps:
-      - name: gitnexus
-        command: npx
-        args: ["-y", "gitnexus@latest", "mcp"]
-
   - id: codex
     type: cli
     provider: codex
@@ -31,7 +15,7 @@ runners:
         command: npx
         args: ["-y", "gitnexus@latest", "mcp"]
 
-default_runner: claude
+default_runner: codex
 
 # ── Sources ────────────────────────────────────────────────────────────────────
 sources:
@@ -52,49 +36,49 @@ agents:
   - id: investigator
     description: "Analyzes and classifies new issues by complexity"
     soul_file: .apiary/souls/investigator.md
-    model: claude-opus-4-8
+    model: gpt-5.5
     max_workers: 2
 
   - id: po
     description: "Transforms business demands into specifications"
     soul_file: .apiary/souls/po.md
-    model: claude-opus-4-8
+    model: gpt-5.5
     max_workers: 2
 
   - id: staff
     description: "Designs complex solutions and decomposes tasks"
     soul_file: .apiary/souls/staff.md
-    model: claude-opus-4-8
+    model: gpt-5.5
     max_workers: 2
 
   - id: engineer
     description: "Implements tasks following project conventions"
     soul_file: .apiary/souls/engineer.md
-    model: claude-sonnet-4-6
+    model: gpt-5.5
     max_workers: 2
 
   - id: backend
     description: "Implements backend tasks"
     soul_file: .apiary/souls/backend.md
-    model: claude-sonnet-4-6
+    model: gpt-5.5
     max_workers: 2
 
   - id: frontend
     description: "Implements frontend tasks"
     soul_file: .apiary/souls/frontend.md
-    model: claude-sonnet-4-6
+    model: gpt-5.5
     max_workers: 2
 
   - id: reviewer
     description: "Performs code review and quality checks"
     soul_file: .apiary/souls/reviewer.md
-    model: claude-sonnet-4-6
+    model: gpt-5.5
     max_workers: 2
 
   - id: qa
     description: "Validates implementation against acceptance criteria"
     soul_file: .apiary/souls/qa.md
-    model: claude-sonnet-4-6
+    model: gpt-5.5
     max_workers: 2
 
 # ── Workflows ──────────────────────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8314 symbols, 18979 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8345 symbols, 19060 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8314 symbols, 18979 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8345 symbols, 19060 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
## Summary
- remove the Claude runner from the checked-in Apiary runtime config
- make the Codex CLI runner the default runner
- switch all agent models to `gpt-5.5`
- refresh GitNexus context stats

## Test plan
- `apiary validate --config .apiary/apiary.yaml`
- `gitnexus analyze`

Closes #193