### PR TITLE
feat: add multi-channel human approvals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6170 symbols, 22304 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6170 symbols, 22304 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -472,6 +472,21 @@ notifications:
 
 ## Execution event retention and redaction
 
+## Human approval policy
+
+```yaml
+settings:
+  approvals:
+    webhook_secret: ${APIARY_APPROVAL_SECRET}
+    require_for: [push, deploy, destructive, external_publication]
+```
+
+`webhook_secret` authenticates provider-neutral approval responses.
+`require_for` rejects workflows whose matching `action_class` step is not guarded
+by an approval step. See [Human-in-the-loop approvals](human-approvals.md).
+
+## Execution event retention and redaction
+
 Structured task timelines are persisted automatically when SQLite is enabled.
 Configure their retention and additional sensitive metadata keys under
 `settings.events`:

--- a/docs/human-approvals.md
+++ b/docs/human-approvals.md
@@ -1,0 +1,106 @@
+# Human-in-the-loop approvals
+
+Apiary approval steps can collect authorized, structured responses through the
+terminal dashboard or a provider-neutral signed webhook. Requests and individual
+responses are durable, auditable, and safe to retry.
+
+## Workflow declaration
+
+```yaml
+settings:
+  approvals:
+    webhook_secret: ${APIARY_APPROVAL_SECRET}
+    require_for: [push, deploy, destructive, external_publication]
+
+workflows:
+  - id: production-release
+    steps:
+      - id: authorize
+        type: approval
+        message: Approve the production release.
+        approvers: [alice, carol]
+        required_approvals: 2
+        delegates:
+          alice: [bob]
+        fields:
+          - name: change_ticket
+            label: Change ticket
+            type: string
+            required: true
+          - name: maintenance_window
+            type: choice
+            options: [now, scheduled]
+            required: true
+        remind_after: 2h
+        escalate_after: 8h
+        escalate_to: [release-managers]
+        timeout: 24h
+      - id: deploy
+        agent: release-engineer
+        action_class: deploy
+```
+
+Field types are `string`, `text`, `boolean`, `number`, and `choice`. A rejection
+ends the gate immediately; approvals wait until `required_approvals` distinct
+approver slots respond. A delegate answers the slot named by `for_approver`, so a
+delegate and their principal cannot both count toward the quorum.
+
+`settings.approvals.require_for` is a validation-time policy. A step carrying a
+listed `action_class` must directly follow or depend on an approval step. Apiary
+rejects an unsafe configuration before execution.
+
+## Dashboard and webhook responses
+
+The task detail and workflow monitor show the pending request. For a request
+without structured fields, press `y` to approve or `n` to reject. The local OS
+username is the actor and must match an approver or configured delegate.
+
+Provider-neutral endpoints on the daemon socket are:
+
+- `GET /approvals?status=pending`
+- `POST /approvals/<request-id>/respond` for the local dashboard channel
+- `POST /approvals/<request-id>/webhook` for signed integrations
+
+Webhook JSON:
+
+```json
+{
+  "decision": "approve",
+  "actor": "bob",
+  "for_approver": "alice",
+  "idempotency_key": "provider-delivery-0192",
+  "feedback": "Proceed during the scheduled window.",
+  "values": {
+    "change_ticket": "OPS-482",
+    "maintenance_window": "scheduled"
+  }
+}
+```
+
+Sign the exact request body with HMAC-SHA256 using `webhook_secret` and send the
+hex digest as `X-Apiary-Signature: sha256=<digest>`. Apiary rejects missing or
+invalid signatures, unknown actors, invalid delegation, missing required fields,
+and invalid field types/options. The socket can be exposed through an authenticated
+reverse proxy or consumed by a provider adapter; it should not be made public
+without TLS and request-size/rate limits.
+
+## Idempotency, recovery, and audit
+
+Every provider delivery needs a globally unique `idempotency_key`. Responses are
+also unique per request and approver slot. SQLite transactions ensure concurrent
+channels cannot count the same approver twice or advance the workflow past its
+quorum more than once. A response persisted immediately before a process crash is
+applied after the parked workflow is rehydrated.
+
+The execution timeline records `approval.requested`, `approval.reminder`,
+`approval.escalated`, `approval.granted`, `approval.rejected`, and
+`approval.timed_out`. Actor, channel, feedback, form values, request identity, and
+escalation targets are retained in redacted event metadata.
+
+Submitted values and rejection feedback enter workflow memory as
+`memory.<field>`, `memory.approval_decision`, and `memory.approval_feedback`, so
+subsequent conditions and agent prompts can act on the human response.
+
+Legacy approval steps without `approvers` continue to use source comments, labels,
+or state changes. When `approvers` is present, unauthenticated source signals are
+ignored because source comment records do not carry a verified author identity.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -382,6 +382,10 @@ the step if nobody responds in time.
 Parked approvals are durable: they are **rehydrated after a daemon restart**
 with their original timestamps and timeout intact.
 
+For authorized approvers, quorum, delegation, structured fields, dashboard and
+signed webhook responses, reminders/escalation, and sensitive-action policies,
+see [Human-in-the-loop approvals](human-approvals.md).
+
 ### `wait_for` steps — waiting on CI
 
 A `wait_for` step parks the workflow until an external condition resolves.

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 2026-07-22
 
+- **multi-channel-human-approvals** — First-class human-in-the-loop approval requests with structured fields, authorized quorum/delegation, dashboard and signed webhook responses, idempotent resolution, escalation, sensitive-action policies, and rejection feedback. GitHub issue #212.
 - **structured-execution-events** — Versioned, redacted execution events with persisted queries, live SSE subscriptions, route/fallback reasons, retention, CLI history, and a dashboard task timeline. GitHub issue #211.
 - **reusable-typed-subworkflows** — Reusable local workflow files with typed inputs and outputs, cycle-safe resolution, linked nested execution history, and explicit failure/cancellation semantics. GitHub issue #210.
 - **immutable-execution-replay** — Immutable workflow replay with descendant attempt lineage, selectable resume points, secret-safe workflow-definition snapshots, and CLI comparison of attempts. GitHub issue #209.

--- a/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/design.md
+++ b/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/design.md
@@ -1,0 +1,29 @@
+# Design: multi-channel human approvals
+
+## Decisions
+
+- `approval_requests` is the durable request aggregate; `approval_responses`
+  stores immutable channel deliveries and distinct approver slots.
+- Response insertion and quorum transition share one SQLite transaction.
+- `(request_id, approver)` and global `idempotency_key` uniqueness provide
+  channel-independent exactly-once counting.
+- Rejection is terminal immediately; approval is terminal at the configured
+  quorum. Timers use compare-and-set updates so reminder/escalation events emit once.
+- The workflow engine owns state advancement and memory contribution. Transports
+  implement `ApprovalProvider`; dashboard/webhook handlers validate and persist.
+- A persisted terminal response is replayed when a parked instance is rehydrated.
+- Sensitive action policies are validated statically through `action_class` and
+  `settings.approvals.require_for`.
+
+## Authorization
+
+Direct actors occupy their own approver slot. A delegate may occupy only its
+configured principal's slot. Signed webhook authentication proves channel origin;
+the actor/delegation policy authorizes the decision. Dashboard responses travel
+over the local Unix socket and use the OS username as actor.
+
+## Compatibility
+
+All new YAML fields are optional. Approval steps without explicit approvers keep
+legacy source-trigger behavior. Explicit approvers disable unverified source
+signals. Existing execution-event consumers tolerate the new additive event types.

--- a/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/proposal.md
+++ b/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/proposal.md
@@ -1,0 +1,18 @@
+# Multi-channel human approvals
+
+## Motivation
+
+Approval gates currently depend on source-state polling and carry only a binary
+decision. Production workflows need durable, authorized requests that can be
+answered through multiple channels without advancing twice.
+
+## Scope
+
+- Declare approvers, timeout, escalation, and typed form fields on approval steps.
+- Persist approval requests and idempotent responses with a complete event audit.
+- Support the terminal dashboard and a provider-neutral signed webhook channel.
+- Expose rejection feedback and submitted fields to subsequent workflow logic.
+- Keep transport concerns behind an approval-provider interface.
+
+Slack, Teams, and email adapters are deferred; they can implement the same
+provider interface after the provider-neutral contract is stable.

--- a/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/tasks.md
+++ b/openspec/changes/archive/2026-07-22-multi-channel-human-approvals/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Define approval request, response, field, approver, delegation, quorum, and escalation schemas.
+- [x] Persist requests and atomically count only authorized, idempotent responses.
+- [x] Add provider interface and signed provider-neutral webhook endpoints.
+- [x] Add dashboard request display and approve/reject actions.
+- [x] Feed structured values and rejection feedback into workflow context.
+- [x] Emit requested, granted, rejected, timed-out, reminder, and escalated audit events.
+- [x] Document authorization, signatures, idempotency, and operational behavior.
+- [x] Add persistence, workflow, webhook, dashboard, and concurrency tests.
+- [x] Run repository gates, GitNexus change detection, and archive the change.

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -265,6 +265,7 @@ type Settings struct {
 	LogMaxAgeDays int                `yaml:"log_max_age_days"` // prune backups and task logs older than this; default 30
 	Memory        MemorySettings     `yaml:"memory"`
 	Events        EventSettings      `yaml:"events"`
+	Approvals     ApprovalSettings   `yaml:"approvals"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
@@ -274,6 +275,12 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+}
+
+// ApprovalSettings controls provider-neutral approval response endpoints.
+type ApprovalSettings struct {
+	WebhookSecret string   `yaml:"webhook_secret,omitempty"`
+	RequireFor    []string `yaml:"require_for,omitempty"`
 }
 
 // EventSettings controls persisted structured execution events. Events are

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -176,16 +176,26 @@ type StepConfig struct {
 	// Env is the step-scope environment overlay. It is the highest-precedence
 	// explicit scope: it overrides workflow.env and agent.env for the same key.
 	Env map[string]string `yaml:"env,omitempty"`
+	// ActionClass lets settings.approvals.require_for enforce an approval gate
+	// before sensitive work such as push, deploy, destructive, or publication.
+	ActionClass string `yaml:"action_class,omitempty"`
 
 	// ── split step ────────────────────────────────────────────────
 	Multi    bool          `yaml:"multi,omitempty"`
 	Branches []SplitBranch `yaml:"branches,omitempty"`
 
 	// ── approval step ─────────────────────────────────────────────
-	Message  string           `yaml:"message,omitempty"`
-	ResumeOn *ApprovalTrigger `yaml:"resume_on,omitempty"`
-	AbortOn  *ApprovalTrigger `yaml:"abort_on,omitempty"`
-	Timeout  string           `yaml:"timeout,omitempty"`
+	Message           string              `yaml:"message,omitempty"`
+	ResumeOn          *ApprovalTrigger    `yaml:"resume_on,omitempty"`
+	AbortOn           *ApprovalTrigger    `yaml:"abort_on,omitempty"`
+	Timeout           string              `yaml:"timeout,omitempty"`
+	Approvers         []string            `yaml:"approvers,omitempty"`
+	RequiredApprovals int                 `yaml:"required_approvals,omitempty"`
+	ApprovalFields    []ApprovalField     `yaml:"fields,omitempty"`
+	RemindAfter       string              `yaml:"remind_after,omitempty"`
+	EscalateAfter     string              `yaml:"escalate_after,omitempty"`
+	EscalateTo        []string            `yaml:"escalate_to,omitempty"`
+	Delegates         map[string][]string `yaml:"delegates,omitempty"`
 
 	// ── wait_for step ─────────────────────────────────────────────
 	// WaitFor holds configuration for a wait_for step (e.g., wait for CI). The
@@ -237,6 +247,15 @@ type StepConfig struct {
 	Max int `yaml:"max,omitempty"`
 	// Output is the v2 alias for OutputSchema (shorter key in authored YAML).
 	Output *OutputSchema `yaml:"output,omitempty"`
+}
+
+// ApprovalField describes one typed value collected with a response.
+type ApprovalField struct {
+	Name     string   `yaml:"name" json:"name"`
+	Label    string   `yaml:"label,omitempty" json:"label,omitempty"`
+	Type     string   `yaml:"type,omitempty" json:"type,omitempty"`
+	Required bool     `yaml:"required,omitempty" json:"required,omitempty"`
+	Options  []string `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 // StepType returns the step's type, defaulting to StepTypeAgent when unset.

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -104,6 +104,34 @@ func (c *Config) validateWorkflow(
 	for i, s := range wf.Steps {
 		errs = append(errs, c.validateStep(ctx, i, s, wf, agentIDs, stepIDs, wfByID)...)
 	}
+	requiredClasses := map[string]bool{}
+	for _, class := range c.Settings.Approvals.RequireFor {
+		requiredClasses[class] = true
+	}
+	for i, step := range wf.Steps {
+		if step.ActionClass == "" {
+			continue
+		}
+		switch step.ActionClass {
+		case "push", "deploy", "destructive", "external_publication":
+		default:
+			errs = append(errs, fmt.Errorf("%s: step %q has invalid action_class %q", ctx, step.ID, step.ActionClass))
+		}
+		if !requiredClasses[step.ActionClass] {
+			continue
+		}
+		guarded := i > 0 && wf.Steps[i-1].StepType() == StepTypeApproval && len(wf.Steps[i-1].Approvers) > 0
+		for _, dep := range append(append([]string{}, step.DependsOn...), step.SeqDependsOn...) {
+			for _, candidate := range wf.Steps {
+				if candidate.ID == dep && candidate.StepType() == StepTypeApproval && len(candidate.Approvers) > 0 {
+					guarded = true
+				}
+			}
+		}
+		if !guarded {
+			errs = append(errs, fmt.Errorf("%s: step %q action_class %q requires a preceding approval step", ctx, step.ID, step.ActionClass))
+		}
+	}
 
 	// Graph: depends_on references + cycle detection + back-edge ancestry.
 	errs = append(errs, validateStepGraph(ctx, wf, stepIDs)...)
@@ -335,8 +363,56 @@ func validateApprovalStep(sctx string, s StepConfig) []error {
 	if s.Message == "" {
 		errs = append(errs, fmt.Errorf("%s: approval step requires a message", sctx))
 	}
-	if s.ResumeOn == nil || s.ResumeOn.IsEmpty() {
-		errs = append(errs, fmt.Errorf("%s: approval step requires resume_on with at least one condition", sctx))
+	if (s.ResumeOn == nil || s.ResumeOn.IsEmpty()) && len(s.Approvers) == 0 {
+		errs = append(errs, fmt.Errorf("%s: approval step requires resume_on or at least one approver", sctx))
+	}
+	for name, raw := range map[string]string{"remind_after": s.RemindAfter, "escalate_after": s.EscalateAfter} {
+		if raw != "" {
+			if d, err := time.ParseDuration(raw); err != nil || d <= 0 {
+				errs = append(errs, fmt.Errorf("%s: invalid %s %q", sctx, name, raw))
+			}
+		}
+	}
+	seen := map[string]bool{}
+	if s.RequiredApprovals < 0 || (s.RequiredApprovals > 0 && s.RequiredApprovals > len(s.Approvers)) {
+		errs = append(errs, fmt.Errorf("%s: required_approvals cannot exceed the number of approvers", sctx))
+	}
+	approverSet := map[string]bool{}
+	delegateOwner := map[string]string{}
+	for _, approver := range s.Approvers {
+		approverSet[approver] = true
+	}
+	for approver, delegates := range s.Delegates {
+		if !approverSet[approver] {
+			errs = append(errs, fmt.Errorf("%s: delegate owner %q is not an approver", sctx, approver))
+		}
+		if len(delegates) == 0 {
+			errs = append(errs, fmt.Errorf("%s: delegate owner %q has no delegates", sctx, approver))
+		}
+		for _, delegate := range delegates {
+			if owner, exists := delegateOwner[delegate]; exists && owner != approver {
+				errs = append(errs, fmt.Errorf("%s: delegate %q is assigned to multiple approvers", sctx, delegate))
+			}
+			delegateOwner[delegate] = approver
+		}
+	}
+	for _, field := range s.ApprovalFields {
+		if field.Name == "" {
+			errs = append(errs, fmt.Errorf("%s: approval field name is required", sctx))
+			continue
+		}
+		if seen[field.Name] {
+			errs = append(errs, fmt.Errorf("%s: duplicate approval field %q", sctx, field.Name))
+		}
+		seen[field.Name] = true
+		switch field.Type {
+		case "", "string", "text", "boolean", "number", "choice":
+		default:
+			errs = append(errs, fmt.Errorf("%s: approval field %q has invalid type %q", sctx, field.Name, field.Type))
+		}
+		if field.Type == "choice" && len(field.Options) == 0 {
+			errs = append(errs, fmt.Errorf("%s: choice field %q requires options", sctx, field.Name))
+		}
 	}
 	if s.Timeout != "" {
 		if _, err := time.ParseDuration(s.Timeout); err != nil {

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -439,6 +439,23 @@ func TestWorkflow_ApprovalMissingResumeOn(t *testing.T) {
 	assertError(t, cfg, "requires resume_on")
 }
 
+func TestWorkflow_SensitiveActionRequiresApprovalPolicy(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Settings.Approvals.RequireFor = []string{"deploy"}
+	cfg.Workflows = []config.WorkflowConfig{{ID: "release", Steps: []config.StepConfig{{ID: "deploy", Agent: "backend-dev", ActionClass: "deploy"}}}}
+	assertError(t, cfg, "requires a preceding approval step")
+	cfg.Workflows[0].Steps = []config.StepConfig{{ID: "gate", Type: config.StepTypeApproval, Message: "Deploy?", Approvers: []string{"alice"}}, {ID: "deploy", Agent: "backend-dev", ActionClass: "deploy"}}
+	assertNoError(t, cfg)
+}
+
+func TestWorkflow_ApprovalQuorumAndDelegatesValidate(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{{ID: "release", Steps: []config.StepConfig{{ID: "gate", Type: config.StepTypeApproval, Message: "Deploy?", Approvers: []string{"alice", "carol"}, RequiredApprovals: 2, Delegates: map[string][]string{"alice": {"bob"}}, ApprovalFields: []config.ApprovalField{{Name: "ticket", Type: "string", Required: true}}}}}}
+	assertNoError(t, cfg)
+	cfg.Workflows[0].Steps[0].RequiredApprovals = 3
+	assertError(t, cfg, "cannot exceed")
+}
+
 func TestWorkflow_ApprovalInvalidTimeout(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{

--- a/src/internal/daemon/approval_http.go
+++ b/src/internal/daemon/approval_http.go
@@ -1,0 +1,181 @@
+package daemon
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func (d *Dispatcher) handleApprovals(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if d.db == nil {
+		http.Error(w, "approval store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	requests, err := d.db.ListApprovalRequests(r.Context(), r.URL.Query().Get("status"), limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(requests)
+}
+
+func (d *Dispatcher) handleApprovalResponse(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if d.db == nil {
+		http.Error(w, "approval store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/approvals/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || (parts[1] != "respond" && parts[1] != "webhook") {
+		http.NotFound(w, r)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	channel := "dashboard"
+	if parts[1] == "webhook" {
+		channel = "webhook"
+		if !validApprovalSignature(d.cfg.Settings.Approvals.WebhookSecret, body, r.Header.Get("X-Apiary-Signature")) {
+			http.Error(w, "invalid webhook signature", http.StatusUnauthorized)
+			return
+		}
+	}
+	var response db.ApprovalResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	response.Channel = channel
+	if response.IdempotencyKey == "" {
+		response.IdempotencyKey = r.Header.Get("Idempotency-Key")
+	}
+	request, err := d.db.GetApprovalRequest(r.Context(), parts[0])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if request == nil {
+		http.Error(w, "approval request not found", http.StatusNotFound)
+		return
+	}
+	if err := validateApprovalResponse(request, &response); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	stored, won, err := d.db.ResolveApprovalRequest(r.Context(), request.ID, response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if won {
+		if d.engine == nil {
+			d.workflowEngine()
+		}
+		if d.engine != nil {
+			_, _ = d.engine.ResolveApprovalResponse(r.Context(), request.WorkflowInstanceID, response)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(map[bool]int{true: http.StatusAccepted, false: http.StatusOK}[won])
+	_ = json.NewEncoder(w).Encode(map[string]any{"recorded": true, "resolved": won, "request": stored})
+}
+
+func validApprovalSignature(secret string, body []byte, header string) bool {
+	if secret == "" {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write(body)
+	want := mac.Sum(nil)
+	header = strings.TrimPrefix(header, "sha256=")
+	got, err := hex.DecodeString(header)
+	return err == nil && hmac.Equal(want, got)
+}
+
+func validateApprovalResponse(request *db.ApprovalRequest, response *db.ApprovalResponse) error {
+	decision := strings.ToLower(response.Decision)
+	if decision != "approve" && decision != "approved" && decision != "reject" && decision != "rejected" {
+		return fmt.Errorf("decision must be approve or reject")
+	}
+	if response.Actor == "" {
+		return fmt.Errorf("actor is required")
+	}
+	if len(request.Approvers) > 0 {
+		principal := ""
+		for _, actor := range request.Approvers {
+			if strings.EqualFold(actor, response.Actor) {
+				principal = actor
+				break
+			}
+		}
+		if principal == "" {
+			for approver, delegates := range request.Delegates {
+				for _, delegate := range delegates {
+					if strings.EqualFold(delegate, response.Actor) && (response.Approver == "" || strings.EqualFold(response.Approver, approver)) {
+						principal = approver
+					}
+				}
+			}
+		}
+		if principal == "" {
+			return fmt.Errorf("actor %q is not an authorized approver", response.Actor)
+		}
+		response.Approver = principal
+	}
+	for _, field := range request.Fields {
+		name, _ := field["name"].(string)
+		required, _ := field["required"].(bool)
+		value, present := response.Values[name]
+		if required && (!present || value == nil || value == "") {
+			return fmt.Errorf("field %q is required", name)
+		}
+		if !present {
+			continue
+		}
+		typeName, _ := field["type"].(string)
+		switch typeName {
+		case "boolean":
+			if _, ok := value.(bool); !ok {
+				return fmt.Errorf("field %q must be boolean", name)
+			}
+		case "number":
+			if _, ok := value.(float64); !ok {
+				return fmt.Errorf("field %q must be number", name)
+			}
+		case "choice":
+			allowed := false
+			if options, ok := field["options"].([]any); ok {
+				for _, option := range options {
+					if option == value {
+						allowed = true
+					}
+				}
+			}
+			if !allowed {
+				return fmt.Errorf("field %q is not an allowed choice", name)
+			}
+		}
+	}
+	return nil
+}

--- a/src/internal/daemon/approval_http_test.go
+++ b/src/internal/daemon/approval_http_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func TestApprovalWebhookSignature(t *testing.T) {
+	body := []byte(`{"decision":"approve"}`)
+	mac := hmac.New(sha256.New, []byte("secret"))
+	_, _ = mac.Write(body)
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if !validApprovalSignature("secret", body, sig) {
+		t.Fatal("valid signature rejected")
+	}
+	if validApprovalSignature("wrong", body, sig) || validApprovalSignature("", body, sig) {
+		t.Fatal("invalid signature accepted")
+	}
+}
+
+func TestApprovalWebhookPersistsAuthorizedResponse(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "approvals.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbc.Close()
+	request := &db.ApprovalRequest{ID: "inst:gate", WorkflowInstanceID: "inst", StepID: "gate", Approvers: []string{"alice"}}
+	if err := dbc.CreateApprovalRequest(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{Settings: config.Settings{Approvals: config.ApprovalSettings{WebhookSecret: "secret"}}}}
+	body := []byte(`{"decision":"approve","actor":"alice","idempotency_key":"delivery-1"}`)
+	mac := hmac.New(sha256.New, []byte("secret"))
+	_, _ = mac.Write(body)
+	req := httptest.NewRequest(http.MethodPost, "/approvals/inst:gate/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Apiary-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+	w := httptest.NewRecorder()
+	d.handleApprovalResponse(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ := dbc.GetApprovalRequest(ctx, request.ID)
+	if stored.Status != db.ApprovalApproved || stored.RespondedBy != "alice" {
+		t.Fatalf("stored=%+v", stored)
+	}
+}
+
+func TestValidateApprovalResponseAuthorizationAndFields(t *testing.T) {
+	req := &db.ApprovalRequest{Approvers: []string{"alice"}, Fields: []map[string]any{{"name": "ticket", "required": true, "type": "string"}}}
+	good := db.ApprovalResponse{Decision: "approve", Actor: "alice", Values: map[string]any{"ticket": "OPS-7"}}
+	if err := validateApprovalResponse(req, &good); err != nil {
+		t.Fatal(err)
+	}
+	badActor := good
+	badActor.Actor = "mallory"
+	if err := validateApprovalResponse(req, &badActor); err == nil {
+		t.Fatal("unauthorized actor accepted")
+	}
+	missing := good
+	missing.Values = nil
+	if err := validateApprovalResponse(req, &missing); err == nil {
+		t.Fatal("missing required field accepted")
+	}
+}
+
+func TestValidateApprovalResponseDelegationUsesApproverSlot(t *testing.T) {
+	req := &db.ApprovalRequest{Approvers: []string{"alice"}, Delegates: map[string][]string{"alice": {"bob"}}}
+	response := db.ApprovalResponse{Decision: "approve", Actor: "bob"}
+	if err := validateApprovalResponse(req, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Approver != "alice" {
+		t.Fatalf("approver slot=%q", response.Approver)
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -958,6 +958,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	})
 	mux.HandleFunc("/events", d.handleExecutionEvents)
 	mux.HandleFunc("/events/stream", d.handleExecutionEventStream)
+	mux.HandleFunc("/approvals", d.handleApprovals)
+	mux.HandleFunc("/approvals/", d.handleApprovalResponse)
 	mux.HandleFunc("/restart/", func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/restart/")
 		if cellID == "" {

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -278,7 +278,17 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 			defer d.approvalAdvancing.Delete(p.InstanceID)
 
 			// Cheap re-evaluation, ungated. Still waiting → leave it parked.
-			decision := d.engine.RecheckApproval(ctx, p.InstanceID, poll)
+			var stored *db.ApprovalRequest
+			decision := workflow.ApprovalWait
+			if req, _ := d.db.GetApprovalByInstance(ctx, p.InstanceID); req != nil && (req.Status == db.ApprovalApproved || req.Status == db.ApprovalRejected) {
+				stored = req
+				decision = workflow.ApprovalResume
+				if req.Status == db.ApprovalRejected {
+					decision = workflow.ApprovalAbort
+				}
+			} else {
+				decision = d.engine.RecheckApproval(ctx, p.InstanceID, poll)
+			}
 			if decision == workflow.ApprovalWait {
 				return
 			}
@@ -294,7 +304,11 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 				}
 				defer func() { <-agentCh }()
 			}
-			_, _ = d.engine.ResolveApproval(ctx, p.InstanceID, decision)
+			if stored != nil {
+				_, _ = d.engine.ResolveApprovalResponse(ctx, p.InstanceID, db.ApprovalResponse{Decision: stored.Status, Actor: stored.RespondedBy, Channel: stored.ResponseChannel, IdempotencyKey: stored.IdempotencyKey, Feedback: stored.Feedback, Values: stored.Values})
+			} else {
+				_, _ = d.engine.ResolveApproval(ctx, p.InstanceID, decision)
+			}
 		}()
 	}
 }

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1126,6 +1126,14 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 			a.model.loading = true
 			return a, tea.Batch(a.fetchTaskDetail(row.TaskID, row.InternalTaskID), a.refreshTaskPullsCmd(row.InternalTaskID))
 		}
+	case "y", "n":
+		if t.View == TaskViewDetail && t.DetailInstance != nil && t.DetailInstance.Approval != nil {
+			decision := "approve"
+			if key == "n" {
+				decision = "reject"
+			}
+			return a, a.approvalResponseCmd(t.DetailInstance.Approval.ID, decision)
+		}
 	case "l", "enter":
 		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
@@ -1311,6 +1319,15 @@ func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
 		// Restart the whole workflow (force-restart the cell).
 		a.model.confirmAction = "restart"
 		a.model.confirmTaskID = inst.CellID
+
+	case "y", "n":
+		if inst.Approval != nil {
+			decision := "approve"
+			if key == "n" {
+				decision = "reject"
+			}
+			return a, a.approvalResponseCmd(inst.Approval.ID, decision)
+		}
 	}
 	return a, nil
 }
@@ -1632,6 +1649,27 @@ func (a *App) stopInstanceCmd(instanceID string) tea.Cmd {
 	}
 }
 
+func (a *App) approvalResponseCmd(requestID, decision string) tea.Cmd {
+	return func() tea.Msg {
+		actor := os.Getenv("USER")
+		if actor == "" {
+			actor = "dashboard-user"
+		}
+		body, _ := json.Marshal(map[string]any{"decision": decision, "actor": actor, "idempotency_key": fmt.Sprintf("dashboard:%s:%s:%s", requestID, actor, decision)})
+		transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", a.socketPath)
+		}}
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		req, _ := http.NewRequest(http.MethodPost, "http://apiary/approvals/"+requestID+"/respond", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err == nil {
+			resp.Body.Close()
+		}
+		return nil
+	}
+}
+
 // openWorkflowMonitorOrLogs opens the workflow monitor if the task has a
 // workflow instance, or the logs view otherwise.
 func (a *App) openWorkflowMonitorOrLogs(taskID string) tea.Cmd {
@@ -1669,6 +1707,7 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 	}
 	if inst.State == "approval_waiting" {
 		item.Message = "Awaiting human approval — reply on the task to resume or abort."
+		item.Approval, _ = dbConn.GetApprovalByInstance(ctx, inst.ID)
 	}
 	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
 	if err == nil {
@@ -3564,6 +3603,14 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 
 	if inst.State == db.InstanceStateApprovalWaiting && inst.Message != "" {
 		b.WriteString("  " + StyleWarning.Render("⏸ "+inst.Message) + "\n")
+		if inst.Approval != nil {
+			b.WriteString("  " + StyleMuted.Render("Approvers: "+strings.Join(inst.Approval.Approvers, ", ")) + "\n")
+			if len(inst.Approval.Fields) == 0 {
+				b.WriteString("  " + StyleAccent.Render("Press y to approve or n to reject") + "\n")
+			} else {
+				b.WriteString("  " + StyleMuted.Render("Structured fields required; submit through the signed webhook channel.") + "\n")
+			}
+		}
 	}
 
 	if len(inst.Steps) > 0 {

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -140,6 +140,7 @@ type WorkflowInstanceItem struct {
 	CreatedAt        time.Time
 	Steps            []WorkflowStepItem
 	CIPolls          []CIPollItem // recorded wait_for CI poll history (oldest first)
+	Approval         *db.ApprovalRequest
 
 	// Span and token totals aggregated across this instance's steps (StartedAt =
 	// earliest step start, FinishedAt = latest step finish). Used for the per-

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
 )
 
 func TestRenderWorkflowSteps_CIPolls(t *testing.T) {
@@ -85,6 +87,21 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 	}
 	if !strings.Contains(out, "Awaiting human approval") {
 		t.Errorf("expected approval message banner:\n%s", out)
+	}
+}
+
+func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
+	inst := &WorkflowInstanceItem{ID: "wf-1", Workflow: "release", State: db.InstanceStateApprovalWaiting, Message: "Awaiting approval", Approval: &db.ApprovalRequest{ID: "wf-1:gate", Approvers: []string{"alice", "carol"}, RequiredApprovals: 2}}
+	out := stripANSI(renderWorkflowSteps(inst))
+	for _, want := range []string{"alice, carol", "Press y to approve or n to reject"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q:\n%s", want, out)
+		}
+	}
+	inst.Approval.Fields = []map[string]any{{"name": "ticket", "required": true}}
+	out = stripANSI(renderWorkflowSteps(inst))
+	if !strings.Contains(out, "signed webhook") {
+		t.Fatalf("structured-field guidance missing:\n%s", out)
 	}
 }
 

--- a/src/internal/db/approval_store.go
+++ b/src/internal/db/approval_store.go
@@ -1,0 +1,232 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ApprovalPending   = "pending"
+	ApprovalEscalated = "escalated"
+	ApprovalApproved  = "approved"
+	ApprovalRejected  = "rejected"
+	ApprovalTimedOut  = "timed_out"
+)
+
+type ApprovalRequest struct {
+	ID                 string              `json:"id"`
+	WorkflowInstanceID string              `json:"workflow_instance_id"`
+	TaskID             string              `json:"task_id,omitempty"`
+	WorkflowID         string              `json:"workflow_id,omitempty"`
+	StepID             string              `json:"step_id"`
+	Message            string              `json:"message,omitempty"`
+	Approvers          []string            `json:"approvers,omitempty"`
+	Delegates          map[string][]string `json:"delegates,omitempty"`
+	RequiredApprovals  int                 `json:"required_approvals"`
+	Fields             []map[string]any    `json:"fields,omitempty"`
+	Status             string              `json:"status"`
+	Values             map[string]any      `json:"values,omitempty"`
+	Feedback           string              `json:"feedback,omitempty"`
+	RespondedBy        string              `json:"responded_by,omitempty"`
+	ResponseChannel    string              `json:"response_channel,omitempty"`
+	IdempotencyKey     string              `json:"idempotency_key,omitempty"`
+	CreatedAt          time.Time           `json:"created_at"`
+	ExpiresAt          *time.Time          `json:"expires_at,omitempty"`
+	RemindedAt         *time.Time          `json:"reminded_at,omitempty"`
+	EscalatedAt        *time.Time          `json:"escalated_at,omitempty"`
+	RespondedAt        *time.Time          `json:"responded_at,omitempty"`
+}
+
+type ApprovalResponse struct {
+	Decision       string         `json:"decision"`
+	Actor          string         `json:"actor"`
+	Approver       string         `json:"for_approver,omitempty"`
+	Channel        string         `json:"channel"`
+	IdempotencyKey string         `json:"idempotency_key"`
+	Feedback       string         `json:"feedback,omitempty"`
+	Values         map[string]any `json:"values,omitempty"`
+}
+
+func (c *Client) CreateApprovalRequest(ctx context.Context, req *ApprovalRequest) error {
+	if req.ID == "" || req.WorkflowInstanceID == "" || req.StepID == "" {
+		return fmt.Errorf("approval id, instance, and step are required")
+	}
+	if req.RequiredApprovals <= 0 {
+		req.RequiredApprovals = 1
+	}
+	if req.Status == "" {
+		req.Status = ApprovalPending
+	}
+	if req.CreatedAt.IsZero() {
+		req.CreatedAt = time.Now().UTC()
+	}
+	approvers, _ := json.Marshal(req.Approvers)
+	delegates, _ := json.Marshal(req.Delegates)
+	fields, _ := json.Marshal(req.Fields)
+	_, err := c.db.ExecContext(ctx, `INSERT INTO approval_requests
+		(id, workflow_instance_id, task_id, workflow_id, step_id, message, approvers, delegates, required_approvals, fields, status, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(workflow_instance_id, step_id) DO NOTHING`,
+		req.ID, req.WorkflowInstanceID, nullStr(req.TaskID), nullStr(req.WorkflowID), req.StepID, nullStr(req.Message), string(approvers), string(delegates), req.RequiredApprovals, string(fields), req.Status, req.CreatedAt, req.ExpiresAt)
+	return err
+}
+
+func (c *Client) GetApprovalRequest(ctx context.Context, id string) (*ApprovalRequest, error) {
+	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE id=?`, id))
+}
+func (c *Client) GetApprovalByInstance(ctx context.Context, id string) (*ApprovalRequest, error) {
+	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE workflow_instance_id=? ORDER BY created_at DESC LIMIT 1`, id))
+}
+func (c *Client) ListApprovalRequests(ctx context.Context, status string, limit int) ([]ApprovalRequest, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	query := approvalSelect
+	args := []any{}
+	if status != "" {
+		query += ` WHERE status=?`
+		args = append(args, status)
+	}
+	query += ` ORDER BY created_at DESC LIMIT ?`
+	args = append(args, limit)
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ApprovalRequest
+	for rows.Next() {
+		req, err := scanApprovalRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *req)
+	}
+	return out, rows.Err()
+}
+
+func (c *Client) ResolveApprovalRequest(ctx context.Context, id string, response ApprovalResponse) (*ApprovalRequest, bool, error) {
+	status := ApprovalApproved
+	if strings.EqualFold(response.Decision, "reject") || strings.EqualFold(response.Decision, "rejected") {
+		status = ApprovalRejected
+	}
+	values, err := json.Marshal(response.Values)
+	if err != nil {
+		return nil, false, err
+	}
+	if response.IdempotencyKey == "" {
+		return nil, false, fmt.Errorf("idempotency key is required")
+	}
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback()
+	var current string
+	var required int
+	if err := tx.QueryRowContext(ctx, `SELECT status, required_approvals FROM approval_requests WHERE id=?`, id).Scan(&current, &required); err != nil {
+		return nil, false, err
+	}
+	if current != ApprovalPending && current != ApprovalEscalated {
+		tx.Rollback()
+		req, getErr := c.GetApprovalRequest(ctx, id)
+		return req, false, getErr
+	}
+	now := time.Now().UTC()
+	approver := response.Approver
+	if approver == "" {
+		approver = response.Actor
+	}
+	res, err := tx.ExecContext(ctx, `INSERT INTO approval_responses (request_id, decision, actor, approver, channel, idempotency_key, feedback, values_json, created_at) VALUES (?,?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING`, id, status, response.Actor, approver, response.Channel, response.IdempotencyKey, nullStr(response.Feedback), string(values), now)
+	if err != nil {
+		return nil, false, err
+	}
+	inserted, _ := res.RowsAffected()
+	if inserted == 0 {
+		tx.Rollback()
+		req, getErr := c.GetApprovalRequest(ctx, id)
+		return req, false, getErr
+	}
+	resolved := status == ApprovalRejected
+	if !resolved {
+		var approvals int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM approval_responses WHERE request_id=? AND decision=?`, id, ApprovalApproved).Scan(&approvals); err != nil {
+			return nil, false, err
+		}
+		resolved = approvals >= required
+	}
+	if resolved {
+		if _, err := tx.ExecContext(ctx, `UPDATE approval_requests SET status=?, response_values=?, feedback=?, responded_by=?, response_channel=?, idempotency_key=?, responded_at=? WHERE id=? AND status IN (?,?)`, status, string(values), nullStr(response.Feedback), response.Actor, response.Channel, response.IdempotencyKey, now, id, ApprovalPending, ApprovalEscalated); err != nil {
+			return nil, false, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	req, getErr := c.GetApprovalRequest(ctx, id)
+	return req, resolved, getErr
+}
+func (c *Client) MarkApprovalTimedOut(ctx context.Context, id string) (bool, error) {
+	return c.updateApprovalStatus(ctx, id, ApprovalTimedOut, ApprovalPending, ApprovalEscalated)
+}
+func (c *Client) MarkApprovalReminded(ctx context.Context, id string) (bool, error) {
+	res, err := c.db.ExecContext(ctx, `UPDATE approval_requests SET reminded_at=? WHERE id=? AND status IN (?,?) AND reminded_at IS NULL`, time.Now().UTC(), id, ApprovalPending, ApprovalEscalated)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+func (c *Client) EscalateApproval(ctx context.Context, id string) (bool, error) {
+	res, err := c.db.ExecContext(ctx, `UPDATE approval_requests SET status=?, escalated_at=? WHERE id=? AND status=?`, ApprovalEscalated, time.Now().UTC(), id, ApprovalPending)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+func (c *Client) updateApprovalStatus(ctx context.Context, id, status string, from ...string) (bool, error) {
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(from)), ",")
+	args := []any{status, time.Now().UTC(), id}
+	for _, s := range from {
+		args = append(args, s)
+	}
+	res, err := c.db.ExecContext(ctx, `UPDATE approval_requests SET status=?, responded_at=? WHERE id=? AND status IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}
+
+const approvalSelect = `SELECT id, workflow_instance_id, COALESCE(task_id,''), COALESCE(workflow_id,''), step_id, COALESCE(message,''), approvers, delegates, required_approvals, fields, status, response_values, COALESCE(feedback,''), COALESCE(responded_by,''), COALESCE(response_channel,''), COALESCE(idempotency_key,''), created_at, expires_at, reminded_at, escalated_at, responded_at FROM approval_requests`
+
+type approvalScanner interface{ Scan(...any) error }
+
+func (c *Client) scanApproval(row approvalScanner) (*ApprovalRequest, error) {
+	req, err := scanApprovalRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return req, err
+}
+func scanApprovalRow(row approvalScanner) (*ApprovalRequest, error) {
+	var req ApprovalRequest
+	var approvers, delegates, fields, values string
+	err := row.Scan(&req.ID, &req.WorkflowInstanceID, &req.TaskID, &req.WorkflowID, &req.StepID, &req.Message, &approvers, &delegates, &req.RequiredApprovals, &fields, &req.Status, &values, &req.Feedback, &req.RespondedBy, &req.ResponseChannel, &req.IdempotencyKey, &req.CreatedAt, &req.ExpiresAt, &req.RemindedAt, &req.EscalatedAt, &req.RespondedAt)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal([]byte(approvers), &req.Approvers)
+	_ = json.Unmarshal([]byte(delegates), &req.Delegates)
+	_ = json.Unmarshal([]byte(fields), &req.Fields)
+	_ = json.Unmarshal([]byte(values), &req.Values)
+	return &req, nil
+}
+func (c *Client) getApprovalByKey(ctx context.Context, key string) (*ApprovalRequest, error) {
+	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE idempotency_key=?`, key))
+}

--- a/src/internal/db/approval_store_test.go
+++ b/src/internal/db/approval_store_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestApprovalRequestAtomicIdempotentResolution(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	req := &ApprovalRequest{ID: "inst:gate", WorkflowInstanceID: "inst", TaskID: "task", WorkflowID: "deploy", StepID: "gate", Approvers: []string{"alice"}, Fields: []map[string]any{{"name": "ticket", "required": true}}}
+	if err := c.CreateApprovalRequest(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	var wins atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, won, err := c.ResolveApprovalRequest(ctx, req.ID, ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "webhook", IdempotencyKey: fmt.Sprintf("key-%d", i), Values: map[string]any{"ticket": "OPS-7"}})
+			if err != nil {
+				t.Errorf("resolve: %v", err)
+			}
+			if won {
+				wins.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if wins.Load() != 1 {
+		t.Fatalf("wins=%d, want 1", wins.Load())
+	}
+	stored, err := c.GetApprovalRequest(ctx, req.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != ApprovalApproved || stored.RespondedBy != "alice" {
+		t.Fatalf("stored=%+v", stored)
+	}
+}
+
+func TestApprovalRequestDuplicateIdempotencyKeyDoesNotAdvanceAnotherRequest(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	for _, id := range []string{"one", "two"} {
+		if err := c.CreateApprovalRequest(ctx, &ApprovalRequest{ID: id, WorkflowInstanceID: id, StepID: "gate"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	response := ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "webhook", IdempotencyKey: "delivery-1"}
+	if _, won, err := c.ResolveApprovalRequest(ctx, "one", response); err != nil || !won {
+		t.Fatalf("first: won=%v err=%v", won, err)
+	}
+	_, won, err := c.ResolveApprovalRequest(ctx, "two", response)
+	if err != nil || won {
+		t.Fatalf("duplicate: won=%v err=%v", won, err)
+	}
+	two, _ := c.GetApprovalRequest(ctx, "two")
+	if two.Status != ApprovalPending {
+		t.Fatalf("second status=%s", two.Status)
+	}
+}
+
+func TestApprovalRequestRequiresConfiguredQuorum(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	req := &ApprovalRequest{ID: "quorum", WorkflowInstanceID: "quorum-inst", StepID: "gate", Approvers: []string{"alice", "bob"}, RequiredApprovals: 2}
+	if err := c.CreateApprovalRequest(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	stored, resolved, err := c.ResolveApprovalRequest(ctx, req.ID, ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "webhook", IdempotencyKey: "a"})
+	if err != nil || resolved || stored.Status != ApprovalPending {
+		t.Fatalf("first response resolved=%v status=%s err=%v", resolved, stored.Status, err)
+	}
+	stored, resolved, err = c.ResolveApprovalRequest(ctx, req.ID, ApprovalResponse{Decision: "approve", Actor: "bob", Channel: "dashboard", IdempotencyKey: "b"})
+	if err != nil || !resolved || stored.Status != ApprovalApproved {
+		t.Fatalf("quorum resolved=%v status=%s err=%v", resolved, stored.Status, err)
+	}
+}
+
+func TestApprovalReminderAndEscalationAreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	req := &ApprovalRequest{ID: "timers", WorkflowInstanceID: "timers", StepID: "gate"}
+	if err := c.CreateApprovalRequest(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	if won, err := c.MarkApprovalReminded(ctx, req.ID); err != nil || !won {
+		t.Fatalf("reminder won=%v err=%v", won, err)
+	}
+	if won, _ := c.MarkApprovalReminded(ctx, req.ID); won {
+		t.Fatal("duplicate reminder won")
+	}
+	if won, err := c.EscalateApproval(ctx, req.ID); err != nil || !won {
+		t.Fatalf("escalation won=%v err=%v", won, err)
+	}
+	stored, _ := c.GetApprovalRequest(ctx, req.ID)
+	if stored.Status != ApprovalEscalated || stored.RemindedAt == nil || stored.EscalatedAt == nil {
+		t.Fatalf("stored=%+v", stored)
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -230,6 +230,27 @@ CREATE INDEX IF NOT EXISTS idx_service_logs_timestamp ON service_logs(timestamp 
 CREATE INDEX IF NOT EXISTS idx_execution_events_task ON execution_events(task_id, id);
 CREATE INDEX IF NOT EXISTS idx_execution_events_instance ON execution_events(workflow_instance_id, id);
 CREATE INDEX IF NOT EXISTS idx_execution_events_type ON execution_events(type, id);
+
+CREATE TABLE IF NOT EXISTS approval_requests (
+  id TEXT PRIMARY KEY,
+  workflow_instance_id TEXT NOT NULL,
+  task_id TEXT, workflow_id TEXT, step_id TEXT NOT NULL, message TEXT,
+  approvers TEXT NOT NULL DEFAULT '[]', delegates TEXT NOT NULL DEFAULT '{}', required_approvals INTEGER NOT NULL DEFAULT 1, fields TEXT NOT NULL DEFAULT '[]',
+  status TEXT NOT NULL DEFAULT 'pending', response_values TEXT NOT NULL DEFAULT '{}',
+  feedback TEXT, responded_by TEXT, response_channel TEXT,
+  idempotency_key TEXT UNIQUE, created_at DATETIME NOT NULL, expires_at DATETIME,
+  reminded_at DATETIME, escalated_at DATETIME, responded_at DATETIME,
+  UNIQUE(workflow_instance_id, step_id)
+);
+CREATE TABLE IF NOT EXISTS approval_responses (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  request_id TEXT NOT NULL, decision TEXT NOT NULL, actor TEXT NOT NULL, approver TEXT NOT NULL,
+  channel TEXT NOT NULL, idempotency_key TEXT NOT NULL UNIQUE,
+  feedback TEXT, values_json TEXT NOT NULL DEFAULT '{}', created_at DATETIME NOT NULL,
+  UNIQUE(request_id, approver), FOREIGN KEY(request_id) REFERENCES approval_requests(id)
+);
+CREATE INDEX IF NOT EXISTS idx_approval_requests_status ON approval_requests(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_approval_requests_instance ON approval_requests(workflow_instance_id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_state ON workflow_instances(state);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_cell ON workflow_instances(cell_id);
 CREATE INDEX IF NOT EXISTS idx_wf_instances_parent ON workflow_instances(parent_instance_id);

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -30,6 +30,11 @@ const (
 // waiting, given the live task. resume_on takes precedence over abort_on when
 // both would match (an explicit approval wins).
 func EvaluateApproval(step config.StepConfig, cell model.SourceItem) ApprovalDecision {
+	// Explicit approvers require an authenticated dashboard/webhook response;
+	// legacy source comments have no author identity and cannot satisfy policy.
+	if len(step.Approvers) > 0 {
+		return ApprovalWait
+	}
 	if step.ResumeOn != nil && matchApprovalTrigger(*step.ResumeOn, cell) {
 		return ApprovalResume
 	}
@@ -117,6 +122,39 @@ func (e *Engine) ParkedApprovals() []ParkedApproval {
 // terminal or suspended state. Returns whether the instance then completed
 // successfully. It errors if the instance is not currently awaiting approval.
 func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decision ApprovalDecision) (bool, error) {
+	name := "approve"
+	if decision == ApprovalAbort {
+		name = "reject"
+	}
+	response := db.ApprovalResponse{Decision: name, Actor: "source-trigger", Channel: "source", IdempotencyKey: "source:" + instanceID + ":" + name}
+	if store, ok := e.store.(approvalRequestStore); ok {
+		if req, _ := store.GetApprovalByInstance(ctx, instanceID); req != nil {
+			stored, won, err := store.ResolveApprovalRequest(ctx, req.ID, response)
+			if err != nil {
+				return false, err
+			}
+			if !won && stored != nil {
+				if stored.Status == db.ApprovalPending || stored.Status == db.ApprovalEscalated {
+					return false, nil
+				}
+				response.Decision = "reject"
+				if stored.Status == db.ApprovalApproved {
+					response.Decision = "approve"
+				}
+				response.Actor, response.Channel, response.Feedback, response.Values = stored.RespondedBy, stored.ResponseChannel, stored.Feedback, stored.Values
+			}
+		}
+	}
+	return e.ResolveApprovalResponse(ctx, instanceID, response)
+}
+
+// ResolveApprovalResponse applies a persisted multi-channel response and exposes
+// its feedback and values to subsequent steps as approval.<field> memory values.
+func (e *Engine) ResolveApprovalResponse(ctx context.Context, instanceID string, response db.ApprovalResponse) (bool, error) {
+	decision := ApprovalResume
+	if strings.EqualFold(response.Decision, "reject") || strings.EqualFold(response.Decision, "rejected") {
+		decision = ApprovalAbort
+	}
 	e.mu.Lock()
 	r, ok := e.parked[instanceID]
 	if ok {
@@ -131,7 +169,16 @@ func (e *Engine) ResolveApproval(ctx context.Context, instanceID string, decisio
 	if decision == ApprovalAbort {
 		eventType, decisionName = "approval.rejected", "abort"
 	}
-	e.recordExecutionEvent(ctx, r, eventType, map[string]any{"decision": decisionName})
+	metadata := map[string]any{"decision": decisionName, "actor": response.Actor, "channel": response.Channel, "feedback": response.Feedback, "values": response.Values}
+	e.recordExecutionEvent(ctx, r, eventType, metadata)
+	stepID := r.waitingStep
+	structured := map[string]any{"approval_decision": decisionName, "approval_feedback": response.Feedback}
+	write := []string{"approval_decision", "approval_feedback"}
+	for key, value := range response.Values {
+		structured[key] = value
+		write = append(write, key)
+	}
+	r.contrib[stepID] = MemoryStep{StepID: stepID, WriteFields: write, Structured: structured, Summary: response.Feedback}
 
 	r.resolveApproval(decision)
 	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
@@ -171,8 +218,50 @@ func (e *Engine) RecheckApproval(ctx context.Context, instanceID string, poll fu
 	if step.StepType() != config.StepTypeApproval {
 		return ApprovalWait
 	}
+	if raw := step.RemindAfter; raw != "" {
+		if after, err := time.ParseDuration(raw); err == nil && e.now().Sub(parkedAt) >= after {
+			if store, ok := e.store.(approvalRequestStore); ok {
+				if req, _ := store.GetApprovalByInstance(ctx, instanceID); req != nil {
+					won, _ := store.MarkApprovalReminded(ctx, req.ID)
+					if won {
+						e.recordExecutionEvent(ctx, r, "approval.reminder", map[string]any{"request_id": req.ID, "approvers": step.Approvers})
+						for _, provider := range e.approvalProviders {
+							if lifecycle, ok := provider.(ApprovalLifecycleProvider); ok {
+								_ = lifecycle.RemindApproval(ctx, req)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if raw := step.EscalateAfter; raw != "" {
+		if after, err := time.ParseDuration(raw); err == nil && e.now().Sub(parkedAt) >= after {
+			if store, ok := e.store.(approvalRequestStore); ok {
+				if req, _ := store.GetApprovalByInstance(ctx, instanceID); req != nil {
+					won, _ := store.EscalateApproval(ctx, req.ID)
+					if won {
+						e.recordExecutionEvent(ctx, r, "approval.escalated", map[string]any{"request_id": req.ID, "escalate_to": step.EscalateTo})
+						for _, provider := range e.approvalProviders {
+							if lifecycle, ok := provider.(ApprovalLifecycleProvider); ok {
+								_ = lifecycle.EscalateApproval(ctx, req, step.EscalateTo)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 	if to := step.ParsedTimeout(); to > 0 && e.now().Sub(parkedAt) >= to {
 		aplog.Info("workflow: approval on instance %s timed out after %s — aborting", instanceID, to)
+		if store, ok := e.store.(approvalRequestStore); ok {
+			if req, _ := store.GetApprovalByInstance(ctx, instanceID); req != nil {
+				won, _ := store.MarkApprovalTimedOut(ctx, req.ID)
+				if won {
+					e.recordExecutionEvent(ctx, r, "approval.timed_out", map[string]any{"request_id": req.ID, "timeout": to.String()})
+				}
+			}
+		}
 		return ApprovalAbort
 	}
 	for _, b := range bindings {
@@ -207,6 +296,7 @@ func (e *Engine) CheckParkedApprovals(ctx context.Context, poll func(sourceID, s
 	for _, p := range e.ParkedApprovals() {
 		if to := p.Step.ParsedTimeout(); to > 0 && e.now().Sub(p.ParkedAt) >= to {
 			aplog.Info("workflow: approval on instance %s timed out after %s — aborting", p.InstanceID, to)
+			_ = e.RecheckApproval(ctx, p.InstanceID, poll) // persists timeout + audit event
 			_, _ = e.ResolveApproval(ctx, p.InstanceID, ApprovalAbort)
 			continue
 		}

--- a/src/internal/workflow/approval_test.go
+++ b/src/internal/workflow/approval_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +11,13 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 )
+
+type recordingApprovalProvider struct{ requests []*db.ApprovalRequest }
+
+func (p *recordingApprovalProvider) RequestApproval(_ context.Context, req *db.ApprovalRequest) error {
+	p.requests = append(p.requests, req)
+	return nil
+}
 
 func TestEvaluateApproval_Conditions(t *testing.T) {
 	step := config.StepConfig{
@@ -81,6 +90,99 @@ func TestApproval_SuspendsAtApprovalStep(t *testing.T) {
 	}
 }
 
+func TestApprovalProviderReceivesTransportNeutralRequest(t *testing.T) {
+	provider := &recordingApprovalProvider{}
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := NewEngine(cfg, store, exec, WithSideEffects(&fakeSide{}), WithApprovalProvider(provider), WithIDGen(func(prefix string) string { return prefix + "-1" }))
+	wf := approvalWorkflow()
+	wf.Steps[1].Approvers = []string{"alice"}
+	wf.Steps[1].RequiredApprovals = 1
+	wf.Steps[1].ApprovalFields = []config.ApprovalField{{Name: "ticket", Required: true}}
+	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "task"})
+	if len(provider.requests) != 1 {
+		t.Fatalf("requests=%d", len(provider.requests))
+	}
+	req := provider.requests[0]
+	if req.WorkflowInstanceID != instID || req.ID != instID+":gate" || req.Approvers[0] != "alice" {
+		t.Fatalf("request=%+v", req)
+	}
+}
+
+func TestApprovalAuditEventsPersistForRequestAndGrant(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "approval-events.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbc.Close()
+	exec := &fakeExecutor{}
+	eng := NewEngine(baseCfg(), dbc, exec, WithSideEffects(&fakeSide{}), WithIDGen(func(prefix string) string { return prefix + "-audit" }))
+	wf := approvalWorkflow()
+	wf.Steps[1].Approvers = []string{"alice"}
+	wf.Steps[1].ResumeOn = nil
+	instID, _, _ := eng.RunInstance(ctx, wf, model.InternalTask{ID: "task-audit"})
+	req, err := dbc.GetApprovalByInstance(ctx, instID)
+	if err != nil || req == nil {
+		t.Fatalf("request=%+v err=%v", req, err)
+	}
+	response := db.ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "webhook", IdempotencyKey: "audit-delivery"}
+	if _, won, err := dbc.ResolveApprovalRequest(ctx, req.ID, response); err != nil || !won {
+		t.Fatalf("persist response: won=%v err=%v", won, err)
+	}
+	if _, err := eng.ResolveApprovalResponse(ctx, instID, response); err != nil {
+		t.Fatal(err)
+	}
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "task-audit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, event := range events {
+		seen[event.Type] = true
+	}
+	if !seen["approval.requested"] || !seen["approval.granted"] {
+		t.Fatalf("events=%+v", events)
+	}
+}
+
+func TestApprovalTimeoutPersistsAndCannotResume(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "approval-timeout.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbc.Close()
+	clock := time.Unix(1000, 0)
+	eng := NewEngine(baseCfg(), dbc, &fakeExecutor{}, WithSideEffects(&fakeSide{}), WithClock(func() time.Time { return clock }), WithIDGen(func(prefix string) string { return prefix + "-timeout" }))
+	wf := approvalWorkflow()
+	wf.Steps[1].Approvers = []string{"alice"}
+	wf.Steps[1].ResumeOn = nil
+	wf.Steps[1].Timeout = "1h"
+	instID, _, _ := eng.RunInstance(ctx, wf, model.InternalTask{ID: "task-timeout"})
+	clock = clock.Add(2 * time.Hour)
+	decision := eng.RecheckApproval(ctx, instID, func(string, string) (model.SourceItem, error) { return model.SourceItem{}, nil })
+	if decision != ApprovalAbort {
+		t.Fatalf("decision=%v", decision)
+	}
+	if success, err := eng.ResolveApproval(ctx, instID, decision); err != nil || success {
+		t.Fatalf("resolve success=%v err=%v", success, err)
+	}
+	inst, _ := dbc.GetWorkflowInstance(ctx, instID)
+	if inst.State != db.InstanceStateFailed {
+		t.Fatalf("instance state=%s", inst.State)
+	}
+	req, _ := dbc.GetApprovalByInstance(ctx, instID)
+	if req.Status != db.ApprovalTimedOut {
+		t.Fatalf("request status=%s", req.Status)
+	}
+	events, _ := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "task-timeout", Type: "approval.timed_out"})
+	if len(events) != 1 {
+		t.Fatalf("timeout events=%d", len(events))
+	}
+}
+
 func TestApproval_ResumeContinuesWorkflow(t *testing.T) {
 	cfg := baseCfg()
 	store := newFakeStore()
@@ -105,6 +207,27 @@ func TestApproval_ResumeContinuesWorkflow(t *testing.T) {
 	// No longer parked.
 	if len(eng.ParkedApprovals()) != 0 {
 		t.Error("instance should no longer be parked")
+	}
+}
+
+func TestApproval_ResponseFeedbackFlowsToNextStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+	instID, _, _ := eng.RunInstance(context.Background(), approvalWorkflow(), model.InternalTask{ID: "c1"})
+	response := db.ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "webhook", Feedback: "Ship during the maintenance window", Values: map[string]any{"change_ticket": "OPS-7"}}
+	if success, err := eng.ResolveApprovalResponse(context.Background(), instID, response); err != nil || !success {
+		t.Fatalf("resolve: success=%v err=%v", success, err)
+	}
+	var prompt string
+	for _, seen := range exec.seen {
+		if seen.Step.ID == "implement" {
+			prompt = seen.MemoryDoc
+		}
+	}
+	if !strings.Contains(prompt, "OPS-7") || !strings.Contains(prompt, "Ship during the maintenance window") {
+		t.Fatalf("approval response missing from next-step memory:\n%s", prompt)
 	}
 }
 

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -9,6 +9,7 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -457,7 +458,26 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 	r.state[step.ID] = stWaiting
 	r.waitingStep = step.ID
 	r.parkedAt = e.now()
-	e.recordExecutionEvent(ctx, r, "approval.requested", map[string]any{"message": step.Message})
+	requestID := r.instID + ":" + step.ID
+	fields := make([]map[string]any, 0, len(step.ApprovalFields))
+	for _, f := range step.ApprovalFields {
+		fields = append(fields, map[string]any{"name": f.Name, "label": f.Label, "type": f.Type, "required": f.Required, "options": f.Options})
+	}
+	var expires *time.Time
+	if timeout := step.ParsedTimeout(); timeout > 0 {
+		deadline := r.parkedAt.Add(timeout)
+		expires = &deadline
+	}
+	request := &db.ApprovalRequest{ID: requestID, WorkflowInstanceID: r.instID, TaskID: r.task.ID, WorkflowID: r.wf.ID, StepID: step.ID, Message: step.Message, Approvers: step.Approvers, Delegates: step.Delegates, RequiredApprovals: step.RequiredApprovals, Fields: fields, CreatedAt: r.parkedAt, ExpiresAt: expires}
+	if store, ok := e.store.(approvalRequestStore); ok {
+		_ = store.CreateApprovalRequest(ctx, request)
+	}
+	for _, provider := range e.approvalProviders {
+		if err := provider.RequestApproval(ctx, request); err != nil {
+			aplog.Warn("workflow: approval provider for %s: %v", requestID, err)
+		}
+	}
+	e.recordExecutionEvent(ctx, r, "approval.requested", map[string]any{"request_id": requestID, "message": step.Message, "approvers": step.Approvers, "fields": fields})
 	aplog.Info("workflow %s: instance %s parked at approval step %q", r.wf.ID, r.instID, step.ID)
 }
 

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -50,6 +50,15 @@ type executionEventRecorder interface {
 	RecordExecutionEvent(context.Context, *db.ExecutionEvent) error
 }
 
+type approvalRequestStore interface {
+	CreateApprovalRequest(context.Context, *db.ApprovalRequest) error
+	GetApprovalByInstance(context.Context, string) (*db.ApprovalRequest, error)
+	MarkApprovalTimedOut(context.Context, string) (bool, error)
+	MarkApprovalReminded(context.Context, string) (bool, error)
+	EscalateApproval(context.Context, string) (bool, error)
+	ResolveApprovalRequest(context.Context, string, db.ApprovalResponse) (*db.ApprovalRequest, bool, error)
+}
+
 func (e *Engine) recordExecutionEvent(ctx context.Context, r *dagRun, eventType string, metadata map[string]any) {
 	recorder, ok := e.store.(executionEventRecorder)
 	if !ok || r == nil {
@@ -211,6 +220,20 @@ type SideEffects interface {
 	MaterializeChild(ctx context.Context, parent model.InternalTask, parentBindings []model.SourceBinding, child model.InternalTask) error
 }
 
+// ApprovalProvider delivers a provider-neutral approval request to an external
+// transport. Slack, Teams, email, and custom webhooks can implement this without
+// coupling transport behavior to the workflow scheduler.
+type ApprovalProvider interface {
+	RequestApproval(context.Context, *db.ApprovalRequest) error
+}
+
+// ApprovalLifecycleProvider optionally delivers reminders and escalations.
+type ApprovalLifecycleProvider interface {
+	ApprovalProvider
+	RemindApproval(context.Context, *db.ApprovalRequest) error
+	EscalateApproval(context.Context, *db.ApprovalRequest, []string) error
+}
+
 // Engine orchestrates a workflow instance: it persists the instance and its step
 // runs, threads workflow memory between steps, and applies side effects. In
 // Phase 2 it executes agent steps sequentially in declaration order (single-step
@@ -226,16 +249,17 @@ type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (s
 type DependencyChecker func(ctx context.Context, sourceID, sourceItemID, linkType string) ([]source.BlockerRef, error)
 
 type Engine struct {
-	cfg        *config.Config
-	store      Store
-	exec       StepExecutor
-	side       SideEffects
-	mem        MemoryBuilder
-	memStore   MemoryStore
-	spawner    WorkflowSpawner
-	tracker    TaskTracker
-	ciChecker  CIStatusChecker
-	depChecker DependencyChecker
+	cfg               *config.Config
+	store             Store
+	exec              StepExecutor
+	side              SideEffects
+	mem               MemoryBuilder
+	memStore          MemoryStore
+	spawner           WorkflowSpawner
+	tracker           TaskTracker
+	ciChecker         CIStatusChecker
+	depChecker        DependencyChecker
+	approvalProviders []ApprovalProvider
 
 	now   func() time.Time
 	newID func(prefix string) string
@@ -284,6 +308,15 @@ func WithCIStatusChecker(checker CIStatusChecker) Option {
 // kind "dependency".
 func WithDependencyChecker(checker DependencyChecker) Option {
 	return func(e *Engine) { e.depChecker = checker }
+}
+
+// WithApprovalProvider registers an external approval request transport.
+func WithApprovalProvider(provider ApprovalProvider) Option {
+	return func(e *Engine) {
+		if provider != nil {
+			e.approvalProviders = append(e.approvalProviders, provider)
+		}
+	}
 }
 
 // NewEngine builds an Engine. cfg, store, and exec are required.


### PR DESCRIPTION
Closes #212

## Summary
- add durable, auditable approval requests with quorum, delegation, structured fields, reminders, escalation, and timeout handling
- add transport-neutral approval providers plus authenticated local and signed webhook response endpoints
- expose pending approvals in the dashboard and enforce approval policies for sensitive workflow actions
- document the approval model and archive the completed OpenSpec change

## Test plan
- [x] `make check`
- [x] `make vet`
- [x] `go test -race ./internal/config ./internal/db ./internal/workflow ./internal/daemon ./internal/dashboard`