### PR TITLE
feat: add reusable typed subworkflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8821 symbols, 20023 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8974 symbols, 20493 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8821 symbols, 20023 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (8974 symbols, 20493 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,10 @@ apiary status [--watch]    # --watch refreshes every 2 seconds
 
 Validate `apiary.yaml` — schema, reference integrity (agents → runners,
 steps → agents, goto targets), workflow graph rules, and condition expression
-syntax (`if:`, `reject_when:`, split branches, `${{ }}` joins).
+syntax (`if:`, `reject_when:`, split branches, `${{ }}` joins). Local
+subworkflow `uses` references are resolved recursively relative to their
+declaring file; typed contracts, output mappings, and reference cycles are
+validated before connectivity checks run.
 
 ```sh
 apiary validate [--connectivity]    # --connectivity also tests each source

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -26,6 +26,7 @@ loops. This page covers the whole surface.
 |---|---|
 | `id` | Unique workflow identifier |
 | `description` | Human-readable description |
+| `inputs` / `outputs` | Typed public contract for a [reusable subworkflow](#reusable-subworkflows) |
 | `trigger` | What starts it — see [Triggers](#triggers). Omit for [spawn-only workflows](tasks-and-fanout.md#named-workflows-without-triggers) |
 | `steps` | The pipeline — see [Steps](#steps) |
 | `on_complete` / `on_fail` | [Hooks](#completion-hooks) applied when the instance finishes |
@@ -475,9 +476,9 @@ How it works:
 - Every check is recorded in the same poll history as CI waits, so the
   dashboard shows which blockers are still pending.
 
-### Sub-workflows
+### Reusable subworkflows
 
-A step can run another workflow as a child:
+A step can still run another workflow declared in the same `apiary.yaml` by ID:
 
 ```yaml
 - id: validate
@@ -485,8 +486,72 @@ A step can run another workflow as a child:
   workflow: qa-suite
 ```
 
-The child runs as its own instance linked to the parent. For *runtime*
-fan-out — an agent deciding to create child tasks — see
+For reusable pipelines, place one workflow definition in a local YAML file. The
+file declares its typed inputs and explicitly maps its public outputs:
+
+```yaml
+# workflows/prepare-repository.yaml
+id: prepare-repository
+inputs:
+  repository:
+    type: string
+    required: true
+  branch:
+    type: string
+    default: main
+outputs:
+  workspace:
+    type: string
+    value: ${{ steps.checkout.workspace }}
+steps:
+  - id: checkout
+    agent: engineer
+    prompt: Clone ${{ inputs.repository }} at ${{ inputs.branch }}.
+    output:
+      type: object
+      properties:
+        workspace: {type: string}
+      required: [workspace]
+```
+
+Reference the file relative to the YAML file containing the call. `.yaml` or
+`.yml` may be omitted:
+
+```yaml
+steps:
+  - id: prepare
+    uses: ./workflows/prepare-repository
+    with:
+      repository: ${{ task.repository }}
+
+  - id: test
+    uses: ./workflows/run-tests.yaml
+    with:
+      workspace: ${{ steps.prepare.workspace }}
+    timeout: 30m
+```
+
+Input and output types are `string`, `number`, `integer`, `boolean`, `array`,
+and `object`. `with` accepts literals and expressions rooted at `task`, `cell`,
+`memory`, or a prior step's structured output (`steps.<id>.<field>`). A child
+may use its values in prompts and nested `with` bindings through
+`${{ inputs.<name> }}`. Only outputs listed in the child's `outputs` map return
+to the parent.
+
+`apiary validate` recursively resolves every local reference, strictly decodes
+the referenced files, validates required/default values and output mappings,
+and rejects direct or indirect cycles with the complete reference chain. Remote
+URLs and versioned packages are not supported yet.
+
+Each call is recorded as a step in the parent instance. The child runs as its
+own instance linked through `parent_instance_id`, so task history exposes the
+call plus every internal child step, log, token count, and cost record. Child
+failure fails the call step and prevents dependent parent steps from running.
+Parent cancellation and an optional call `timeout` cancel the child; both the
+child instance and parent call are recorded as failed. Child hooks do not mutate
+the parent's source item.
+
+For *runtime* fan-out—an agent deciding to create child tasks—see
 [Tasks & fan-out](tasks-and-fanout.md).
 
 ## Completion hooks

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -8,6 +8,7 @@ _Nenhuma change ativa no momento._
 
 ### 2026-07-22
 
+- **reusable-typed-subworkflows** — Reusable local workflow files with typed inputs and outputs, cycle-safe resolution, linked nested execution history, and explicit failure/cancellation semantics. GitHub issue #210.
 - **immutable-execution-replay** — Immutable workflow replay with descendant attempt lineage, selectable resume points, secret-safe workflow-definition snapshots, and CLI comparison of attempts. GitHub issue #209.
 
 ### 2026-07-07

--- a/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/design.md
+++ b/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/design.md
@@ -1,0 +1,70 @@
+# Design: reusable typed subworkflows
+
+## Authoring contract
+
+A reusable file contains one workflow definition at its root. Inputs and outputs
+use a small JSON-compatible type set: `string`, `number`, `integer`, `boolean`,
+`array`, and `object`.
+
+```yaml
+id: prepare-repository
+inputs:
+  repository:
+    type: string
+    required: true
+outputs:
+  workspace:
+    type: string
+    value: ${{ steps.checkout.workspace }}
+steps:
+  - id: checkout
+    agent: engineer
+    prompt: Clone ${{ inputs.repository }}.
+    output:
+      type: object
+      properties:
+        workspace: {type: string}
+      required: [workspace]
+```
+
+Callers use a local path and bind values explicitly:
+
+```yaml
+- id: prepare
+  uses: ./workflows/prepare-repository.yaml
+  with:
+    repository: ${{ task.repository }}
+```
+
+## Loading and validation
+
+`config.Load` retains its public signature. After decoding the primary config it
+recursively loads referenced local files, assigns the resolved child workflow ID
+to the existing engine IR field, and appends each canonical file once. A DFS over
+canonical paths reports file cycles during loading; a second DFS over workflow
+IDs protects configs assembled directly in Go.
+
+Strict YAML decoding is applied to reusable files. Relative references resolve
+from the file that declares them. Extensionless references try `.yaml` and
+`.yml`. Duplicate IDs from different files are rejected.
+
+## Runtime data flow
+
+The caller's `with` values are resolved from literals, task/cell fields, workflow
+memory, or structured outputs of earlier steps. Resolved inputs are type-checked,
+defaults are applied, and the child receives them as an isolated seed contribution.
+Child prompts render `${{ inputs.<name> }}`.
+
+After the child completes, each declared output expression is resolved from the
+child's step contributions. The resulting map becomes the structured output of
+the parent call step, making it available to later `with` bindings without
+leaking the child's entire memory.
+
+## History and lifecycle
+
+The parent call is persisted as a normal step run. The child remains a linked
+`workflow_instance` through `parent_instance_id`, and its internal step runs keep
+their individual logs and usage/cost records. A child failure fails the call
+step. The parent's context is passed into the child; cancellation and an optional
+call timeout cancel the child and mark both the child instance and call step as
+failed. A depth guard protects runtime execution even after validation.

--- a/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/proposal.md
+++ b/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/proposal.md
@@ -1,0 +1,29 @@
+# Reusable typed subworkflows
+
+## Why
+
+Common workflow sequences are currently either duplicated or declared as another
+workflow in the same `apiary.yaml`. The existing child-instance engine provides
+execution isolation, but it has no reusable file boundary, declared contract, or
+explicit output mapping.
+
+## What changes
+
+- Allow a workflow step to reference a local YAML workflow through `uses`.
+- Let reusable workflows declare typed inputs, defaults, required values, and
+  explicitly mapped outputs.
+- Resolve files relative to the declaring file and reject missing files,
+  duplicate workflow IDs, invalid contracts, and recursive reference cycles.
+- Execute nested workflows as linked child instances while recording the parent
+  call step and returning declared child outputs to downstream callers.
+- Propagate context cancellation, timeout, failure, logs, usage history, and cost
+  visibility through the existing linked execution tree.
+
+## Scope
+
+The first version supports local `.yaml` and `.yml` files. Remote registries and
+versioned workflow packages remain future extensions of the same `uses` syntax.
+
+## Tracking
+
+Closes GitHub issue #210.

--- a/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/tasks.md
+++ b/openspec/changes/archive/2026-07-22-reusable-typed-subworkflows/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Add reusable workflow input/output and call-site configuration types.
+- [x] Resolve local workflow files recursively from `config.Load`.
+- [x] Validate contracts, references, output mappings, and indirect cycles.
+- [x] Resolve typed inputs and explicit outputs during nested execution.
+- [x] Persist parent call steps and retain linked child execution history.
+- [x] Cover successful composition, defaults, invalid types, cycles, failure,
+      cancellation, timeout, and history with tests.
+- [x] Document authoring and lifecycle semantics.
+- [x] Run `make check`, `make vet`, GitNexus change detection, and archive this change.

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -642,6 +642,9 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 	cfg.rawContent = raw
+	if err := resolveLocalWorkflows(path, &cfg); err != nil {
+		return nil, err
+	}
 
 	if cfg.Settings.Concurrency == 0 {
 		cfg.Settings.Concurrency = 2

--- a/src/internal/config/subworkflow_load.go
+++ b/src/internal/config/subworkflow_load.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// resolveLocalWorkflows expands every local uses reference into the existing
+// workflow registry. The primary Config remains the owner of runners, agents,
+// sources, and settings; reusable files contain exactly one WorkflowConfig.
+func resolveLocalWorkflows(configPath string, cfg *Config) error {
+	abs, err := filepath.Abs(configPath)
+	if err != nil {
+		return fmt.Errorf("resolving config path: %w", err)
+	}
+	r := &workflowFileResolver{
+		cfg:      cfg,
+		byFile:   map[string]string{},
+		byID:     map[string]string{},
+		visiting: map[string]int{},
+	}
+	for _, wf := range cfg.Workflows {
+		if wf.ID != "" {
+			r.byID[wf.ID] = abs
+		}
+	}
+	for i := range cfg.Workflows {
+		if err := r.resolveSteps(&cfg.Workflows[i], abs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type workflowFileResolver struct {
+	cfg      *Config
+	byFile   map[string]string // canonical file -> workflow id
+	byID     map[string]string // workflow id -> declaring file
+	visiting map[string]int    // canonical file -> stack index
+	stack    []string
+}
+
+func (r *workflowFileResolver) resolveSteps(wf *WorkflowConfig, declaringFile string) error {
+	for i := range wf.Steps {
+		if err := r.resolveStep(wf.ID, &wf.Steps[i], declaringFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *workflowFileResolver) resolveStep(workflowID string, s *StepConfig, declaringFile string) error {
+	if s.Uses != "" {
+		if s.Workflow != "" {
+			return fmt.Errorf("workflow %q step %q: use only one of uses or workflow", workflowID, s.ID)
+		}
+		path, err := resolveWorkflowPath(filepath.Dir(declaringFile), s.Uses)
+		if err != nil {
+			return fmt.Errorf("workflow %q step %q: %w", workflowID, s.ID, err)
+		}
+		childID, err := r.load(path)
+		if err != nil {
+			return fmt.Errorf("workflow %q step %q: %w", workflowID, s.ID, err)
+		}
+		s.Type = StepTypeWorkflow
+		s.Workflow = childID
+	}
+	for i := range s.SubSteps {
+		if err := r.resolveStep(workflowID, &s.SubSteps[i], declaringFile); err != nil {
+			return err
+		}
+	}
+	for i := range s.ParallelSteps {
+		if err := r.resolveStep(workflowID, &s.ParallelSteps[i], declaringFile); err != nil {
+			return err
+		}
+	}
+	if s.Step != nil {
+		if err := r.resolveStep(workflowID, s.Step, declaringFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *workflowFileResolver) load(path string) (string, error) {
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		canonical = filepath.Clean(path)
+	}
+	if id, ok := r.byFile[canonical]; ok {
+		return id, nil
+	}
+	if at, ok := r.visiting[canonical]; ok {
+		cycle := append(append([]string{}, r.stack[at:]...), canonical)
+		for i := range cycle {
+			cycle[i] = filepath.Base(cycle[i])
+		}
+		return "", fmt.Errorf("cyclic subworkflow reference: %s", strings.Join(cycle, " -> "))
+	}
+
+	data, err := os.ReadFile(canonical)
+	if err != nil {
+		return "", fmt.Errorf("reading subworkflow %q: %w", canonical, err)
+	}
+	dec := yaml.NewDecoder(strings.NewReader(expandEnv(string(data))))
+	dec.KnownFields(true)
+	var child WorkflowConfig
+	if err := dec.Decode(&child); err != nil {
+		return "", fmt.Errorf("parsing subworkflow %q: %w", canonical, err)
+	}
+	if child.ID == "" {
+		return "", fmt.Errorf("subworkflow %q: id is required", canonical)
+	}
+	if previous, exists := r.byID[child.ID]; exists && previous != canonical {
+		return "", fmt.Errorf("subworkflow %q declares duplicate workflow id %q (already declared by %q)", canonical, child.ID, previous)
+	}
+
+	r.visiting[canonical] = len(r.stack)
+	r.stack = append(r.stack, canonical)
+	if err := r.resolveSteps(&child, canonical); err != nil {
+		return "", err
+	}
+	r.stack = r.stack[:len(r.stack)-1]
+	delete(r.visiting, canonical)
+
+	r.byFile[canonical] = child.ID
+	r.byID[child.ID] = canonical
+	r.cfg.Workflows = append(r.cfg.Workflows, child)
+	return child.ID, nil
+}
+
+func resolveWorkflowPath(baseDir, ref string) (string, error) {
+	if strings.Contains(ref, "://") {
+		return "", fmt.Errorf("remote subworkflow reference %q is not supported; use a local .yaml or .yml file", ref)
+	}
+	path := ref
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	candidates := []string{path}
+	if filepath.Ext(path) == "" {
+		candidates = append(candidates, path+".yaml", path+".yml")
+	}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			abs, absErr := filepath.Abs(candidate)
+			if absErr != nil {
+				return "", absErr
+			}
+			return filepath.Clean(abs), nil
+		}
+	}
+	return "", fmt.Errorf("subworkflow file %q not found (resolved from %q)", ref, baseDir)
+}

--- a/src/internal/config/subworkflow_load_test.go
+++ b/src/internal/config/subworkflow_load_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadResolvesLocalTypedSubworkflow(t *testing.T) {
+	dir := t.TempDir()
+	workflows := filepath.Join(dir, "workflows")
+	if err := os.Mkdir(workflows, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	child := `id: prepare-repository
+inputs:
+  repository: {type: string, required: true}
+outputs:
+  workspace: {type: string, value: "${{ steps.checkout.workspace }}"}
+steps:
+  - id: checkout
+    agent: engineer
+    output:
+      type: object
+      properties:
+        workspace: {type: string}
+`
+	if err := os.WriteFile(filepath.Join(workflows, "prepare.yaml"), []byte(child), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	main := `version: "1"
+runners:
+  - id: local
+    type: script
+    config: {}
+default_runner: local
+agents:
+  - id: engineer
+    runner: local
+    model: test
+workflows:
+  - id: main
+    steps:
+      - id: prepare
+        uses: ./workflows/prepare
+        with:
+          repository: "${{ task.repository }}"
+`
+	path := filepath.Join(dir, "apiary.yaml")
+	if err := os.WriteFile(path, []byte(main), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Workflows) != 2 {
+		t.Fatalf("workflows = %d, want 2", len(cfg.Workflows))
+	}
+	call := cfg.Workflows[0].Steps[0]
+	if call.StepType() != StepTypeWorkflow || call.Workflow != "prepare-repository" {
+		t.Fatalf("resolved call = %#v", call)
+	}
+	if cfg.Workflows[1].Inputs["repository"].Type != "string" {
+		t.Fatalf("child input contract was not loaded: %#v", cfg.Workflows[1].Inputs)
+	}
+	if errs := cfg.Validate(); len(errs) > 0 {
+		t.Fatalf("resolved config should validate: %v", errs)
+	}
+}
+
+func TestLoadRejectsCyclicLocalSubworkflows(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.yaml", "id: a\nsteps:\n  - id: b\n    uses: ./b.yaml\n")
+	write("b.yaml", "id: b\nsteps:\n  - id: a\n    uses: ./a.yaml\n")
+	write("apiary.yaml", "version: \"1\"\nworkflows:\n  - id: main\n    steps:\n      - id: a\n        uses: ./a.yaml\n")
+
+	_, err := Load(filepath.Join(dir, "apiary.yaml"))
+	if err == nil || !strings.Contains(err.Error(), "cyclic subworkflow reference: a.yaml -> b.yaml -> a.yaml") {
+		t.Fatalf("expected actionable cycle error, got %v", err)
+	}
+}
+
+func TestLoadRejectsUnknownFieldInReusableWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "child.yaml"), []byte("id: child\nunknown: true\nsteps: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	main := "version: \"1\"\nworkflows:\n  - id: main\n    steps:\n      - id: child\n        uses: ./child.yaml\n"
+	path := filepath.Join(dir, "apiary.yaml")
+	if err := os.WriteFile(path, []byte(main), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), "field unknown not found") {
+		t.Fatalf("expected strict child decode error, got %v", err)
+	}
+}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -71,6 +71,10 @@ const (
 type WorkflowConfig struct {
 	ID          string `yaml:"id"`
 	Description string `yaml:"description,omitempty"`
+	// Inputs and Outputs form the public contract of a reusable workflow. They
+	// are optional for top-level workflows and for legacy same-file references.
+	Inputs  map[string]WorkflowInput  `yaml:"inputs,omitempty"`
+	Outputs map[string]WorkflowOutput `yaml:"outputs,omitempty"`
 	// Resume controls how a failed/interrupted instance may be restarted:
 	// allowed (default), forbidden, or auto. Empty means allowed.
 	Resume string `yaml:"resume,omitempty"`
@@ -197,7 +201,14 @@ type StepConfig struct {
 	Step        *StepConfig `yaml:"step,omitempty"`
 
 	// ── sub-workflow step ─────────────────────────────────────────
+	// Workflow is the resolved child workflow ID used by the engine. It remains
+	// authorable for backwards-compatible same-file references.
 	Workflow string `yaml:"workflow,omitempty"`
+	// Uses references a reusable workflow file relative to the declaring YAML.
+	// Config.Load resolves it into Workflow before validation/execution.
+	Uses string `yaml:"uses,omitempty"`
+	// With binds values to the reusable workflow's declared inputs.
+	With map[string]any `yaml:"with,omitempty"`
 
 	// ── v2 authored fields (present before lowering; absent after) ───
 	// These are written by humans in v2 syntax and lowered to the IR fields
@@ -479,6 +490,19 @@ type OutputSchema struct {
 	Type       string                 `yaml:"type"`
 	Properties map[string]SchemaField `yaml:"properties,omitempty"`
 	Required   []string               `yaml:"required,omitempty"`
+}
+
+// WorkflowInput declares one typed value accepted by a reusable workflow.
+type WorkflowInput struct {
+	Type     string `yaml:"type"`
+	Required bool   `yaml:"required,omitempty"`
+	Default  any    `yaml:"default,omitempty"`
+}
+
+// WorkflowOutput maps one typed public result to a child step output.
+type WorkflowOutput struct {
+	Type  string `yaml:"type"`
+	Value string `yaml:"value"`
 }
 
 // SchemaField describes one property within an OutputSchema. Items is set for

--- a/src/internal/config/workflow_contract.go
+++ b/src/internal/config/workflow_contract.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func validateWorkflowContract(ctx string, wf WorkflowConfig) []error {
+	var errs []error
+	for name, input := range wf.Inputs {
+		ictx := fmt.Sprintf("%s: input %q", ctx, name)
+		if name == "" {
+			errs = append(errs, fmt.Errorf("%s: input name must not be empty", ctx))
+		}
+		if !supportedSchemaTypes[input.Type] {
+			errs = append(errs, fmt.Errorf("%s: unsupported type %q", ictx, input.Type))
+		} else if input.Default != nil && !WorkflowValueMatchesType(input.Default, input.Type) {
+			errs = append(errs, fmt.Errorf("%s: default value does not match type %q", ictx, input.Type))
+		}
+	}
+
+	stepByID := make(map[string]StepConfig, len(wf.Steps))
+	for _, step := range wf.Steps {
+		stepByID[step.ID] = step
+	}
+	for name, output := range wf.Outputs {
+		octx := fmt.Sprintf("%s: output %q", ctx, name)
+		if name == "" {
+			errs = append(errs, fmt.Errorf("%s: output name must not be empty", ctx))
+		}
+		if !supportedSchemaTypes[output.Type] {
+			errs = append(errs, fmt.Errorf("%s: unsupported type %q", octx, output.Type))
+		}
+		stepID, field, ok := workflowStepOutputRef(output.Value)
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s: value must reference ${{ steps.<step>.<field> }}", octx))
+			continue
+		}
+		step, exists := stepByID[stepID]
+		if !exists {
+			errs = append(errs, fmt.Errorf("%s: value references unknown step %q", octx, stepID))
+			continue
+		}
+		if field == "output" {
+			if output.Type != "string" {
+				errs = append(errs, fmt.Errorf("%s: raw step output must have type string", octx))
+			}
+			continue
+		}
+		schema := step.OutputSchema
+		if schema == nil {
+			schema = step.Output
+		}
+		if schema == nil || schema.Properties[field].Type == "" {
+			errs = append(errs, fmt.Errorf("%s: step %q does not declare output field %q", octx, stepID, field))
+			continue
+		}
+		if output.Type != "" && schema.Properties[field].Type != output.Type {
+			errs = append(errs, fmt.Errorf("%s: type %q does not match step %q field %q type %q", octx, output.Type, stepID, field, schema.Properties[field].Type))
+		}
+	}
+	return errs
+}
+
+func validateWorkflowReferenceCycles(wfByID map[string]WorkflowConfig) []error {
+	state := map[string]int{}
+	var stack []string
+	var errs []error
+	var visit func(string)
+	visit = func(id string) {
+		if state[id] == 2 {
+			return
+		}
+		if state[id] == 1 {
+			at := 0
+			for at < len(stack) && stack[at] != id {
+				at++
+			}
+			cycle := append(append([]string{}, stack[at:]...), id)
+			errs = append(errs, fmt.Errorf("cyclic subworkflow reference: %s", strings.Join(cycle, " -> ")))
+			return
+		}
+		state[id] = 1
+		stack = append(stack, id)
+		for _, step := range wfByID[id].Steps {
+			if step.StepType() == StepTypeWorkflow {
+				if _, ok := wfByID[step.Workflow]; ok {
+					visit(step.Workflow)
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[id] = 2
+	}
+	ids := make([]string, 0, len(wfByID))
+	for id := range wfByID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		visit(id)
+	}
+	return errs
+}
+
+func workflowStepOutputRef(value string) (stepID, field string, ok bool) {
+	s := strings.TrimSpace(value)
+	if !strings.HasPrefix(s, "${{") || !strings.HasSuffix(s, "}}") {
+		return "", "", false
+	}
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(s, "${{"), "}}"))
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 || parts[0] != "steps" || parts[1] == "" || parts[2] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[2], true
+}
+
+func isWorkflowExpression(value any) bool {
+	s, ok := value.(string)
+	if !ok {
+		return false
+	}
+	s = strings.TrimSpace(s)
+	return strings.HasPrefix(s, "${{") && strings.HasSuffix(s, "}}")
+}
+
+// WorkflowValueMatchesType checks a runtime or literal value against the small
+// JSON-compatible type set used by reusable workflow contracts.
+func WorkflowValueMatchesType(value any, typ string) bool {
+	switch typ {
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "number":
+		switch value.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			return true
+		}
+	case "integer":
+		switch x := value.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			return true
+		case float64:
+			return x == float64(int64(x))
+		case float32:
+			return x == float32(int64(x))
+		}
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "array":
+		switch value.(type) {
+		case []any, []string:
+			return true
+		}
+	case "object":
+		switch value.(type) {
+		case map[string]any, map[string]string:
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/config/workflow_contract_test.go
+++ b/src/internal/config/workflow_contract_test.go
@@ -1,0 +1,35 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func TestWorkflowContractRequiredInput(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "child", Inputs: map[string]config.WorkflowInput{
+			"repository": {Type: "string", Required: true},
+		}, Steps: []config.StepConfig{{ID: "run", Agent: "architect"}}},
+		{ID: "parent", Steps: []config.StepConfig{{ID: "call", Type: config.StepTypeWorkflow, Workflow: "child"}}},
+	}
+	assertError(t, cfg, `required input "repository"`)
+}
+
+func TestWorkflowContractRejectsOutputTypeMismatch(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{{
+		ID: "child",
+		Outputs: map[string]config.WorkflowOutput{
+			"workspace": {Type: "boolean", Value: "${{ steps.run.workspace }}"},
+		},
+		Steps: []config.StepConfig{{
+			ID: "run", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object", Properties: map[string]config.SchemaField{
+				"workspace": {Type: "string"},
+			}},
+		}},
+	}}
+	assertError(t, cfg, `does not match step "run" field "workspace" type "string"`)
+}

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -47,6 +47,7 @@ func (c *Config) validateWorkflows() []error {
 	for i, wf := range c.Workflows {
 		errs = append(errs, c.validateWorkflow(i, wf, agentIDs, sourceIDs, wfByID)...)
 	}
+	errs = append(errs, validateWorkflowReferenceCycles(wfByID)...)
 
 	return errs
 }
@@ -60,6 +61,7 @@ func (c *Config) validateWorkflow(
 ) []error {
 	var errs []error
 	ctx := fmt.Sprintf("workflows[%d] %q", idx, wf.ID)
+	errs = append(errs, validateWorkflowContract(ctx, wf)...)
 
 	// Resume policy.
 	switch wf.Resume {
@@ -444,6 +446,10 @@ func validateWorkflowStep(sctx string, s StepConfig, parent WorkflowConfig, wfBy
 	if s.Agent != "" {
 		errs = append(errs, fmt.Errorf("%s: workflow step must not have an agent field", sctx))
 	}
+	if s.Uses != "" && s.Workflow == "" {
+		errs = append(errs, fmt.Errorf("%s: local uses reference %q was not resolved; load the config with config.Load", sctx, s.Uses))
+		return errs
+	}
 	if s.Workflow == "" {
 		errs = append(errs, fmt.Errorf("%s: workflow step requires a workflow reference", sctx))
 		return errs
@@ -457,11 +463,25 @@ func validateWorkflowStep(sctx string, s StepConfig, parent WorkflowConfig, wfBy
 		errs = append(errs, fmt.Errorf("%s: workflow %q not defined", sctx, s.Workflow))
 		return errs
 	}
-	// One level of nesting only: the child must not itself contain workflow steps.
-	for _, cs := range child.Steps {
-		if cs.StepType() == StepTypeWorkflow {
-			errs = append(errs, fmt.Errorf("%s: referenced workflow %q contains a sub-workflow step %q; nesting is not allowed", sctx, s.Workflow, cs.ID))
-			break
+	if s.Timeout != "" {
+		if _, err := time.ParseDuration(s.Timeout); err != nil {
+			errs = append(errs, fmt.Errorf("%s: invalid timeout %q: %v", sctx, s.Timeout, err))
+		}
+	}
+	for name, value := range s.With {
+		input, exists := child.Inputs[name]
+		if !exists {
+			errs = append(errs, fmt.Errorf("%s: with.%s is not declared by workflow %q", sctx, name, child.ID))
+			continue
+		}
+		if !isWorkflowExpression(value) && !WorkflowValueMatchesType(value, input.Type) {
+			errs = append(errs, fmt.Errorf("%s: with.%s does not match input type %q", sctx, name, input.Type))
+		}
+	}
+	for name, input := range child.Inputs {
+		_, provided := s.With[name]
+		if input.Required && input.Default == nil && !provided {
+			errs = append(errs, fmt.Errorf("%s: required input %q for workflow %q is missing", sctx, name, child.ID))
 		}
 	}
 

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -607,7 +607,7 @@ func TestWorkflow_StepUnknownWorkflowRef(t *testing.T) {
 	assertError(t, cfg, "workflow \"ghost\" not defined")
 }
 
-func TestWorkflow_SubWorkflowNestingNotAllowed(t *testing.T) {
+func TestWorkflow_SubWorkflowNestingAllowedWhenAcyclic(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{
 		{ID: "leaf", Steps: []config.StepConfig{{ID: "x", Agent: "architect"}}},
@@ -618,7 +618,19 @@ func TestWorkflow_SubWorkflowNestingNotAllowed(t *testing.T) {
 			{ID: "s", Type: config.StepTypeWorkflow, Workflow: "mid"},
 		}},
 	}
-	assertError(t, cfg, "nesting is not allowed")
+	if errs := cfg.Validate(); len(errs) > 0 {
+		t.Fatalf("expected acyclic nested workflows to validate, got %v", errs)
+	}
+}
+
+func TestWorkflow_SubWorkflowIndirectCycleRejected(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "a", Steps: []config.StepConfig{{ID: "call-b", Type: config.StepTypeWorkflow, Workflow: "b"}}},
+		{ID: "b", Steps: []config.StepConfig{{ID: "call-c", Type: config.StepTypeWorkflow, Workflow: "c"}}},
+		{ID: "c", Steps: []config.StepConfig{{ID: "call-a", Type: config.StepTypeWorkflow, Workflow: "a"}}},
+	}
+	assertError(t, cfg, "cyclic subworkflow reference: a -> b -> c -> a")
 }
 
 func TestWorkflow_OutputSchemaTypeNotObject(t *testing.T) {

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -236,7 +236,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 					}
 					foreachExitCode = fr.failed
 				case config.StepTypeWorkflow:
-					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, r.depth, r.wf.ID)
+					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, contribSnap, r.depth, r.wf.ID)
 				case config.StepTypeWaitFor:
 					res, _ = e.RunWaitStep(ctx, r.instID, step, r.cell.SourceID, r.cell.ID, waitDeadline)
 				default: // StepTypeAgent
@@ -299,6 +299,11 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		}
 
 		res := wr.res
+		if ctx.Err() != nil {
+			res.Success = false
+			res.Output = "workflow canceled: " + ctx.Err().Error()
+			res.Err = ctx.Err()
+		}
 
 		// Wait_for step with no terminal result yet: suspend the instance at this step
 		// (releasing the worker) and resume it on a later poll cycle, exactly like

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -2,7 +2,11 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
@@ -10,10 +14,9 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
-// maxSubWorkflowDepth bounds sub-workflow nesting at runtime. Config validation
-// already forbids nesting (a referenced workflow may not contain workflow
-// steps), so depth 1 is the only legal level; this is a backstop.
-const maxSubWorkflowDepth = 1
+// maxSubWorkflowDepth is a runtime backstop for configs that bypass validation.
+// Normal recursive references are rejected by the config graph validator.
+const maxSubWorkflowDepth = 16
 
 // executeSubWorkflowStep runs a sub-workflow step without touching dagRun; it is
 // safe to call from a worker goroutine. memSnap is a snapshot of the parent's
@@ -21,26 +24,86 @@ const maxSubWorkflowDepth = 1
 func (e *Engine) executeSubWorkflowStep(
 	ctx context.Context, parentInstID string,
 	step config.StepConfig, task model.InternalTask, bindings []model.SourceBinding,
-	memSnap []MemoryStep, depth int, wfID string,
+	memSnap []MemoryStep, contribSnap map[string]MemoryStep, depth int, wfID string,
 ) StepResult {
+	started := e.now()
+	sr := &db.StepRun{
+		ID:                 e.newID("sr"),
+		WorkflowInstanceID: parentInstID,
+		StepID:             step.ID,
+		State:              db.StepStateRunning,
+		StartedAt:          &started,
+	}
+	_ = e.store.CreateStepRun(ctx, sr)
+	finish := func(res StepResult) StepResult {
+		persistCtx := context.WithoutCancel(ctx)
+		finished := e.now()
+		sr.FinishedAt = &finished
+		sr.Output = res.Output
+		sr.Summary = res.Summary
+		if res.Success {
+			sr.State = db.StepStatePassed
+		} else {
+			sr.State = db.StepStateFailed
+		}
+		if len(res.StructuredOutput) > 0 {
+			if data, err := json.Marshal(res.StructuredOutput); err == nil {
+				sr.StructuredOutput = string(data)
+			}
+		}
+		_ = e.store.UpdateStepRun(persistCtx, sr)
+		return res
+	}
+
 	if depth >= maxSubWorkflowDepth {
 		aplog.Error("workflow %s: step %q: sub-workflow nesting beyond depth %d is not allowed",
 			wfID, step.ID, maxSubWorkflowDepth)
-		return StepResult{Success: false, Output: "sub-workflow nesting limit exceeded"}
+		return finish(StepResult{Success: false, Output: "sub-workflow nesting limit exceeded"})
 	}
 
 	child := e.findWorkflow(step.Workflow)
 	if child == nil {
 		aplog.Error("workflow %s: step %q: referenced workflow %q not found", wfID, step.ID, step.Workflow)
-		return StepResult{Success: false, Output: fmt.Sprintf("workflow %q not found", step.Workflow)}
+		return finish(StepResult{Success: false, Output: fmt.Sprintf("workflow %q not found", step.Workflow)})
 	}
 
-	_, success := e.runChildInstance(ctx, parentInstID, *child, task, bindings, memSnap, depth+1)
-	summary := ""
-	if success {
-		summary = fmt.Sprintf("sub-workflow %q completed", child.ID)
+	inputs, err := resolveSubworkflowInputs(step, *child, task, bindings, memSnap, contribSnap)
+	if err != nil {
+		return finish(StepResult{Success: false, Output: err.Error(), Err: err})
 	}
-	return StepResult{Success: success, Summary: summary}
+	resolvedChild := renderSubworkflowInputs(*child, inputs)
+	seed := append([]MemoryStep{}, memSnap...)
+	if len(inputs) > 0 {
+		keys := make([]string, 0, len(inputs))
+		for key := range inputs {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		seed = append(seed, MemoryStep{StepID: "inputs", WriteFields: keys, Structured: inputs})
+	}
+
+	childCtx := ctx
+	var cancel context.CancelFunc
+	if step.Timeout != "" {
+		if timeout, parseErr := time.ParseDuration(step.Timeout); parseErr == nil {
+			childCtx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+	}
+	childID, outputs, success := e.runChildInstance(childCtx, parentInstID, resolvedChild, task, bindings, seed, depth+1)
+	if !success {
+		message := fmt.Sprintf("sub-workflow %q failed", child.ID)
+		if childCtx.Err() != nil {
+			message = fmt.Sprintf("sub-workflow %q canceled: %v", child.ID, childCtx.Err())
+		}
+		return finish(StepResult{Success: false, Output: message, Err: childCtx.Err()})
+	}
+	return finish(StepResult{
+		Success:          true,
+		Output:           childID,
+		Summary:          fmt.Sprintf("sub-workflow %q completed", child.ID),
+		StructuredOutput: outputs,
+	})
 }
 
 // runChildInstance creates and runs a linked child workflow instance. It does
@@ -48,7 +111,7 @@ func (e *Engine) executeSubWorkflowStep(
 // instance) and does not apply the child's on_complete/on_fail hooks against the
 // shared cell — the child is an isolated pipeline whose only outward signal is
 // success/failure.
-func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, child config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) (string, bool) {
+func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, child config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, seed []MemoryStep, depth int) (string, map[string]any, bool) {
 	childID := e.newID("wf")
 	cell := sourceItemView(task, bindings)
 	inst := &db.WorkflowInstance{
@@ -63,16 +126,19 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 	}
 	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
 		aplog.Error("sub-workflow %s: create child instance: %v", child.ID, err)
-		return "", false
+		return "", nil, false
 	}
 	if err := e.persistWorkflowSnapshot(ctx, childID, child); err != nil {
 		_ = e.store.UpdateWorkflowInstanceState(ctx, childID, db.InstanceStateFailed)
 		aplog.Error("sub-workflow %s: persist snapshot: %v", child.ID, err)
-		return childID, false
+		return childID, nil, false
 	}
 
 	r := e.initDAG(childID, child, task, bindings, seed, depth)
 	outcome := e.driveDAG(ctx, r)
+	if ctx.Err() != nil {
+		outcome = outcomeFailed
+	}
 	// A sub-workflow cannot park independently in Phase 4: an approval step inside
 	// a child is treated as a failure (unsupported). Top-level approvals are the
 	// supported case.
@@ -85,8 +151,18 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 	if outcome == outcomeFailed {
 		finalState = db.InstanceStateFailed
 	}
-	_ = e.store.UpdateWorkflowInstanceState(ctx, childID, finalState)
-	return childID, outcome == outcomeDone
+	outputs := map[string]any{}
+	if outcome == outcomeDone {
+		var err error
+		outputs, err = resolveSubworkflowOutputs(child, r)
+		if err != nil {
+			aplog.Error("sub-workflow %s: resolve outputs: %v", child.ID, err)
+			outcome = outcomeFailed
+			finalState = db.InstanceStateFailed
+		}
+	}
+	_ = e.store.UpdateWorkflowInstanceState(context.WithoutCancel(ctx), childID, finalState)
+	return childID, outputs, outcome == outcomeDone
 }
 
 // findWorkflow looks up a workflow definition by ID in the config.
@@ -97,4 +173,214 @@ func (e *Engine) findWorkflow(id string) *config.WorkflowConfig {
 		}
 	}
 	return nil
+}
+
+func resolveSubworkflowInputs(step config.StepConfig, child config.WorkflowConfig, task model.InternalTask, bindings []model.SourceBinding, memSnap []MemoryStep, contrib map[string]MemoryStep) (map[string]any, error) {
+	inputs := make(map[string]any, len(child.Inputs))
+	for name, declaration := range child.Inputs {
+		value, provided := step.With[name]
+		if !provided {
+			if declaration.Default != nil {
+				value = declaration.Default
+				provided = true
+			} else if declaration.Required {
+				return nil, fmt.Errorf("sub-workflow %q: required input %q is missing", child.ID, name)
+			}
+		}
+		if !provided {
+			continue
+		}
+		resolved, err := resolveSubworkflowValue(value, task, bindings, memSnap, contrib)
+		if err != nil {
+			return nil, fmt.Errorf("sub-workflow %q input %q: %w", child.ID, name, err)
+		}
+		if !config.WorkflowValueMatchesType(resolved, declaration.Type) {
+			return nil, fmt.Errorf("sub-workflow %q input %q: value does not match type %q", child.ID, name, declaration.Type)
+		}
+		inputs[name] = resolved
+	}
+	return inputs, nil
+}
+
+func resolveSubworkflowValue(value any, task model.InternalTask, bindings []model.SourceBinding, memSnap []MemoryStep, contrib map[string]MemoryStep) (any, error) {
+	s, ok := value.(string)
+	if !ok {
+		return value, nil
+	}
+	expr := strings.TrimSpace(s)
+	if !strings.HasPrefix(expr, "${{") || !strings.HasSuffix(expr, "}}") {
+		return value, nil
+	}
+	expr = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expr, "${{"), "}}"))
+	parts := strings.Split(expr, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid value expression %q", s)
+	}
+	switch parts[0] {
+	case "task":
+		key := strings.Join(parts[1:], ".")
+		switch key {
+		case "id":
+			return task.ID, nil
+		case "title":
+			return task.Title, nil
+		case "description":
+			return task.Description, nil
+		}
+		if value, exists := task.Input[key]; exists {
+			return value, nil
+		}
+	case "cell":
+		cell := sourceItemView(task, bindings)
+		switch strings.Join(parts[1:], ".") {
+		case "id":
+			return cell.ID, nil
+		case "title":
+			return cell.Title, nil
+		case "description":
+			return cell.Description, nil
+		case "source":
+			return cell.SourceID, nil
+		case "priority":
+			return cell.Priority, nil
+		case "type":
+			return cell.Type, nil
+		}
+	case "memory":
+		key := strings.Join(parts[1:], ".")
+		if value, exists := memoryValuesFrom(memSnap)[key]; exists {
+			return value, nil
+		}
+	case "steps":
+		if len(parts) == 3 {
+			if contribution, exists := contrib[parts[1]]; exists {
+				if value, exists := contribution.Structured[parts[2]]; exists {
+					return value, nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("value expression %q did not resolve", s)
+}
+
+func renderSubworkflowInputs(child config.WorkflowConfig, inputs map[string]any) config.WorkflowConfig {
+	steps := make([]config.StepConfig, len(child.Steps))
+	for i := range child.Steps {
+		steps[i] = cloneSubworkflowStep(child.Steps[i])
+	}
+	child.Steps = steps
+	for i := range child.Steps {
+		renderStepInputs(&child.Steps[i], inputs)
+	}
+	return child
+}
+
+func cloneSubworkflowStep(step config.StepConfig) config.StepConfig {
+	if step.With != nil {
+		with := make(map[string]any, len(step.With))
+		for key, value := range step.With {
+			with[key] = value
+		}
+		step.With = with
+	}
+	if step.Env != nil {
+		env := make(map[string]string, len(step.Env))
+		for key, value := range step.Env {
+			env[key] = value
+		}
+		step.Env = env
+	}
+	if step.Step != nil {
+		inner := cloneSubworkflowStep(*step.Step)
+		step.Step = &inner
+	}
+	if len(step.SubSteps) > 0 {
+		children := make([]config.StepConfig, len(step.SubSteps))
+		for i := range step.SubSteps {
+			children[i] = cloneSubworkflowStep(step.SubSteps[i])
+		}
+		step.SubSteps = children
+	}
+	if len(step.ParallelSteps) > 0 {
+		children := make([]config.StepConfig, len(step.ParallelSteps))
+		for i := range step.ParallelSteps {
+			children[i] = cloneSubworkflowStep(step.ParallelSteps[i])
+		}
+		step.ParallelSteps = children
+	}
+	return step
+}
+
+func renderStepInputs(step *config.StepConfig, inputs map[string]any) {
+	step.Prompt = renderInputString(step.Prompt, inputs)
+	step.SummaryPrompt = renderInputString(step.SummaryPrompt, inputs)
+	step.Message = renderInputString(step.Message, inputs)
+	for key, value := range step.With {
+		step.With[key] = renderInputValue(value, inputs)
+	}
+	if step.Step != nil {
+		renderStepInputs(step.Step, inputs)
+	}
+	for i := range step.SubSteps {
+		renderStepInputs(&step.SubSteps[i], inputs)
+	}
+	for i := range step.ParallelSteps {
+		renderStepInputs(&step.ParallelSteps[i], inputs)
+	}
+}
+
+func renderInputValue(value any, inputs map[string]any) any {
+	s, ok := value.(string)
+	if !ok {
+		return value
+	}
+	trimmed := strings.TrimSpace(s)
+	if strings.HasPrefix(trimmed, "${{") && strings.HasSuffix(trimmed, "}}") {
+		expr := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "${{"), "}}"))
+		parts := strings.Split(expr, ".")
+		if len(parts) == 2 && parts[0] == "inputs" {
+			if value, exists := inputs[parts[1]]; exists {
+				return value
+			}
+		}
+	}
+	return renderInputString(s, inputs)
+}
+
+func renderInputString(value string, inputs map[string]any) string {
+	for name, input := range inputs {
+		value = strings.ReplaceAll(value, "${{ inputs."+name+" }}", renderValue(input))
+		value = strings.ReplaceAll(value, "${{inputs."+name+"}}", renderValue(input))
+	}
+	return value
+}
+
+func resolveSubworkflowOutputs(child config.WorkflowConfig, run *dagRun) (map[string]any, error) {
+	outputs := make(map[string]any, len(child.Outputs))
+	for name, declaration := range child.Outputs {
+		expr := strings.TrimSpace(declaration.Value)
+		expr = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expr, "${{"), "}}"))
+		parts := strings.Split(expr, ".")
+		if len(parts) != 3 || parts[0] != "steps" {
+			return nil, fmt.Errorf("output %q has invalid value expression %q", name, declaration.Value)
+		}
+		var value any
+		var exists bool
+		if parts[2] == "output" {
+			state, ok := run.stepStates[parts[1]]
+			if ok {
+				value, exists = state.Output, true
+			}
+		} else if contribution, ok := run.contrib[parts[1]]; ok {
+			value, exists = contribution.Structured[parts[2]]
+		}
+		if !exists {
+			return nil, fmt.Errorf("output %q could not resolve %q", name, declaration.Value)
+		}
+		if !config.WorkflowValueMatchesType(value, declaration.Type) {
+			return nil, fmt.Errorf("output %q does not match type %q", name, declaration.Type)
+		}
+		outputs[name] = value
+	}
+	return outputs, nil
 }

--- a/src/internal/workflow/subworkflow_test.go
+++ b/src/internal/workflow/subworkflow_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -86,6 +87,11 @@ func TestSubWorkflow_ChildFailureFailsParentStep(t *testing.T) {
 	if contains(executedIDs(exec.seen), "after") {
 		t.Error("step after a failed sub-workflow should not run")
 	}
+	for _, sr := range store.stepRuns {
+		if sr.StepID == "sub" && sr.State != db.StepStateFailed {
+			t.Errorf("parent call step state = %q, want failed", sr.State)
+		}
+	}
 }
 
 func TestSubWorkflow_UnknownReferenceFails(t *testing.T) {
@@ -140,9 +146,7 @@ func TestSubWorkflow_ParentMemorySeedsChild(t *testing.T) {
 	}
 }
 
-func TestSubWorkflow_NoNestingBeyondDepth(t *testing.T) {
-	// Build a child that itself contains a workflow step; runtime must refuse it
-	// (config validation also forbids this, but the engine guards independently).
+func TestSubWorkflow_AcyclicNestingRuns(t *testing.T) {
 	grandchild := config.WorkflowConfig{ID: "gc", Steps: []config.StepConfig{{ID: "x", Agent: "architect"}}}
 	child := config.WorkflowConfig{ID: "child", Steps: []config.StepConfig{
 		{ID: "nested", Type: config.StepTypeWorkflow, Workflow: "gc"},
@@ -156,7 +160,154 @@ func TestSubWorkflow_NoNestingBeyondDepth(t *testing.T) {
 	eng := testEngine(cfg, store, &fakeExecutor{}, &fakeSide{})
 
 	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "c1"})
+	if !success {
+		t.Fatal("expected acyclic nested workflows to succeed")
+	}
+	if !contains(executedIDs(eng.exec.(*fakeExecutor).seen), "x") {
+		t.Fatal("expected grandchild step to execute")
+	}
+}
+
+func TestSubWorkflow_TypedInputsOutputsAndCallHistory(t *testing.T) {
+	prepare := config.WorkflowConfig{
+		ID: "prepare",
+		Inputs: map[string]config.WorkflowInput{
+			"repository": {Type: "string", Required: true},
+		},
+		Outputs: map[string]config.WorkflowOutput{
+			"workspace": {Type: "string", Value: "${{ steps.checkout.workspace }}"},
+		},
+		Steps: []config.StepConfig{{
+			ID: "checkout", Agent: "architect", Prompt: "Clone ${{ inputs.repository }}",
+			OutputSchema: &config.OutputSchema{Type: "object", Properties: map[string]config.SchemaField{
+				"workspace": {Type: "string"},
+			}},
+		}},
+	}
+	test := config.WorkflowConfig{
+		ID: "test",
+		Inputs: map[string]config.WorkflowInput{
+			"workspace": {Type: "string", Required: true},
+		},
+		Steps: []config.StepConfig{{ID: "run-tests", Agent: "backend-dev", Prompt: "Test ${{ inputs.workspace }}"}},
+	}
+	parent := config.WorkflowConfig{ID: "main", Steps: []config.StepConfig{
+		{ID: "prepare-call", Type: config.StepTypeWorkflow, Workflow: "prepare", With: map[string]any{"repository": "${{ task.repository }}"}},
+		{ID: "test-call", Type: config.StepTypeWorkflow, Workflow: "test", DependsOn: []string{"prepare-call"}, With: map[string]any{"workspace": "${{ steps.prepare-call.workspace }}"}},
+	}}
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"checkout": {Success: true, StructuredOutput: map[string]any{"workspace": "/tmp/apiary"}},
+	}}
+	eng := testEngine(cfgWithWorkflows(prepare, test, parent), store, exec, &fakeSide{})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{
+		ID: "task-1", Input: map[string]any{"repository": "orlandoburli/apiary"},
+	})
+	if !success {
+		t.Fatal("expected typed subworkflow chain to succeed")
+	}
+	var checkoutPrompt, testPrompt string
+	for _, req := range exec.seen {
+		switch req.Step.ID {
+		case "checkout":
+			checkoutPrompt = req.Prompt
+		case "run-tests":
+			testPrompt = req.Prompt
+		}
+	}
+	if checkoutPrompt != "Clone orlandoburli/apiary" || testPrompt != "Test /tmp/apiary" {
+		t.Fatalf("rendered prompts = %q, %q", checkoutPrompt, testPrompt)
+	}
+	var call *db.StepRun
+	for _, sr := range store.stepRuns {
+		if sr.StepID == "prepare-call" {
+			call = sr
+		}
+	}
+	if call == nil || call.State != db.StepStatePassed {
+		t.Fatalf("parent call history = %#v", call)
+	}
+	var outputs map[string]any
+	if err := json.Unmarshal([]byte(call.StructuredOutput), &outputs); err != nil {
+		t.Fatalf("decode call outputs: %v", err)
+	}
+	if outputs["workspace"] != "/tmp/apiary" {
+		t.Fatalf("call outputs = %#v", outputs)
+	}
+}
+
+func TestSubWorkflow_InputDefault(t *testing.T) {
+	child := config.WorkflowConfig{
+		ID: "child",
+		Inputs: map[string]config.WorkflowInput{
+			"branch": {Type: "string", Default: "main"},
+		},
+		Steps: []config.StepConfig{{ID: "run", Agent: "architect", Prompt: "Build ${{ inputs.branch }}"}},
+	}
+	parent := config.WorkflowConfig{ID: "parent", Steps: []config.StepConfig{{ID: "call", Type: config.StepTypeWorkflow, Workflow: "child"}}}
+	exec := &fakeExecutor{}
+	eng := testEngine(cfgWithWorkflows(child, parent), newFakeStore(), exec, &fakeSide{})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "task-1"})
+	if !success || len(exec.seen) != 1 || exec.seen[0].Prompt != "Build main" {
+		t.Fatalf("default input was not applied: success=%v requests=%#v", success, exec.seen)
+	}
+}
+
+type contextExecutor struct {
+	started chan<- struct{}
+}
+
+func (e contextExecutor) ExecuteStep(ctx context.Context, _ StepRequest) StepResult {
+	if e.started != nil {
+		e.started <- struct{}{}
+	}
+	<-ctx.Done()
+	return StepResult{Success: false, Err: ctx.Err(), Output: ctx.Err().Error()}
+}
+
+func TestSubWorkflow_TimeoutCancelsChildAndFailsHistory(t *testing.T) {
+	child := config.WorkflowConfig{ID: "child", Steps: []config.StepConfig{{ID: "block", Agent: "architect"}}}
+	parent := config.WorkflowConfig{ID: "parent", Steps: []config.StepConfig{{
+		ID: "call", Type: config.StepTypeWorkflow, Workflow: "child", Timeout: "5ms",
+	}}}
+	store := newFakeStore()
+	eng := testEngine(cfgWithWorkflows(child, parent), store, contextExecutor{}, &fakeSide{})
+	_, success, _ := eng.RunInstance(context.Background(), parent, model.InternalTask{ID: "task-1"})
 	if success {
-		t.Fatal("expected failure: nesting beyond one level must be refused")
+		t.Fatal("expected timed-out child to fail parent")
+	}
+	for _, inst := range store.instances {
+		if inst.WorkflowID == "child" && inst.State != db.InstanceStateFailed {
+			t.Fatalf("child state = %q, want failed", inst.State)
+		}
+	}
+	for _, sr := range store.stepRuns {
+		if sr.StepID == "call" && (sr.State != db.StepStateFailed || !strings.Contains(sr.Output, "deadline exceeded")) {
+			t.Fatalf("call history = %#v", sr)
+		}
+	}
+}
+
+func TestSubWorkflow_ParentCancellationCancelsChild(t *testing.T) {
+	child := config.WorkflowConfig{ID: "child", Steps: []config.StepConfig{{ID: "block", Agent: "architect"}}}
+	parent := config.WorkflowConfig{ID: "parent", Steps: []config.StepConfig{{ID: "call", Type: config.StepTypeWorkflow, Workflow: "child"}}}
+	started := make(chan struct{}, 1)
+	store := newFakeStore()
+	eng := testEngine(cfgWithWorkflows(child, parent), store, contextExecutor{started: started}, &fakeSide{})
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan bool, 1)
+	go func() {
+		_, success, _ := eng.RunInstance(ctx, parent, model.InternalTask{ID: "task-1"})
+		result <- success
+	}()
+	<-started
+	cancel()
+	if success := <-result; success {
+		t.Fatal("expected parent cancellation to fail the child call")
+	}
+	for _, inst := range store.instances {
+		if inst.WorkflowID == "child" && inst.State != db.InstanceStateFailed {
+			t.Fatalf("canceled child state = %q, want failed", inst.State)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- resolve reusable local workflow files with typed inputs, defaults, and explicit outputs
- validate strict file contracts and direct or indirect cycles while preserving same-file workflow calls
- record parent call steps, linked child history, and failure, timeout, and cancellation propagation

## Test plan

- [x] `make check`
- [x] `make vet`
- [x] `go test -race ./internal/config ./internal/workflow`
- [x] GitNexus change detection and worktree reindex

Closes #210