### PR TITLE
feat: add durable distributed worker queue

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,6 +46,23 @@ Show daemon status and active runs.
 apiary status [--watch]    # --watch refreshes every 2 seconds
 ```
 
+The status payload includes durable job counts and each registered worker's
+readiness, drain state, capacity, active jobs, and last heartbeat.
+
+### `apiary worker`
+
+Connect a separate worker process to a control plane. The worker loads the same
+runner and workflow configuration but does not poll sources.
+
+```sh
+apiary worker --control-plane https://apiary.example \
+  --token "$APIARY_WORKER_TOKEN" --id build-01 --pool build --capacity 4
+```
+
+Use repeatable `--label` and `--capability` flags to advertise scheduling
+attributes. On SIGTERM/SIGINT the worker enters drain mode, stops claiming, lets
+active jobs finish while extending their leases, then becomes unready.
+
 ### `apiary validate`
 
 Validate `apiary.yaml` — schema, reference integrity (agents → runners,

--- a/docs/distributed-workers.md
+++ b/docs/distributed-workers.md
@@ -1,0 +1,128 @@
+# Durable Queue and Distributed Workers
+
+Apiary persists every daemon-mode workflow dispatch in SQLite before a worker
+can execute it. The default remains a single `apiary run` command: it starts an
+embedded worker against that durable queue. Separate workers are optional.
+
+## Delivery and recovery
+
+Delivery is **at least once**. Enqueueing uses a unique
+`task:generation:workflow` key, so polling the same source item repeatedly does
+not create duplicate jobs in one dispatch generation. A claim creates a fenced
+attempt with an opaque token and a time-bounded lease. Workers extend that lease
+with heartbeats. If a worker disappears, the control plane expires the attempt
+and makes the job available again; a late worker cannot heartbeat or finish the
+new attempt with its stale token.
+
+This means workflow actions should remain idempotent. A process can fail after
+performing an external action but before acknowledging completion, causing a
+retry. Apiary's existing workflow instance, publish, spawn, and hook
+idempotency protections still apply.
+
+Cancellation is cooperative. Canceling an instance marks its queued or leased
+job, and the next attempt heartbeat cancels the runner context. A cancellation
+wins over a simultaneous successful finish.
+
+## Local mode
+
+No queue configuration is required:
+
+```yaml
+settings:
+  concurrency: 2
+```
+
+The embedded worker has capacity 1 unless `worker_capacity` is set. Set
+`embedded_worker: false` only after at least one remote worker is available.
+
+## Remote workers
+
+Expose the versioned worker protocol from the control plane:
+
+```yaml
+settings:
+  queue:
+    listen: 0.0.0.0:8080
+    worker_token: ${APIARY_WORKER_TOKEN}
+    embedded_worker: false
+    lease_duration: 30s
+    heartbeat_interval: 10s
+    worker_timeout: 30s
+```
+
+`worker_token` is mandatory whenever `listen` is configured. Put the listener
+behind TLS (a reverse proxy or private service mesh) when it crosses a trusted
+network boundary; the protocol itself is HTTP with Bearer authentication.
+
+Start a worker with the same `apiary.yaml` and runner credentials:
+
+```sh
+apiary worker --control-plane https://apiary.example \
+  --token "$APIARY_WORKER_TOKEN" --id linux-build-01 \
+  --pool build --label linux --capability docker --capacity 4
+```
+
+Each remote worker stores detailed workflow/step execution history in
+`.apiary/workers/<worker-id>.db`. The control plane stores the canonical queue,
+terminal workflow summary, and task state. If the final response is lost, the
+control plane reconciles terminal queue jobs at startup.
+
+## Scheduling
+
+Agents can require a pool, labels, capabilities, and task-level workspace
+affinity:
+
+```yaml
+agents:
+  - id: engineer
+    runner: codex
+    model: gpt-5
+    worker_pool: build
+    requires_labels: [linux]
+    requires_capabilities: [docker]
+    workspace_affinity: true
+```
+
+The queue automatically requires `apiary.workflow` and the configured runner
+adapter (for example `runner:codex-cli`). A worker must satisfy every required
+label and capability. Affinity pins later claims for the task to the first
+worker until explicitly released; it is useful for non-portable workspaces but
+reduces failover options if that worker is unavailable.
+
+Concurrency limits are checked transactionally against active leases. Zero or
+an omitted value means unlimited; a keyed value overrides its default:
+
+```yaml
+settings:
+  queue:
+    concurrency:
+      default_project: 12
+      default_agent: 4
+      agents:
+        deployer: 1
+      runners:
+        codex-cli: 6
+      pools:
+        production: 1
+```
+
+Limits are available for project, source, agent, runner, and pool. Worker
+capacity is enforced independently.
+
+## Operations
+
+`apiary status` reports job counts and registered workers, including health,
+capacity, active jobs, and drain/readiness state. Graceful worker shutdown sets
+drain first, waits for active jobs, and then marks the worker unready. An
+ungraceful shutdown is detected from the stale worker heartbeat and expired job
+leases; work is then reclaimed automatically.
+
+For safe operations:
+
+1. Keep heartbeat interval comfortably below the lease duration.
+2. Use stable, unique worker IDs; affinity is stored against that ID.
+3. Run the control plane database on durable storage and back up
+   `.apiary/apiary.db`.
+4. Rotate the Bearer token by restarting the control plane and workers within a
+   controlled drain window.
+5. Monitor queued/leased job growth and stale worker heartbeats.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Tasks & Fan-out: tasks-and-fanout.md
       - Agent Memory: memory.md
       - Rate Limits & Resilience: resilience.md
+      - Distributed Workers: distributed-workers.md
   - Sources:
       - Supported Integrations: supported-integrations.md
       - GitHub: github-source.md

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 2026-07-22
 
+- **persistent-distributed-queue** — Durable SQLite queue and versioned worker protocol with leased at-least-once delivery, capability matching, scoped concurrency, workspace affinity, cancellation, drain, health, and an embedded local worker. GitHub issue #214.
 - **versioned-plugin-sdk** — Versioned out-of-process plugin manifest and JSON protocol with discovery, compatibility/capability checks, schema-backed configuration validation, isolated execution, CLI inspection, and a reference plugin. GitHub issue #213.
 - **multi-channel-human-approvals** — First-class human-in-the-loop approval requests with structured fields, authorized quorum/delegation, dashboard and signed webhook responses, idempotent resolution, escalation, sensitive-action policies, and rejection feedback. GitHub issue #212.
 - **structured-execution-events** — Versioned, redacted execution events with persisted queries, live SSE subscriptions, route/fallback reasons, retention, CLI history, and a dashboard task timeline. GitHub issue #211.

--- a/openspec/changes/archive/2026-07-22-persistent-distributed-queue/design.md
+++ b/openspec/changes/archive/2026-07-22-persistent-distributed-queue/design.md
@@ -1,0 +1,64 @@
+# Design: persistent distributed queue
+
+## Durable model
+
+`dispatch_jobs` stores the immutable dispatch snapshot and mutable scheduling
+state (`queued`, `leased`, `succeeded`, `failed`, `canceled`). The snapshot
+contains task/source/workflow/agent/runner identifiers, normalized source item,
+route/worker configuration, required labels/capabilities, affinity key, and
+concurrency scopes. A deterministic idempotency key prevents polling from
+enqueuing the same active task/workflow twice.
+
+`dispatch_attempts` stores every claim. A claim transaction selects one compatible
+job whose scopes have capacity, marks it leased, and inserts an attempt with a
+random claim token and expiry. Heartbeat, completion, failure, cancellation, and
+lease extension require `(job_id, attempt_id, claim_token)` and the current
+leased state. A stale worker therefore cannot finish a reclaimed job.
+
+`worker_registrations` stores worker protocol version, labels, capabilities,
+pool, capacity, readiness/drain state, heartbeat, and current-job count. Expired
+workers are unhealthy and their attempts become reclaimable after lease expiry.
+
+## Delivery and recovery
+
+Delivery is at least once. Lease expiry transitions the abandoned attempt to
+expired and requeues the job in one transaction. Exactly one later claimant can
+hold the active lease because the job row is updated with a compare-and-set
+predicate. Execution side effects continue to require existing Apiary
+idempotency keys; the queue guarantees no two valid active claim tokens, not
+exactly-once external effects.
+
+Control-plane restart loses no queued/leased row. On startup the recovery loop
+requeues expired leases and the embedded worker resumes claims. Graceful drain
+marks the worker draining, stops new claims, waits for active claims, and leaves
+unfinished claims leased for another worker to reclaim after shutdown/expiry.
+
+## Scheduling
+
+Workers advertise a set of labels/capabilities; required job values must be a
+subset. An optional affinity key binds follow-up attempts to the same worker;
+when that worker is permanently unavailable an explicit affinity-release action
+is required, avoiding silent execution in a different workspace.
+
+Concurrency usage is derived transactionally from active leases and checked
+against configured limits for project, source, agent, runner, and pool. Worker
+capacity is an additional hard limit. This makes admission consistent across all
+workers sharing a backend.
+
+## Protocol and local mode
+
+Worker protocol `1` exposes register, heartbeat/readiness, claim, attempt
+heartbeat, complete/fail, cancellation polling, and drain endpoints. Every
+request is authenticated by a configured worker token. Enqueue, registration,
+heartbeat, drain, and cancellation are idempotent; claim completion is fenced by
+its opaque attempt token, so a replay after acknowledgement is rejected as stale.
+
+Local mode constructs the same worker client in-process against the SQLite queue
+and starts it with the dispatcher. No external service or configuration is
+required. Remote mode disables or supplements the embedded worker and serves the
+same queue through the daemon API.
+
+Remote workers keep detailed workflow and step state in a worker-local SQLite
+database. A terminal completion writes an idempotent summary to the canonical
+control-plane database and settles task accounting. Startup reconciliation heals
+terminal jobs whose acknowledgement or settlement response was interrupted.

--- a/openspec/changes/archive/2026-07-22-persistent-distributed-queue/proposal.md
+++ b/openspec/changes/archive/2026-07-22-persistent-distributed-queue/proposal.md
@@ -1,0 +1,27 @@
+# Persistent queue and distributed worker protocol
+
+## Motivation
+
+The dispatcher currently launches one in-memory goroutine per matched workflow.
+Agent semaphores, active-run state, and cancellation handles exist only in that
+process, so queued work disappears on restart and multiple Apiary processes
+cannot enforce one scheduling policy or safely reclaim abandoned execution.
+
+## Scope
+
+- Add a queue abstraction and SQLite implementation for local mode.
+- Persist self-contained dispatch jobs before execution and deliver them at least once.
+- Claim jobs transactionally with attempt identity, leases, heartbeats, and
+  compare-and-set completion/requeue/cancellation.
+- Register workers with labels, capabilities, capacity, readiness, drain state,
+  health, and current jobs; claim only compatible work.
+- Enforce concurrency limits per project, source, agent, runner, and worker pool
+  inside queue admission rather than process-local semaphores.
+- Preserve workspace affinity for retries/resumes and propagate cancellation to
+  the active worker.
+- Run an embedded local worker by default so `apiary run` remains one command.
+- Expose a versioned worker HTTP/JSON protocol suitable for remote workers.
+
+Postgres/Redis queue implementations, artifact/workspace transfer, automatic
+worker provisioning, and cross-region scheduling are deferred. The abstraction
+and protocol leave those backends possible without changing workflow semantics.

--- a/openspec/changes/archive/2026-07-22-persistent-distributed-queue/tasks.md
+++ b/openspec/changes/archive/2026-07-22-persistent-distributed-queue/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [x] Define queue, job, attempt, worker, capability, affinity, and concurrency contracts.
+- [x] Add SQLite schema and atomic enqueue/claim/heartbeat/complete/reclaim operations.
+- [x] Replace in-memory fan-out admission with durable job enqueueing.
+- [x] Add the embedded local worker and preserve single-command local mode.
+- [x] Add authenticated worker protocol endpoints and remote worker client.
+- [x] Enforce capability matching, worker capacity, and scoped concurrency limits.
+- [x] Propagate cancellation and implement readiness, health, drain, and graceful shutdown.
+- [x] Expose queue/worker/job status through CLI and daemon status APIs.
+- [x] Document delivery guarantees, recovery, affinity, deployment, and operations.
+- [x] Add restart, reclaim, exclusivity, compatibility, concurrency, cancellation, and drain tests.
+- [x] Run repository gates, GitNexus change detection, and archive the change.

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -246,6 +246,25 @@
             "description": "Maximum concurrent workers for this agent",
             "minimum": 1
           },
+          "worker_pool": {
+            "type": "string",
+            "description": "Queue pool required for workflows using this agent"
+          },
+          "requires_labels": {
+            "type": "array",
+            "description": "Worker labels required before a workflow can be claimed",
+            "items": { "type": "string" }
+          },
+          "requires_capabilities": {
+            "type": "array",
+            "description": "Worker capabilities required before a workflow can be claimed",
+            "items": { "type": "string" }
+          },
+          "workspace_affinity": {
+            "type": "boolean",
+            "description": "Pin retries for this task to the worker that first claims it",
+            "default": false
+          },
           "max_turns": {
             "type": "integer",
             "description": "Maximum agent turns per step run. 0 (default) = unlimited: CLI runners omit the provider's turns flag",
@@ -578,6 +597,43 @@
               "minItems": 1
             }
           }
+        },
+        "queue": {
+          "type": "object",
+          "description": "Durable dispatch queue and distributed worker protocol. Enabled with an embedded local worker by default",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "embedded_worker": { "type": "boolean", "default": true },
+            "project_id": { "type": "string" },
+            "worker_id": { "type": "string" },
+            "worker_pool": { "type": "string", "default": "default" },
+            "worker_labels": { "type": "array", "items": { "type": "string" } },
+            "worker_capabilities": { "type": "array", "items": { "type": "string" } },
+            "worker_capacity": { "type": "integer", "minimum": 0, "default": 1 },
+            "lease_duration": { "type": "string", "default": "30s", "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" },
+            "heartbeat_interval": { "type": "string", "default": "10s", "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" },
+            "worker_timeout": { "type": "string", "default": "30s", "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" },
+            "poll_interval": { "type": "string", "default": "500ms", "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$" },
+            "listen": { "type": "string", "description": "TCP address for the authenticated worker protocol, for example 0.0.0.0:8080" },
+            "worker_token": { "type": "string", "description": "Bearer token required by remote workers; use an environment reference such as ${APIARY_WORKER_TOKEN}" },
+            "concurrency": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "default_project": { "type": "integer", "minimum": 0 },
+                "projects": { "$ref": "#/definitions/QueueLimits" },
+                "default_source": { "type": "integer", "minimum": 0 },
+                "sources": { "$ref": "#/definitions/QueueLimits" },
+                "default_agent": { "type": "integer", "minimum": 0 },
+                "agents": { "$ref": "#/definitions/QueueLimits" },
+                "default_runner": { "type": "integer", "minimum": 0 },
+                "runners": { "$ref": "#/definitions/QueueLimits" },
+                "default_pool": { "type": "integer", "minimum": 0 },
+                "pools": { "$ref": "#/definitions/QueueLimits" }
+              }
+            }
+          }
         }
       }
     },
@@ -631,6 +687,11 @@
     }
   },
   "definitions": {
+    "QueueLimits": {
+      "type": "object",
+      "description": "Positive concurrency limits keyed by scope id",
+      "additionalProperties": { "type": "integer", "minimum": 1 }
+    },
     "MCPServer": {
       "type": "object",
       "description": "A Model Context Protocol server launched over stdio and exposed to the CLI tool",

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -61,6 +61,7 @@ func init() {
 		newMemoryCmd(),
 		newTranscriptCmd(),
 		newPluginsCmd(),
+		newWorkerCmd(),
 	)
 }
 

--- a/src/internal/cli/status.go
+++ b/src/internal/cli/status.go
@@ -129,6 +129,25 @@ func renderStatus(r *daemon.StatusResponse) string {
 		}
 	}
 	b.WriteString("\n")
+	if r.Queue.Enabled {
+		fmt.Fprintf(&b, "%s  queued: %d  leased: %d  succeeded: %d  failed: %d  canceled: %d\n",
+			statusKey.Render("Queue"), r.Queue.Jobs["queued"], r.Queue.Jobs["leased"], r.Queue.Jobs["succeeded"], r.Queue.Jobs["failed"], r.Queue.Jobs["canceled"])
+		if len(r.Queue.Workers) == 0 {
+			b.WriteString(statusMuted.Render("  no registered workers") + "\n")
+		}
+		for _, worker := range r.Queue.Workers {
+			state := "ready"
+			if !worker.Healthy {
+				state = "unhealthy"
+			} else if worker.Draining {
+				state = "draining"
+			} else if !worker.Ready {
+				state = "unready"
+			}
+			fmt.Fprintf(&b, "  %-18s pool: %-12s jobs: %d/%d  %-9s heartbeat: %s\n", worker.ID, worker.Pool, worker.ActiveJobs, worker.Capacity, state, worker.LastHeartbeat)
+		}
+		b.WriteString("\n")
+	}
 
 	return b.String()
 }

--- a/src/internal/cli/status_test.go
+++ b/src/internal/cli/status_test.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+func TestRenderStatusIncludesQueueAndWorkers(t *testing.T) {
+	result := renderStatus(&daemon.StatusResponse{Version: "test", Queue: daemon.QueueStatus{Enabled: true, Jobs: map[string]int{"queued": 2, "leased": 1}, Workers: []daemon.QueueWorkerStatus{{ID: "build-1", Pool: "build", Ready: true, Healthy: true, Capacity: 4, ActiveJobs: 1, LastHeartbeat: "2s ago"}}}})
+	for _, want := range []string{"Queue", "queued: 2", "leased: 1", "build-1", "jobs: 1/4", "heartbeat: 2s ago"} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("status missing %q:\n%s", want, result)
+		}
+	}
+}

--- a/src/internal/cli/worker.go
+++ b/src/internal/cli/worker.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/queuehttp"
+	"github.com/orlandoburli/apiary/internal/worker"
+)
+
+func newWorkerCmd() *cobra.Command {
+	var controlPlane, token, workerID, pool string
+	var labels, capabilities []string
+	var capacity int
+	cmd := &cobra.Command{
+		Use:   "worker",
+		Short: "Run a distributed queue worker",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return err
+			}
+			if errs := cfg.Validate(); len(errs) > 0 {
+				return fmt.Errorf("config validation failed: %v", errs)
+			}
+			if controlPlane == "" {
+				controlPlane = queueControlPlaneURL(cfg.Settings.Queue.Listen)
+			}
+			if controlPlane == "" {
+				return fmt.Errorf("--control-plane is required (for example http://apiary-control:8080)")
+			}
+			if token == "" {
+				token = cfg.Settings.Queue.WorkerToken
+			}
+			if token == "" {
+				return fmt.Errorf("--token or settings.queue.worker_token is required")
+			}
+			if workerID == "" {
+				workerID = cfg.Settings.Queue.WorkerID
+			}
+			if workerID == "" {
+				host, _ := os.Hostname()
+				workerID = host
+			}
+			if strings.TrimSpace(workerID) == "" {
+				return fmt.Errorf("--id is required when the hostname is unavailable")
+			}
+			if pool == "" {
+				pool = cfg.Settings.Queue.WorkerPool
+			}
+			if pool == "" {
+				pool = "default"
+			}
+			if capacity == 0 {
+				capacity = cfg.Settings.Queue.WorkerCapacityValue()
+			}
+			labels = append(labels, cfg.Settings.Queue.WorkerLabels...)
+			labels = append(labels, runtime.GOOS)
+			capabilities = append(capabilities, cfg.Settings.Queue.WorkerCapabilities...)
+			capabilities = append(capabilities, "apiary.workflow")
+			for i := range cfg.Runners {
+				capabilities = append(capabilities, "runner:"+cfg.Runners[i].AdapterName())
+			}
+			labels, capabilities = normalizedValues(labels), normalizedValues(capabilities)
+
+			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer cancel()
+			workerDataDir := filepath.Join(projectDataDir(), "workers")
+			if err := os.MkdirAll(workerDataDir, 0755); err != nil {
+				return fmt.Errorf("create worker data directory: %w", err)
+			}
+			workerDB, err := db.New(ctx, filepath.Join(workerDataDir, safeWorkerFilename(workerID)+".db"))
+			if err != nil {
+				return fmt.Errorf("open worker execution database: %w", err)
+			}
+			defer workerDB.Close()
+			workerCfg := *cfg
+			workerCfg.Settings = cfg.Settings
+			disabled := false
+			workerCfg.Settings.Queue.Enabled = &disabled
+			dispatcher, err := daemon.New(ctx, &workerCfg, configFile, workerDB, nil)
+			if err != nil {
+				return fmt.Errorf("initialize worker runners: %w", err)
+			}
+			remote := &queuehttp.Client{BaseURL: controlPlane, Token: token}
+			runtimeWorker, err := worker.New(remote, worker.ExecutorFunc(func(execCtx context.Context, job queue.Job) queue.FinishResult {
+				return dispatcher.ExecuteQueuedJob(execCtx, job, workerID)
+			}), worker.Config{
+				Worker:        queue.Worker{ID: workerID, ProtocolVersion: queue.WorkerProtocolVersion, Pool: pool, Labels: labels, Capabilities: capabilities, Capacity: capacity, Ready: true},
+				LeaseDuration: cfg.Settings.Queue.LeaseDurationValue(), HeartbeatInterval: cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerHeartbeat: cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerTimeout: cfg.Settings.Queue.WorkerTimeoutValue(), PollInterval: cfg.Settings.Queue.PollIntervalValue(),
+				OnError: func(err error) { aplog.Error("remote worker: %v", err) },
+			})
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "apiary worker %s connected to %s (pool=%s capacity=%d)\n", workerID, controlPlane, pool, capacity)
+			return runtimeWorker.Run(ctx)
+		},
+	}
+	cmd.Flags().StringVar(&controlPlane, "control-plane", "", "control-plane base URL")
+	cmd.Flags().StringVar(&token, "token", "", "worker bearer token (defaults to settings.queue.worker_token)")
+	cmd.Flags().StringVar(&workerID, "id", "", "stable worker id")
+	cmd.Flags().StringVar(&pool, "pool", "", "worker pool")
+	cmd.Flags().StringSliceVar(&labels, "label", nil, "worker label (repeatable)")
+	cmd.Flags().StringSliceVar(&capabilities, "capability", nil, "worker capability (repeatable)")
+	cmd.Flags().IntVar(&capacity, "capacity", 0, "maximum concurrent jobs")
+	return cmd
+}
+
+func queueControlPlaneURL(listen string) string {
+	listen = strings.TrimSpace(listen)
+	if listen == "" {
+		return ""
+	}
+	if strings.HasPrefix(listen, "http://") || strings.HasPrefix(listen, "https://") {
+		return listen
+	}
+	if strings.HasPrefix(listen, ":") {
+		return "http://127.0.0.1" + listen
+	}
+	if strings.HasPrefix(listen, "0.0.0.0:") {
+		return "http://127.0.0.1:" + strings.TrimPrefix(listen, "0.0.0.0:")
+	}
+	if strings.HasPrefix(listen, "[") || strings.Count(listen, ":") == 1 {
+		return "http://" + listen
+	}
+	return listen
+}
+
+func normalizedValues(values []string) []string {
+	set := map[string]bool{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = true
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func safeWorkerFilename(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, value)
+	if value == "" {
+		return "worker"
+	}
+	return value
+}

--- a/src/internal/cli/worker_test.go
+++ b/src/internal/cli/worker_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import "testing"
+
+func TestQueueControlPlaneURL(t *testing.T) {
+	for input, want := range map[string]string{
+		":8080":                  "http://127.0.0.1:8080",
+		"0.0.0.0:8080":           "http://127.0.0.1:8080",
+		"apiary.local:8080":      "http://apiary.local:8080",
+		"https://apiary.example": "https://apiary.example",
+	} {
+		if got := queueControlPlaneURL(input); got != want {
+			t.Errorf("queueControlPlaneURL(%q)=%q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestSafeWorkerFilename(t *testing.T) {
+	if got := safeWorkerFilename("build/us west#1"); got != "build_us_west_1" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -120,6 +120,14 @@ type AgentConfig struct {
 	// layered on top of the runner's MCPs (RunnerConfig.MCPs), overriding any
 	// runner-scope server with the same name.
 	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
+	// Worker scheduling requirements are applied by the durable queue before a
+	// workflow is delivered. Empty values accept any ready worker.
+	WorkerPool           string   `yaml:"worker_pool,omitempty"`
+	RequiresLabels       []string `yaml:"requires_labels,omitempty"`
+	RequiresCapabilities []string `yaml:"requires_capabilities,omitempty"`
+	// WorkspaceAffinity pins retries/resumes to the first worker that claims the
+	// task, preserving a local checkout or other non-portable environment.
+	WorkspaceAffinity bool `yaml:"workspace_affinity,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner
@@ -272,12 +280,80 @@ type Settings struct {
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
+	Queue         QueueSettings      `yaml:"queue"`
 	// DefaultFallbacks is a fallback chain applied to every agent that does not
 	// define its own fallbacks[]. Entries must reference defined runner IDs.
 	DefaultFallbacks []FallbackConfig `yaml:"default_fallbacks,omitempty"`
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+}
+
+// QueueSettings controls durable dispatch and the embedded protocol-1 worker.
+// Zero values preserve single-command local mode with safe defaults.
+type QueueSettings struct {
+	Enabled            *bool                    `yaml:"enabled,omitempty"`
+	EmbeddedWorker     *bool                    `yaml:"embedded_worker,omitempty"`
+	ProjectID          string                   `yaml:"project_id,omitempty"`
+	WorkerID           string                   `yaml:"worker_id,omitempty"`
+	WorkerPool         string                   `yaml:"worker_pool,omitempty"`
+	WorkerLabels       []string                 `yaml:"worker_labels,omitempty"`
+	WorkerCapabilities []string                 `yaml:"worker_capabilities,omitempty"`
+	WorkerCapacity     int                      `yaml:"worker_capacity,omitempty"`
+	LeaseDuration      string                   `yaml:"lease_duration,omitempty"`
+	HeartbeatInterval  string                   `yaml:"heartbeat_interval,omitempty"`
+	WorkerTimeout      string                   `yaml:"worker_timeout,omitempty"`
+	PollInterval       string                   `yaml:"poll_interval,omitempty"`
+	Listen             string                   `yaml:"listen,omitempty"`
+	WorkerToken        string                   `yaml:"worker_token,omitempty"`
+	Concurrency        QueueConcurrencySettings `yaml:"concurrency,omitempty"`
+}
+
+type QueueConcurrencySettings struct {
+	DefaultProject int            `yaml:"default_project,omitempty"`
+	Projects       map[string]int `yaml:"projects,omitempty"`
+	DefaultSource  int            `yaml:"default_source,omitempty"`
+	Sources        map[string]int `yaml:"sources,omitempty"`
+	DefaultAgent   int            `yaml:"default_agent,omitempty"`
+	Agents         map[string]int `yaml:"agents,omitempty"`
+	DefaultRunner  int            `yaml:"default_runner,omitempty"`
+	Runners        map[string]int `yaml:"runners,omitempty"`
+	DefaultPool    int            `yaml:"default_pool,omitempty"`
+	Pools          map[string]int `yaml:"pools,omitempty"`
+}
+
+func (q QueueSettings) IsEnabled() bool          { return q.Enabled == nil || *q.Enabled }
+func (q QueueSettings) UsesEmbeddedWorker() bool { return q.EmbeddedWorker == nil || *q.EmbeddedWorker }
+
+func (q QueueSettings) WorkerCapacityValue() int {
+	if q.WorkerCapacity > 0 {
+		return q.WorkerCapacity
+	}
+	return 1
+}
+
+func (q QueueSettings) LeaseDurationValue() time.Duration {
+	return queueDuration(q.LeaseDuration, 30*time.Second)
+}
+func (q QueueSettings) HeartbeatIntervalValue() time.Duration {
+	return queueDuration(q.HeartbeatInterval, 10*time.Second)
+}
+func (q QueueSettings) WorkerTimeoutValue() time.Duration {
+	return queueDuration(q.WorkerTimeout, 30*time.Second)
+}
+func (q QueueSettings) PollIntervalValue() time.Duration {
+	return queueDuration(q.PollInterval, 500*time.Millisecond)
+}
+
+func queueDuration(value string, fallback time.Duration) time.Duration {
+	if value == "" {
+		return fallback
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return fallback
+	}
+	return duration
 }
 
 // ApprovalSettings controls provider-neutral approval response endpoints.

--- a/src/internal/config/queue_test.go
+++ b/src/internal/config/queue_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateQueueSettings(t *testing.T) {
+	cases := []struct {
+		name     string
+		settings QueueSettings
+		contains string
+	}{
+		{"listener requires token", QueueSettings{Listen: ":8080"}, "worker_token is required"},
+		{"heartbeat before lease", QueueSettings{LeaseDuration: "5s", HeartbeatInterval: "5s"}, "must be shorter"},
+		{"positive scoped limit", QueueSettings{Concurrency: QueueConcurrencySettings{Pools: map[string]int{"build": 0}}}, "positive limit"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateQueueSettings(tc.settings)
+			if len(errs) == 0 || !strings.Contains(errs[0].Error(), tc.contains) {
+				t.Fatalf("errors=%v, want %q", errs, tc.contains)
+			}
+		})
+	}
+	if errs := validateQueueSettings(QueueSettings{Listen: "127.0.0.1:8080", WorkerToken: "secret", LeaseDuration: "30s", HeartbeatInterval: "10s", WorkerCapacity: 4}); len(errs) != 0 {
+		t.Fatalf("valid settings: %v", errs)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -218,6 +218,7 @@ func (c *Config) Validate() []error {
 	if c.Settings.Memory.MaxEntryBytes < 0 {
 		errs = append(errs, fmt.Errorf("settings.memory.max_entry_bytes must be >= 0"))
 	}
+	errs = append(errs, validateQueueSettings(c.Settings.Queue)...)
 
 	// settings.git_hooks: dir and repos only make sense together — one without
 	// the other is a config mistake, not a partial setup.
@@ -274,6 +275,55 @@ func (c *Config) Validate() []error {
 
 	errs = append(errs, c.validateNotifications()...)
 
+	return errs
+}
+
+func validateQueueSettings(settings QueueSettings) []error {
+	var errs []error
+	if strings.TrimSpace(settings.Listen) != "" && strings.TrimSpace(settings.WorkerToken) == "" {
+		errs = append(errs, fmt.Errorf("settings.queue.worker_token is required when settings.queue.listen is configured"))
+	}
+	durations := []struct {
+		name, value string
+		fallback    time.Duration
+	}{
+		{"lease_duration", settings.LeaseDuration, 30 * time.Second},
+		{"heartbeat_interval", settings.HeartbeatInterval, 10 * time.Second},
+		{"worker_timeout", settings.WorkerTimeout, 30 * time.Second},
+		{"poll_interval", settings.PollInterval, 500 * time.Millisecond},
+	}
+	parsed := map[string]time.Duration{}
+	for _, field := range durations {
+		parsed[field.name] = field.fallback
+		if field.value == "" {
+			continue
+		}
+		duration, err := time.ParseDuration(field.value)
+		if err != nil || duration <= 0 {
+			errs = append(errs, fmt.Errorf("settings.queue.%s %q: must be a positive duration", field.name, field.value))
+			continue
+		}
+		parsed[field.name] = duration
+	}
+	if parsed["heartbeat_interval"] >= parsed["lease_duration"] {
+		errs = append(errs, fmt.Errorf("settings.queue.heartbeat_interval must be shorter than lease_duration"))
+	}
+	if settings.WorkerCapacity < 0 {
+		errs = append(errs, fmt.Errorf("settings.queue.worker_capacity must be >= 0"))
+	}
+	limits := settings.Concurrency
+	for name, value := range map[string]int{"default_project": limits.DefaultProject, "default_source": limits.DefaultSource, "default_agent": limits.DefaultAgent, "default_runner": limits.DefaultRunner, "default_pool": limits.DefaultPool} {
+		if value < 0 {
+			errs = append(errs, fmt.Errorf("settings.queue.concurrency.%s must be >= 0", name))
+		}
+	}
+	for name, values := range map[string]map[string]int{"projects": limits.Projects, "sources": limits.Sources, "agents": limits.Agents, "runners": limits.Runners, "pools": limits.Pools} {
+		for key, value := range values {
+			if strings.TrimSpace(key) == "" || value <= 0 {
+				errs = append(errs, fmt.Errorf("settings.queue.concurrency.%s[%q] must have a non-empty key and positive limit", name, key))
+			}
+		}
+	}
 	return errs
 }
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -25,10 +25,12 @@ import (
 	"github.com/orlandoburli/apiary/internal/memory"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/plugin"
+	queuepkg "github.com/orlandoburli/apiary/internal/queue"
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
 	"github.com/orlandoburli/apiary/internal/version"
+	workerpkg "github.com/orlandoburli/apiary/internal/worker"
 	"github.com/orlandoburli/apiary/internal/workflow"
 )
 
@@ -104,6 +106,12 @@ type Dispatcher struct {
 	// always completes first; exporter failures are reported but never returned
 	// into dispatcher control flow.
 	eventExporters []*plugin.Client
+
+	// Durable dispatch queue and optional embedded local protocol-1 worker.
+	dispatchQueue  queuepkg.Store
+	localWorker    *workerpkg.Runtime
+	queueProjectID string
+	queueWorkerID  string
 }
 
 // runnerCandidate is one rung in an agent's rate-limit failover chain: a
@@ -208,6 +216,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 	d.eventExporters, pluginErrs = plugin.EnabledClients(registry, cfg.Plugins, plugin.CapabilityEventExporter)
 	if len(pluginErrs) > 0 {
 		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
+	}
+	if err := d.configureDispatchQueue(); err != nil {
+		return nil, err
 	}
 	if dbClient != nil {
 		dbClient.SetEventSensitiveFields(cfg.Settings.Events.SensitiveFields)
@@ -416,6 +427,15 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 // Start launches one poll goroutine per source.
 // Cancel ctx to initiate a graceful shutdown; then call wg.Wait().
 func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
+	if d.localWorker != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := d.localWorker.Run(ctx); err != nil {
+				aplog.Error("embedded worker: %v", err)
+			}
+		}()
+	}
 	// Enforce the shared git hooks directory on the agents' repo checkouts
 	// (settings.git_hooks) before the first dispatch, so pre-push hooks gate
 	// agent pushes from the very first run.
@@ -453,6 +473,7 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		} else if n > 0 {
 			aplog.Info("reconciled %d orphaned step run(s) from a previous run", n)
 		}
+		d.reconcileTerminalQueueJobs(ctx)
 
 		// Repair each non-terminal task's outstanding-workflow counter and settle
 		// tasks stranded 'running' with no live instance. The instances just
@@ -810,6 +831,20 @@ func (d *Dispatcher) Status() StatusResponse {
 		})
 		return true
 	})
+	if d.dispatchQueue != nil {
+		resp.Queue.Enabled = true
+		resp.Queue.Jobs = map[string]int{}
+		if jobs, err := d.dispatchQueue.ListJobs(context.Background(), "", 1000); err == nil {
+			for _, job := range jobs {
+				resp.Queue.Jobs[string(job.State)]++
+			}
+		}
+		if workers, err := d.dispatchQueue.ListWorkers(context.Background()); err == nil {
+			for _, worker := range workers {
+				resp.Queue.Workers = append(resp.Queue.Workers, QueueWorkerStatus{ID: worker.ID, Pool: worker.Pool, Ready: worker.Ready, Healthy: time.Since(worker.LastHeartbeat) <= d.cfg.Settings.Queue.WorkerTimeoutValue(), Draining: worker.Draining, Capacity: worker.Capacity, ActiveJobs: worker.ActiveJobs, LastHeartbeat: humanDuration(time.Since(worker.LastHeartbeat)) + " ago"})
+			}
+		}
+	}
 
 	return resp
 }
@@ -1269,6 +1304,10 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		defer cancel()
 		_ = srv.Shutdown(shutdownCtx)
 	}()
+	if err := d.startQueueProtocolServer(ctx, wg); err != nil {
+		_ = srv.Close()
+		return err
+	}
 
 	return nil
 }
@@ -1358,6 +1397,11 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 // (so RunOnce can wait); onFail, if set, is called with the cell ID per failure.
 func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, persisted bool, matches []router.Match, wg *sync.WaitGroup, onFail func(cellID string)) {
 	if len(matches) == 0 {
+		d.inFlight.Delete(cell.ID)
+		return
+	}
+	if persisted && d.dispatchQueue != nil && wg == nil {
+		d.enqueueFanOut(ctx, cell, task, matches)
 		d.inFlight.Delete(cell.ID)
 		return
 	}

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -1,0 +1,316 @@
+package daemon
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/worker"
+)
+
+const dispatchPayloadVersion = 1
+
+type dispatchJobPayload struct {
+	Version int                `json:"version"`
+	Cell    model.SourceItem   `json:"cell"`
+	Task    model.InternalTask `json:"task"`
+	Match   router.Match       `json:"match"`
+}
+
+func (d *Dispatcher) configureDispatchQueue() error {
+	if d.db == nil || !d.cfg.Settings.Queue.IsEnabled() {
+		return nil
+	}
+	d.dispatchQueue = d.db.Queue()
+	d.queueProjectID = strings.TrimSpace(d.cfg.Settings.Queue.ProjectID)
+	if d.queueProjectID == "" {
+		absolute, _ := filepath.Abs(d.configFile)
+		d.queueProjectID = filepath.Dir(absolute)
+	}
+	if !d.cfg.Settings.Queue.UsesEmbeddedWorker() {
+		return nil
+	}
+	workerID := strings.TrimSpace(d.cfg.Settings.Queue.WorkerID)
+	if workerID == "" {
+		workerID = defaultQueueWorkerID(d.queueProjectID)
+	}
+	d.queueWorkerID = workerID
+	labels := append([]string{"local", "trusted", runtime.GOOS}, d.cfg.Settings.Queue.WorkerLabels...)
+	capabilities := append([]string{"apiary.workflow"}, d.cfg.Settings.Queue.WorkerCapabilities...)
+	for _, adapter := range d.agentRunner {
+		capabilities = append(capabilities, "runner:"+adapter)
+	}
+	runtimeWorker, err := worker.New(d.dispatchQueue, worker.ExecutorFunc(d.executeQueuedJob), worker.Config{
+		Worker:        queue.Worker{ID: workerID, ProtocolVersion: queue.WorkerProtocolVersion, Pool: defaultString(d.cfg.Settings.Queue.WorkerPool, "default"), Labels: uniqueStrings(labels), Capabilities: uniqueStrings(capabilities), Capacity: d.cfg.Settings.Queue.WorkerCapacityValue(), Ready: true},
+		LeaseDuration: d.cfg.Settings.Queue.LeaseDurationValue(), HeartbeatInterval: d.cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerHeartbeat: d.cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerTimeout: d.cfg.Settings.Queue.WorkerTimeoutValue(), PollInterval: d.cfg.Settings.Queue.PollIntervalValue(), Policy: d.queuePolicy(),
+		OnError: func(err error) { aplog.Error("embedded worker: %v", err) },
+	})
+	if err != nil {
+		return fmt.Errorf("configure embedded worker: %w", err)
+	}
+	d.localWorker = runtimeWorker
+	return nil
+}
+
+func (d *Dispatcher) queuePolicy() queue.ConcurrencyPolicy {
+	configured := d.cfg.Settings.Queue.Concurrency
+	policy := queue.ConcurrencyPolicy{DefaultProject: configured.DefaultProject, Projects: configured.Projects, DefaultSource: configured.DefaultSource, Sources: configured.Sources, DefaultAgent: configured.DefaultAgent, Agents: copyLimits(configured.Agents), DefaultRunner: configured.DefaultRunner, Runners: configured.Runners, DefaultPool: configured.DefaultPool, Pools: configured.Pools}
+	if policy.DefaultProject == 0 {
+		policy.DefaultProject = d.cfg.Settings.Concurrency
+	}
+	if policy.Agents == nil {
+		policy.Agents = map[string]int{}
+	}
+	for _, agent := range d.cfg.Agents {
+		if _, explicit := policy.Agents[agent.ID]; !explicit && agent.MaxWorkers > 0 {
+			policy.Agents[agent.ID] = agent.MaxWorkers
+		}
+	}
+	return policy
+}
+
+func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, task model.InternalTask, matches []router.Match) {
+	if _, err := d.db.InternalTasks().IncrementOutstanding(ctx, task.ID, len(matches)); err != nil {
+		aplog.Error("task %s: increment outstanding by %d before enqueue: %v", task.ID, len(matches), err)
+		return
+	}
+	generation, err := d.db.InternalTasks().Generation(ctx, task.ID)
+	if err != nil {
+		aplog.Error("task %s: read dispatch generation: %v", task.ID, err)
+	}
+	for _, match := range matches {
+		payload, err := json.Marshal(dispatchJobPayload{Version: dispatchPayloadVersion, Cell: cell, Task: task, Match: match})
+		if err != nil {
+			d.rollbackQueuedOutstanding(ctx, task.ID, fmt.Errorf("marshal dispatch payload: %w", err))
+			continue
+		}
+		pool, labels, capabilities, affinity := d.requirementsForMatch(task.ID, match)
+		job := &queue.Job{IdempotencyKey: fmt.Sprintf("%s:%d:%s", task.ID, generation, match.Route.ID), ProjectID: d.queueProjectID, SourceID: cell.SourceID, TaskID: task.ID, WorkflowID: match.Route.ID, AgentID: match.Route.Agent, RunnerID: d.agentRunner[match.Route.Agent], Pool: pool, RequiredLabels: labels, RequiredCapabilities: capabilities, AffinityKey: affinity, PayloadVersion: dispatchPayloadVersion, Payload: payload, Priority: -match.Route.Priority, MaxAttempts: d.cfg.Settings.MaxAttempts}
+		created, err := d.dispatchQueue.Enqueue(ctx, job)
+		if err != nil {
+			d.rollbackQueuedOutstanding(ctx, task.ID, fmt.Errorf("enqueue workflow %s: %w", match.Route.ID, err))
+			continue
+		}
+		if !created {
+			d.rollbackQueuedOutstanding(ctx, task.ID, nil)
+			continue
+		}
+		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "queue.enqueued", TaskID: task.ID, WorkflowID: match.Route.ID, Metadata: map[string]any{"job_id": job.ID, "generation": generation, "pool": pool, "required_labels": labels, "required_capabilities": capabilities}})
+	}
+}
+
+func (d *Dispatcher) rollbackQueuedOutstanding(ctx context.Context, taskID string, err error) {
+	_, _ = d.db.InternalTasks().DecrementOutstanding(ctx, taskID)
+	if err != nil {
+		aplog.Error("task %s: %v", taskID, err)
+	}
+}
+
+func (d *Dispatcher) executeQueuedJob(ctx context.Context, job queue.Job) queue.FinishResult {
+	return d.ExecuteQueuedJob(ctx, job, d.queueWorkerID)
+}
+
+// ExecuteQueuedJob executes a protocol job using this dispatcher's configured
+// runners. Remote workers use this entry point without polling project sources.
+func (d *Dispatcher) ExecuteQueuedJob(ctx context.Context, job queue.Job, workerID string) queue.FinishResult {
+	var payload dispatchJobPayload
+	if err := json.Unmarshal(job.Payload, &payload); err != nil {
+		return queue.FinishResult{Error: fmt.Sprintf("decode dispatch payload: %v", err)}
+	}
+	if payload.Version != dispatchPayloadVersion {
+		return queue.FinishResult{Error: fmt.Sprintf("unsupported dispatch payload version %d", payload.Version)}
+	}
+	if d.db != nil && payload.Task.ID != "" {
+		completed, err := d.db.HasCompletedInstanceForRoute(ctx, payload.Task.ID, payload.Match.Route.ID)
+		if err != nil {
+			return queue.FinishResult{Error: fmt.Sprintf("check completed workflow: %v", err), Retry: true}
+		}
+		if completed {
+			return queue.FinishResult{Success: true}
+		}
+	}
+	d.active.Add(1)
+	defer d.active.Add(-1)
+	d.activeRuns.Store(job.ID, model.ActiveRun{ID: job.ID, Cell: payload.Cell, WorkerID: workerID, Model: payload.Match.Worker.Model, Status: model.RunStatusRunning, StartedAt: time.Now()})
+	defer d.activeRuns.Delete(job.ID)
+	result := d.dispatch(ctx, payload.Cell, nil, payload.Task, payload.Match)
+	if ctx.Err() != nil {
+		return queue.FinishResult{Error: ctx.Err().Error()}
+	}
+	if !result.Success {
+		return queue.FinishResult{Error: "workflow dispatch failed"}
+	}
+	return queue.FinishResult{Success: true}
+}
+
+// settleRemoteQueueJob mirrors the terminal workflow state into the canonical
+// control-plane database. The remote worker keeps detailed step state locally;
+// this summary makes task accounting and re-dispatch guards durable centrally.
+func (d *Dispatcher) settleRemoteQueueJob(ctx context.Context, job queue.Job) error {
+	if d.db == nil || job.TaskID == "" {
+		return nil
+	}
+	instanceID := "queue-" + job.ID
+	if existing, err := d.db.GetWorkflowInstance(ctx, instanceID); err != nil {
+		return err
+	} else if existing != nil {
+		return nil
+	}
+	// An embedded worker persists its real instance and settles the task itself.
+	instances, err := d.db.ListWorkflowInstancesByTask(ctx, job.TaskID)
+	if err != nil {
+		return err
+	}
+	for _, instance := range instances {
+		if instance.WorkflowID == job.WorkflowID && !instance.CreatedAt.Before(job.CreatedAt) && (instance.State == db.InstanceStateDone || instance.State == db.InstanceStateFailed || instance.State == db.InstanceStateInterrupted) {
+			return nil
+		}
+	}
+	state := db.InstanceStateFailed
+	if job.State == queue.JobSucceeded {
+		state = db.InstanceStateDone
+	}
+	if job.State == queue.JobCanceled {
+		state = db.InstanceStateInterrupted
+	}
+	if err := d.db.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: instanceID, WorkflowID: job.WorkflowID, TaskID: job.TaskID, SourceID: job.SourceID, State: state}); err != nil {
+		return err
+	}
+	remaining, err := d.db.InternalTasks().DecrementOutstanding(ctx, job.TaskID)
+	if err != nil || remaining > 0 {
+		return err
+	}
+	if job.State == queue.JobCanceled {
+		return nil
+	}
+	failed := job.State == queue.JobFailed
+	if !failed {
+		failed, err = d.db.HasFailedInstance(ctx, job.TaskID)
+		if err != nil {
+			return err
+		}
+	}
+	taskState := model.TaskStateDone
+	if failed {
+		taskState = model.TaskStateFailed
+	}
+	return d.db.InternalTasks().UpdateTaskState(ctx, job.TaskID, taskState)
+}
+
+func (d *Dispatcher) reconcileTerminalQueueJobs(ctx context.Context) {
+	if d.dispatchQueue == nil {
+		return
+	}
+	for _, state := range []queue.JobState{queue.JobSucceeded, queue.JobFailed, queue.JobCanceled} {
+		jobs, err := d.dispatchQueue.ListJobs(ctx, state, 1000)
+		if err != nil {
+			aplog.Error("reconcile %s queue jobs: %v", state, err)
+			continue
+		}
+		for _, job := range jobs {
+			if err := d.settleRemoteQueueJob(ctx, job); err != nil {
+				aplog.Error("settle queue job %s: %v", job.ID, err)
+			}
+		}
+	}
+}
+
+func (d *Dispatcher) requirementsForMatch(taskID string, match router.Match) (string, []string, []string, string) {
+	agents := []string{match.Route.Agent}
+	for _, workflow := range d.cfg.Workflows {
+		if workflow.ID == match.Route.ID {
+			agents = workflowAgentIDs(workflow.Steps)
+			break
+		}
+	}
+	pool, affinity := "default", ""
+	var labels, capabilities []string
+	for _, id := range uniqueStrings(agents) {
+		for _, agent := range d.cfg.Agents {
+			if agent.ID != id {
+				continue
+			}
+			if agent.WorkerPool != "" {
+				pool = agent.WorkerPool
+			}
+			labels = append(labels, agent.RequiresLabels...)
+			capabilities = append(capabilities, agent.RequiresCapabilities...)
+			if adapter := d.agentRunner[id]; adapter != "" {
+				capabilities = append(capabilities, "runner:"+adapter)
+			}
+			if agent.WorkspaceAffinity {
+				affinity = "task:" + taskID
+			}
+		}
+	}
+	capabilities = append(capabilities, "apiary.workflow")
+	return pool, uniqueStrings(labels), uniqueStrings(capabilities), affinity
+}
+
+func workflowAgentIDs(steps []config.StepConfig) []string {
+	var result []string
+	for _, step := range steps {
+		if step.Agent != "" {
+			result = append(result, step.Agent)
+		}
+		if step.Step != nil {
+			result = append(result, workflowAgentIDs([]config.StepConfig{*step.Step})...)
+		}
+		result = append(result, workflowAgentIDs(step.ParallelSteps)...)
+	}
+	return result
+}
+
+func defaultQueueWorkerID(project string) string {
+	host, _ := os.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	digest := sha256.Sum256([]byte(project))
+	return host + "-" + hex.EncodeToString(digest[:4])
+}
+
+func uniqueStrings(values []string) []string {
+	set := map[string]bool{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			set[value] = true
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+func copyLimits(values map[string]int) map[string]int {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]int, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}

--- a/src/internal/daemon/queue_dispatch_test.go
+++ b/src/internal/daemon/queue_dispatch_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+func TestSettleRemoteQueueJobIsDurableAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client, err := db.New(ctx, filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	task := &model.InternalTask{ID: "task-1", Title: "Remote work"}
+	if err := client.InternalTasks().CreateTask(ctx, task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.InternalTasks().IncrementOutstanding(ctx, task.ID, 1); err != nil {
+		t.Fatal(err)
+	}
+	job := &queue.Job{IdempotencyKey: "task-1:0:build", TaskID: task.ID, WorkflowID: "build", SourceID: "github", PayloadVersion: 1, Payload: []byte(`{}`), MaxAttempts: 1}
+	if _, err := client.Queue().Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	job.State = queue.JobSucceeded
+	dispatcher := &Dispatcher{db: client, dispatchQueue: client.Queue()}
+	if err := dispatcher.settleRemoteQueueJob(ctx, *job); err != nil {
+		t.Fatal(err)
+	}
+	if err := dispatcher.settleRemoteQueueJob(ctx, *job); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := client.InternalTasks().GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != model.TaskStateDone || stored.OutstandingWorkflows != 0 {
+		t.Fatalf("task=%+v", stored)
+	}
+	instance, err := client.GetWorkflowInstance(ctx, "queue-"+job.ID)
+	if err != nil || instance == nil || instance.State != db.InstanceStateDone {
+		t.Fatalf("instance=%+v err=%v", instance, err)
+	}
+}

--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -1,0 +1,52 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/queuehttp"
+)
+
+func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.WaitGroup) error {
+	address := strings.TrimSpace(d.cfg.Settings.Queue.Listen)
+	if address == "" {
+		return nil
+	}
+	if d.dispatchQueue == nil {
+		return fmt.Errorf("queue protocol listener requires the durable queue")
+	}
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("listen for queue workers on %s: %w", address, err)
+	}
+	handler := queuehttp.Server{
+		Store: d.dispatchQueue, Token: d.cfg.Settings.Queue.WorkerToken,
+		LeaseDuration: d.cfg.Settings.Queue.LeaseDurationValue(),
+		WorkerTimeout: d.cfg.Settings.Queue.WorkerTimeoutValue(), Policy: d.queuePolicy(),
+		OnTerminal: d.settleRemoteQueueJob,
+	}.Handler()
+	server := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			aplog.Error("queue protocol server: %v", err)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	aplog.Info("queue worker protocol listening on %s", listener.Addr())
+	return nil
+}

--- a/src/internal/daemon/status.go
+++ b/src/internal/daemon/status.go
@@ -10,6 +10,24 @@ type StatusResponse struct {
 	Sources     []SourceStatus    `json:"sources"`
 	ActiveRuns  []ActiveRunStatus `json:"active_runs"`
 	Concurrency ConcurrencyStatus `json:"concurrency"`
+	Queue       QueueStatus       `json:"queue"`
+}
+
+type QueueStatus struct {
+	Enabled bool                `json:"enabled"`
+	Jobs    map[string]int      `json:"jobs,omitempty"`
+	Workers []QueueWorkerStatus `json:"workers,omitempty"`
+}
+
+type QueueWorkerStatus struct {
+	ID            string `json:"id"`
+	Pool          string `json:"pool"`
+	Ready         bool   `json:"ready"`
+	Healthy       bool   `json:"healthy"`
+	Draining      bool   `json:"draining"`
+	Capacity      int    `json:"capacity"`
+	ActiveJobs    int    `json:"active_jobs"`
+	LastHeartbeat string `json:"last_heartbeat"`
 }
 
 type SourceStatus struct {

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -269,6 +269,11 @@ func (d *Dispatcher) StopInstance(ctx context.Context, instanceID string) error 
 	if err != nil || inst == nil {
 		return err
 	}
+	if d.dispatchQueue != nil {
+		if _, err := d.dispatchQueue.RequestCancelFor(ctx, inst.TaskID, inst.WorkflowID); err != nil {
+			aplog.Error("stop instance %s: cancel queued work: %v", instanceID, err)
+		}
+	}
 	// Cancel the in-flight run for this cell.
 	if val, ok := d.runCancel.LoadAndDelete(inst.CellID); ok {
 		cancel := val.(context.CancelFunc)

--- a/src/internal/db/queue_store.go
+++ b/src/internal/db/queue_store.go
@@ -1,0 +1,567 @@
+package db
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+type QueueStore struct{ db *sql.DB }
+
+func (c *Client) Queue() *QueueStore { return &QueueStore{db: c.db} }
+
+func NewQueueStore(database *sql.DB) *QueueStore { return &QueueStore{db: database} }
+
+func (s *QueueStore) Enqueue(ctx context.Context, job *queue.Job) (bool, error) {
+	if job == nil || strings.TrimSpace(job.IdempotencyKey) == "" {
+		return false, fmt.Errorf("queue job idempotency_key is required")
+	}
+	if job.ID == "" {
+		job.ID = randomQueueID("job")
+	}
+	if job.PayloadVersion <= 0 {
+		return false, fmt.Errorf("queue job payload_version must be positive")
+	}
+	if !json.Valid(job.Payload) {
+		return false, fmt.Errorf("queue job payload must be valid JSON")
+	}
+	if job.MaxAttempts <= 0 {
+		job.MaxAttempts = 3
+	}
+	now := time.Now().UTC()
+	if job.AvailableAt.IsZero() {
+		job.AvailableAt = now
+	}
+	labels, _ := json.Marshal(uniqueSorted(job.RequiredLabels))
+	capabilities, _ := json.Marshal(uniqueSorted(job.RequiredCapabilities))
+	result, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO dispatch_jobs
+		  (id, idempotency_key, project_id, source_id, task_id, workflow_id, agent_id, runner_id, pool,
+		   required_labels, required_capabilities, affinity_key, affinity_worker_id, payload_version, payload,
+		   priority, state, attempt_count, max_attempts, cancel_requested, available_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', 0, ?, 0, ?, ?, ?)
+	`, job.ID, job.IdempotencyKey, nullStr(job.ProjectID), nullStr(job.SourceID), nullStr(job.TaskID), nullStr(job.WorkflowID),
+		nullStr(job.AgentID), nullStr(job.RunnerID), nullStr(job.Pool), string(labels), string(capabilities), nullStr(job.AffinityKey),
+		nullStr(job.AffinityWorkerID), job.PayloadVersion, string(job.Payload), job.Priority, job.MaxAttempts, job.AvailableAt.UTC(), now, now)
+	if err != nil {
+		return false, fmt.Errorf("enqueue dispatch job: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if rows == 0 {
+		existing, getErr := s.getJobByKey(ctx, job.IdempotencyKey)
+		if getErr == nil {
+			*job = *existing
+		}
+		return false, getErr
+	}
+	job.State, job.AttemptCount, job.CancelRequested = queue.JobQueued, 0, false
+	job.CreatedAt, job.UpdatedAt = now, now
+	job.RequiredLabels, job.RequiredCapabilities = uniqueSorted(job.RequiredLabels), uniqueSorted(job.RequiredCapabilities)
+	return true, nil
+}
+
+func (s *QueueStore) RegisterWorker(ctx context.Context, worker *queue.Worker) error {
+	if worker == nil || strings.TrimSpace(worker.ID) == "" {
+		return fmt.Errorf("worker id is required")
+	}
+	if worker.ProtocolVersion != queue.WorkerProtocolVersion {
+		return fmt.Errorf("worker %q protocol %d is incompatible; expected %d", worker.ID, worker.ProtocolVersion, queue.WorkerProtocolVersion)
+	}
+	if worker.Capacity <= 0 {
+		return fmt.Errorf("worker %q capacity must be positive", worker.ID)
+	}
+	now := time.Now().UTC()
+	labels, _ := json.Marshal(uniqueSorted(worker.Labels))
+	capabilities, _ := json.Marshal(uniqueSorted(worker.Capabilities))
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO worker_registrations
+		  (id, protocol_version, pool, labels, capabilities, capacity, ready, draining, active_jobs, last_heartbeat, registered_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET protocol_version=excluded.protocol_version, pool=excluded.pool,
+		  labels=excluded.labels, capabilities=excluded.capabilities, capacity=excluded.capacity,
+		  ready=excluded.ready, draining=excluded.draining, last_heartbeat=excluded.last_heartbeat, updated_at=excluded.updated_at
+	`, worker.ID, worker.ProtocolVersion, nullStr(worker.Pool), string(labels), string(capabilities), worker.Capacity,
+		boolToInt(worker.Ready), boolToInt(worker.Draining), now, now, now)
+	if err != nil {
+		return fmt.Errorf("register worker %q: %w", worker.ID, err)
+	}
+	worker.LastHeartbeat, worker.RegisteredAt = now, now
+	return nil
+}
+
+func (s *QueueStore) HeartbeatWorker(ctx context.Context, workerID string, ready bool) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE worker_registrations SET ready=?, last_heartbeat=?, updated_at=? WHERE id=?`, boolToInt(ready), time.Now().UTC(), time.Now().UTC(), workerID)
+	if err != nil {
+		return err
+	}
+	return requireWorkerRow(result)
+}
+
+func (s *QueueStore) SetWorkerDrain(ctx context.Context, workerID string, draining bool) error {
+	ready := 1
+	if draining {
+		ready = 0
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE worker_registrations SET draining=?, ready=?, updated_at=? WHERE id=?`, boolToInt(draining), ready, time.Now().UTC(), workerID)
+	if err != nil {
+		return err
+	}
+	return requireWorkerRow(result)
+}
+
+func (s *QueueStore) Claim(ctx context.Context, request queue.ClaimRequest) (*queue.Claim, error) {
+	if request.LeaseDuration <= 0 {
+		request.LeaseDuration = 30 * time.Second
+	}
+	if request.WorkerTimeout <= 0 {
+		request.WorkerTimeout = 30 * time.Second
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	worker, err := scanWorker(tx.QueryRowContext(ctx, `SELECT id, protocol_version, COALESCE(pool,''), labels, capabilities, capacity, ready, draining, active_jobs, last_heartbeat, registered_at FROM worker_registrations WHERE id=?`, request.WorkerID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, queue.ErrWorkerUnknown
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !worker.Ready || worker.Draining {
+		return nil, queue.ErrWorkerDraining
+	}
+	if worker.LastHeartbeat.Before(time.Now().UTC().Add(-request.WorkerTimeout)) {
+		return nil, queue.ErrWorkerUnhealthy
+	}
+	if worker.ActiveJobs >= worker.Capacity {
+		return nil, queue.ErrNoJob
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, idempotency_key, COALESCE(project_id,''), COALESCE(source_id,''), COALESCE(task_id,''),
+		       COALESCE(workflow_id,''), COALESCE(agent_id,''), COALESCE(runner_id,''), COALESCE(pool,''),
+		       required_labels, required_capabilities, COALESCE(affinity_key,''), COALESCE(affinity_worker_id,''),
+		       payload_version, payload, priority, state, attempt_count, max_attempts, cancel_requested,
+		       available_at, lease_expires_at, created_at, updated_at
+		FROM dispatch_jobs
+		WHERE state='queued' AND cancel_requested=0 AND available_at <= ?
+		  AND (affinity_worker_id IS NULL OR affinity_worker_id='' OR affinity_worker_id=?)
+		ORDER BY priority DESC, created_at ASC LIMIT 100
+	`, time.Now().UTC(), worker.ID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var selected *queue.Job
+	for rows.Next() {
+		job, scanErr := scanJob(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if compatible(worker, job) {
+			allowed, policyErr := withinPolicy(ctx, tx, job, request.Policy)
+			if policyErr != nil {
+				return nil, policyErr
+			}
+			if allowed {
+				selected = job
+				break
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if selected == nil {
+		return nil, queue.ErrNoJob
+	}
+	_ = rows.Close()
+
+	now := time.Now().UTC()
+	expires := now.Add(request.LeaseDuration)
+	attemptID, claimToken := randomQueueID("attempt"), randomQueueID("claim")
+	result, err := tx.ExecContext(ctx, `
+		UPDATE dispatch_jobs SET state='leased', attempt_count=attempt_count+1,
+		  lease_attempt_id=?, lease_token=?, lease_worker_id=?, lease_expires_at=?,
+		  affinity_worker_id=CASE WHEN affinity_key IS NOT NULL AND affinity_key!='' AND (affinity_worker_id IS NULL OR affinity_worker_id='') THEN ? ELSE affinity_worker_id END,
+		  updated_at=?
+		WHERE id=? AND state='queued' AND cancel_requested=0
+	`, attemptID, claimToken, worker.ID, expires, worker.ID, now, selected.ID)
+	if err != nil {
+		return nil, err
+	}
+	if affected, _ := result.RowsAffected(); affected != 1 {
+		return nil, queue.ErrNoJob
+	}
+	selected.AttemptCount++
+	_, err = tx.ExecContext(ctx, `INSERT INTO dispatch_attempts
+		(id, job_id, attempt_number, worker_id, claim_token, state, lease_expires_at, heartbeat_at, started_at)
+		VALUES (?, ?, ?, ?, ?, 'active', ?, ?, ?)`, attemptID, selected.ID, selected.AttemptCount, worker.ID, claimToken, expires, now, now)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE worker_registrations SET active_jobs=active_jobs+1, updated_at=? WHERE id=?`, now, worker.ID); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	selected.State, selected.LeaseExpiresAt, selected.UpdatedAt = queue.JobLeased, &expires, now
+	if selected.AffinityKey != "" && selected.AffinityWorkerID == "" {
+		selected.AffinityWorkerID = worker.ID
+	}
+	return &queue.Claim{Job: *selected, Attempt: queue.Attempt{ID: attemptID, JobID: selected.ID, Number: selected.AttemptCount, WorkerID: worker.ID, ClaimToken: claimToken, State: queue.AttemptActive, LeaseExpiresAt: expires, HeartbeatAt: now, StartedAt: now}}, nil
+}
+
+func (s *QueueStore) Heartbeat(ctx context.Context, jobID, attemptID, token string, extension time.Duration) (*queue.HeartbeatResult, error) {
+	if extension <= 0 {
+		extension = 30 * time.Second
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	now, expires := time.Now().UTC(), time.Now().UTC().Add(extension)
+	result, err := tx.ExecContext(ctx, `UPDATE dispatch_attempts SET heartbeat_at=?, lease_expires_at=? WHERE id=? AND job_id=? AND claim_token=? AND state='active'`, now, expires, attemptID, jobID, token)
+	if err != nil {
+		return nil, err
+	}
+	if affected, _ := result.RowsAffected(); affected != 1 {
+		return nil, queue.ErrStaleClaim
+	}
+	var canceled int
+	err = tx.QueryRowContext(ctx, `UPDATE dispatch_jobs SET lease_expires_at=?, updated_at=? WHERE id=? AND state='leased' AND lease_attempt_id=? AND lease_token=? RETURNING cancel_requested`, expires, now, jobID, attemptID, token).Scan(&canceled)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, queue.ErrStaleClaim
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return &queue.HeartbeatResult{LeaseExpiresAt: expires, CancelRequested: canceled != 0}, nil
+}
+
+func (s *QueueStore) Finish(ctx context.Context, jobID, attemptID, token string, result queue.FinishResult) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	var workerID string
+	var attempts, maxAttempts, canceled int
+	err = tx.QueryRowContext(ctx, `SELECT COALESCE(lease_worker_id,''), attempt_count, max_attempts, cancel_requested FROM dispatch_jobs WHERE id=? AND state='leased' AND lease_attempt_id=? AND lease_token=?`, jobID, attemptID, token).Scan(&workerID, &attempts, &maxAttempts, &canceled)
+	if errors.Is(err, sql.ErrNoRows) {
+		return queue.ErrStaleClaim
+	}
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	attemptState, jobState := queue.AttemptFailed, queue.JobFailed
+	available := now
+	if canceled != 0 {
+		attemptState, jobState = queue.AttemptCanceled, queue.JobCanceled
+	} else if result.Success {
+		attemptState, jobState = queue.AttemptSucceeded, queue.JobSucceeded
+	} else if result.Retry && attempts < maxAttempts {
+		jobState = queue.JobQueued
+		if result.RetryAt != nil {
+			available = result.RetryAt.UTC()
+		}
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE dispatch_attempts SET state=?, finished_at=?, error_message=? WHERE id=? AND claim_token=? AND state='active'`, attemptState, now, nullStr(result.Error), attemptID, token); err != nil {
+		return err
+	}
+	terminal := any(nil)
+	if jobState == queue.JobSucceeded || jobState == queue.JobFailed || jobState == queue.JobCanceled {
+		terminal = now
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE dispatch_jobs SET state=?, available_at=?, lease_attempt_id=NULL, lease_token=NULL, lease_worker_id=NULL, lease_expires_at=NULL, terminal_at=?, updated_at=? WHERE id=? AND lease_attempt_id=? AND lease_token=?`, jobState, available, terminal, now, jobID, attemptID, token); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE worker_registrations SET active_jobs=CASE WHEN active_jobs>0 THEN active_jobs-1 ELSE 0 END, updated_at=? WHERE id=?`, now, workerID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *QueueStore) RequestCancel(ctx context.Context, jobID string) error {
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `UPDATE dispatch_jobs SET cancel_requested=1, state=CASE WHEN state='queued' THEN 'canceled' ELSE state END, terminal_at=CASE WHEN state='queued' THEN ? ELSE terminal_at END, updated_at=? WHERE id=? AND state IN ('queued','leased')`, now, now, jobID)
+	if err != nil {
+		return err
+	}
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		return fmt.Errorf("queue job %q is not cancelable", jobID)
+	}
+	return nil
+}
+
+func (s *QueueStore) RequestCancelFor(ctx context.Context, taskID, workflowID string) (int, error) {
+	now := time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `UPDATE dispatch_jobs SET cancel_requested=1, state=CASE WHEN state='queued' THEN 'canceled' ELSE state END, terminal_at=CASE WHEN state='queued' THEN ? ELSE terminal_at END, updated_at=? WHERE task_id=? AND workflow_id=? AND state IN ('queued','leased')`, now, now, taskID, workflowID)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := result.RowsAffected()
+	return int(rows), err
+}
+
+func (s *QueueStore) ReleaseAffinity(ctx context.Context, jobID string) error {
+	result, err := s.db.ExecContext(ctx, `UPDATE dispatch_jobs SET affinity_worker_id=NULL, updated_at=? WHERE id=? AND state='queued'`, time.Now().UTC(), jobID)
+	if err != nil {
+		return err
+	}
+	if rows, _ := result.RowsAffected(); rows != 1 {
+		return fmt.Errorf("queue job %q affinity can only be released while queued", jobID)
+	}
+	return nil
+}
+
+func (s *QueueStore) ReclaimExpired(ctx context.Context, cutoff time.Time) (int, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	rows, err := tx.QueryContext(ctx, `SELECT id, lease_attempt_id, COALESCE(lease_worker_id,''), attempt_count, max_attempts, cancel_requested FROM dispatch_jobs WHERE state='leased' AND lease_expires_at <= ?`, cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	type expired struct {
+		jobID, attemptID, workerID string
+		attempts, max, canceled    int
+	}
+	var jobs []expired
+	for rows.Next() {
+		var item expired
+		if err := rows.Scan(&item.jobID, &item.attemptID, &item.workerID, &item.attempts, &item.max, &item.canceled); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		jobs = append(jobs, item)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	for _, item := range jobs {
+		if _, err := tx.ExecContext(ctx, `UPDATE dispatch_attempts SET state='expired', finished_at=?, error_message='lease expired' WHERE id=? AND state='active'`, now, item.attemptID); err != nil {
+			return 0, err
+		}
+		state := queue.JobQueued
+		terminal := any(nil)
+		if item.canceled != 0 {
+			state, terminal = queue.JobCanceled, now
+		} else if item.attempts >= item.max {
+			state, terminal = queue.JobFailed, now
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE dispatch_jobs SET state=?, available_at=?, lease_attempt_id=NULL, lease_token=NULL, lease_worker_id=NULL, lease_expires_at=NULL, terminal_at=?, updated_at=? WHERE id=? AND state='leased' AND lease_attempt_id=?`, state, now, terminal, now, item.jobID, item.attemptID); err != nil {
+			return 0, err
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE worker_registrations SET active_jobs=CASE WHEN active_jobs>0 THEN active_jobs-1 ELSE 0 END, updated_at=? WHERE id=?`, now, item.workerID); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return len(jobs), nil
+}
+
+func (s *QueueStore) GetJob(ctx context.Context, id string) (*queue.Job, error) {
+	return scanJob(s.db.QueryRowContext(ctx, jobSelect+` WHERE id=?`, id))
+}
+
+func (s *QueueStore) ListJobs(ctx context.Context, state queue.JobState, limit int) ([]queue.Job, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	query, args := jobSelect, []any{}
+	if state != "" {
+		query += ` WHERE state=?`
+		args = append(args, state)
+	}
+	query += ` ORDER BY created_at DESC LIMIT ?`
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var jobs []queue.Job
+	for rows.Next() {
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, *job)
+	}
+	return jobs, rows.Err()
+}
+
+func (s *QueueStore) getJobByKey(ctx context.Context, key string) (*queue.Job, error) {
+	return scanJob(s.db.QueryRowContext(ctx, jobSelect+` WHERE idempotency_key=?`, key))
+}
+
+func (s *QueueStore) ListWorkers(ctx context.Context) ([]queue.Worker, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, protocol_version, COALESCE(pool,''), labels, capabilities, capacity, ready, draining, active_jobs, last_heartbeat, registered_at FROM worker_registrations ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var workers []queue.Worker
+	for rows.Next() {
+		worker, err := scanWorker(rows)
+		if err != nil {
+			return nil, err
+		}
+		workers = append(workers, *worker)
+	}
+	return workers, rows.Err()
+}
+
+const jobSelect = `SELECT id, idempotency_key, COALESCE(project_id,''), COALESCE(source_id,''), COALESCE(task_id,''), COALESCE(workflow_id,''), COALESCE(agent_id,''), COALESCE(runner_id,''), COALESCE(pool,''), required_labels, required_capabilities, COALESCE(affinity_key,''), COALESCE(affinity_worker_id,''), payload_version, payload, priority, state, attempt_count, max_attempts, cancel_requested, available_at, lease_expires_at, created_at, updated_at FROM dispatch_jobs`
+
+type rowScanner interface{ Scan(...any) error }
+
+func scanJob(row rowScanner) (*queue.Job, error) {
+	var job queue.Job
+	var labels, capabilities, payload string
+	var canceled int
+	var lease sql.NullTime
+	err := row.Scan(&job.ID, &job.IdempotencyKey, &job.ProjectID, &job.SourceID, &job.TaskID, &job.WorkflowID, &job.AgentID, &job.RunnerID, &job.Pool, &labels, &capabilities, &job.AffinityKey, &job.AffinityWorkerID, &job.PayloadVersion, &payload, &job.Priority, &job.State, &job.AttemptCount, &job.MaxAttempts, &canceled, &job.AvailableAt, &lease, &job.CreatedAt, &job.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal([]byte(labels), &job.RequiredLabels)
+	_ = json.Unmarshal([]byte(capabilities), &job.RequiredCapabilities)
+	job.Payload, job.CancelRequested = json.RawMessage(payload), canceled != 0
+	if lease.Valid {
+		value := lease.Time
+		job.LeaseExpiresAt = &value
+	}
+	return &job, nil
+}
+
+func scanWorker(row rowScanner) (*queue.Worker, error) {
+	var worker queue.Worker
+	var labels, capabilities string
+	var ready, draining int
+	err := row.Scan(&worker.ID, &worker.ProtocolVersion, &worker.Pool, &labels, &capabilities, &worker.Capacity, &ready, &draining, &worker.ActiveJobs, &worker.LastHeartbeat, &worker.RegisteredAt)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal([]byte(labels), &worker.Labels)
+	_ = json.Unmarshal([]byte(capabilities), &worker.Capabilities)
+	worker.Ready, worker.Draining = ready != 0, draining != 0
+	return &worker, nil
+}
+
+func compatible(worker *queue.Worker, job *queue.Job) bool {
+	if job.Pool != "" && job.Pool != worker.Pool {
+		return false
+	}
+	return containsAll(worker.Labels, job.RequiredLabels) && containsAll(worker.Capabilities, job.RequiredCapabilities)
+}
+
+func containsAll(have, need []string) bool {
+	set := map[string]bool{}
+	for _, value := range have {
+		set[value] = true
+	}
+	for _, value := range need {
+		if !set[value] {
+			return false
+		}
+	}
+	return true
+}
+
+func withinPolicy(ctx context.Context, tx *sql.Tx, job *queue.Job, policy queue.ConcurrencyPolicy) (bool, error) {
+	checks := []struct {
+		field, value string
+		limit        int
+	}{
+		{"project_id", job.ProjectID, scopedLimit(policy.Projects, job.ProjectID, policy.DefaultProject)},
+		{"source_id", job.SourceID, scopedLimit(policy.Sources, job.SourceID, policy.DefaultSource)},
+		{"agent_id", job.AgentID, scopedLimit(policy.Agents, job.AgentID, policy.DefaultAgent)},
+		{"runner_id", job.RunnerID, scopedLimit(policy.Runners, job.RunnerID, policy.DefaultRunner)},
+		{"pool", job.Pool, scopedLimit(policy.Pools, job.Pool, policy.DefaultPool)},
+	}
+	for _, check := range checks {
+		if check.limit <= 0 || check.value == "" {
+			continue
+		}
+		var active int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM dispatch_jobs WHERE state='leased' AND `+check.field+`=?`, check.value).Scan(&active); err != nil {
+			return false, err
+		}
+		if active >= check.limit {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func scopedLimit(overrides map[string]int, value string, fallback int) int {
+	if limit, ok := overrides[value]; ok {
+		return limit
+	}
+	return fallback
+}
+
+func requireWorkerRow(result sql.Result) error {
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return queue.ErrWorkerUnknown
+	}
+	return nil
+}
+
+func uniqueSorted(values []string) []string {
+	set := map[string]bool{}
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			set[trimmed] = true
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func randomQueueID(prefix string) string {
+	buffer := make([]byte, 16)
+	if _, err := rand.Read(buffer); err != nil {
+		return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+	}
+	return prefix + "-" + hex.EncodeToString(buffer)
+}
+
+var _ queue.Store = (*QueueStore)(nil)

--- a/src/internal/db/queue_store_test.go
+++ b/src/internal/db/queue_store_test.go
@@ -1,0 +1,267 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+func queueTestClient(t *testing.T) (*Client, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "queue.db")
+	client, err := New(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, path
+}
+
+func testJob(key string) *queue.Job {
+	return &queue.Job{IdempotencyKey: key, ProjectID: "project", SourceID: "source", AgentID: "engineer", RunnerID: "codex", Pool: "default", PayloadVersion: 1, Payload: []byte(`{"task":"work"}`), MaxAttempts: 3}
+}
+
+func registerQueueWorker(t *testing.T, store *QueueStore, id string, capacity int, labels, capabilities []string) {
+	t.Helper()
+	err := store.RegisterWorker(context.Background(), &queue.Worker{ID: id, ProtocolVersion: queue.WorkerProtocolVersion, Pool: "default", Labels: labels, Capabilities: capabilities, Capacity: capacity, Ready: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueuePersistsAndEnqueueIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	client, path := queueTestClient(t)
+	job := testJob("task:workflow:generation")
+	created, err := client.Queue().Enqueue(ctx, job)
+	if err != nil || !created {
+		t.Fatalf("created=%v err=%v", created, err)
+	}
+	duplicate := testJob(job.IdempotencyKey)
+	created, err = client.Queue().Enqueue(ctx, duplicate)
+	if err != nil || created || duplicate.ID != job.ID {
+		t.Fatalf("duplicate created=%v id=%s want=%s err=%v", created, duplicate.ID, job.ID, err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := New(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	stored, err := reopened.Queue().GetJob(ctx, job.ID)
+	if err != nil || stored.State != queue.JobQueued || string(stored.Payload) != string(job.Payload) {
+		t.Fatalf("stored=%+v err=%v", stored, err)
+	}
+}
+
+func TestQueueClaimsOnlyCompatibleWorkerAndHonorsDrain(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	job := testJob("compatible")
+	job.RequiredLabels = []string{"linux", "gpu"}
+	job.RequiredCapabilities = []string{"docker"}
+	if _, err := store.Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	registerQueueWorker(t, store, "cpu", 1, []string{"linux"}, []string{"docker"})
+	registerQueueWorker(t, store, "gpu", 1, []string{"gpu", "linux"}, []string{"docker", "git"})
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "cpu"}); !errors.Is(err, queue.ErrNoJob) {
+		t.Fatalf("cpu claim err=%v", err)
+	}
+	if err := store.SetWorkerDrain(ctx, "gpu", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "gpu"}); !errors.Is(err, queue.ErrWorkerDraining) {
+		t.Fatalf("draining claim err=%v", err)
+	}
+	if err := store.SetWorkerDrain(ctx, "gpu", false); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "gpu", LeaseDuration: time.Minute})
+	if err != nil || claim.Job.ID != job.ID {
+		t.Fatalf("claim=%+v err=%v", claim, err)
+	}
+}
+
+func TestQueueReclaimsAbandonedLeaseAndFencesStaleWorker(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	job := testJob("reclaim")
+	job.AffinityKey = "workspace:task"
+	if _, err := store.Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	registerQueueWorker(t, store, "worker-a", 1, nil, nil)
+	registerQueueWorker(t, store, "worker-b", 1, nil, nil)
+	first, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-a", LeaseDuration: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reclaimed, err := store.ReclaimExpired(ctx, first.Attempt.LeaseExpiresAt.Add(time.Millisecond))
+	if err != nil || reclaimed != 1 {
+		t.Fatalf("reclaimed=%d err=%v", reclaimed, err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-b"}); !errors.Is(err, queue.ErrNoJob) {
+		t.Fatalf("affinity escaped to worker-b: %v", err)
+	}
+	second, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-a", LeaseDuration: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Attempt.Number != 2 {
+		t.Fatalf("attempt=%d", second.Attempt.Number)
+	}
+	if err := store.Finish(ctx, first.Job.ID, first.Attempt.ID, first.Attempt.ClaimToken, queue.FinishResult{Success: true}); !errors.Is(err, queue.ErrStaleClaim) {
+		t.Fatalf("stale finish err=%v", err)
+	}
+	if err := store.Finish(ctx, second.Job.ID, second.Attempt.ID, second.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _ := store.GetJob(ctx, job.ID)
+	if stored.State != queue.JobSucceeded {
+		t.Fatalf("state=%s", stored.State)
+	}
+}
+
+func TestQueueConcurrencyPolicyAndCapacityAreTransactional(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	for _, key := range []string{"limit-1", "limit-2"} {
+		if _, err := store.Enqueue(ctx, testJob(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	registerQueueWorker(t, store, "worker", 2, nil, nil)
+	policy := queue.ConcurrencyPolicy{Agents: map[string]int{"engineer": 1}}
+	first, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", Policy: policy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", Policy: policy}); !errors.Is(err, queue.ErrNoJob) {
+		t.Fatalf("second claim err=%v", err)
+	}
+	if err := store.Finish(ctx, first.Job.ID, first.Attempt.ID, first.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", Policy: policy}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueueCancellationPropagatesThroughHeartbeatAndWinsFinish(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	job := testJob("cancel")
+	if _, err := store.Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	registerQueueWorker(t, store, "worker", 1, nil, nil)
+	claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", LeaseDuration: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RequestCancel(ctx, job.ID); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat, err := store.Heartbeat(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, time.Minute)
+	if err != nil || !heartbeat.CancelRequested {
+		t.Fatalf("heartbeat=%+v err=%v", heartbeat, err)
+	}
+	if err := store.Finish(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatal(err)
+	}
+	stored, _ := store.GetJob(ctx, job.ID)
+	if stored.State != queue.JobCanceled {
+		t.Fatalf("state=%s", stored.State)
+	}
+}
+
+func TestQueueRetriesOnlyExplicitlyRetryableFailures(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	registerQueueWorker(t, store, "worker", 1, nil, nil)
+	terminal := testJob("terminal-failure")
+	if _, err := store.Enqueue(ctx, terminal); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Finish(ctx, terminal.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Error: "workflow failed"}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.GetJob(ctx, terminal.ID)
+	if got.State != queue.JobFailed {
+		t.Fatalf("ordinary failure state=%s", got.State)
+	}
+
+	retryable := testJob("retryable-failure")
+	if _, err := store.Enqueue(ctx, retryable); err != nil {
+		t.Fatal(err)
+	}
+	claim, err = store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Finish(ctx, retryable.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Error: "transport lost", Retry: true}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = store.GetJob(ctx, retryable.ID)
+	if got.State != queue.JobQueued {
+		t.Fatalf("retryable failure state=%s", got.State)
+	}
+}
+
+func TestQueueConcurrentClaimHasOneActiveAttempt(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+	job := testJob("concurrent")
+	if _, err := store.Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	registerQueueWorker(t, store, "worker", 32, nil, nil)
+	var won atomic.Int32
+	var unexpected atomic.Value
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", LeaseDuration: time.Minute})
+			if err == nil {
+				won.Add(1)
+				return
+			}
+			if !errors.Is(err, queue.ErrNoJob) {
+				unexpected.Store(err)
+			}
+		}()
+	}
+	wg.Wait()
+	if value := unexpected.Load(); value != nil {
+		t.Fatalf("unexpected claim error: %v", value)
+	}
+	if won.Load() != 1 {
+		t.Fatalf("successful claims=%d", won.Load())
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -231,6 +231,71 @@ CREATE INDEX IF NOT EXISTS idx_execution_events_task ON execution_events(task_id
 CREATE INDEX IF NOT EXISTS idx_execution_events_instance ON execution_events(workflow_instance_id, id);
 CREATE INDEX IF NOT EXISTS idx_execution_events_type ON execution_events(type, id);
 
+-- Durable dispatch queue. A job holds one immutable, versioned dispatch
+-- snapshot and at most one active lease. The lease attempt/token pair is the
+-- compare-and-set fence that prevents a reclaimed worker from completing stale
+-- work after another worker has claimed it.
+CREATE TABLE IF NOT EXISTS dispatch_jobs (
+  id TEXT PRIMARY KEY,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  project_id TEXT, source_id TEXT, task_id TEXT, workflow_id TEXT,
+  agent_id TEXT, runner_id TEXT, pool TEXT,
+  required_labels TEXT NOT NULL DEFAULT '[]',
+  required_capabilities TEXT NOT NULL DEFAULT '[]',
+  affinity_key TEXT, affinity_worker_id TEXT,
+  payload_version INTEGER NOT NULL,
+  payload TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  state TEXT NOT NULL DEFAULT 'queued',
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 3,
+  cancel_requested INTEGER NOT NULL DEFAULT 0,
+  available_at TIMESTAMP NOT NULL,
+  lease_attempt_id TEXT, lease_token TEXT, lease_worker_id TEXT,
+  lease_expires_at TIMESTAMP,
+  terminal_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS dispatch_attempts (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  attempt_number INTEGER NOT NULL,
+  worker_id TEXT NOT NULL,
+  claim_token TEXT NOT NULL,
+  state TEXT NOT NULL,
+  lease_expires_at TIMESTAMP NOT NULL,
+  heartbeat_at TIMESTAMP NOT NULL,
+  started_at TIMESTAMP NOT NULL,
+  finished_at TIMESTAMP,
+  error_message TEXT,
+  FOREIGN KEY(job_id) REFERENCES dispatch_jobs(id),
+  UNIQUE(job_id, attempt_number)
+);
+
+CREATE TABLE IF NOT EXISTS worker_registrations (
+  id TEXT PRIMARY KEY,
+  protocol_version INTEGER NOT NULL,
+  pool TEXT,
+  labels TEXT NOT NULL DEFAULT '[]',
+  capabilities TEXT NOT NULL DEFAULT '[]',
+  capacity INTEGER NOT NULL DEFAULT 1,
+  ready INTEGER NOT NULL DEFAULT 1,
+  draining INTEGER NOT NULL DEFAULT 0,
+  active_jobs INTEGER NOT NULL DEFAULT 0,
+  last_heartbeat TIMESTAMP NOT NULL,
+  registered_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispatch_jobs_claim ON dispatch_jobs(state, available_at, priority DESC, created_at);
+CREATE INDEX IF NOT EXISTS idx_dispatch_jobs_lease ON dispatch_jobs(state, lease_expires_at);
+CREATE INDEX IF NOT EXISTS idx_dispatch_jobs_scopes ON dispatch_jobs(state, project_id, source_id, agent_id, runner_id, pool);
+CREATE INDEX IF NOT EXISTS idx_dispatch_attempts_job ON dispatch_attempts(job_id, attempt_number);
+CREATE INDEX IF NOT EXISTS idx_dispatch_attempts_lease ON dispatch_attempts(state, lease_expires_at);
+CREATE INDEX IF NOT EXISTS idx_workers_heartbeat ON worker_registrations(last_heartbeat);
+
 CREATE TABLE IF NOT EXISTS approval_requests (
   id TEXT PRIMARY KEY,
   workflow_instance_id TEXT NOT NULL,

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -217,6 +217,18 @@ func (s *InternalTaskStore) outstanding(ctx context.Context, id string) (int, er
 	return n, err
 }
 
+// Generation returns the task's current dispatch generation. Queue
+// idempotency keys include it so re-polls deduplicate one active round while a
+// later explicit re-dispatch can enqueue a fresh job.
+func (s *InternalTaskStore) Generation(ctx context.Context, id string) (int, error) {
+	var generation int
+	err := s.db.QueryRowContext(ctx, `SELECT COALESCE(generation,0) FROM internal_tasks WHERE id=?`, id).Scan(&generation)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return generation, err
+}
+
 // DeleteTask removes a task row by ID. Workflow instances, bindings, and logs are
 // removed by their own stores; this only drops the internal_tasks row. Deleting a
 // non-existent id is a no-op (no error), so it is safe to call for orphaned cells.

--- a/src/internal/queue/queue.go
+++ b/src/internal/queue/queue.go
@@ -1,0 +1,155 @@
+// Package queue defines durable dispatch and distributed-worker contracts.
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+const WorkerProtocolVersion = 1
+
+var (
+	ErrNoJob           = errors.New("no compatible queued job")
+	ErrStaleClaim      = errors.New("stale or inactive job claim")
+	ErrWorkerUnknown   = errors.New("worker is not registered")
+	ErrWorkerDraining  = errors.New("worker is draining or not ready")
+	ErrWorkerUnhealthy = errors.New("worker heartbeat is stale")
+)
+
+type JobState string
+
+const (
+	JobQueued    JobState = "queued"
+	JobLeased    JobState = "leased"
+	JobSucceeded JobState = "succeeded"
+	JobFailed    JobState = "failed"
+	JobCanceled  JobState = "canceled"
+)
+
+type AttemptState string
+
+const (
+	AttemptActive    AttemptState = "active"
+	AttemptSucceeded AttemptState = "succeeded"
+	AttemptFailed    AttemptState = "failed"
+	AttemptExpired   AttemptState = "expired"
+	AttemptCanceled  AttemptState = "canceled"
+)
+
+// Job is one immutable dispatch snapshot plus its durable scheduling state.
+// Payload is versioned by the control plane and contains the concrete dispatch
+// request needed by a worker; the queue treats it as opaque JSON.
+type Job struct {
+	ID                   string          `json:"id"`
+	IdempotencyKey       string          `json:"idempotency_key"`
+	ProjectID            string          `json:"project_id,omitempty"`
+	SourceID             string          `json:"source_id,omitempty"`
+	TaskID               string          `json:"task_id,omitempty"`
+	WorkflowID           string          `json:"workflow_id,omitempty"`
+	AgentID              string          `json:"agent_id,omitempty"`
+	RunnerID             string          `json:"runner_id,omitempty"`
+	Pool                 string          `json:"pool,omitempty"`
+	RequiredLabels       []string        `json:"required_labels,omitempty"`
+	RequiredCapabilities []string        `json:"required_capabilities,omitempty"`
+	AffinityKey          string          `json:"affinity_key,omitempty"`
+	AffinityWorkerID     string          `json:"affinity_worker_id,omitempty"`
+	PayloadVersion       int             `json:"payload_version"`
+	Payload              json.RawMessage `json:"payload"`
+	Priority             int             `json:"priority"`
+	State                JobState        `json:"state"`
+	AttemptCount         int             `json:"attempt_count"`
+	MaxAttempts          int             `json:"max_attempts"`
+	CancelRequested      bool            `json:"cancel_requested"`
+	AvailableAt          time.Time       `json:"available_at"`
+	LeaseExpiresAt       *time.Time      `json:"lease_expires_at,omitempty"`
+	CreatedAt            time.Time       `json:"created_at"`
+	UpdatedAt            time.Time       `json:"updated_at"`
+}
+
+type Attempt struct {
+	ID             string       `json:"id"`
+	JobID          string       `json:"job_id"`
+	Number         int          `json:"number"`
+	WorkerID       string       `json:"worker_id"`
+	ClaimToken     string       `json:"claim_token,omitempty"`
+	State          AttemptState `json:"state"`
+	LeaseExpiresAt time.Time    `json:"lease_expires_at"`
+	HeartbeatAt    time.Time    `json:"heartbeat_at"`
+	StartedAt      time.Time    `json:"started_at"`
+	FinishedAt     *time.Time   `json:"finished_at,omitempty"`
+	Error          string       `json:"error,omitempty"`
+}
+
+type Claim struct {
+	Job     Job     `json:"job"`
+	Attempt Attempt `json:"attempt"`
+}
+
+type Worker struct {
+	ID              string    `json:"id"`
+	ProtocolVersion int       `json:"protocol_version"`
+	Pool            string    `json:"pool,omitempty"`
+	Labels          []string  `json:"labels,omitempty"`
+	Capabilities    []string  `json:"capabilities,omitempty"`
+	Capacity        int       `json:"capacity"`
+	Ready           bool      `json:"ready"`
+	Draining        bool      `json:"draining"`
+	ActiveJobs      int       `json:"active_jobs"`
+	LastHeartbeat   time.Time `json:"last_heartbeat"`
+	RegisteredAt    time.Time `json:"registered_at"`
+}
+
+// ConcurrencyPolicy is evaluated transactionally from active leases. A zero
+// limit means unlimited. Per-value maps override the corresponding default.
+type ConcurrencyPolicy struct {
+	DefaultProject int            `json:"default_project,omitempty"`
+	Projects       map[string]int `json:"projects,omitempty"`
+	DefaultSource  int            `json:"default_source,omitempty"`
+	Sources        map[string]int `json:"sources,omitempty"`
+	DefaultAgent   int            `json:"default_agent,omitempty"`
+	Agents         map[string]int `json:"agents,omitempty"`
+	DefaultRunner  int            `json:"default_runner,omitempty"`
+	Runners        map[string]int `json:"runners,omitempty"`
+	DefaultPool    int            `json:"default_pool,omitempty"`
+	Pools          map[string]int `json:"pools,omitempty"`
+}
+
+type ClaimRequest struct {
+	WorkerID      string
+	LeaseDuration time.Duration
+	WorkerTimeout time.Duration
+	Policy        ConcurrencyPolicy
+}
+
+type HeartbeatResult struct {
+	LeaseExpiresAt  time.Time `json:"lease_expires_at"`
+	CancelRequested bool      `json:"cancel_requested"`
+}
+
+type FinishResult struct {
+	Success bool
+	Error   string
+	// Retry is reserved for infrastructure failures where execution is safe to
+	// repeat. Ordinary workflow failures are terminal at the queue layer.
+	Retry   bool
+	RetryAt *time.Time
+}
+
+type Store interface {
+	Enqueue(context.Context, *Job) (bool, error)
+	RegisterWorker(context.Context, *Worker) error
+	HeartbeatWorker(context.Context, string, bool) error
+	SetWorkerDrain(context.Context, string, bool) error
+	Claim(context.Context, ClaimRequest) (*Claim, error)
+	Heartbeat(context.Context, string, string, string, time.Duration) (*HeartbeatResult, error)
+	Finish(context.Context, string, string, string, FinishResult) error
+	RequestCancel(context.Context, string) error
+	RequestCancelFor(context.Context, string, string) (int, error)
+	ReleaseAffinity(context.Context, string) error
+	ReclaimExpired(context.Context, time.Time) (int, error)
+	GetJob(context.Context, string) (*Job, error)
+	ListJobs(context.Context, JobState, int) ([]Job, error)
+	ListWorkers(context.Context) ([]Worker, error)
+}

--- a/src/internal/queuehttp/protocol.go
+++ b/src/internal/queuehttp/protocol.go
@@ -1,0 +1,374 @@
+// Package queuehttp exposes the durable queue contract to remote workers over
+// an authenticated, versioned HTTP/JSON protocol.
+package queuehttp
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+const Prefix = "/v1/queue"
+
+type Server struct {
+	Store         queue.Store
+	Token         string
+	LeaseDuration time.Duration
+	WorkerTimeout time.Duration
+	Policy        queue.ConcurrencyPolicy
+	OnTerminal    func(context.Context, queue.Job) error
+}
+
+func (s Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(Prefix+"/health", s.health)
+	mux.HandleFunc(Prefix+"/workers/register", s.register)
+	mux.HandleFunc(Prefix+"/workers/", s.worker)
+	mux.HandleFunc(Prefix+"/claim", s.claim)
+	mux.HandleFunc(Prefix+"/jobs", s.jobs)
+	mux.HandleFunc(Prefix+"/jobs/", s.job)
+	return s.authenticate(mux)
+}
+
+func (s Server) authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(s.Token) == "" {
+			http.Error(w, "remote worker protocol is not configured", http.StatusServiceUnavailable)
+			return
+		}
+		provided := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if len(provided) != len(s.Token) || subtle.ConstantTimeCompare([]byte(provided), []byte(s.Token)) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s Server) health(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"protocol_version": queue.WorkerProtocolVersion, "ready": s.Store != nil})
+}
+
+func (s Server) register(w http.ResponseWriter, r *http.Request) {
+	if !method(w, r, http.MethodPost) {
+		return
+	}
+	var worker queue.Worker
+	if !decode(w, r, &worker) {
+		return
+	}
+	if worker.ProtocolVersion != queue.WorkerProtocolVersion {
+		http.Error(w, fmt.Sprintf("unsupported protocol version %d", worker.ProtocolVersion), http.StatusUnprocessableEntity)
+		return
+	}
+	if err := s.Store.RegisterWorker(r.Context(), &worker); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, worker)
+}
+
+func (s Server) worker(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, Prefix+"/workers/")
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 1 && parts[0] == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		workers, err := s.Store.ListWorkers(r.Context())
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		for _, worker := range workers {
+			if worker.ID == parts[0] {
+				writeJSON(w, http.StatusOK, worker)
+				return
+			}
+		}
+		http.NotFound(w, r)
+		return
+	}
+	if len(parts) != 2 || r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	var body struct {
+		Ready    bool `json:"ready"`
+		Draining bool `json:"draining"`
+	}
+	if !decode(w, r, &body) {
+		return
+	}
+	var err error
+	switch parts[1] {
+	case "heartbeat":
+		err = s.Store.HeartbeatWorker(r.Context(), parts[0], body.Ready)
+	case "drain":
+		err = s.Store.SetWorkerDrain(r.Context(), parts[0], body.Draining)
+	default:
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s Server) claim(w http.ResponseWriter, r *http.Request) {
+	if !method(w, r, http.MethodPost) {
+		return
+	}
+	var body struct {
+		WorkerID string `json:"worker_id"`
+	}
+	if !decode(w, r, &body) {
+		return
+	}
+	claim, err := s.Store.Claim(r.Context(), queue.ClaimRequest{WorkerID: body.WorkerID, LeaseDuration: s.LeaseDuration, WorkerTimeout: s.WorkerTimeout, Policy: s.Policy})
+	if errors.Is(err, queue.ErrNoJob) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, claim)
+}
+
+func (s Server) jobs(w http.ResponseWriter, r *http.Request) {
+	if !method(w, r, http.MethodGet) {
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	jobs, err := s.Store.ListJobs(r.Context(), queue.JobState(r.URL.Query().Get("state")), limit)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, jobs)
+}
+
+func (s Server) job(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, Prefix+"/jobs/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 1 && r.Method == http.MethodGet {
+		job, err := s.Store.GetJob(r.Context(), parts[0])
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		if job == nil {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, http.StatusOK, job)
+		return
+	}
+	if len(parts) == 2 && parts[1] == "cancel" && r.Method == http.MethodPost {
+		if err := s.Store.RequestCancel(r.Context(), parts[0]); err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+		return
+	}
+	if len(parts) != 4 || parts[1] != "attempts" || r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
+	jobID, attemptID, action := parts[0], parts[2], parts[3]
+	var body struct {
+		Token     string             `json:"token"`
+		Extension time.Duration      `json:"extension"`
+		Result    queue.FinishResult `json:"result"`
+	}
+	if !decode(w, r, &body) {
+		return
+	}
+	switch action {
+	case "heartbeat":
+		result, err := s.Store.Heartbeat(r.Context(), jobID, attemptID, body.Token, body.Extension)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	case "finish":
+		if err := s.Store.Finish(r.Context(), jobID, attemptID, body.Token, body.Result); err != nil {
+			writeError(w, err)
+			return
+		}
+		if s.OnTerminal != nil {
+			job, err := s.Store.GetJob(r.Context(), jobID)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			if job != nil && (job.State == queue.JobSucceeded || job.State == queue.JobFailed || job.State == queue.JobCanceled) {
+				if err := s.OnTerminal(r.Context(), *job); err != nil {
+					writeError(w, err)
+					return
+				}
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func method(w http.ResponseWriter, r *http.Request, expected string) bool {
+	if r.Method == expected {
+		return true
+	}
+	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	return false
+}
+func decode(w http.ResponseWriter, r *http.Request, target any) bool {
+	decoder := json.NewDecoder(io.LimitReader(r.Body, 4<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+func writeError(w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+	if errors.Is(err, queue.ErrStaleClaim) || errors.Is(err, queue.ErrWorkerUnknown) {
+		status = http.StatusConflict
+	}
+	if errors.Is(err, queue.ErrWorkerDraining) || errors.Is(err, queue.ErrWorkerUnhealthy) {
+		status = http.StatusServiceUnavailable
+	}
+	http.Error(w, err.Error(), status)
+}
+
+type Client struct {
+	BaseURL, Token string
+	HTTPClient     *http.Client
+}
+
+func (c *Client) do(ctx context.Context, method, path string, request, response any) (int, error) {
+	var body io.Reader
+	if request != nil {
+		encoded, err := json.Marshal(request)
+		if err != nil {
+			return 0, err
+		}
+		body = strings.NewReader(string(encoded))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.BaseURL, "/")+Prefix+path, body)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	if request != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNoContent {
+		return res.StatusCode, nil
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return res.StatusCode, fmt.Errorf("queue protocol: %s", strings.TrimSpace(string(message)))
+	}
+	if response != nil {
+		if err := json.NewDecoder(res.Body).Decode(response); err != nil {
+			return res.StatusCode, err
+		}
+	}
+	return res.StatusCode, nil
+}
+
+func (c *Client) RegisterWorker(ctx context.Context, w *queue.Worker) error {
+	_, err := c.do(ctx, http.MethodPost, "/workers/register", w, w)
+	return err
+}
+func (c *Client) HeartbeatWorker(ctx context.Context, id string, ready bool) error {
+	_, err := c.do(ctx, http.MethodPost, "/workers/"+url.PathEscape(id)+"/heartbeat", map[string]any{"ready": ready}, nil)
+	return err
+}
+func (c *Client) SetWorkerDrain(ctx context.Context, id string, draining bool) error {
+	_, err := c.do(ctx, http.MethodPost, "/workers/"+url.PathEscape(id)+"/drain", map[string]any{"draining": draining}, nil)
+	return err
+}
+func (c *Client) Claim(ctx context.Context, request queue.ClaimRequest) (*queue.Claim, error) {
+	var claim queue.Claim
+	status, err := c.do(ctx, http.MethodPost, "/claim", map[string]string{"worker_id": request.WorkerID}, &claim)
+	if status == http.StatusNoContent {
+		return nil, queue.ErrNoJob
+	}
+	return &claim, err
+}
+func (c *Client) Heartbeat(ctx context.Context, job, attempt, token string, extension time.Duration) (*queue.HeartbeatResult, error) {
+	var result queue.HeartbeatResult
+	_, err := c.do(ctx, http.MethodPost, "/jobs/"+url.PathEscape(job)+"/attempts/"+url.PathEscape(attempt)+"/heartbeat", map[string]any{"token": token, "extension": extension}, &result)
+	return &result, err
+}
+func (c *Client) Finish(ctx context.Context, job, attempt, token string, result queue.FinishResult) error {
+	_, err := c.do(ctx, http.MethodPost, "/jobs/"+url.PathEscape(job)+"/attempts/"+url.PathEscape(attempt)+"/finish", map[string]any{"token": token, "result": result}, nil)
+	return err
+}
+func (c *Client) RequestCancel(ctx context.Context, id string) error {
+	_, err := c.do(ctx, http.MethodPost, "/jobs/"+url.PathEscape(id)+"/cancel", map[string]any{}, nil)
+	return err
+}
+func (c *Client) GetJob(ctx context.Context, id string) (*queue.Job, error) {
+	var job queue.Job
+	status, err := c.do(ctx, http.MethodGet, "/jobs/"+url.PathEscape(id), nil, &job)
+	if status == http.StatusNotFound {
+		return nil, nil
+	}
+	return &job, err
+}
+func (c *Client) ListJobs(ctx context.Context, state queue.JobState, limit int) ([]queue.Job, error) {
+	var jobs []queue.Job
+	query := "?state=" + url.QueryEscape(string(state)) + "&limit=" + strconv.Itoa(limit)
+	_, err := c.do(ctx, http.MethodGet, "/jobs"+query, nil, &jobs)
+	return jobs, err
+}
+
+// Reclaim and affinity/cross-job cancellation remain control-plane operations.
+func (c *Client) Enqueue(context.Context, *queue.Job) (bool, error) {
+	return false, errors.New("enqueue is a control-plane operation")
+}
+func (c *Client) RequestCancelFor(context.Context, string, string) (int, error) {
+	return 0, errors.New("bulk cancellation is a control-plane operation")
+}
+func (c *Client) ReleaseAffinity(context.Context, string) error {
+	return errors.New("affinity release is a control-plane operation")
+}
+func (c *Client) ReclaimExpired(context.Context, time.Time) (int, error) { return 0, nil }
+func (c *Client) ListWorkers(context.Context) ([]queue.Worker, error) {
+	return nil, errors.New("worker listing is a control-plane operation")
+}

--- a/src/internal/queuehttp/protocol_test.go
+++ b/src/internal/queuehttp/protocol_test.go
@@ -1,0 +1,109 @@
+package queuehttp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/queuehttp"
+)
+
+func TestAuthenticatedWorkerLifecycle(t *testing.T) {
+	ctx := context.Background()
+	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clientDB.Close() })
+	store := clientDB.Queue()
+
+	server := httptest.NewServer(queuehttp.Server{Store: store, Token: "test-secret", LeaseDuration: time.Minute, WorkerTimeout: time.Minute}.Handler())
+	t.Cleanup(server.Close)
+	remote := &queuehttp.Client{BaseURL: server.URL, Token: "test-secret", HTTPClient: server.Client()}
+
+	worker := &queue.Worker{ID: "worker-1", ProtocolVersion: queue.WorkerProtocolVersion, Pool: "build", Labels: []string{"linux"}, Capabilities: []string{"runner:codex"}, Capacity: 2, Ready: true}
+	if err := remote.RegisterWorker(ctx, worker); err != nil {
+		t.Fatal(err)
+	}
+	job := &queue.Job{IdempotencyKey: "task:1", Pool: "build", RequiredLabels: []string{"linux"}, RequiredCapabilities: []string{"runner:codex"}, PayloadVersion: 1, Payload: []byte(`{"task":"one"}`), MaxAttempts: 2}
+	if created, err := store.Enqueue(ctx, job); err != nil || !created {
+		t.Fatalf("enqueue created=%v err=%v", created, err)
+	}
+
+	claim, err := remote.Claim(ctx, queue.ClaimRequest{WorkerID: worker.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.Job.ID != job.ID || claim.Attempt.ClaimToken == "" {
+		t.Fatalf("unexpected claim: %+v", claim)
+	}
+	heartbeat, err := remote.Heartbeat(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if heartbeat.CancelRequested {
+		t.Fatal("unexpected cancellation")
+	}
+	if err := remote.RequestCancel(ctx, job.ID); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat, err = remote.Heartbeat(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !heartbeat.CancelRequested {
+		t.Fatal("cancellation was not delivered")
+	}
+	if err := remote.Finish(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := remote.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != queue.JobCanceled {
+		t.Fatalf("state=%s, want canceled", got.State)
+	}
+}
+
+func TestProtocolRejectsInvalidAuthenticationAndVersion(t *testing.T) {
+	ctx := context.Background()
+	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clientDB.Close() })
+	server := httptest.NewServer(queuehttp.Server{Store: clientDB.Queue(), Token: "correct", LeaseDuration: time.Minute, WorkerTimeout: time.Minute}.Handler())
+	t.Cleanup(server.Close)
+
+	bad := &queuehttp.Client{BaseURL: server.URL, Token: "wrong", HTTPClient: server.Client()}
+	err = bad.RegisterWorker(ctx, &queue.Worker{ID: "worker", ProtocolVersion: queue.WorkerProtocolVersion, Capacity: 1})
+	if err == nil {
+		t.Fatal("expected authentication failure")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+queuehttp.Prefix+"/workers/register", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer correct")
+	res, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", res.StatusCode)
+	}
+
+	remote := &queuehttp.Client{BaseURL: server.URL, Token: "correct", HTTPClient: server.Client()}
+	err = remote.RegisterWorker(ctx, &queue.Worker{ID: "worker", ProtocolVersion: queue.WorkerProtocolVersion + 1, Capacity: 1})
+	if err == nil {
+		t.Fatal("expected version rejection")
+	}
+}

--- a/src/internal/worker/worker.go
+++ b/src/internal/worker/worker.go
@@ -1,0 +1,179 @@
+// Package worker runs protocol-1 queue workers against a queue.Store.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+type Executor interface {
+	Execute(context.Context, queue.Job) queue.FinishResult
+}
+
+type ExecutorFunc func(context.Context, queue.Job) queue.FinishResult
+
+func (f ExecutorFunc) Execute(ctx context.Context, job queue.Job) queue.FinishResult {
+	return f(ctx, job)
+}
+
+type Config struct {
+	Worker            queue.Worker
+	LeaseDuration     time.Duration
+	HeartbeatInterval time.Duration
+	WorkerHeartbeat   time.Duration
+	WorkerTimeout     time.Duration
+	PollInterval      time.Duration
+	Policy            queue.ConcurrencyPolicy
+	OnError           func(error)
+}
+
+type Runtime struct {
+	store    queue.Store
+	executor Executor
+	config   Config
+}
+
+func New(store queue.Store, executor Executor, config Config) (*Runtime, error) {
+	if store == nil {
+		return nil, fmt.Errorf("worker queue store is required")
+	}
+	if executor == nil {
+		return nil, fmt.Errorf("worker executor is required")
+	}
+	if config.Worker.ID == "" {
+		return nil, fmt.Errorf("worker id is required")
+	}
+	if config.Worker.ProtocolVersion == 0 {
+		config.Worker.ProtocolVersion = queue.WorkerProtocolVersion
+	}
+	if config.Worker.Capacity <= 0 {
+		config.Worker.Capacity = 1
+	}
+	config.Worker.Ready = true
+	if config.LeaseDuration <= 0 {
+		config.LeaseDuration = 30 * time.Second
+	}
+	if config.HeartbeatInterval <= 0 {
+		config.HeartbeatInterval = config.LeaseDuration / 3
+	}
+	if config.HeartbeatInterval >= config.LeaseDuration {
+		return nil, fmt.Errorf("worker heartbeat interval must be shorter than lease duration")
+	}
+	if config.WorkerHeartbeat <= 0 {
+		config.WorkerHeartbeat = config.HeartbeatInterval
+	}
+	if config.WorkerTimeout <= 0 {
+		config.WorkerTimeout = 30 * time.Second
+	}
+	if config.PollInterval <= 0 {
+		config.PollInterval = 500 * time.Millisecond
+	}
+	return &Runtime{store: store, executor: executor, config: config}, nil
+}
+
+// Run registers the worker and claims until ctx is canceled. Cancellation begins
+// graceful drain: no new claims are taken, active claims keep heartbeating and
+// finish, then the worker becomes unready and Run returns.
+func (r *Runtime) Run(ctx context.Context) error {
+	if err := r.store.RegisterWorker(ctx, &r.config.Worker); err != nil {
+		return err
+	}
+	heartbeatCtx, stopHeartbeat := context.WithCancel(context.Background())
+	var heartbeatWG sync.WaitGroup
+	heartbeatWG.Add(1)
+	go func() { defer heartbeatWG.Done(); r.workerHeartbeatLoop(heartbeatCtx) }()
+
+	var active sync.WaitGroup
+	poll := time.NewTicker(r.config.PollInterval)
+	defer poll.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = r.store.SetWorkerDrain(context.Background(), r.config.Worker.ID, true)
+			active.Wait()
+			_ = r.store.HeartbeatWorker(context.Background(), r.config.Worker.ID, false)
+			stopHeartbeat()
+			heartbeatWG.Wait()
+			return nil
+		case <-poll.C:
+			if _, err := r.store.ReclaimExpired(ctx, time.Now().UTC()); err != nil {
+				r.report(fmt.Errorf("worker %s reclaim expired: %w", r.config.Worker.ID, err))
+			}
+			for {
+				claim, err := r.store.Claim(ctx, queue.ClaimRequest{WorkerID: r.config.Worker.ID, LeaseDuration: r.config.LeaseDuration, WorkerTimeout: r.config.WorkerTimeout, Policy: r.config.Policy})
+				if errors.Is(err, queue.ErrNoJob) {
+					break
+				}
+				if errors.Is(err, queue.ErrWorkerDraining) || errors.Is(err, context.Canceled) {
+					break
+				}
+				if err != nil {
+					r.report(fmt.Errorf("worker %s claim: %w", r.config.Worker.ID, err))
+					break
+				}
+				active.Add(1)
+				go func() { defer active.Done(); r.execute(claim) }()
+			}
+		}
+	}
+}
+
+func (r *Runtime) workerHeartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(r.config.WorkerHeartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := r.store.HeartbeatWorker(context.Background(), r.config.Worker.ID, true); err != nil {
+				r.report(fmt.Errorf("worker %s heartbeat: %w", r.config.Worker.ID, err))
+			}
+		}
+	}
+}
+
+func (r *Runtime) execute(claim *queue.Claim) {
+	jobCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	heartbeatDone := make(chan struct{})
+	go func() {
+		defer close(heartbeatDone)
+		ticker := time.NewTicker(r.config.HeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				heartbeat, err := r.store.Heartbeat(context.Background(), claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, r.config.LeaseDuration)
+				if err != nil {
+					r.report(fmt.Errorf("job %s heartbeat: %w", claim.Job.ID, err))
+					cancel()
+					return
+				}
+				if heartbeat.CancelRequested {
+					cancel()
+				}
+			}
+		}
+	}()
+	result := r.executor.Execute(jobCtx, claim.Job)
+	cancel()
+	close(done)
+	<-heartbeatDone
+	if err := r.store.Finish(context.Background(), claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, result); err != nil && !errors.Is(err, queue.ErrStaleClaim) {
+		r.report(fmt.Errorf("job %s finish: %w", claim.Job.ID, err))
+	}
+}
+
+func (r *Runtime) report(err error) {
+	if r.config.OnError != nil {
+		r.config.OnError(err)
+	}
+}

--- a/src/internal/worker/worker_test.go
+++ b/src/internal/worker/worker_test.go
@@ -1,0 +1,131 @@
+package worker_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/worker"
+)
+
+func workerTestStore(t *testing.T) (*db.Client, *db.QueueStore) {
+	t.Helper()
+	client, err := db.New(context.Background(), filepath.Join(t.TempDir(), "worker.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	return client, client.Queue()
+}
+
+func enqueueWorkerJob(t *testing.T, store *db.QueueStore, key string) *queue.Job {
+	t.Helper()
+	job := &queue.Job{IdempotencyKey: key, PayloadVersion: 1, Payload: []byte(`{"work":true}`)}
+	if _, err := store.Enqueue(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	return job
+}
+
+func TestRuntimeGracefulDrainWaitsForActiveJob(t *testing.T) {
+	_, store := workerTestStore(t)
+	job := enqueueWorkerJob(t, store, "drain")
+	started, release := make(chan struct{}), make(chan struct{})
+	runtime, err := worker.New(store, worker.ExecutorFunc(func(context.Context, queue.Job) queue.FinishResult {
+		close(started)
+		<-release
+		return queue.FinishResult{Success: true}
+	}), worker.Config{Worker: queue.Worker{ID: "local", Capacity: 1}, PollInterval: 5 * time.Millisecond, HeartbeatInterval: 10 * time.Millisecond, LeaseDuration: 100 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runtime.Run(ctx) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("job did not start")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		t.Fatalf("worker returned before active job drained: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	workers, err := store.ListWorkers(context.Background())
+	if err != nil || len(workers) != 1 || !workers[0].Draining {
+		t.Fatalf("workers=%+v err=%v", workers, err)
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not finish drain")
+	}
+	stored, _ := store.GetJob(context.Background(), job.ID)
+	if stored.State != queue.JobSucceeded {
+		t.Fatalf("job state=%s", stored.State)
+	}
+	workers, _ = store.ListWorkers(context.Background())
+	if workers[0].Ready || !workers[0].Draining || workers[0].ActiveJobs != 0 {
+		t.Fatalf("worker after drain=%+v", workers[0])
+	}
+}
+
+func TestRuntimePropagatesQueueCancellation(t *testing.T) {
+	_, store := workerTestStore(t)
+	job := enqueueWorkerJob(t, store, "cancel")
+	started, canceled := make(chan struct{}), make(chan struct{})
+	runtime, err := worker.New(store, worker.ExecutorFunc(func(ctx context.Context, _ queue.Job) queue.FinishResult {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return queue.FinishResult{Error: ctx.Err().Error()}
+	}), worker.Config{Worker: queue.Worker{ID: "local", Capacity: 1}, PollInterval: 5 * time.Millisecond, HeartbeatInterval: 5 * time.Millisecond, LeaseDuration: 100 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, stop := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runtime.Run(ctx) }()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("job did not start")
+	}
+	if err := store.RequestCancel(context.Background(), job.ID); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("cancellation did not reach executor")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		stored, _ := store.GetJob(context.Background(), job.ID)
+		if stored.State == queue.JobCanceled {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job state=%s", stored.State)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	stop()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not stop")
+	}
+}


### PR DESCRIPTION
## Summary

- persist daemon dispatches with idempotent enqueue, fenced attempts, leases, heartbeats, reclaim, cancellation, and affinity
- add embedded and remote workers with authenticated protocol v1, capability matching, scoped concurrency, health, capacity, drain, and graceful shutdown
- expose queue status, configuration schema, CLI worker command, recovery documentation, and comprehensive concurrency/integration tests

Closes #214

## Test plan

- [x] `make check` passed locally
- [x] `make vet` passed locally
- [x] `go test -race ./internal/db ./internal/worker ./internal/queuehttp ./internal/daemon` passed locally
- [x] `jq empty schema/apiary.json` passed locally
- [x] `git diff --check` passed locally
- [x] GitNexus staged change detection reviewed (critical scope expected: daemon startup, poll/fan-out, config validation, schema, cancellation, and CLI registration)