### PR TITLE
security: enforce collaborator gate at daemon ingest (SEC-01 rework)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -360,6 +360,18 @@ func queueDuration(value string, fallback time.Duration) time.Duration {
 type ApprovalSettings struct {
 	WebhookSecret string   `yaml:"webhook_secret,omitempty"`
 	RequireFor    []string `yaml:"require_for,omitempty"`
+	// GateUntrustedAuthors, when true, prepends a human-approval step to every
+	// workflow triggered by a source item whose author is not a repository
+	// collaborator. The source adapter must implement CollaboratorChecker;
+	// sources that do not are treated as always-trusted (no gate injected).
+	GateUntrustedAuthors bool `yaml:"gate_untrusted_authors,omitempty"`
+	// UntrustedApprovers is the list of GitHub/source logins that may approve
+	// the injected gate. When empty, any valid approval response (webhook or
+	// dashboard) resolves the gate.
+	UntrustedApprovers []string `yaml:"untrusted_approvers,omitempty"`
+	// UntrustedMessage is the comment posted on the task when the gate parks.
+	// Defaults to a generic message when empty.
+	UntrustedMessage string `yaml:"untrusted_message,omitempty"`
 }
 
 // EventSettings controls persisted structured execution events. Events are

--- a/src/internal/daemon/author_gate_test.go
+++ b/src/internal/daemon/author_gate_test.go
@@ -1,0 +1,235 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// fakeCollaboratorChecker implements source.CollaboratorChecker in tests.
+type fakeCollaboratorChecker struct {
+	collaborators map[string]bool
+	err           error
+}
+
+func (f *fakeCollaboratorChecker) IsCollaborator(_ context.Context, login string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.collaborators[login], nil
+}
+
+// TestInjectApprovalGate verifies that injectApprovalGate prepends the gate
+// step and wires every root step through it.
+func TestInjectApprovalGate(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "test-wf",
+		Steps: []config.StepConfig{
+			{ID: "step-a", Agent: "eng"},
+			{ID: "step-b", Agent: "eng", SeqDependsOn: []string{"step-a"}},
+		},
+	}
+	cfg := config.ApprovalSettings{
+		UntrustedApprovers: []string{"alice"},
+	}
+	out := injectApprovalGate(wf, cfg, "mallory")
+
+	// Gate step is first.
+	if len(out.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(out.Steps))
+	}
+	gate := out.Steps[0]
+	if gate.ID != untrustedGateStepID {
+		t.Errorf("first step should be gate, got %q", gate.ID)
+	}
+	if gate.Type != config.StepTypeApproval {
+		t.Errorf("gate step type should be approval, got %q", gate.Type)
+	}
+	if len(gate.Approvers) != 1 || gate.Approvers[0] != "alice" {
+		t.Errorf("gate should carry approvers, got %v", gate.Approvers)
+	}
+
+	// step-a (root) now depends on the gate.
+	stepA := out.Steps[1]
+	if stepA.ID != "step-a" {
+		t.Fatalf("unexpected step order")
+	}
+	if len(stepA.DependsOn) != 1 || stepA.DependsOn[0] != untrustedGateStepID {
+		t.Errorf("step-a should depend on gate, got DependsOn=%v", stepA.DependsOn)
+	}
+
+	// step-b already has SeqDependsOn; it must NOT get gate added to DependsOn
+	// (it is not a root — it depends on step-a which depends on the gate).
+	stepB := out.Steps[2]
+	if stepB.ID != "step-b" {
+		t.Fatalf("unexpected step order")
+	}
+	if len(stepB.DependsOn) != 0 {
+		t.Errorf("step-b should have no DependsOn (it is not a root), got %v", stepB.DependsOn)
+	}
+}
+
+// TestInjectApprovalGate_DefaultMessage verifies the default message includes
+// the author login when no custom message is configured.
+func TestInjectApprovalGate_DefaultMessage(t *testing.T) {
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s", Agent: "eng"}}}
+	out := injectApprovalGate(wf, config.ApprovalSettings{}, "mallory")
+	gate := out.Steps[0]
+	if gate.Message == "" {
+		t.Error("gate message should not be empty")
+	}
+	// The login should appear in the default message.
+	if len(gate.Message) == 0 {
+		t.Error("expected non-empty gate message")
+	}
+}
+
+// TestInjectApprovalGate_DoesNotMutateOriginal verifies the returned workflow
+// is a new copy; the original steps slice is unmodified.
+func TestInjectApprovalGate_DoesNotMutateOriginal(t *testing.T) {
+	original := config.WorkflowConfig{
+		Steps: []config.StepConfig{{ID: "s", Agent: "eng"}},
+	}
+	_ = injectApprovalGate(original, config.ApprovalSettings{}, "x")
+	// original.Steps[0].DependsOn must still be empty.
+	if len(original.Steps[0].DependsOn) != 0 {
+		t.Error("injectApprovalGate must not mutate the original steps slice")
+	}
+}
+
+// TestMaybeInjectAuthorGate_Disabled verifies no gate is injected when the
+// feature is off, even for a non-collaborator author.
+func TestMaybeInjectAuthorGate_Disabled(t *testing.T) {
+	d := &Dispatcher{
+		cfg: &config.Config{},
+		sources: map[string]source.Adapter{},
+	}
+	cell := model.SourceItem{AuthorLogin: "attacker"}
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s"}}}
+	out := d.maybeInjectAuthorGate(context.Background(), cell, wf)
+	if len(out.Steps) != 1 {
+		t.Errorf("gate should not be injected when disabled; got %d steps", len(out.Steps))
+	}
+}
+
+// TestMaybeInjectAuthorGate_NoAuthor verifies no gate is injected when the
+// source item has no author login.
+func TestMaybeInjectAuthorGate_NoAuthor(t *testing.T) {
+	d := &Dispatcher{
+		cfg: &config.Config{
+			Settings: config.Settings{
+				Approvals: config.ApprovalSettings{GateUntrustedAuthors: true},
+			},
+		},
+		sources: map[string]source.Adapter{},
+	}
+	cell := model.SourceItem{AuthorLogin: ""}
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s"}}}
+	out := d.maybeInjectAuthorGate(context.Background(), cell, wf)
+	if len(out.Steps) != 1 {
+		t.Errorf("gate should not be injected when author is empty; got %d steps", len(out.Steps))
+	}
+}
+
+// collaboratorFakeAdapter is a minimal source.Adapter that also implements
+// source.CollaboratorChecker for testing.
+type collaboratorFakeAdapter struct {
+	id      string
+	checker *fakeCollaboratorChecker
+}
+
+var _ source.Adapter = (*collaboratorFakeAdapter)(nil)
+var _ source.CollaboratorChecker = (*collaboratorFakeAdapter)(nil)
+
+func (a *collaboratorFakeAdapter) ID() string  { return a.id }
+func (a *collaboratorFakeAdapter) SetID(id string) { a.id = id }
+func (a *collaboratorFakeAdapter) Connect(_ context.Context, _ map[string]any) error { return nil }
+func (a *collaboratorFakeAdapter) Poll(_ context.Context, _ time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (a *collaboratorFakeAdapter) Acknowledge(_ context.Context, _ model.SourceItem, _ model.AckAction) error {
+	return nil
+}
+func (a *collaboratorFakeAdapter) WriteResult(_ context.Context, _ model.SourceItem, _ model.RunResult) error {
+	return nil
+}
+func (a *collaboratorFakeAdapter) WebhookHandler() http.Handler { return nil }
+func (a *collaboratorFakeAdapter) IsCollaborator(ctx context.Context, login string) (bool, error) {
+	return a.checker.IsCollaborator(ctx, login)
+}
+
+// TestMaybeInjectAuthorGate_Collaborator verifies no gate for a trusted author.
+func TestMaybeInjectAuthorGate_Collaborator(t *testing.T) {
+	checker := &fakeCollaboratorChecker{collaborators: map[string]bool{"alice": true}}
+	adapter := &collaboratorFakeAdapter{id: "gh", checker: checker}
+	d := &Dispatcher{
+		cfg: &config.Config{
+			Settings: config.Settings{
+				Approvals: config.ApprovalSettings{GateUntrustedAuthors: true},
+			},
+		},
+		sources: map[string]source.Adapter{"gh": adapter},
+	}
+	cell := model.SourceItem{SourceID: "gh", AuthorLogin: "alice"}
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s"}}}
+	out := d.maybeInjectAuthorGate(context.Background(), cell, wf)
+	if len(out.Steps) != 1 {
+		t.Errorf("gate should not be injected for a collaborator; got %d steps", len(out.Steps))
+	}
+}
+
+// TestMaybeInjectAuthorGate_NonCollaborator verifies the gate IS injected for
+// an author who is not a repository collaborator.
+func TestMaybeInjectAuthorGate_NonCollaborator(t *testing.T) {
+	checker := &fakeCollaboratorChecker{collaborators: map[string]bool{}}
+	adapter := &collaboratorFakeAdapter{id: "gh", checker: checker}
+	d := &Dispatcher{
+		cfg: &config.Config{
+			Settings: config.Settings{
+				Approvals: config.ApprovalSettings{GateUntrustedAuthors: true},
+			},
+		},
+		sources: map[string]source.Adapter{"gh": adapter},
+	}
+	cell := model.SourceItem{SourceID: "gh", AuthorLogin: "attacker"}
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s"}}}
+	out := d.maybeInjectAuthorGate(context.Background(), cell, wf)
+	if len(out.Steps) != 2 {
+		t.Fatalf("gate should be injected; got %d steps", len(out.Steps))
+	}
+	if out.Steps[0].ID != untrustedGateStepID {
+		t.Errorf("first step should be gate, got %q", out.Steps[0].ID)
+	}
+}
+
+// TestMaybeInjectAuthorGate_APIError verifies fail-open: an API error skips
+// the gate rather than blocking the run.
+func TestMaybeInjectAuthorGate_APIError(t *testing.T) {
+	checker := &fakeCollaboratorChecker{err: errCollabAPIError}
+	adapter := &collaboratorFakeAdapter{id: "gh", checker: checker}
+	d := &Dispatcher{
+		cfg: &config.Config{
+			Settings: config.Settings{
+				Approvals: config.ApprovalSettings{GateUntrustedAuthors: true},
+			},
+		},
+		sources: map[string]source.Adapter{"gh": adapter},
+	}
+	cell := model.SourceItem{SourceID: "gh", AuthorLogin: "unknown"}
+	wf := config.WorkflowConfig{Steps: []config.StepConfig{{ID: "s"}}}
+	out := d.maybeInjectAuthorGate(context.Background(), cell, wf)
+	if len(out.Steps) != 1 {
+		t.Errorf("API error should be fail-open (no gate); got %d steps", len(out.Steps))
+	}
+}
+
+var errCollabAPIError = &collaboratorAPIError{}
+
+type collaboratorAPIError struct{}
+
+func (e *collaboratorAPIError) Error() string { return "github: collaborator check: status 403" }

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -215,6 +215,7 @@ func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem
 	}
 
 	wf := d.resolveWorkflow(match)
+	wf = d.maybeInjectAuthorGate(ctx, cell, wf)
 	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
 	if err != nil {
 		aplog.Error("cell %s: workflow run failed: %v", cell.LogLabel(), err)
@@ -222,6 +223,78 @@ func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem
 	}
 	aplog.Info("cell %s: workflow instance %s started (success=%v; may be awaiting approval)", cell.LogLabel(), instID, success)
 	return model.RunResult{Success: success, WorkerID: match.Route.Agent}
+}
+
+// maybeInjectAuthorGate returns wf unmodified when gate_untrusted_authors is
+// disabled, the source item has no author, or the author is confirmed as a
+// collaborator. When the author cannot be verified as a collaborator, a
+// synthetic approval step is prepended so the instance parks before any
+// shell/edit-capable agent runs. API errors are fail-open: a non-200 response
+// that is not a definitive "not a collaborator" (404) is logged and skipped so
+// a transient API outage cannot block legitimate work.
+func (d *Dispatcher) maybeInjectAuthorGate(ctx context.Context, cell model.SourceItem, wf config.WorkflowConfig) config.WorkflowConfig {
+	if !d.cfg.Settings.Approvals.GateUntrustedAuthors {
+		return wf
+	}
+	login := cell.AuthorLogin
+	if login == "" {
+		return wf
+	}
+	adapter, ok := d.sources[cell.SourceID]
+	if !ok {
+		return wf
+	}
+	checker, ok := adapter.(source.CollaboratorChecker)
+	if !ok {
+		// Source doesn't support collaborator checking; treat as trusted.
+		return wf
+	}
+	collab, err := checker.IsCollaborator(ctx, login)
+	if err != nil {
+		aplog.Warn("cell %s: collaborator check for @%s: %v (skipping gate)", cell.LogLabel(), login, err)
+		return wf
+	}
+	if collab {
+		aplog.Debug("cell %s: author @%s is a collaborator — no gate injected", cell.LogLabel(), login)
+		return wf
+	}
+
+	aplog.Info("cell %s: author @%s is not a collaborator — injecting approval gate", cell.LogLabel(), login)
+	return injectApprovalGate(wf, d.cfg.Settings.Approvals, login)
+}
+
+const untrustedGateStepID = "_untrusted_author_gate"
+
+// injectApprovalGate prepends a synthetic approval step to wf and wires all
+// root steps (those with no existing explicit or sequential deps) to depend on
+// it, ensuring no agent step executes before a human approves the run.
+func injectApprovalGate(wf config.WorkflowConfig, cfg config.ApprovalSettings, login string) config.WorkflowConfig {
+	msg := cfg.UntrustedMessage
+	if msg == "" {
+		msg = fmt.Sprintf("Run triggered by @%s who is not a repository collaborator. Review the task and approve only if the request is safe to execute.", login)
+	}
+	gate := config.StepConfig{
+		ID:        untrustedGateStepID,
+		Type:      config.StepTypeApproval,
+		Message:   msg,
+		Approvers: cfg.UntrustedApprovers,
+	}
+
+	// Clone steps so we do not mutate the shared config.WorkflowConfig.
+	steps := make([]config.StepConfig, len(wf.Steps))
+	copy(steps, wf.Steps)
+
+	// Wire every root step (no existing deps) to depend on the gate so no
+	// agent starts before approval. Root = both DependsOn and SeqDependsOn empty.
+	for i := range steps {
+		if len(steps[i].DependsOn) == 0 && len(steps[i].SeqDependsOn) == 0 {
+			steps[i].DependsOn = []string{untrustedGateStepID}
+		}
+	}
+
+	out := wf
+	out.Steps = append([]config.StepConfig{gate}, steps...)
+	return out
 }
 
 // resolveWorkflow returns the workflow to run for a matched route: a workflow

--- a/src/internal/model/source_item.go
+++ b/src/internal/model/source_item.go
@@ -25,6 +25,10 @@ type SourceItem struct {
 	Metadata    map[string]any
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// AuthorLogin is the source-native username of whoever opened or triggered
+	// this item. Populated by adapters that carry author identity (e.g. GitHub
+	// issues carry the opener's login). Empty when the source does not expose it.
+	AuthorLogin string
 	// Comments is populated only by a TaskPoller (per-task fetch used for
 	// approval steps), not by Poll. It holds comments relevant to evaluating an
 	// approval condition.

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -21,13 +21,14 @@ func init() {
 // Compile-time checks: the GitHub adapter supports the optional source
 // capabilities used by the dispatcher and the workflow engine.
 var (
-	_ source.StateSetter     = (*Adapter)(nil)
-	_ source.LabelAdder      = (*Adapter)(nil)
-	_ source.LabelRemover    = (*Adapter)(nil)
-	_ source.TaskPoller      = (*Adapter)(nil)
-	_ source.CIStatusPoller  = (*Adapter)(nil)
-	_ source.SubIssueCreator = (*Adapter)(nil)
-	_ source.BlockerLister   = (*Adapter)(nil)
+	_ source.StateSetter        = (*Adapter)(nil)
+	_ source.LabelAdder         = (*Adapter)(nil)
+	_ source.LabelRemover       = (*Adapter)(nil)
+	_ source.TaskPoller         = (*Adapter)(nil)
+	_ source.CIStatusPoller     = (*Adapter)(nil)
+	_ source.SubIssueCreator    = (*Adapter)(nil)
+	_ source.BlockerLister      = (*Adapter)(nil)
+	_ source.CollaboratorChecker = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -687,9 +688,19 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		Type:        "issue",
 		State:       item.State,
 		URL:         item.HTMLURL,
+		AuthorLogin: item.User.Login,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 	}
+}
+
+// IsCollaborator reports whether the given GitHub login is a collaborator on
+// the configured repo. It calls GET /repos/{owner}/{repo}/collaborators/{login}
+// which returns 204 for collaborators and 404 for non-members. Any other error
+// is returned to the caller; the caller should fail-safe (treat as trusted) on
+// non-authoritative errors.
+func (a *Adapter) IsCollaborator(ctx context.Context, login string) (bool, error) {
+	return a.client.isCollaborator(ctx, a.owner, a.repo, login)
 }
 
 func formatComment(result model.RunResult) string {

--- a/src/internal/source/github/client.go
+++ b/src/internal/source/github/client.go
@@ -170,6 +170,34 @@ func (c *client) getAllIssues(ctx context.Context, path string, params url.Value
 	return all, nil
 }
 
+// isCollaborator checks whether login is a collaborator on owner/repo.
+// GitHub returns 204 No Content for collaborators and 404 for non-members.
+// Any error other than a 404 is propagated; the caller should treat API
+// errors as non-authoritative and fail open (assume trusted) rather than
+// blocking legitimate work.
+func (c *client) isCollaborator(ctx context.Context, owner, repo, login string) (bool, error) {
+	path := fmt.Sprintf("/repos/%s/%s/collaborators/%s", owner, repo, login)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	aplog.Debug("github: GET %s → %d", path, resp.StatusCode)
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("github: collaborator check: status %d: %s", resp.StatusCode, body)
+	}
+}
+
 var linkNextRe = regexp.MustCompile(`<[^>]+>;\s*rel="([^"]+)"`)
 
 func hasNextPage(link string) bool {

--- a/src/internal/source/github/collaborator_test.go
+++ b/src/internal/source/github/collaborator_test.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsCollaborator_True(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/owner/repo/collaborators/alice" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{owner: "owner", repo: "repo", client: newClient(srv.URL, "")}
+	ok, err := a.IsCollaborator(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected alice to be a collaborator")
+	}
+}
+
+func TestIsCollaborator_False(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{owner: "owner", repo: "repo", client: newClient(srv.URL, "")}
+	ok, err := a.IsCollaborator(context.Background(), "mallory")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("mallory should not be a collaborator")
+	}
+}
+
+func TestIsCollaborator_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	a := &Adapter{owner: "owner", repo: "repo", client: newClient(srv.URL, "")}
+	_, err := a.IsCollaborator(context.Background(), "someone")
+	if err == nil {
+		t.Error("expected error for non-200/204/404 response")
+	}
+}
+
+// TestToSourceItemPopulatesAuthorLogin verifies that the GitHub adapter sets
+// AuthorLogin from the issue's User.Login field.
+func TestToSourceItemPopulatesAuthorLogin(t *testing.T) {
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient("", "")}
+	item := issue{
+		Number: 42,
+		Title:  "Test issue",
+		State:  "open",
+		User:   user{Login: "alice"},
+	}
+	si := a.toSourceItem(item)
+	if si.AuthorLogin != "alice" {
+		t.Errorf("expected AuthorLogin=alice, got %q", si.AuthorLogin)
+	}
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -142,6 +142,14 @@ type SubIssueCreator interface {
 	CreateSubIssue(ctx context.Context, parent, child model.SourceItem) (model.SourceItem, error)
 }
 
+// CollaboratorChecker is an optional interface a source may implement to check
+// whether a given user login is a collaborator on the backing repository.
+// The dispatcher uses it to gate untrusted-author runs behind a human-approval
+// step when settings.approvals.gate_untrusted_authors is true.
+type CollaboratorChecker interface {
+	IsCollaborator(ctx context.Context, login string) (bool, error)
+}
+
 // Factory creates a new, unconfigured Adapter instance.
 type Factory func() Adapter
 


### PR DESCRIPTION
## Summary

Reworks #242's Action-only approach (which had a TOCTOU race) by enforcing the collaborator gate at daemon ingest time, before any workflow is dispatched.

- **`model.SourceItem`** gains `AuthorLogin`, populated by source adapters.
- **GitHub adapter** populates `AuthorLogin` from `issue.User.Login` and implements the new `source.CollaboratorChecker` interface via `GET /repos/{owner}/{repo}/collaborators/{login}` (204 = member, 404 = not).
- **`config.ApprovalSettings`** adds `gate_untrusted_authors`, `untrusted_approvers`, and `untrusted_message` fields.
- **`daemon.dispatchWorkflow`** calls `maybeInjectAuthorGate`, which performs the collaborator check and calls `injectApprovalGate` to prepend a synthetic `_untrusted_author_gate` approval step — parking the instance in `approval_waiting` before any shell/edit-capable agent step runs.
- **Fail-open:** API errors skip the gate rather than blocking legitimate work; the error is logged.
- **`triage-gate` Action** (from #242) remains as defense-in-depth; the daemon gate removes the TOCTOU race entirely.

## Test plan

- [ ] `TestInjectApprovalGate` — gate step is prepended and all root steps get `DependsOn`
- [ ] `TestMaybeInjectAuthorGate_Disabled` — skipped when feature flag is off
- [ ] `TestMaybeInjectAuthorGate_NoAuthor` — skipped when `AuthorLogin` is empty
- [ ] `TestMaybeInjectAuthorGate_Collaborator` — no gate injected for collaborators
- [ ] `TestMaybeInjectAuthorGate_NonCollaborator` — gate injected for non-collaborators
- [ ] `TestMaybeInjectAuthorGate_APIError` — fail-open on GitHub API errors
- [ ] `TestIsCollaborator_*` — 204/404/error cases in GitHub client

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)