### PR TITLE
docs: notifications block in configuration reference and apiary-guide skill

### DIFF
--- a/.claude/skills/apiary-guide/SKILL.md
+++ b/.claude/skills/apiary-guide/SKILL.md
@@ -358,6 +358,22 @@ runaway loop:
 - **Non-blocking dispatch.** A busy agent's `max_workers` slot is acquired inside
   the dispatch goroutine, so a saturated agent never stalls polling/dispatch for
   other sources or agents.
+- **Escalation notifications (`notifications:`).** When any hook (workflow
+  `on_fail`/`on_complete`, task-level `tasks:` hooks, failure-cap park) adds a
+  label listed in `on_labels` (e.g. `needs-attention`), every configured channel
+  fires — so a parked flow pings a human instead of freezing silently. Only
+  `type: command` (arbitrary shell hook: ntfy, Slack webhook, osascript).
+  Placeholders `{{task_id}} {{cell_id}} {{number}} {{title}} {{url}} {{label}}
+  {{summary}}` are shell-quoted; raw values exported as `APIARY_*` env vars.
+  Channels run async (60s timeout) and never block the hook.
+
+  ```yaml
+  notifications:
+    on_labels: [needs-attention]
+    channels:
+      - type: command
+        run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-alerts
+  ```
 
 ## Agent Memory
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -453,6 +453,23 @@ tasks:
     add_labels: [ai-failed]
 ```
 
+## `notifications`
+
+Escalation hooks that ping a human whenever a workflow hook (per-workflow
+`on_fail`/`on_complete`, the task-level `tasks:` hooks, or the failure-cap
+park) adds one of the watched labels to a source item — so a task parked
+with `needs-attention` doesn't wait silently for someone to look. See
+[Rate limits & resilience](resilience.md#escalation-notifications) for
+placeholders, environment variables, and behavior.
+
+```yaml
+notifications:
+  on_labels: [needs-attention]
+  channels:
+    - type: command
+      run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-alerts
+```
+
 ## Environment variables
 
 Agent subprocesses inherit the daemon's environment plus an overlay you


### PR DESCRIPTION
Follow-up to #207 (escalation notifications, issue #201). That PR updated [resilience.md](docs/resilience.md), the JSON schema, and the example config; this completes the doc surfaces:

- `docs/configuration.md`: new `notifications` top-level block section (linking to the resilience page for details)
- `.claude/skills/apiary-guide/SKILL.md`: bullet + example in the Rate limits & resilience section