### PR TITLE
feat: escalation notification hooks (needs-attention pings a human)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -507,3 +507,19 @@ tasks:
   on_fail:
     set_state: blocked
     add_labels: [ai-failed]
+
+# ── Escalation notifications (#201) ──────────────────────────────────────────────
+# Whenever a hook (a workflow's on_fail/on_complete, the task-level hooks above,
+# or the failure-cap park) adds one of `on_labels` to a source item, every channel
+# fires — so a flow parked with needs-attention pings a human instead of freezing
+# silently. Only `type: command` exists: an arbitrary shell hook (ntfy, Slack
+# webhook via curl, osascript, ...) so apiary carries no provider integrations.
+# Placeholders {{task_id}} {{cell_id}} {{number}} {{title}} {{url}} {{label}}
+# {{summary}} are substituted shell-quoted; the same values are exported as
+# APIARY_TASK_ID, APIARY_CELL_ID, APIARY_NUMBER, APIARY_TITLE, APIARY_URL,
+# APIARY_LABEL, APIARY_SUMMARY.
+# notifications:
+#   on_labels: [needs-attention]
+#   channels:
+#     - type: command
+#       run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-apiary-alerts

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -141,6 +141,39 @@ settings:
   max_attempts: 3
 ```
 
+## Escalation notifications
+
+Escalating to a human is only useful if the human finds out. Without
+configuration, a workflow that parks a task with `needs-attention` leaves the
+label sitting on the issue until someone happens to look — a failed staging
+deploy can freeze the pipeline silently.
+
+The top-level `notifications:` block fires whenever a hook (a workflow's
+`on_fail`/`on_complete`, the task-level `tasks:` hooks, or the failure-cap
+park above) adds one of the watched labels to a source item:
+
+```yaml
+notifications:
+  on_labels: [needs-attention]
+  channels:
+    - type: command
+      run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-alerts
+```
+
+Only `type: command` exists — an arbitrary shell hook (ntfy, a Slack webhook
+via `curl`, `osascript`, e-mail, …), so Apiary carries no provider
+integrations. Channels run asynchronously with a 60-second timeout and never
+block or fail the hook that triggered them.
+
+The command may use `{{task_id}}`, `{{cell_id}}`, `{{number}}`, `{{title}}`,
+`{{url}}`, `{{label}}`, and `{{summary}}` placeholders — values are
+shell-quoted on substitution, so titles with quotes cannot break or inject
+into the command line. The same values are exported to the hook as
+`APIARY_TASK_ID`, `APIARY_CELL_ID`, `APIARY_NUMBER`, `APIARY_TITLE`,
+`APIARY_URL`, `APIARY_LABEL`, and `APIARY_SUMMARY`. `{{summary}}` is the
+latest step summary of the task's newest workflow instance (falling back to
+the last failed step's error, then the task title).
+
 ## Non-blocking dispatch
 
 Each agent's `max_workers` slot is acquired inside the dispatch goroutine,

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -557,6 +557,41 @@
           "$ref": "#/definitions/OnComplete"
         }
       }
+    },
+    "notifications": {
+      "type": "object",
+      "description": "Escalation notifications: whenever a hook (workflow on_fail/on_complete, task-level hooks, or the failure-cap park) adds one of on_labels to a source item, every channel fires — so a flow parked with needs-attention pings a human instead of freezing silently",
+      "additionalProperties": false,
+      "required": ["on_labels", "channels"],
+      "properties": {
+        "on_labels": {
+          "type": "array",
+          "description": "Escalation labels to watch (e.g. needs-attention)",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "channels": {
+          "type": "array",
+          "description": "Notification hooks fired in order for each matched label",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "run"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Channel kind; only \"command\" is supported (an arbitrary shell hook: ntfy, Slack webhook via curl, osascript, ...)",
+                "enum": ["command"]
+              },
+              "run": {
+                "type": "string",
+                "description": "Shell command to run. {{task_id}}, {{cell_id}}, {{number}}, {{title}}, {{url}}, {{label}}, {{summary}} placeholders are substituted shell-quoted; the same values are exported as APIARY_* environment variables"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Profiles      map[string]map[string]ProfileConfig `yaml:"profiles,omitempty"` // NEW: named runner profiles
 	Settings      Settings         `yaml:"settings"`
 	Tasks         *TasksConfig     `yaml:"tasks"`
+	Notifications *NotificationsConfig `yaml:"notifications"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 }
@@ -206,6 +207,30 @@ type OnComplete struct {
 	// AssignLabelPrefix is the label prefix used for AssignFromOutput. Defaults
 	// to "agent:" so the assigned label matches the agent:* route convention.
 	AssignLabelPrefix string `yaml:"assign_label_prefix"`
+}
+
+// NotificationsConfig is the top-level `notifications:` block: it makes
+// escalation visible to a human. Whenever a hook (a workflow's on_fail /
+// on_complete, the task-level hooks, or the failure-cap park) adds one of
+// OnLabels to a source item, every channel fires — so a flow parked with
+// needs-attention pings an operator instead of freezing silently (#201).
+type NotificationsConfig struct {
+	// OnLabels are the escalation labels to watch (e.g. needs-attention).
+	OnLabels []string `yaml:"on_labels"`
+	// Channels are the notification hooks to fire, in order.
+	Channels []NotificationChannel `yaml:"channels"`
+}
+
+// NotificationChannel is one notification hook. Only type "command" exists: an
+// arbitrary shell command (ntfy, Slack webhook via curl, osascript, …) so the
+// engine takes on no provider integrations. The command string may use
+// {{task_id}}, {{cell_id}}, {{number}}, {{title}}, {{url}}, {{label}}, and
+// {{summary}} placeholders (values are shell-quoted on substitution); the same
+// values are also exported as APIARY_TASK_ID, APIARY_CELL_ID, APIARY_NUMBER,
+// APIARY_TITLE, APIARY_URL, APIARY_LABEL, and APIARY_SUMMARY.
+type NotificationChannel struct {
+	Type string `yaml:"type"`
+	Run  string `yaml:"run"`
 }
 
 // TasksConfig is the top-level `tasks:` block. Its hooks fire once per

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -260,5 +260,35 @@ func (c *Config) Validate() []error {
 	// config was built in code rather than loaded from a file).
 	errs = append(errs, c.lint()...)
 
+	errs = append(errs, c.validateNotifications()...)
+
+	return errs
+}
+
+// validateNotifications checks the top-level notifications block: watching
+// labels without a channel (or vice versa) is a configuration mistake that
+// would silently never notify.
+func (c *Config) validateNotifications() []error {
+	n := c.Notifications
+	if n == nil {
+		return nil
+	}
+	var errs []error
+	if len(n.OnLabels) == 0 {
+		errs = append(errs, fmt.Errorf("notifications: on_labels is required (which labels should trigger a notification)"))
+	}
+	if len(n.Channels) == 0 {
+		errs = append(errs, fmt.Errorf("notifications: at least one channel is required"))
+	}
+	for i, ch := range n.Channels {
+		switch ch.Type {
+		case "command":
+			if strings.TrimSpace(ch.Run) == "" {
+				errs = append(errs, fmt.Errorf("notifications.channels[%d]: run is required for type \"command\"", i))
+			}
+		default:
+			errs = append(errs, fmt.Errorf("notifications.channels[%d]: unknown type %q (only \"command\" is supported)", i, ch.Type))
+		}
+	}
 	return errs
 }

--- a/src/internal/daemon/notify.go
+++ b/src/internal/daemon/notify.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// notifyTimeout bounds each notification command so a hung hook (network
+// webhook, stuck script) can never pile up goroutines.
+const notifyTimeout = 60 * time.Second
+
+// escalationEvent carries everything a notification channel may reference.
+type escalationEvent struct {
+	TaskID  string
+	CellID  string
+	Number  string
+	Title   string
+	URL     string
+	Label   string
+	Summary string
+}
+
+// matchedEscalationLabels returns the hook labels that are configured as
+// escalation labels, preserving hook order.
+func matchedEscalationLabels(cfg *config.NotificationsConfig, added []string) []string {
+	if cfg == nil || len(cfg.Channels) == 0 {
+		return nil
+	}
+	watch := make(map[string]bool, len(cfg.OnLabels))
+	for _, l := range cfg.OnLabels {
+		watch[l] = true
+	}
+	var out []string
+	for _, l := range added {
+		if watch[l] {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// notifyEscalation fires every configured channel for one escalation label,
+// asynchronously — notification is observability, it must never block or fail
+// a hook. Errors are logged and swallowed.
+func (d *Dispatcher) notifyEscalation(ev escalationEvent) {
+	n := d.cfg.Notifications
+	if n == nil {
+		return
+	}
+	for i, ch := range n.Channels {
+		if ch.Type != "command" || strings.TrimSpace(ch.Run) == "" {
+			continue
+		}
+		idx, run := i, ch.Run
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
+			defer cancel()
+			cmdline := renderNotifyCommand(run, ev)
+			cmd := exec.CommandContext(ctx, "sh", "-c", cmdline)
+			cmd.Env = append(os.Environ(),
+				"APIARY_TASK_ID="+ev.TaskID,
+				"APIARY_CELL_ID="+ev.CellID,
+				"APIARY_NUMBER="+ev.Number,
+				"APIARY_TITLE="+ev.Title,
+				"APIARY_URL="+ev.URL,
+				"APIARY_LABEL="+ev.Label,
+				"APIARY_SUMMARY="+ev.Summary,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				aplog.Error("notification channel %d for %s (label %q): %v — %s",
+					idx, ev.CellID, ev.Label, err, strings.TrimSpace(string(out)))
+				return
+			}
+			aplog.Info("notification sent: channel %d for %s (label %q)", idx, ev.CellID, ev.Label)
+		}()
+	}
+}
+
+// renderNotifyCommand substitutes {{placeholder}} tokens with shell-quoted
+// values, so titles/summaries with spaces or quotes can never break (or
+// inject into) the command line. Operators who prefer raw values can use the
+// APIARY_* environment variables instead.
+func renderNotifyCommand(tmpl string, ev escalationEvent) string {
+	r := strings.NewReplacer(
+		"{{task_id}}", shellQuote(ev.TaskID),
+		"{{cell_id}}", shellQuote(ev.CellID),
+		"{{number}}", shellQuote(ev.Number),
+		"{{title}}", shellQuote(ev.Title),
+		"{{url}}", shellQuote(ev.URL),
+		"{{label}}", shellQuote(ev.Label),
+		"{{summary}}", shellQuote(ev.Summary),
+	)
+	return r.Replace(tmpl)
+}
+
+// shellQuote wraps s in single quotes, escaping embedded single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// escalationSummary digs up the most useful one-liner for the event: the last
+// non-empty step summary of the task's newest workflow instance, falling back
+// to the last failed step's error, then to the task title. Best-effort — any
+// DB error just falls back.
+func (d *Dispatcher) escalationSummary(ctx context.Context, task model.InternalTask) string {
+	if d.db == nil {
+		return task.Title
+	}
+	instances, err := d.db.ListWorkflowInstancesByTask(ctx, task.ID)
+	if err != nil || len(instances) == 0 {
+		return task.Title
+	}
+	// Newest first is not guaranteed by the store; scan for the latest.
+	latest := instances[0]
+	for _, in := range instances[1:] {
+		if in.CreatedAt.After(latest.CreatedAt) {
+			latest = in
+		}
+	}
+	steps, err := d.db.ListStepRuns(ctx, latest.ID)
+	if err != nil {
+		return task.Title
+	}
+	for i := len(steps) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(steps[i].Summary); s != "" {
+			return s
+		}
+	}
+	for i := len(steps) - 1; i >= 0; i-- {
+		if steps[i].State == "failed" && strings.TrimSpace(steps[i].Output) != "" {
+			return firstLine(steps[i].Output)
+		}
+	}
+	return task.Title
+}
+
+// firstLine returns the first non-empty line of s, capped for notification use.
+func firstLine(s string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		const max = 300
+		if len(line) > max {
+			return line[:max] + "…"
+		}
+		return line
+	}
+	return ""
+}

--- a/src/internal/daemon/notify_test.go
+++ b/src/internal/daemon/notify_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func TestMatchedEscalationLabels(t *testing.T) {
+	cfg := &config.NotificationsConfig{
+		OnLabels: []string{"needs-attention", "needs-human"},
+		Channels: []config.NotificationChannel{{Type: "command", Run: "true"}},
+	}
+	got := matchedEscalationLabels(cfg, []string{"blocked", "needs-attention"})
+	if len(got) != 1 || got[0] != "needs-attention" {
+		t.Fatalf("got %v", got)
+	}
+	if matchedEscalationLabels(nil, []string{"needs-attention"}) != nil {
+		t.Fatal("nil config must match nothing")
+	}
+	if matchedEscalationLabels(&config.NotificationsConfig{OnLabels: []string{"x"}}, []string{"x"}) != nil {
+		t.Fatal("config without channels must match nothing")
+	}
+}
+
+func TestRenderNotifyCommandQuotesValues(t *testing.T) {
+	ev := escalationEvent{
+		Title:   `deploy failed; rm -rf / '"$(reboot)"`,
+		Label:   "needs-attention",
+		CellID:  "3743",
+		Summary: "staging deploy exited 1",
+	}
+	out := renderNotifyCommand(`notify.sh {{cell_id}} {{label}} {{title}} {{summary}}`, ev)
+	if strings.Contains(out, "$(reboot)") && !strings.Contains(out, `'`) {
+		t.Fatalf("unquoted substitution: %s", out)
+	}
+	// The dangerous title must be inside single quotes with inner quotes escaped.
+	if !strings.Contains(out, `'deploy failed; rm -rf / '\''"$(reboot)"'`) {
+		t.Fatalf("title not safely quoted: %s", out)
+	}
+	if !strings.Contains(out, "'3743' 'needs-attention'") {
+		t.Fatalf("simple values not substituted: %s", out)
+	}
+}
+
+func TestNotifyEscalationRunsCommand(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "out.txt")
+	d := &Dispatcher{cfg: &config.Config{
+		Notifications: &config.NotificationsConfig{
+			OnLabels: []string{"needs-attention"},
+			Channels: []config.NotificationChannel{{
+				Type: "command",
+				Run:  `printf '%s|%s|%s' {{cell_id}} {{label}} "$APIARY_TITLE" > ` + outFile,
+			}},
+		},
+	}}
+	d.notifyEscalation(escalationEvent{
+		CellID: "owner/repo#42",
+		Label:  "needs-attention",
+		Title:  "deploy failed",
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, err := os.ReadFile(outFile)
+		if err == nil && len(data) > 0 {
+			if got, want := string(data), "owner/repo#42|needs-attention|deploy failed"; got != want {
+				t.Fatalf("got %q want %q", got, want)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("notification command never ran")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// The full path issue #201 describes: a hook parks a task with
+// needs-attention → the configured channel fires with the item's identity.
+func TestApplyHookFiresEscalationNotification(t *testing.T) {
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "out.txt")
+	fake := &fakeHookSource{}
+	d := &Dispatcher{
+		sources: map[string]source.Adapter{"fake": fake},
+		cfg: &config.Config{
+			Notifications: &config.NotificationsConfig{
+				OnLabels: []string{"needs-attention"},
+				Channels: []config.NotificationChannel{{
+					Type: "command",
+					Run:  `printf '%s %s' {{number}} {{label}} > ` + outFile,
+				}},
+			},
+		},
+	}
+	task := model.InternalTask{ID: "T-9", Title: "Deploy staging"}
+	bindings := []model.SourceBinding{{SourceID: "fake", SourceItemID: "I-9", SourceItemNumber: "ERP-42"}}
+	hook := config.OnComplete{AddLabels: []string{"needs-attention"}}
+
+	if err := (&wfSideEffects{d: d}).ApplyHook(context.Background(), task, bindings, hook); err != nil {
+		t.Fatalf("ApplyHook: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		data, _ := os.ReadFile(outFile)
+		if string(data) == "ERP-42 needs-attention" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("notification never fired, got %q", string(data))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestValidateNotifications(t *testing.T) {
+	c := &config.Config{
+		Version: "1",
+		Notifications: &config.NotificationsConfig{
+			Channels: []config.NotificationChannel{{Type: "slack"}, {Type: "command", Run: " "}},
+		},
+	}
+	errs := c.Validate()
+	var msgs []string
+	for _, e := range errs {
+		msgs = append(msgs, e.Error())
+	}
+	all := strings.Join(msgs, "\n")
+	for _, want := range []string{
+		"notifications: on_labels is required",
+		`unknown type "slack"`,
+		`run is required for type "command"`,
+	} {
+		if !strings.Contains(all, want) {
+			t.Errorf("missing validation error %q in:\n%s", want, all)
+		}
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -713,6 +713,35 @@ func (s *wfSideEffects) ApplyHook(ctx context.Context, task model.InternalTask, 
 			}
 		}
 	}
+
+	// Escalation notifications (#201): when a hook adds a watched label (e.g.
+	// needs-attention), ping the configured channels — otherwise the escalation
+	// is silent and the parked flow waits for someone to happen to look. Every
+	// escalation path funnels through this hook applier (engine on_fail /
+	// on_complete, task-level hooks, and the failure-cap park), so this is the
+	// single choke point. Fired once per label per hook, not per binding.
+	var notifCfg *config.NotificationsConfig
+	if s.d.cfg != nil {
+		notifCfg = s.d.cfg.Notifications
+	}
+	if matched := matchedEscalationLabels(notifCfg, hook.AddLabels); len(matched) > 0 {
+		ev := escalationEvent{
+			TaskID:  task.ID,
+			CellID:  task.ID,
+			Title:   task.Title,
+			Summary: s.d.escalationSummary(ctx, task),
+		}
+		if len(bindings) > 0 {
+			b := bindings[0]
+			ev.CellID = b.SourceItemID
+			ev.Number = b.SourceItemNumber
+			ev.URL = b.SourceItemURL
+		}
+		for _, label := range matched {
+			ev.Label = label
+			s.d.notifyEscalation(ev)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #201.

When a workflow (or the failure cap) escalates by adding `needs-attention`, nothing notified a human — the label sat on the issue until someone looked, and a failed staging deploy froze the pipeline silently.

## What's new

Top-level `notifications:` block, exactly as proposed in the issue:

```yaml
notifications:
  on_labels: [needs-attention, needs-human]
  channels:
    - type: command
      run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-alerts
```

- **Single choke point**: every escalation path funnels through `wfSideEffects.ApplyHook` — workflow `on_fail`/`on_complete`, task-level `tasks:` hooks, and the failure-cap park — so a watched label added by any of them fires the channels. Fired once per label per hook, not per binding.
- **Generic command hook only** (ntfy, Slack webhook via curl, osascript, e-mail…): the engine takes on no provider integrations.
- **Injection-safe templating**: `{{task_id}} {{cell_id}} {{number}} {{title}} {{url}} {{label}} {{summary}}` are substituted shell-quoted; raw values are also exported as `APIARY_*` env vars for scripts that prefer them.
- **Useful `{{summary}}`**: the latest step summary of the task's newest workflow instance, falling back to the last failed step's first error line, then the task title.
- **Never blocks**: channels run asynchronously with a 60 s timeout; failures are logged and swallowed — notification is observability, not control flow.
- Config validation (`apiary validate` rejects missing on_labels/channels and unknown channel types), JSON schema, example config, and resilience docs updated.

## Testing

- Unit: label matching, shell-quoting (incl. a hostile title with `$(reboot)`), command execution with env + placeholders, validation errors.
- Wiring: `ApplyHook` with a fake source + `needs-attention` hook fires the channel with the item's number and label.
- `apiary validate` exercised end-to-end on good and bad configs. Full `go test ./...` green.