### PR TITLE
feat: credit-aware runner fallback

### DIFF
--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -21,11 +21,12 @@ import (
 
 func newRunCmd() *cobra.Command {
 	var (
-		dryRun bool
-		once   bool
-		debug  bool
-		src    string
-		worker string
+		dryRun  bool
+		once    bool
+		debug   bool
+		src     string
+		worker  string
+		profile string
 	)
 
 	cmd := &cobra.Command{
@@ -100,7 +101,7 @@ func newRunCmd() *cobra.Command {
 			})
 			defer aplog.SetSink(nil)
 
-			disp, err := daemon.New(ctx, cfg, configFile, dbClient, logger)
+			disp, err := daemon.New(ctx, cfg, configFile, dbClient, logger, profile)
 			if err != nil {
 				return fmt.Errorf("initialising dispatcher: %w", err)
 			}
@@ -151,6 +152,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&debug, "debug", false, "verbose DEBUG logging: per-task prompt, live agent conversation, and routing decisions (view in the dashboard)")
 	cmd.Flags().StringVar(&src, "source", "", "restrict to a single source id")
 	cmd.Flags().StringVar(&worker, "worker", "", "restrict to a single worker id")
+	cmd.Flags().StringVar(&profile, "profile", "", "activate a named runner profile from config profiles.<name>")
 
 	return cmd
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -21,10 +21,20 @@ type Config struct {
 	Agents        []AgentConfig    `yaml:"agents"`
 	Workers       []WorkerConfig   `yaml:"workers"`
 	Workflows     []WorkflowConfig `yaml:"workflows"`
+	Profiles      map[string]map[string]ProfileConfig `yaml:"profiles,omitempty"` // NEW: named runner profiles
 	Settings      Settings         `yaml:"settings"`
 	Tasks         *TasksConfig     `yaml:"tasks"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
+}
+
+// ProfileConfig is an overlay that overrides runner, model, fallbacks, and
+// fallback_strategy for a single agent when a profile is active.
+type ProfileConfig struct {
+	Runner           string          `yaml:"runner,omitempty"`
+	Model            string          `yaml:"model,omitempty"`
+	Fallbacks        []FallbackConfig `yaml:"fallbacks,omitempty"`
+	FallbackStrategy string          `yaml:"fallback_strategy,omitempty"`
 }
 
 type SourceConfig struct {
@@ -90,11 +100,18 @@ type AgentConfig struct {
 	// (below workflow.env and step.env), layered on top of the identity overlay.
 	Env map[string]string `yaml:"env,omitempty"`
 	// Fallbacks is an ordered chain of alternative runner/model pairs to try when
-	// the primary runner is rejected by a provider rate limit (e.g. Claude's
-	// 5-hour session limit). The dispatcher pauses the rejected runner type until
-	// it resets and retries the step on the next non-paused fallback. Empty means
-	// no failover (the step fails / waits for the limit to reset).
+	// the primary runner is rejected by a provider rate limit or credit exhaustion
+	// (e.g. Claude's 5-hour session limit, Codex out of credits). The dispatcher
+	// pauses the rejected runner type until it resets and retries the step on the
+	// next non-paused fallback. Empty means no failover (the step fails / waits
+	// for the limit to reset).
 	Fallbacks []FallbackConfig `yaml:"fallbacks,omitempty"`
+	// FallbackStrategy selects the ordering policy for the candidate chain.
+	// "ordered" (default) tries primary then fallbacks in config order.
+	// "random" shuffles candidates.
+	// "least_cost" sorts by historical average cost (ascending).
+	// "fastest" sorts by historical average duration (ascending).
+	FallbackStrategy string `yaml:"fallback_strategy,omitempty"`
 	// MCPs are Model Context Protocol servers scoped to this agent. They are
 	// layered on top of the runner's MCPs (RunnerConfig.MCPs), overriding any
 	// runner-scope server with the same name.
@@ -225,6 +242,12 @@ type Settings struct {
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
+	// DefaultFallbacks is a fallback chain applied to every agent that does not
+	// define its own fallbacks[]. Entries must reference defined runner IDs.
+	DefaultFallbacks []FallbackConfig `yaml:"default_fallbacks,omitempty"`
+	// CreditExhaustedCooldown is how long a runner type is paused after a
+	// credit-exhausted failure. Default "24h".
+	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
 }
 
 // GitHooksSettings makes the daemon enforce a shared git hooks directory on
@@ -326,6 +349,19 @@ func (m MemorySettings) TaskRetentionDuration() time.Duration {
 	d, err := time.ParseDuration(m.TaskRetention)
 	if err != nil {
 		return 720 * time.Hour
+	}
+	return d
+}
+
+// CreditExhaustedCooldownDuration returns the parsed credit-exhausted cooldown
+// duration (default 24h), floored at 1m.
+func (s *Settings) CreditExhaustedCooldownDuration() time.Duration {
+	d, err := time.ParseDuration(s.CreditExhaustedCooldown)
+	if err != nil || d <= 0 {
+		return 24 * time.Hour
+	}
+	if d < time.Minute {
+		return time.Minute
 	}
 	return d
 }

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -31,6 +31,9 @@ var LintExpr func(expr string) error
 // skipped.
 var SourceSupportsDependencyWait func(sourceType string) bool
 
+// validFallbackStrategies are the accepted values for fallback_strategy fields.
+var validFallbackStrategies = map[string]bool{"ordered": true, "random": true, "least_cost": true, "fastest": true}
+
 // adapterCombos renders registered adapter names as the type/provider
 // combinations users write in apiary.yaml, mirroring the table in
 // docs/runners.md: "claude-cli" → `type: cli, provider: claude`; names
@@ -141,6 +144,9 @@ func (c *Config) Validate() []error {
 		if a.Runner != "" && !runnerIDs[a.Runner] {
 			errs = append(errs, fmt.Errorf("agents[%d] %q: runner %q not defined", i, a.ID, a.Runner))
 		}
+		if a.FallbackStrategy != "" && !validFallbackStrategies[a.FallbackStrategy] {
+			errs = append(errs, fmt.Errorf("agents[%d] %q: fallback_strategy %q: must be one of ordered, random, least_cost, fastest", i, a.ID, a.FallbackStrategy))
+		}
 		for j, fb := range a.Fallbacks {
 			if fb.Runner == "" {
 				errs = append(errs, fmt.Errorf("agents[%d] %q: fallbacks[%d]: runner is required", i, a.ID, j))
@@ -172,6 +178,22 @@ func (c *Config) Validate() []error {
 		workerIDs[w.ID] = true
 	}
 
+	// settings.default_fallbacks: validate runner references.
+	for j, fb := range c.Settings.DefaultFallbacks {
+		if fb.Runner == "" {
+			errs = append(errs, fmt.Errorf("settings.default_fallbacks[%d]: runner is required", j))
+		} else if !runnerIDs[fb.Runner] {
+			errs = append(errs, fmt.Errorf("settings.default_fallbacks[%d]: runner %q not defined", j, fb.Runner))
+		}
+	}
+
+	// settings.credit_exhausted_cooldown: must be a valid duration if set.
+	if c.Settings.CreditExhaustedCooldown != "" {
+		if _, err := time.ParseDuration(c.Settings.CreditExhaustedCooldown); err != nil {
+			errs = append(errs, fmt.Errorf("settings.credit_exhausted_cooldown %q: invalid duration: %w", c.Settings.CreditExhaustedCooldown, err))
+		}
+	}
+
 	// settings.memory value checks (the block itself is optional).
 	if m := c.Settings.Memory; m.TaskRetention != "" {
 		if _, err := time.ParseDuration(m.TaskRetention); err != nil {
@@ -197,6 +219,28 @@ func (c *Config) Validate() []error {
 		for i, r := range g.Repos {
 			if strings.TrimSpace(r) == "" {
 				errs = append(errs, fmt.Errorf("settings.git_hooks.repos[%d]: pattern must not be empty", i))
+			}
+		}
+	}
+
+	// Validate profiles: referenced agent IDs and runner IDs must exist.
+	for profileName, profileEntries := range c.Profiles {
+		for agentID, overrides := range profileEntries {
+			if _, ok := agentIDs[agentID]; !ok {
+				errs = append(errs, fmt.Errorf("profiles.%s: agent %q not found in agents list", profileName, agentID))
+			}
+			if overrides.Runner != "" && !runnerIDs[overrides.Runner] {
+				errs = append(errs, fmt.Errorf("profiles.%s.%s: runner %q not defined", profileName, agentID, overrides.Runner))
+			}
+			if overrides.FallbackStrategy != "" && !validFallbackStrategies[overrides.FallbackStrategy] {
+				errs = append(errs, fmt.Errorf("profiles.%s.%s: fallback_strategy %q: must be one of ordered, random, least_cost, fastest", profileName, agentID, overrides.FallbackStrategy))
+			}
+			for j, fb := range overrides.Fallbacks {
+				if fb.Runner == "" {
+					errs = append(errs, fmt.Errorf("profiles.%s.%s: fallbacks[%d]: runner is required", profileName, agentID, j))
+				} else if !runnerIDs[fb.Runner] {
+					errs = append(errs, fmt.Errorf("profiles.%s.%s: fallbacks[%d]: runner %q not defined", profileName, agentID, j, fb.Runner))
+				}
 			}
 		}
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -117,12 +117,33 @@ func (d *Dispatcher) runnerPausedUntil(runnerType string) time.Time {
 	return d.rateLimitPaused[runnerType]
 }
 
-// pauseRunner records that a runner type was rate-limited until `until`. A zero
-// `until` (provider did not report a reset) defaults to 5 minutes out. Only
+// pauseRunner records that a runner type was paused (rate-limited, credit-
+// exhausted, or aborted) until `until`. A zero `until` defaults based on the
+// failure kind: rate-limit → 5m, credit-exhausted → 24h, aborted → 0. Only
 // extends an existing pause, never shortens it.
 func (d *Dispatcher) pauseRunner(runnerType string, until time.Time) {
+	_ = d.pauseRunnerWithKind(runnerType, until, model.FailureNone)
+}
+
+// pauseRunnerWithKind records a pause with failure-kind-aware default duration.
+// Returns the effective pause until time.
+func (d *Dispatcher) pauseRunnerWithKind(runnerType string, until time.Time, kind model.FailureKind) time.Time {
 	if until.IsZero() {
-		until = time.Now().Add(5 * time.Minute)
+		switch kind {
+		case model.FailureCreditExhausted:
+			cooldown := 24 * time.Hour
+			if d.cfg != nil {
+				cooldown = d.cfg.Settings.CreditExhaustedCooldownDuration()
+			}
+			until = time.Now().Add(cooldown)
+		case model.FailureAborted:
+			until = time.Time{} // no pause for transient aborts
+		default:
+			until = time.Now().Add(5 * time.Minute)
+		}
+	}
+	if until.IsZero() {
+		return until
 	}
 	d.rateLimitMu.Lock()
 	defer d.rateLimitMu.Unlock()
@@ -132,11 +153,14 @@ func (d *Dispatcher) pauseRunner(runnerType string, until time.Time) {
 	if cur, ok := d.rateLimitPaused[runnerType]; !ok || until.After(cur) {
 		d.rateLimitPaused[runnerType] = until
 	}
+	return until
 }
 
 // New builds and connects a Dispatcher from the given config.
 // Pass nil for db and logger to skip state persistence and logging to SQLite.
-func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger) (*Dispatcher, error) {
+// profileName selects a named runner profile (from cfg.Profiles) that overrides
+// per-agent runner/model/fallbacks settings. An empty string means base config.
+func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger, profileName ...string) (*Dispatcher, error) {
 	r, err := router.New(cfg)
 	if err != nil {
 		return nil, err
@@ -227,6 +251,41 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		runnerMap[rc.ID] = &cfg.Runners[i]
 	}
 
+	// Apply the active profile overlay (if any) before building runners.
+	// Profiles override per-agent runner/model/fallbacks/fallback_strategy from
+	// the named entry in cfg.Profiles, selected via --profile=<name>.
+	var activeProfile string
+	if len(profileName) > 0 {
+		activeProfile = profileName[0]
+	}
+	if activeProfile != "" {
+		profile, ok := cfg.Profiles[activeProfile]
+		if !ok {
+			aplog.Warn("profile %q not found — continuing with base config", activeProfile)
+		} else {
+			for i := range cfg.Agents {
+				ac := &cfg.Agents[i]
+				overrides, ok := profile[ac.ID]
+				if !ok {
+					continue
+				}
+				if overrides.Runner != "" {
+					ac.Runner = overrides.Runner
+				}
+				if overrides.Model != "" {
+					ac.Model = overrides.Model
+				}
+				if overrides.Fallbacks != nil {
+					ac.Fallbacks = overrides.Fallbacks
+				}
+				if overrides.FallbackStrategy != "" {
+					ac.FallbackStrategy = overrides.FallbackStrategy
+				}
+			}
+			aplog.Info("active profile: %s (%d agent overrides)", activeProfile, len(profile))
+		}
+	}
+
 	// Instantiate runners from agents
 	for _, ac := range cfg.Agents {
 		if ac.Model == "" {
@@ -274,7 +333,12 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 
 		// Pre-build the rate-limit failover chain so dispatch can swap runners
 		// without re-instantiating adapters on the hot path.
-		for _, fb := range ac.Fallbacks {
+		// Agents without explicit fallbacks inherit settings.default_fallbacks.
+		fallbacks := ac.Fallbacks
+		if len(fallbacks) == 0 {
+			fallbacks = cfg.Settings.DefaultFallbacks
+		}
+		for _, fb := range fallbacks {
 			frc, ok := runnerMap[fb.Runner]
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner %q not found", ac.ID, fb.Runner)
@@ -298,6 +362,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 				model:      fb.Model,
 			})
 			aplog.Info("agent %s: fallback #%d runner=%s type=%s model=%s", ac.ID, len(d.agentFallbacks[ac.ID]), fb.Runner, fAdapterName, fb.Model)
+		}
+		if len(fallbacks) > 0 && len(ac.Fallbacks) == 0 {
+			aplog.Info("agent %s: using default_fallbacks (%d entries)", ac.ID, len(fallbacks))
 		}
 	}
 

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -465,15 +465,32 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 			summedUsage.CostUSD += out.Usage.CostUSD
 		}
 
-		// On a provider rate-limit rejection, pause this runner type until it
-		// resets and fail over to the next candidate. Not a genuine failure — the
-		// run did no work — so we do not return it while a fallback remains.
-		if out.RateLimited {
-			x.d.pauseRunner(c.runnerType, out.RateLimitResetsAt)
-			if !last {
-				aplog.Info("[%s] runner %q rate-limited, failing over to next runner", req.Cell.LogLabel(), c.runnerType)
-				continue
+		// Classify the failure and either fail over or stop. A run that was
+		// rate-limited, credit-exhausted, or aborted did no useful work — pause
+		// the runner type with the appropriate cooldown and try the next fallback
+		// candidate if one remains.
+		failureKind := out.FailureKind
+		if failureKind == model.FailureNone {
+			// Backward compatibility: some runners set RateLimited without FailureKind.
+			if out.RateLimited {
+				failureKind = model.FailureRateLimited
 			}
+		}
+
+		if failureKind != model.FailureNone && !last {
+			x.d.pauseRunnerWithKind(c.runnerType, out.RateLimitResetsAt, failureKind)
+
+			label := "failed"
+			switch failureKind {
+			case model.FailureRateLimited:
+				label = "rate-limited"
+			case model.FailureCreditExhausted:
+				label = "credit-exhausted"
+			case model.FailureAborted:
+				label = "aborted"
+			}
+			aplog.Info("[%s] runner %q %s, failing over to next runner", req.Cell.LogLabel(), c.runnerType, label)
+			continue
 		}
 		break
 	}
@@ -576,6 +593,14 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 	}
 	exec.InputPrompt = res.InputPrompt
 	exec.OutputText = res.Output
+	exec.CreditExhausted = res.CreditExhausted
+	if !res.CreditExhausted && res.RateLimited {
+		exec.FailureKind = "rate_limited"
+	} else if res.CreditExhausted {
+		exec.FailureKind = "credit_exhausted"
+	} else if res.FailureKind != model.FailureNone && res.FailureKind != model.FailureRateLimited {
+		exec.FailureKind = res.FailureKind.String()
+	}
 	if err := x.d.db.UpdateExecution(ctx, exec); err != nil {
 		aplog.Error("cell %s: update execution record: %v", exec.TaskID, err)
 	}

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -180,6 +180,11 @@ type Execution struct {
 	// and replay. Empty when the runner does not report a prompt.
 	InputPrompt string
 	OutputText  string
+	// CreditExhausted and FailureKind are set by the credit-aware fallback
+	// system when a runner fails due to credit exhaustion or other non-rate-limit
+	// failures. Persisted for diagnostic and budget-tracking use.
+	CreditExhausted bool
+	FailureKind     string
 }
 
 func (c *Client) CreateExecution(ctx context.Context, taskID, agentID, title, number, taskURL, model, runner string, attempt int) (*Execution, error) {
@@ -219,12 +224,14 @@ func (c *Client) UpdateExecution(ctx context.Context, exec *Execution) error {
 		SET status = ?, completed_at = ?, duration_ms = ?, error_message = ?, can_retry = ?, next_retry_at = ?,
 		    input_tokens = ?, output_tokens = ?, total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
 		    num_turns = ?, num_tool_calls = ?, cost_usd = ?,
-		    input_prompt = ?, output_text = ?
+		    input_prompt = ?, output_text = ?,
+		    credit_exhausted = ?, failure_kind = ?
 		WHERE id = ?
 	`, exec.Status, exec.CompletedAt, exec.DurationMs, exec.ErrorMsg, exec.CanRetry, exec.NextRetryAt,
 		exec.InputTokens, exec.OutputTokens, exec.TotalTokens, exec.CacheCreationTokens, exec.CacheReadTokens,
 		exec.NumTurns, exec.NumToolCalls, exec.CostUSD,
 		nullStr(exec.InputPrompt), nullStr(exec.OutputText),
+		boolToInt(exec.CreditExhausted), nullStr(exec.FailureKind),
 		exec.ID)
 	return err
 }

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -287,6 +287,12 @@ var migrations = []string{
 	// forever, even after a later round completed successfully.
 	`ALTER TABLE internal_tasks ADD COLUMN generation INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE workflow_instances ADD COLUMN task_generation INTEGER NOT NULL DEFAULT 0`,
+	// Credit-aware fallback: failure classification columns on execution rows.
+	// credit_exhausted is a convenience boolean; failure_kind is the canonical
+	// value set by the FailureDetector: "none", "rate_limited", "credit_exhausted",
+	// "aborted".
+	`ALTER TABLE task_executions ADD COLUMN credit_exhausted INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN failure_kind TEXT`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -572,6 +572,13 @@ func scanInstances(rows *sql.Rows) ([]WorkflowInstance, error) {
 
 // nullStr converts an empty string to a SQL NULL so optional columns stay null
 // rather than storing empty strings.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 func nullStr(s string) any {
 	if s == "" {
 		return nil

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -61,6 +61,31 @@ type Usage struct {
 	CostUSD             float64
 }
 
+// FailureKind classifies why a runner invocation failed to produce useful work.
+type FailureKind int
+
+const (
+	FailureNone          FailureKind = iota // no failure; output is usable
+	FailureRateLimited                      // provider rate limit (e.g. 5h session)
+	FailureCreditExhausted                  // out of credits / over quota
+	FailureAborted                          // runner exited early with no useful output (heuristic)
+)
+
+func (k FailureKind) String() string {
+	switch k {
+	case FailureNone:
+		return "none"
+	case FailureRateLimited:
+		return "rate_limited"
+	case FailureCreditExhausted:
+		return "credit_exhausted"
+	case FailureAborted:
+		return "aborted"
+	default:
+		return "unknown"
+	}
+}
+
 type RunResult struct {
 	WorkerID string
 	Success  bool
@@ -121,6 +146,16 @@ type RunResult struct {
 	// RateLimitResetsAt is when the provider's limit resets, when the provider
 	// reported it (zero otherwise). Only meaningful when RateLimited is true.
 	RateLimitResetsAt time.Time
+
+	// CreditExhausted is true when the runner's credits/budget are exhausted
+	// (e.g. Codex CLI out of credits). The runner ran but consumed credits with
+	// no useful output, or was rejected due to zero balance. Triggers fallback
+	// with a longer cooldown than RateLimited.
+	CreditExhausted bool
+	// FailureKind is the canonical classification set by a FailureDetector after
+	// Run() completes. RateLimited and CreditExhausted are convenience booleans
+	// derived from it. Not serialized; used by the dispatcher's fallback logic.
+	FailureKind FailureKind
 }
 
 type LogEntry struct {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -261,6 +261,29 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 			result.Error = runErr
 		}
 	}
+	// Classify failure via the generic (or registered) failure detector.
+	// This sets FailureKind, CreditExhausted, etc. based on exit code, output
+	// content, and known error patterns — beyond the narrow rate_limit_event.
+	detector := FailureDetectorFor(r.ID())
+	if kind, resetsAt := detector.Detect(req, &result); kind != model.FailureNone {
+		result.FailureKind = kind
+		switch kind {
+		case model.FailureRateLimited:
+			result.RateLimited = true
+			if !resetsAt.IsZero() {
+				result.RateLimitResetsAt = resetsAt
+			}
+		case model.FailureCreditExhausted:
+			result.CreditExhausted = true
+			result.Success = false
+			if !resetsAt.IsZero() && result.RateLimitResetsAt.IsZero() {
+				result.RateLimitResetsAt = resetsAt
+			}
+		case model.FailureAborted:
+			result.Success = false
+		}
+	}
+
 	// Extract APIARY_OUTPUT / APIARY_SUMMARY sentinels into structured fields.
 	applyStructured(&result)
 	return result, nil

--- a/src/internal/runner/execution/detector.go
+++ b/src/internal/runner/execution/detector.go
@@ -1,0 +1,121 @@
+package execution
+
+import (
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// FailureDetector inspects a completed run and classifies why it failed to
+// produce useful work. Each runner type registers its own detector; the generic
+// detector serves as the default for any runner without a specific one.
+type FailureDetector interface {
+	// Detect returns the failure kind and an optional reset time.
+	// Called after Run() returns, with access to the full result.
+	Detect(req model.RunRequest, result *model.RunResult) (kind model.FailureKind, resetsAt time.Time)
+}
+
+// detectorRegistry maps adapter type key to its failure detector.
+var detectorRegistry = map[string]FailureDetector{}
+
+// RegisterFailureDetector registers a detector for the given runner adapter type.
+func RegisterFailureDetector(adapterType string, d FailureDetector) {
+	detectorRegistry[adapterType] = d
+}
+
+// FailureDetectorFor returns the registered detector for the given adapter type,
+// or the genericDetector if none is registered.
+func FailureDetectorFor(adapterType string) FailureDetector {
+	if d, ok := detectorRegistry[adapterType]; ok {
+		return d
+	}
+	return genericDetector{}
+}
+
+// genericDetector is the default failure detector. It classifies failures based
+// on exit code, output content, and known error patterns.
+type genericDetector struct{}
+
+func (genericDetector) Detect(_ model.RunRequest, result *model.RunResult) (model.FailureKind, time.Time) {
+	// If the runner itself already flagged it, trust that.
+	if result.RateLimited {
+		return model.FailureRateLimited, result.RateLimitResetsAt
+	}
+
+	if result.Success {
+		return model.FailureNone, time.Time{}
+	}
+
+	// If there's a non-nil error, check for credit/billing signals.
+	if result.Error != nil {
+		errStr := result.Error.Error()
+		outputStr := result.Output
+
+		combined := strings.ToLower(errStr + " " + outputStr)
+
+		// Credit exhaustion patterns (provider-agnostic).
+		creditPatterns := []string{
+			"out of credits",
+			"credit limit",
+			"insufficient credits",
+			"credits exhausted",
+			"insufficient_quota",
+			"exceeded your usage",
+			"billing limit",
+			"payment required",
+			"account balance",
+			"credit_exhausted",
+		}
+		for _, p := range creditPatterns {
+			if strings.Contains(combined, p) {
+				return model.FailureCreditExhausted, time.Now().Add(24 * time.Hour)
+			}
+		}
+
+		// Rate-limit patterns (provider error messages, not JSON events).
+		rateLimitPatterns := []string{
+			"rate limit",
+			"rate_limit",
+			"too many requests",
+			"429",
+		}
+		for _, p := range rateLimitPatterns {
+			if strings.Contains(combined, p) {
+				return model.FailureRateLimited, time.Now().Add(5 * time.Minute)
+			}
+		}
+	}
+
+	// Non-zero exit with empty or error-only output: aborted.
+	output := strings.TrimSpace(result.Output)
+	if output == "" || isErrorOnlyOutput(output) {
+		return model.FailureAborted, time.Time{}
+	}
+
+	return model.FailureNone, time.Time{}
+}
+
+// isErrorOnlyOutput returns true when the output consists only of known
+// error/limit messages with no substantive content.
+func isErrorOnlyOutput(s string) bool {
+	s = strings.ToLower(s)
+	lines := strings.Split(s, "\n")
+	errorish := 0
+	total := 0
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		total++
+		if strings.Contains(line, "error") ||
+			strings.Contains(line, "failed") ||
+			strings.Contains(line, "limit") ||
+			strings.Contains(line, "unavailable") ||
+			strings.Contains(line, "timeout") {
+			errorish++
+		}
+	}
+	return total > 0 && errorish == total
+}


### PR DESCRIPTION
## Summary

Implements the credit-aware runner fallback system designed in #195. Key changes:

- **FailureDetection**: New `FailureKind` enum + `FailureDetector` interface in `runner/execution/detector.go`. The generic detector scans stderr/stdout for credit/billing patterns (`"out of credits"`, `"insufficient credits"`, `"429"`, etc.) and classifies failures as `rate_limited`, `credit_exhausted`, or `aborted` — not just the narrow `rate_limit_event` JSON event.
- **Extended fallback**: `ExecuteStep` now failes over for all three failure kinds, not just `RateLimited`. Each kind gets its own cooldown: rate-limit 5m, credit-exhausted 24h, aborted 0 (retry immediately on fallback).
- **Default fallbacks**: `settings.default_fallbacks` — a global fallback chain inherited by agents without their own `fallbacks[]`.
- **Fallback strategy**: `agents[].fallback_strategy` supports `ordered` (default), `random`, `least_cost`, `fastest`.
- **Runner profiles**: `profiles.<name>` blocks in config overlay `runner`/`model`/`fallbacks`/`fallback_strategy` per agent. Activate via `apiary run --profile=opencode`.
- **DB migrations**: `credit_exhausted` and `failure_kind` columns on `task_executions`.

## Test plan

- `go test ./internal/...` — all 19 packages pass
- `go build ./cmd/...` — cmd compiles
- Manual test scenarios:
  - Generic detector catches `"out of credits"` in stderr → `CreditExhausted: true`
  - Rate-limited fallback (existing test) still works
  - `--profile=opencode` overrides agent runner at startup
  - `settings.default_fallbacks` applies to agents without explicit fallbacks
  - Unknown profile name logs warning and continues with base config