### PR TITLE
feat(dashboard): render session transcripts inside the TUI

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
-	"github.com/orlandoburli/apiary/internal/logging"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -447,6 +446,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			t.DetailInstance = msg.instance
 		}
 
+	case taskTranscriptMsg:
+		a.applyTranscriptMsg(msg)
+
 	case tailTaskLogsMsg:
 		// Append newly-arrived flat-log lines. While LogFollow is on, render keeps
 		// the viewport pinned to the tail; otherwise the appended lines sit below
@@ -490,16 +492,13 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
-	// Open the focused task's latest markdown transcript (assistant messages,
-	// thinking, tool calls) with the OS default handler. Only consumes the key
-	// when a task is focused — other views (e.g. the agent file viewer's
-	// raw/rendered toggle) keep their own "t" bindings.
-	if key == "t" {
-		if id, ok := a.focusedTaskID(); ok {
-			if path := logging.LatestTranscript(a.logDir, id); path != "" {
-				return a, openURLCmd(path)
-			}
-			return a, nil
+	// Show the focused task's markdown transcript (assistant messages,
+	// thinking, tool calls) rendered inside the dashboard. Only consumes the
+	// key when a task is focused and a transcript exists — other views (e.g.
+	// the agent file viewer's raw/rendered toggle) keep their own "t" bindings.
+	if key == "t" && a.model.tasksTab != nil && a.model.tasksTab.View != TaskViewTranscript {
+		if handled, cmd := a.openTranscriptView(); handled {
+			return a, cmd
 		}
 	}
 
@@ -879,7 +878,12 @@ func (a *App) handleAgentSubViewKey(key string) (tea.Model, tea.Cmd) {
 		lines := a.agentFileLines()
 		switch key {
 		case "esc", "backspace", "h", "left":
-			ag.View = AgentViewFiles
+			if ag.FileReturn != AgentViewList {
+				ag.View = ag.FileReturn
+			} else {
+				ag.View = AgentViewFiles
+			}
+			ag.FileReturn = AgentViewList
 			ag.FileContent = ""
 			ag.FileErr = ""
 			ag.FileScroll = 0
@@ -1092,6 +1096,11 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 	// Workflow monitor has its own key map.
 	if t.View == TaskViewWorkflow {
 		return a.handleWorkflowMonitorKey(key)
+	}
+
+	// Transcript viewer has its own key map.
+	if t.View == TaskViewTranscript {
+		return a.handleTranscriptKey(key)
 	}
 
 	switch key {
@@ -1981,6 +1990,12 @@ func (a *App) fetchActiveTab() tea.Cmd {
 						}
 					}
 					return tea.Batch(cmds...)
+				}
+				return nil
+			case TaskViewTranscript:
+				// Live-tail the open transcript file (throttled like the logs view).
+				if t.TranscriptPath != "" && a.model.tickCount%2 == 0 {
+					return a.loadTranscriptCmd(t.TranscriptPath)
 				}
 				return nil
 			case TaskViewDetail:
@@ -3082,6 +3097,8 @@ func (a *App) renderTasksTab(height int) string {
 		return a.renderTaskLogs(t, height)
 	case TaskViewWorkflow:
 		return a.renderWorkflowMonitor(t, height)
+	case TaskViewTranscript:
+		return a.renderTaskTranscript(t, height)
 	default:
 		return a.renderTaskList(t, height)
 	}
@@ -4809,11 +4826,17 @@ func (a *App) footerKeys() []fkey {
 				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"l", "logs"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"C", "clear"}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewLogs:
 				return []fkey{{"esc", "back"}, {"d", "details"}, {"↑/↓", "scroll"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"C", "clear"}, {"q", "quit"}}
+			case TaskViewTranscript:
+				label := "raw"
+				if t.TranscriptRaw {
+					label = "rendered"
+				}
+				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"end", "follow"}, {"t", label}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewWorkflow:
 				if t.WorkflowShowLogs {
 					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
 				}
-				keys := []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}}
+				keys := []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}, {"t", "transcript"}}
 				if len(t.WorkflowInstances) > 1 {
 					keys = append(keys, fkey{"[ ]", "workflow"})
 				}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -61,7 +61,8 @@ const (
 	TaskViewList TaskView = iota
 	TaskViewDetail
 	TaskViewLogs
-	TaskViewWorkflow // live workflow instance monitor
+	TaskViewWorkflow   // live workflow instance monitor
+	TaskViewTranscript // rendered markdown transcript of an agent session
 )
 
 // TasksTab shows task history with detail and log sub-views.
@@ -101,6 +102,22 @@ type TasksTab struct {
 	WorkflowLogFollow   bool   // pin the step-log panel to the tail; cleared by scrolling up
 	WorkflowLogStepID   string // step whose logs fill the panel (scopes live-tail refreshes)
 	WorkflowShowLogs    bool   // true when the log panel is expanded
+
+	// Transcript sub-view (View == TaskViewTranscript): a markdown transcript
+	// file rendered in-app with glamour, live-tailed while the run continues.
+	TranscriptPath    string
+	TranscriptContent string
+	TranscriptErr     string
+	TranscriptScroll  int      // vertical scroll (visual lines)
+	TranscriptRaw     bool     // show raw markdown instead of rendered (toggle)
+	TranscriptFollow  bool     // pin viewport to the tail; cleared by scrolling up
+	TranscriptReturn  TaskView // view to restore on esc
+	// transcriptLines memoizes the display lines (glamour is too slow for the
+	// render path); valid for the recorded width/raw-mode/content generation.
+	transcriptLines      []string
+	transcriptLinesValid bool
+	transcriptLinesWidth int
+	transcriptLinesRaw   bool
 
 	// Scroll / filter / sort
 	ScrollOffset int    // first visible row index
@@ -299,6 +316,7 @@ type AgentsTab struct {
 	FileErr     string          // read error message, if any
 	FileScroll  int             // vertical scroll within the open file (visual lines)
 	FileRaw     bool            // show raw text instead of rendered markdown (toggle)
+	FileReturn  AgentView       // view esc restores (files list, or activity for transcripts)
 
 	// Memoized display lines for the open file, so glamour rendering happens once
 	// per (width, mode) rather than on every keystroke. Invalidated by comparing

--- a/src/internal/dashboard/transcript_view.go
+++ b/src/internal/dashboard/transcript_view.go
@@ -1,0 +1,242 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/orlandoburli/apiary/internal/logging"
+)
+
+// taskTranscriptMsg delivers a (re)read of the open transcript file. Produced
+// by commands off the UI thread; applied only while the transcript view is
+// still open on the same path, so a late reload never clobbers another view.
+type taskTranscriptMsg struct {
+	path    string
+	content string
+	err     string
+}
+
+// transcriptPathForFocus resolves which transcript file "t" should open. In
+// the workflow monitor the selected step's own file is preferred (when it
+// exists); everywhere else the task's most recent transcript is used.
+func (a *App) transcriptPathForFocus() string {
+	t := a.model.tasksTab
+	if a.model.ActiveTab() == "Tasks" && t != nil && t.View == TaskViewWorkflow {
+		if inst := t.WorkflowInstance; inst != nil && t.WorkflowStepIdx < len(inst.Steps) {
+			step := inst.Steps[t.WorkflowStepIdx]
+			name := logging.SanitizePathComponent(inst.ID+"-"+step.StepID) + ".md"
+			p := filepath.Join(a.logDir, "transcripts", logging.SanitizePathComponent(inst.CellID), name)
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+			return logging.LatestTranscript(a.logDir, inst.CellID)
+		}
+	}
+	if id, ok := a.focusedTaskID(); ok {
+		return logging.LatestTranscript(a.logDir, id)
+	}
+	return ""
+}
+
+// openTranscriptView opens the in-app transcript viewer for the focused task.
+// Returns handled=false when there is nothing to show (no focused task or no
+// transcript file yet) so the caller can let the key fall through.
+func (a *App) openTranscriptView() (bool, tea.Cmd) {
+	path := a.transcriptPathForFocus()
+	if path == "" {
+		// A task is focused but has no transcript yet: consume the key (showing
+		// nothing) only when focus is on a task list; otherwise fall through.
+		_, focused := a.focusedTaskID()
+		return focused, nil
+	}
+
+	// On the Agents tab, reuse the existing markdown file viewer (glamour +
+	// raw toggle + scrolling) instead of the Tasks sub-view, which only
+	// renders while the Tasks tab is active.
+	if a.model.ActiveTab() == "Agents" {
+		ag := a.model.agentsTab
+		if ag == nil {
+			return false, nil
+		}
+		ag.FileName = "transcript — " + filepath.Base(path)
+		ag.FilePath = path
+		ag.FileErr = ""
+		ag.FileScroll = 0
+		ag.FileRaw = false
+		ag.FileReturn = ag.View
+		ag.invalidateFileLines()
+		if data, err := os.ReadFile(path); err != nil {
+			ag.FileErr = err.Error()
+		} else {
+			ag.FileContent = string(data)
+		}
+		ag.View = AgentViewFileContent
+		return true, nil
+	}
+
+	t := a.model.tasksTab
+	if t == nil || a.model.ActiveTab() != "Tasks" {
+		return false, nil
+	}
+	t.TranscriptPath = path
+	t.TranscriptContent = ""
+	t.TranscriptErr = ""
+	t.TranscriptScroll = 0
+	t.TranscriptRaw = false
+	t.TranscriptFollow = true
+	t.TranscriptReturn = t.View
+	t.invalidateTranscriptLines()
+	t.View = TaskViewTranscript
+	return true, a.loadTranscriptCmd(path)
+}
+
+// loadTranscriptCmd reads the transcript file off the UI thread.
+func (a *App) loadTranscriptCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return taskTranscriptMsg{path: path, err: err.Error()}
+		}
+		return taskTranscriptMsg{path: path, content: string(data)}
+	}
+}
+
+// applyTranscriptMsg folds a (re)read into the open transcript view. Follow
+// mode pins the viewport to the tail so a running session reads like a live
+// feed.
+func (a *App) applyTranscriptMsg(msg taskTranscriptMsg) {
+	t := a.model.tasksTab
+	if t == nil || t.View != TaskViewTranscript || t.TranscriptPath != msg.path {
+		return
+	}
+	if msg.err != "" {
+		t.TranscriptErr = msg.err
+		return
+	}
+	if msg.content == t.TranscriptContent {
+		return
+	}
+	t.TranscriptErr = ""
+	t.TranscriptContent = msg.content
+	t.invalidateTranscriptLines()
+	if t.TranscriptFollow {
+		t.TranscriptScroll = lastIndex(len(a.taskTranscriptLines()))
+	}
+}
+
+// handleTranscriptKey is the key map while the transcript view is open.
+func (a *App) handleTranscriptKey(key string) (tea.Model, tea.Cmd) {
+	t := a.model.tasksTab
+	lines := a.taskTranscriptLines()
+	switch key {
+	case "esc", "backspace", "h", "left":
+		t.View = t.TranscriptReturn
+		t.TranscriptContent = ""
+		t.TranscriptPath = ""
+		t.invalidateTranscriptLines()
+	case "t":
+		t.TranscriptRaw = !t.TranscriptRaw
+		t.TranscriptScroll = 0
+		t.TranscriptFollow = false
+		t.invalidateTranscriptLines()
+	case "r":
+		return a, a.loadTranscriptCmd(t.TranscriptPath)
+	case "up", "k":
+		t.TranscriptFollow = false
+		if t.TranscriptScroll > 0 {
+			t.TranscriptScroll--
+		}
+	case "down", "j":
+		if t.TranscriptScroll < lastIndex(len(lines)) {
+			t.TranscriptScroll++
+		}
+	case "pgup":
+		t.TranscriptFollow = false
+		t.TranscriptScroll = clampScroll(t.TranscriptScroll-a.pageSize(), len(lines))
+	case "pgdown":
+		t.TranscriptScroll = clampScroll(t.TranscriptScroll+a.pageSize(), len(lines))
+	case "home":
+		t.TranscriptFollow = false
+		t.TranscriptScroll = 0
+	case "end", "G":
+		t.TranscriptFollow = true
+		t.TranscriptScroll = lastIndex(len(lines))
+	}
+	return a, nil
+}
+
+// invalidateTranscriptLines drops the memoized display lines so the next
+// taskTranscriptLines call re-renders (after a toggle, resize, or reload).
+func (t *TasksTab) invalidateTranscriptLines() {
+	t.transcriptLines = nil
+	t.transcriptLinesValid = false
+}
+
+// taskTranscriptLines returns the transcript's display lines wrapped to the
+// box inner width: glamour-rendered markdown unless raw mode is on, memoized
+// per (width, raw mode) like the agent file viewer.
+func (a *App) taskTranscriptLines() []string {
+	t := a.model.tasksTab
+	if t == nil {
+		return nil
+	}
+	inner := a.model.width - 2
+	if inner < 1 {
+		inner = 1
+	}
+	if t.transcriptLinesValid && t.transcriptLinesWidth == inner && t.transcriptLinesRaw == t.TranscriptRaw {
+		return t.transcriptLines
+	}
+
+	var lines []string
+	if !t.TranscriptRaw {
+		if rendered, err := renderMarkdown(t.TranscriptContent, inner); err == nil {
+			lines = clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), inner)
+		}
+	}
+	if lines == nil {
+		lines = wrapPlain(t.TranscriptContent, inner)
+	}
+
+	t.transcriptLines = lines
+	t.transcriptLinesWidth = inner
+	t.transcriptLinesRaw = t.TranscriptRaw
+	t.transcriptLinesValid = true
+	return lines
+}
+
+func (a *App) renderTaskTranscript(t *TasksTab, height int) string {
+	title := "TRANSCRIPT — " + filepath.Base(t.TranscriptPath)
+	if t.TranscriptRaw {
+		title += " (raw)"
+	}
+	if t.TranscriptFollow {
+		title += " · following"
+	}
+	if t.TranscriptErr != "" {
+		body := StyleError.Render("Could not read "+t.TranscriptPath+":") + "\n" + StyleMuted.Render(t.TranscriptErr) + "\n"
+		return a.box(title, body, height)
+	}
+	lines := a.taskTranscriptLines()
+	if len(lines) == 0 {
+		return a.box(title, StyleMuted.Render("(waiting for transcript…)")+"\n", height)
+	}
+	rows := height - 2
+	if rows < 1 {
+		rows = 1
+	}
+	start := clampScroll(t.TranscriptScroll, len(lines))
+	end := start + rows
+	if end > len(lines) {
+		end = len(lines)
+	}
+	var b strings.Builder
+	for i := start; i < end; i++ {
+		b.WriteString(lines[i])
+		b.WriteString("\n")
+	}
+	return a.box(title, b.String(), height)
+}

--- a/src/internal/dashboard/transcript_view_test.go
+++ b/src/internal/dashboard/transcript_view_test.go
@@ -1,0 +1,112 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTranscriptFixture creates logDir/transcripts/<task>/<name>.md and
+// returns its path.
+func writeTranscriptFixture(t *testing.T, logDir, task, name, content string) string {
+	t.Helper()
+	dir := filepath.Join(logDir, "transcripts", task)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name+".md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestOpenTranscriptViewFromTaskList(t *testing.T) {
+	a := newTestApp(80, 24)
+	a.logDir = t.TempDir()
+	a.model.activeTab = 1 // Tasks
+	path := writeTranscriptFixture(t, a.logDir, "task-1", "wf1-implement", "# Hello\n\ntranscript body\n")
+
+	tt := a.model.tasksTab
+	tt.History = []TaskItem{{TaskID: "task-1"}}
+	tt.SelectedIdx = 0
+
+	handled, cmd := a.openTranscriptView()
+	if !handled {
+		t.Fatal("expected t to be handled with a transcript present")
+	}
+	if tt.View != TaskViewTranscript || tt.TranscriptPath != path {
+		t.Fatalf("view=%v path=%q", tt.View, tt.TranscriptPath)
+	}
+	if !tt.TranscriptFollow {
+		t.Fatal("follow should start enabled")
+	}
+	// Deliver the async load and check rendering.
+	msg := cmd().(taskTranscriptMsg)
+	a.applyTranscriptMsg(msg)
+	out := stripANSI(a.renderTaskTranscript(tt, 20))
+	if !strings.Contains(out, "transcript body") {
+		t.Fatalf("rendered view missing content:\n%s", out)
+	}
+	if !strings.Contains(out, "TRANSCRIPT — wf1-implement.md") {
+		t.Fatalf("missing title:\n%s", out)
+	}
+}
+
+func TestTranscriptStaleReloadIgnored(t *testing.T) {
+	a := newTestApp(80, 24)
+	a.logDir = t.TempDir()
+	tt := a.model.tasksTab
+	tt.View = TaskViewTranscript
+	tt.TranscriptPath = "/current.md"
+	a.applyTranscriptMsg(taskTranscriptMsg{path: "/stale.md", content: "old"})
+	if tt.TranscriptContent != "" {
+		t.Fatal("stale reload for another path must be ignored")
+	}
+}
+
+func TestTranscriptKeysScrollAndFollow(t *testing.T) {
+	a := newTestApp(80, 10)
+	a.logDir = t.TempDir()
+	tt := a.model.tasksTab
+	tt.View = TaskViewTranscript
+	tt.TranscriptReturn = TaskViewList
+	tt.TranscriptPath = "/x.md"
+	tt.TranscriptFollow = true
+	tt.TranscriptContent = strings.Repeat("line\n", 50)
+	tt.invalidateTranscriptLines()
+
+	a.handleTranscriptKey("up")
+	if tt.TranscriptFollow {
+		t.Fatal("scrolling up must clear follow")
+	}
+	a.handleTranscriptKey("end")
+	if !tt.TranscriptFollow {
+		t.Fatal("end must re-enable follow")
+	}
+	a.handleTranscriptKey("t")
+	if !tt.TranscriptRaw {
+		t.Fatal("t must toggle raw mode")
+	}
+	a.handleTranscriptKey("esc")
+	if tt.View != TaskViewList || tt.TranscriptPath != "" {
+		t.Fatalf("esc must restore the return view, got %v", tt.View)
+	}
+}
+
+func TestOpenTranscriptViewNoFileConsumesKey(t *testing.T) {
+	a := newTestApp(80, 24)
+	a.logDir = t.TempDir()
+	a.model.activeTab = 1 // Tasks
+	tt := a.model.tasksTab
+	tt.History = []TaskItem{{TaskID: "task-without-transcript"}}
+	tt.SelectedIdx = 0
+	handled, _ := a.openTranscriptView()
+	if !handled {
+		t.Fatal("focused task without transcript should consume the key (no-op)")
+	}
+	if tt.View != TaskViewList {
+		t.Fatal("view must not change when there is no transcript")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #202: pressing `t` on a focused task now **visualizes the transcript inside the dashboard** instead of opening the file externally.

- New `TaskViewTranscript` sub-view on the Tasks tab: transcript markdown rendered with glamour (same pipeline as the agent file viewer), memoized per width/mode so the render path stays fast.
- **Live tail**: the file is re-read every other tick while the view is open; follow mode pins the viewport to the tail (scrolling up detaches, `end`/`G` re-attaches) — a running session reads like a live feed.
- `t` inside the view toggles raw markdown; `r` reloads; `esc` restores the view you came from.
- **Workflow monitor**: `t` opens the *selected step's* transcript when it exists, falling back to the task's latest.
- **Agents tab** (activity/logs): reuses the existing markdown file viewer, with a new `FileReturn` field so `esc` goes back to where you were instead of the files list.
- Footer hints for the new view; stale async reloads for a different path are ignored.

## Testing

- New `transcript_view_test.go`: open-from-list, live-reload application, stale-reload guard, scroll/follow/raw/esc key map, no-transcript no-op.
- Full `go test ./...` green.