### PR TITLE
feat: add versioned plugin SDK

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,14 @@ give you live validation and autocomplete while editing.
 version: "1"        # currently the only accepted value
 ```
 
+## Plugins
+
+Out-of-process extensions are discovered through `plugin_dirs` and enabled in
+the top-level `plugins` list. `apiary validate` checks installed manifests,
+Apiary/protocol compatibility, and each enabled instance's configuration schema.
+See [Out-of-process plugins](plugins.md) for the manifest, protocol, CLI, and
+security model.
+
 ## `runners`
 
 Runners define **how** agents execute — a CLI subprocess (`claude`,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,152 @@
+# Out-of-process plugins
+
+Apiary protocol 1 runs third-party extensions as child processes instead of
+loading Go binaries. A plugin crash, invalid response, or timeout terminates only
+that invocation; it does not crash the dispatcher. Plugins are never executed
+during discovery or configuration validation.
+
+## Install and enable
+
+An installed plugin is a directory containing `apiary-plugin.json` and the
+executable named by that manifest. The default search directory is
+`.apiary/plugins` beside `apiary.yaml`; `plugin_dirs` overrides it.
+
+```yaml
+plugin_dirs:
+  - .apiary/plugins
+  - ~/.local/share/apiary/plugins
+
+plugins:
+  - id: dev.apiary.event-file
+    enabled: true                 # omitted means true
+    timeout: 5s                   # default: 10s, per invocation
+    config:
+      path: .apiary/events.jsonl
+```
+
+Use `apiary plugins`, `apiary plugins inspect <id>`, and
+`apiary plugins validate` to inspect installations. `apiary validate` also
+discovers every enabled plugin and validates its configuration against the
+manifest's JSON Schema. Set `enabled: false` to keep an installed/configured
+plugin available without starting or schema-validating it.
+
+Relative plugin directories resolve beside `apiary.yaml`. Discovery is
+deterministic and rejects duplicate IDs rather than choosing one by path order.
+
+## Manifest version 1
+
+```json
+{
+  "schema_version": 1,
+  "id": "dev.apiary.event-file",
+  "version": "1.0.0",
+  "apiary": ">= 0.10.0-0",
+  "protocol": 1,
+  "executable": "apiary-plugin-event-file",
+  "capabilities": ["event_exporter"],
+  "config_schema": {
+    "type": "object",
+    "properties": {"path": {"type": "string", "minLength": 1}},
+    "required": ["path"],
+    "additionalProperties": false
+  },
+  "security": {
+    "network": false,
+    "read_paths": [],
+    "write_paths": ["configured event file"],
+    "secret_env": []
+  }
+}
+```
+
+- `id` is a lowercase reverse-DNS identifier and is stable across releases.
+- `version` follows semantic versioning; `apiary` is a semantic-version constraint.
+- `protocol` must be `1`. Unknown manifest/protocol versions fail closed.
+- `executable` is relative to the plugin directory. Absolute paths, traversal,
+  symlinks, non-regular files, and non-executable files are rejected.
+- `capabilities` accepts `source`, `runner`, `workflow_action`,
+  `approval_provider`, `secret_provider`, and `event_exporter`.
+- `config_schema` supports `type`, `properties`, `required`,
+  `additionalProperties`, `enum`, `items`, `minLength`, `maxLength`, `minimum`,
+  `maximum`, `minItems`, and `maxItems`. Unknown validation keywords fail closed.
+- `security` is an inspectable declaration, not an OS sandbox guarantee.
+
+## Protocol version 1
+
+Apiary starts a fresh process for each invocation, writes one compact JSON object
+plus a newline to stdin, and expects one JSON response on stdout. Diagnostic
+output belongs on stderr. Stdout is limited to 4 MiB and captured stderr to 64
+KiB. The per-instance deadline cancels and terminates the child process.
+
+Request:
+
+```json
+{
+  "protocol": 1,
+  "request_id": "1784736000000000000",
+  "capability": "event_exporter",
+  "method": "export",
+  "config": {"path": ".apiary/events.jsonl"},
+  "payload": {"schema_version": 1, "type": "runner.started"}
+}
+```
+
+Success and failure responses echo the request ID:
+
+```json
+{"protocol":1,"request_id":"1784736000000000000","result":{"written":true}}
+{"protocol":1,"request_id":"1784736000000000000","error":{"code":"write_failed","message":"permission denied"}}
+```
+
+Capability method vocabulary:
+
+| Capability | Protocol methods |
+|---|---|
+| `source` | `connect`, `poll`, `acknowledge`, `write_result`, plus optional source capabilities |
+| `runner` | `configure`, `run` |
+| `workflow_action` | `run` |
+| `approval_provider` | `notify`, `remind`, `escalate` |
+| `secret_provider` | `resolve` |
+| `event_exporter` | `export` |
+
+Protocol envelopes are stable; capability payloads use the corresponding
+versioned Apiary internal contract. The first runtime integration is
+`event_exporter`. The remaining capability names reserve the same manifest and
+transport boundary for their proxies without requiring a new installation model.
+
+Go plugin authors can import `github.com/orlandoburli/apiary/sdk/plugin` and call
+`plugin.Main(handler)`. The SDK decodes one request, rejects protocol mismatches,
+echoes the request ID, and emits the structured response envelope. Plugins in
+other languages can implement the JSON examples above directly.
+
+## Trust and secrets
+
+Plugins execute with the Apiary service account's OS permissions. Before install:
+
+1. Obtain the binary from a trusted publisher.
+2. Verify its checksum and signature out of band.
+3. Inspect the manifest's network, path, and secret requirements.
+4. Install into a directory writable only by the Apiary operator/service account.
+
+Apiary does not download or auto-upgrade plugins. Upgrade atomically by verifying
+the new artifact in a staging directory, stopping Apiary, replacing the complete
+plugin directory, running `apiary plugins validate`, and restarting. Keep the old
+directory for rollback, but never leave two versions with the same ID in searched
+directories.
+
+Child processes receive a minimal environment (`PATH`, home/temp/locale/timezone)
+plus only variables listed in `security.secret_env`. Secret values are never
+included in protocol requests or error messages. Plugin configuration should
+contain references or non-secret options, not credentials. Event exporters
+receive the persisted event after Apiary's metadata redaction.
+
+Process isolation is not a security sandbox: a malicious executable can still use
+the service account's filesystem and network access. Use OS-level sandboxing,
+containers, restricted service users, and egress controls where the trust level
+requires them.
+
+## Reference plugin
+
+`src/examples/plugins/event-file` demonstrates an `event_exporter` that appends one
+redacted event JSON object per line. Its README contains build and installation
+commands.

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 2026-07-22
 
+- **versioned-plugin-sdk** — Versioned out-of-process plugin manifest and JSON protocol with discovery, compatibility/capability checks, schema-backed configuration validation, isolated execution, CLI inspection, and a reference plugin. GitHub issue #213.
 - **multi-channel-human-approvals** — First-class human-in-the-loop approval requests with structured fields, authorized quorum/delegation, dashboard and signed webhook responses, idempotent resolution, escalation, sensitive-action policies, and rejection feedback. GitHub issue #212.
 - **structured-execution-events** — Versioned, redacted execution events with persisted queries, live SSE subscriptions, route/fallback reasons, retention, CLI history, and a dashboard task timeline. GitHub issue #211.
 - **reusable-typed-subworkflows** — Reusable local workflow files with typed inputs and outputs, cycle-safe resolution, linked nested execution history, and explicit failure/cancellation semantics. GitHub issue #210.

--- a/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/design.md
+++ b/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/design.md
@@ -1,0 +1,42 @@
+# Design: versioned plugin SDK
+
+## Manifest and discovery
+
+Each installed plugin occupies one directory containing `apiary-plugin.json` and
+its executable. The manifest declares a reverse-DNS ID, semantic version, Apiary
+version constraint, protocol version, executable, capabilities, configuration
+JSON Schema, and security requirements. Apiary searches configured plugin
+directories deterministically and rejects duplicate IDs.
+
+The top-level `plugins` configuration enables installed plugins by ID and supplies
+instance configuration. Disabled entries remain inspectable but are not started
+or schema-validated.
+
+## Protocol
+
+Protocol `1` is newline-delimited JSON over stdin/stdout. Apiary starts a fresh
+child process per invocation, sends one envelope containing protocol, request ID,
+capability, method, configuration, and payload, then reads one response envelope.
+The child must return the same request ID and either a result or structured error.
+
+Per-invocation processes deliberately trade startup cost for strong crash and
+state isolation. Context cancellation and configured deadlines terminate only the
+plugin process. Stderr is captured separately and truncated in reported errors;
+stdout is bounded before decoding.
+
+## Compatibility and validation
+
+- Manifests use semantic versions and an Apiary compatibility constraint.
+- Unknown protocol versions, capabilities, malformed schemas, unsafe executable
+  paths, duplicate IDs, and incompatible Apiary versions fail with remediation.
+- A small built-in JSON Schema validator supports the manifest subset used by
+  plugin configuration: type, properties, required, additionalProperties, enum,
+  items, and scalar bounds. Unsupported schema keywords fail closed.
+
+## Security
+
+Discovery never executes a plugin. Enabling is explicit. Executables must resolve
+inside the plugin directory and may not be symlinks. Only explicitly named secret
+environment variables are forwarded, and their values never appear in protocol
+payloads or diagnostics. Installation and upgrade remain operator-controlled file
+operations with checksum/signature verification documented as a trust boundary.

--- a/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/proposal.md
+++ b/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/proposal.md
@@ -1,0 +1,25 @@
+# Versioned plugin SDK and extension manifest
+
+## Motivation
+
+Apiary's source and runner extension contracts are currently Go interfaces backed
+by statically registered factories. Adding every integration to the core binary
+would couple unrelated release cycles and let third-party failures affect the
+dispatcher process.
+
+## Scope
+
+- Define a versioned plugin manifest for sources, runners, workflow actions,
+  approval providers, secret providers, and event exporters.
+- Discover installed plugins from explicit directories, validate compatibility
+  and capabilities, and expose inspection through the CLI.
+- Validate enabled plugin configuration against each manifest's JSON Schema as
+  part of `apiary validate`.
+- Define a newline-delimited JSON request/response protocol over child-process
+  stdio with deadlines, bounded output, and crash isolation.
+- Include a reference event-exporter plugin and document installation, trust,
+  upgrades, permissions, and secret handling.
+
+Remote registries, automatic binary downloads, sandbox/container provisioning,
+and migration of every built-in integration are deferred. Built-ins continue to
+use the same internal contracts that plugin proxies adapt to.

--- a/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/tasks.md
+++ b/openspec/changes/archive/2026-07-22-versioned-plugin-sdk/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+- [x] Define and validate the versioned plugin manifest and capability vocabulary.
+- [x] Discover deterministic installed plugin directories and reject duplicate IDs.
+- [x] Add enabled plugin configuration and JSON Schema validation to `apiary validate`.
+- [x] Implement bounded, timed, out-of-process JSON protocol invocation.
+- [x] Add CLI list/inspect/validate surfaces for installed plugins.
+- [x] Adapt at least one extension point and provide a runnable reference plugin.
+- [x] Document protocol, trust, installation, upgrade, permission, and secret risks.
+- [x] Add manifest, schema, discovery, process failure, timeout, CLI, and integration tests.
+- [x] Run repository gates, GitNexus change detection, and archive the change.

--- a/openspec/specs/plugin-api/spec.md
+++ b/openspec/specs/plugin-api/spec.md
@@ -1,6 +1,8 @@
 # Apiary — Plugin API
 
-Apiary is extended through two plugin types: **Source Adapters** and **Runner Adapters**. Both implement Go interfaces.
+Apiary's built-in extensions implement Go interfaces. Third-party extensions use
+the versioned out-of-process protocol documented below and are adapted to the
+same internal contracts.
 
 ## Source Adapter
 
@@ -230,11 +232,24 @@ func main() {
 }
 ```
 
-## External Plugin Protocol (v2 — planned)
+## External Plugin Protocol (manifest 1 / protocol 1)
 
-In v2, Apiary will support out-of-process plugin binaries via a gRPC-based protocol (similar to the Terraform/Vault plugin model). Plugin binaries will be discovered by name convention (`apiary-source-<type>`, `apiary-runner-<type>`) and launched as child processes with a stable gRPC interface.
+External plugins are installed as directories containing `apiary-plugin.json`
+and a relative executable. The manifest declares semantic plugin and Apiary
+compatibility versions, capabilities, configuration JSON Schema, protocol, and
+security requirements. Supported capability IDs are `source`, `runner`,
+`workflow_action`, `approval_provider`, `secret_provider`, and `event_exporter`.
 
-This allows the community to distribute adapters as standalone binaries without forking Apiary.
+Protocol 1 uses one newline-delimited JSON request and response over child-process
+stdin/stdout. Apiary starts a fresh process per invocation, enforces a deadline
+and output bounds, forwards only declared secret environment variables, and
+reports crash/protocol/timeout errors without crashing the dispatcher. Discovery
+and validation never execute plugin code.
+
+The first runtime proxy is `event_exporter`, method `export`, which receives the
+persisted and redacted execution-event envelope. The other capability IDs reserve
+the same manifest and transport boundary for adapters to the Go contracts above.
+See `docs/plugins.md` for the normative field and envelope definitions.
 
 ## Cell Env Vars (for `script` runner)
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -170,6 +170,42 @@
         }
       }
     },
+    "plugin_dirs": {
+      "type": "array",
+      "description": "Directories searched for installed plugin folders. Relative paths resolve beside apiary.yaml; defaults to .apiary/plugins",
+      "items": {"type": "string"}
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Installed out-of-process plugin instances. Omitted enabled defaults to true; disabled plugins remain discoverable but are not started or schema-validated",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Reverse-DNS plugin ID from apiary-plugin.json"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable this plugin instance",
+            "default": true
+          },
+          "timeout": {
+            "type": "string",
+            "description": "Per-invocation deadline as a Go duration",
+            "default": "10s",
+            "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+          },
+          "config": {
+            "type": "object",
+            "description": "Plugin-specific configuration validated against the manifest config_schema",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
     "agents": {
       "type": "array",
       "description": "Agent definitions",

--- a/src/examples/plugins/event-file/README.md
+++ b/src/examples/plugins/event-file/README.md
@@ -1,0 +1,29 @@
+# Event-file reference plugin
+
+This minimal protocol-1 `event_exporter` appends each persisted, redacted Apiary
+execution event to a JSON Lines file.
+
+Build and install it from the repository root:
+
+```bash
+go build -o src/examples/plugins/event-file/apiary-plugin-event-file ./src/examples/plugins/event-file
+mkdir -p .apiary/plugins/dev.apiary.event-file
+cp src/examples/plugins/event-file/apiary-plugin.json \
+  src/examples/plugins/event-file/apiary-plugin-event-file \
+  .apiary/plugins/dev.apiary.event-file/
+apiary plugins validate
+```
+
+Then enable it in `apiary.yaml`:
+
+```yaml
+plugins:
+  - id: dev.apiary.event-file
+    timeout: 5s
+    config:
+      path: .apiary/events.jsonl
+```
+
+The plugin intentionally has no network access requirement and requests write
+access only to the configured event file. It is a protocol example, not a log
+rotation or delivery-retry service.

--- a/src/examples/plugins/event-file/apiary-plugin.json
+++ b/src/examples/plugins/event-file/apiary-plugin.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "dev.apiary.event-file",
+  "version": "1.0.0",
+  "apiary": ">= 0.10.0-0",
+  "protocol": 1,
+  "executable": "apiary-plugin-event-file",
+  "capabilities": ["event_exporter"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "minLength": 1}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  },
+  "security": {
+    "network": false,
+    "write_paths": ["configured event file"]
+  }
+}

--- a/src/examples/plugins/event-file/main.go
+++ b/src/examples/plugins/event-file/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+func main() {
+	pluginsdk.Main(export)
+}
+
+func export(_ context.Context, req pluginsdk.Request) (any, *pluginsdk.ResponseError) {
+	if req.Capability != pluginsdk.CapabilityEventExporter || req.Method != "export" {
+		return nil, &pluginsdk.ResponseError{Code: "unsupported_method", Message: "expected event_exporter.export"}
+	}
+	path, _ := req.Config["path"].(string)
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, &pluginsdk.ResponseError{Code: "write_failed", Message: err.Error()}
+	}
+	_, err = file.Write(append(req.Payload, '\n'))
+	closeErr := file.Close()
+	if err != nil {
+		return nil, &pluginsdk.ResponseError{Code: "write_failed", Message: err.Error()}
+	}
+	if closeErr != nil {
+		return nil, &pluginsdk.ResponseError{Code: "close_failed", Message: closeErr.Error()}
+	}
+	return map[string]any{"written": true}, nil
+}

--- a/src/internal/cli/plugins.go
+++ b/src/internal/cli/plugins.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/plugin"
+	"github.com/orlandoburli/apiary/internal/version"
+	"github.com/spf13/cobra"
+)
+
+func configuredPlugins(cfg *config.Config) (*plugin.Registry, []error) {
+	registry, errs := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
+	errs = append(errs, plugin.ValidateConfigured(registry, cfg.Plugins)...)
+	return registry, errs
+}
+
+func newPluginsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugins",
+		Short: "Inspect installed out-of-process plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listPlugins(cmd)
+		},
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List discovered plugins",
+		RunE:  func(cmd *cobra.Command, args []string) error { return listPlugins(cmd) },
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "inspect <id>",
+		Short: "Print one installed plugin manifest",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return err
+			}
+			registry, discoveryErrs := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
+			if len(discoveryErrs) > 0 {
+				return errors.Join(discoveryErrs...)
+			}
+			installed, ok := registry.Get(args[0])
+			if !ok {
+				return fmt.Errorf("plugin %q is not installed in plugin_dirs", args[0])
+			}
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(installed)
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "validate",
+		Short: "Validate discovered manifests and enabled plugin configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return err
+			}
+			_, errs := configuredPlugins(cfg)
+			if len(errs) > 0 {
+				return errors.Join(errs...)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "✓ plugins are valid")
+			return nil
+		},
+	})
+	return cmd
+}
+
+func listPlugins(cmd *cobra.Command) error {
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		return err
+	}
+	registry, discoveryErrs := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
+	if len(discoveryErrs) > 0 {
+		return errors.Join(discoveryErrs...)
+	}
+	enabled := map[string]bool{}
+	for _, instance := range cfg.Plugins {
+		enabled[instance.ID] = instance.IsEnabled()
+	}
+	for _, installed := range registry.List() {
+		state := "installed"
+		if active, configured := enabled[installed.Manifest.ID]; configured {
+			if active {
+				state = "enabled"
+			} else {
+				state = "disabled"
+			}
+		}
+		capabilities := make([]string, len(installed.Manifest.Capabilities))
+		for i, capability := range installed.Manifest.Capabilities {
+			capabilities[i] = string(capability)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", installed.Manifest.ID, installed.Manifest.Version, state, strings.Join(capabilities, ","))
+	}
+	return nil
+}

--- a/src/internal/cli/plugins_test.go
+++ b/src/internal/cli/plugins_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+func TestValidateCommandIncludesPluginSchema(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := t.TempDir()
+	pluginRoot := filepath.Join(root, "plugins", "exporter")
+	if err := os.MkdirAll(pluginRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := plugin.Manifest{SchemaVersion: 1, ID: "dev.apiary.cli-test", Version: "1.0.0", Apiary: ">= 0.0.0-0", Protocol: 1, Executable: "plugin.sh", Capabilities: []plugin.Capability{plugin.CapabilityEventExporter}, ConfigSchema: json.RawMessage(`{"type":"object","properties":{"endpoint":{"type":"string"}},"required":["endpoint"],"additionalProperties":false}`)}
+	rawManifest, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(pluginRoot, plugin.ManifestFilename), rawManifest, 0644); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(root, "apiary.yaml")
+	yaml := "version: \"1.0\"\nplugin_dirs: [plugins]\nplugins:\n  - id: dev.apiary.cli-test\n    config: {}\n"
+	if err := os.WriteFile(configPath, []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	previous := configFile
+	configFile = configPath
+	t.Cleanup(func() { configFile = previous })
+	cmd := newValidateCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	err := cmd.RunE(cmd, nil)
+	if err == nil || !strings.Contains(stderr.String(), "$.endpoint is required") {
+		t.Fatalf("err=%v stderr=%q", err, stderr.String())
+	}
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -60,6 +60,7 @@ func init() {
 		newUpdateCmd(),
 		newMemoryCmd(),
 		newTranscriptCmd(),
+		newPluginsCmd(),
 	)
 }
 

--- a/src/internal/cli/validate.go
+++ b/src/internal/cli/validate.go
@@ -20,6 +20,10 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			errs := cfg.Validate()
+			if len(errs) == 0 {
+				_, pluginErrs := configuredPlugins(cfg)
+				errs = append(errs, pluginErrs...)
+			}
 			if len(errs) > 0 {
 				for _, e := range errs {
 					fmt.Fprintf(cmd.ErrOrStderr(), "  ✗ %s\n", e)

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/plugin"
 )
 
 type Config struct {
@@ -25,6 +26,8 @@ type Config struct {
 	Settings      Settings                            `yaml:"settings"`
 	Tasks         *TasksConfig                        `yaml:"tasks"`
 	Notifications *NotificationsConfig                `yaml:"notifications"`
+	PluginDirs    []string                            `yaml:"plugin_dirs,omitempty"`
+	Plugins       []plugin.InstanceConfig             `yaml:"plugins,omitempty"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 }

--- a/src/internal/config/plugin_validate_test.go
+++ b/src/internal/config/plugin_validate_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+func TestValidatePluginBasics(t *testing.T) {
+	cfg := LoadDefaults()
+	cfg.PluginDirs = []string{""}
+	cfg.Plugins = []plugin.InstanceConfig{{ID: "dev.apiary.test", Timeout: "never"}, {ID: "dev.apiary.test"}}
+	errs := cfg.Validate()
+	joined := make([]string, len(errs))
+	for i, err := range errs {
+		joined[i] = err.Error()
+	}
+	message := strings.Join(joined, "\n")
+	for _, want := range []string{"plugin_dirs[0]: path must not be empty", "timeout \"never\"", "duplicate id \"dev.apiary.test\""} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("missing %q in %s", want, message)
+		}
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/plugin"
 )
 
 // KnownAdapters reports the registered runner adapter names. The cli package
@@ -74,6 +75,12 @@ func validateMCPs(scope string, mcps []model.MCPServer) []error {
 // Validate checks the config for structural errors.
 func (c *Config) Validate() []error {
 	var errs []error
+	errs = append(errs, plugin.ValidateInstanceBasics(c.Plugins)...)
+	for i, path := range c.PluginDirs {
+		if strings.TrimSpace(path) == "" {
+			errs = append(errs, fmt.Errorf("plugin_dirs[%d]: path must not be empty", i))
+		}
+	}
 
 	if c.Version == "" {
 		errs = append(errs, fmt.Errorf("version is required"))

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/logging"
 	"github.com/orlandoburli/apiary/internal/memory"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/plugin"
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
@@ -98,6 +99,11 @@ type Dispatcher struct {
 	// instances parked at approval steps survive across dispatch cycles.
 	engine     *workflow.Engine
 	engineOnce sync.Once
+
+	// eventExporters are isolated out-of-process plugin clients. Event storage
+	// always completes first; exporter failures are reported but never returned
+	// into dispatcher control flow.
+	eventExporters []*plugin.Client
 }
 
 // runnerCandidate is one rung in an agent's rate-limit failover chain: a
@@ -107,6 +113,17 @@ type runnerCandidate struct {
 	adapter    runnerimpl.Runner
 	runnerType string
 	model      string
+}
+
+// pluginExportStore preserves *db.Client's complete workflow Store surface via
+// embedding while intercepting execution events for configured exporters.
+type pluginExportStore struct {
+	*db.Client
+	dispatcher *Dispatcher
+}
+
+func (s pluginExportStore) RecordExecutionEvent(ctx context.Context, event *db.ExecutionEvent) error {
+	return s.dispatcher.persistAndExportExecutionEvent(ctx, event)
 }
 
 // runnerPausedUntil returns the time a runner type's provider rate limit resets,
@@ -181,6 +198,16 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		sem:             make(chan struct{}, 1), // poll: one at a time
 		agentSem:        make(map[string]chan struct{}),
 		stats:           make(map[string]*sourceStat),
+	}
+
+	registry, pluginErrs := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
+	pluginErrs = append(pluginErrs, plugin.ValidateConfigured(registry, cfg.Plugins)...)
+	if len(pluginErrs) > 0 {
+		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
+	}
+	d.eventExporters, pluginErrs = plugin.EnabledClients(registry, cfg.Plugins, plugin.CapabilityEventExporter)
+	if len(pluginErrs) > 0 {
+		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
 	}
 	if dbClient != nil {
 		dbClient.SetEventSensitiveFields(cfg.Settings.Events.SensitiveFields)
@@ -1452,9 +1479,27 @@ func (d *Dispatcher) bindItem(ctx context.Context, cell model.SourceItem) (task 
 }
 
 func (d *Dispatcher) recordExecutionEvent(ctx context.Context, event db.ExecutionEvent) {
-	if d.db != nil {
-		_ = d.db.RecordExecutionEvent(ctx, &event)
+	if d.db == nil {
+		return
 	}
+	if err := d.persistAndExportExecutionEvent(ctx, &event); err != nil {
+		aplog.Error("execution event %s: persist: %v", event.Type, err)
+	}
+}
+
+func (d *Dispatcher) persistAndExportExecutionEvent(ctx context.Context, event *db.ExecutionEvent) error {
+	if d.db == nil {
+		return nil
+	}
+	if err := d.db.RecordExecutionEvent(ctx, event); err != nil {
+		return err
+	}
+	for _, exporter := range d.eventExporters {
+		if err := exporter.Invoke(ctx, plugin.CapabilityEventExporter, "export", *event, nil); err != nil {
+			aplog.Error("plugin %s: export execution event %s: %v", exporter.ID(), event.Type, err)
+		}
+	}
+	return nil
 }
 
 func (d *Dispatcher) recordRouteEvents(ctx context.Context, task model.InternalTask) {

--- a/src/internal/daemon/plugin_test.go
+++ b/src/internal/daemon/plugin_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+func installDaemonTestPlugin(t *testing.T, parent, id, script string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	root := filepath.Join(parent, strings.TrimPrefix(id, "dev.apiary."))
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := plugin.Manifest{SchemaVersion: 1, ID: id, Version: "1.0.0", Apiary: ">= 0.0.0-0", Protocol: 1, Executable: "plugin.sh", Capabilities: []plugin.Capability{plugin.CapabilityEventExporter}}
+	raw, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(root, plugin.ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEventExporterReceivesPersistedRedactedEvent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	output := filepath.Join(root, "exported.jsonl")
+	script := `IFS= read -r request
+printf '%s\n' "$request" >> '` + output + `'
+id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"exported":true}}\n' "$id"`
+	installDaemonTestPlugin(t, root, "dev.apiary.exporter", script)
+	enabled := true
+	cfg := config.LoadDefaults()
+	cfg.PluginDirs = []string{root}
+	cfg.Plugins = []plugin.InstanceConfig{{ID: "dev.apiary.exporter", Enabled: &enabled}}
+	dbc, err := db.New(ctx, filepath.Join(root, "apiary.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbc.Close()
+	dispatcher, err := New(ctx, cfg, filepath.Join(root, "apiary.yaml"), dbc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatcher.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "test.export", Metadata: map[string]any{"token": "ghp_secret-value"}})
+	raw, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "ghp_secret-value") || !strings.Contains(text, "[REDACTED]") {
+		t.Fatalf("exported event was not redacted: %s", text)
+	}
+}
+
+func TestEventExporterCrashAndTimeoutDoNotBreakDispatcher(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct{ name, script, timeout string }{
+		{name: "crash", script: "echo boom >&2; exit 9", timeout: "1s"},
+		{name: "timeout", script: "sleep 1", timeout: "20ms"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "dev.apiary." + test.name
+			installDaemonTestPlugin(t, root, id, test.script)
+			cfg := config.LoadDefaults()
+			cfg.PluginDirs = []string{root}
+			cfg.Plugins = []plugin.InstanceConfig{{ID: id, Timeout: test.timeout}}
+			dbc, err := db.New(ctx, filepath.Join(root, "apiary.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dbc.Close()
+			dispatcher, err := New(ctx, cfg, filepath.Join(root, "apiary.yaml"), dbc, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			started := time.Now()
+			dispatcher.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "test." + test.name})
+			if time.Since(started) > 2*time.Second {
+				t.Fatalf("dispatcher blocked for %s", time.Since(started))
+			}
+			events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{Type: "test." + test.name})
+			if err != nil || len(events) != 1 {
+				t.Fatalf("event persistence after plugin failure: events=%v err=%v", events, err)
+			}
+		})
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -55,7 +55,11 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			}
 			return lister.ListBlockers(ctx, sourceItemID, linkType)
 		}))
-		d.engine = workflow.NewEngine(d.cfg, d.db, &wfStepExecutor{d: d}, opts...)
+		var store workflow.Store = d.db
+		if d.db != nil {
+			store = pluginExportStore{Client: d.db, dispatcher: d}
+		}
+		d.engine = workflow.NewEngine(d.cfg, store, &wfStepExecutor{d: d}, opts...)
 	})
 	return d.engine
 }

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -1,0 +1,182 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+const maxProtocolOutput = 4 << 20
+
+type hostRequest struct {
+	Protocol   int            `json:"protocol"`
+	RequestID  string         `json:"request_id"`
+	Capability Capability     `json:"capability"`
+	Method     string         `json:"method"`
+	Config     map[string]any `json:"config,omitempty"`
+	Payload    any            `json:"payload,omitempty"`
+}
+
+type hostResponse struct {
+	Protocol  int                      `json:"protocol"`
+	RequestID string                   `json:"request_id"`
+	Result    json.RawMessage          `json:"result,omitempty"`
+	Error     *pluginsdk.ResponseError `json:"error,omitempty"`
+}
+
+type Client struct {
+	installed  *Installed
+	instance   InstanceConfig
+	timeout    time.Duration
+	executable string
+}
+
+func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
+	if installed == nil {
+		return nil, fmt.Errorf("installed plugin is required")
+	}
+	timeout, err := instance.TimeoutDuration()
+	if err != nil {
+		return nil, err
+	}
+	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{installed: installed, instance: instance, timeout: timeout, executable: executable}, nil
+}
+
+func (c *Client) ID() string { return c.installed.Manifest.ID }
+
+func (c *Client) Invoke(ctx context.Context, capability Capability, method string, payload any, result any) error {
+	if !c.installed.Manifest.HasCapability(capability) {
+		return fmt.Errorf("plugin %q does not declare capability %q", c.ID(), capability)
+	}
+	if strings.TrimSpace(method) == "" {
+		return fmt.Errorf("plugin %q method is required", c.ID())
+	}
+	requestID := fmt.Sprintf("%d", time.Now().UnixNano())
+	request := hostRequest{Protocol: ProtocolVersion, RequestID: requestID, Capability: capability, Method: method, Config: c.instance.Config, Payload: payload}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("plugin %q encode request: %w", c.ID(), err)
+	}
+	raw = append(raw, '\n')
+
+	callCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	command := exec.CommandContext(callCtx, c.executable)
+	command.Dir = c.installed.Root
+	command.Env = c.environment()
+	command.Stdin = bytes.NewReader(raw)
+	stdout := &boundedBuffer{limit: maxProtocolOutput}
+	stderr := &boundedBuffer{limit: 64 << 10}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	err = command.Run()
+	if errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+		return fmt.Errorf("plugin %q timed out after %s while handling %s.%s; process terminated", c.ID(), c.timeout, capability, method)
+	}
+	if callCtx.Err() != nil {
+		return fmt.Errorf("plugin %q invocation canceled while handling %s.%s: %w", c.ID(), capability, method, callCtx.Err())
+	}
+	if err != nil {
+		return fmt.Errorf("plugin %q crashed or exited unsuccessfully while handling %s.%s: %w%s", c.ID(), capability, method, err, stderrSuffix(c.sanitizeDiagnostic(stderr.String())))
+	}
+	if stdout.truncated {
+		return fmt.Errorf("plugin %q response exceeded %d bytes", c.ID(), maxProtocolOutput)
+	}
+	var response hostResponse
+	decoder := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&response); err != nil {
+		return fmt.Errorf("plugin %q returned invalid protocol JSON: %w%s", c.ID(), err, stderrSuffix(c.sanitizeDiagnostic(stderr.String())))
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf("plugin %q returned more than one protocol response", c.ID())
+	}
+	if response.Protocol != ProtocolVersion {
+		return fmt.Errorf("plugin %q responded with protocol %d, expected %d", c.ID(), response.Protocol, ProtocolVersion)
+	}
+	if response.RequestID != requestID {
+		return fmt.Errorf("plugin %q response request_id %q does not match %q", c.ID(), response.RequestID, requestID)
+	}
+	if response.Error != nil {
+		if len(response.Result) > 0 || strings.TrimSpace(response.Error.Code) == "" || strings.TrimSpace(response.Error.Message) == "" {
+			return fmt.Errorf("plugin %q returned a malformed error response", c.ID())
+		}
+		return fmt.Errorf("plugin %q error %s: %s", c.ID(), c.sanitizeDiagnostic(response.Error.Code), c.sanitizeDiagnostic(response.Error.Message))
+	}
+	if result != nil && len(response.Result) > 0 {
+		if err := json.Unmarshal(response.Result, result); err != nil {
+			return fmt.Errorf("plugin %q result decode: %w", c.ID(), err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) sanitizeDiagnostic(value string) string {
+	for _, key := range c.installed.Manifest.Security.SecretEnv {
+		if secret, ok := os.LookupEnv(key); ok && secret != "" {
+			value = strings.ReplaceAll(value, secret, "[REDACTED]")
+		}
+	}
+	return value
+}
+
+func (c *Client) environment() []string {
+	allowed := []string{"PATH", "HOME", "TMPDIR", "TEMP", "LANG", "LC_ALL", "TZ"}
+	allowed = append(allowed, c.installed.Manifest.Security.SecretEnv...)
+	env := make([]string, 0, len(allowed)+2)
+	seen := map[string]bool{}
+	for _, key := range allowed {
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if value, ok := os.LookupEnv(key); ok {
+			env = append(env, key+"="+value)
+		}
+	}
+	env = append(env, "APIARY_PLUGIN_ID="+c.ID(), fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion))
+	return env
+}
+
+type boundedBuffer struct {
+	bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	original := len(p)
+	remaining := b.limit - b.Len()
+	if remaining <= 0 {
+		b.truncated = true
+		return original, nil
+	}
+	if len(p) > remaining {
+		b.truncated = true
+		p = p[:remaining]
+	}
+	_, _ = b.Buffer.Write(p)
+	return original, nil
+}
+
+func stderrSuffix(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return ""
+	}
+	return "; stderr: " + stderr
+}

--- a/src/internal/plugin/config.go
+++ b/src/internal/plugin/config.go
@@ -1,0 +1,99 @@
+package plugin
+
+import (
+	"fmt"
+	"time"
+)
+
+type InstanceConfig struct {
+	ID      string         `yaml:"id" json:"id"`
+	Enabled *bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Timeout string         `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	Config  map[string]any `yaml:"config,omitempty" json:"config,omitempty"`
+}
+
+func (c InstanceConfig) IsEnabled() bool { return c.Enabled == nil || *c.Enabled }
+
+func (c InstanceConfig) TimeoutDuration() (time.Duration, error) {
+	if c.Timeout == "" {
+		return 10 * time.Second, nil
+	}
+	duration, err := time.ParseDuration(c.Timeout)
+	if err != nil || duration <= 0 {
+		return 0, fmt.Errorf("timeout %q must be a positive Go duration", c.Timeout)
+	}
+	return duration, nil
+}
+
+func ValidateConfigured(registry *Registry, instances []InstanceConfig) []error {
+	errs := ValidateInstanceBasics(instances)
+	seen := map[string]bool{}
+	for i, instance := range instances {
+		prefix := fmt.Sprintf("plugins[%d]", i)
+		if instance.ID == "" {
+			continue
+		}
+		if seen[instance.ID] {
+			continue
+		}
+		seen[instance.ID] = true
+		if !instance.IsEnabled() {
+			continue
+		}
+		installed, ok := registry.Get(instance.ID)
+		if !ok {
+			errs = append(errs, fmt.Errorf("%s %q: plugin is enabled but not installed in plugin_dirs; install it or set enabled: false", prefix, instance.ID))
+			continue
+		}
+		if len(installed.Manifest.ConfigSchema) > 0 {
+			if err := ValidateValue(installed.Manifest.ConfigSchema, instance.Config); err != nil {
+				errs = append(errs, fmt.Errorf("%s %q config: %w", prefix, instance.ID, err))
+			}
+		}
+	}
+	return errs
+}
+
+func ValidateInstanceBasics(instances []InstanceConfig) []error {
+	var errs []error
+	seen := map[string]bool{}
+	for i, instance := range instances {
+		prefix := fmt.Sprintf("plugins[%d]", i)
+		if instance.ID == "" {
+			errs = append(errs, fmt.Errorf("%s: id is required", prefix))
+			continue
+		}
+		if seen[instance.ID] {
+			errs = append(errs, fmt.Errorf("%s: duplicate id %q", prefix, instance.ID))
+		}
+		seen[instance.ID] = true
+		if _, err := instance.TimeoutDuration(); err != nil {
+			errs = append(errs, fmt.Errorf("%s %q: %w", prefix, instance.ID, err))
+		}
+	}
+	return errs
+}
+
+func EnabledClients(registry *Registry, instances []InstanceConfig, capability Capability) ([]*Client, []error) {
+	var clients []*Client
+	var errs []error
+	for i, instance := range instances {
+		if !instance.IsEnabled() || instance.ID == "" {
+			continue
+		}
+		installed, ok := registry.Get(instance.ID)
+		if !ok {
+			continue
+		}
+		if !installed.Manifest.HasCapability(capability) {
+			continue
+		}
+		client, err := NewClient(installed, instance)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("plugins[%d] %q: %w", i, instance.ID, err))
+			continue
+		}
+		clients = append(clients, client)
+	}
+	return clients, errs
+}

--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -1,0 +1,102 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Registry struct {
+	plugins map[string]*Installed
+}
+
+func DiscoverConfigured(paths []string, configFile, apiaryVersion string) (*Registry, []error) {
+	absoluteConfig, err := filepath.Abs(configFile)
+	if err != nil {
+		absoluteConfig = configFile
+	}
+	baseDir := filepath.Dir(absoluteConfig)
+	if len(paths) == 0 {
+		paths = []string{filepath.Join(".apiary", "plugins")}
+	}
+	return Discover(paths, baseDir, apiaryVersion)
+}
+
+func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error) {
+	registry := &Registry{plugins: map[string]*Installed{}}
+	var errs []error
+	for _, configuredPath := range paths {
+		path := expandPath(configuredPath, baseDir)
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("discover plugins in %q: %w", path, err))
+			continue
+		}
+		roots := []string{}
+		if _, err := os.Stat(filepath.Join(path, ManifestFilename)); err == nil {
+			roots = append(roots, path)
+		} else {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					roots = append(roots, filepath.Join(path, entry.Name()))
+				}
+			}
+		}
+		sort.Strings(roots)
+		for _, root := range roots {
+			if _, err := os.Stat(filepath.Join(root, ManifestFilename)); err != nil {
+				continue
+			}
+			installed, err := Load(root, apiaryVersion)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if previous, exists := registry.plugins[installed.Manifest.ID]; exists {
+				errs = append(errs, fmt.Errorf("duplicate plugin id %q in %q and %q; remove one installation", installed.Manifest.ID, previous.Root, installed.Root))
+				continue
+			}
+			registry.plugins[installed.Manifest.ID] = installed
+		}
+	}
+	return registry, errs
+}
+
+func (r *Registry) Get(id string) (*Installed, bool) {
+	if r == nil {
+		return nil, false
+	}
+	p, ok := r.plugins[id]
+	return p, ok
+}
+
+func (r *Registry) List() []*Installed {
+	if r == nil {
+		return nil
+	}
+	result := make([]*Installed, 0, len(r.plugins))
+	for _, installed := range r.plugins {
+		result = append(result, installed)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Manifest.ID < result[j].Manifest.ID })
+	return result
+}
+
+func expandPath(path, baseDir string) string {
+	path = strings.TrimSpace(path)
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+		}
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	path, _ = filepath.Abs(path)
+	return filepath.Clean(path)
+}

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -1,0 +1,221 @@
+// Package plugin implements Apiary's versioned out-of-process extension protocol.
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+const (
+	ManifestFilename      = "apiary-plugin.json"
+	ManifestSchemaVersion = 1
+	ProtocolVersion       = pluginsdk.ProtocolVersion
+)
+
+type Capability = pluginsdk.Capability
+
+const (
+	CapabilitySource           = pluginsdk.CapabilitySource
+	CapabilityRunner           = pluginsdk.CapabilityRunner
+	CapabilityWorkflowAction   = pluginsdk.CapabilityWorkflowAction
+	CapabilityApprovalProvider = pluginsdk.CapabilityApprovalProvider
+	CapabilitySecretProvider   = pluginsdk.CapabilitySecretProvider
+	CapabilityEventExporter    = pluginsdk.CapabilityEventExporter
+)
+
+var supportedCapabilities = map[Capability]struct{}{
+	CapabilitySource: {}, CapabilityRunner: {}, CapabilityWorkflowAction: {},
+	CapabilityApprovalProvider: {}, CapabilitySecretProvider: {}, CapabilityEventExporter: {},
+}
+
+type SecurityRequirements struct {
+	Network    bool     `json:"network,omitempty"`
+	ReadPaths  []string `json:"read_paths,omitempty"`
+	WritePaths []string `json:"write_paths,omitempty"`
+	SecretEnv  []string `json:"secret_env,omitempty"`
+}
+
+type Manifest struct {
+	SchemaVersion int                  `json:"schema_version"`
+	ID            string               `json:"id"`
+	Version       string               `json:"version"`
+	Apiary        string               `json:"apiary"`
+	Protocol      int                  `json:"protocol"`
+	Executable    string               `json:"executable"`
+	Capabilities  []Capability         `json:"capabilities"`
+	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
+	Security      SecurityRequirements `json:"security,omitempty"`
+}
+
+type Installed struct {
+	Manifest Manifest `json:"manifest"`
+	Root     string   `json:"root"`
+	Path     string   `json:"path"`
+}
+
+func Load(root, apiaryVersion string) (*Installed, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("plugin directory %q: %w", root, err)
+	}
+	manifestPath := filepath.Join(root, ManifestFilename)
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read plugin manifest %q: %w", manifestPath, err)
+	}
+	var manifest Manifest
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode plugin manifest %q: %w", manifestPath, err)
+	}
+	installed := &Installed{Manifest: manifest, Root: root, Path: manifestPath}
+	if err := installed.Validate(apiaryVersion); err != nil {
+		return nil, fmt.Errorf("plugin manifest %q: %w", manifestPath, err)
+	}
+	return installed, nil
+}
+
+func (p *Installed) Validate(apiaryVersion string) error {
+	m := p.Manifest
+	if m.SchemaVersion != ManifestSchemaVersion {
+		return fmt.Errorf("unsupported schema_version %d; this Apiary supports %d", m.SchemaVersion, ManifestSchemaVersion)
+	}
+	if !validPluginID(m.ID) {
+		return fmt.Errorf("id %q must be a lowercase reverse-DNS identifier", m.ID)
+	}
+	if _, err := semver.StrictNewVersion(m.Version); err != nil {
+		return fmt.Errorf("version %q is not semantic versioning: %w", m.Version, err)
+	}
+	if strings.TrimSpace(m.Apiary) == "" {
+		return fmt.Errorf("apiary compatibility constraint is required")
+	}
+	constraint, err := semver.NewConstraint(m.Apiary)
+	if err != nil {
+		return fmt.Errorf("apiary compatibility %q is invalid: %w", m.Apiary, err)
+	}
+	if apiaryVersion != "" && apiaryVersion != "dev" {
+		v, err := semver.NewVersion(apiaryVersion)
+		if err != nil {
+			return fmt.Errorf("host Apiary version %q cannot be checked: %w", apiaryVersion, err)
+		}
+		if !constraint.Check(v) {
+			return fmt.Errorf("requires Apiary %s, but host is %s; install a compatible plugin release", m.Apiary, v)
+		}
+	}
+	if m.Protocol != ProtocolVersion {
+		return fmt.Errorf("unsupported protocol %d; this Apiary supports protocol %d", m.Protocol, ProtocolVersion)
+	}
+	if len(m.Capabilities) == 0 {
+		return fmt.Errorf("at least one capability is required")
+	}
+	seen := map[Capability]bool{}
+	for _, capability := range m.Capabilities {
+		if _, ok := supportedCapabilities[capability]; !ok {
+			return fmt.Errorf("unsupported capability %q; supported: %s", capability, strings.Join(SupportedCapabilityNames(), ", "))
+		}
+		if seen[capability] {
+			return fmt.Errorf("duplicate capability %q", capability)
+		}
+		seen[capability] = true
+	}
+	if len(m.ConfigSchema) > 0 {
+		if err := ValidateSchema(m.ConfigSchema); err != nil {
+			return fmt.Errorf("config_schema: %w", err)
+		}
+	}
+	if err := validateSecurity(m.Security); err != nil {
+		return err
+	}
+	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+		return err
+	}
+	p.Manifest = m
+	p.Path = filepath.Join(p.Root, ManifestFilename)
+	p.Root, _ = filepath.Abs(p.Root)
+	return nil
+}
+
+func (m Manifest) HasCapability(capability Capability) bool {
+	for _, current := range m.Capabilities {
+		if current == capability {
+			return true
+		}
+	}
+	return false
+}
+
+func SupportedCapabilityNames() []string {
+	names := make([]string, 0, len(supportedCapabilities))
+	for capability := range supportedCapabilities {
+		names = append(names, string(capability))
+	}
+	sort.Strings(names)
+	return names
+}
+
+func validPluginID(id string) bool {
+	parts := strings.Split(id, ".")
+	if len(parts) < 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || part[0] < 'a' || part[0] > 'z' {
+			return false
+		}
+		for _, r := range part {
+			if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func secureExecutable(root, name string) (string, error) {
+	if strings.TrimSpace(name) == "" || filepath.IsAbs(name) {
+		return "", fmt.Errorf("executable must be a relative path inside the plugin directory")
+	}
+	root, _ = filepath.Abs(root)
+	path := filepath.Clean(filepath.Join(root, name))
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("executable %q escapes the plugin directory", name)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", fmt.Errorf("executable %q is not installed: %w", name, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("executable %q must not be a symlink", name)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("executable %q is not a regular file", name)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
+		return "", fmt.Errorf("executable %q is not executable; run chmod +x", name)
+	}
+	return path, nil
+}
+
+func validateSecurity(security SecurityRequirements) error {
+	seen := map[string]bool{}
+	for _, name := range security.SecretEnv {
+		if name == "" || strings.Trim(name, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_") != "" {
+			return fmt.Errorf("security.secret_env %q is not a valid uppercase environment variable", name)
+		}
+		if seen[name] {
+			return fmt.Errorf("security.secret_env contains duplicate %q", name)
+		}
+		seen[name] = true
+	}
+	return nil
+}

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -1,0 +1,141 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifest) string {
+	t.Helper()
+	root := filepath.Join(parent, name)
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	executable := "plugin.sh"
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	manifest.SchemaVersion = ManifestSchemaVersion
+	manifest.Protocol = ProtocolVersion
+	manifest.Executable = executable
+	if manifest.ID == "" {
+		manifest.ID = "dev.apiary." + name
+	}
+	if manifest.Version == "" {
+		manifest.Version = "1.0.0"
+	}
+	if manifest.Apiary == "" {
+		manifest.Apiary = ">= 0.10.0-0"
+	}
+	if len(manifest.Capabilities) == 0 {
+		manifest.Capabilities = []Capability{CapabilityEventExporter}
+	}
+	raw, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
+	parent := t.TempDir()
+	schema := json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","minLength":1}},"required":["path"],"additionalProperties":false}`)
+	writeTestPlugin(t, parent, "exporter", `read request; id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p'); printf '{"protocol":1,"request_id":"%s","result":{}}\n' "$id"`, Manifest{ConfigSchema: schema})
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+	if len(errs) != 0 {
+		t.Fatalf("discover: %v", errs)
+	}
+	if _, ok := registry.Get("dev.apiary.exporter"); !ok {
+		t.Fatal("plugin not discovered")
+	}
+	invalid := []InstanceConfig{{ID: "dev.apiary.exporter", Config: map[string]any{"extra": true}}}
+	errs = ValidateConfigured(registry, invalid)
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "path is required") {
+		t.Fatalf("schema errors = %v", errs)
+	}
+	valid := []InstanceConfig{{ID: "dev.apiary.exporter", Config: map[string]any{"path": "events.jsonl"}}}
+	if errs := ValidateConfigured(registry, valid); len(errs) != 0 {
+		t.Fatalf("valid config: %v", errs)
+	}
+}
+
+func TestManifestCompatibilityAndUnsupportedKeywordAreActionable(t *testing.T) {
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "future", "exit 0", Manifest{Apiary: ">= 99.0.0"})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "install a compatible plugin release") {
+		t.Fatalf("compatibility error = %v", err)
+	}
+	root = writeTestPlugin(t, parent, "schema", "exit 0", Manifest{ConfigSchema: json.RawMessage(`{"type":"object","oneOf":[]}`)})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "unsupported keyword") {
+		t.Fatalf("schema error = %v", err)
+	}
+}
+
+func TestDiscoverRejectsDuplicateIDs(t *testing.T) {
+	parent := t.TempDir()
+	manifest := Manifest{ID: "dev.apiary.duplicate"}
+	writeTestPlugin(t, parent, "one", "exit 0", manifest)
+	writeTestPlugin(t, parent, "two", "exit 0", manifest)
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+	if len(registry.List()) != 1 || len(errs) != 1 || !strings.Contains(errs[0].Error(), "duplicate plugin id") {
+		t.Fatalf("plugins=%d errs=%v", len(registry.List()), errs)
+	}
+}
+
+func TestClientInvocationCrashTimeoutAndSecretAllowlist(t *testing.T) {
+	parent := t.TempDir()
+	okRoot := writeTestPlugin(t, parent, "ok", `read request; id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p'); printf '{"protocol":1,"request_id":"%s","result":{"secret":"%s","hidden":"%s"}}\n' "$id" "$PLUGIN_TOKEN" "$HIDDEN_TOKEN"`, Manifest{Security: SecurityRequirements{SecretEnv: []string{"PLUGIN_TOKEN"}}})
+	t.Setenv("PLUGIN_TOKEN", "allowed")
+	t.Setenv("HIDDEN_TOKEN", "blocked")
+	installed, err := Load(okRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, _ := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", map[string]any{"x": 1}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["secret"] != "allowed" || result["hidden"] != "" {
+		t.Fatalf("result = %#v", result)
+	}
+
+	crashRoot := writeTestPlugin(t, parent, "crash", "echo boom >&2; exit 7", Manifest{})
+	crashed, _ := Load(crashRoot, "v0.10.0")
+	crashClient, _ := NewClient(crashed, InstanceConfig{})
+	if err := crashClient.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err == nil || !strings.Contains(err.Error(), "crashed or exited") {
+		t.Fatalf("crash error = %v", err)
+	}
+	secretCrashRoot := writeTestPlugin(t, parent, "secretcrash", "echo $PLUGIN_TOKEN >&2; exit 8", Manifest{Security: SecurityRequirements{SecretEnv: []string{"PLUGIN_TOKEN"}}})
+	secretCrash, _ := Load(secretCrashRoot, "v0.10.0")
+	secretCrashClient, _ := NewClient(secretCrash, InstanceConfig{})
+	if err := secretCrashClient.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err == nil || strings.Contains(err.Error(), "allowed") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Fatalf("secret diagnostic error = %v", err)
+	}
+	trailingRoot := writeTestPlugin(t, parent, "trailing", `read request; id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p'); printf '{"protocol":1,"request_id":"%s","result":{}}\n{}\n' "$id"`, Manifest{})
+	trailing, _ := Load(trailingRoot, "v0.10.0")
+	trailingClient, _ := NewClient(trailing, InstanceConfig{})
+	if err := trailingClient.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err == nil || !strings.Contains(err.Error(), "more than one") {
+		t.Fatalf("trailing response error = %v", err)
+	}
+
+	timeoutRoot := writeTestPlugin(t, parent, "timeout", "sleep 2", Manifest{})
+	timed, _ := Load(timeoutRoot, "v0.10.0")
+	timeoutClient, _ := NewClient(timed, InstanceConfig{Timeout: "20ms"})
+	started := time.Now()
+	if err := timeoutClient.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("timeout error = %v", err)
+	}
+	if time.Since(started) > time.Second {
+		t.Fatalf("timeout took %s", time.Since(started))
+	}
+}

--- a/src/internal/plugin/schema.go
+++ b/src/internal/plugin/schema.go
@@ -1,0 +1,278 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+var supportedSchemaKeywords = map[string]bool{
+	"$schema": true, "title": true, "description": true, "type": true,
+	"properties": true, "required": true, "additionalProperties": true,
+	"enum": true, "items": true, "minLength": true, "maxLength": true,
+	"minimum": true, "maximum": true, "minItems": true, "maxItems": true,
+}
+
+func ValidateSchema(raw json.RawMessage) error {
+	var schema any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	root, ok := schema.(map[string]any)
+	if !ok {
+		return fmt.Errorf("root must be an object")
+	}
+	return validateSchemaNode("$", root)
+}
+
+func ValidateValue(raw json.RawMessage, value any) error {
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return fmt.Errorf("invalid schema JSON: %w", err)
+	}
+	if err := validateSchemaNode("$", schema); err != nil {
+		return err
+	}
+	return validateAgainst("$", schema, normalizeValue(value))
+}
+
+func validateSchemaNode(path string, schema map[string]any) error {
+	for keyword := range schema {
+		if !supportedSchemaKeywords[keyword] {
+			return fmt.Errorf("%s: unsupported keyword %q; plugin schemas fail closed", path, keyword)
+		}
+	}
+	if rawType, exists := schema["type"]; exists {
+		typeName, ok := rawType.(string)
+		if !ok || !validSchemaType(typeName) {
+			return fmt.Errorf("%s.type must be one of object, array, string, number, integer, boolean, null", path)
+		}
+	}
+	if properties, exists := schema["properties"]; exists {
+		propertyMap, ok := properties.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.properties must be an object", path)
+		}
+		for name, child := range propertyMap {
+			childSchema, ok := child.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s.properties.%s must be an object", path, name)
+			}
+			if err := validateSchemaNode(path+".properties."+name, childSchema); err != nil {
+				return err
+			}
+		}
+	}
+	if required, exists := schema["required"]; exists {
+		items, ok := required.([]any)
+		if !ok {
+			return fmt.Errorf("%s.required must be an array", path)
+		}
+		for _, item := range items {
+			if _, ok := item.(string); !ok {
+				return fmt.Errorf("%s.required values must be strings", path)
+			}
+		}
+	}
+	if additional, exists := schema["additionalProperties"]; exists {
+		if _, ok := additional.(bool); !ok {
+			return fmt.Errorf("%s.additionalProperties must be a boolean", path)
+		}
+	}
+	if enum, exists := schema["enum"]; exists {
+		values, ok := enum.([]any)
+		if !ok || len(values) == 0 {
+			return fmt.Errorf("%s.enum must be a non-empty array", path)
+		}
+	}
+	for _, keyword := range []string{"minLength", "maxLength", "minItems", "maxItems"} {
+		if value, exists := schema[keyword]; exists {
+			number, ok := value.(float64)
+			if !ok || number < 0 || math.Trunc(number) != number {
+				return fmt.Errorf("%s.%s must be a non-negative integer", path, keyword)
+			}
+		}
+	}
+	for _, keyword := range []string{"minimum", "maximum"} {
+		if value, exists := schema[keyword]; exists {
+			if _, ok := value.(float64); !ok {
+				return fmt.Errorf("%s.%s must be a number", path, keyword)
+			}
+		}
+	}
+	if items, exists := schema["items"]; exists {
+		child, ok := items.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s.items must be an object", path)
+		}
+		if err := validateSchemaNode(path+".items", child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAgainst(path string, schema map[string]any, value any) error {
+	if enum, ok := schema["enum"].([]any); ok {
+		matched := false
+		for _, candidate := range enum {
+			if reflect.DeepEqual(normalizeValue(candidate), value) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("%s must be one of %s", path, renderEnum(enum))
+		}
+	}
+	typeName, _ := schema["type"].(string)
+	if typeName != "" && !valueMatchesType(value, typeName) {
+		return fmt.Errorf("%s must be %s, got %s", path, typeName, valueType(value))
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		properties, _ := schema["properties"].(map[string]any)
+		if required, ok := schema["required"].([]any); ok {
+			for _, item := range required {
+				name := item.(string)
+				if _, exists := typed[name]; !exists {
+					return fmt.Errorf("%s.%s is required", path, name)
+				}
+			}
+		}
+		additional, restrict := schema["additionalProperties"].(bool)
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			child, declared := properties[key]
+			if !declared {
+				if restrict && !additional {
+					return fmt.Errorf("%s.%s is not allowed", path, key)
+				}
+				continue
+			}
+			if err := validateAgainst(path+"."+key, child.(map[string]any), typed[key]); err != nil {
+				return err
+			}
+		}
+	case []any:
+		if err := checkLength(path, len(typed), schema, "minItems", "maxItems"); err != nil {
+			return err
+		}
+		if itemSchema, ok := schema["items"].(map[string]any); ok {
+			for i, item := range typed {
+				if err := validateAgainst(fmt.Sprintf("%s[%d]", path, i), itemSchema, item); err != nil {
+					return err
+				}
+			}
+		}
+	case string:
+		if err := checkLength(path, len([]rune(typed)), schema, "minLength", "maxLength"); err != nil {
+			return err
+		}
+	case float64:
+		if minimum, ok := numberKeyword(schema, "minimum"); ok && typed < minimum {
+			return fmt.Errorf("%s must be >= %v", path, minimum)
+		}
+		if maximum, ok := numberKeyword(schema, "maximum"); ok && typed > maximum {
+			return fmt.Errorf("%s must be <= %v", path, maximum)
+		}
+	}
+	return nil
+}
+
+func normalizeValue(value any) any {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var normalized any
+	if json.Unmarshal(raw, &normalized) != nil {
+		return value
+	}
+	return normalized
+}
+
+func validSchemaType(value string) bool {
+	return strings.Contains(" object array string number integer boolean null ", " "+value+" ")
+}
+
+func valueMatchesType(value any, typeName string) bool {
+	switch typeName {
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "number":
+		_, ok := value.(float64)
+		return ok
+	case "integer":
+		n, ok := value.(float64)
+		return ok && math.Trunc(n) == n
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "null":
+		return value == nil
+	default:
+		return true
+	}
+}
+
+func valueType(value any) string {
+	switch value.(type) {
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	case string:
+		return "string"
+	case float64:
+		return "number"
+	case bool:
+		return "boolean"
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%T", value)
+	}
+}
+
+func checkLength(path string, length int, schema map[string]any, minKey, maxKey string) error {
+	if minimum, ok := integerKeyword(schema, minKey); ok && length < minimum {
+		return fmt.Errorf("%s length must be >= %d", path, minimum)
+	}
+	if maximum, ok := integerKeyword(schema, maxKey); ok && length > maximum {
+		return fmt.Errorf("%s length must be <= %d", path, maximum)
+	}
+	return nil
+}
+
+func integerKeyword(schema map[string]any, key string) (int, bool) {
+	number, ok := numberKeyword(schema, key)
+	return int(number), ok && math.Trunc(number) == number && number >= 0
+}
+
+func numberKeyword(schema map[string]any, key string) (float64, bool) {
+	value, ok := schema[key].(float64)
+	return value, ok
+}
+
+func renderEnum(values []any) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = fmt.Sprint(value)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/src/sdk/plugin/protocol.go
+++ b/src/sdk/plugin/protocol.go
@@ -1,0 +1,81 @@
+// Package plugin is the public SDK for Apiary's out-of-process JSON protocol.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+const ProtocolVersion = 1
+
+type Capability string
+
+const (
+	CapabilitySource           Capability = "source"
+	CapabilityRunner           Capability = "runner"
+	CapabilityWorkflowAction   Capability = "workflow_action"
+	CapabilityApprovalProvider Capability = "approval_provider"
+	CapabilitySecretProvider   Capability = "secret_provider"
+	CapabilityEventExporter    Capability = "event_exporter"
+)
+
+type Request struct {
+	Protocol   int             `json:"protocol"`
+	RequestID  string          `json:"request_id"`
+	Capability Capability      `json:"capability"`
+	Method     string          `json:"method"`
+	Config     map[string]any  `json:"config,omitempty"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+}
+
+type Response struct {
+	Protocol  int            `json:"protocol"`
+	RequestID string         `json:"request_id"`
+	Result    any            `json:"result,omitempty"`
+	Error     *ResponseError `json:"error,omitempty"`
+}
+
+type ResponseError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type Handler func(context.Context, Request) (any, *ResponseError)
+
+// ServeOne decodes one request, invokes handler, and writes one response. It is
+// intentionally single-shot because the host starts a fresh process for every
+// isolated invocation.
+func ServeOne(ctx context.Context, input io.Reader, output io.Writer, handler Handler) error {
+	if handler == nil {
+		return fmt.Errorf("plugin handler is required")
+	}
+	var request Request
+	decoder := json.NewDecoder(input)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		return fmt.Errorf("decode request: %w", err)
+	}
+	response := Response{Protocol: ProtocolVersion, RequestID: request.RequestID}
+	if request.Protocol != ProtocolVersion {
+		response.Error = &ResponseError{Code: "unsupported_protocol", Message: fmt.Sprintf("protocol %d is unsupported; expected %d", request.Protocol, ProtocolVersion)}
+	} else {
+		response.Result, response.Error = handler(ctx, request)
+	}
+	if err := json.NewEncoder(output).Encode(response); err != nil {
+		return fmt.Errorf("encode response: %w", err)
+	}
+	return nil
+}
+
+// Main serves one request on stdin/stdout and writes startup/protocol failures
+// to stderr with a non-zero exit status. Plugin executables can call Main from
+// their main function.
+func Main(handler Handler) {
+	if err := ServeOne(context.Background(), os.Stdin, os.Stdout, handler); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}

--- a/src/sdk/plugin/protocol_test.go
+++ b/src/sdk/plugin/protocol_test.go
@@ -1,0 +1,53 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestServeOneEchoesRequestAndStructuredErrors(t *testing.T) {
+	input := strings.NewReader(`{"protocol":1,"request_id":"req-1","capability":"event_exporter","method":"export","payload":{"type":"test"}}`)
+	var output bytes.Buffer
+	err := ServeOne(context.Background(), input, &output, func(_ context.Context, request Request) (any, *ResponseError) {
+		if request.Capability != CapabilityEventExporter || request.Method != "export" {
+			t.Fatalf("request=%+v", request)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(request.Payload, &payload); err != nil {
+			t.Fatal(err)
+		}
+		return map[string]any{"accepted": payload["type"]}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response Response
+	if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Protocol != ProtocolVersion || response.RequestID != "req-1" || response.Error != nil {
+		t.Fatalf("response=%+v", response)
+	}
+}
+
+func TestServeOneRejectsProtocolMismatchWithoutCallingHandler(t *testing.T) {
+	input := strings.NewReader(`{"protocol":99,"request_id":"req-2","capability":"runner","method":"run"}`)
+	var output bytes.Buffer
+	called := false
+	if err := ServeOne(context.Background(), input, &output, func(context.Context, Request) (any, *ResponseError) { called = true; return nil, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("handler called for unsupported protocol")
+	}
+	var response Response
+	if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Error == nil || response.Error.Code != "unsupported_protocol" {
+		t.Fatalf("response=%+v", response)
+	}
+}


### PR DESCRIPTION
Closes #213

## Summary
- add a versioned plugin manifest, deterministic discovery, compatibility/capability validation, and JSON Schema-backed instance configuration
- add a bounded, timed, out-of-process JSON protocol plus a public Go SDK and CLI list/inspect/validate commands
- integrate isolated execution-event exporters with persisted/redacted lifecycle events
- add a runnable event-file reference plugin and document installation, upgrades, trust, permissions, and secret handling

## Test plan
- [x] `make check`
- [x] `make vet`
- [x] `go test -race ./sdk/plugin ./internal/plugin ./internal/config ./internal/cli ./internal/daemon ./internal/workflow`
- [x] `go build -o /private/tmp/apiary-plugin-event-file-213 ./examples/plugins/event-file`
- [x] `jq empty schema/apiary.json`
- [x] GitNexus change detection reviewed