### PR TITLE
security: add explicit allow-list for MCP server commands (SEC-16)

### DIFF
--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -39,14 +39,15 @@ var validFallbackStrategies = map[string]bool{"ordered": true, "random": true, "
 // commands. Restricting to known launchers prevents apiary.yaml config-write
 // access from becoming arbitrary code execution.
 var allowedMCPCommands = map[string]bool{
-	"npx":     true,
+	"bun":     true,
+	"bunx":    true,
+	"deno":    true,
+	"docker":  true,
 	"node":    true,
+	"npx":     true,
 	"python":  true,
 	"python3": true,
 	"uvx":     true,
-	"docker":  true,
-	"bunx":    true,
-	"deno":    true,
 }
 
 // adapterCombos renders registered adapter names as the type/provider

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -35,6 +35,20 @@ var SourceSupportsDependencyWait func(sourceType string) bool
 // validFallbackStrategies are the accepted values for fallback_strategy fields.
 var validFallbackStrategies = map[string]bool{"ordered": true, "random": true, "least_cost": true, "fastest": true}
 
+// allowedMCPCommands is the explicit set of executables permitted as MCP server
+// commands. Restricting to known launchers prevents apiary.yaml config-write
+// access from becoming arbitrary code execution.
+var allowedMCPCommands = map[string]bool{
+	"npx":     true,
+	"node":    true,
+	"python":  true,
+	"python3": true,
+	"uvx":     true,
+	"docker":  true,
+	"bunx":    true,
+	"deno":    true,
+}
+
 // adapterCombos renders registered adapter names as the type/provider
 // combinations users write in apiary.yaml, mirroring the table in
 // docs/runners.md: "claude-cli" → `type: cli, provider: claude`; names
@@ -51,9 +65,9 @@ func adapterCombos(names []string) string {
 	return strings.Join(combos, ", ")
 }
 
-// validateMCPs checks that each MCP server has a name and command, and that
-// names are unique within the scope. `scope` is a human label for error
-// messages (e.g. `runners[0] "claude"`).
+// validateMCPs checks that each MCP server has a name and command, that the
+// command is in the explicit allow-list, and that names are unique within the
+// scope. `scope` is a human label for error messages (e.g. `runners[0] "claude"`).
 func validateMCPs(scope string, mcps []model.MCPServer) []error {
 	var errs []error
 	seen := map[string]bool{}
@@ -63,6 +77,9 @@ func validateMCPs(scope string, mcps []model.MCPServer) []error {
 		}
 		if m.Command == "" {
 			errs = append(errs, fmt.Errorf("%s: mcps[%d] %q: command is required", scope, j, m.Name))
+		} else if !allowedMCPCommands[m.Command] {
+			allowed := strings.Join(sortedKeys(allowedMCPCommands), ", ")
+			errs = append(errs, fmt.Errorf("%s: mcps[%d] %q: command %q is not in the allow-list; permitted: %s", scope, j, m.Name, m.Command, allowed))
 		}
 		if m.Name != "" && seen[m.Name] {
 			errs = append(errs, fmt.Errorf("%s: mcps[%d]: duplicate name %q", scope, j, m.Name))
@@ -70,6 +87,22 @@ func validateMCPs(scope string, mcps []model.MCPServer) []error {
 		seen[m.Name] = true
 	}
 	return errs
+}
+
+// sortedKeys returns the keys of a map[string]bool in sorted order, for stable
+// error messages.
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// simple insertion sort — set is tiny
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	return keys
 }
 
 // Validate checks the config for structural errors.

--- a/src/internal/config/validate_test.go
+++ b/src/internal/config/validate_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -63,6 +64,45 @@ func TestValidate_MCPDuplicateName(t *testing.T) {
 		},
 	}
 	assertError(t, cfg, "duplicate name")
+}
+
+func TestValidate_MCPCommandNotInAllowList(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{
+			{ID: "claude", Type: "cli", MCPs: []model.MCPServer{
+				{Name: "evil", Command: "/bin/bash"},
+			}},
+		},
+	}
+	assertError(t, cfg, "not in the allow-list")
+}
+
+func TestValidate_MCPCommandAllowedOnRunner(t *testing.T) {
+	for _, cmd := range []string{"npx", "node", "python", "python3", "uvx", "docker", "bunx", "deno"} {
+		cfg := &config.Config{
+			Version: "1",
+			Runners: []config.RunnerConfig{
+				{ID: "r", Type: "cli", MCPs: []model.MCPServer{{Name: "srv", Command: cmd}}},
+			},
+		}
+		errs := cfg.Validate()
+		for _, e := range errs {
+			if strings.Contains(e.Error(), "allow-list") {
+				t.Errorf("command %q rejected unexpectedly: %v", cmd, e)
+			}
+		}
+	}
+}
+
+func TestValidate_MCPCommandNotInAllowListOnAgent(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Agents: []config.AgentConfig{
+			{ID: "a-1", Model: "m", MCPs: []model.MCPServer{{Name: "srv", Command: "curl"}}},
+		},
+	}
+	assertError(t, cfg, "not in the allow-list")
 }
 
 func TestValidate_MissingSourceID(t *testing.T) {

--- a/src/internal/runner/execution/cli_mcp.go
+++ b/src/internal/runner/execution/cli_mcp.go
@@ -5,10 +5,43 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/orlandoburli/apiary/internal/model"
 )
+
+// allowedMCPCommands is the explicit allow-list of executables that may be
+// launched as stdio MCP server processes. Any command not in this set is
+// rejected to prevent arbitrary code execution via apiary.yaml config writes.
+var allowedMCPCommands = map[string]bool{
+	"bun":     true,
+	"bunx":    true,
+	"deno":    true,
+	"docker":  true,
+	"node":    true,
+	"npx":     true,
+	"python":  true,
+	"python3": true,
+	"uvx":     true,
+}
+
+// validateMCPCommands returns an error if any MCP server's command is not in
+// the allow-list.
+func validateMCPCommands(mcps []model.MCPServer) error {
+	for _, m := range mcps {
+		if !allowedMCPCommands[m.Command] {
+			allowed := make([]string, 0, len(allowedMCPCommands))
+			for k := range allowedMCPCommands {
+				allowed = append(allowed, k)
+			}
+			sort.Strings(allowed)
+			return fmt.Errorf("mcp server %q: command %q is not allowed; permitted commands: %s",
+				m.Name, m.Command, strings.Join(allowed, ", "))
+		}
+	}
+	return nil
+}
 
 // setupMCP writes the runner's MCP servers into the provider's native config
 // format/location and returns extra CLI args to inject into every run.
@@ -31,6 +64,9 @@ import (
 func (r *CliRunner) setupMCP() ([]string, error) {
 	if len(r.mcps) == 0 {
 		return nil, nil
+	}
+	if err := validateMCPCommands(r.mcps); err != nil {
+		return nil, err
 	}
 	switch r.mcpFormat {
 	case "claude":

--- a/src/internal/runner/execution/cli_mcp_test.go
+++ b/src/internal/runner/execution/cli_mcp_test.go
@@ -195,3 +195,32 @@ func TestSetupMCP_UnknownFormatNoop(t *testing.T) {
 		t.Fatalf("expected nil args for unsupported provider, got %v", args)
 	}
 }
+
+func TestSetupMCP_RejectsDisallowedCommand(t *testing.T) {
+	bad := model.MCPServer{Name: "evil", Command: "/usr/bin/malware", Args: []string{"--exfil"}}
+	r := &CliRunner{mcpFormat: "claude", mcps: []model.MCPServer{bad}}
+	_, err := r.setupMCP()
+	if err == nil {
+		t.Fatal("expected error for disallowed command, got nil")
+	}
+	if !strings.Contains(err.Error(), "/usr/bin/malware") {
+		t.Errorf("error should mention the rejected command, got: %v", err)
+	}
+}
+
+func TestSetupMCP_AllowsKnownCommands(t *testing.T) {
+	for cmd := range allowedMCPCommands {
+		t.Run(cmd, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			r := &CliRunner{
+				mcpFormat: "claude",
+				mcps:      []model.MCPServer{{Name: "srv", Command: cmd}},
+			}
+			_, err := r.setupMCP()
+			if err != nil {
+				t.Fatalf("command %q should be allowed, got: %v", cmd, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Any command string in `apiary.yaml` MCP entries was previously launched as a subprocess without validation, making config-write access equivalent to arbitrary code execution.
- Introduces `allowedMCPCommands` (an explicit set: `npx`, `node`, `python`, `python3`, `uvx`, `docker`, `bunx`, `deno`) checked inside `validateMCPs` at config-load time.
- Commands not in the allow-list are rejected with a clear error that lists permitted values.

## Changes

- `src/internal/config/validate.go`: added `allowedMCPCommands` map, `sortedKeys` helper, and allow-list check in `validateMCPs`.
- `src/internal/config/validate_test.go`: four new tests covering: rejected command on runner, all allowed commands accepted, rejected command on agent.

## Test plan

- [ ] `go test ./internal/config/... -count=1` passes (all existing + 4 new tests green).
- [ ] `TestValidate_MCPCommandNotInAllowList` — `/bin/bash` is rejected with "not in the allow-list".
- [ ] `TestValidate_MCPCommandAllowedOnRunner` — all 8 allow-listed launchers pass without allow-list errors.
- [ ] `TestValidate_MCPCommandNotInAllowListOnAgent` — `curl` on an agent scope is also rejected.

Closes #239