### PR TITLE
fix(dashboard): anchor transcript follow mode to the last page, not the last line

### DIFF
--- a/src/internal/dashboard/transcript_view.go
+++ b/src/internal/dashboard/transcript_view.go
@@ -122,9 +122,8 @@ func (a *App) applyTranscriptMsg(msg taskTranscriptMsg) {
 	t.TranscriptErr = ""
 	t.TranscriptContent = msg.content
 	t.invalidateTranscriptLines()
-	if t.TranscriptFollow {
-		t.TranscriptScroll = lastIndex(len(a.taskTranscriptLines()))
-	}
+	// Follow mode is tail-anchored at render time (pinToTail), so no scroll
+	// bookkeeping is needed here.
 }
 
 // handleTranscriptKey is the key map while the transcript view is open.
@@ -162,8 +161,7 @@ func (a *App) handleTranscriptKey(key string) (tea.Model, tea.Cmd) {
 		t.TranscriptFollow = false
 		t.TranscriptScroll = 0
 	case "end", "G":
-		t.TranscriptFollow = true
-		t.TranscriptScroll = lastIndex(len(lines))
+		t.TranscriptFollow = true // render pins to the tail
 	}
 	return a, nil
 }
@@ -228,7 +226,13 @@ func (a *App) renderTaskTranscript(t *TasksTab, height int) string {
 	if rows < 1 {
 		rows = 1
 	}
+	// Follow mode anchors the viewport to the tail: show the last full page,
+	// not a window starting at the last line.
 	start := clampScroll(t.TranscriptScroll, len(lines))
+	if t.TranscriptFollow {
+		start = pinToTail(len(lines), rows)
+		t.TranscriptScroll = start
+	}
 	end := start + rows
 	if end > len(lines) {
 		end = len(lines)

--- a/src/internal/dashboard/transcript_view_test.go
+++ b/src/internal/dashboard/transcript_view_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +64,41 @@ func TestTranscriptStaleReloadIgnored(t *testing.T) {
 	a.applyTranscriptMsg(taskTranscriptMsg{path: "/stale.md", content: "old"})
 	if tt.TranscriptContent != "" {
 		t.Fatal("stale reload for another path must be ignored")
+	}
+}
+
+// Regression: follow mode must anchor the viewport to the LAST PAGE of the
+// transcript. Pinning to the last line index rendered one line followed by an
+// empty screen (and every live reload snapped back to it), which made the
+// view look completely broken on real transcripts.
+func TestTranscriptFollowShowsTail(t *testing.T) {
+	a := newTestApp(120, 40)
+	a.model.activeTab = 1
+	tt := a.model.tasksTab
+	tt.View = TaskViewTranscript
+	tt.TranscriptPath = "/x.md"
+	tt.TranscriptFollow = true
+
+	var content strings.Builder
+	for i := 1; i <= 200; i++ {
+		fmt.Fprintf(&content, "line %d\n\n", i)
+	}
+	content.WriteString("FINAL LINE\n")
+	a.applyTranscriptMsg(taskTranscriptMsg{path: "/x.md", content: content.String()})
+
+	out := stripANSI(a.renderTaskTranscript(tt, 38))
+	if !strings.Contains(out, "FINAL LINE") {
+		t.Fatalf("follow mode must show the tail of the transcript:\n%s", out)
+	}
+	// The visible window must be full of content, not one line + blanks.
+	nonEmpty := 0
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Trim(l, "│ ┌┐└┘─") != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty < 10 {
+		t.Fatalf("follow window nearly empty (%d content lines):\n%s", nonEmpty, out)
 	}
 }
 


### PR DESCRIPTION
Follow mode pinned the scroll offset to the last line **index**, so the viewport started at the final line: one line of content, then an empty screen — and every ~4s live reload snapped back to it. On real transcripts (reported on project-erp task 3743) the view looked completely broken.

Fix: follow is now tail-anchored at render time with the existing `pinToTail` helper (same semantics as the log views' follow mode), and the redundant scroll bookkeeping in reload/`end` was removed.

Regression test renders a 200-block transcript in follow mode and asserts the tail page is visible and the window is full of content. Verified visually against the real 47 KB transcript from the report. Full `go test ./...` green.