### PR TITLE
security: sandbox agent execution to contain prompt injection (SEC-09)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10303 symbols, 23448 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10303 symbols, 23448 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -73,6 +73,11 @@ type RunnerConfig struct {
 	// format/location (see runner/execution). Agent-scope MCPs (AgentConfig.MCPs)
 	// are layered on top of these, overriding by name.
 	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
+	// Sandbox, when set, wraps every agent subprocess in a Docker container with
+	// the specified image, restricted user, and network policy. Use this for
+	// runners that process issues from external/untrusted authors to contain
+	// prompt-injection attempts.
+	Sandbox *SandboxConfig `yaml:"sandbox,omitempty"`
 }
 
 // AdapterName returns the runner adapter name as "{provider}-{type}" when both
@@ -128,6 +133,31 @@ type AgentConfig struct {
 	// WorkspaceAffinity pins retries/resumes to the first worker that claims the
 	// task, preserving a local checkout or other non-portable environment.
 	WorkspaceAffinity bool `yaml:"workspace_affinity,omitempty"`
+	// Permissions overrides the default tool permissions written into the OpenCode
+	// agent file. Keys are tool names ("bash", "edit", "webfetch", etc.); values
+	// are "allow" or "deny". Absent keys use the runner's least-privilege defaults
+	// (read/glob/grep/task: allow; bash/edit/webfetch: deny). To grant shell
+	// access explicitly set permissions: {bash: allow, edit: allow}.
+	Permissions map[string]string `yaml:"permissions,omitempty"`
+}
+
+// SandboxConfig describes a container isolation layer for CLI runner processes.
+// When set on a RunnerConfig, every agent subprocess is launched inside a
+// Docker container with the given image, restricted user, and network policy,
+// preventing prompt-injection escapes from reaching the host or other services.
+type SandboxConfig struct {
+	// Image is the Docker image that provides the agent binary (required when
+	// sandbox is enabled).
+	Image string `yaml:"image"`
+	// User is passed as --user to docker run (e.g. "nobody", "1000:1000").
+	// Defaults to "nobody" when empty.
+	User string `yaml:"user,omitempty"`
+	// Network is the --network value for docker run (e.g. "none", "host", or a
+	// named bridge). Defaults to "none" when empty.
+	Network string `yaml:"network,omitempty"`
+	// ExtraArgs are appended verbatim after `docker run --rm` and before the
+	// image name, e.g. ["-v", "/cache:/cache:ro"] for read-only bind mounts.
+	ExtraArgs []string `yaml:"extra_args,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -357,7 +357,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			return nil, fmt.Errorf("agent %q: runner type %q not found", ac.ID, rc.Type)
 		}
 
-		if err := ra.Configure(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)); err != nil {
+		if err := ra.Configure(injectSandbox(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs), rc.Sandbox)); err != nil {
 			return nil, fmt.Errorf("agent %q: configure runner: %w", ac.ID, err)
 		}
 
@@ -389,7 +389,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
 			}
-			if err := fra.Configure(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)); err != nil {
+			if err := fra.Configure(injectSandbox(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs), frc.Sandbox)); err != nil {
 				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
 			}
 			if fAdapterName == "opencode" {
@@ -1733,18 +1733,30 @@ func (d *Dispatcher) writeOpencodeAgent(ctx context.Context, ac config.AgentConf
 		}
 	}
 
+	// Least-privilege defaults: read-only tools allowed; write/shell/network
+	// tools denied. Agents that require bash or edit access must opt in via
+	// permissions: {bash: allow, edit: allow} in their agent config.
+	perms := map[string]string{
+		"read":     "allow",
+		"glob":     "allow",
+		"grep":     "allow",
+		"task":     "allow",
+		"edit":     "deny",
+		"bash":     "deny",
+		"webfetch": "deny",
+	}
+	for k, v := range ac.Permissions {
+		perms[k] = v
+	}
+
 	var b strings.Builder
 	b.WriteString("---\n")
 	fmt.Fprintf(&b, "description: %s\n", ac.Description)
 	b.WriteString("mode: primary\n")
 	b.WriteString("permission:\n")
-	b.WriteString("  edit: allow\n")
-	b.WriteString("  bash: allow\n")
-	b.WriteString("  read: allow\n")
-	b.WriteString("  glob: allow\n")
-	b.WriteString("  grep: allow\n")
-	b.WriteString("  webfetch: allow\n")
-	b.WriteString("  task: allow\n")
+	for _, tool := range []string{"read", "glob", "grep", "task", "edit", "bash", "webfetch"} {
+		fmt.Fprintf(&b, "  %s: %s\n", tool, perms[tool])
+	}
 	b.WriteString("---\n")
 	if promptBody != "" {
 		b.WriteString("\n")
@@ -1797,20 +1809,27 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		_ = json.Unmarshal(data, &cfg)
 	}
 
+	// Build permission map with least-privilege defaults, overridden by agent config.
+	permMap := map[string]any{
+		"read":     "allow",
+		"glob":     "allow",
+		"grep":     "allow",
+		"task":     "allow",
+		"edit":     "deny",
+		"bash":     "deny",
+		"webfetch": "deny",
+	}
+	for k, v := range ac.Permissions {
+		permMap[k] = v
+	}
+
 	// Use a relative reference from the global config directory
 	agentEntry := map[string]any{
 		"description": ac.Description,
 		"mode":        "primary",
 		"prompt":      "{file:./agents/" + ac.ID + ".md}",
 		"skills":      ac.Skills,
-		"permission": map[string]any{
-			"edit": "allow",
-			"bash": "allow",
-			"read": "allow",
-			"glob": "allow",
-			"grep": "allow",
-			"task": "allow",
-		},
+		"permission":  permMap,
 	}
 
 	agents, _ := cfg["agent"].(map[string]any)
@@ -1842,6 +1861,32 @@ func runnerConfigWithMCPs(base map[string]any, runnerMCPs, agentMCPs []model.MCP
 		out[k] = v
 	}
 	out["mcps"] = merged
+	return out
+}
+
+// injectSandbox folds a RunnerConfig.Sandbox into the config map passed to
+// CliRunner.Configure. The base map is never mutated; a copy is returned only
+// when a sandbox is present.
+func injectSandbox(base map[string]any, s *config.SandboxConfig) map[string]any {
+	if s == nil {
+		return base
+	}
+	out := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["sandbox"] = map[string]any{
+		"image":      s.Image,
+		"user":       s.User,
+		"network":    s.Network,
+		"extra_args": func() []any {
+			a := make([]any, len(s.ExtraArgs))
+			for i, v := range s.ExtraArgs {
+				a[i] = v
+			}
+			return a
+		}(),
+	}
 	return out
 }
 
@@ -1891,7 +1936,7 @@ func (d *Dispatcher) UpdateAgentConfig(ctx context.Context, agentID, newModel, n
 		if !ok {
 			return fmt.Errorf("runner type %q not registered", rc.Type)
 		}
-		if err := ra.Configure(rc.Config); err != nil {
+		if err := ra.Configure(injectSandbox(rc.Config, rc.Sandbox)); err != nil {
 			return fmt.Errorf("configure runner %q: %w", newRunner, err)
 		}
 

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -35,6 +35,80 @@ type CliRunner struct {
 	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
 	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
 	mcpRunArgs []string
+	// sandbox, when non-nil, wraps every agent subprocess in a Docker container
+	// with the given image, restricted user, and network policy.
+	sandbox *cliSandbox
+}
+
+// cliSandbox describes the Docker container isolation applied to a CliRunner.
+type cliSandbox struct {
+	image     string
+	user      string // defaults to "nobody" when empty
+	network   string // defaults to "none" when empty
+	extraArgs []string
+}
+
+// wrapCommand rewrites (binary, argv) to run inside the sandbox container.
+// Per-task credentials in env are injected via --env flags (not host-inherited).
+// Returns the docker binary and the full argument list.
+func (s *cliSandbox) wrapCommand(binary string, argv []string, workDir string, env map[string]string) (string, []string) {
+	user := s.user
+	if user == "" {
+		user = "nobody"
+	}
+	network := s.network
+	if network == "" {
+		network = "none"
+	}
+	dockerArgs := []string{"run", "--rm", "--network", network, "--user", user}
+	if workDir != "" {
+		dockerArgs = append(dockerArgs, "-v", workDir+":"+workDir, "-w", workDir)
+	}
+	for k, v := range env {
+		dockerArgs = append(dockerArgs, "--env", k+"="+v)
+	}
+	dockerArgs = append(dockerArgs, s.extraArgs...)
+	dockerArgs = append(dockerArgs, s.image, binary)
+	dockerArgs = append(dockerArgs, argv...)
+	return "docker", dockerArgs
+}
+
+// hostEnvAllowList is the set of host environment variable names that are safe
+// to inherit by agent subprocesses. All other host variables (API keys, secrets,
+// AWS credentials, etc. that belong to the daemon) are excluded. Per-task
+// credentials arrive via req.Env and are overlaid explicitly.
+var hostEnvAllowList = map[string]bool{
+	"PATH":          true,
+	"HOME":          true,
+	"TMPDIR":        true,
+	"TEMP":          true,
+	"TMP":           true,
+	"TERM":          true,
+	"USER":          true,
+	"LOGNAME":       true,
+	"LANG":          true,
+	"LC_ALL":        true,
+	"LC_CTYPE":      true,
+	"SSL_CERT_FILE": true,
+	"SSL_CERT_DIR":  true,
+	"SSH_AUTH_SOCK": true,
+	"DOCKER_HOST":   true, // needed when the daemon invokes docker for sandboxing
+}
+
+// filteredHostEnv builds the subprocess environment from the safe allowlist of
+// host variables plus the explicitly scoped per-task overlay (req.Env).
+func filteredHostEnv(overlay map[string]string) []string {
+	env := make([]string, 0, len(hostEnvAllowList)+len(overlay))
+	for _, kv := range os.Environ() {
+		k, _, found := strings.Cut(kv, "=")
+		if found && hostEnvAllowList[k] {
+			env = append(env, kv)
+		}
+	}
+	for k, v := range overlay {
+		env = append(env, k+"="+v)
+	}
+	return env
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -80,6 +154,29 @@ func (r *CliRunner) Configure(config map[string]any) error {
 		}
 		r.mcpRunArgs = args
 	}
+	if raw, ok := config["sandbox"].(map[string]any); ok {
+		sc := &cliSandbox{}
+		if v, ok := raw["image"].(string); ok {
+			sc.image = v
+		}
+		if v, ok := raw["user"].(string); ok {
+			sc.user = v
+		}
+		if v, ok := raw["network"].(string); ok {
+			sc.network = v
+		}
+		if extras, ok := raw["extra_args"].([]any); ok {
+			for _, a := range extras {
+				if s, ok := a.(string); ok {
+					sc.extraArgs = append(sc.extraArgs, s)
+				}
+			}
+		}
+		if sc.image == "" {
+			return fmt.Errorf("cli runner: sandbox.image is required when sandbox is configured")
+		}
+		r.sandbox = sc
+	}
 	return nil
 }
 
@@ -103,11 +200,17 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		argv = append(argv, r.promptFlag, prompt)
 	}
 
-	cmd := exec.CommandContext(ctx, r.command, argv...)
-	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
-	for k, v := range req.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
+	var cmd *exec.Cmd
+	if r.sandbox != nil {
+		// Container isolation: credentials are passed via --env flags inside
+		// wrapCommand; the docker host process inherits only the safe allowlist.
+		binary, sandboxArgv := r.sandbox.wrapCommand(r.command, argv, req.WorkingDir, req.Env)
+		cmd = exec.CommandContext(ctx, binary, sandboxArgv...)
+		cmd.Env = filteredHostEnv(nil)
+	} else {
+		cmd = exec.CommandContext(ctx, r.command, argv...)
+		cmd.Dir = req.WorkingDir
+		cmd.Env = filteredHostEnv(req.Env)
 	}
 	if r.promptFlag == "" && !r.promptPositional {
 		cmd.Stdin = strings.NewReader(prompt)

--- a/src/internal/runner/execution/sandbox_test.go
+++ b/src/internal/runner/execution/sandbox_test.go
@@ -1,0 +1,168 @@
+package execution
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFilteredHostEnv_ExcludesSecrets(t *testing.T) {
+	// Simulate a daemon environment that leaks API keys.
+	t.Setenv("ANTHROPIC_API_KEY", "secret-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "aws-secret")
+	t.Setenv("GITHUB_TOKEN", "ghp_leaked")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	env := filteredHostEnv(nil)
+
+	for _, kv := range env {
+		k, _, _ := strings.Cut(kv, "=")
+		switch k {
+		case "ANTHROPIC_API_KEY", "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN":
+			t.Errorf("secret variable %q must not be inherited by agent subprocess", k)
+		}
+	}
+}
+
+func TestFilteredHostEnv_PreservesAllowList(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/home/runner")
+
+	env := filteredHostEnv(nil)
+
+	found := map[string]bool{}
+	for _, kv := range env {
+		k, _, _ := strings.Cut(kv, "=")
+		found[k] = true
+	}
+	for _, want := range []string{"PATH", "HOME"} {
+		if !found[want] {
+			t.Errorf("expected allowlisted variable %q to be present", want)
+		}
+	}
+}
+
+func TestFilteredHostEnv_OverlayTakesPrecedence(t *testing.T) {
+	t.Setenv("HOME", "/home/daemon")
+	overlay := map[string]string{
+		"GITHUB_TOKEN":    "scoped-token",
+		"ANTHROPIC_API_KEY": "task-key",
+	}
+
+	env := filteredHostEnv(overlay)
+
+	found := map[string]string{}
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		found[k] = v
+	}
+	if found["GITHUB_TOKEN"] != "scoped-token" {
+		t.Errorf("overlay GITHUB_TOKEN not present or wrong: %q", found["GITHUB_TOKEN"])
+	}
+	if found["ANTHROPIC_API_KEY"] != "task-key" {
+		t.Errorf("overlay ANTHROPIC_API_KEY not present or wrong: %q", found["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestCliSandbox_WrapCommand(t *testing.T) {
+	s := &cliSandbox{
+		image:   "ghcr.io/example/agent:latest",
+		user:    "nobody",
+		network: "none",
+	}
+	binary, argv := s.wrapCommand("opencode", []string{"run", "do-task"}, "/workspace", map[string]string{
+		"GITHUB_TOKEN": "tok",
+	})
+	if binary != "docker" {
+		t.Fatalf("expected binary=docker, got %q", binary)
+	}
+	joined := strings.Join(argv, " ")
+	for _, want := range []string{
+		"run", "--rm",
+		"--network", "none",
+		"--user", "nobody",
+		"-v", "/workspace:/workspace",
+		"-w", "/workspace",
+		"--env", "GITHUB_TOKEN=tok",
+		"ghcr.io/example/agent:latest",
+		"opencode", "run", "do-task",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("docker argv missing %q; got: %s", want, joined)
+		}
+	}
+}
+
+func TestCliSandbox_DefaultsUserAndNetwork(t *testing.T) {
+	s := &cliSandbox{image: "img:latest"}
+	binary, argv := s.wrapCommand("claude", []string{}, "", nil)
+	if binary != "docker" {
+		t.Fatalf("expected docker")
+	}
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "--user nobody") {
+		t.Errorf("expected default user=nobody; got: %s", joined)
+	}
+	if !strings.Contains(joined, "--network none") {
+		t.Errorf("expected default network=none; got: %s", joined)
+	}
+}
+
+func TestCliRunner_Configure_Sandbox(t *testing.T) {
+	r := &CliRunner{}
+	err := r.Configure(map[string]any{
+		"command": "opencode",
+		"sandbox": map[string]any{
+			"image":   "img:v1",
+			"user":    "agent",
+			"network": "egress-only",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Configure error: %v", err)
+	}
+	if r.sandbox == nil {
+		t.Fatal("expected sandbox to be set")
+	}
+	if r.sandbox.image != "img:v1" {
+		t.Errorf("image: got %q", r.sandbox.image)
+	}
+	if r.sandbox.user != "agent" {
+		t.Errorf("user: got %q", r.sandbox.user)
+	}
+	if r.sandbox.network != "egress-only" {
+		t.Errorf("network: got %q", r.sandbox.network)
+	}
+}
+
+func TestCliRunner_Configure_Sandbox_RequiresImage(t *testing.T) {
+	r := &CliRunner{}
+	err := r.Configure(map[string]any{
+		"command": "opencode",
+		"sandbox": map[string]any{
+			"user": "nobody",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when sandbox.image is missing")
+	}
+}
+
+// ensure filteredHostEnv does not panic when overlay is nil and no env set
+func TestFilteredHostEnv_NilOverlay(t *testing.T) {
+	// Save and restore the real env
+	origEnv := os.Environ()
+	os.Clearenv()
+	defer func() {
+		os.Clearenv()
+		for _, kv := range origEnv {
+			k, v, _ := strings.Cut(kv, "=")
+			os.Setenv(k, v)
+		}
+	}()
+
+	env := filteredHostEnv(nil)
+	if env == nil {
+		t.Error("expected non-nil slice even when env is empty")
+	}
+}


### PR DESCRIPTION
## Summary

- **Minimal env allowlist** (`runner/execution/cli.go`): replaces the blanket `os.Environ()` inheritance with `filteredHostEnv()`, which only passes safe host variables (PATH, HOME, TMPDIR, etc.) to agent subprocesses. API keys, AWS credentials, and other daemon secrets are no longer leaked.

- **Docker sandbox wrapper** (`runner/execution/cli.go`): new `cliSandbox` type wraps agent subprocesses in a `docker run --rm` with a restricted user (default: `nobody`), network policy (default: `none`), and a bind-mounted working directory. Per-task credentials flow via `--env` flags, not host inheritance. Enabled via `sandbox:` in runner config.

- **Least-privilege OpenCode permissions** (`daemon/dispatcher.go`): `writeOpencodeAgent` and `registerAgentInConfig` now default to `bash: deny`, `edit: deny`, `webfetch: deny`. Agents that need shell/write access opt in via `permissions: {bash: allow, edit: allow}` in their `AgentConfig`.

- **New config types** (`config/config.go`): `SandboxConfig` (runner-level) and `Permissions map[string]string` (agent-level).

## Usage example

```yaml
runners:
  - id: opencode-sandboxed
    type: cli
    provider: opencode
    sandbox:
      image: "ghcr.io/example/opencode-agent:latest"
      user: "nobody"
      network: "none"
    config:
      command: opencode

agents:
  - id: engineer
    runner: opencode-sandboxed
    # opt in to bash + edit only when truly needed:
    permissions:
      bash: allow
      edit: allow
```

## Test plan

- [x] 8 new unit tests in `sandbox_test.go` cover: secret exclusion, allowlist preservation, overlay precedence, docker arg construction, default user/network, configure parsing, missing-image error, nil-overlay safety
- [x] Full test suite passes (`go test ./...` — all 24 packages)
- [x] `go build ./...` clean

Closes #232