### PR TITLE
security: strip host env vars via allow-list before spawning agent subprocesses (SEC-07)

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,16 +5,14 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
-
-> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
+All commands work via `npx` — no global install required.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-node .gitnexus/run.cjs analyze
+npx gitnexus analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -24,14 +22,13 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
-| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
 
 ### status — Check index freshness
 
 ```bash
-node .gitnexus/run.cjs status
+npx gitnexus status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -39,7 +36,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-node .gitnexus/run.cjs clean
+npx gitnexus clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -52,7 +49,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-node .gitnexus/run.cjs wiki
+npx gitnexus wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -69,7 +66,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-node .gitnexus/run.cjs list
+npx gitnexus list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. query({search_query: "<error or symptom>"})            → Find related execution flows
-2. context({name: "<suspect>"})                    → See callers/callees/processes
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. cypher({statement: "MATCH path..."})                 → Custom traces if needed
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] query for error text or related code
+- [ ] gitnexus_query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] context to see callers and callees
+- [ ] gitnexus_context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] cypher for custom call chain traces if needed
+- [ ] gitnexus_cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,58 +40,46 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `query` for error text → `context` on throw sites |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
 | Recent regression    | `detect_changes` to see what your changes affect           |
-| "How does A reach B?" | `trace` between the two symbols — shortest call chain in one call |
 
 ## Tools
 
-**query** — find code related to error:
+**gitnexus_query** — find code related to error:
 
 ```
-query({search_query: "payment validation error"})
+gitnexus_query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**context** — full context for a suspect:
+**gitnexus_context** — full context for a suspect:
 
 ```
-context({name: "validatePayment"})
+gitnexus_context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**cypher** — custom call chain traces:
+**gitnexus_cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
 RETURN [n IN nodes(path) | n.name] AS chain
 ```
 
-**trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
-
-```
-trace({ from: "processCheckout", to: "fetchRates" })
-→ status: ok, hopCount: 3
-→ hops: processCheckout → validatePayment → verifyCard → fetchRates
-→ edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
-```
-
-When no path exists, `trace` reports the furthest reachable node — exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
-
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. query({search_query: "payment error handling"})
+1. gitnexus_query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. context({name: "validatePayment"})
+2. gitnexus_context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -18,20 +18,20 @@ description: "Use when the user asks how code works, wants to understand archite
 ```
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. query({search_query: "<what you want to understand>"})  → Find related execution flows
-4. context({name: "<symbol>"})            → Deep dive on specific symbol
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] query for the concept you want to understand
+- [ ] gitnexus_query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] context on key symbols for callers/callees
+- [ ] gitnexus_context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**query** — find execution flows related to a concept:
+**gitnexus_query** — find execution flows related to a concept:
 
 ```
-query({search_query: "payment processing"})
+gitnexus_query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**context** — 360-degree view of a symbol:
+**gitnexus_context** — 360-degree view of a symbol:
 
 ```
-context({name: "validateUser"})
+gitnexus_context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -68,10 +68,10 @@ context({name: "validateUser"})
 
 ```
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. query({search_query: "payment processing"})
+2. gitnexus_query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. context({name: "processPayment"})
+3. gitnexus_context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
 
 ## Skills
 
@@ -35,82 +35,10 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `query`          | Process-grouped code intelligence — execution flows related to a concept |
 | `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
 | `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
-| `trace`          | Shortest path between two symbols — "how does A reach B?" in one call     |
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `explain`        | Persisted taint findings — source→sink data flows (needs `analyze --pdg`) |
-| `pdg_query`      | Control/data dependence — what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
-| `check`          | Check graph invariants such as circular imports                          |
-| `route_map`      | API route map — which components/hooks fetch which endpoints, and the handler files that serve them |
-| `shape_check`    | Response-shape drift — keys each route returns vs keys its consumers access (flags MISMATCH) |
-| `api_impact`     | Pre-change report for an API route — consumers, middleware, shape mismatches, risk level |
-| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
-| `group_list`     | List configured multi-repo groups, or one group's config                 |
-| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
-| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
-
-### Paginating `list_repos`
-
-`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
-
-```jsonc
-{
-  "repositories": [
-    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
-  ],
-  "pagination": {
-    "total": 437,
-    "limit": 50,
-    "offset": 0,
-    "returned": 50,
-    "hasMore": true,
-    "nextOffset": 50
-  }
-}
-```
-
-To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
-
-```text
-list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
-list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
-…
-list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
-```
-
-Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
-
-### Taint findings (`explain`)
-
-`explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
-
-- `explain {}` — enumerate all findings for the repo (bounded by `limit`, deterministic order)
-- `explain { target: "src/vuln.ts" }` — findings in a file (suffix path match accepted)
-- `explain { target: "runUserCommand" }` — findings in a function (resolved like `context`; ambiguous names return ranked candidates)
-
-A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
-
-### Control & data dependence (`pdg_query`)
-
-`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) — the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
-
-- `pdg_query { mode: "controls", target: "..." }` — CDG: "under what condition does X run?". Each edge is a controlling predicate block → dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery — the sense depends on the predicate, so don't filter guards by a fixed label).
-- `pdg_query { mode: "flows", target: "...", variable?: "..." }` — REACHING_DEF def→use edges within the function; pass `variable` to trace one binding.
-
-A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only — cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
-
-### Shortest path between two symbols (`trace`)
-
-`trace` answers "how does A reach B?" in one call — the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3–8 `context`/`impact` hops by hand.
-
-- `trace { from: "validateUser", to: "executeQuery" }` — shortest path between two symbols.
-- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
-- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
-
-Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
-
-Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos — the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
+| `list_repos`     | Discover indexed repos                                                   |
 
 ## Resources Reference
 
@@ -127,10 +55,8 @@ Lightweight reads (~100-500 tokens) for navigation:
 
 ## Graph Schema
 
-**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, …) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
-**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG — zero rows on a default index).
-
-Read `gitnexus://repo/{name}/schema` before writing Cypher — it is the authoritative schema for the indexed repo.
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -17,22 +17,22 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. impact({target: "X", direction: "upstream"})  → What depends on this
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. detect_changes()                               → Map current git changes to affected flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
-- [ ] impact({target, direction: "upstream"}) to find dependents
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] detect_changes() for pre-commit check
+- [ ] gitnexus_detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**impact** — the primary tool for symbol blast radius:
+**gitnexus_impact** — the primary tool for symbol blast radius:
 
 ```
-impact({
+gitnexus_impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**detect_changes** — git-diff based impact analysis:
+**gitnexus_detect_changes** — git-diff based impact analysis:
 
 ```
-detect_changes({scope: "staged"})
+gitnexus_detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -86,7 +86,7 @@ detect_changes({scope: "staged"})
 ## Example: "What breaks if I change validateUser?"
 
 ```
-1. impact({target: "validateUser", direction: "upstream"})
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -16,78 +16,78 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. impact({target: "X", direction: "upstream"})  → Map all dependents
-2. query({search_query: "X"})                            → Find execution flows involving X
-3. context({name: "X"})                           → See all incoming/outgoing refs
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
-- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
-- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
-- [ ] detect_changes() — verify only expected files changed
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] context({name: target}) — see all incoming/outgoing refs
-- [ ] impact({target, direction: "upstream"}) — find all external callers
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] detect_changes() — verify affected scope
+- [ ] gitnexus_detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] context({name: target}) — understand all callees
+- [ ] gitnexus_context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] impact({target, direction: "upstream"}) — map callers to update
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] detect_changes() — verify affected scope
+- [ ] gitnexus_detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**rename** — automated multi-file rename:
+**gitnexus_rename** — automated multi-file rename:
 
 ```
-rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
-→ 10 graph edits (high confidence), 2 text_search edits (review)
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**impact** — map all dependents first:
+**gitnexus_impact** — map all dependents first:
 
 ```
-impact({target: "validateUser", direction: "upstream"})
+gitnexus_impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**detect_changes** — verify your changes after refactoring:
+**gitnexus_detect_changes** — verify your changes after refactoring:
 
 ```
-detect_changes({scope: "all"})
+gitnexus_detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**cypher** — custom reference queries:
+**gitnexus_cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use rename for automated updates |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | query to find them               |
+| String/dynamic refs | gitnexus_query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
-   → 12 edits: 10 graph (safe), 2 text_search (review)
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
-2. Review text_search edits (config.json: dynamic reference!)
+2. Review ast_search edits (config.json: dynamic reference!)
 
-3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. detect_changes({scope: "all"})
+4. gitnexus_detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10279 symbols, 23389 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10279 symbols, 23389 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -873,9 +873,11 @@ func readSoulFile(agent config.AgentConfig, cellID string) string {
 // the agent runs itself authenticate as the agent, not the daemon's inherited
 // default account). The `gh` CLI honours both variables; we set both for safety.
 //
-// These overlay os.Environ() at the call site (Env on the RunRequest, applied
-// after the inherited environment in the runner), so the agent's token wins over
-// any GITHUB_TOKEN the daemon inherited.
+// These are passed as req.Env, which the runner overlays on top of the
+// allow-listed host environment, so the agent's token wins over any GITHUB_TOKEN
+// the host process might carry. Use per-repo fine-grained tokens via
+// agent.source_token rather than a broad personal access token so that a
+// compromised agent can only affect the repositories it was explicitly granted.
 func agentIdentityEnv(agent config.AgentConfig) map[string]string {
 	env := map[string]string{}
 	if agent.SourceName != "" {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -105,7 +104,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)
 	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
+	cmd.Env = hostEnv()
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/src/internal/runner/execution/env.go
+++ b/src/internal/runner/execution/env.go
@@ -1,0 +1,96 @@
+package execution
+
+import (
+	"os"
+	"strings"
+)
+
+// allowedEnvKeys is the set of host environment variable names that are safe
+// to inherit by agent subprocesses. Everything not in this set (or matching
+// allowedEnvPrefixes) is stripped before the subprocess starts.
+//
+// Design rationale: agent subprocesses run untrusted (or semi-trusted) code
+// that could exfiltrate host secrets via the inherited environment. Stripping
+// to an explicit allow-list ensures that credentials — cloud provider keys,
+// API tokens, webhook secrets, database URLs — are never silently present in
+// the subprocess environment unless the operator has explicitly configured them
+// via agent.env / workflow.env / step.env.
+//
+// Credentials the agent legitimately needs (GITHUB_TOKEN, ANTHROPIC_API_KEY,
+// …) must be declared in config and arrive via req.Env, which is overlaid on
+// top of the filtered host environment in the runner. See: agent.source_token
+// for per-repo fine-grained tokens (preferred over a broad host GITHUB_TOKEN).
+var allowedEnvKeys = map[string]bool{
+	// Process execution essentials.
+	"PATH":  true,
+	"HOME":  true,
+	"USER":  true,
+	"UID":   true,
+	"SHELL": true,
+	// POSIX / glibc alternate user-identity names.
+	"LOGNAME":  true,
+	"USERNAME": true,
+	// Terminal / colour output.
+	"TERM":         true,
+	"TERM_PROGRAM": true,
+	"COLORTERM":    true,
+	"NO_COLOR":     true,
+	// Locale (root key; LC_* prefix is covered by allowedEnvPrefixes).
+	"LANG": true,
+	// Temporary directories.
+	"TMPDIR":  true,
+	"TMP":     true,
+	"TEMP":    true,
+	"TEMPDIR": true,
+	// SSH agent socket — agents that push over SSH (git push) need this.
+	"SSH_AUTH_SOCK": true,
+	"SSH_AGENT_PID": true,
+	// Graphics/display — needed by some GUI-adjacent tools on Linux.
+	"DISPLAY":         true,
+	"WAYLAND_DISPLAY": true,
+	// XDG base directories — used by many CLI tools for config/cache/data.
+	"XDG_RUNTIME_DIR": true,
+	"XDG_CONFIG_HOME": true,
+	"XDG_DATA_HOME":   true,
+	"XDG_CACHE_HOME":  true,
+	"XDG_STATE_HOME":  true,
+	// CI flag — some tooling adjusts output/behaviour in CI environments.
+	"CI": true,
+}
+
+// allowedEnvPrefixes lists key prefixes for host variables that are safe to
+// pass through as a group rather than by individual name.
+var allowedEnvPrefixes = []string{
+	"LC_", // locale categories: LC_CTYPE, LC_MESSAGES, LC_ALL, etc.
+}
+
+// hostEnv returns the filtered subset of os.Environ() that is safe to expose
+// to agent subprocesses. Only variables in allowedEnvKeys or matching
+// allowedEnvPrefixes are kept; everything else — cloud credentials, API keys,
+// database URLs, webhook secrets, and any other ambient secret the daemon
+// happens to carry — is stripped.
+//
+// Callers overlay req.Env on top of the result so that any credential
+// explicitly configured for the agent is still present in the subprocess
+// environment; see CliRunner.Run.
+func hostEnv() []string {
+	raw := os.Environ()
+	out := make([]string, 0, len(raw))
+	for _, kv := range raw {
+		key, _, found := strings.Cut(kv, "=")
+		if !found {
+			continue
+		}
+		if allowedEnvKeys[key] {
+			out = append(out, kv)
+			continue
+		}
+		for _, prefix := range allowedEnvPrefixes {
+			if strings.HasPrefix(key, prefix) {
+				out = append(out, kv)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/src/internal/runner/execution/env_test.go
+++ b/src/internal/runner/execution/env_test.go
@@ -1,0 +1,76 @@
+package execution
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHostEnv_stripsSecrets(t *testing.T) {
+	// Set a canary secret and a safe var; verify only the safe var survives.
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "should-be-stripped")
+	t.Setenv("ANTHROPIC_API_KEY", "should-be-stripped")
+	t.Setenv("GITHUB_TOKEN", "should-be-stripped")
+	t.Setenv("MY_WEBHOOK_SECRET", "should-be-stripped")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	got := hostEnv()
+
+	for _, kv := range got {
+		key, _, _ := strings.Cut(kv, "=")
+		switch key {
+		case "AWS_SECRET_ACCESS_KEY", "ANTHROPIC_API_KEY", "GITHUB_TOKEN", "MY_WEBHOOK_SECRET":
+			t.Errorf("hostEnv leaked secret var %q", key)
+		}
+	}
+	if !containsKey(got, "PATH") {
+		t.Error("hostEnv dropped PATH")
+	}
+}
+
+func TestHostEnv_allowsLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "en_US.UTF-8")
+	t.Setenv("LC_CTYPE", "en_US.UTF-8")
+
+	got := hostEnv()
+	if !containsKey(got, "LC_ALL") {
+		t.Error("hostEnv dropped LC_ALL")
+	}
+	if !containsKey(got, "LC_CTYPE") {
+		t.Error("hostEnv dropped LC_CTYPE")
+	}
+}
+
+func TestHostEnv_allowsAllowedKeys(t *testing.T) {
+	for key := range allowedEnvKeys {
+		t.Setenv(key, "test-value")
+	}
+
+	got := hostEnv()
+	for key := range allowedEnvKeys {
+		if !containsKey(got, key) {
+			t.Errorf("hostEnv dropped allowed key %q", key)
+		}
+	}
+}
+
+func TestHostEnv_noUnsetVarsLeak(t *testing.T) {
+	// Verify that a var not in the allow-list is absent even when set.
+	_ = os.Unsetenv("DATABASE_URL")
+	t.Setenv("DATABASE_URL", "postgres://user:pass@host/db")
+
+	got := hostEnv()
+	if containsKey(got, "DATABASE_URL") {
+		t.Error("hostEnv leaked DATABASE_URL")
+	}
+}
+
+func containsKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Agent subprocesses previously inherited the **full daemon environment** via `os.Environ()`, silently exposing every ambient secret (cloud credentials, API tokens, webhook secrets, database URLs) to agent-run code.
- Introduces `hostEnv()` in a new `execution/env.go` file: an explicit allow-list that keeps only well-known safe variables (`PATH`, `HOME`, locale, SSH agent socket, XDG dirs, terminal vars) and **strips everything else**.
- Credentials agents legitimately need (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, …) must now be declared in `agent.env` / `workflow.env` / `step.env` config and arrive via `req.Env`, which is overlaid on top of the filtered environment — as they already were for `GITHUB_TOKEN` via `agentIdentityEnv()`.
- Updates the `agentIdentityEnv()` doc comment to document the preferred **per-repo fine-grained token** pattern via `agent.source_token` rather than a broad host `GITHUB_TOKEN`.
- Adds `env_test.go` with four table-driven tests covering secret stripping, locale pass-through, full allow-list coverage, and unlisted-key exclusion.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 23 packages pass
- [x] `go test ./internal/runner/execution/...` — 4 new env tests pass
- [ ] Verify that a deployed agent can still `git push` and call `gh` (needs `GH_TOKEN` / `GITHUB_TOKEN` in `agent.env` or via `source_token`)
- [ ] Confirm no ambient secrets appear in the subprocess environment in a real run

Closes #230