### PR TITLE
security: refuse to load plugins from group/world-writable directories

### DIFF
--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -37,6 +37,10 @@ func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error
 			errs = append(errs, fmt.Errorf("discover plugins in %q: %w", path, err))
 			continue
 		}
+		if warn := checkDirOwnerOnly(path); warn != nil {
+			errs = append(errs, warn)
+			continue
+		}
 		roots := []string{}
 		if _, err := os.Stat(filepath.Join(path, ManifestFilename)); err == nil {
 			roots = append(roots, path)

--- a/src/internal/plugin/discovery_unix.go
+++ b/src/internal/plugin/discovery_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDirOwnerOnly returns a warning error if path has group- or world-write
+// bits set. Attackers with group/world write access to a plugin directory can
+// plant or replace executables; refusing to load from such directories is the
+// stopgap until binary signing is in place.
+func checkDirOwnerOnly(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil // ReadDir already handled existence; ignore stat failures here
+	}
+	if perm := info.Mode().Perm(); perm&0o022 != 0 {
+		return fmt.Errorf("plugin directory %q is group- or world-writable (mode %04o); skipping for security — run: chmod o-w,g-w %q", path, perm, path)
+	}
+	return nil
+}

--- a/src/internal/plugin/discovery_unix_test.go
+++ b/src/internal/plugin/discovery_unix_test.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverSkipsGroupAndWorldWritableDirs(t *testing.T) {
+	parent := t.TempDir()
+
+	// Write a valid plugin so we can confirm it is NOT loaded.
+	writeTestPlugin(t, parent, "legit", "exit 0", Manifest{})
+
+	// Make the plugin directory group-writable — discovery must refuse it.
+	if err := os.Chmod(parent, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+	if len(registry.List()) != 0 {
+		t.Fatalf("expected 0 plugins loaded from writable dir, got %d", len(registry.List()))
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+		t.Fatalf("expected permission warning, got errs=%v", errs)
+	}
+
+	// A second path with correct permissions should still load fine.
+	safeParent := t.TempDir() // TempDir creates 0700 — passes the check
+	writeTestPlugin(t, safeParent, "safe", "exit 0", Manifest{})
+	_ = os.WriteFile(filepath.Join(safeParent, "safe", "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+
+	registry2, errs2 := Discover([]string{parent, safeParent}, safeParent, "v0.10.0")
+	if len(errs2) != 1 || !strings.Contains(errs2[0].Error(), "group- or world-writable") {
+		t.Fatalf("expected exactly 1 warning for the bad path, got errs=%v", errs2)
+	}
+	if _, ok := registry2.Get("dev.apiary.safe"); !ok {
+		t.Fatal("safe plugin from good path should still load")
+	}
+}

--- a/src/internal/plugin/discovery_windows.go
+++ b/src/internal/plugin/discovery_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package plugin
+
+// checkDirOwnerOnly is a no-op on Windows; ACL-based access control is outside
+// the scope of this stopgap check.
+func checkDirOwnerOnly(_ string) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `checkDirOwnerOnly(path)` called inside `Discover()` immediately after a plugin directory is confirmed to exist. If the directory has group- or world-write bits set (Unix mode `& 0o022 != 0`), the directory is skipped and a descriptive warning error is appended to the returned error slice with a `chmod` remediation hint.
- Platform-specific implementation: `discovery_unix.go` (`//go:build !windows`) does the `os.Stat` + mode check; `discovery_windows.go` is a no-op stub.
- New test `TestDiscoverSkipsGroupAndWorldWritableDirs` in `discovery_unix_test.go` verifies:
  - Zero plugins loaded from a `0o775` directory.
  - Exactly one `"group- or world-writable"` warning returned.
  - A second path with correct permissions still loads its plugin successfully in the same `Discover` call.

## Test plan

- [x] `go test ./internal/plugin/... -count=1` passes (all existing tests green, new test green)
- [x] Existing `TestDiscoverAndValidateConfiguredSchema`, `TestDiscoverRejectsDuplicateIDs` unaffected

Closes #227