### PR TITLE
fix(dashboard): render transcripts off the UI thread so the spinner shows

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -208,8 +208,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.model.width = msg.Width
 		a.model.height = msg.Height
 		// The resize drops the width-scoped markdown cache; re-warm whatever log
-		// entries are currently loaded so styled output comes back.
-		return a, a.warmOpenLogsCmd()
+		// entries are currently loaded so styled output comes back. An open
+		// transcript view re-renders at the new width the same way.
+		return a, tea.Batch(a.warmOpenLogsCmd(), a.warmTranscriptCmd())
 
 	case mdWarmedMsg:
 		// Merge the off-thread glamour renders. A batch from before a resize no
@@ -447,7 +448,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case taskTranscriptMsg:
-		a.applyTranscriptMsg(msg)
+		if cmd := a.applyTranscriptMsg(msg); cmd != nil {
+			return a, cmd
+		}
+
+	case transcriptWarmedMsg:
+		a.applyTranscriptWarmed(msg)
 
 	case tailTaskLogsMsg:
 		// Append newly-arrived flat-log lines. While LogFollow is on, render keeps

--- a/src/internal/dashboard/transcript_view.go
+++ b/src/internal/dashboard/transcript_view.go
@@ -104,26 +104,81 @@ func (a *App) loadTranscriptCmd(path string) tea.Cmd {
 	}
 }
 
-// applyTranscriptMsg folds a (re)read into the open transcript view. Follow
-// mode pins the viewport to the tail so a running session reads like a live
-// feed.
-func (a *App) applyTranscriptMsg(msg taskTranscriptMsg) {
+// transcriptWarmedMsg delivers glamour-rendered display lines computed off
+// the UI thread. glamour is too slow for the render path — rendering a large
+// transcript synchronously froze the UI for exactly the time the loading
+// spinner should have been animating.
+type transcriptWarmedMsg struct {
+	path  string
+	width int
+	raw   bool
+	lines []string
+}
+
+// applyTranscriptMsg folds a (re)read into the open transcript view and
+// kicks off the off-thread render. The previously warmed lines stay on
+// screen until the new render lands, so live reloads never flicker back to
+// the spinner. Follow mode is tail-anchored at render time (pinToTail).
+func (a *App) applyTranscriptMsg(msg taskTranscriptMsg) tea.Cmd {
+	t := a.model.tasksTab
+	if t == nil || t.View != TaskViewTranscript || t.TranscriptPath != msg.path {
+		return nil
+	}
+	if msg.err != "" {
+		t.TranscriptErr = msg.err
+		return nil
+	}
+	if msg.content == t.TranscriptContent {
+		return nil
+	}
+	t.TranscriptErr = ""
+	t.TranscriptContent = msg.content
+	return a.warmTranscriptCmd()
+}
+
+// warmTranscriptCmd renders the current transcript content into display
+// lines in a background goroutine, for the current width and raw mode.
+func (a *App) warmTranscriptCmd() tea.Cmd {
+	t := a.model.tasksTab
+	if t == nil || t.TranscriptPath == "" {
+		return nil
+	}
+	path, content, raw := t.TranscriptPath, t.TranscriptContent, t.TranscriptRaw
+	inner := a.transcriptInnerWidth()
+	return func() tea.Msg {
+		return transcriptWarmedMsg{
+			path:  path,
+			width: inner,
+			raw:   raw,
+			lines: computeTranscriptLines(content, inner, raw),
+		}
+	}
+}
+
+// applyTranscriptWarmed merges an off-thread render into the memo. A warm
+// from before a resize, a raw toggle, or a navigation away no longer
+// matches and is dropped.
+func (a *App) applyTranscriptWarmed(msg transcriptWarmedMsg) {
 	t := a.model.tasksTab
 	if t == nil || t.View != TaskViewTranscript || t.TranscriptPath != msg.path {
 		return
 	}
-	if msg.err != "" {
-		t.TranscriptErr = msg.err
+	if msg.width != a.transcriptInnerWidth() || msg.raw != t.TranscriptRaw {
 		return
 	}
-	if msg.content == t.TranscriptContent {
-		return
+	t.transcriptLines = msg.lines
+	t.transcriptLinesWidth = msg.width
+	t.transcriptLinesRaw = msg.raw
+	t.transcriptLinesValid = true
+}
+
+// transcriptInnerWidth is the content width transcript lines are wrapped to.
+func (a *App) transcriptInnerWidth() int {
+	inner := a.model.width - 2
+	if inner < 1 {
+		inner = 1
 	}
-	t.TranscriptErr = ""
-	t.TranscriptContent = msg.content
-	t.invalidateTranscriptLines()
-	// Follow mode is tail-anchored at render time (pinToTail), so no scroll
-	// bookkeeping is needed here.
+	return inner
 }
 
 // handleTranscriptKey is the key map while the transcript view is open.
@@ -141,6 +196,7 @@ func (a *App) handleTranscriptKey(key string) (tea.Model, tea.Cmd) {
 		t.TranscriptScroll = 0
 		t.TranscriptFollow = false
 		t.invalidateTranscriptLines()
+		return a, a.warmTranscriptCmd()
 	case "r":
 		return a, a.loadTranscriptCmd(t.TranscriptPath)
 	case "up", "k":
@@ -190,38 +246,32 @@ func (t *TasksTab) invalidateTranscriptLines() {
 	t.transcriptLinesValid = false
 }
 
-// taskTranscriptLines returns the transcript's display lines wrapped to the
-// box inner width: glamour-rendered markdown unless raw mode is on, memoized
-// per (width, raw mode) like the agent file viewer.
+// taskTranscriptLines returns the warmed display lines, or nil while the
+// off-thread render for the current width/raw mode is still in flight (the
+// view shows the loading spinner). It never renders synchronously — glamour
+// on a large transcript would freeze the UI.
 func (a *App) taskTranscriptLines() []string {
 	t := a.model.tasksTab
 	if t == nil {
 		return nil
 	}
-	inner := a.model.width - 2
-	if inner < 1 {
-		inner = 1
-	}
-	if t.transcriptLinesValid && t.transcriptLinesWidth == inner && t.transcriptLinesRaw == t.TranscriptRaw {
+	if t.transcriptLinesValid && t.transcriptLinesWidth == a.transcriptInnerWidth() && t.transcriptLinesRaw == t.TranscriptRaw {
 		return t.transcriptLines
 	}
+	return nil
+}
 
-	content := sanitizeForTUI(t.TranscriptContent)
-	var lines []string
-	if !t.TranscriptRaw {
+// computeTranscriptLines renders transcript content into display lines
+// wrapped to inner width: glamour-rendered markdown unless raw is set. Pure
+// function, safe to call off the UI thread.
+func computeTranscriptLines(content string, inner int, raw bool) []string {
+	content = sanitizeForTUI(content)
+	if !raw {
 		if rendered, err := renderMarkdown(content, inner); err == nil {
-			lines = clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), inner)
+			return clampToWidth(strings.Split(strings.TrimRight(rendered, "\n"), "\n"), inner)
 		}
 	}
-	if lines == nil {
-		lines = wrapPlain(content, inner)
-	}
-
-	t.transcriptLines = lines
-	t.transcriptLinesWidth = inner
-	t.transcriptLinesRaw = t.TranscriptRaw
-	t.transcriptLinesValid = true
-	return lines
+	return wrapPlain(content, inner)
 }
 
 func (a *App) renderTaskTranscript(t *TasksTab, height int) string {
@@ -237,7 +287,7 @@ func (a *App) renderTaskTranscript(t *TasksTab, height int) string {
 		return a.box(title, body, height)
 	}
 	lines := a.taskTranscriptLines()
-	if len(lines) == 0 || strings.TrimSpace(t.TranscriptContent) == "" {
+	if lines == nil || strings.TrimSpace(t.TranscriptContent) == "" {
 		frame := spinnerFrames[a.model.spinnerFrame%len(spinnerFrames)]
 		return a.box(title, StyleMuted.Render(frame+" loading transcript…")+"\n", height)
 	}

--- a/src/internal/dashboard/transcript_view_test.go
+++ b/src/internal/dashboard/transcript_view_test.go
@@ -10,6 +10,21 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// deliverTranscript runs the async load+warm pipeline synchronously: applies
+// the read message, then executes and applies the warm command it returns.
+func deliverTranscript(t *testing.T, a *App, msg taskTranscriptMsg) {
+	t.Helper()
+	cmd := a.applyTranscriptMsg(msg)
+	if cmd == nil {
+		return
+	}
+	warmed, ok := cmd().(transcriptWarmedMsg)
+	if !ok {
+		t.Fatalf("expected transcriptWarmedMsg from warm command")
+	}
+	a.applyTranscriptWarmed(warmed)
+}
+
 // writeTranscriptFixture creates logDir/transcripts/<task>/<name>.md and
 // returns its path.
 func writeTranscriptFixture(t *testing.T, logDir, task, name, content string) string {
@@ -47,7 +62,7 @@ func TestOpenTranscriptViewFromTaskList(t *testing.T) {
 	}
 	// Deliver the async load and check rendering.
 	msg := cmd().(taskTranscriptMsg)
-	a.applyTranscriptMsg(msg)
+	deliverTranscript(t, a, msg)
 	out := stripANSI(a.renderTaskTranscript(tt, 20))
 	if !strings.Contains(out, "transcript body") {
 		t.Fatalf("rendered view missing content:\n%s", out)
@@ -86,7 +101,7 @@ func TestTranscriptFollowShowsTail(t *testing.T) {
 		fmt.Fprintf(&content, "line %d\n\n", i)
 	}
 	content.WriteString("FINAL LINE\n")
-	a.applyTranscriptMsg(taskTranscriptMsg{path: "/x.md", content: content.String()})
+	deliverTranscript(t, a, taskTranscriptMsg{path: "/x.md", content: content.String()})
 
 	out := stripANSI(a.renderTaskTranscript(tt, 38))
 	if !strings.Contains(out, "FINAL LINE") {
@@ -115,11 +130,14 @@ func TestTranscriptTabsDoNotBreakBox(t *testing.T) {
 	tt.View = TaskViewTranscript
 	tt.TranscriptPath = "/x.md"
 	code := "### 🔧 Tool: `Bash`\n\n```go\nfunc create() {\n\t_, err := pool.Exec(ctx,\n\t\t`INSERT INTO tenants (id, nome, slug)`)\n\tif err != nil {\n\t\tt.Fatalf(\"schema: %v\", err)\n\t}\n}\n```\n"
-	a.applyTranscriptMsg(taskTranscriptMsg{path: "/x.md", content: code})
+	deliverTranscript(t, a, taskTranscriptMsg{path: "/x.md", content: code})
 
 	for _, raw := range []bool{false, true} {
 		tt.TranscriptRaw = raw
 		tt.invalidateTranscriptLines()
+		if warmed, ok := a.warmTranscriptCmd()().(transcriptWarmedMsg); ok {
+			a.applyTranscriptWarmed(warmed)
+		}
 		for i, l := range a.taskTranscriptLines() {
 			if strings.Contains(l, "\t") {
 				t.Fatalf("raw=%v line %d still contains a tab: %q", raw, i, l)


### PR DESCRIPTION
The loading spinner added in #205 never actually appeared: the slow part of opening a transcript is the **glamour render**, which ran synchronously inside the render path — the UI simply froze for the duration the spinner should have been spinning.

Transcript rendering now runs in a background command (`transcriptWarmedMsg`, the same pattern as the log view's async markdown warm-up):

- the view animates the braille spinner until the warmed display lines land
- live reloads keep the previous render on screen until the new one is ready — no flicker back to the spinner every ~4s
- resize and the raw toggle re-warm at the new width/mode; stale warms (old width, mode, or path) are dropped
- `taskTranscriptLines` is now a pure memo read and never renders synchronously

Tests updated to drive the async load→warm pipeline explicitly; spinner regression test kept. Full `go test ./...` green.