### PR TITLE
sec: authenticate Unix-socket control plane (SEC-11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10304 symbols, 23468 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10304 symbols, 23468 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/cli/dashboard_cmd.go
+++ b/src/internal/cli/dashboard_cmd.go
@@ -44,8 +44,9 @@ func runDashboard(ctx context.Context) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	socketPath := daemon.SocketPath(config.DataDir(configFile))
-	app := dashboard.New(dbConn, socketPath, cfg, getLogDir())
+	dataDir := config.DataDir(configFile)
+	socketPath := daemon.SocketPath(dataDir)
+	app := dashboard.New(dbConn, socketPath, dataDir, cfg, getLogDir())
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("dashboard error: %w", err)
 	}

--- a/src/internal/cli/delete.go
+++ b/src/internal/cli/delete.go
@@ -52,7 +52,8 @@ func newDeleteCmd() *cobra.Command {
 				}
 			}
 
-			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			dataDir := config.DataDir(configFile)
+			socketPath := daemon.SocketPath(dataDir)
 			transport := &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -61,7 +62,12 @@ func newDeleteCmd() *cobra.Command {
 			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 
 			url := fmt.Sprintf("http://apiary/tasks/delete/%s", taskID)
-			resp, err := client.Post(url, "application/json", nil)
+			req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, nil)
+			if err != nil {
+				return fmt.Errorf("build request: %w", err)
+			}
+			req.Header.Set("X-Apiary-Control", daemon.ReadControlToken(dataDir))
+			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("cannot reach daemon: %w", err)
 			}

--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -32,7 +32,8 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 				return fmt.Errorf("cell id is required")
 			}
 
-			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			dataDir := config.DataDir(configFile)
+			socketPath := daemon.SocketPath(dataDir)
 			transport := &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -41,7 +42,12 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 
 			url := fmt.Sprintf("http://apiary/restart/%s", cellID)
-			resp, err := client.Post(url, "application/json", nil)
+			req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, nil)
+			if err != nil {
+				return fmt.Errorf("build request: %w", err)
+			}
+			req.Header.Set("X-Apiary-Control", daemon.ReadControlToken(dataDir))
+			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("cannot reach daemon: %w", err)
 			}

--- a/src/internal/cli/resume.go
+++ b/src/internal/cli/resume.go
@@ -166,7 +166,8 @@ func confirm(prompt string) bool {
 // JSON response into out (when non-nil). It returns the HTTP status code (0 on
 // transport failure) so callers can map distinct exit codes.
 func ipcDo(method, path string, out any) (int, error) {
-	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	dataDir := config.DataDir(configFile)
+	socketPath := daemon.SocketPath(dataDir)
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -178,6 +179,7 @@ func ipcDo(method, path string, out any) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	req.Header.Set("X-Apiary-Control", daemon.ReadControlToken(dataDir))
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err

--- a/src/internal/daemon/approval_http.go
+++ b/src/internal/daemon/approval_http.go
@@ -60,6 +60,15 @@ func (d *Dispatcher) handleApprovalResponse(w http.ResponseWriter, r *http.Reque
 			http.Error(w, "invalid webhook signature", http.StatusUnauthorized)
 			return
 		}
+	} else {
+		// Dashboard (/respond) path: require the control token so that only
+		// authenticated local processes can approve or reject gates. This closes
+		// the bypass described in SEC-11 where an unauthenticated local caller
+		// could approve gates without the signature check the webhook path enforces.
+		if d.controlToken == "" || r.Header.Get("X-Apiary-Control") != d.controlToken {
+			http.Error(w, "unauthorized: control token required", http.StatusUnauthorized)
+			return
+		}
 	}
 	var response db.ApprovalResponse
 	if err := json.Unmarshal(body, &response); err != nil {

--- a/src/internal/daemon/approval_http_test.go
+++ b/src/internal/daemon/approval_http_test.go
@@ -74,6 +74,70 @@ func TestValidateApprovalResponseAuthorizationAndFields(t *testing.T) {
 	}
 }
 
+func TestDashboardApprovalRequiresControlToken(t *testing.T) {
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "approvals.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbc.Close()
+	request := &db.ApprovalRequest{ID: "inst:gate", WorkflowInstanceID: "inst", StepID: "gate", Approvers: []string{"alice"}}
+	if err := dbc.CreateApprovalRequest(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}, controlToken: "secret-token"}
+	body := []byte(`{"decision":"approve","actor":"alice","idempotency_key":"d-1"}`)
+
+	// No token → 401.
+	req := httptest.NewRequest(http.MethodPost, "/approvals/inst:gate/respond", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	d.handleApprovalResponse(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", w.Code)
+	}
+
+	// Wrong token → 401.
+	req = httptest.NewRequest(http.MethodPost, "/approvals/inst:gate/respond", bytes.NewReader(body))
+	req.Header.Set("X-Apiary-Control", "wrong-token")
+	w = httptest.NewRecorder()
+	d.handleApprovalResponse(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong token, got %d", w.Code)
+	}
+
+	// Correct token → succeeds.
+	req = httptest.NewRequest(http.MethodPost, "/approvals/inst:gate/respond", bytes.NewReader(body))
+	req.Header.Set("X-Apiary-Control", "secret-token")
+	w = httptest.NewRecorder()
+	d.handleApprovalResponse(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 with correct token, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireControlTokenMiddleware(t *testing.T) {
+	d := &Dispatcher{controlToken: "tok"}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := d.requireControlToken(inner)
+
+	// Missing header.
+	req := httptest.NewRequest(http.MethodPost, "/restart/x", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+
+	// Correct header.
+	req = httptest.NewRequest(http.MethodPost, "/restart/x", nil)
+	req.Header.Set("X-Apiary-Control", "tok")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
 func TestValidateApprovalResponseDelegationUsesApproverSlot(t *testing.T) {
 	req := &db.ApprovalRequest{Approvers: []string{"alice"}, Delegates: map[string][]string{"alice": {"bob"}}}
 	response := db.ApprovalResponse{Decision: "approve", Actor: "bob"}

--- a/src/internal/daemon/control_token.go
+++ b/src/internal/daemon/control_token.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const controlTokenFile = "control.token"
+
+// ControlTokenPath returns the path to the per-project control token file.
+func ControlTokenPath(dataDir string) string {
+	if dataDir == "" {
+		return filepath.Join(os.TempDir(), "apiary-"+controlTokenFile)
+	}
+	return filepath.Join(dataDir, controlTokenFile)
+}
+
+// GenerateControlToken creates a fresh 32-byte random token, writes it to
+// ControlTokenPath(dataDir) with mode 0600, and returns it. Replaces any
+// existing token so stale copies from a previous run are invalidated.
+func GenerateControlToken(dataDir string) (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate control token: %w", err)
+	}
+	token := hex.EncodeToString(raw)
+
+	path := ControlTokenPath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", fmt.Errorf("control token dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(token+"\n"), 0600); err != nil {
+		return "", fmt.Errorf("write control token: %w", err)
+	}
+	return token, nil
+}
+
+// ReadControlToken reads the token written by GenerateControlToken. Returns an
+// empty string (and no error) when the file does not exist so that read-only
+// CLI commands still work against a daemon that has not yet written a token.
+func ReadControlToken(dataDir string) string {
+	data, err := os.ReadFile(ControlTokenPath(dataDir))
+	if err != nil {
+		return ""
+	}
+	// Trim any trailing newline written by GenerateControlToken.
+	raw := string(data)
+	for len(raw) > 0 && (raw[len(raw)-1] == '\n' || raw[len(raw)-1] == '\r') {
+		raw = raw[:len(raw)-1]
+	}
+	return raw
+}

--- a/src/internal/daemon/control_token_test.go
+++ b/src/internal/daemon/control_token_test.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateAndReadControlToken(t *testing.T) {
+	dir := t.TempDir()
+
+	token, err := GenerateControlToken(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(token) != 64 { // 32 bytes hex-encoded
+		t.Fatalf("expected 64-char token, got %d chars", len(token))
+	}
+
+	// File must exist with mode 0600.
+	path := ControlTokenPath(dir)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected mode 0600, got %o", got)
+	}
+
+	// ReadControlToken must return the same value.
+	if got := ReadControlToken(dir); got != token {
+		t.Fatalf("read %q, want %q", got, token)
+	}
+
+	// Re-generating must invalidate the old token.
+	token2, _ := GenerateControlToken(dir)
+	if token2 == token {
+		t.Fatal("second generate returned same token")
+	}
+	if got := ReadControlToken(dir); got != token2 {
+		t.Fatalf("after regen read %q, want %q", got, token2)
+	}
+}
+
+func TestReadControlTokenMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	// File doesn't exist — ReadControlToken should return "".
+	if got := ReadControlToken(dir); got != "" {
+		t.Fatalf("expected empty string for missing token, got %q", got)
+	}
+}
+
+func TestControlTokenPath(t *testing.T) {
+	got := ControlTokenPath("/some/dir")
+	want := filepath.Join("/some/dir", "control.token")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -112,6 +112,10 @@ type Dispatcher struct {
 	localWorker    *workerpkg.Runtime
 	queueProjectID string
 	queueWorkerID  string
+
+	// controlToken is the per-run secret required on every mutating IPC endpoint.
+	// Generated once in StartServer and written to ControlTokenPath(dataDir).
+	controlToken string
 }
 
 // runnerCandidate is one rung in an agent's rate-limit failover chain: a
@@ -995,15 +999,35 @@ func (d *Dispatcher) controlLabels(cell model.SourceItem) []string {
 	return out
 }
 
+// requireControlToken returns middleware that rejects requests without a valid
+// X-Apiary-Control header. Handlers that need auth are wrapped with this so
+// read-only endpoints (status, health, events, etc.) remain freely accessible.
+func (d *Dispatcher) requireControlToken(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.controlToken == "" || r.Header.Get("X-Apiary-Control") != d.controlToken {
+			http.Error(w, "unauthorized: control token required", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
 // StartServer starts an HTTP server on the Unix socket for IPC.
 // It removes any stale socket file before binding.
 func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error {
-	path := SocketPath(config.DataDir(d.configFile))
+	dataDir := config.DataDir(d.configFile)
+	path := SocketPath(dataDir)
 	if err := ensureSocketDir(path); err != nil {
 		return fmt.Errorf("socket dir: %w", err)
 	}
 	// remove stale socket
 	_ = os.Remove(path)
+
+	token, err := GenerateControlToken(dataDir)
+	if err != nil {
+		return fmt.Errorf("control token: %w", err)
+	}
+	d.controlToken = token
 
 	ln, err := net.Listen("unix", path)
 	if err != nil {
@@ -1021,8 +1045,10 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	mux.HandleFunc("/events", d.handleExecutionEvents)
 	mux.HandleFunc("/events/stream", d.handleExecutionEventStream)
 	mux.HandleFunc("/approvals", d.handleApprovals)
+	// /approvals/<id>/respond requires control-token auth (see handleApprovalResponse).
+	// /approvals/<id>/webhook uses HMAC signature auth instead.
 	mux.HandleFunc("/approvals/", d.handleApprovalResponse)
-	mux.HandleFunc("/restart/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/restart/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/restart/")
 		if cellID == "" {
 			http.Error(w, "missing cell id", http.StatusBadRequest)
@@ -1033,8 +1059,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/api/config/agent/", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/api/config/agent/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -1061,7 +1087,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"updated": agentID, "model": req.Model, "max_workers": req.MaxWorkers})
-	})
+	}))
 	mux.HandleFunc("/instances", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		limit := 20
@@ -1159,7 +1185,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(hist)
 	})
-	mux.HandleFunc("/tasks/pulls/refresh/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/tasks/pulls/refresh/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -1180,8 +1206,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/resume/", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/resume/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		id := strings.TrimPrefix(r.URL.Path, "/resume/")
 		opts := ResumeOptions{FromStep: r.URL.Query().Get("from"), ConfigMode: r.URL.Query().Get("config")}
 		if id == "" {
@@ -1222,7 +1248,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
-	})
+	}))
 	mux.HandleFunc("/workflows", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1231,7 +1257,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(d.WorkflowList())
 	})
-	mux.HandleFunc("/instances/stop/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/instances/stop/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -1247,8 +1273,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"stopped": instanceID})
-	})
-	mux.HandleFunc("/clearlogs/", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/clearlogs/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		cellID := strings.TrimPrefix(r.URL.Path, "/clearlogs/")
 		if cellID == "" {
 			http.Error(w, "missing cell id", http.StatusBadRequest)
@@ -1261,8 +1287,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			}
 		}
 		w.WriteHeader(http.StatusOK)
-	})
-	mux.HandleFunc("/tasks/delete/", func(w http.ResponseWriter, r *http.Request) {
+	}))
+	mux.HandleFunc("/tasks/delete/", d.requireControlToken(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -1282,7 +1308,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"deleted": taskRef})
-	})
+	}))
 
 	srv := &http.Server{Handler: mux}
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 )
@@ -56,6 +57,7 @@ type App struct {
 	model      *Model
 	dbConn     *db.Client
 	socketPath string
+	dataDir    string
 	cfg        *config.Config
 	// logDir is the daemon's log directory, used to locate per-task markdown
 	// transcripts (logDir/transcripts/<task>/...).
@@ -74,11 +76,12 @@ type App struct {
 	logMDWidth   int
 }
 
-func New(dbConn *db.Client, socketPath string, cfg *config.Config, logDir string) *App {
+func New(dbConn *db.Client, socketPath, dataDir string, cfg *config.Config, logDir string) *App {
 	return &App{
 		model:      NewModel(),
 		dbConn:     dbConn,
 		socketPath: socketPath,
+		dataDir:    dataDir,
 		cfg:        cfg,
 		logDir:     logDir,
 	}
@@ -1560,18 +1563,48 @@ func (a *App) focusedTaskID() (string, bool) {
 	return "", false
 }
 
-// restartTaskCmd sends a force-restart request to the daemon via the IPC socket.
-func (a *App) restartTaskCmd(taskID string) tea.Cmd {
-	return func() tea.Msg {
-		socketPath := a.socketPath
-		transport := &http.Transport{
+// ipcClient returns an HTTP client that dials a.socketPath over Unix.
+func (a *App) ipcClient(timeout time.Duration) *http.Client {
+	socketPath := a.socketPath
+	return &http.Client{
+		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 			},
+		},
+		Timeout: timeout,
+	}
+}
+
+// ipcPost builds an authenticated POST request for a mutating IPC endpoint.
+func (a *App) ipcPost(ctx context.Context, url string, body []byte) (*http.Request, error) {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Apiary-Control", daemon.ReadControlToken(a.dataDir))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}
+
+// restartTaskCmd sends a force-restart request to the daemon via the IPC socket.
+func (a *App) restartTaskCmd(taskID string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := a.ipcPost(ctx, fmt.Sprintf("http://apiary/restart/%s", taskID), nil)
+		if err != nil {
+			return nil
 		}
-		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/restart/%s", taskID)
-		resp, err := client.Post(url, "application/json", nil)
+		resp, err := a.ipcClient(5 * time.Second).Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1589,16 +1622,14 @@ func (a *App) refreshTaskPullsCmd(internalTaskID string) tea.Cmd {
 	if internalTaskID == "" {
 		return nil
 	}
-	socketPath := a.socketPath
 	return func() tea.Msg {
-		transport := &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
-			},
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		req, err := a.ipcPost(ctx, fmt.Sprintf("http://apiary/tasks/pulls/refresh/%s", internalTaskID), nil)
+		if err != nil {
+			return nil
 		}
-		client := &http.Client{Transport: transport, Timeout: 8 * time.Second}
-		url := fmt.Sprintf("http://apiary/tasks/pulls/refresh/%s", internalTaskID)
-		resp, err := client.Post(url, "application/json", nil)
+		resp, err := a.ipcClient(8 * time.Second).Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1612,15 +1643,13 @@ func (a *App) refreshTaskPullsCmd(internalTaskID string) tea.Cmd {
 
 func (a *App) clearLogsCmd(taskID string) tea.Cmd {
 	return func() tea.Msg {
-		socketPath := a.socketPath
-		transport := &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
-			},
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := a.ipcPost(ctx, fmt.Sprintf("http://apiary/clearlogs/%s", taskID), nil)
+		if err != nil {
+			return nil
 		}
-		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/clearlogs/%s", taskID)
-		resp, err := client.Post(url, "application/json", nil)
+		resp, err := a.ipcClient(5 * time.Second).Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1633,14 +1662,13 @@ func (a *App) clearLogsCmd(taskID string) tea.Cmd {
 // instance without re-dispatching it.
 func (a *App) stopInstanceCmd(instanceID string) tea.Cmd {
 	return func() tea.Msg {
-		transport := &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, "unix", a.socketPath)
-			},
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := a.ipcPost(ctx, fmt.Sprintf("http://apiary/instances/stop/%s", instanceID), nil)
+		if err != nil {
+			return nil
 		}
-		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/instances/stop/%s", instanceID)
-		resp, err := client.Post(url, "application/json", nil)
+		resp, err := a.ipcClient(5 * time.Second).Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1656,13 +1684,13 @@ func (a *App) approvalResponseCmd(requestID, decision string) tea.Cmd {
 			actor = "dashboard-user"
 		}
 		body, _ := json.Marshal(map[string]any{"decision": decision, "actor": actor, "idempotency_key": fmt.Sprintf("dashboard:%s:%s:%s", requestID, actor, decision)})
-		transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", a.socketPath)
-		}}
-		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		req, _ := http.NewRequest(http.MethodPost, "http://apiary/approvals/"+requestID+"/respond", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := client.Do(req)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req, err := a.ipcPost(ctx, "http://apiary/approvals/"+requestID+"/respond", body)
+		if err != nil {
+			return nil
+		}
+		resp, err := a.ipcClient(5 * time.Second).Do(req)
 		if err == nil {
 			resp.Body.Close()
 		}
@@ -1921,13 +1949,6 @@ func (a *App) updateAgentConfigCmd(agentID, model, runner string, maxWorkers int
 }
 
 func (a *App) patchAgentViaSocket(agentID, model, runner string, maxWorkers int) error {
-	transport := &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", a.socketPath)
-		},
-	}
-	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-
 	body := map[string]any{}
 	if model != "" {
 		body["model"] = model
@@ -1941,12 +1962,15 @@ func (a *App) patchAgentViaSocket(agentID, model, runner string, maxWorkers int)
 	payload, _ := json.Marshal(body)
 	url := fmt.Sprintf("http://apiary/api/config/agent/%s", agentID)
 
-	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(payload))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
+	req.Header.Set("X-Apiary-Control", daemon.ReadControlToken(a.dataDir))
+	resp, err := a.ipcClient(5 * time.Second).Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Generate a per-run 256-bit random token at daemon startup; write it to `<dataDir>/control.token` (mode 0600) so only the daemon owner can read it.
- Add `requireControlToken` middleware that checks the `X-Apiary-Control` header on every mutating IPC endpoint (`/restart/`, `/api/config/agent/`, `/resume/`, `/tasks/pulls/refresh/`, `/instances/stop/`, `/clearlogs/`, `/tasks/delete/`).
- Fix the SEC-11 approval-gate bypass: the dashboard `/approvals/<id>/respond` path was unauthenticated, letting any local process approve or reject gates without the HMAC check the `/webhook` path enforces. It now requires the control token.
- Update all callers (CLI commands `restart`, `delete`, `resume`; dashboard `restartTaskCmd`, `stopInstanceCmd`, `clearLogsCmd`, `refreshTaskPullsCmd`, `patchAgentViaSocket`, `approvalResponseCmd`) to read the token from the data directory and attach it as `X-Apiary-Control`.
- Read-only endpoints (`/status`, `/health`, `/events`, `/instances`, `/workflows`, etc.) are not gated.

## Test plan

- [x] `TestGenerateAndReadControlToken` — token is 64-char hex, file mode 0600, re-generate invalidates old token
- [x] `TestReadControlTokenMissingFile` — returns empty string when file absent (backward compat)
- [x] `TestControlTokenPath` — correct path construction
- [x] `TestDashboardApprovalRequiresControlToken` — `/respond` returns 401 without token, 401 with wrong token, 202 with correct token
- [x] `TestRequireControlTokenMiddleware` — middleware returns 401 without header, 200 with correct header
- [x] Existing `TestApprovalWebhookPersistsAuthorizedResponse` and `TestApprovalWebhookSignature` still pass (webhook HMAC path unchanged)
- [x] Full test suite: `go test ./...` passes

Closes #234