### PR TITLE
feat: add immutable workflow replay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8345 symbols, 19060 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8821 symbols, 20023 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8345 symbols, 19060 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8821 symbols, 20023 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,14 +96,30 @@ apiary task <id> --json
 
 ### `apiary resume`
 
-Resume a failed or interrupted workflow instance from the last completed
-step. Cached steps are replayed (their outputs and memory restored), then
-execution continues.
+Replay a failed or interrupted workflow instance as a new immutable descendant.
+Cached steps are copied into the new attempt (their outputs and memory restored),
+then execution continues. The source attempt is never modified.
 
 ```sh
 apiary resume <instance-id> [--yes]
 apiary resume --workflow <workflow-id> [--yes]   # most recent failed/interrupted instance
+apiary resume <instance-id> --from implement     # rerun this step and later steps
+apiary resume <instance-id> --definition original # use the snapshotted definition
 ```
+
+`--definition current` is the default. `--definition original` requires an instance
+created after workflow snapshots were introduced.
+
+Compare any two attempts step by step:
+
+```sh
+apiary instances compare <before-id> <after-id>
+apiary instances compare <before-id> <after-id> --json
+```
+
+The comparison reports state, input/output changes, token and cost deltas, and
+model/runner changes. Use `apiary run --dry-run` to evaluate source matching and
+routing without starting an agent.
 
 ### `apiary dispatch`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -520,13 +520,32 @@ over:
 ```sh
 apiary instances                  # list instances and their states
 apiary instances <instance-id>    # step-level detail
-apiary resume <instance-id>       # replay cached steps, continue from failure
+apiary resume <instance-id>       # create a descendant and continue from failure
+apiary resume <instance-id> --from <step-id>
+apiary resume <instance-id> --definition original
 ```
 
 The workflow's `resume` policy controls eligibility: `allowed` (default),
-`forbidden`, or `auto`. Completed steps are skipped on resume (their cached
-outputs and memory are restored); steps marked `idempotent: true` are safe to
-re-run when the engine needs to.
+`forbidden`, or `auto`. A manual resume creates a new workflow instance whose
+`resumed_from` field points to the source attempt. Completed step rows selected
+for reuse are copied into that descendant and marked cached; the original
+attempt remains immutable. Their outputs and memory are restored without
+re-firing side effects.
+
+By default Apiary uses the current workflow definition. Every new instance also
+stores a definition snapshot, allowing `--definition original` to replay the exact
+definition used by the selected attempt. `--from` reuses passed steps declared
+before the selected step and reruns that step plus subsequent steps. Split steps
+are always re-evaluated so branch activation reflects the restored memory.
+
+Workflow- and step-level environment overlays are not persisted in snapshots,
+because expanded values may contain secrets. Original-definition replay resolves
+those overlays from the current workflow configuration.
+
+Use `apiary instances compare <before> <after>` to compare step states, prompts,
+outputs, model/runner selection, token usage, cost, and timing between attempts.
+Steps marked `idempotent: true` remain the operator's signal that rerunning their
+external effects is safe.
 
 A complete annotated pipeline using most of this page lives at
 [`.apiary/example-workflow.yaml`](https://github.com/orlandoburli/apiary/blob/main/.apiary/example-workflow.yaml).

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -6,6 +6,10 @@ _Nenhuma change ativa no momento._
 
 ## Arquivadas
 
+### 2026-07-22
+
+- **immutable-execution-replay** — Immutable workflow replay with descendant attempt lineage, selectable resume points, secret-safe workflow-definition snapshots, and CLI comparison of attempts. GitHub issue #209.
+
 ### 2026-07-07
 
 - **credit-aware-fallback** — Credit-aware runner fallback: out-of-credits detection beyond rate-limit-only with `FailureDetector` interface, failure-kind-specific cooldowns (5m rate-limit / 24h credit / 0 abort), `settings.default_fallbacks` global fallback chain, per-agent `fallback_strategy` (ordered/random/least_cost/fastest), named runner profiles via `profiles.<name>` activated with `--profile=<name>`, `credit_exhausted` and `failure_kind` columns on `task_executions`, config validation for all new fields, and full documentation updates.

--- a/openspec/changes/archive/2026-07-22-immutable-execution-replay/design.md
+++ b/openspec/changes/archive/2026-07-22-immutable-execution-replay/design.md
@@ -1,0 +1,17 @@
+# Design
+
+## Immutable descendants
+
+The workflow engine creates a fresh `workflow_instances` row for resume and sets `resumed_from` to the source instance. Passed steps eligible for reuse are copied to new `step_runs` rows with new IDs and `skipped_cached = true`. The original instance and step rows are never updated.
+
+## Resume point
+
+Without `--from`, all compatible passed steps are reused. With `--from`, only passed steps declared before the selected step are reused; the selected step and all later declared steps execute again. Split steps are always re-evaluated because they are side-effect free and activate branches.
+
+## Workflow snapshots
+
+Snapshots live in a separate `workflow_instance_snapshots` table keyed by instance ID. This avoids widening the high-fan-out workflow-instance scan contract. Normal and resumed runs record the structural `WorkflowConfig` used. Workflow and step environment overlays are deliberately omitted because config expansion may place secrets in those maps; original-definition replay resolves those overlays from the current configuration.
+
+## Comparison
+
+The daemon builds comparison data from two instance details. Steps are aligned by step ID. Repeated loop executions use the last row for change detection and aggregate usage already persisted on the logical step row.

--- a/openspec/changes/archive/2026-07-22-immutable-execution-replay/proposal.md
+++ b/openspec/changes/archive/2026-07-22-immutable-execution-replay/proposal.md
@@ -1,0 +1,19 @@
+# Immutable execution replay
+
+## Why
+
+`apiary resume` currently mutates the failed or interrupted workflow instance and marks its previously passed step rows as cached. That loses the immutable record of the original attempt and prevents reliable before/after comparison.
+
+## What changes
+
+- Every resume creates a new workflow instance linked through `resumed_from`.
+- Passed step outputs selected for reuse are copied into the descendant attempt and marked cached; source rows remain unchanged.
+- Workflow definitions are snapshotted per instance so operators may replay the original definition or the current configuration.
+- `--from <step>` selects the first step to execute again; `--definition`
+  selects `current` or `original` without conflicting with the global config-file flag.
+- `apiary instances compare <a> <b>` compares step state, input/output changes, usage, cost, runner, model, and timing.
+- Existing routing dry-run remains the supported no-run route/condition preview.
+
+## Compatibility
+
+The default configuration mode remains `current` for compatibility. Instances created before workflow snapshots exist can still resume with current configuration; requesting `original` returns an actionable error.

--- a/openspec/changes/archive/2026-07-22-immutable-execution-replay/tasks.md
+++ b/openspec/changes/archive/2026-07-22-immutable-execution-replay/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Persist and load workflow-definition snapshots.
+- [x] Create immutable descendant instances on resume.
+- [x] Copy cached step rows without mutating the source attempt.
+- [x] Add selectable resume points and configuration mode to IPC and CLI.
+- [x] Add instance comparison IPC and CLI output.
+- [x] Add unit and integration coverage.
+- [x] Update CLI and workflow documentation.
+- [x] Run tests, lint, and GitNexus change detection.
+- [x] Prepare the branch for the PR workflow after local validation.

--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -50,7 +50,60 @@ func newInstancesCmd() *cobra.Command {
 	cmd.Flags().StringVar(&state, "state", "", "filter by state (pending, running, approval_waiting, interrupted, done, failed)")
 	cmd.Flags().IntVar(&limit, "limit", 20, "max rows")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	cmd.AddCommand(newInstancesCompareCmd())
 	return cmd
+}
+
+func newInstancesCompareCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "compare <before-id> <after-id>",
+		Short: "Compare two workflow attempts step by step",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return compareInstances(args[0], args[1], asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+func compareInstances(beforeID, afterID string, asJSON bool) error {
+	q := url.Values{"before": {beforeID}, "after": {afterID}}
+	var comparison daemon.InstanceComparison
+	if err := ipcGetJSON("/instances/compare?"+q.Encode(), &comparison); err != nil {
+		return daemonDownHint()
+	}
+	if asJSON {
+		line, _ := json.MarshalIndent(comparison, "", "  ")
+		fmt.Println(string(line))
+		return nil
+	}
+	fmt.Printf("Comparing %s → %s\n\n", comparison.BeforeID, comparison.AfterID)
+	fmt.Println(instHeader.Render(fmt.Sprintf("%-18s %-13s %-13s %-10s %-10s %-12s %-10s", "STEP", "BEFORE", "AFTER", "INPUT", "OUTPUT", "USAGE Δ", "TIME Δ")))
+	for _, row := range comparison.Steps {
+		before, after := "—", "—"
+		if row.Before != nil {
+			before = row.Before.State
+		}
+		if row.After != nil {
+			after = row.After.State
+		}
+		input, output := "same", "same"
+		if row.InputChanged {
+			input = "changed"
+		}
+		if row.OutputChanged {
+			output = "changed"
+		}
+		usage := fmt.Sprintf("%+d / %+.5f", row.TokenDelta, row.CostDeltaUSD)
+		timing := fmt.Sprintf("%+dms", row.DurationDeltaMS)
+		fmt.Printf("%-18s %-13s %-13s %-10s %-10s %-12s %-10s\n", truncate(row.StepID, 18), before, after, input, output, usage, timing)
+		if row.BeforeModel != row.AfterModel || row.BeforeRunner != row.AfterRunner {
+			fmt.Printf("  %s\n", instMuted.Render(fmt.Sprintf("model/runner: %s/%s → %s/%s", row.BeforeModel, row.BeforeRunner, row.AfterModel, row.AfterRunner)))
+		}
+	}
+	return nil
 }
 
 func listInstances(workflow, state string, limit int, asJSON bool) error {

--- a/src/internal/cli/resume.go
+++ b/src/internal/cli/resume.go
@@ -21,34 +21,45 @@ import (
 
 func newResumeCmd() *cobra.Command {
 	var (
-		yes      bool
-		workflow string
+		yes        bool
+		workflow   string
+		fromStep   string
+		configMode string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "resume [instance-id]",
 		Short: "Resume a failed or interrupted workflow instance",
-		Long: "Resume a failed or interrupted workflow instance from its last completed step. " +
-			"Completed steps are replayed from cache (not re-executed); the run continues from the failure point.",
+		Long: "Replay a failed or interrupted workflow instance as a new immutable descendant. " +
+			"Completed steps are copied from cache (not re-executed); the descendant continues from the failure point.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id := ""
 			if len(args) == 1 {
 				id = args[0]
 			}
-			return runResume(id, workflow, yes)
+			return runResume(id, workflow, fromStep, configMode, yes)
 		},
 	}
 
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
 	cmd.Flags().StringVar(&workflow, "workflow", "", "resume the most recent failed/interrupted instance of this workflow")
+	cmd.Flags().StringVar(&fromStep, "from", "", "re-run from this step instead of the first incomplete step")
+	cmd.Flags().StringVar(&configMode, "definition", daemon.ResumeConfigCurrent, "workflow definition to use: current or original")
 	return cmd
 }
 
-func runResume(id, workflow string, yes bool) error {
+func runResume(id, workflow, fromStep, configMode string, yes bool) error {
 	if (id == "") == (workflow == "") {
 		fmt.Println(instErr.Render("Provide exactly one of <instance-id> or --workflow."))
 		os.Exit(1)
+	}
+	if configMode != daemon.ResumeConfigCurrent && configMode != daemon.ResumeConfigOriginal {
+		return fmt.Errorf("invalid --definition %q: expected current or original", configMode)
+	}
+	resumeQuery := url.Values{"config": {configMode}}
+	if fromStep != "" {
+		resumeQuery.Set("from", fromStep)
 	}
 
 	// Resolve the target instance from --workflow if no id was given.
@@ -65,7 +76,7 @@ func runResume(id, workflow string, yes bool) error {
 
 	// Preview (also validates resumability and maps exit codes).
 	var preview daemon.ResumePreview
-	status, err := ipcDo(http.MethodGet, "/resume/"+url.PathEscape(id), &preview)
+	status, err := ipcDo(http.MethodGet, "/resume/"+url.PathEscape(id)+"?"+resumeQuery.Encode(), &preview)
 	if err != nil {
 		return resumeFail(status, err, id)
 	}
@@ -79,11 +90,14 @@ func runResume(id, workflow string, yes bool) error {
 	}
 
 	// Execute.
-	status, err = ipcDo(http.MethodPost, "/resume/"+url.PathEscape(id), nil)
+	var queued struct {
+		InstanceID string `json:"instance_id"`
+	}
+	status, err = ipcDo(http.MethodPost, "/resume/"+url.PathEscape(id)+"?"+resumeQuery.Encode(), &queued)
 	if err != nil {
 		return resumeFail(status, err, id)
 	}
-	fmt.Println(instOK.Render("✓") + " Resume queued for " + id + " — the daemon will pick it up.")
+	fmt.Println(instOK.Render("✓") + " Resume queued as " + queued.InstanceID + " (from " + id + ").")
 	return nil
 }
 
@@ -93,6 +107,11 @@ func printResumePreview(p daemon.ResumePreview) {
 		cell += " — " + p.Title
 	}
 	fmt.Printf("\nResuming instance %s (%s / %s)\n\n", p.InstanceID, p.Workflow, cell)
+	fmt.Printf("Configuration: %s", p.ConfigMode)
+	if p.FromStep != "" {
+		fmt.Printf("  ·  from step: %s", p.FromStep)
+	}
+	fmt.Println()
 
 	if len(p.Skip) > 0 {
 		fmt.Println(instHeader.Render("Steps to skip (already completed):"))

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -985,6 +985,28 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
 	})
+	mux.HandleFunc("/instances/compare", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		before, after := r.URL.Query().Get("before"), r.URL.Query().Get("after")
+		if before == "" || after == "" {
+			http.Error(w, "before and after instance ids are required", http.StatusBadRequest)
+			return
+		}
+		comparison, err := d.CompareInstances(r.Context(), before, after)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if comparison == nil {
+			http.Error(w, "instance not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(comparison)
+	})
 	mux.HandleFunc("/instances/", func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimPrefix(r.URL.Path, "/instances/")
 		if id == "" {
@@ -1068,6 +1090,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	})
 	mux.HandleFunc("/resume/", func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimPrefix(r.URL.Path, "/resume/")
+		opts := ResumeOptions{FromStep: r.URL.Query().Get("from"), ConfigMode: r.URL.Query().Get("config")}
 		if id == "" {
 			// `apiary resume --workflow <id>`: resolve the most recent
 			// resumable instance for the workflow.
@@ -1087,7 +1110,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		switch r.Method {
 		case http.MethodGet:
-			preview, err := d.ResumePreview(r.Context(), id)
+			preview, err := d.ResumePreview(r.Context(), id, opts)
 			if err != nil {
 				http.Error(w, err.Error(), resumeHTTPStatus(err))
 				return
@@ -1096,12 +1119,13 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			_ = json.NewEncoder(w).Encode(preview)
 		case http.MethodPost:
 			// Launch on the daemon-lifetime ctx so the run outlives the request.
-			if err := d.StartResume(ctx, id); err != nil {
+			newID, err := d.StartResume(ctx, id, opts)
+			if err != nil {
 				http.Error(w, err.Error(), resumeHTTPStatus(err))
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"queued": true, "instance_id": id})
+			_ = json.NewEncoder(w).Encode(map[string]any{"queued": true, "instance_id": newID, "resumed_from": id})
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}

--- a/src/internal/daemon/instance_compare_test.go
+++ b/src/internal/daemon/instance_compare_test.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func TestCompareInstancesAlignsStepsAndComputesDeltas(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "compare.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	for _, inst := range []*db.WorkflowInstance{
+		{ID: "before", WorkflowID: "feature", CellID: "1", State: db.InstanceStateFailed},
+		{ID: "after", WorkflowID: "feature", CellID: "1", State: db.InstanceStateDone, ResumedFrom: "before"},
+	} {
+		if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+			t.Fatal(err)
+		}
+	}
+	steps := []*db.StepRun{
+		{ID: "before-plan", WorkflowInstanceID: "before", StepID: "plan", State: db.StepStatePassed, InputPrompt: "old", Output: "a", TotalTokens: 10, CostUSD: 0.1},
+		{ID: "after-plan", WorkflowInstanceID: "after", StepID: "plan", State: db.StepStatePassed, InputPrompt: "new", Output: "b", TotalTokens: 15, CostUSD: 0.15},
+		{ID: "after-review", WorkflowInstanceID: "after", StepID: "review", State: db.StepStatePassed},
+	}
+	for _, step := range steps {
+		if err := dbc.CreateStepRun(ctx, step); err != nil {
+			t.Fatal(err)
+		}
+	}
+	comparison, err := (&Dispatcher{db: dbc}).CompareInstances(ctx, "before", "after")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comparison.Steps) != 2 {
+		t.Fatalf("steps = %d", len(comparison.Steps))
+	}
+	plan := comparison.Steps[0]
+	if !plan.InputChanged || !plan.OutputChanged || plan.TokenDelta != 5 {
+		t.Errorf("plan comparison = %+v", plan)
+	}
+	if plan.CostDeltaUSD < 0.049 || plan.CostDeltaUSD > 0.051 {
+		t.Errorf("cost delta = %f", plan.CostDeltaUSD)
+	}
+	if comparison.Steps[1].Before != nil || comparison.Steps[1].After == nil {
+		t.Errorf("added step = %+v", comparison.Steps[1])
+	}
+}

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -39,6 +39,7 @@ type StepRunView struct {
 	Cached              bool       `json:"cached"`
 	Output              string     `json:"output"`
 	Summary             string     `json:"summary"`
+	InputPrompt         string     `json:"input_prompt,omitempty"`
 	InputTokens         int        `json:"input_tokens"`
 	OutputTokens        int        `json:"output_tokens"`
 	TotalTokens         int        `json:"total_tokens"`
@@ -65,8 +66,9 @@ type CIPollView struct {
 // InstanceDetail is the payload for `apiary instances <id>`.
 type InstanceDetail struct {
 	InstanceSummary
-	Steps   []StepRunView `json:"steps"`
-	CIPolls []CIPollView  `json:"ci_polls"`
+	ResumedFrom string        `json:"resumed_from,omitempty"`
+	Steps       []StepRunView `json:"steps"`
+	CIPolls     []CIPollView  `json:"ci_polls"`
 }
 
 // ciPollViews maps stored CI poll rows to their IPC views.
@@ -330,7 +332,7 @@ func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDe
 	title, _ := d.db.GetTaskTitle(ctx, inst.CellID)
 	now := time.Now()
 	view := db.WorkflowInstanceView{WorkflowInstance: *inst, Title: title}
-	detail := &InstanceDetail{InstanceSummary: instanceSummary(view, now)}
+	detail := &InstanceDetail{InstanceSummary: instanceSummary(view, now), ResumedFrom: inst.ResumedFrom}
 
 	steps, err := d.db.ListStepRuns(ctx, id)
 	if err != nil {
@@ -349,15 +351,16 @@ func (d *Dispatcher) InstanceDetail(ctx context.Context, id string) (*InstanceDe
 // via the step link columns. Shared by InstanceDetail and TaskHistory.
 func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.StepRun, now time.Time) StepRunView {
 	srv := StepRunView{
-		StepID:     s.StepID,
-		AgentID:    s.AgentID,
-		State:      s.State,
-		Duration:   stepDuration(s, now),
-		Cached:     s.SkippedCached,
-		Output:     s.Output,
-		Summary:    s.Summary,
-		StartedAt:  s.StartedAt,
-		FinishedAt: s.FinishedAt,
+		StepID:      s.StepID,
+		AgentID:     s.AgentID,
+		State:       s.State,
+		Duration:    stepDuration(s, now),
+		Cached:      s.SkippedCached,
+		Output:      s.Output,
+		Summary:     s.Summary,
+		InputPrompt: s.InputPrompt,
+		StartedAt:   s.StartedAt,
+		FinishedAt:  s.FinishedAt,
 	}
 	// Prefer the step's own usage rollup (summed across failover attempts). Fall
 	// back to the latest task_execution for rows written before step_runs carried
@@ -382,6 +385,103 @@ func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.St
 		srv.NumToolCalls = usage.NumToolCalls
 	}
 	return srv
+}
+
+type StepComparison struct {
+	StepID          string       `json:"step_id"`
+	Before          *StepRunView `json:"before,omitempty"`
+	After           *StepRunView `json:"after,omitempty"`
+	InputChanged    bool         `json:"input_changed"`
+	OutputChanged   bool         `json:"output_changed"`
+	TokenDelta      int          `json:"token_delta"`
+	CostDeltaUSD    float64      `json:"cost_delta_usd"`
+	DurationDeltaMS int64        `json:"duration_delta_ms"`
+	BeforeModel     string       `json:"before_model,omitempty"`
+	AfterModel      string       `json:"after_model,omitempty"`
+	BeforeRunner    string       `json:"before_runner,omitempty"`
+	AfterRunner     string       `json:"after_runner,omitempty"`
+}
+
+type InstanceComparison struct {
+	BeforeID string           `json:"before_id"`
+	AfterID  string           `json:"after_id"`
+	Steps    []StepComparison `json:"steps"`
+}
+
+func (d *Dispatcher) CompareInstances(ctx context.Context, beforeID, afterID string) (*InstanceComparison, error) {
+	before, err := d.InstanceDetail(ctx, beforeID)
+	if err != nil || before == nil {
+		return nil, err
+	}
+	after, err := d.InstanceDetail(ctx, afterID)
+	if err != nil || after == nil {
+		return nil, err
+	}
+	bm, am := map[string]StepRunView{}, map[string]StepRunView{}
+	order, seen := []string{}, map[string]bool{}
+	for _, s := range before.Steps {
+		bm[s.StepID] = s
+		if !seen[s.StepID] {
+			order = append(order, s.StepID)
+			seen[s.StepID] = true
+		}
+	}
+	for _, s := range after.Steps {
+		am[s.StepID] = s
+		if !seen[s.StepID] {
+			order = append(order, s.StepID)
+			seen[s.StepID] = true
+		}
+	}
+	out := &InstanceComparison{BeforeID: beforeID, AfterID: afterID}
+	for _, id := range order {
+		row := StepComparison{StepID: id}
+		if s, ok := bm[id]; ok {
+			copy := s
+			row.Before = &copy
+		}
+		if s, ok := am[id]; ok {
+			copy := s
+			row.After = &copy
+		}
+		if row.Before != nil {
+			if usage, err := d.db.GetStepUsage(ctx, beforeID, id); err == nil && usage != nil {
+				row.BeforeModel, row.BeforeRunner = usage.Model, usage.Runner
+				if row.Before.InputPrompt == "" {
+					row.Before.InputPrompt = usage.InputPrompt
+				}
+			}
+		}
+		if row.After != nil {
+			if usage, err := d.db.GetStepUsage(ctx, afterID, id); err == nil && usage != nil {
+				row.AfterModel, row.AfterRunner = usage.Model, usage.Runner
+				if row.After.InputPrompt == "" {
+					row.After.InputPrompt = usage.InputPrompt
+				}
+			}
+		}
+		if row.After != nil && row.After.Cached && row.AfterModel == "" {
+			row.AfterModel, row.AfterRunner = row.BeforeModel, row.BeforeRunner
+		}
+		if row.Before != nil && row.After != nil {
+			row.InputChanged = row.Before.InputPrompt != row.After.InputPrompt
+			row.OutputChanged = row.Before.Output != row.After.Output
+			row.TokenDelta = row.After.TotalTokens - row.Before.TotalTokens
+			row.CostDeltaUSD = row.After.CostUSD - row.Before.CostUSD
+			row.DurationDeltaMS = stepViewDurationMS(*row.After) - stepViewDurationMS(*row.Before)
+		} else {
+			row.InputChanged, row.OutputChanged = true, true
+		}
+		out.Steps = append(out.Steps, row)
+	}
+	return out, nil
+}
+
+func stepViewDurationMS(step StepRunView) int64 {
+	if step.StartedAt == nil || step.FinishedAt == nil {
+		return 0
+	}
+	return step.FinishedAt.Sub(*step.StartedAt).Milliseconds()
 }
 
 // TaskLogLineView is one log line scoped to a task-history segment's instance.

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -17,8 +19,20 @@ import (
 var (
 	ErrInstanceNotFound     = errors.New("instance not found")
 	ErrInstanceNotResumable = errors.New("instance is not resumable")
+	ErrResumeForbidden      = errors.New("workflow resume policy forbids replay")
 	ErrWorkflowChanged      = errors.New("workflow definition changed or removed")
+	ErrSnapshotNotFound     = errors.New("original workflow snapshot not found")
 )
+
+const (
+	ResumeConfigCurrent  = "current"
+	ResumeConfigOriginal = "original"
+)
+
+type ResumeOptions struct {
+	FromStep   string
+	ConfigMode string
+}
 
 // ResumeStep is one entry in a resume preview's skip/run list.
 type ResumeStep struct {
@@ -34,6 +48,8 @@ type ResumePreview struct {
 	CellID     string       `json:"cell_id"`
 	Title      string       `json:"title"`
 	State      string       `json:"state"`
+	FromStep   string       `json:"from_step,omitempty"`
+	ConfigMode string       `json:"config_mode"`
 	Skip       []ResumeStep `json:"skip"`
 	Run        []ResumeStep `json:"run"`
 }
@@ -57,7 +73,7 @@ func (d *Dispatcher) workflowByID(id string) (config.WorkflowConfig, bool) {
 
 // ResumePreview validates resumability and computes the skip/run breakdown for
 // the confirmation prompt. It returns a typed error for each rejection reason.
-func (d *Dispatcher) ResumePreview(ctx context.Context, id string) (*ResumePreview, error) {
+func (d *Dispatcher) ResumePreview(ctx context.Context, id string, opts ResumeOptions) (*ResumePreview, error) {
 	if d.db == nil {
 		return nil, ErrInstanceNotFound
 	}
@@ -71,9 +87,12 @@ func (d *Dispatcher) ResumePreview(ctx context.Context, id string) (*ResumePrevi
 	if !resumableState(inst.State) {
 		return nil, ErrInstanceNotResumable
 	}
-	wf, ok := d.workflowByID(inst.WorkflowID)
-	if !ok {
-		return nil, ErrWorkflowChanged
+	wf, err := d.resumeWorkflow(ctx, inst, opts.ConfigMode)
+	if err != nil {
+		return nil, err
+	}
+	if wf.ResumePolicy() == config.ResumeForbidden {
+		return nil, ErrResumeForbidden
 	}
 
 	steps, err := d.db.ListStepRuns(ctx, id)
@@ -94,11 +113,26 @@ func (d *Dispatcher) ResumePreview(ctx context.Context, id string) (*ResumePrevi
 		CellID:     inst.CellID,
 		Title:      title,
 		State:      inst.State,
+		FromStep:   opts.FromStep,
+		ConfigMode: normalizeResumeConfigMode(opts.ConfigMode),
 	}
-	for _, st := range wf.Steps {
+	fromIndex := len(wf.Steps)
+	if opts.FromStep != "" {
+		fromIndex = -1
+		for i, st := range wf.Steps {
+			if st.ID == opts.FromStep {
+				fromIndex = i
+				break
+			}
+		}
+		if fromIndex < 0 {
+			return nil, fmt.Errorf("%w: resume step %q not found", ErrWorkflowChanged, opts.FromStep)
+		}
+	}
+	for i, st := range wf.Steps {
 		// Splits are re-evaluated on resume; list them under "run" since they
 		// re-execute (cheaply, with no side effects).
-		if passed[st.ID] && st.StepType() != config.StepTypeSplit {
+		if i < fromIndex && passed[st.ID] && st.StepType() != config.StepTypeSplit {
 			preview.Skip = append(preview.Skip, ResumeStep{StepID: st.ID, Agent: st.Agent, Note: "already passed"})
 		} else {
 			preview.Run = append(preview.Run, ResumeStep{StepID: st.ID, Agent: st.Agent})
@@ -110,39 +144,102 @@ func (d *Dispatcher) ResumePreview(ctx context.Context, id string) (*ResumePrevi
 // StartResume validates the instance and launches the resume on the supplied
 // (daemon-lifetime) context. It returns promptly; the engine replays cached
 // steps and continues the run in the background. ctx must outlive the request.
-func (d *Dispatcher) StartResume(ctx context.Context, id string) error {
+func (d *Dispatcher) StartResume(ctx context.Context, id string, opts ResumeOptions) (string, error) {
 	if d.db == nil {
-		return ErrInstanceNotFound
+		return "", ErrInstanceNotFound
 	}
 	inst, err := d.db.GetWorkflowInstance(ctx, id)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if inst == nil {
-		return ErrInstanceNotFound
+		return "", ErrInstanceNotFound
 	}
 	if !resumableState(inst.State) {
-		return ErrInstanceNotResumable
+		return "", ErrInstanceNotResumable
 	}
-	wf, ok := d.workflowByID(inst.WorkflowID)
-	if !ok {
-		return ErrWorkflowChanged
+	wf, err := d.resumeWorkflow(ctx, inst, opts.ConfigMode)
+	if err != nil {
+		return "", err
+	}
+	if wf.ResumePolicy() == config.ResumeForbidden {
+		return "", ErrResumeForbidden
+	}
+	if opts.FromStep != "" {
+		found := false
+		for _, step := range wf.Steps {
+			if step.ID == opts.FromStep {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "", fmt.Errorf("%w: resume step %q not found", ErrWorkflowChanged, opts.FromStep)
+		}
 	}
 	steps, err := d.db.ListStepRuns(ctx, id)
 	if err != nil {
-		return err
+		return "", err
 	}
 	task := d.taskForInstance(ctx, inst)
+	if task.ID != "" {
+		if _, err := d.db.InternalTasks().IncrementOutstanding(ctx, task.ID, 1); err != nil {
+			return "", err
+		}
+	}
+	newID := d.workflowEngine().NewInstanceID()
 
 	go func() {
-		success, rerr := d.workflowEngine().ResumeInstance(ctx, id, wf, task, steps)
+		_, success, rerr := d.workflowEngine().ResumeInstance(ctx, inst, wf, task, steps, opts.FromStep, newID)
 		if rerr != nil {
+			if task.ID != "" {
+				_, _ = d.db.InternalTasks().DecrementOutstanding(ctx, task.ID)
+			}
 			aplog.Error("resume %s: %v", id, rerr)
 			return
 		}
-		aplog.Info("resume %s: finished (success=%v; may be awaiting approval)", id, success)
+		aplog.Info("resume %s: descendant %s finished (success=%v; may be awaiting approval)", id, newID, success)
 	}()
-	return nil
+	return newID, nil
+}
+
+func normalizeResumeConfigMode(mode string) string {
+	if mode == ResumeConfigOriginal {
+		return mode
+	}
+	return ResumeConfigCurrent
+}
+
+func (d *Dispatcher) resumeWorkflow(ctx context.Context, inst *db.WorkflowInstance, mode string) (config.WorkflowConfig, error) {
+	if normalizeResumeConfigMode(mode) == ResumeConfigCurrent {
+		wf, ok := d.workflowByID(inst.WorkflowID)
+		if !ok {
+			return config.WorkflowConfig{}, ErrWorkflowChanged
+		}
+		return wf, nil
+	}
+	snapshot, err := d.db.GetWorkflowSnapshot(ctx, inst.ID)
+	if err != nil {
+		return config.WorkflowConfig{}, err
+	}
+	if snapshot == "" {
+		return config.WorkflowConfig{}, ErrSnapshotNotFound
+	}
+	var wf config.WorkflowConfig
+	if err := json.Unmarshal([]byte(snapshot), &wf); err != nil {
+		return config.WorkflowConfig{}, ErrWorkflowChanged
+	}
+	if current, ok := d.workflowByID(inst.WorkflowID); ok {
+		wf.Env = current.Env
+		stepEnv := make(map[string]map[string]string, len(current.Steps))
+		for _, step := range current.Steps {
+			stepEnv[step.ID] = step.Env
+		}
+		for i := range wf.Steps {
+			wf.Steps[i].Env = stepEnv[wf.Steps[i].ID]
+		}
+	}
+	return wf, nil
 }
 
 // ResolveResumeTarget finds the most recent resumable instance of a workflow,
@@ -168,7 +265,11 @@ func resumeHTTPStatus(err error) int {
 		return http.StatusNotFound
 	case errors.Is(err, ErrInstanceNotResumable):
 		return http.StatusConflict
+	case errors.Is(err, ErrResumeForbidden):
+		return http.StatusConflict
 	case errors.Is(err, ErrWorkflowChanged):
+		return http.StatusUnprocessableEntity
+	case errors.Is(err, ErrSnapshotNotFound):
 		return http.StatusUnprocessableEntity
 	default:
 		return http.StatusInternalServerError

--- a/src/internal/daemon/workflow_resume_test.go
+++ b/src/internal/daemon/workflow_resume_test.go
@@ -1,7 +1,10 @@
 package daemon
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -31,6 +34,7 @@ func TestResumeHTTPStatus(t *testing.T) {
 	}{
 		{ErrInstanceNotFound, http.StatusNotFound},
 		{ErrInstanceNotResumable, http.StatusConflict},
+		{ErrResumeForbidden, http.StatusConflict},
 		{ErrWorkflowChanged, http.StatusUnprocessableEntity},
 		{errOther{}, http.StatusInternalServerError},
 	}
@@ -61,5 +65,37 @@ func TestWorkflowByID(t *testing.T) {
 	}
 	if _, ok := d.workflowByID("ghost"); ok {
 		t.Error("unknown id should not resolve")
+	}
+}
+
+func TestResumePreviewUsesOriginalSnapshotAndFromStep(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "resume.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	original := config.WorkflowConfig{ID: "feature", Steps: []config.StepConfig{{ID: "plan", Agent: "a"}, {ID: "build", Agent: "b"}}}
+	b, _ := json.Marshal(original)
+	inst := &db.WorkflowInstance{ID: "source", WorkflowID: original.ID, CellID: "1", State: db.InstanceStateFailed}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatal(err)
+	}
+	if err := dbc.PutWorkflowSnapshot(ctx, inst.ID, string(b)); err != nil {
+		t.Fatal(err)
+	}
+	if err := dbc.CreateStepRun(ctx, &db.StepRun{ID: "plan", WorkflowInstanceID: inst.ID, StepID: "plan", State: db.StepStatePassed}); err != nil {
+		t.Fatal(err)
+	}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{Workflows: []config.WorkflowConfig{{ID: "feature", Steps: []config.StepConfig{{ID: "replacement"}}}}}}
+	preview, err := d.ResumePreview(ctx, inst.ID, ResumeOptions{FromStep: "build", ConfigMode: ResumeConfigOriginal})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview.Skip) != 1 || preview.Skip[0].StepID != "plan" {
+		t.Errorf("skip = %+v", preview.Skip)
+	}
+	if len(preview.Run) != 1 || preview.Run[0].StepID != "build" {
+		t.Errorf("run = %+v", preview.Run)
 	}
 }

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -270,7 +270,9 @@ func (c *Client) GetStepUsage(ctx context.Context, instanceID, stepID string) (*
 	row := c.db.QueryRowContext(ctx, `
 		SELECT input_tokens, output_tokens, total_tokens,
 		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
-		       num_turns, num_tool_calls, cost_usd
+		       num_turns, num_tool_calls, cost_usd,
+		       COALESCE(model,''), COALESCE(runner,''),
+		       COALESCE(input_prompt,''), COALESCE(output_text,'')
 		FROM task_executions
 		WHERE workflow_instance_id = ? AND step_id = ?
 		ORDER BY created_at DESC LIMIT 1
@@ -278,7 +280,8 @@ func (c *Client) GetStepUsage(ctx context.Context, instanceID, stepID string) (*
 	var e Execution
 	err := row.Scan(&e.InputTokens, &e.OutputTokens, &e.TotalTokens,
 		&e.CacheCreationTokens, &e.CacheReadTokens,
-		&e.NumTurns, &e.NumToolCalls, &e.CostUSD)
+		&e.NumTurns, &e.NumToolCalls, &e.CostUSD,
+		&e.Model, &e.Runner, &e.InputPrompt, &e.OutputText)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -117,6 +117,15 @@ CREATE TABLE IF NOT EXISTS workflow_instances (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Immutable workflow definition used by an instance. Kept separately from
+-- workflow_instances so the hot instance-list scan remains narrow.
+CREATE TABLE IF NOT EXISTS workflow_instance_snapshots (
+  instance_id TEXT PRIMARY KEY,
+  workflow_json TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(instance_id) REFERENCES workflow_instances(id) ON DELETE CASCADE
+);
+
 -- Step runs: one row per step execution within a workflow instance.
 CREATE TABLE IF NOT EXISTS step_runs (
   id TEXT PRIMARY KEY,

--- a/src/internal/db/workflow_snapshot.go
+++ b/src/internal/db/workflow_snapshot.go
@@ -1,0 +1,30 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+)
+
+// PutWorkflowSnapshot stores the exact serialized workflow definition used by
+// an instance. Replacing makes the operation idempotent for startup/retry paths.
+func (c *Client) PutWorkflowSnapshot(ctx context.Context, instanceID, workflowJSON string) error {
+	_, err := c.db.ExecContext(ctx, `
+		INSERT INTO workflow_instance_snapshots (instance_id, workflow_json)
+		VALUES (?, ?)
+		ON CONFLICT(instance_id) DO UPDATE SET workflow_json = excluded.workflow_json
+	`, instanceID, workflowJSON)
+	return err
+}
+
+// GetWorkflowSnapshot returns the serialized workflow definition for an
+// instance, or an empty string for instances created before snapshots existed.
+func (c *Client) GetWorkflowSnapshot(ctx context.Context, instanceID string) (string, error) {
+	var snapshot string
+	err := c.db.QueryRowContext(ctx, `
+		SELECT workflow_json FROM workflow_instance_snapshots WHERE instance_id = ?
+	`, instanceID).Scan(&snapshot)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return snapshot, err
+}

--- a/src/internal/db/workflow_snapshot_test.go
+++ b/src/internal/db/workflow_snapshot_test.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWorkflowSnapshotRoundTrip(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "wf-snapshot", WorkflowID: "feature", CellID: "1", State: InstanceStateRunning}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.PutWorkflowSnapshot(ctx, "wf-snapshot", `{"id":"feature"}`); err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.GetWorkflowSnapshot(ctx, "wf-snapshot")
+	if err != nil || got != `{"id":"feature"}` {
+		t.Fatalf("snapshot = %q, err = %v", got, err)
+	}
+	missing, err := c.GetWorkflowSnapshot(ctx, "missing")
+	if err != nil || missing != "" {
+		t.Fatalf("missing snapshot = %q, err = %v", missing, err)
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -679,6 +679,10 @@ func (c *Client) DeleteWorkflowInstances(ctx context.Context, instanceIDs []stri
 	if _, err := c.db.ExecContext(ctx, stmt, args...); err != nil {
 		return err
 	}
+	stmt = "DELETE FROM workflow_instance_snapshots WHERE instance_id IN (" + placeholders + ")"
+	if _, err := c.db.ExecContext(ctx, stmt, args...); err != nil {
+		return err
+	}
 
 	// Delete the workflow instances themselves.
 	stmt = "DELETE FROM workflow_instances WHERE id IN (" + placeholders + ")"

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -26,6 +26,12 @@ type Store interface {
 	UpdateStepRun(ctx context.Context, sr *db.StepRun) error
 }
 
+// workflowSnapshotStore is implemented by persistent stores that retain the
+// exact workflow definition used by each instance for reproducible replay.
+type workflowSnapshotStore interface {
+	PutWorkflowSnapshot(ctx context.Context, instanceID, workflowJSON string) error
+}
+
 // bindingLister is the optional capability the engine uses to resolve a task's
 // source bindings (for side-effect fan-out and the execution view). *db.Client
 // satisfies it; fake stores in tests that omit it simply yield no bindings.
@@ -285,6 +291,10 @@ func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Optio
 	return e
 }
 
+// NewInstanceID reserves a process-unique workflow instance identifier for
+// callers that must return a replay ID before asynchronous execution starts.
+func (e *Engine) NewInstanceID() string { return e.newID("wf") }
+
 // RunInstance executes a workflow for an InternalTask. It returns the created
 // instance ID and whether the instance completed successfully. An instance that
 // suspends at an approval step returns success=false with no error — it is parked
@@ -309,6 +319,9 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task
 	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
 		return "", false, fmt.Errorf("create workflow instance: %w", err)
 	}
+	if err := e.persistWorkflowSnapshot(ctx, instID, wf); err != nil {
+		return "", false, err
+	}
 
 	// state_lock fires once at workflow start (not per step).
 	if e.cfg.Settings.StateLock && e.side != nil {
@@ -318,6 +331,30 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task
 	r := e.initDAG(instID, wf, task, bindings, nil, 0)
 	outcome := e.driveDAG(ctx, r)
 	return instID, e.settle(ctx, r, outcome), nil
+}
+
+func (e *Engine) persistWorkflowSnapshot(ctx context.Context, instanceID string, wf config.WorkflowConfig) error {
+	store, ok := e.store.(workflowSnapshotStore)
+	if !ok {
+		return nil
+	}
+	snapshot := wf
+	// Environment overlays may contain secrets after config expansion. Snapshots
+	// retain workflow structure and prompts but resolve env overlays from the
+	// current configuration when replayed.
+	snapshot.Env = nil
+	snapshot.Steps = append([]config.StepConfig(nil), wf.Steps...)
+	for i := range snapshot.Steps {
+		snapshot.Steps[i].Env = nil
+	}
+	b, err := json.Marshal(snapshot)
+	if err != nil {
+		return fmt.Errorf("marshal workflow snapshot: %w", err)
+	}
+	if err := store.PutWorkflowSnapshot(ctx, instanceID, string(b)); err != nil {
+		return fmt.Errorf("persist workflow snapshot: %w", err)
+	}
+	return nil
 }
 
 // bindingsFor resolves a task's source bindings via the Store when it supports

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
 
@@ -11,40 +12,95 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
-// ResumeInstance continues an existing failed or interrupted instance by
-// replaying its already-passed steps from cache and running the rest. It reuses
-// the instance id, restores cached steps' memory and expression context without
-// re-executing them or re-firing their side effects, and drives the DAG for the
-// remaining steps.
+// ResumeInstance creates an immutable descendant of a failed or interrupted
+// instance, restores eligible passed steps from cache, and runs the rest.
 //
 // priorSteps are the instance's persisted step runs in execution order. Split
 // steps are intentionally re-evaluated (they are side-effect-free and their
 // branch routing must re-activate the chosen target), while agent, foreach,
 // sub-workflow, and approval steps that passed are carried over untouched.
-func (e *Engine) ResumeInstance(ctx context.Context, instID string, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun) (success bool, err error) {
-	_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateRunning)
+func (e *Engine) ResumeInstance(ctx context.Context, source *db.WorkflowInstance, wf config.WorkflowConfig, task model.InternalTask, priorSteps []db.StepRun, fromStep, instanceID string) (string, bool, error) {
+	instID := instanceID
+	if instID == "" {
+		instID = e.NewInstanceID()
+	}
+	inst := &db.WorkflowInstance{
+		ID:          instID,
+		WorkflowID:  source.WorkflowID,
+		TaskID:      source.TaskID,
+		CellID:      source.CellID,
+		SourceID:    source.SourceID,
+		State:       db.InstanceStateRunning,
+		ResumedFrom: source.ID,
+		CreatedAt:   e.now(),
+	}
+	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
+		return "", false, err
+	}
+	if err := e.persistWorkflowSnapshot(ctx, instID, wf); err != nil {
+		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed)
+		return "", false, err
+	}
 
 	bindings := e.bindingsFor(ctx, task.ID)
 	r := e.initDAG(instID, wf, task, bindings, nil, 0)
-	e.seedResume(ctx, r, priorSteps)
+	selected, err := resumeCacheSelection(wf, priorSteps, fromStep)
+	if err != nil {
+		return "", false, err
+	}
+	if err := e.seedResume(ctx, r, selected); err != nil {
+		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed)
+		return "", false, err
+	}
 
-	aplog.Info("workflow %s: resuming instance %s (%d cached step(s))", wf.ID, instID, len(r.passedOrder))
+	aplog.Info("workflow %s: resuming instance %s from %s (%d cached step(s))", wf.ID, instID, source.ID, len(r.passedOrder))
 	outcome := e.driveDAG(ctx, r)
-	return e.settle(ctx, r, outcome), nil
+	return instID, e.settle(ctx, r, outcome), nil
 }
 
 // seedResume restores the graph state of already-passed steps so a resumed run
 // continues from the first incomplete step, and marks each carried-over step run
 // as skipped_cached (display only). It returns nothing; on completion
 // r.passedOrder/contrib/stepStates reflect the cached steps.
-func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.StepRun) {
-	for _, sr := range e.restoreCachedSteps(r, priorSteps) {
-		// Record that this run was carried over a resume (display only).
-		if !sr.SkippedCached {
-			sr.SkippedCached = true
-			_ = e.store.UpdateStepRun(ctx, &sr)
+func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.StepRun) error {
+	for _, source := range e.restoreCachedSteps(r, priorSteps) {
+		cached := source
+		cached.ID = e.newID("sr")
+		cached.WorkflowInstanceID = r.instID
+		cached.SkippedCached = true
+		if err := e.store.CreateStepRun(ctx, &cached); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+// resumeCacheSelection returns passed rows eligible for reuse. When fromStep is
+// set, only rows for steps declared before it are reused; the selected step and
+// everything after it run again. Split steps remain in the list but are ignored
+// by restoreCachedSteps so branch routing is always re-evaluated.
+func resumeCacheSelection(wf config.WorkflowConfig, prior []db.StepRun, fromStep string) ([]db.StepRun, error) {
+	if fromStep == "" {
+		return prior, nil
+	}
+	limit := -1
+	order := make(map[string]int, len(wf.Steps))
+	for i, step := range wf.Steps {
+		order[step.ID] = i
+		if step.ID == fromStep {
+			limit = i
+		}
+	}
+	if limit < 0 {
+		return nil, fmt.Errorf("resume step %q not found in workflow %q", fromStep, wf.ID)
+	}
+	out := make([]db.StepRun, 0, len(prior))
+	for _, sr := range prior {
+		if i, ok := order[sr.StepID]; ok && i < limit {
+			out = append(out, sr)
+		}
+	}
+	return out, nil
 }
 
 // restoreCachedSteps replays already-passed steps into the in-memory graph so a

--- a/src/internal/workflow/resume_test.go
+++ b/src/internal/workflow/resume_test.go
@@ -39,7 +39,7 @@ func TestResume_SkipsCachedAndContinues(t *testing.T) {
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
 
-	success, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior)
+	newID, success, err := eng.ResumeInstance(context.Background(), store.instances[instID], linearWF(), model.InternalTask{ID: "c1"}, prior, "", "")
 	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
@@ -54,8 +54,11 @@ func TestResume_SkipsCachedAndContinues(t *testing.T) {
 	if !contains(ids, "implement") || !contains(ids, "review") {
 		t.Errorf("expected implement and review to run, got %v", ids)
 	}
-	if store.instances[instID].State != db.InstanceStateDone {
-		t.Errorf("expected final state done, got %s", store.instances[instID].State)
+	if store.instances[newID].State != db.InstanceStateDone {
+		t.Errorf("expected descendant state done, got %s", store.instances[newID].State)
+	}
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("source instance was mutated: %s", store.instances[instID].State)
 	}
 }
 
@@ -72,7 +75,8 @@ func TestResume_CachedMemoryAvailableDownstream(t *testing.T) {
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
 
-	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior); err != nil {
+	source := &db.WorkflowInstance{ID: instID, WorkflowID: "feature", CellID: "c1", State: db.InstanceStateFailed}
+	if _, _, err := eng.ResumeInstance(context.Background(), source, linearWF(), model.InternalTask{ID: "c1"}, prior, "", ""); err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
 
@@ -104,12 +108,54 @@ func TestResume_MarksPriorStepCached(t *testing.T) {
 			StructuredOutput: `{"approach":"layered"}`},
 		{ID: "sr-impl", WorkflowInstanceID: instID, StepID: "implement", State: db.StepStateFailed},
 	}
+	for i := range prior {
+		_ = store.CreateStepRun(context.Background(), &prior[i])
+	}
 
-	if _, err := eng.ResumeInstance(context.Background(), instID, linearWF(), model.InternalTask{ID: "c1"}, prior); err != nil {
+	source := &db.WorkflowInstance{ID: instID, WorkflowID: "feature", CellID: "c1", State: db.InstanceStateFailed}
+	newID, _, err := eng.ResumeInstance(context.Background(), source, linearWF(), model.InternalTask{ID: "c1"}, prior, "", "")
+	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
-	if sr := store.stepRuns["sr-plan"]; sr == nil || !sr.SkippedCached {
-		t.Errorf("expected sr-plan to be marked skipped_cached, got %+v", sr)
+	if sr := store.stepRuns["sr-plan"]; sr == nil || sr.SkippedCached {
+		t.Errorf("source step should remain unchanged, got %+v", sr)
+	}
+	var cached *db.StepRun
+	for _, sr := range store.stepRuns {
+		if sr.WorkflowInstanceID == newID && sr.StepID == "plan" {
+			cached = sr
+		}
+	}
+	if cached == nil || !cached.SkippedCached {
+		t.Errorf("expected a cached descendant plan step, got %+v", cached)
+	}
+}
+
+func TestResume_FromStepRerunsPassedStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+	wf := linearWF()
+	source := &db.WorkflowInstance{ID: "wf-source", WorkflowID: wf.ID, CellID: "c1", State: db.InstanceStateFailed}
+	prior := []db.StepRun{
+		{ID: "sr-plan", WorkflowInstanceID: source.ID, StepID: "plan", State: db.StepStatePassed},
+		{ID: "sr-implement", WorkflowInstanceID: source.ID, StepID: "implement", State: db.StepStatePassed},
+		{ID: "sr-review", WorkflowInstanceID: source.ID, StepID: "review", State: db.StepStateFailed},
+	}
+	newID, success, err := eng.ResumeInstance(context.Background(), source, wf, model.InternalTask{ID: "c1"}, prior, "implement", "")
+	if err != nil || !success {
+		t.Fatalf("resume: id=%s success=%v err=%v", newID, success, err)
+	}
+	ids := executedIDs(exec.seen)
+	if contains(ids, "plan") {
+		t.Errorf("plan should remain cached: %v", ids)
+	}
+	if !contains(ids, "implement") || !contains(ids, "review") {
+		t.Errorf("implement and review should rerun: %v", ids)
+	}
+	if store.instances[newID].ResumedFrom != source.ID {
+		t.Errorf("resumed_from = %q", store.instances[newID].ResumedFrom)
 	}
 }
 
@@ -144,7 +190,8 @@ func TestResume_ReevaluatesSplit(t *testing.T) {
 		{ID: "sr-senior", WorkflowInstanceID: instID, StepID: "senior", State: db.StepStateFailed},
 	}
 
-	success, err := eng.ResumeInstance(context.Background(), instID, wf, model.InternalTask{ID: "c1"}, prior)
+	source := &db.WorkflowInstance{ID: instID, WorkflowID: wf.ID, CellID: "c1", State: db.InstanceStateFailed}
+	_, success, err := eng.ResumeInstance(context.Background(), source, wf, model.InternalTask{ID: "c1"}, prior, "", "")
 	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}
@@ -204,7 +251,8 @@ func TestRestoreCachedSteps_LastPassedRunWins(t *testing.T) {
 			State: db.StepStatePassed, StructuredOutput: `{"action":"already_done"}`},
 	}
 
-	success, err := eng.ResumeInstance(context.Background(), instID, alreadyDoneWF(), model.InternalTask{ID: "c1"}, prior)
+	source := &db.WorkflowInstance{ID: instID, WorkflowID: "implementation", CellID: "c1", State: db.InstanceStateFailed}
+	_, success, err := eng.ResumeInstance(context.Background(), source, alreadyDoneWF(), model.InternalTask{ID: "c1"}, prior, "", "")
 	if err != nil {
 		t.Fatalf("ResumeInstance: %v", err)
 	}

--- a/src/internal/workflow/snapshot_test.go
+++ b/src/internal/workflow/snapshot_test.go
@@ -1,0 +1,46 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestRunInstancePersistsSnapshotWithoutEnvironmentSecrets(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "snapshot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	cfg := baseCfg()
+	wf := config.WorkflowConfig{
+		ID: "feature", Env: map[string]string{"TOKEN": "workflow-secret"},
+		Steps: []config.StepConfig{{ID: "run", Agent: "backend-dev", Env: map[string]string{"KEY": "step-secret"}}},
+	}
+	eng := testEngine(cfg, dbc, &fakeExecutor{}, &fakeSide{})
+	instanceID, _, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "task-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := dbc.GetWorkflowSnapshot(ctx, instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(snapshot, "workflow-secret") || strings.Contains(snapshot, "step-secret") {
+		t.Fatalf("snapshot leaked environment values: %s", snapshot)
+	}
+	var got config.WorkflowConfig
+	if err := json.Unmarshal([]byte(snapshot), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != wf.ID || len(got.Steps) != 1 || got.Steps[0].ID != "run" {
+		t.Fatalf("snapshot lost workflow structure: %+v", got)
+	}
+}

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -65,6 +65,11 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 		aplog.Error("sub-workflow %s: create child instance: %v", child.ID, err)
 		return "", false
 	}
+	if err := e.persistWorkflowSnapshot(ctx, childID, child); err != nil {
+		_ = e.store.UpdateWorkflowInstanceState(ctx, childID, db.InstanceStateFailed)
+		aplog.Error("sub-workflow %s: persist snapshot: %v", child.ID, err)
+		return childID, false
+	}
 
 	r := e.initDAG(childID, child, task, bindings, seed, depth)
 	outcome := e.driveDAG(ctx, r)


### PR DESCRIPTION
## Summary

- create immutable descendant attempts with cached-step lineage and selectable resume points
- persist secret-safe workflow snapshots and support current/original replay definitions
- add step-level attempt comparison in the CLI and IPC API

## Test plan

- [x] `make check`
- [x] `make vet`
- [x] CLI help smoke tests for `apiary resume` and `apiary instances compare`

Closes #209