### PR TITLE
fix(daemon): repair outstanding_workflows leak on restart (tasks stuck 'running')

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -423,6 +423,19 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		} else if n > 0 {
 			aplog.Info("reconciled %d orphaned step run(s) from a previous run", n)
 		}
+
+		// Repair each non-terminal task's outstanding-workflow counter and settle
+		// tasks stranded 'running' with no live instance. The instances just
+		// interrupted above never decremented their task's counter, so without
+		// this every mid-flight restart leaks +1 and the task can never reach
+		// zero — it stays 'running' forever even after a later re-dispatch
+		// completes (issue #198). Must run after the two reconciles above and
+		// before the rehydration passes below.
+		if recounted, settled, err := d.db.ReconcileOrphanTaskCounters(ctx); err != nil {
+			aplog.Warn("reconcile orphan task counters: %v", err)
+		} else if recounted > 0 || settled > 0 {
+			aplog.Info("reconciled outstanding counter on %d task(s), settled %d stranded task(s)", recounted, settled)
+		}
 	}
 
 	// Reconstruct workflow instances parked at an approval step into the engine's

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -413,6 +413,75 @@ func (c *Client) ReconcileOrphanStepRuns(ctx context.Context) (int64, error) {
 	return res.RowsAffected()
 }
 
+// ReconcileOrphanTaskCounters repairs the outstanding_workflows accounting after
+// a daemon restart. The counter is incremented at dispatch and decremented only
+// by Engine.completeTask when an instance settles inside a live process — an
+// instance flipped to 'interrupted' by ReconcileOrphanWorkflowInstances never
+// decrements it, so every mid-flight restart leaks +1 and the task can no longer
+// reach zero: it stays 'running' forever even after a later instance completes
+// (issue #198).
+//
+// Two self-healing passes, in order, both scoped to non-terminal tasks:
+//
+//  1. Recount: set outstanding_workflows to the number of live instances
+//     (pending/running/approval_waiting/waiting). Parked instances count — they
+//     are rehydrated and will still complete-and-decrement; interrupted/done/
+//     failed do not. Recounting (rather than decrementing the rows just
+//     interrupted) also repairs counters already leaked by earlier restarts.
+//  2. Settle: a 'running' task whose recounted counter is zero and whose current
+//     generation has at least one terminal instance gets the lifecycle
+//     transition completeTask would have applied — 'failed' if any instance of
+//     the current generation failed (mirroring HasFailedInstance), else 'done'.
+//     A task whose current-generation instances were all interrupted is left
+//     'running': the next poll re-dispatches it and the now-correct counter
+//     settles it on completion.
+//
+// Must run after ReconcileOrphanWorkflowInstances (so orphans are already
+// interrupted) and before the rehydration passes.
+func (c *Client) ReconcileOrphanTaskCounters(ctx context.Context) (recounted, settled int64, err error) {
+	now := time.Now()
+	liveStates := `('` + InstanceStatePending + `','` + InstanceStateRunning + `','` +
+		InstanceStateApprovalWaiting + `','` + InstanceStateWaiting + `')`
+
+	res, err := c.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET outstanding_workflows = (
+		      SELECT COUNT(*) FROM workflow_instances wi
+		       WHERE wi.task_id = internal_tasks.id AND wi.state IN `+liveStates+`),
+		    updated_at = ?
+		WHERE state IN ('registered', 'running', 'approval_waiting')
+		  AND COALESCE(outstanding_workflows, 0) <> (
+		      SELECT COUNT(*) FROM workflow_instances wi
+		       WHERE wi.task_id = internal_tasks.id AND wi.state IN `+liveStates+`)
+	`, now)
+	if err != nil {
+		return 0, 0, err
+	}
+	recounted, _ = res.RowsAffected()
+
+	res, err = c.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET state = CASE WHEN EXISTS (
+		      SELECT 1 FROM workflow_instances wi
+		       WHERE wi.task_id = internal_tasks.id AND wi.state = ?
+		         AND wi.task_generation = internal_tasks.generation)
+		    THEN 'failed' ELSE 'done' END,
+		    updated_at = ?
+		WHERE state = 'running'
+		  AND COALESCE(outstanding_workflows, 0) = 0
+		  AND EXISTS (
+		      SELECT 1 FROM workflow_instances wi
+		       WHERE wi.task_id = internal_tasks.id
+		         AND wi.state IN (?, ?)
+		         AND wi.task_generation = internal_tasks.generation)
+	`, InstanceStateFailed, now, InstanceStateDone, InstanceStateFailed)
+	if err != nil {
+		return recounted, 0, err
+	}
+	settled, _ = res.RowsAffected()
+	return recounted, settled, nil
+}
+
 // StepRunHasUsage reports whether a step run carries its own token/cost rollup
 // (populated since step_runs gained the usage columns). Rows written earlier
 // leave these at zero, in which case callers fall back to GetStepUsage.

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 func newTestClient(t *testing.T) *Client {
@@ -482,5 +484,102 @@ func TestReconcileOrphanStepRuns(t *testing.T) {
 	// render a duration instead of an open-ended in-progress step.
 	if got["sr_run"].FinishedAt == nil {
 		t.Error("sr_run: expected finished_at to be stamped on reconcile")
+	}
+}
+
+func TestReconcileOrphanTaskCounters(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	ts := c.InternalTasks()
+
+	mkTask := func(id string, state model.TaskState, outstanding int) {
+		t.Helper()
+		if err := ts.CreateTask(ctx, &model.InternalTask{ID: id, Title: id}); err != nil {
+			t.Fatalf("create task %s: %v", id, err)
+		}
+		if outstanding > 0 {
+			if _, err := ts.IncrementOutstanding(ctx, id, outstanding); err != nil {
+				t.Fatalf("increment %s: %v", id, err)
+			}
+		}
+		if err := ts.UpdateTaskState(ctx, id, state); err != nil {
+			t.Fatalf("set state %s: %v", id, err)
+		}
+	}
+	taskState := func(id string) (string, int) {
+		t.Helper()
+		var st string
+		var n int
+		err := c.db.QueryRowContext(ctx,
+			`SELECT state, COALESCE(outstanding_workflows,0) FROM internal_tasks WHERE id = ?`, id).Scan(&st, &n)
+		if err != nil {
+			t.Fatalf("read task %s: %v", id, err)
+		}
+		return st, n
+	}
+
+	// T1 — the issue #198 leak: an interrupted instance never decremented, a
+	// later instance completed. Counter stuck at 1, task stuck 'running'.
+	mkTask("T1", model.TaskStateRunning, 2)
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-a", WorkflowID: "w", CellID: "1", TaskID: "T1", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-b", WorkflowID: "w", CellID: "1", TaskID: "T1", State: InstanceStateDone})
+	if _, err := ts.DecrementOutstanding(ctx, "T1"); err != nil { // completeTask of t1-b
+		t.Fatalf("decrement T1: %v", err)
+	}
+
+	// T2 — same leak but the completed instance of the current generation failed.
+	mkTask("T2", model.TaskStateRunning, 2)
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-a", WorkflowID: "w", CellID: "2", TaskID: "T2", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-b", WorkflowID: "w", CellID: "2", TaskID: "T2", State: InstanceStateFailed})
+	if _, err := ts.DecrementOutstanding(ctx, "T2"); err != nil {
+		t.Fatalf("decrement T2: %v", err)
+	}
+
+	// T3 — parked at approval: live instance, counter correct. Must be untouched.
+	mkTask("T3", model.TaskStateRunning, 1)
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-a", WorkflowID: "w", CellID: "3", TaskID: "T3", State: InstanceStateApprovalWaiting})
+
+	// T4 — every current-generation instance interrupted: counter must drop to
+	// zero but the task stays 'running' for the next poll to re-dispatch.
+	mkTask("T4", model.TaskStateRunning, 1)
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t4-a", WorkflowID: "w", CellID: "4", TaskID: "T4", State: InstanceStateInterrupted})
+
+	// T5 — terminal task: out of scope, never touched even with a bogus counter.
+	mkTask("T5", model.TaskStateDone, 3)
+
+	recounted, settled, err := c.ReconcileOrphanTaskCounters(ctx)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if recounted != 3 { // T1, T2, T4 (T3 already correct, T5 terminal)
+		t.Errorf("expected 3 recounted, got %d", recounted)
+	}
+	if settled != 2 { // T1 → done, T2 → failed
+		t.Errorf("expected 2 settled, got %d", settled)
+	}
+
+	if st, n := taskState("T1"); st != string(model.TaskStateDone) || n != 0 {
+		t.Errorf("T1: expected done/0, got %s/%d", st, n)
+	}
+	if st, n := taskState("T2"); st != string(model.TaskStateFailed) || n != 0 {
+		t.Errorf("T2: expected failed/0, got %s/%d", st, n)
+	}
+	if st, n := taskState("T3"); st != string(model.TaskStateRunning) || n != 1 {
+		t.Errorf("T3: expected running/1, got %s/%d", st, n)
+	}
+	if st, n := taskState("T4"); st != string(model.TaskStateRunning) || n != 0 {
+		t.Errorf("T4: expected running/0, got %s/%d", st, n)
+	}
+	if st, n := taskState("T5"); st != string(model.TaskStateDone) || n != 3 {
+		t.Errorf("T5: expected done/3 untouched, got %s/%d", st, n)
+	}
+
+	// Idempotent: a second pass finds nothing to repair.
+	recounted, settled, err = c.ReconcileOrphanTaskCounters(ctx)
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if recounted != 0 || settled != 0 {
+		t.Errorf("expected idempotent no-op, got recounted=%d settled=%d", recounted, settled)
 	}
 }


### PR DESCRIPTION
Fixes #198

## Root cause
`ReconcileOrphanWorkflowInstances` flips orphaned instances `running → interrupted` without decrementing the task's `outstanding_workflows`. Every mid-flight restart leaks +1; when a later instance completes, `completeTask` decrements to 1 (not 0) and returns early — the task never transitions to `done`/`failed` and stays `running` forever.

## Fix
New `Client.ReconcileOrphanTaskCounters`, called at startup after the instance/step reconciles and before the rehydration passes:

1. **Recount** — recomputes `outstanding_workflows` for every non-terminal task as the count of live instances (`pending/running/approval_waiting/waiting`). Recounting (rather than decrementing only the just-interrupted rows) also repairs databases already polluted by earlier leaks.
2. **Settle** — a `running` task with a zero counter and at least one terminal instance in the current generation gets the transition `completeTask` would have applied (`failed` if any instance of the current generation failed, else `done` — mirroring `HasFailedInstance`). A task whose current generation only has interrupted instances stays `running` for re-dispatch.

## Testing
`TestReconcileOrphanTaskCounters` covers: the exact leak from the issue (settle → done), the failed variant (settle → failed), a parked instance left untouched, a fully-interrupted generation (counter zeroed, task stays running), a terminal task out of scope, and idempotency. Full `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)