### PR TITLE
security: gate ai-ready label behind collaborator check (SEC-01)

### DIFF
--- a/.github/workflows/triage-gate.yml
+++ b/.github/workflows/triage-gate.yml
@@ -1,0 +1,64 @@
+name: triage-gate
+
+# SEC-01 — Guard against prompt-injection via untrusted issue content.
+#
+# When an issue is opened or labeled with `ai-ready` by a non-collaborator,
+# remove the trigger label and add `needs-triage` so a maintainer must
+# explicitly approve before Apiary picks it up.
+#
+# "Trusted" = OWNER | MEMBER | COLLABORATOR per GitHub's author_association.
+# CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE all park in the triage queue.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    # Only fire when the author is not already trusted.
+    if: |
+      !contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.issue.author_association)
+
+    steps:
+      - name: Remove ai-ready label (if present)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Ignore 404 — label may not be present yet (opened event before labeling).
+          gh api --method DELETE \
+            /repos/$REPO/issues/$ISSUE/labels/ai-ready \
+            --silent || true
+
+      - name: Add needs-triage label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue edit $ISSUE --repo $REPO --add-label needs-triage || true
+
+      - name: Post triage notice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          gh issue comment $ISSUE --repo $REPO --body \
+          "👋 Hi @$AUTHOR — thank you for filing this issue!
+
+          Apiary auto-runs AI agents against issues labeled \`ai-ready\`. To prevent
+          prompt-injection attacks, only repository collaborators may trigger that
+          flow directly.
+
+          A maintainer will review this issue and add \`ai-ready\` once it has been
+          triaged. In the meantime the \`needs-triage\` label has been added.
+
+          _This is an automated message from the triage gate (SEC-01)._"

--- a/README.md
+++ b/README.md
@@ -210,6 +210,19 @@ See [`docs/vscode-extension.md`](docs/vscode-extension.md) for usage and what
 the diagram shows. The extension source lives under
 [`tools/vscode-apiary`](tools/vscode-apiary).
 
+## Security — Rollout Freeze
+
+> **Org-wide rollout is frozen** until all issues labeled
+> [`bucket:rollout-gate`](https://github.com/orlandoburli/apiary/issues?q=is%3Aopen+label%3Abucket%3Arollout-gate)
+> are closed. See [`security-rollout-issues.md`](security-rollout-issues.md) for the
+> full backlog and rationale.
+>
+> **Issue-creation gate (SEC-01):** Apiary ingests GitHub issues and runs AI agents
+> against their content. To block prompt-injection attacks, the `triage-gate` workflow
+> automatically removes the `ai-ready` label from issues filed by non-collaborators and
+> marks them `needs-triage`. A maintainer must explicitly re-add `ai-ready` after review.
+> Only users with `OWNER`, `MEMBER`, or `COLLABORATOR` association bypass the gate.
+
 ## Status
 
 > **Public beta.** Apiary works end-to-end and is in active use. Config and adapter


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/triage-gate.yml`: fires on every `issues:opened` and `issues:labeled` event; if the author's `author_association` is not `OWNER`, `MEMBER`, or `COLLABORATOR`, removes the `ai-ready` label and adds `needs-triage`, then posts a comment explaining the restriction.
- Documents the org-wide rollout freeze in `README.md` — do not enable Apiary on connected repos until all `bucket:rollout-gate` issues close.

## Why `author_association` instead of the collaborators API

`github.event.issue.author_association` is available for free in the Actions context with no extra API call and no token-permission edge cases. `OWNER` / `MEMBER` / `COLLABORATOR` is the stable set that maps to "has write access or belongs to the org" — the exact trust boundary we need.

## Test plan

- [ ] Open an issue as a non-collaborator → `ai-ready` is removed, `needs-triage` is added, comment is posted.
- [ ] Add `ai-ready` to an issue by a non-collaborator → same result.
- [ ] Open an issue as a collaborator/owner → workflow job condition is `false`, nothing is removed.

Closes #224