### PR TITLE
security: redact JWT tokens in stderr logs; add govulncheck + Dependabot to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,21 @@
+name: govulncheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+      - name: Run govulncheck
+        working-directory: src
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -5,9 +5,15 @@ package log
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 )
+
+// jwtPattern matches JWT-shaped bearer tokens (three base64url segments
+// starting with "eyJ"). Mirrors the redaction used in transcript writes so
+// tokens never appear in plain text on stderr either.
+var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`)
 
 var (
 	verbose bool
@@ -55,7 +61,7 @@ func Error(format string, args ...any) {
 
 func print(level, format string, args ...any) {
 	ts := time.Now().Format("15:04:05")
-	msg := fmt.Sprintf(format, args...)
+	msg := jwtPattern.ReplaceAllString(fmt.Sprintf(format, args...), "«redacted-jwt»")
 	fmt.Fprintf(os.Stderr, "%s  %-5s  %s\n", ts, level, msg)
 
 	sinkMu.RLock()


### PR DESCRIPTION
## Summary

- **Redaction consistency** (`internal/log/log.go`): the `print` helper now applies the same `eyJ…` JWT regex used by transcript writes before emitting to stderr, so bearer tokens never appear in plain text in daemon output or any registered sink.
- **govulncheck in CI** (`.github/workflows/govulncheck.yml`): runs `govulncheck ./...` on every push and PR so dependency CVEs surface automatically.
- **Dependabot** (`.github/dependabot.yml`): weekly PRs for Go module and GitHub Actions pin updates.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] GitNexus `detect_changes` — risk: low, 0 affected processes

Closes #240