### PR TITLE
sec: add persist_prompts=false option and scrub existing prompt data (SEC-15)

### DIFF
--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -85,6 +85,13 @@ func newRunCmd() *cobra.Command {
 			}
 			defer logger.Close()
 
+			logger.SetPersistPrompts(cfg.Settings.ShouldPersistPrompts())
+			if !cfg.Settings.ShouldPersistPrompts() {
+				if err := dbClient.ScrubPrompts(ctx); err != nil {
+					aplog.Warn("scrub prompts: %v", err)
+				}
+			}
+
 			// Persist operational (aplog) messages as service logs so they show
 			// up in the dashboard's Logs tab — not just on the run terminal.
 			aplog.SetSink(func(level, msg string) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -287,6 +287,16 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+	// PersistPrompts controls whether full agent prompts are written to the
+	// database (task_logs "prompt sent to agent:" entries and the input_prompt
+	// columns on task_executions / step_runs). Defaults to true when omitted.
+	// Set to false to stop recording prompts and to scrub any already on disk.
+	PersistPrompts *bool `yaml:"persist_prompts,omitempty"`
+}
+
+// ShouldPersistPrompts returns true unless PersistPrompts is explicitly false.
+func (s Settings) ShouldPersistPrompts() bool {
+	return s.PersistPrompts == nil || *s.PersistPrompts
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -644,7 +644,9 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 		exec.NumToolCalls = res.Usage.NumToolCalls
 		exec.CostUSD = res.Usage.CostUSD
 	}
-	exec.InputPrompt = res.InputPrompt
+	if x.d.cfg.Settings.ShouldPersistPrompts() {
+		exec.InputPrompt = res.InputPrompt
+	}
 	exec.OutputText = res.Output
 	exec.CreditExhausted = res.CreditExhausted
 	if !res.CreditExhausted && res.RateLimited {

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -404,6 +404,27 @@ func (c *Client) ClearTaskLogs(ctx context.Context, taskID string) error {
 	return err
 }
 
+// ScrubPrompts removes full-prompt data already persisted on disk:
+//   - Deletes task_logs rows whose message begins with "prompt sent to agent:".
+//   - Clears input_prompt on task_executions and step_runs.
+//
+// Call once at startup when settings.persist_prompts is false to retroactively
+// apply the opt-out to historical rows. The operation is idempotent and
+// best-effort: errors are returned but partial progress is not rolled back.
+func (c *Client) ScrubPrompts(ctx context.Context) error {
+	stmts := []string{
+		`DELETE FROM task_logs WHERE message LIKE 'prompt sent to agent:%'`,
+		`UPDATE task_executions SET input_prompt = NULL WHERE input_prompt IS NOT NULL`,
+		`UPDATE step_runs SET input_prompt = NULL WHERE input_prompt IS NOT NULL`,
+	}
+	for _, s := range stmts {
+		if _, err := c.db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("scrub prompts: %w", err)
+		}
+	}
+	return nil
+}
+
 // Logging
 
 func (c *Client) WriteTaskLog(ctx context.Context, taskID, level, message string) error {

--- a/src/internal/db/scrub_prompts_test.go
+++ b/src/internal/db/scrub_prompts_test.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// ScrubPrompts must delete task_logs rows whose message starts with
+// "prompt sent to agent:", clear input_prompt on task_executions and
+// step_runs, and leave unrelated rows untouched.
+func TestScrubPrompts(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	insert := func(stmt string, args ...any) {
+		t.Helper()
+		if _, err := c.db.ExecContext(ctx, stmt, args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// Seed task_logs: two prompt rows and one unrelated row.
+	insert(`INSERT INTO task_logs (task_id, level, message) VALUES ('t1', 'DEBUG', 'prompt sent to agent: full ticket text')`)
+	insert(`INSERT INTO task_logs (task_id, level, message) VALUES ('t1', 'DEBUG', 'prompt sent to agent: another prompt')`)
+	insert(`INSERT INTO task_logs (task_id, level, message) VALUES ('t1', 'INFO',  'task started')`)
+
+	// Seed task_executions: two rows with input_prompt set, one without.
+	insert(`INSERT INTO task_executions (task_id, agent_id, status, input_prompt) VALUES ('t1', 'eng', 'success', 'full prompt')`)
+	insert(`INSERT INTO task_executions (task_id, agent_id, status, input_prompt) VALUES ('t1', 'eng', 'success', 'another full prompt')`)
+	insert(`INSERT INTO task_executions (task_id, agent_id, status) VALUES ('t1', 'eng', 'success')`)
+
+	// Seed step_runs with a workflow_instance_id to satisfy the NOT NULL constraint.
+	insert(`INSERT INTO workflow_instances (id, cell_id, workflow_id, state) VALUES ('inst1', 't1', 'wf1', 'passed')`)
+	insert(`INSERT INTO step_runs (id, workflow_instance_id, step_id, state, input_prompt) VALUES ('sr1', 'inst1', 'plan', 'passed', 'prompt text')`)
+	insert(`INSERT INTO step_runs (id, workflow_instance_id, step_id, state) VALUES ('sr2', 'inst1', 'impl', 'passed')`)
+
+	if err := c.ScrubPrompts(ctx); err != nil {
+		t.Fatalf("ScrubPrompts: %v", err)
+	}
+
+	count := func(query string, args ...any) int {
+		t.Helper()
+		var n int
+		if err := c.db.QueryRowContext(ctx, query, args...).Scan(&n); err != nil {
+			t.Fatalf("count query %q: %v", query, err)
+		}
+		return n
+	}
+
+	// Only the non-prompt task_log row should remain.
+	if n := count(`SELECT COUNT(*) FROM task_logs`); n != 1 {
+		t.Errorf("task_logs rows = %d, want 1", n)
+	}
+	if n := count(`SELECT COUNT(*) FROM task_logs WHERE message LIKE 'prompt sent to agent:%'`); n != 0 {
+		t.Errorf("prompt task_logs rows = %d, want 0", n)
+	}
+
+	// All task_executions.input_prompt must be NULL now.
+	if n := count(`SELECT COUNT(*) FROM task_executions WHERE input_prompt IS NOT NULL`); n != 0 {
+		t.Errorf("task_executions with input_prompt = %d, want 0", n)
+	}
+
+	// All step_runs.input_prompt must be NULL now.
+	if n := count(`SELECT COUNT(*) FROM step_runs WHERE input_prompt IS NOT NULL`); n != 0 {
+		t.Errorf("step_runs with input_prompt = %d, want 0", n)
+	}
+
+	// Calling again is idempotent.
+	if err := c.ScrubPrompts(ctx); err != nil {
+		t.Fatalf("ScrubPrompts (2nd): %v", err)
+	}
+}

--- a/src/internal/logging/logger.go
+++ b/src/internal/logging/logger.go
@@ -63,13 +63,24 @@ func DefaultRotation() Rotation {
 
 // Logger writes to file and optional SQLite.
 type Logger struct {
-	file   *os.File
-	size   int64
-	db     *db.Client
-	mu     sync.Mutex
-	level  Level
-	logDir string
-	rot    Rotation
+	file           *os.File
+	size           int64
+	db             *db.Client
+	mu             sync.Mutex
+	level          Level
+	logDir         string
+	rot            Rotation
+	persistPrompts bool
+}
+
+// SetPersistPrompts controls whether task-log entries whose message begins with
+// "prompt sent to agent:" are written to the database. The default (true)
+// preserves the historical behaviour; false suppresses DB writes for those
+// entries while still printing them to the log file at DEBUG level.
+func (l *Logger) SetPersistPrompts(v bool) {
+	l.mu.Lock()
+	l.persistPrompts = v
+	l.mu.Unlock()
 }
 
 // New creates a logger that writes to a log file in logDir.
@@ -93,12 +104,13 @@ func New(logDir string, dbClient *db.Client, level Level, rot Rotation) (*Logger
 	}
 
 	l := &Logger{
-		file:   f,
-		size:   size,
-		db:     dbClient,
-		level:  level,
-		logDir: logDir,
-		rot:    rot,
+		file:           f,
+		size:           size,
+		db:             dbClient,
+		level:          level,
+		logDir:         logDir,
+		rot:            rot,
+		persistPrompts: true,
 	}
 	l.pruneOldLogs()
 	return l, nil
@@ -183,10 +195,15 @@ func (l *Logger) log(ctx context.Context, level Level, msg, component, taskID st
 		l.writeLine(line)
 	}
 
-	// Write to database
+	// Write to database. Prompt log entries ("prompt sent to agent:…") are
+	// suppressed when persistPrompts is false so the full ticket text is not
+	// stored on disk. All other entries (including the rest of the agent stream)
+	// are unaffected.
 	if l.db != nil {
 		if taskID != "" {
-			l.db.WriteTaskLog(ctx, taskID, string(level), msg)
+			if l.persistPrompts || !strings.HasPrefix(msg, "prompt sent to agent:") {
+				l.db.WriteTaskLog(ctx, taskID, string(level), msg)
+			}
 		} else {
 			l.db.WriteServiceLog(ctx, string(level), msg, component)
 		}

--- a/src/internal/logging/logger_test.go
+++ b/src/internal/logging/logger_test.go
@@ -60,6 +60,44 @@ func TestLog_TaskDebugPersistsBelowThreshold(t *testing.T) {
 	}
 }
 
+// When SetPersistPrompts(false), task-log entries that begin with
+// "prompt sent to agent:" must be silently dropped from the DB while all
+// other entries — including the rest of the agent stream — are still written.
+func TestLog_SetPersistPromptsDropsPromptEntries(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	dbClient, err := db.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	defer dbClient.Close()
+
+	logger, err := New(t.TempDir(), dbClient, LevelDebug, DefaultRotation())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer logger.Close()
+
+	logger.SetPersistPrompts(false)
+
+	logger.TaskDebug(ctx, "task-1", "prompt sent to agent:\nfull ticket text here")
+	logger.TaskDebug(ctx, "task-1", "$ claude --model claude-sonnet-5 -p ...")
+	logger.TaskDebug(ctx, "task-1", "[assistant] working on it")
+
+	logs, err := dbClient.GetTaskLogs(ctx, "task-1", 100)
+	if err != nil {
+		t.Fatalf("GetTaskLogs: %v", err)
+	}
+	for _, l := range logs {
+		if strings.HasPrefix(l.Message, "prompt sent to agent:") {
+			t.Errorf("prompt entry must not reach DB, got: %q", l.Message)
+		}
+	}
+	if len(logs) != 2 {
+		t.Errorf("DB log count = %d, want 2 (non-prompt entries only)", len(logs))
+	}
+}
+
 // A write that would push apiary.log past the size limit must rotate the file
 // into a .1 backup and start a fresh one, shifting older backups up a slot and
 // dropping the oldest beyond MaxBackups.

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -593,7 +593,9 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	sr.FinishedAt = &finished
 	sr.Output = res.Output
 	sr.Summary = res.Summary
-	sr.InputPrompt = res.InputPrompt
+	if e.cfg.Settings.ShouldPersistPrompts() {
+		sr.InputPrompt = res.InputPrompt
+	}
 	if res.Usage != nil {
 		sr.InputTokens = res.Usage.InputTokens
 		sr.OutputTokens = res.Usage.OutputTokens


### PR DESCRIPTION
## Summary

- Adds `settings.persist_prompts: false` to `apiary.yaml` to stop recording full agent prompts in the database.
- `Logger.SetPersistPrompts(false)` suppresses DB writes for `"prompt sent to agent:…"` task-log entries; the message still appears in the log file at debug level so local debugging is unaffected.
- `finishExecution` (daemon) and the workflow engine skip copying `InputPrompt` into `task_executions.input_prompt` / `step_runs.input_prompt` when the flag is off.
- `db.Client.ScrubPrompts()` removes historical prompt rows from `task_logs`, `task_executions`, and `step_runs` — a forward-only flag is not enough per the AC.
- At daemon startup (`cli/run.go`) when `persist_prompts: false` is detected, `SetPersistPrompts` is applied to the logger and `ScrubPrompts` is executed once against the existing database.
- Default behaviour (`PersistPrompts == nil` or `true`) is identical to before — no changes for existing deployments.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all 23 packages pass
- [ ] Manual: start daemon with `settings: { persist_prompts: false }`, run a task, confirm `task_logs` has no `"prompt sent to agent:"` row and `task_executions.input_prompt` is NULL
- [ ] Manual: start daemon once *without* the flag (prompts accumulate), add `persist_prompts: false`, restart — confirm `ScrubPrompts` clears the historical rows on the first run

Closes #238