### PR TITLE
fix(dashboard): expand tabs in transcript/file viewers, add loading spinner

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -4421,16 +4421,17 @@ func (a *App) agentFileLines() []string {
 		return ag.fileLines
 	}
 
+	content := sanitizeForTUI(ag.FileContent)
 	var lines []string
 	if !ag.FileRaw && isMarkdownFile(ag.FilePath) {
-		if rendered, err := renderMarkdown(ag.FileContent, inner); err == nil {
+		if rendered, err := renderMarkdown(content, inner); err == nil {
 			// glamour emits its own wrapping + a trailing blank line; trim it and
 			// hard-wrap any over-long line so the box border stays aligned.
 			lines = clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), inner)
 		}
 	}
 	if lines == nil {
-		lines = wrapPlain(ag.FileContent, inner)
+		lines = wrapPlain(content, inner)
 	}
 
 	ag.fileLines = lines

--- a/src/internal/dashboard/transcript_view.go
+++ b/src/internal/dashboard/transcript_view.go
@@ -166,6 +166,23 @@ func (a *App) handleTranscriptKey(key string) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
+// sanitizeForTUI makes arbitrary file content safe for box rendering: tabs
+// are expanded (lipgloss counts a tab as one cell but terminals expand it to
+// the next tab stop, overflowing the box border — agent transcripts are full
+// of tab-indented Go code), carriage returns are dropped, and remaining C0
+// control characters (except newline) are stripped so embedded escapes can
+// never corrupt the terminal.
+func sanitizeForTUI(s string) string {
+	s = strings.ReplaceAll(s, "\t", "    ")
+	s = strings.ReplaceAll(s, "\r", "")
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r >= 0x20 {
+			return r
+		}
+		return -1
+	}, s)
+}
+
 // invalidateTranscriptLines drops the memoized display lines so the next
 // taskTranscriptLines call re-renders (after a toggle, resize, or reload).
 func (t *TasksTab) invalidateTranscriptLines() {
@@ -189,14 +206,15 @@ func (a *App) taskTranscriptLines() []string {
 		return t.transcriptLines
 	}
 
+	content := sanitizeForTUI(t.TranscriptContent)
 	var lines []string
 	if !t.TranscriptRaw {
-		if rendered, err := renderMarkdown(t.TranscriptContent, inner); err == nil {
+		if rendered, err := renderMarkdown(content, inner); err == nil {
 			lines = clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), inner)
 		}
 	}
 	if lines == nil {
-		lines = wrapPlain(t.TranscriptContent, inner)
+		lines = wrapPlain(content, inner)
 	}
 
 	t.transcriptLines = lines
@@ -219,8 +237,9 @@ func (a *App) renderTaskTranscript(t *TasksTab, height int) string {
 		return a.box(title, body, height)
 	}
 	lines := a.taskTranscriptLines()
-	if len(lines) == 0 {
-		return a.box(title, StyleMuted.Render("(waiting for transcript…)")+"\n", height)
+	if len(lines) == 0 || strings.TrimSpace(t.TranscriptContent) == "" {
+		frame := spinnerFrames[a.model.spinnerFrame%len(spinnerFrames)]
+		return a.box(title, StyleMuted.Render(frame+" loading transcript…")+"\n", height)
 	}
 	rows := height - 2
 	if rows < 1 {

--- a/src/internal/dashboard/transcript_view_test.go
+++ b/src/internal/dashboard/transcript_view_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // writeTranscriptFixture creates logDir/transcripts/<task>/<name>.md and
@@ -99,6 +101,45 @@ func TestTranscriptFollowShowsTail(t *testing.T) {
 	}
 	if nonEmpty < 10 {
 		t.Fatalf("follow window nearly empty (%d content lines):\n%s", nonEmpty, out)
+	}
+}
+
+// Regression: tab-indented code in tool calls (Go code is tab-indented)
+// overflowed the box — lipgloss counts a tab as one cell but the terminal
+// expands it to the next tab stop, so every tabbed line pushed past the right
+// border and shattered the layout. Tabs must be expanded before rendering.
+func TestTranscriptTabsDoNotBreakBox(t *testing.T) {
+	a := newTestApp(100, 30)
+	a.model.activeTab = 1
+	tt := a.model.tasksTab
+	tt.View = TaskViewTranscript
+	tt.TranscriptPath = "/x.md"
+	code := "### 🔧 Tool: `Bash`\n\n```go\nfunc create() {\n\t_, err := pool.Exec(ctx,\n\t\t`INSERT INTO tenants (id, nome, slug)`)\n\tif err != nil {\n\t\tt.Fatalf(\"schema: %v\", err)\n\t}\n}\n```\n"
+	a.applyTranscriptMsg(taskTranscriptMsg{path: "/x.md", content: code})
+
+	for _, raw := range []bool{false, true} {
+		tt.TranscriptRaw = raw
+		tt.invalidateTranscriptLines()
+		for i, l := range a.taskTranscriptLines() {
+			if strings.Contains(l, "\t") {
+				t.Fatalf("raw=%v line %d still contains a tab: %q", raw, i, l)
+			}
+			if w := lipgloss.Width(l); w > 98 {
+				t.Fatalf("raw=%v line %d width %d exceeds box inner width: %q", raw, i, w, l)
+			}
+		}
+	}
+}
+
+func TestTranscriptLoadingSpinner(t *testing.T) {
+	a := newTestApp(100, 30)
+	a.model.activeTab = 1
+	tt := a.model.tasksTab
+	tt.View = TaskViewTranscript
+	tt.TranscriptPath = "/x.md"
+	out := stripANSI(a.renderTaskTranscript(tt, 20))
+	if !strings.Contains(out, "loading transcript") {
+		t.Fatalf("empty view must show the loading spinner:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Two fixes for the transcript viewer, reported on real project-erp transcripts:

1. **Tab-indented code shattered the layout.** `lipgloss.Width` counts a tab as one cell but terminals expand it to the next tab stop, so every tab-indented line (all Go code in tool calls — 80+ lines in a typical implement-step transcript) overflowed the right border and corrupted the whole screen. New `sanitizeForTUI` expands tabs to spaces, drops `\r`, and strips remaining C0 control characters before rendering. Applied to both the transcript view and the agent file viewer, which had the same latent bug.
2. **Loading spinner.** The view now shows the braille spinner until the first async read lands, instead of a static "waiting" placeholder.

Regression tests: tab-heavy code renders with no tabs left and every line within the box inner width (rendered and raw modes); empty view shows the spinner. Verified against the real 3755 implement transcript (643 rendered lines, zero overflowing). Full `go test ./...` green.