### PR TITLE
feat(queue): native TLS for the worker protocol listener (SEC-13)

### DIFF
--- a/docs/distributed-workers.md
+++ b/docs/distributed-workers.md
@@ -55,7 +55,7 @@ traffic must be encrypted; use one of the two options below.
 
 ### Option A — Native TLS
 
-Provide a PEM certificate and key (absolute paths or relative to `apiary.yaml`):
+Provide a PEM certificate and key (absolute paths recommended; relative paths resolve from the daemon's working directory):
 
 ```yaml
 settings:

--- a/docs/distributed-workers.md
+++ b/docs/distributed-workers.md
@@ -50,11 +50,50 @@ settings:
     worker_timeout: 30s
 ```
 
-`worker_token` is mandatory whenever `listen` is configured. Put the listener
-behind TLS (a reverse proxy or private service mesh) when it crosses a trusted
-network boundary; the protocol itself is HTTP with Bearer authentication.
+`worker_token` is mandatory whenever `listen` is configured. Remote worker
+traffic must be encrypted; use one of the two options below.
 
-Start a worker with the same `apiary.yaml` and runner credentials:
+### Option A — Native TLS
+
+Provide a PEM certificate and key (absolute paths or relative to `apiary.yaml`):
+
+```yaml
+settings:
+  queue:
+    listen: 0.0.0.0:8443
+    worker_token: ${APIARY_WORKER_TOKEN}
+    tls_cert_file: /etc/apiary/tls.crt
+    tls_key_file:  /etc/apiary/tls.key
+    embedded_worker: false
+```
+
+When both fields are present the listener starts with TLS (minimum TLS 1.2).
+`apiary worker` auto-derives `https://` from `settings.queue.listen` when TLS is
+configured, so `--control-plane` is optional for co-located workers.
+
+### Option B — TLS-terminating reverse proxy
+
+Run the listener on a loopback address and terminate TLS externally (nginx,
+Caddy, a private service mesh):
+
+```yaml
+settings:
+  queue:
+    listen: 127.0.0.1:8080
+    worker_token: ${APIARY_WORKER_TOKEN}
+    embedded_worker: false
+```
+
+Workers point at the proxy's HTTPS address:
+
+```sh
+apiary worker --control-plane https://apiary.example \
+  --token "$APIARY_WORKER_TOKEN"
+```
+
+Start a worker with the same `apiary.yaml` and runner credentials (choose either
+option above for encryption; `--control-plane` accepts both `http://` and
+`https://` URLs):
 
 ```sh
 apiary worker --control-plane https://apiary.example \

--- a/src/internal/cli/worker.go
+++ b/src/internal/cli/worker.go
@@ -38,7 +38,7 @@ func newWorkerCmd() *cobra.Command {
 				return fmt.Errorf("config validation failed: %v", errs)
 			}
 			if controlPlane == "" {
-				controlPlane = queueControlPlaneURL(cfg.Settings.Queue.Listen)
+				controlPlane = queueControlPlaneURL(cfg.Settings.Queue.Listen, cfg.Settings.Queue.TLSEnabled())
 			}
 			if controlPlane == "" {
 				return fmt.Errorf("--control-plane is required (for example http://apiary-control:8080)")
@@ -121,7 +121,7 @@ func newWorkerCmd() *cobra.Command {
 	return cmd
 }
 
-func queueControlPlaneURL(listen string) string {
+func queueControlPlaneURL(listen string, tlsEnabled bool) string {
 	listen = strings.TrimSpace(listen)
 	if listen == "" {
 		return ""
@@ -129,14 +129,18 @@ func queueControlPlaneURL(listen string) string {
 	if strings.HasPrefix(listen, "http://") || strings.HasPrefix(listen, "https://") {
 		return listen
 	}
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
 	if strings.HasPrefix(listen, ":") {
-		return "http://127.0.0.1" + listen
+		return scheme + "://127.0.0.1" + listen
 	}
 	if strings.HasPrefix(listen, "0.0.0.0:") {
-		return "http://127.0.0.1:" + strings.TrimPrefix(listen, "0.0.0.0:")
+		return scheme + "://127.0.0.1:" + strings.TrimPrefix(listen, "0.0.0.0:")
 	}
 	if strings.HasPrefix(listen, "[") || strings.Count(listen, ":") == 1 {
-		return "http://" + listen
+		return scheme + "://" + listen
 	}
 	return listen
 }

--- a/src/internal/cli/worker_test.go
+++ b/src/internal/cli/worker_test.go
@@ -3,14 +3,28 @@ package cli
 import "testing"
 
 func TestQueueControlPlaneURL(t *testing.T) {
+	// Plain HTTP (tlsEnabled=false)
 	for input, want := range map[string]string{
 		":8080":                  "http://127.0.0.1:8080",
-		"0.0.0.0:8080":           "http://127.0.0.1:8080",
-		"apiary.local:8080":      "http://apiary.local:8080",
+		"0.0.0.0:8080":          "http://127.0.0.1:8080",
+		"apiary.local:8080":     "http://apiary.local:8080",
 		"https://apiary.example": "https://apiary.example",
 	} {
-		if got := queueControlPlaneURL(input); got != want {
-			t.Errorf("queueControlPlaneURL(%q)=%q, want %q", input, got, want)
+		if got := queueControlPlaneURL(input, false); got != want {
+			t.Errorf("queueControlPlaneURL(%q, false)=%q, want %q", input, got, want)
+		}
+	}
+	// TLS (tlsEnabled=true) — plain addresses get https:// prefix
+	for input, want := range map[string]string{
+		":8443":                  "https://127.0.0.1:8443",
+		"0.0.0.0:8443":          "https://127.0.0.1:8443",
+		"apiary.local:8443":     "https://apiary.local:8443",
+		// Explicit scheme always wins.
+		"https://apiary.example": "https://apiary.example",
+		"http://apiary.example":  "http://apiary.example",
+	} {
+		if got := queueControlPlaneURL(input, true); got != want {
+			t.Errorf("queueControlPlaneURL(%q, true)=%q, want %q", input, got, want)
 		}
 	}
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -304,9 +304,20 @@ type QueueSettings struct {
 	HeartbeatInterval  string                   `yaml:"heartbeat_interval,omitempty"`
 	WorkerTimeout      string                   `yaml:"worker_timeout,omitempty"`
 	PollInterval       string                   `yaml:"poll_interval,omitempty"`
-	Listen             string                   `yaml:"listen,omitempty"`
-	WorkerToken        string                   `yaml:"worker_token,omitempty"`
-	Concurrency        QueueConcurrencySettings `yaml:"concurrency,omitempty"`
+	Listen      string `yaml:"listen,omitempty"`
+	WorkerToken string `yaml:"worker_token,omitempty"`
+	// TLSCertFile and TLSKeyFile enable native TLS on the queue protocol listener.
+	// Both must be set together; omitting both keeps plain HTTP (use a TLS-
+	// terminating reverse proxy in that case). Paths may be absolute or relative
+	// to the directory that contains apiary.yaml.
+	TLSCertFile string                   `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile  string                   `yaml:"tls_key_file,omitempty"`
+	Concurrency QueueConcurrencySettings `yaml:"concurrency,omitempty"`
+}
+
+// TLSEnabled reports whether both cert and key are configured.
+func (q QueueSettings) TLSEnabled() bool {
+	return q.TLSCertFile != "" && q.TLSKeyFile != ""
 }
 
 type QueueConcurrencySettings struct {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -308,8 +308,8 @@ type QueueSettings struct {
 	WorkerToken string `yaml:"worker_token,omitempty"`
 	// TLSCertFile and TLSKeyFile enable native TLS on the queue protocol listener.
 	// Both must be set together; omitting both keeps plain HTTP (use a TLS-
-	// terminating reverse proxy in that case). Paths may be absolute or relative
-	// to the directory that contains apiary.yaml.
+	// terminating reverse proxy in that case). Use absolute paths; relative paths
+	// are resolved from the daemon's working directory, not the config file location.
 	TLSCertFile string                   `yaml:"tls_cert_file,omitempty"`
 	TLSKeyFile  string                   `yaml:"tls_key_file,omitempty"`
 	Concurrency QueueConcurrencySettings `yaml:"concurrency,omitempty"`

--- a/src/internal/config/queue_test.go
+++ b/src/internal/config/queue_test.go
@@ -14,6 +14,8 @@ func TestValidateQueueSettings(t *testing.T) {
 		{"listener requires token", QueueSettings{Listen: ":8080"}, "worker_token is required"},
 		{"heartbeat before lease", QueueSettings{LeaseDuration: "5s", HeartbeatInterval: "5s"}, "must be shorter"},
 		{"positive scoped limit", QueueSettings{Concurrency: QueueConcurrencySettings{Pools: map[string]int{"build": 0}}}, "positive limit"},
+		{"tls cert without key", QueueSettings{TLSCertFile: "/etc/tls.crt"}, "tls_cert_file and tls_key_file must both be set"},
+		{"tls key without cert", QueueSettings{TLSKeyFile: "/etc/tls.key"}, "tls_cert_file and tls_key_file must both be set"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -283,6 +283,11 @@ func validateQueueSettings(settings QueueSettings) []error {
 	if strings.TrimSpace(settings.Listen) != "" && strings.TrimSpace(settings.WorkerToken) == "" {
 		errs = append(errs, fmt.Errorf("settings.queue.worker_token is required when settings.queue.listen is configured"))
 	}
+	certSet := strings.TrimSpace(settings.TLSCertFile) != ""
+	keySet := strings.TrimSpace(settings.TLSKeyFile) != ""
+	if certSet != keySet {
+		errs = append(errs, fmt.Errorf("settings.queue.tls_cert_file and tls_key_file must both be set or both be empty"))
+	}
 	durations := []struct {
 		name, value string
 		fallback    time.Duration

--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,14 +22,37 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 	if d.dispatchQueue == nil {
 		return fmt.Errorf("queue protocol listener requires the durable queue")
 	}
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		return fmt.Errorf("listen for queue workers on %s: %w", address, err)
+
+	qs := d.cfg.Settings.Queue
+	var listener net.Listener
+	var proto string
+	if qs.TLSEnabled() {
+		cert, err := tls.LoadX509KeyPair(qs.TLSCertFile, qs.TLSKeyFile)
+		if err != nil {
+			return fmt.Errorf("load TLS certificate for queue listener: %w", err)
+		}
+		tlsCfg := &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		}
+		listener, err = tls.Listen("tcp", address, tlsCfg)
+		if err != nil {
+			return fmt.Errorf("listen (TLS) for queue workers on %s: %w", address, err)
+		}
+		proto = "https"
+	} else {
+		var err error
+		listener, err = net.Listen("tcp", address)
+		if err != nil {
+			return fmt.Errorf("listen for queue workers on %s: %w", address, err)
+		}
+		proto = "http"
 	}
+
 	handler := queuehttp.Server{
-		Store: d.dispatchQueue, Token: d.cfg.Settings.Queue.WorkerToken,
-		LeaseDuration: d.cfg.Settings.Queue.LeaseDurationValue(),
-		WorkerTimeout: d.cfg.Settings.Queue.WorkerTimeoutValue(), Policy: d.queuePolicy(),
+		Store: d.dispatchQueue, Token: qs.WorkerToken,
+		LeaseDuration: qs.LeaseDurationValue(),
+		WorkerTimeout: qs.WorkerTimeoutValue(), Policy: d.queuePolicy(),
 		OnTerminal: d.settleRemoteQueueJob,
 	}.Handler()
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
@@ -47,6 +71,6 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()
-	aplog.Info("queue worker protocol listening on %s", listener.Addr())
+	aplog.Info("queue worker protocol listening on %s://%s", proto, listener.Addr())
 	return nil
 }

--- a/src/internal/queuehttp/protocol_test.go
+++ b/src/internal/queuehttp/protocol_test.go
@@ -71,6 +71,40 @@ func TestAuthenticatedWorkerLifecycle(t *testing.T) {
 	}
 }
 
+// TestWorkerLifecycleOverTLS verifies the client/server protocol over a TLS
+// connection. httptest.NewTLSServer wraps the same handler in a real TLS
+// listener so this exercises the full round-trip without modifying the handler.
+func TestWorkerLifecycleOverTLS(t *testing.T) {
+	ctx := context.Background()
+	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clientDB.Close() })
+	store := clientDB.Queue()
+
+	server := httptest.NewTLSServer(queuehttp.Server{Store: store, Token: "tls-secret", LeaseDuration: time.Minute, WorkerTimeout: time.Minute}.Handler())
+	t.Cleanup(server.Close)
+	// server.Client() trusts the test server's self-signed certificate.
+	remote := &queuehttp.Client{BaseURL: server.URL, Token: "tls-secret", HTTPClient: server.Client()}
+
+	w := &queue.Worker{ID: "tls-worker", ProtocolVersion: queue.WorkerProtocolVersion, Pool: "default", Capacity: 1, Ready: true}
+	if err := remote.RegisterWorker(ctx, w); err != nil {
+		t.Fatalf("RegisterWorker over TLS: %v", err)
+	}
+	job := &queue.Job{IdempotencyKey: "tls:1", Pool: "default", PayloadVersion: 1, Payload: []byte(`{}`), MaxAttempts: 1}
+	if created, err := store.Enqueue(ctx, job); err != nil || !created {
+		t.Fatalf("enqueue created=%v err=%v", created, err)
+	}
+	claim, err := remote.Claim(ctx, queue.ClaimRequest{WorkerID: w.ID})
+	if err != nil {
+		t.Fatalf("Claim over TLS: %v", err)
+	}
+	if err := remote.Finish(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatalf("Finish over TLS: %v", err)
+	}
+}
+
 func TestProtocolRejectsInvalidAuthenticationAndVersion(t *testing.T) {
 	ctx := context.Background()
 	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))


### PR DESCRIPTION
## Summary

- Adds `tls_cert_file` and `tls_key_file` fields to `settings.queue` so the control-plane listener can terminate TLS natively without a reverse proxy.
- When both fields are set the listener is started with `crypto/tls` (minimum TLS 1.2); omitting both keeps the existing plain-HTTP behaviour.
- `queueControlPlaneURL` now accepts a `tlsEnabled` flag and auto-derives `https://` for workers reading their control-plane URL from config.
- Docs updated to document native TLS (Option A) alongside the existing proxy approach (Option B).

## Changes

| File | Change |
|---|---|
| `src/internal/config/config.go` | `TLSCertFile`, `TLSKeyFile` fields + `TLSEnabled()` on `QueueSettings` |
| `src/internal/daemon/queue_server.go` | Load X.509 key pair; use `tls.Listen` when TLS is configured |
| `src/internal/cli/worker.go` | `queueControlPlaneURL(listen, tlsEnabled)` — emit `https://` when TLS on |
| `src/internal/cli/worker_test.go` | Updated `TestQueueControlPlaneURL` to cover TLS case |
| `src/internal/queuehttp/protocol_test.go` | New `TestWorkerLifecycleOverTLS` using `httptest.NewTLSServer` |
| `docs/distributed-workers.md` | Document Option A (native TLS) and Option B (reverse proxy) |

## Test plan

- [ ] `go test ./internal/cli/... ./internal/queuehttp/...` — all pass including new `TestWorkerLifecycleOverTLS` and updated `TestQueueControlPlaneURL`
- [ ] `go build ./...` — clean build
- [ ] Plain-HTTP path: omitting `tls_cert_file`/`tls_key_file` keeps existing behaviour
- [ ] `--control-plane https://...` continues to work (explicit scheme wins over auto-derive)

Closes #236