### PR TITLE
fix: tighten on-disk file permissions to 0600/0700 (SEC-02)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,6 +92,33 @@ as the original.
     [release notes](https://github.com/orlandoburli/apiary/releases) before
     upgrading.
 
+## Security hardening (shared hosts)
+
+Apiary writes its config file (`apiary.yaml`), the SQLite database, log files,
+per-task transcripts, and the agent memory store with **0600/0700**
+permissions, so only the owning OS user can read them.  Those files hold
+tokens, prompt history, and issue content that must stay private.
+
+On a shared Linux/macOS host, the additional recommended step is to run the
+daemon under a **dedicated non-login service account** rather than your
+personal user:
+
+```sh
+# Create a dedicated user (Linux)
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin apiary
+
+# Transfer ownership of the data directory
+sudo chown -R apiary:apiary /var/lib/apiary
+
+# Run as the service account (systemd example)
+# User=apiary in your [Service] unit
+```
+
+Because Apiary itself enforces 0600/0700 on everything it creates, the
+service account ensures that no other human login on the same machine can
+reach the data directory even if the directory was created before Apiary
+tightened its permissions.
+
 ## Next step
 
 Continue with the [Quickstart](quickstart.md) — from a fresh install to your

--- a/src/internal/cli/init_cmd.go
+++ b/src/internal/cli/init_cmd.go
@@ -76,7 +76,7 @@ func newInitCmd() *cobra.Command {
 			if _, err := os.Stat("apiary.yaml"); err == nil {
 				return fmt.Errorf("apiary.yaml already exists")
 			}
-			if err := os.WriteFile("apiary.yaml", []byte(starterConfig), 0644); err != nil {
+			if err := os.WriteFile("apiary.yaml", []byte(starterConfig), 0o600); err != nil {
 				return err
 			}
 			fmt.Println("✓ apiary.yaml created — edit it to configure your sources and agents")

--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -56,10 +56,10 @@ func newRunCmd() *cobra.Command {
 
 			// Create directories
 			dbDir := filepath.Dir(dbPath)
-			if err := os.MkdirAll(dbDir, 0755); err != nil {
+			if err := os.MkdirAll(dbDir, 0o700); err != nil {
 				return fmt.Errorf("creating database directory: %w", err)
 			}
-			if err := os.MkdirAll(logDir, 0755); err != nil {
+			if err := os.MkdirAll(logDir, 0o700); err != nil {
 				return fmt.Errorf("creating log directory: %w", err)
 			}
 

--- a/src/internal/cli/update_notify.go
+++ b/src/internal/cli/update_notify.go
@@ -138,9 +138,9 @@ func saveUpdateCheckState(path string, state updateCheckState) {
 	if err != nil {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return
 	}
 	// Best-effort cache: ignore write errors (read-only HOME, etc.).
-	_ = os.WriteFile(path, data, 0o644)
+	_ = os.WriteFile(path, data, 0o600)
 }

--- a/src/internal/cli/worker.go
+++ b/src/internal/cli/worker.go
@@ -80,7 +80,7 @@ func newWorkerCmd() *cobra.Command {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer cancel()
 			workerDataDir := filepath.Join(projectDataDir(), "workers")
-			if err := os.MkdirAll(workerDataDir, 0755); err != nil {
+			if err := os.MkdirAll(workerDataDir, 0o700); err != nil {
 				return fmt.Errorf("create worker data directory: %w", err)
 			}
 			workerDB, err := db.New(ctx, filepath.Join(workerDataDir, safeWorkerFilename(workerID)+".db"))

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -538,7 +538,7 @@ func (c *Config) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, []byte(out), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(out), 0o600); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 	return nil

--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -76,13 +76,13 @@ type Logger struct {
 // If db is provided, logs also go to SQLite.
 func New(logDir string, dbClient *db.Client, level Level, rot Rotation) (*Logger, error) {
 	if logDir != "" {
-		if err := os.MkdirAll(logDir, 0755); err != nil {
+		if err := os.MkdirAll(logDir, 0o700); err != nil {
 			return nil, fmt.Errorf("create log dir: %w", err)
 		}
 	}
 
 	logFile := filepath.Join(logDir, "apiary.log")
-	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open log file: %w", err)
 	}
@@ -225,7 +225,7 @@ func (l *Logger) rotate() {
 		os.Remove(logFile)
 	}
 
-	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	f, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		// Leave size past the limit so the next write retries the rotation
 		// (and the reopen) instead of silently giving up for good.
@@ -264,12 +264,12 @@ func (l *Logger) CreateTaskLogger(taskID string) (io.WriteCloser, error) {
 	}
 
 	taskLogDir := filepath.Join(l.logDir, "tasks")
-	if err := os.MkdirAll(taskLogDir, 0755); err != nil {
+	if err := os.MkdirAll(taskLogDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create task log dir: %w", err)
 	}
 
 	taskLogFile := filepath.Join(taskLogDir, taskID+".log")
-	return os.OpenFile(taskLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	return os.OpenFile(taskLogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 }
 
 // CreateTranscript opens (append) the markdown transcript file for one step
@@ -280,11 +280,11 @@ func (l *Logger) CreateTranscript(taskID, name string) (*os.File, string, error)
 		return nil, "", fmt.Errorf("no log directory configured")
 	}
 	dir := filepath.Join(l.logDir, "transcripts", SanitizePathComponent(taskID))
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, "", fmt.Errorf("create transcript dir: %w", err)
 	}
 	path := filepath.Join(dir, SanitizePathComponent(name)+".md")
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, "", err
 	}

--- a/src/internal/memory/store.go
+++ b/src/internal/memory/store.go
@@ -111,8 +111,11 @@ type Store struct {
 // from hand edits since the last write.
 func Open(root string) (*Store, error) {
 	for _, dir := range []string{root, filepath.Join(root, globalDir), filepath.Join(root, tasksDir)} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return nil, fmt.Errorf("memory: create %s: %w", dir, err)
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("memory: chmod %s: %w", dir, err)
 		}
 	}
 	s := &Store{root: root, now: time.Now}
@@ -589,7 +592,7 @@ func atomicWrite(path, content string) error {
 		os.Remove(tmpName)
 		return err
 	}
-	if err := os.Chmod(tmpName, 0o644); err != nil {
+	if err := os.Chmod(tmpName, 0o600); err != nil {
 		os.Remove(tmpName)
 		return err
 	}

--- a/src/internal/memory/store_test.go
+++ b/src/internal/memory/store_test.go
@@ -236,3 +236,46 @@ func TestListTaskNotesAndDelete(t *testing.T) {
 		t.Fatalf("delete absent should be no-op: %v", err)
 	}
 }
+
+func TestFilePermissions(t *testing.T) {
+	root := t.TempDir()
+	s, err := Open(root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	for _, dir := range []string{root, filepath.Join(root, globalDir), filepath.Join(root, tasksDir)} {
+		fi, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if got := fi.Mode().Perm(); got != 0o700 {
+			t.Errorf("dir %s: want 0700 got %04o", dir, got)
+		}
+	}
+
+	if err := s.UpsertGlobal(Entry{Name: "perm-test", Description: "perm test", Content: "ok"}); err != nil {
+		t.Fatalf("UpsertGlobal: %v", err)
+	}
+	for _, name := range []string{IndexFile, filepath.Join(globalDir, "perm-test.md")} {
+		fi, err := os.Stat(filepath.Join(root, name))
+		if err != nil {
+			t.Fatalf("stat %s: %v", name, err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("file %s: want 0600 got %04o", name, got)
+		}
+	}
+
+	s.now = func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) }
+	if err := s.AppendTaskNote("01TASK", Note{Content: "note"}); err != nil {
+		t.Fatalf("AppendTaskNote: %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(root, tasksDir, "01TASK.md"))
+	if err != nil {
+		t.Fatalf("stat task note: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("task note: want 0600 got %04o", got)
+	}
+}


### PR DESCRIPTION
## Summary

- All Apiary-owned persisted artifacts (config, logs, task logs, transcripts, memory entries/task-notes, update-check cache) are now created with **0600** file mode and **0700** directory mode, so no other OS user on a shared host can read tokens, prompt history, or issue content.
- `memory.Open()` now `Chmod`s the root and its subdirs to 0700 even when they already existed with looser permissions.
- Added `TestFilePermissions` to `internal/memory/store_test.go` asserting 0700 dirs and 0600 files.
- Added a "Security hardening" section to `docs/installation.md` recommending a dedicated non-login service account for shared-host deployments.

Files changed:
- `src/internal/config/config.go` — `Save()` 0644 → 0o600
- `src/internal/cli/init_cmd.go` — `apiary init` writes 0o600
- `src/internal/cli/run.go` — db + log dirs 0755 → 0o700
- `src/internal/cli/worker.go` — worker data dir 0755 → 0o700
- `src/internal/cli/update_notify.go` — cache dir/file 0755/0644 → 0o700/0o600
- `src/internal/logging/logger.go` — all log/transcript dirs 0755 → 0o700; all log files 0644 → 0o600
- `src/internal/memory/store.go` — dirs Chmod'd to 0o700; atomicWrite 0o644 → 0o600
- `src/internal/memory/store_test.go` — new `TestFilePermissions`
- `docs/installation.md` — security hardening section

## Test plan

- [x] `go test ./...` passes (all 20 packages)
- [x] `TestFilePermissions` asserts 0700 on dirs and 0600 on entry/task-note files
- [x] `go build ./...` succeeds

Closes #225