### PR TITLE
feat: add structured execution events

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,14 +5,16 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-All commands work via `npx` — no global install required.
+Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
+
+> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-npx gitnexus analyze
+node .gitnexus/run.cjs analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -22,13 +24,14 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
+| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
 
 ### status — Check index freshness
 
 ```bash
-npx gitnexus status
+node .gitnexus/run.cjs status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -36,7 +39,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-npx gitnexus clean
+node .gitnexus/run.cjs clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -49,7 +52,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-npx gitnexus wiki
+node .gitnexus/run.cjs wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -66,7 +69,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-npx gitnexus list
+node .gitnexus/run.cjs list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
-2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
+1. query({search_query: "<error or symptom>"})            → Find related execution flows
+2. context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
+4. cypher({statement: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] gitnexus_query for error text or related code
+- [ ] query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] gitnexus_context to see callers and callees
+- [ ] context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] gitnexus_cypher for custom call chain traces if needed
+- [ ] cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,46 +40,58 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `gitnexus_query` for error text → `context` on throw sites |
+| Error message        | `query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
 | Recent regression    | `detect_changes` to see what your changes affect           |
+| "How does A reach B?" | `trace` between the two symbols — shortest call chain in one call |
 
 ## Tools
 
-**gitnexus_query** — find code related to error:
+**query** — find code related to error:
 
 ```
-gitnexus_query({query: "payment validation error"})
+query({search_query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**gitnexus_context** — full context for a suspect:
+**context** — full context for a suspect:
 
 ```
-gitnexus_context({name: "validatePayment"})
+context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**gitnexus_cypher** — custom call chain traces:
+**cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
 RETURN [n IN nodes(path) | n.name] AS chain
 ```
 
+**trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
+
+```
+trace({ from: "processCheckout", to: "fetchRates" })
+→ status: ok, hopCount: 3
+→ hops: processCheckout → validatePayment → verifyCard → fetchRates
+→ edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
+```
+
+When no path exists, `trace` reports the furthest reachable node — exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
+
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. gitnexus_query({query: "payment error handling"})
+1. query({search_query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. gitnexus_context({name: "validatePayment"})
+2. context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -18,20 +18,20 @@ description: "Use when the user asks how code works, wants to understand archite
 ```
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
-4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
+3. query({search_query: "<what you want to understand>"})  → Find related execution flows
+4. context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] gitnexus_query for the concept you want to understand
+- [ ] query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] gitnexus_context on key symbols for callers/callees
+- [ ] context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**gitnexus_query** — find execution flows related to a concept:
+**query** — find execution flows related to a concept:
 
 ```
-gitnexus_query({query: "payment processing"})
+query({search_query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**gitnexus_context** — 360-degree view of a symbol:
+**context** — 360-degree view of a symbol:
 
 ```
-gitnexus_context({name: "validateUser"})
+context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -68,10 +68,10 @@ gitnexus_context({name: "validateUser"})
 
 ```
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. gitnexus_query({query: "payment processing"})
+2. query({search_query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. gitnexus_context({name: "processPayment"})
+3. context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
+> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
 
 ## Skills
 
@@ -35,10 +35,82 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `query`          | Process-grouped code intelligence — execution flows related to a concept |
 | `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
 | `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
+| `trace`          | Shortest path between two symbols — "how does A reach B?" in one call     |
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `list_repos`     | Discover indexed repos                                                   |
+| `explain`        | Persisted taint findings — source→sink data flows (needs `analyze --pdg`) |
+| `pdg_query`      | Control/data dependence — what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
+| `check`          | Check graph invariants such as circular imports                          |
+| `route_map`      | API route map — which components/hooks fetch which endpoints, and the handler files that serve them |
+| `shape_check`    | Response-shape drift — keys each route returns vs keys its consumers access (flags MISMATCH) |
+| `api_impact`     | Pre-change report for an API route — consumers, middleware, shape mismatches, risk level |
+| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
+| `group_list`     | List configured multi-repo groups, or one group's config                 |
+| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
+| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
+
+### Paginating `list_repos`
+
+`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
+
+```jsonc
+{
+  "repositories": [
+    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
+  ],
+  "pagination": {
+    "total": 437,
+    "limit": 50,
+    "offset": 0,
+    "returned": 50,
+    "hasMore": true,
+    "nextOffset": 50
+  }
+}
+```
+
+To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
+
+```text
+list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
+list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
+…
+list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
+```
+
+Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
+
+### Taint findings (`explain`)
+
+`explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
+
+- `explain {}` — enumerate all findings for the repo (bounded by `limit`, deterministic order)
+- `explain { target: "src/vuln.ts" }` — findings in a file (suffix path match accepted)
+- `explain { target: "runUserCommand" }` — findings in a function (resolved like `context`; ambiguous names return ranked candidates)
+
+A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
+
+### Control & data dependence (`pdg_query`)
+
+`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) — the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
+
+- `pdg_query { mode: "controls", target: "..." }` — CDG: "under what condition does X run?". Each edge is a controlling predicate block → dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery — the sense depends on the predicate, so don't filter guards by a fixed label).
+- `pdg_query { mode: "flows", target: "...", variable?: "..." }` — REACHING_DEF def→use edges within the function; pass `variable` to trace one binding.
+
+A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only — cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
+
+### Shortest path between two symbols (`trace`)
+
+`trace` answers "how does A reach B?" in one call — the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3–8 `context`/`impact` hops by hand.
+
+- `trace { from: "validateUser", to: "executeQuery" }` — shortest path between two symbols.
+- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
+- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
+
+Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
+
+Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos — the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
 
 ## Resources Reference
 
@@ -55,8 +127,10 @@ Lightweight reads (~100-500 tokens) for navigation:
 
 ## Graph Schema
 
-**Nodes:** File, Function, Class, Interface, Method, Community, Process
-**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
+**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, …) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG — zero rows on a default index).
+
+Read `gitnexus://repo/{name}/schema` before writing Cypher — it is the authoritative schema for the indexed repo.
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -17,22 +17,22 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
+1. impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. gitnexus_detect_changes()                               → Map current git changes to affected flows
+3. detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklist
 
 ```
-- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
+- [ ] impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] gitnexus_detect_changes() for pre-commit check
+- [ ] detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**gitnexus_impact** — the primary tool for symbol blast radius:
+**impact** — the primary tool for symbol blast radius:
 
 ```
-gitnexus_impact({
+impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ gitnexus_impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**gitnexus_detect_changes** — git-diff based impact analysis:
+**detect_changes** — git-diff based impact analysis:
 
 ```
-gitnexus_detect_changes({scope: "staged"})
+detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -86,7 +86,7 @@ gitnexus_detect_changes({scope: "staged"})
 ## Example: "What breaks if I change validateUser?"
 
 ```
-1. gitnexus_impact({target: "validateUser", direction: "upstream"})
+1. impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -16,78 +16,78 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
-2. gitnexus_query({query: "X"})                            → Find execution flows involving X
-3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
+1. impact({target: "X", direction: "upstream"})  → Map all dependents
+2. query({search_query: "X"})                            → Find execution flows involving X
+3. context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `npx gitnexus analyze` in terminal.
+> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
-- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
-- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
-- [ ] gitnexus_detect_changes() — verify only expected files changed
+- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
+- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
+- [ ] detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
-- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
+- [ ] context({name: target}) — see all incoming/outgoing refs
+- [ ] impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] gitnexus_context({name: target}) — understand all callees
+- [ ] context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
+- [ ] impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] gitnexus_detect_changes() — verify affected scope
+- [ ] detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**gitnexus_rename** — automated multi-file rename:
+**rename** — automated multi-file rename:
 
 ```
-gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
-→ 10 graph edits (high confidence), 2 ast_search edits (review)
+→ 10 graph edits (high confidence), 2 text_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**gitnexus_impact** — map all dependents first:
+**impact** — map all dependents first:
 
 ```
-gitnexus_impact({target: "validateUser", direction: "upstream"})
+impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**gitnexus_detect_changes** — verify your changes after refactoring:
+**detect_changes** — verify your changes after refactoring:
 
 ```
-gitnexus_detect_changes({scope: "all"})
+detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**gitnexus_cypher** — custom reference queries:
+**cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use gitnexus_rename for automated updates |
+| Many callers (>5)   | Use rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | gitnexus_query to find them               |
+| String/dynamic refs | query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
-   → 12 edits: 10 graph (safe), 2 ast_search (review)
+1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 text_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
-2. Review ast_search edits (config.json: dynamic reference!)
+2. Review text_search edits (config.json: dynamic reference!)
 
-3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. gitnexus_detect_changes({scope: "all"})
+4. detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,25 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8974 symbols, 20493 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (6170 symbols, 22304 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,25 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (8974 symbols, 20493 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (6170 symbols, 22304 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -470,6 +470,23 @@ notifications:
       run: curl -s -d "{{number}} escalated ({{label}}): {{summary}}" ntfy.sh/my-alerts
 ```
 
+## Execution event retention and redaction
+
+Structured task timelines are persisted automatically when SQLite is enabled.
+Configure their retention and additional sensitive metadata keys under
+`settings.events`:
+
+```yaml
+settings:
+  events:
+    retention: 720h
+    sensitive_fields: [customer_key]
+```
+
+The default retention is 30 days. Non-positive durations disable pruning. See
+[Structured execution events](execution-events.md) for the envelope, local query
+API, SSE subscription, compatibility contract, and built-in redaction behavior.
+
 ## Environment variables
 
 Agent subprocesses inherit the daemon's environment plus an overlay you

--- a/docs/execution-events.md
+++ b/docs/execution-events.md
@@ -1,0 +1,52 @@
+# Structured execution events
+
+Apiary records a versioned, append-only event timeline in SQLite. The timeline
+is the supported way to reconstruct task execution without parsing service or
+runner logs.
+
+## Envelope and compatibility
+
+Every event has `id`, `schema_version`, `type`, and `timestamp`, plus optional
+`task_id`, `workflow_id`, `workflow_instance_id`, `step_id`, `attempt_id`, and
+`metadata`. Schema version `1` is additive: consumers must ignore unknown fields
+and unknown event types. A future breaking envelope change will increment
+`schema_version`; stored rows retain their original version.
+
+Lifecycle types include task discovery and binding, route selection/rejection,
+workflow and step start/terminal states, runner start/stop, rate-limit detection,
+and fallback selection. Route and fallback events carry a human-readable
+`reason` in metadata.
+
+## Query and live subscription
+
+The daemon's local Unix-socket HTTP API exposes:
+
+- `GET /events?task=<id>&instance=<id>&type=<type>&after_id=<id>&limit=<n>`
+  for chronological persisted events. The maximum page size is 1000.
+- `GET /events/stream` with the same filters for Server-Sent Events. Existing
+  rows after `after_id` are replayed before live delivery. Reconnect with the
+  last received event ID to recover from a slow or disconnected subscriber.
+
+`apiary task history` and the dashboard task detail view read this same event
+store and render a chronological timeline.
+
+## Redaction and retention
+
+Metadata is recursively redacted before persistence and live delivery. Apiary
+always redacts common credential keys and recognizable GitHub, Slack, bearer,
+and AWS access-token values. Extend key redaction in configuration:
+
+```yaml
+settings:
+  events:
+    retention: 720h
+    sensitive_fields: [customer_key, signing_material]
+```
+
+Key matching is case-insensitive and ignores `_`, `-`, and `.`. The default
+retention is 720 hours (30 days). A zero or negative duration disables pruning.
+Pruning runs at daemon startup and daily. Retention deletes event rows only; it
+does not alter workflow, step, execution, or task records.
+
+Events currently remain local to Apiary. External webhook and OpenTelemetry
+exporters can be layered on the versioned envelope without changing producers.

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## Ativas
 
-_Nenhuma change ativa no momento._
-
 ## Arquivadas
 
 ### 2026-07-22
 
+- **structured-execution-events** — Versioned, redacted execution events with persisted queries, live SSE subscriptions, route/fallback reasons, retention, CLI history, and a dashboard task timeline. GitHub issue #211.
 - **reusable-typed-subworkflows** — Reusable local workflow files with typed inputs and outputs, cycle-safe resolution, linked nested execution history, and explicit failure/cancellation semantics. GitHub issue #210.
 - **immutable-execution-replay** — Immutable workflow replay with descendant attempt lineage, selectable resume points, secret-safe workflow-definition snapshots, and CLI comparison of attempts. GitHub issue #209.
 

--- a/openspec/changes/archive/2026-07-22-structured-execution-events/design.md
+++ b/openspec/changes/archive/2026-07-22-structured-execution-events/design.md
@@ -1,0 +1,67 @@
+# Design: structured execution events
+
+## Event envelope
+
+Every event uses schema version `1` and carries a stable type, UTC timestamp,
+optional correlation IDs, and JSON metadata:
+
+```json
+{
+  "id": 42,
+  "schema_version": 1,
+  "type": "route.selected",
+  "timestamp": "2026-07-22T12:00:00Z",
+  "task_id": "task_...",
+  "workflow_id": "implementation",
+  "workflow_instance_id": "wf_...",
+  "step_id": "implement",
+  "attempt_id": "128",
+  "metadata": {"reason": "labels=agent:engineer"}
+}
+```
+
+New optional metadata fields are backward compatible within version 1. Removing
+or changing field meaning requires a schema-version increment. Consumers must
+ignore unknown event types and metadata keys.
+
+## Persistence and live delivery
+
+SQLite is the source of truth. Recording an event inserts it first, then fans it
+out best-effort to bounded in-process subscriber channels. Slow subscribers may
+miss live delivery and recover through the persisted `after_id` query.
+
+`GET /events` supports task, instance, type, `after_id`, and limit filters.
+`GET /events/stream` returns SSE, optionally replaying persisted events after an
+ID before subscribing to live events.
+
+## Emission boundaries
+
+- Source polling/binding emits discovered, bound, and refreshed events.
+- Router traces emit explicit selected/rejected reasons.
+- Workflow-instance and step persistence emit lifecycle events.
+- The workflow engine emits approval and task-terminal semantics.
+- Runner attempt creation/completion and failover selection emit runner and
+  fallback events with model/runner/failure metadata.
+
+This keeps event creation adjacent to authoritative state changes rather than
+parsing text logs after the fact.
+
+## Redaction
+
+Metadata is recursively copied before storage. Keys matching built-in credential
+names (`token`, `secret`, `password`, `authorization`, `api_key`, and variants)
+or `settings.events.sensitive_fields` are replaced with `[REDACTED]`. String
+values containing common token prefixes are also redacted. Correlation IDs and
+event types never contain config values.
+
+## Retention
+
+`settings.events.retention` is a duration, defaulting to `720h` (30 days).
+Non-positive values disable automatic pruning. The daemon prunes at startup and
+daily. Event deletion does not affect canonical task/workflow/step records.
+
+## Timeline
+
+Task history queries return events oldest-first. The CLI and TUI render timestamp,
+event type, and concise typed metadata from this stream, so the timeline does not
+depend on parsing log prose.

--- a/openspec/changes/archive/2026-07-22-structured-execution-events/proposal.md
+++ b/openspec/changes/archive/2026-07-22-structured-execution-events/proposal.md
@@ -1,0 +1,29 @@
+# Structured execution events
+
+## Why
+
+Apiary's text logs are useful for diagnostics but cannot reliably reconstruct
+why a task was routed, which fallback was chosen, or how lifecycle transitions
+relate across tasks, workflow instances, steps, and runner attempts.
+
+## What changes
+
+- Add a versioned, append-only execution-event schema with task, workflow,
+  instance, step, and runner-attempt correlation IDs.
+- Emit structured events for discovery/binding, routing decisions, workflow and
+  step lifecycle, runners/fallbacks, approvals, and task completion/escalation.
+- Redact built-in secret keys and configured sensitive metadata fields before
+  events are persisted or broadcast.
+- Support persisted filtering and live Server-Sent Events over the local socket.
+- Use the same event stream in task CLI history and the terminal dashboard.
+- Prune events according to a documented retention setting.
+
+## Scope
+
+Webhook and OpenTelemetry exporters are deferred. The local persisted/query/live
+contract is designed as their future source so exporters do not require another
+instrumentation model.
+
+## Tracking
+
+Closes GitHub issue #211.

--- a/openspec/changes/archive/2026-07-22-structured-execution-events/tasks.md
+++ b/openspec/changes/archive/2026-07-22-structured-execution-events/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [x] Add the event schema, store, query filters, subscriptions, and pruning.
+- [x] Add recursive built-in and configured metadata redaction.
+- [x] Emit source discovery/binding and explicit route decision events.
+- [x] Emit workflow, step, runner, and fallback events.
+- [x] Expose persisted queries and live SSE through the local socket.
+- [x] Add task events to CLI history and the terminal dashboard timeline.
+- [x] Document schema compatibility, query/subscription, redaction, and retention.
+- [x] Cover persistence, lifecycle reconstruction, routing/fallback reasons,
+      redaction, live subscription, retention, API, and rendering with tests.
+- [x] Run `make check`, `make vet`, race tests, GitNexus change detection, and archive the change.

--- a/src/internal/cli/task.go
+++ b/src/internal/cli/task.go
@@ -73,6 +73,13 @@ func renderTaskHistory(resp daemon.TaskHistoryResponse) {
 		head += " — " + resp.Title
 	}
 	fmt.Printf("%s  %s\n", instMuted.Render("Task:"), head)
+	if len(resp.Events) > 0 {
+		fmt.Println()
+		fmt.Println(instHeader.Render("Timeline"))
+		for _, event := range resp.Events {
+			fmt.Printf("  %s %-24s %s\n", instMuted.Render(event.Timestamp.Local().Format("15:04:05")), event.Type, event.StepID)
+		}
+	}
 
 	if len(resp.Segments) == 0 {
 		fmt.Println(instMuted.Render("No workflow instances yet."))

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -14,17 +14,17 @@ import (
 )
 
 type Config struct {
-	Version       string           `yaml:"version"`
-	Runners       []RunnerConfig   `yaml:"runners"`
-	DefaultRunner string           `yaml:"default_runner"`
-	Sources       []SourceConfig   `yaml:"sources"`
-	Agents        []AgentConfig    `yaml:"agents"`
-	Workers       []WorkerConfig   `yaml:"workers"`
-	Workflows     []WorkflowConfig `yaml:"workflows"`
+	Version       string                              `yaml:"version"`
+	Runners       []RunnerConfig                      `yaml:"runners"`
+	DefaultRunner string                              `yaml:"default_runner"`
+	Sources       []SourceConfig                      `yaml:"sources"`
+	Agents        []AgentConfig                       `yaml:"agents"`
+	Workers       []WorkerConfig                      `yaml:"workers"`
+	Workflows     []WorkflowConfig                    `yaml:"workflows"`
 	Profiles      map[string]map[string]ProfileConfig `yaml:"profiles,omitempty"` // NEW: named runner profiles
-	Settings      Settings         `yaml:"settings"`
-	Tasks         *TasksConfig     `yaml:"tasks"`
-	Notifications *NotificationsConfig `yaml:"notifications"`
+	Settings      Settings                            `yaml:"settings"`
+	Tasks         *TasksConfig                        `yaml:"tasks"`
+	Notifications *NotificationsConfig                `yaml:"notifications"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 }
@@ -32,10 +32,10 @@ type Config struct {
 // ProfileConfig is an overlay that overrides runner, model, fallbacks, and
 // fallback_strategy for a single agent when a profile is active.
 type ProfileConfig struct {
-	Runner           string          `yaml:"runner,omitempty"`
-	Model            string          `yaml:"model,omitempty"`
+	Runner           string           `yaml:"runner,omitempty"`
+	Model            string           `yaml:"model,omitempty"`
 	Fallbacks        []FallbackConfig `yaml:"fallbacks,omitempty"`
-	FallbackStrategy string          `yaml:"fallback_strategy,omitempty"`
+	FallbackStrategy string           `yaml:"fallback_strategy,omitempty"`
 }
 
 type SourceConfig struct {
@@ -264,6 +264,7 @@ type Settings struct {
 	LogMaxBackups int                `yaml:"log_max_backups"`  // rotated files to keep; default 5
 	LogMaxAgeDays int                `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
 	Memory        MemorySettings     `yaml:"memory"`
+	Events        EventSettings      `yaml:"events"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
@@ -273,6 +274,31 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+}
+
+// EventSettings controls persisted structured execution events. Events are
+// enabled whenever a database is configured; these fields govern retention and
+// additional metadata keys that must be redacted before persistence/export.
+type EventSettings struct {
+	// Retention is a duration string. Empty defaults to 720h (30 days); zero or a
+	// negative duration disables automatic pruning.
+	Retention string `yaml:"retention"`
+	// SensitiveFields extends the built-in credential-key denylist. Matching is
+	// case-insensitive and ignores '-', '_', and '.'.
+	SensitiveFields []string `yaml:"sensitive_fields"`
+}
+
+// RetentionDuration returns the configured event-retention window. Empty or
+// invalid values use 720h; non-positive valid values disable pruning.
+func (e EventSettings) RetentionDuration() time.Duration {
+	if e.Retention == "" {
+		return 720 * time.Hour
+	}
+	d, err := time.ParseDuration(e.Retention)
+	if err != nil {
+		return 720 * time.Hour
+	}
+	return d
 }
 
 // GitHooksSettings makes the daemon enforce a shared git hooks directory on

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -200,6 +200,11 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("settings.memory.task_retention %q: invalid duration: %w", m.TaskRetention, err))
 		}
 	}
+	if e := c.Settings.Events; e.Retention != "" {
+		if _, err := time.ParseDuration(e.Retention); err != nil {
+			errs = append(errs, fmt.Errorf("settings.events.retention %q: invalid duration: %w", e.Retention, err))
+		}
+	}
 	if c.Settings.Memory.MaxInjectChars < 0 {
 		errs = append(errs, fmt.Errorf("settings.memory.max_inject_chars must be >= 0"))
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -182,6 +182,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		agentSem:        make(map[string]chan struct{}),
 		stats:           make(map[string]*sourceStat),
 	}
+	if dbClient != nil {
+		dbClient.SetEventSensitiveFields(cfg.Settings.Events.SensitiveFields)
+	}
 
 	// The binder persists InternalTasks + SourceBindings; it needs the DB.
 	if dbClient != nil {
@@ -437,6 +440,29 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 			aplog.Info("reconciled outstanding counter on %d task(s), settled %d stranded task(s)", recounted, settled)
 		}
 	}
+	if d.db != nil {
+		if retention := d.cfg.Settings.Events.RetentionDuration(); retention > 0 {
+			if n, err := d.db.PruneExecutionEventsBefore(ctx, time.Now().Add(-retention)); err != nil {
+				aplog.Warn("prune execution events: %v", err)
+			} else if n > 0 {
+				aplog.Info("pruned %d expired execution event(s)", n)
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ticker := time.NewTicker(24 * time.Hour)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						_, _ = d.db.PruneExecutionEventsBefore(ctx, time.Now().Add(-retention))
+					}
+				}
+			}()
+		}
+	}
 
 	// Reconstruct workflow instances parked at an approval step into the engine's
 	// in-memory parked set. That set is empty after a restart, so without this the
@@ -682,6 +708,7 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 				continue
 			}
 			task, persisted := d.bindItem(ctx, cell)
+			d.recordRouteEvents(ctx, task)
 			matches := d.router.RouteAll(task)
 			if len(matches) == 0 {
 				aplog.Debug("  %q: no route matched (source=%q labels=%v)", cell.Title, cell.SourceID, cell.Labels)
@@ -929,6 +956,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("/events", d.handleExecutionEvents)
+	mux.HandleFunc("/events/stream", d.handleExecutionEventStream)
 	mux.HandleFunc("/restart/", func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/restart/")
 		if cellID == "" {
@@ -1270,6 +1299,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			continue
 		}
 		task, persisted := d.bindItem(ctx, cell)
+		d.recordRouteEvents(ctx, task)
 		matches := d.router.RouteAll(task)
 		// Source-agnostic in-flight guard: drop any matched workflow that already
 		// has a non-terminal instance for this task, so a re-poll does not dispatch
@@ -1403,13 +1433,37 @@ func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task 
 	if d.binder == nil {
 		return transientTask(cell), false
 	}
+	existing, _ := d.db.SourceBindings().GetBindingBySourceItem(ctx, cell.SourceID, cell.ID)
 	task, err := d.binder.Bind(ctx, cell)
 	if err != nil {
 		aplog.Error("bind source item %s (%q): %v", cell.LogLabel(), cell.Title, err)
 		return transientTask(cell), false
 	}
 	aplog.Debug("bound source item %s → task %s [%s]", cell.LogLabel(), task.ID, task.State)
+	d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "task.discovered", TaskID: task.ID, Metadata: map[string]any{"source_id": cell.SourceID, "source_item_id": cell.ID, "title": cell.Title}})
+	eventType := "task.bound"
+	if existing != nil {
+		eventType = "task.refreshed"
+	}
+	d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: eventType, TaskID: task.ID, Metadata: map[string]any{"source_id": cell.SourceID, "source_item_id": cell.ID}})
 	return task, true
+}
+
+func (d *Dispatcher) recordExecutionEvent(ctx context.Context, event db.ExecutionEvent) {
+	if d.db != nil {
+		_ = d.db.RecordExecutionEvent(ctx, &event)
+	}
+}
+
+func (d *Dispatcher) recordRouteEvents(ctx context.Context, task model.InternalTask) {
+	for _, trace := range d.router.ExplainTask(task) {
+		eventType := "route.rejected"
+		if trace.Selected {
+			eventType = "route.selected"
+		}
+		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: eventType, TaskID: task.ID, WorkflowID: trace.RouteID,
+			Metadata: map[string]any{"reason": trace.Reason, "priority": trace.Priority, "agent": trace.Agent, "worker": trace.Worker}})
+	}
 }
 
 // dropActiveMatches removes matches whose workflow already has a non-terminal

--- a/src/internal/daemon/events_http.go
+++ b/src/internal/daemon/events_http.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func executionEventFilter(r *http.Request) db.ExecutionEventFilter {
+	q := r.URL.Query()
+	after, _ := strconv.ParseInt(q.Get("after_id"), 10, 64)
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	return db.ExecutionEventFilter{TaskID: q.Get("task"), WorkflowInstanceID: q.Get("instance"), Type: q.Get("type"), AfterID: after, Limit: limit}
+}
+
+func (d *Dispatcher) handleExecutionEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if d.db == nil {
+		http.Error(w, "event store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	events, err := d.db.ListExecutionEvents(r.Context(), executionEventFilter(r))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(events)
+}
+
+func (d *Dispatcher) handleExecutionEventStream(w http.ResponseWriter, r *http.Request) {
+	if d.db == nil {
+		http.Error(w, "event store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	filter := executionEventFilter(r)
+	live, cancel := d.db.SubscribeExecutionEvents(64)
+	defer cancel()
+	write := func(event db.ExecutionEvent) bool {
+		if (filter.TaskID != "" && event.TaskID != filter.TaskID) || (filter.WorkflowInstanceID != "" && event.WorkflowInstanceID != filter.WorkflowInstanceID) || (filter.Type != "" && event.Type != filter.Type) {
+			return true
+		}
+		payload, err := json.Marshal(event)
+		if err != nil {
+			return true
+		}
+		if _, err := fmt.Fprintf(w, "id: %d\nevent: execution\ndata: %s\n\n", event.ID, payload); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+	replayed, err := d.db.ListExecutionEvents(r.Context(), filter)
+	if err != nil {
+		return
+	}
+	lastID := filter.AfterID
+	for _, event := range replayed {
+		if !write(event) {
+			return
+		}
+		lastID = event.ID
+	}
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case event, ok := <-live:
+			if !ok {
+				return
+			}
+			if event.ID > lastID && !write(event) {
+				return
+			}
+		}
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -450,6 +450,8 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		last := i == len(candidates)-1
 		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
 			aplog.Info("[%s] runner %q paused by rate limit, skipping to fallback", req.Cell.LogLabel(), c.runnerType)
+			x.d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "fallback.selected", WorkflowInstanceID: req.InstanceID, StepID: req.Step.ID,
+				Metadata: map[string]any{"from_runner": c.runnerType, "to_runner": candidates[i+1].runnerType, "reason": "runner paused"}})
 			continue
 		}
 
@@ -500,6 +502,12 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 
 		if failureKind != model.FailureNone && !last {
 			x.d.pauseRunnerWithKind(c.runnerType, out.RateLimitResetsAt, failureKind)
+			if failureKind == model.FailureRateLimited || failureKind == model.FailureCreditExhausted {
+				x.d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "rate_limit.detected", WorkflowInstanceID: req.InstanceID, StepID: req.Step.ID,
+					Metadata: map[string]any{"runner": c.runnerType, "kind": failureKind.String()}})
+			}
+			x.d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "fallback.selected", WorkflowInstanceID: req.InstanceID, StepID: req.Step.ID,
+				Metadata: map[string]any{"from_runner": c.runnerType, "to_runner": candidates[i+1].runnerType, "reason": failureKind.String()}})
 
 			label := "failed"
 			switch failureKind {
@@ -583,6 +591,12 @@ func (x *wfStepExecutor) beginExecution(ctx context.Context, req workflow.StepRe
 	if req.InstanceID != "" {
 		_ = x.d.db.SetStepLink(ctx, exec.ID, req.InstanceID, req.Step.ID)
 	}
+	event := db.ExecutionEvent{Type: "runner.started", WorkflowInstanceID: req.InstanceID, StepID: req.Step.ID, AttemptID: fmt.Sprint(exec.ID),
+		Metadata: map[string]any{"runner": runnerType, "model": model, "attempt": attempt}}
+	if inst, _ := x.d.db.GetWorkflowInstance(ctx, req.InstanceID); inst != nil {
+		event.TaskID, event.WorkflowID = inst.TaskID, inst.WorkflowID
+	}
+	x.d.recordExecutionEvent(ctx, event)
 	return exec
 }
 
@@ -625,6 +639,13 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 	if err := x.d.db.UpdateExecution(ctx, exec); err != nil {
 		aplog.Error("cell %s: update execution record: %v", exec.TaskID, err)
 	}
+	event := db.ExecutionEvent{Type: "runner.stopped", WorkflowInstanceID: exec.WorkflowInstanceID, StepID: exec.StepID, AttemptID: fmt.Sprint(exec.ID),
+		Metadata: map[string]any{"runner": exec.Runner, "model": exec.Model, "status": exec.Status, "failure_kind": exec.FailureKind,
+			"duration_ms": exec.DurationMs, "total_tokens": exec.TotalTokens, "cost_usd": exec.CostUSD}}
+	if inst, _ := x.d.db.GetWorkflowInstance(ctx, exec.WorkflowInstanceID); inst != nil {
+		event.TaskID, event.WorkflowID = inst.TaskID, inst.WorkflowID
+	}
+	x.d.recordExecutionEvent(ctx, event)
 }
 
 // wfSideEffects applies source-facing actions for a workflow instance. It fans

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -504,6 +504,7 @@ type TaskHistorySegmentView struct {
 type TaskHistoryResponse struct {
 	TaskID   string                   `json:"task_id"`
 	Title    string                   `json:"title"`
+	Events   []db.ExecutionEvent      `json:"events"`
 	Segments []TaskHistorySegmentView `json:"segments"`
 }
 
@@ -525,6 +526,7 @@ func (d *Dispatcher) TaskHistory(ctx context.Context, internalTaskID string) (*T
 	// All instances of a task share one cell, so one title lookup covers them all.
 	title, _ := d.db.GetTaskTitle(ctx, segs[0].Instance.CellID)
 	resp := &TaskHistoryResponse{TaskID: internalTaskID, Title: title}
+	resp.Events, _ = d.db.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: internalTaskID, Limit: 1000})
 	for _, seg := range segs {
 		view := db.WorkflowInstanceView{WorkflowInstance: seg.Instance, Title: title}
 		sv := TaskHistorySegmentView{Instance: instanceSummary(view, now)}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -2392,6 +2392,7 @@ func (a *App) augmentTaskDetail(ctx context.Context, dbConn *db.Client, detail *
 	if insts, _ := dbConn.ListWorkflowInstancesByTask(ctx, internalTaskID); len(insts) > 0 {
 		detail.Instances = mapInstances(ctx, dbConn, insts)
 	}
+	detail.Events, _ = dbConn.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: internalTaskID, Limit: 200})
 	// PRs are persisted by the daemon (refreshed on detail open); read them back so
 	// the (p) shortcut and the detail panel stay in sync. Re-runs of this function
 	// from the live tick pick up freshly-discovered PRs automatically.
@@ -3421,6 +3422,7 @@ func (a *App) taskDetailLines(t *TasksTab) []string {
 	b.WriteString(renderSourceBindings(d))
 	b.WriteString(renderTaskLineage(d))
 	b.WriteString(renderTaskInstances(d))
+	b.WriteString(renderTaskTimeline(d))
 	return strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
 }
 
@@ -3527,6 +3529,22 @@ func renderTaskInstances(d *TaskItem) string {
 			StyleMuted.Render(padLeft(fmtTokensShort(in.TotalTokens), colTok)),
 			marker,
 		))
+	}
+	return b.String()
+}
+
+func renderTaskTimeline(d *TaskItem) string {
+	if len(d.Events) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n  " + StyleLabel.Render(fmt.Sprintf("Timeline (%d)", len(d.Events))) + "\n")
+	for _, event := range d.Events {
+		b.WriteString(fmt.Sprintf("    %s  %s", StyleMuted.Render(event.Timestamp.Local().Format("15:04:05")), event.Type))
+		if event.StepID != "" {
+			b.WriteString(StyleMuted.Render(" · " + event.StepID))
+		}
+		b.WriteString("\n")
 	}
 	return b.String()
 }

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -257,6 +257,7 @@ type TaskItem struct {
 	Children             []TaskLineageItem      // direct children / spawned tasks (detail only)
 	Instances            []WorkflowInstanceItem // all workflow instances for this task (detail only)
 	PullRequests         []PullRequestItem      // persisted PRs, oldest first; last = most recent
+	Events               []db.ExecutionEvent    // structured task timeline, oldest first
 }
 
 // PullRequestItem is one pull request linked to a task, persisted by the daemon
@@ -301,9 +302,9 @@ type AgentsTab struct {
 	ActivityIdx int          // cursor within Activity
 
 	// Drill-down: logs of the task selected in the activity list.
-	LogsTaskID string
-	LogsTask   *TaskItem // task detail for the logs header
-	TaskLogs   []LogEntry
+	LogsTaskID    string
+	LogsTask      *TaskItem // task detail for the logs header
+	TaskLogs      []LogEntry
 	TaskLogIdx    int  // vertical scroll within TaskLogs (visual lines)
 	TaskLogFollow bool // pin the task-log viewport to the tail; cleared by scrolling up
 

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -15,6 +16,11 @@ import (
 
 type Client struct {
 	db *sql.DB
+
+	eventMu        sync.RWMutex
+	eventSubs      map[uint64]chan ExecutionEvent
+	eventSeq       uint64
+	eventSensitive map[string]struct{}
 }
 
 // execer is the subset of *sql.DB / *sql.Tx used by the insert helpers, so the

--- a/src/internal/db/execution_event.go
+++ b/src/internal/db/execution_event.go
@@ -1,0 +1,243 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const ExecutionEventSchemaVersion = 1
+
+// ExecutionEvent is the stable envelope persisted and exported for lifecycle
+// observability. Metadata is always redacted before ID assignment and delivery.
+type ExecutionEvent struct {
+	ID                 int64          `json:"id"`
+	SchemaVersion      int            `json:"schema_version"`
+	Type               string         `json:"type"`
+	Timestamp          time.Time      `json:"timestamp"`
+	TaskID             string         `json:"task_id,omitempty"`
+	WorkflowID         string         `json:"workflow_id,omitempty"`
+	WorkflowInstanceID string         `json:"workflow_instance_id,omitempty"`
+	StepID             string         `json:"step_id,omitempty"`
+	AttemptID          string         `json:"attempt_id,omitempty"`
+	Metadata           map[string]any `json:"metadata,omitempty"`
+}
+
+// ExecutionEventFilter selects persisted events. Results are chronological.
+type ExecutionEventFilter struct {
+	TaskID             string
+	WorkflowInstanceID string
+	Type               string
+	AfterID            int64
+	Limit              int
+}
+
+// SetEventSensitiveFields replaces the configured metadata-key denylist. The
+// built-in secret keys and token-like value detection always remain active.
+func (c *Client) SetEventSensitiveFields(fields []string) {
+	set := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if key := normalizeSensitiveKey(field); key != "" {
+			set[key] = struct{}{}
+		}
+	}
+	c.eventMu.Lock()
+	c.eventSensitive = set
+	c.eventMu.Unlock()
+}
+
+// RecordExecutionEvent persists first, then broadcasts the stored/redacted
+// envelope best-effort. Slow live subscribers recover with an after_id query.
+func (c *Client) RecordExecutionEvent(ctx context.Context, event *ExecutionEvent) error {
+	if event == nil || strings.TrimSpace(event.Type) == "" {
+		return fmt.Errorf("execution event type is required")
+	}
+	stored := *event
+	stored.SchemaVersion = ExecutionEventSchemaVersion
+	if stored.Timestamp.IsZero() {
+		stored.Timestamp = time.Now().UTC()
+	} else {
+		stored.Timestamp = stored.Timestamp.UTC()
+	}
+	stored.Metadata = c.redactEventMetadata(event.Metadata)
+	metadata, err := json.Marshal(stored.Metadata)
+	if err != nil {
+		return fmt.Errorf("marshal execution event metadata: %w", err)
+	}
+	res, err := c.db.ExecContext(ctx, `
+		INSERT INTO execution_events
+		  (schema_version, type, timestamp, task_id, workflow_id, workflow_instance_id, step_id, attempt_id, metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, stored.SchemaVersion, stored.Type, stored.Timestamp, nullStr(stored.TaskID), nullStr(stored.WorkflowID),
+		nullStr(stored.WorkflowInstanceID), nullStr(stored.StepID), nullStr(stored.AttemptID), string(metadata))
+	if err != nil {
+		return err
+	}
+	stored.ID, err = res.LastInsertId()
+	if err != nil {
+		return err
+	}
+	*event = stored
+	c.publishExecutionEvent(stored)
+	return nil
+}
+
+// ListExecutionEvents returns persisted events oldest-first.
+func (c *Client) ListExecutionEvents(ctx context.Context, filter ExecutionEventFilter) ([]ExecutionEvent, error) {
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	where := []string{"id > ?"}
+	args := []any{filter.AfterID}
+	if filter.TaskID != "" {
+		where = append(where, "task_id = ?")
+		args = append(args, filter.TaskID)
+	}
+	if filter.WorkflowInstanceID != "" {
+		where = append(where, "workflow_instance_id = ?")
+		args = append(args, filter.WorkflowInstanceID)
+	}
+	if filter.Type != "" {
+		where = append(where, "type = ?")
+		args = append(args, filter.Type)
+	}
+	args = append(args, limit)
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, schema_version, type, timestamp, COALESCE(task_id,''), COALESCE(workflow_id,''),
+		       COALESCE(workflow_instance_id,''), COALESCE(step_id,''), COALESCE(attempt_id,''), metadata
+		FROM execution_events WHERE `+strings.Join(where, " AND ")+` ORDER BY id ASC LIMIT ?
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []ExecutionEvent
+	for rows.Next() {
+		var event ExecutionEvent
+		var metadata string
+		if err := rows.Scan(&event.ID, &event.SchemaVersion, &event.Type, &event.Timestamp, &event.TaskID,
+			&event.WorkflowID, &event.WorkflowInstanceID, &event.StepID, &event.AttemptID, &metadata); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal([]byte(metadata), &event.Metadata); err != nil {
+			event.Metadata = map[string]any{"decode_error": true}
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+// SubscribeExecutionEvents registers a bounded live subscriber.
+func (c *Client) SubscribeExecutionEvents(buffer int) (<-chan ExecutionEvent, func()) {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	c.eventMu.Lock()
+	if c.eventSubs == nil {
+		c.eventSubs = map[uint64]chan ExecutionEvent{}
+	}
+	c.eventSeq++
+	id := c.eventSeq
+	ch := make(chan ExecutionEvent, buffer)
+	c.eventSubs[id] = ch
+	c.eventMu.Unlock()
+	return ch, func() {
+		c.eventMu.Lock()
+		if existing, ok := c.eventSubs[id]; ok {
+			delete(c.eventSubs, id)
+			close(existing)
+		}
+		c.eventMu.Unlock()
+	}
+}
+
+// PruneExecutionEventsBefore deletes events older than cutoff.
+func (c *Client) PruneExecutionEventsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := c.db.ExecContext(ctx, `DELETE FROM execution_events WHERE timestamp < ?`, cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (c *Client) publishExecutionEvent(event ExecutionEvent) {
+	c.eventMu.RLock()
+	defer c.eventMu.RUnlock()
+	for _, ch := range c.eventSubs {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+func (c *Client) redactEventMetadata(metadata map[string]any) map[string]any {
+	if metadata == nil {
+		return map[string]any{}
+	}
+	c.eventMu.RLock()
+	configured := make(map[string]struct{}, len(c.eventSensitive))
+	for key := range c.eventSensitive {
+		configured[key] = struct{}{}
+	}
+	c.eventMu.RUnlock()
+	redacted, _ := redactEventValue(metadata, configured).(map[string]any)
+	return redacted
+}
+
+var builtInSensitiveKeys = map[string]struct{}{
+	"token": {}, "accesstoken": {}, "refreshtoken": {}, "secret": {}, "clientsecret": {},
+	"password": {}, "authorization": {}, "apikey": {}, "privatekey": {}, "credential": {},
+}
+
+func redactEventValue(value any, configured map[string]struct{}) any {
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			normalized := normalizeSensitiveKey(key)
+			_, builtIn := builtInSensitiveKeys[normalized]
+			_, custom := configured[normalized]
+			if builtIn || custom {
+				out[key] = "[REDACTED]"
+			} else {
+				out[key] = redactEventValue(child, configured)
+			}
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i := range v {
+			out[i] = redactEventValue(v[i], configured)
+		}
+		return out
+	case string:
+		if looksLikeSecret(v) {
+			return "[REDACTED]"
+		}
+		return v
+	default:
+		return value
+	}
+}
+
+func normalizeSensitiveKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	return strings.NewReplacer("_", "", "-", "", ".", "").Replace(key)
+}
+
+func looksLikeSecret(value string) bool {
+	lower := strings.ToLower(value)
+	for _, marker := range []string{"ghp_", "github_pat_", "xoxb-", "xoxp-", "bearer "} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return strings.Contains(value, "AKIA")
+}

--- a/src/internal/db/execution_event_test.go
+++ b/src/internal/db/execution_event_test.go
@@ -1,0 +1,94 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExecutionEventsPersistFilterRedactAndStream(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	c.SetEventSensitiveFields([]string{"customer_key"})
+	live, cancel := c.SubscribeExecutionEvents(1)
+	defer cancel()
+
+	event := &ExecutionEvent{Type: "runner.started", TaskID: "task-1", WorkflowInstanceID: "inst-1", Metadata: map[string]any{
+		"runner": "codex", "access_token": "plain", "customer_key": "value", "nested": map[string]any{"value": "Bearer abc"},
+	}}
+	if err := c.RecordExecutionEvent(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	if event.ID == 0 || event.SchemaVersion != ExecutionEventSchemaVersion {
+		t.Fatalf("unstable envelope: %+v", event)
+	}
+	if event.Metadata["access_token"] != "[REDACTED]" || event.Metadata["customer_key"] != "[REDACTED]" {
+		t.Fatalf("metadata not redacted: %#v", event.Metadata)
+	}
+	select {
+	case got := <-live:
+		if got.ID != event.ID || got.Metadata["access_token"] != "[REDACTED]" {
+			t.Fatalf("bad live event: %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("live event not delivered")
+	}
+	events, err := c.ListExecutionEvents(ctx, ExecutionEventFilter{TaskID: "task-1", AfterID: event.ID - 1})
+	if err != nil || len(events) != 1 || events[0].Type != "runner.started" {
+		t.Fatalf("query: %+v, %v", events, err)
+	}
+	if nested := events[0].Metadata["nested"].(map[string]any); nested["value"] != "[REDACTED]" {
+		t.Fatalf("nested secret leaked: %#v", nested)
+	}
+}
+
+func TestExecutionEventPruning(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	old := &ExecutionEvent{Type: "task.discovered", Timestamp: time.Now().Add(-48 * time.Hour)}
+	current := &ExecutionEvent{Type: "task.bound"}
+	if err := c.RecordExecutionEvent(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RecordExecutionEvent(ctx, current); err != nil {
+		t.Fatal(err)
+	}
+	n, err := c.PruneExecutionEventsBefore(ctx, time.Now().Add(-24*time.Hour))
+	if err != nil || n != 1 {
+		t.Fatalf("prune = %d, %v", n, err)
+	}
+	events, _ := c.ListExecutionEvents(ctx, ExecutionEventFilter{})
+	if len(events) != 1 || events[0].ID != current.ID {
+		t.Fatalf("events after prune: %+v", events)
+	}
+}
+
+func TestWorkflowAndStepLifecycleEvents(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	inst := &WorkflowInstance{ID: "inst", WorkflowID: "build", TaskID: "task", State: InstanceStateRunning}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatal(err)
+	}
+	step := &StepRun{ID: "run", WorkflowInstanceID: inst.ID, StepID: "test", State: StepStateRunning}
+	if err := c.CreateStepRun(ctx, step); err != nil {
+		t.Fatal(err)
+	}
+	step.State = StepStatePassed
+	if err := c.UpdateStepRun(ctx, step); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.UpdateWorkflowInstanceState(ctx, inst.ID, InstanceStateDone); err != nil {
+		t.Fatal(err)
+	}
+	events, _ := c.ListExecutionEvents(ctx, ExecutionEventFilter{TaskID: "task"})
+	want := []string{"workflow.started", "step.started", "step.completed", "workflow.completed"}
+	if len(events) != len(want) {
+		t.Fatalf("events: %+v", events)
+	}
+	for i := range want {
+		if events[i].Type != want[i] {
+			t.Fatalf("event %d = %s, want %s", i, events[i].Type, want[i])
+		}
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -95,6 +95,21 @@ CREATE TABLE IF NOT EXISTS service_logs (
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Versioned structured lifecycle events. Metadata is redacted before insert;
+-- the same stored envelope powers queries, SSE subscribers, CLI, and dashboard.
+CREATE TABLE IF NOT EXISTS execution_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  schema_version INTEGER NOT NULL,
+  type TEXT NOT NULL,
+  timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  task_id TEXT,
+  workflow_id TEXT,
+  workflow_instance_id TEXT,
+  step_id TEXT,
+  attempt_id TEXT,
+  metadata TEXT NOT NULL DEFAULT '{}'
+);
+
 -- Dispatcher state
 CREATE TABLE IF NOT EXISTS dispatcher_state (
   id INTEGER PRIMARY KEY,
@@ -212,6 +227,9 @@ CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_task_logs_task ON task_logs(task_id);
 CREATE INDEX IF NOT EXISTS idx_task_logs_timestamp ON task_logs(timestamp);
 CREATE INDEX IF NOT EXISTS idx_service_logs_timestamp ON service_logs(timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_execution_events_task ON execution_events(task_id, id);
+CREATE INDEX IF NOT EXISTS idx_execution_events_instance ON execution_events(workflow_instance_id, id);
+CREATE INDEX IF NOT EXISTS idx_execution_events_type ON execution_events(type, id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_parent ON workflow_instances(parent_instance_id);

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -109,14 +109,30 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 		        COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0), ?, ?)
 	`, inst.ID, inst.WorkflowID, nullStr(inst.TaskID), inst.CellID, nullStr(inst.SourceID), inst.State,
 		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.TaskID, inst.CreatedAt, inst.UpdatedAt)
+	if err == nil {
+		c.recordWorkflowEvent(ctx, inst, "workflow.started", map[string]any{"state": inst.State})
+		if inst.ResumedFrom != "" {
+			c.recordWorkflowEvent(ctx, inst, "workflow.resumed", map[string]any{"resumed_from": inst.ResumedFrom})
+		}
+	}
 	return err
 }
 
 // UpdateWorkflowInstanceState transitions an instance to a new state.
 func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state string) error {
+	inst, _ := c.GetWorkflowInstance(ctx, id)
+	if inst != nil && inst.State == state {
+		return nil
+	}
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE workflow_instances SET state = ?, updated_at = ? WHERE id = ?
 	`, state, time.Now(), id)
+	if err == nil && inst != nil {
+		inst.State = state
+		if eventType := workflowStateEventType(state); eventType != "" {
+			c.recordWorkflowEvent(ctx, inst, eventType, map[string]any{"state": state})
+		}
+	}
 	return err
 }
 
@@ -505,12 +521,17 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
 		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
 		sr.CostUSD, sr.StartedAt, sr.FinishedAt)
+	if err == nil {
+		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
+	}
 	return err
 }
 
 // UpdateStepRun persists the mutable fields of a step run (state, output,
 // structured output, summary, exit code, skipped flag, finished timestamp).
 func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
+	var previous string
+	_ = c.db.QueryRowContext(ctx, `SELECT state FROM step_runs WHERE id = ?`, sr.ID).Scan(&previous)
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE step_runs
 		SET state = ?, output = ?, structured_output = ?, summary = ?,
@@ -525,7 +546,57 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
 		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
 		sr.CostUSD, sr.StartedAt, sr.FinishedAt, sr.ID)
+	if err == nil && previous != sr.State {
+		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
+	}
 	return err
+}
+
+func workflowStateEventType(state string) string {
+	switch state {
+	case InstanceStateDone:
+		return "workflow.completed"
+	case InstanceStateFailed:
+		return "workflow.failed"
+	case InstanceStateInterrupted:
+		return "workflow.cancelled"
+	}
+	return ""
+}
+
+func stepStateEventType(state string) string {
+	switch state {
+	case StepStateRunning:
+		return "step.started"
+	case StepStatePassed, StepStateSkipped, StepStateSkippedCached:
+		return "step.completed"
+	case StepStateFailed:
+		return "step.failed"
+	case StepStateInterrupted:
+		return "step.cancelled"
+	}
+	return ""
+}
+
+func (c *Client) recordWorkflowEvent(ctx context.Context, inst *WorkflowInstance, eventType string, metadata map[string]any) {
+	if eventType == "" || inst == nil {
+		return
+	}
+	_ = c.RecordExecutionEvent(ctx, &ExecutionEvent{Type: eventType, TaskID: inst.TaskID, WorkflowID: inst.WorkflowID, WorkflowInstanceID: inst.ID, Metadata: metadata})
+}
+
+func (c *Client) recordStepEvent(ctx context.Context, sr *StepRun, eventType string) {
+	if eventType == "" || sr == nil {
+		return
+	}
+	inst, _ := c.GetWorkflowInstance(ctx, sr.WorkflowInstanceID)
+	event := &ExecutionEvent{Type: eventType, WorkflowInstanceID: sr.WorkflowInstanceID, StepID: sr.StepID,
+		Metadata: map[string]any{"state": sr.State, "agent_id": sr.AgentID, "exit_code": sr.ExitCode, "cached": sr.SkippedCached,
+			"total_tokens": sr.TotalTokens, "cost_usd": sr.CostUSD}}
+	if inst != nil {
+		event.TaskID, event.WorkflowID = inst.TaskID, inst.WorkflowID
+	}
+	_ = c.RecordExecutionEvent(ctx, event)
 }
 
 // ListStepRuns returns all step runs for an instance, in insertion order.

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -144,6 +144,29 @@ func (r *Router) RouteAll(task model.InternalTask) []Match {
 	return matches
 }
 
+// ExplainTask returns the same fan-out decision as RouteAll together with a
+// stable reason for every route evaluated before an exclusive match.
+func (r *Router) ExplainTask(task model.InternalTask) []RouteTrace {
+	t := targetFromTask(task)
+	traces := make([]RouteTrace, 0, len(r.routes))
+	for _, route := range r.routes {
+		matched, reason := r.evaluateTarget(route, t)
+		selected := false
+		if matched {
+			_, selected = r.resolveMatch(route)
+			if !selected {
+				reason = "matched conditions but route has no resolvable agent or worker"
+			}
+		}
+		traces = append(traces, RouteTrace{RouteID: route.ID, Priority: route.Priority, Agent: route.Agent,
+			Worker: route.Worker, Matched: matched, Selected: selected, Reason: reason})
+		if selected && route.Exclusive {
+			break
+		}
+	}
+	return traces
+}
+
 // resolveMatch turns a matched route into a Match: agent-based routing is
 // preferred (route.Agent), falling back to a defined worker for backward compat.
 // Returns false if the route resolves to neither — the caller skips it.

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -126,6 +126,12 @@ func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decisio
 	if !ok {
 		return false, fmt.Errorf("instance %q is not awaiting approval", instanceID)
 	}
+	eventType := "approval.granted"
+	decisionName := "resume"
+	if decision == ApprovalAbort {
+		eventType, decisionName = "approval.rejected", "abort"
+	}
+	e.recordExecutionEvent(ctx, r, eventType, map[string]any{"decision": decisionName})
 
 	r.resolveApproval(decision)
 	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -457,6 +457,7 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 	r.state[step.ID] = stWaiting
 	r.waitingStep = step.ID
 	r.parkedAt = e.now()
+	e.recordExecutionEvent(ctx, r, "approval.requested", map[string]any{"message": step.Message})
 	aplog.Info("workflow %s: instance %s parked at approval step %q", r.wf.ID, r.instID, step.ID)
 }
 

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -46,6 +46,19 @@ type ciPollRecorder interface {
 	RecordCIPollCheck(ctx context.Context, p *db.CIPollCheck) error
 }
 
+type executionEventRecorder interface {
+	RecordExecutionEvent(context.Context, *db.ExecutionEvent) error
+}
+
+func (e *Engine) recordExecutionEvent(ctx context.Context, r *dagRun, eventType string, metadata map[string]any) {
+	recorder, ok := e.store.(executionEventRecorder)
+	if !ok || r == nil {
+		return
+	}
+	_ = recorder.RecordExecutionEvent(ctx, &db.ExecutionEvent{Type: eventType, TaskID: r.task.ID, WorkflowID: r.wf.ID,
+		WorkflowInstanceID: r.instID, StepID: r.waitingStep, Metadata: metadata})
+}
+
 // recordCIPoll persists one CI poll result for a wait_for step when the store
 // supports it. Best-effort: a recording failure never affects the poll outcome.
 func (e *Engine) recordCIPoll(ctx context.Context, instID, stepID, status, url, detail string) {
@@ -476,6 +489,11 @@ func (e *Engine) completeTask(ctx context.Context, r *dagRun, failed bool) {
 	if err := e.tracker.SetTaskState(ctx, r.task.ID, finalState); err != nil {
 		aplog.Error("task %s: set state %s: %v", r.task.ID, finalState, err)
 	}
+	eventType := "task.completed"
+	if anyFailed {
+		eventType = "task.escalated"
+	}
+	e.recordExecutionEvent(ctx, r, eventType, map[string]any{"state": finalState})
 
 	if e.cfg.Tasks == nil || e.side == nil {
 		return


### PR DESCRIPTION
Closes #211

## Summary
- persist versioned, redacted lifecycle events with retention and live subscriptions
- expose chronological queries and SSE streaming through the local daemon API
- add route/fallback reasons plus CLI and dashboard task timelines

## Validation
- make check
- make vet
- go test -race ./internal/db ./internal/daemon ./internal/workflow ./internal/dashboard