### PR TITLE
feat: markdown session transcripts per workflow step

### DIFF
--- a/src/internal/cli/dashboard_cmd.go
+++ b/src/internal/cli/dashboard_cmd.go
@@ -45,7 +45,7 @@ func runDashboard(ctx context.Context) error {
 	}
 
 	socketPath := daemon.SocketPath(config.DataDir(configFile))
-	app := dashboard.New(dbConn, socketPath, cfg)
+	app := dashboard.New(dbConn, socketPath, cfg, getLogDir())
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("dashboard error: %w", err)
 	}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -59,6 +59,7 @@ func init() {
 		newDeleteCmd(),
 		newUpdateCmd(),
 		newMemoryCmd(),
+		newTranscriptCmd(),
 	)
 }
 

--- a/src/internal/cli/transcript.go
+++ b/src/internal/cli/transcript.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newTranscriptCmd() *cobra.Command {
+	var (
+		last     bool
+		pathOnly bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "transcript [task-id] [file]",
+		Short: "Browse markdown transcripts of agent sessions",
+		Long: `Browse the markdown transcripts apiary records for each workflow step run
+(assistant messages, thinking, tool calls and results).
+
+  apiary transcript                    list tasks that have transcripts
+  apiary transcript <task-id>          list that task's transcript files
+  apiary transcript <task-id> --last   print the most recent transcript
+  apiary transcript <task-id> <file>   print a specific transcript
+
+Transcripts live under <config-dir>/.apiary/logs/transcripts/ and are written
+live, so you can also 'tail -f' one while the agent is running.`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := filepath.Join(getLogDir(), "transcripts")
+			switch len(args) {
+			case 0:
+				return listTranscriptTasks(root)
+			case 1:
+				if last {
+					return printTranscript(latestTranscript(filepath.Join(root, args[0])), pathOnly)
+				}
+				return listTranscriptFiles(filepath.Join(root, args[0]))
+			default:
+				name := args[1]
+				if !strings.HasSuffix(name, ".md") {
+					name += ".md"
+				}
+				return printTranscript(filepath.Join(root, args[0], name), pathOnly)
+			}
+		},
+	}
+
+	cmd.Flags().BoolVar(&last, "last", false, "print the most recent transcript for the task")
+	cmd.Flags().BoolVar(&pathOnly, "path", false, "print the file path instead of its contents")
+	return cmd
+}
+
+func listTranscriptTasks(root string) error {
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) || (err == nil && len(entries) == 0) {
+		fmt.Println("no transcripts yet — they are recorded as workflow steps run")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Println(instHeader.Render("TASK                                     FILES  LAST ACTIVITY"))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		files, _ := filepath.Glob(filepath.Join(root, e.Name(), "*.md"))
+		latest := latestOf(files)
+		mod := ""
+		if fi, err := os.Stat(latest); err == nil {
+			mod = fi.ModTime().Format("2006-01-02 15:04")
+		}
+		fmt.Printf("%-40s %5d  %s\n", e.Name(), len(files), instMuted.Render(mod))
+	}
+	return nil
+}
+
+func listTranscriptFiles(dir string) error {
+	files, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	if err != nil || len(files) == 0 {
+		fmt.Printf("no transcripts for task %q\n", filepath.Base(dir))
+		return nil
+	}
+	sortByModTime(files)
+	for _, f := range files {
+		mod := ""
+		if fi, err := os.Stat(f); err == nil {
+			mod = fi.ModTime().Format("2006-01-02 15:04")
+		}
+		fmt.Printf("%s  %s\n", instMuted.Render(mod), filepath.Base(f))
+	}
+	return nil
+}
+
+func printTranscript(path string, pathOnly bool) error {
+	if path == "" {
+		return fmt.Errorf("no transcript found")
+	}
+	if pathOnly {
+		fmt.Println(path)
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(data)
+	return err
+}
+
+func latestTranscript(dir string) string {
+	files, _ := filepath.Glob(filepath.Join(dir, "*.md"))
+	return latestOf(files)
+}
+
+func latestOf(files []string) string {
+	if len(files) == 0 {
+		return ""
+	}
+	sortByModTime(files)
+	return files[len(files)-1]
+}
+
+func sortByModTime(files []string) {
+	sort.Slice(files, func(i, j int) bool {
+		fi, err1 := os.Stat(files[i])
+		fj, err2 := os.Stat(files[j])
+		if err1 != nil || err2 != nil {
+			return files[i] < files[j]
+		}
+		return fi.ModTime().Before(fj.ModTime())
+	})
+}

--- a/src/internal/config/workflow_graph.go
+++ b/src/internal/config/workflow_graph.go
@@ -14,7 +14,17 @@ func validateStepGraph(ctx string, wf WorkflowConfig, stepIDs map[string]bool) [
 	deps := map[string][]string{} // step -> its direct dependencies
 
 	for _, s := range wf.Steps {
-		for _, d := range s.DependsOn {
+		// DependsOn (v1/lowered explicit edges) and SeqDependsOn (v2 implicit
+		// sequential chaining, set by the v2 lowering pass) are both real
+		// dependency edges at runtime — the DAG engine treats them identically
+		// (see workflow/dag.go). They must be merged here too: a v2 workflow
+		// that mixes plain sequential steps with a `parallel:`/`for_each:` step
+		// only gets explicit DependsOn on the parallel/foreach step itself,
+		// leaving every other step's real dependency invisible to this
+		// function if only DependsOn is read — which broke the `len(deps)==0`
+		// sequential-order fallback below for the whole workflow as soon as
+		// any single step had an explicit DependsOn.
+		for _, d := range append(append([]string{}, s.DependsOn...), s.SeqDependsOn...) {
 			if !stepIDs[d] {
 				errs = append(errs, fmt.Errorf("%s: step %q depends_on unknown step %q", ctx, s.ID, d))
 				continue

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -267,6 +267,36 @@ func TestWorkflow_OnFailGotoNotAncestor(t *testing.T) {
 	assertError(t, cfg, "must target an ancestor")
 }
 
+// Regression: a v2 workflow mixes plain sequential steps (chained only via the
+// lowering pass's implicit SeqDependsOn, never DependsOn) with one step that
+// carries an explicit DependsOn (as `lowerParallelStep` sets for its own
+// predecessor edge). Before the fix, validateStepGraph's ancestor check only
+// read DependsOn to build the deps graph, so the presence of ANY explicit
+// DependsOn anywhere in the workflow flipped off the `len(deps)==0` sequential
+// fallback for the WHOLE workflow — leaving SeqDependsOn-only steps invisible
+// to isAncestor and falsely rejecting their legitimate on_fail.goto backedges.
+func TestWorkflow_OnFailGotoAncestor_MixedSeqAndExplicitDeps(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "implement", Agent: "architect"},
+			// Plain sequential step: only SeqDependsOn (set by v2 lowering),
+			// no DependsOn — legitimately targets "implement", an ancestor.
+			{ID: "check-ci", Type: config.StepTypeWaitFor, SeqDependsOn: []string{"implement"},
+				WaitFor:    &config.WaitForConfig{Kind: "ci"},
+				OnConflict: &config.StepOutcome{Goto: "implement", MaxRetries: 1}},
+			// Parallel-lowered step: explicit DependsOn on its own predecessor,
+			// as lowerParallelStep produces.
+			{ID: "gate", Type: config.StepTypeParallel, DependsOn: []string{"check-ci"},
+				SubSteps: []config.StepConfig{
+					{ID: "review", Agent: "architect"},
+				},
+				OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 1}},
+		}},
+	}
+	assertNoError(t, cfg)
+}
+
 func TestWorkflow_OnConflictGotoUnknownStep(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -407,6 +407,27 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		}
 	}
 
+	// Markdown transcript: render the provider's stream-json events (assistant
+	// messages, thinking, tool calls/results) into a per-step markdown file
+	// under <logDir>/transcripts/<cellID>/. Best-effort — a transcript failure
+	// never blocks the run.
+	if x.d.logger != nil {
+		name := fmt.Sprintf("%s-%s", req.InstanceID, req.Step.ID)
+		if f, path, err := x.d.logger.CreateTranscript(req.Cell.ID, name); err == nil {
+			defer f.Close()
+			tr := execution.NewTranscript(f, execution.TranscriptMeta{
+				Title:    fmt.Sprintf("%s — %s", req.Cell.LogLabel(), req.Cell.Title),
+				Agent:    req.Step.Agent,
+				Model:    req.Model,
+				Step:     req.Step.ID,
+				Instance: req.InstanceID,
+				Started:  time.Now(),
+			})
+			rr.TranscriptSink = tr.Feed
+			aplog.Debug("[%s] transcript: %s", req.Cell.LogLabel(), path)
+		}
+	}
+
 	// Run chain: the agent's primary runner first, then its rate-limit failover
 	// chain. A candidate whose runner type is currently paused by a provider rate
 	// limit is skipped (unless it is the last resort). Each attempt is its own

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/logging"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -57,6 +58,9 @@ type App struct {
 	dbConn     *db.Client
 	socketPath string
 	cfg        *config.Config
+	// logDir is the daemon's log directory, used to locate per-task markdown
+	// transcripts (logDir/transcripts/<task>/...).
+	logDir string
 
 	// logMDCache memoizes the display lines of multi-line log messages, keyed by
 	// the message text: glamour-rendered markdown delivered by the async warm-up
@@ -71,12 +75,13 @@ type App struct {
 	logMDWidth   int
 }
 
-func New(dbConn *db.Client, socketPath string, cfg *config.Config) *App {
+func New(dbConn *db.Client, socketPath string, cfg *config.Config, logDir string) *App {
 	return &App{
 		model:      NewModel(),
 		dbConn:     dbConn,
 		socketPath: socketPath,
 		cfg:        cfg,
+		logDir:     logDir,
 	}
 }
 
@@ -483,6 +488,19 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return a, openURLCmd(u)
 		}
 		return a, nil
+	}
+
+	// Open the focused task's latest markdown transcript (assistant messages,
+	// thinking, tool calls) with the OS default handler. Only consumes the key
+	// when a task is focused — other views (e.g. the agent file viewer's
+	// raw/rendered toggle) keep their own "t" bindings.
+	if key == "t" {
+		if id, ok := a.focusedTaskID(); ok {
+			if path := logging.LatestTranscript(a.logDir, id); path != "" {
+				return a, openURLCmd(path)
+			}
+			return a, nil
+		}
 	}
 
 	// Open the focused task's most recent pull request in the browser.
@@ -4788,9 +4806,9 @@ func (a *App) footerKeys() []fkey {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewDetail:
-				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
-				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"C", "clear"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"C", "clear"}, {"q", "quit"}}
 			case TaskViewWorkflow:
 				if t.WorkflowShowLogs {
 					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
@@ -4802,7 +4820,7 @@ func (a *App) footerKeys() []fkey {
 				return append(keys, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
 	case "Workflows":
 		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
 			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}
@@ -4814,9 +4832,9 @@ func (a *App) footerKeys() []fkey {
 			case AgentViewDetail:
 				return []fkey{{"esc", "back"}, {"f", "files"}, {"l", "activity"}, {"m", "model"}, {"r", "runner"}, {"w", "workers"}, {"q", "quit"}}
 			case AgentViewActivity:
-				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"pgup/dn", "page"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"pgup/dn", "page"}, {"q", "quit"}}
 			case AgentViewTaskLogs:
-				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"home/end", "ends"}, {"r", "reload"}, {"q", "quit"}}
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"home/end", "ends"}, {"r", "reload"}, {"q", "quit"}}
 			case AgentViewFiles:
 				return []fkey{{"esc", "back"}, {"↑/↓", "select"}, {"enter/l", "view"}, {"q", "quit"}}
 			case AgentViewFileContent:

--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -247,6 +248,8 @@ func (l *Logger) pruneOldLogs() {
 
 	backups, _ := filepath.Glob(filepath.Join(l.logDir, "apiary.log.*"))
 	taskLogs, _ := filepath.Glob(filepath.Join(l.logDir, "tasks", "*.log"))
+	transcripts, _ := filepath.Glob(filepath.Join(l.logDir, "transcripts", "*", "*.md"))
+	taskLogs = append(taskLogs, transcripts...)
 	for _, path := range append(backups, taskLogs...) {
 		if fi, err := os.Stat(path); err == nil && fi.ModTime().Before(cutoff) {
 			os.Remove(path)
@@ -267,4 +270,45 @@ func (l *Logger) CreateTaskLogger(taskID string) (io.WriteCloser, error) {
 
 	taskLogFile := filepath.Join(taskLogDir, taskID+".log")
 	return os.OpenFile(taskLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+}
+
+// CreateTranscript opens (append) the markdown transcript file for one step
+// run: <logDir>/transcripts/<taskID>/<name>.md. Returns the open file and its
+// path. Callers own closing the file.
+func (l *Logger) CreateTranscript(taskID, name string) (*os.File, string, error) {
+	if l.logDir == "" {
+		return nil, "", fmt.Errorf("no log directory configured")
+	}
+	dir := filepath.Join(l.logDir, "transcripts", SanitizePathComponent(taskID))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, "", fmt.Errorf("create transcript dir: %w", err)
+	}
+	path := filepath.Join(dir, SanitizePathComponent(name)+".md")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, "", err
+	}
+	return f, path, nil
+}
+
+// SanitizePathComponent keeps ids safe to use as file/dir names (cell ids can
+// carry slashes, e.g. "owner/repo#42"). Exported so readers of the transcript
+// tree (dashboard, CLI) resolve the same directory the writer created.
+func SanitizePathComponent(s string) string {
+	repl := strings.NewReplacer("/", "_", "\\", "_", ":", "_", "#", "_", " ", "_")
+	return repl.Replace(s)
+}
+
+// LatestTranscript returns the most recently modified transcript file for a
+// task, or "" when none exist.
+func LatestTranscript(logDir, taskID string) string {
+	files, _ := filepath.Glob(filepath.Join(logDir, "transcripts", SanitizePathComponent(taskID), "*.md"))
+	var best string
+	var bestMod time.Time
+	for _, f := range files {
+		if fi, err := os.Stat(f); err == nil && (best == "" || fi.ModTime().After(bestMod)) {
+			best, bestMod = f, fi.ModTime()
+		}
+	}
+	return best
 }

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -36,6 +36,12 @@ type RunRequest struct {
 	// Must be safe to call from multiple goroutines.
 	LogSink func(LogEntry) `json:"-"`
 
+	// TranscriptSink, when set, receives each raw provider stdout line
+	// (stream-json events) in real time. The daemon uses it to render a
+	// markdown transcript of the session. Must be safe to call from multiple
+	// goroutines.
+	TranscriptSink func(rawLine string) `json:"-"`
+
 	// SetPID is called after the child process starts with its OS PID.
 	SetPID func(pid int) `json:"-"`
 

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -186,6 +186,9 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 			mu.Lock()
 			outBuf.WriteString(line + "\n")
 			mu.Unlock()
+			if req.TranscriptSink != nil {
+				req.TranscriptSink(line)
+			}
 			if res, ok := finalResultText(line); ok {
 				mu.Lock()
 				finalResult = res

--- a/src/internal/runner/execution/transcript.go
+++ b/src/internal/runner/execution/transcript.go
@@ -1,0 +1,298 @@
+package execution
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Transcript renders the provider's stream-json events into an organized,
+// human-readable markdown document as the run progresses. It is fed the same
+// raw stdout lines the CliRunner already scans; non-JSON lines and event types
+// it does not understand are ignored, so it is safe for any provider that
+// emits Claude/Cursor-style stream events.
+//
+// The output is append-only markdown: each assistant message, thinking block,
+// tool call, and tool result becomes its own section, so the file can be
+// tailed or opened in any markdown viewer while the agent is still running.
+type Transcript struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// TranscriptMeta describes the run for the transcript header.
+type TranscriptMeta struct {
+	Title    string // task title, e.g. "ERP-42 — Fix login"
+	Agent    string
+	Model    string
+	Step     string
+	Instance string
+	Started  time.Time
+}
+
+// NewTranscript wraps w and writes the document header. w is not closed by
+// Transcript; the caller owns its lifecycle.
+func NewTranscript(w io.Writer, meta TranscriptMeta) *Transcript {
+	t := &Transcript{w: w}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s\n\n", orDefault(meta.Title, "Agent session"))
+	var facts []string
+	if meta.Step != "" {
+		facts = append(facts, "**Step:** "+meta.Step)
+	}
+	if meta.Agent != "" {
+		facts = append(facts, "**Agent:** "+meta.Agent)
+	}
+	if meta.Model != "" {
+		facts = append(facts, "**Model:** "+meta.Model)
+	}
+	if meta.Instance != "" {
+		facts = append(facts, "**Instance:** `"+meta.Instance+"`")
+	}
+	if len(facts) > 0 {
+		fmt.Fprintf(&b, "> %s\n", strings.Join(facts, " · "))
+	}
+	if !meta.Started.IsZero() {
+		fmt.Fprintf(&b, "> **Started:** %s\n", meta.Started.Format("2006-01-02 15:04:05 MST"))
+	}
+	b.WriteString("\n---\n")
+	t.write(b.String())
+	return t
+}
+
+// transcriptEvent mirrors the stream-json fields the transcript cares about.
+// It is deliberately separate from streamEvent: the transcript needs full
+// (untruncated) content plus thinking blocks and tool ids.
+type transcriptEvent struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	Model   string `json:"model"`
+	Result  string `json:"result"`
+	Message struct {
+		Content []struct {
+			Type      string          `json:"type"`
+			Text      string          `json:"text"`
+			Thinking  string          `json:"thinking"`
+			Name      string          `json:"name"`
+			Input     json.RawMessage `json:"input"`
+			Content   json.RawMessage `json:"content"`
+			ToolUseID string          `json:"tool_use_id"`
+			IsError   bool            `json:"is_error"`
+		} `json:"content"`
+	} `json:"message"`
+	DurationMs   int64   `json:"duration_ms"`
+	NumTurns     int     `json:"num_turns"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	IsError      bool    `json:"is_error"`
+}
+
+// Feed consumes one raw stdout line. Safe for concurrent use.
+func (t *Transcript) Feed(line string) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return
+	}
+	var ev transcriptEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil || ev.Type == "" {
+		return
+	}
+	switch ev.Type {
+	case "system":
+		if ev.Subtype == "init" || ev.Model != "" {
+			t.write(fmt.Sprintf("\n### 🟢 Session started%s\n", suffixIf(ev.Model, " — `"+ev.Model+"`")))
+		}
+	case "assistant":
+		t.feedAssistant(ev)
+	case "user":
+		t.feedToolResults(ev)
+	case "result", "completion":
+		t.feedResult(ev)
+	}
+}
+
+func (t *Transcript) feedAssistant(ev transcriptEvent) {
+	var b strings.Builder
+	for _, c := range ev.Message.Content {
+		switch c.Type {
+		case "thinking":
+			if s := strings.TrimSpace(c.Thinking); s != "" {
+				b.WriteString("\n### 🧠 Thinking\n\n")
+				b.WriteString(blockquote(s))
+				b.WriteString("\n")
+			}
+		case "text":
+			if s := strings.TrimSpace(c.Text); s != "" {
+				b.WriteString("\n### 💬 Assistant\n\n")
+				b.WriteString(s)
+				b.WriteString("\n")
+			}
+		case "tool_use":
+			fmt.Fprintf(&b, "\n### 🔧 Tool: `%s`\n\n", c.Name)
+			if in := prettyJSON(c.Input); in != "" {
+				b.WriteString(fence(in, "json"))
+			}
+		}
+	}
+	if b.Len() > 0 {
+		t.write(b.String())
+	}
+}
+
+// toolResultLimit caps how much of a tool result is embedded in the
+// transcript; full results still live in the raw task log.
+const toolResultLimit = 2000
+
+func (t *Transcript) feedToolResults(ev transcriptEvent) {
+	var b strings.Builder
+	for _, c := range ev.Message.Content {
+		if c.Type != "tool_result" {
+			continue
+		}
+		body := strings.TrimSpace(toolResultText(c.Content))
+		if body == "" {
+			continue
+		}
+		truncated := false
+		if len(body) > toolResultLimit {
+			body = body[:toolResultLimit]
+			truncated = true
+		}
+		label := "Tool result"
+		if c.IsError {
+			label = "Tool result (error)"
+		}
+		if truncated {
+			label += " — truncated"
+		}
+		fmt.Fprintf(&b, "\n<details><summary>↩️ %s</summary>\n\n%s\n</details>\n", label, fence(body, ""))
+	}
+	if b.Len() > 0 {
+		t.write(b.String())
+	}
+}
+
+func (t *Transcript) feedResult(ev transcriptEvent) {
+	status := "✅ success"
+	if ev.IsError || ev.Subtype == "error" {
+		status = "❌ error"
+	} else if ev.Subtype != "" && ev.Subtype != "success" {
+		status = "⚠️ " + ev.Subtype
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n---\n\n## %s", status)
+	if ev.NumTurns > 0 {
+		fmt.Fprintf(&b, " · %d turns", ev.NumTurns)
+	}
+	if ev.DurationMs > 0 {
+		fmt.Fprintf(&b, " · %s", (time.Duration(ev.DurationMs) * time.Millisecond).Round(time.Second))
+	}
+	if ev.TotalCostUSD > 0 {
+		fmt.Fprintf(&b, " · $%.4f", ev.TotalCostUSD)
+	}
+	b.WriteString("\n")
+	if r := strings.TrimSpace(ev.Result); r != "" {
+		b.WriteString("\n")
+		b.WriteString(r)
+		b.WriteString("\n")
+	}
+	t.write(b.String())
+}
+
+// jwtPattern matches JWT-shaped bearer tokens (three base64url segments
+// starting with "eyJ" — the {"alg"/{"typ" JSON header). Agents routinely
+// export tokens in Bash tool calls; keeping them out of transcripts avoids
+// spreading credentials into files meant to be read and shared.
+var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`)
+
+func (t *Transcript) write(s string) {
+	s = jwtPattern.ReplaceAllString(s, "«redacted-jwt»")
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	io.WriteString(t.w, s)
+	if f, ok := t.w.(interface{ Sync() error }); ok {
+		f.Sync()
+	}
+}
+
+// toolResultText extracts the human text from a tool_result content payload,
+// which the CLIs emit either as a plain string or as an array of
+// {type:"text",text:"..."} blocks.
+func toolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var parts []string
+		for _, blk := range blocks {
+			if blk.Type == "text" && strings.TrimSpace(blk.Text) != "" {
+				parts = append(parts, blk.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return string(raw)
+}
+
+func prettyJSON(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" || s == "{}" {
+		return ""
+	}
+	var buf strings.Builder
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return s
+	}
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return s
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// fence wraps body in a code fence long enough to survive backticks inside it.
+func fence(body, lang string) string {
+	marker := "```"
+	for strings.Contains(body, marker) {
+		marker += "`"
+	}
+	return marker + lang + "\n" + body + "\n" + marker + "\n"
+}
+
+func blockquote(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = "> " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func orDefault(s, def string) string {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	return s
+}
+
+func suffixIf(cond, s string) string {
+	if cond == "" {
+		return ""
+	}
+	return s
+}

--- a/src/internal/runner/execution/transcript_test.go
+++ b/src/internal/runner/execution/transcript_test.go
@@ -1,0 +1,92 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Event shapes match the real Claude CLI `--output-format stream-json` output.
+func TestTranscriptRendersMarkdown(t *testing.T) {
+	var buf strings.Builder
+	tr := NewTranscript(&buf, TranscriptMeta{
+		Title:    "ERP-42 — Fix login",
+		Agent:    "dev",
+		Model:    "claude-sonnet-5",
+		Step:     "implement",
+		Instance: "01JXYZ",
+		Started:  time.Date(2026, 7, 19, 10, 0, 0, 0, time.UTC),
+	})
+
+	lines := []string{
+		`{"type":"system","subtype":"init","model":"claude-sonnet-5"}`,
+		`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"I should read the auth file first."}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Looking at the login handler."},{"type":"tool_use","name":"Read","input":{"file_path":"auth.go"}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"text","text":"package auth"}]}]}}`,
+		`not json at all`,
+		`{"type":"result","subtype":"success","result":"Fixed the bug.","num_turns":3,"duration_ms":65000,"total_cost_usd":0.42}`,
+	}
+	for _, l := range lines {
+		tr.Feed(l)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"# ERP-42 — Fix login",
+		"**Step:** implement",
+		"### 🟢 Session started — `claude-sonnet-5`",
+		"### 🧠 Thinking",
+		"> I should read the auth file first.",
+		"### 💬 Assistant",
+		"Looking at the login handler.",
+		"### 🔧 Tool: `Read`",
+		"\"file_path\": \"auth.go\"",
+		"↩️ Tool result",
+		"package auth",
+		"## ✅ success · 3 turns · 1m5s · $0.4200",
+		"Fixed the bug.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("transcript missing %q\n---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "not json at all") {
+		t.Errorf("non-JSON line leaked into transcript")
+	}
+}
+
+func TestTranscriptTruncatesLongToolResults(t *testing.T) {
+	var buf strings.Builder
+	tr := NewTranscript(&buf, TranscriptMeta{})
+	long := strings.Repeat("x", toolResultLimit+500)
+	tr.Feed(`{"type":"user","message":{"content":[{"type":"tool_result","content":"` + long + `"}]}}`)
+	out := buf.String()
+	if !strings.Contains(out, "truncated") {
+		t.Fatalf("expected truncation marker, got:\n%s", out)
+	}
+	if strings.Count(out, "x") > toolResultLimit {
+		t.Fatalf("tool result not truncated")
+	}
+}
+
+func TestTranscriptRedactsJWTs(t *testing.T) {
+	var buf strings.Builder
+	tr := NewTranscript(&buf, TranscriptMeta{})
+	tr.Feed(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"export TOKEN=\"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzN2Y5M2FhYSIsImV4cCI6MX0.abcdefghijklmnop\""}}]}}`)
+	out := buf.String()
+	if strings.Contains(out, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9") {
+		t.Fatalf("JWT leaked into transcript:\n%s", out)
+	}
+	if !strings.Contains(out, "«redacted-jwt»") {
+		t.Fatalf("expected redaction marker:\n%s", out)
+	}
+}
+
+func TestTranscriptFencesBackticks(t *testing.T) {
+	var buf strings.Builder
+	tr := NewTranscript(&buf, TranscriptMeta{})
+	tr.Feed(`{"type":"user","message":{"content":[{"type":"tool_result","content":"code: ` + "```" + `go\\nfmt.Println()\\n` + "```" + `"}]}}`)
+	if !strings.Contains(buf.String(), "````") {
+		t.Fatalf("expected extended fence around backtick content:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Agent runs already stream rich `stream-json` events (assistant messages, thinking, tool calls/results), but they were flattened into truncated one-line debug logs — and thinking blocks were dropped entirely. This PR records each step run as an **organized, live-appended markdown transcript** you can monitor while the agent works.

Transcripts land at `<logDir>/transcripts/<task>/<instance>-<step>.md` and follow the existing `log_max_age_days` retention.

## Format

- `### 🧠 Thinking` — blockquoted thinking blocks (previously discarded)
- `### 💬 Assistant` — assistant text
- `### 🔧 Tool: Name` — pretty-printed JSON input
- collapsible `<details>` tool results (truncated at 2 000 chars; full output stays in the raw task log)
- header (task/step/agent/model/instance) and footer (status · turns · duration · cost)
- backtick-safe code fences; JWT-shaped tokens redacted (`«redacted-jwt»`)

## Surfaces

- **Dashboard**: press `t` on a focused task (Tasks list/detail/logs/monitor, Agents activity/logs) to open the latest transcript with the OS default markdown handler; footer hints updated. Falls through to the file viewer's existing raw/rendered `t` toggle.
- **CLI**: new `apiary transcript` — list tasks, list a task's files, `--last` / `--path` to print or locate one (works with `tail -f` since files are written live).

## Implementation

- `execution.Transcript` renderer fed raw stdout lines via new `RunRequest.TranscriptSink` (nil-checked; zero cost when unset)
- daemon `wfStepExecutor` creates the transcript file per step run, best-effort — never blocks the run
- `logging.CreateTranscript` / `LatestTranscript` + retention pruning of `transcripts/*/*.md`

Covers CLI runners (claude-cli, opencode-cli, cursor-cli); `opencode-api` doesn't stream events, so no transcript there.

## Testing

- New `transcript_test.go` using real Claude CLI event shapes (rendering, truncation, fence escaping, JWT redaction)
- `go build ./...` and full `go test ./...` green
- Smoke-tested `apiary transcript --help`

Rollout: new binary + daemon restart; transcripts start recording for runs dispatched after that.