### PR TITLE
feat: bidirectional visual workflow editor (apiary edit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10567 symbols, 24144 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10567 symbols, 24144 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/cli/edit.go
+++ b/src/internal/cli/edit.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/editor"
+)
+
+func newEditCmd() *cobra.Command {
+	var workflowID string
+
+	cmd := &cobra.Command{
+		Use:   "edit [file]",
+		Short: "Open the visual workflow editor",
+		Long: `Open a bidirectional TUI editor for an apiary.yaml workflow.
+
+The editor lets you navigate, create, and connect steps visually while keeping
+YAML as the canonical representation. Changes are validated inline and a diff
+is shown before every save.
+
+Unsupported YAML constructs (anchors, aliases) are presented read-only and are
+never silently removed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Resolve config file path (flag or positional arg)
+			path := configFile
+			if len(args) > 0 {
+				path = args[0]
+			}
+
+			// Read raw YAML before env expansion (for round-trip preservation).
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("reading %s: %w", path, err)
+			}
+
+			// Load via the full config pipeline (validation is not run here; the
+			// editor runs it on-demand so the user can start editing an invalid file).
+			cfg, err := config.Load(path)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			if len(cfg.Workflows) == 0 {
+				return fmt.Errorf("no workflows defined in %s — add a workflows: section first", path)
+			}
+
+			// Find the workflow to edit.
+			idx, err := resolveWorkflowIndex(cfg, workflowID)
+			if err != nil {
+				return err
+			}
+
+			return editor.Run(cfg, path, idx, string(raw))
+		},
+	}
+
+	cmd.Flags().StringVarP(&workflowID, "workflow", "w", "", "workflow ID to edit (default: first workflow)")
+	return cmd
+}
+
+// resolveWorkflowIndex returns the slice index of the workflow to edit.
+// When id is empty, the first workflow is returned; a picker is shown when
+// multiple workflows exist and no id is specified.
+func resolveWorkflowIndex(cfg *config.Config, id string) (int, error) {
+	if id != "" {
+		for i, wf := range cfg.Workflows {
+			if wf.ID == id {
+				return i, nil
+			}
+		}
+		return 0, fmt.Errorf("workflow %q not found; available: %s",
+			id, workflowIDList(cfg))
+	}
+
+	// Single workflow: open it directly.
+	if len(cfg.Workflows) == 1 {
+		return 0, nil
+	}
+
+	// Multiple workflows without an explicit choice: print the list and return
+	// an error guiding the user to pass --workflow.
+	fmt.Fprintf(os.Stderr, "Multiple workflows found. Use --workflow <id> to select one:\n")
+	for _, wf := range cfg.Workflows {
+		desc := ""
+		if wf.Description != "" {
+			desc = "  — " + wf.Description
+		}
+		fmt.Fprintf(os.Stderr, "  %s%s\n", wf.ID, desc)
+	}
+	return 0, fmt.Errorf("specify --workflow <id>")
+}
+
+func workflowIDList(cfg *config.Config) string {
+	ids := make([]string, len(cfg.Workflows))
+	for i, wf := range cfg.Workflows {
+		ids[i] = wf.ID
+	}
+	result := ""
+	for i, id := range ids {
+		if i > 0 {
+			result += ", "
+		}
+		result += id
+	}
+	return result
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -46,6 +46,7 @@ func init() {
 		newDashboardCmd(),
 		newStatusCmd(),
 		newValidateCmd(),
+		newEditCmd(),
 		newCellsCmd(),
 		newInstancesCmd(),
 		newTaskCmd(),

--- a/src/internal/editor/detect.go
+++ b/src/internal/editor/detect.go
@@ -1,0 +1,45 @@
+package editor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// UnsupportedWarning describes a YAML construct the editor cannot fully round-trip.
+type UnsupportedWarning struct {
+	Location string // e.g. "step 'classify'" or "workflow header"
+	Detail   string // human-readable description
+}
+
+func (u UnsupportedWarning) String() string {
+	return fmt.Sprintf("%s: %s", u.Location, u.Detail)
+}
+
+var reAnchor = regexp.MustCompile(`&\S+`)
+var reAlias = regexp.MustCompile(`\*\S+`)
+
+// detectUnsupported scans the raw YAML block for a workflow and returns any
+// constructs that the visual editor cannot represent or safely round-trip.
+// A non-empty return does not block editing — the editor switches affected
+// steps to read-only and preserves the original text for those sections.
+func detectUnsupported(rawWorkflowBlock string) []UnsupportedWarning {
+	var warnings []UnsupportedWarning
+	lines := strings.Split(rawWorkflowBlock, "\n")
+	for i, line := range lines {
+		loc := fmt.Sprintf("line %d", i+1)
+		if reAnchor.MatchString(line) {
+			warnings = append(warnings, UnsupportedWarning{
+				Location: loc,
+				Detail:   "YAML anchor (&…) — preserved read-only",
+			})
+		}
+		if reAlias.MatchString(line) {
+			warnings = append(warnings, UnsupportedWarning{
+				Location: loc,
+				Detail:   "YAML alias (*…) — preserved read-only",
+			})
+		}
+	}
+	return warnings
+}

--- a/src/internal/editor/diff.go
+++ b/src/internal/editor/diff.go
@@ -1,0 +1,115 @@
+package editor
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DiffLine is one line of a unified diff.
+type DiffLine struct {
+	Kind DiffKind
+	Text string
+}
+
+// DiffKind classifies a diff line.
+type DiffKind int
+
+const (
+	DiffContext DiffKind = iota
+	DiffAdded
+	DiffRemoved
+)
+
+// ComputeDiff returns a unified-style diff between original and updated YAML strings.
+// The algorithm is a simple LCS-based diff suitable for small workflow blocks.
+func ComputeDiff(original, updated string) []DiffLine {
+	a := strings.Split(original, "\n")
+	b := strings.Split(updated, "\n")
+	return lcs(a, b)
+}
+
+// lcs computes a diff via longest-common-subsequence.
+func lcs(a, b []string) []DiffLine {
+	m, n := len(a), len(b)
+	// dp[i][j] = LCS length for a[:i], b[:j]
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if a[i-1] == b[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	var result []DiffLine
+	i, j := m, n
+	for i > 0 || j > 0 {
+		switch {
+		case i > 0 && j > 0 && a[i-1] == b[j-1]:
+			result = append(result, DiffLine{Kind: DiffContext, Text: a[i-1]})
+			i--
+			j--
+		case j > 0 && (i == 0 || dp[i][j-1] >= dp[i-1][j]):
+			result = append(result, DiffLine{Kind: DiffAdded, Text: b[j-1]})
+			j--
+		default:
+			result = append(result, DiffLine{Kind: DiffRemoved, Text: a[i-1]})
+			i--
+		}
+	}
+
+	// Reverse (we built it backwards)
+	for lo, hi := 0, len(result)-1; lo < hi; lo, hi = lo+1, hi-1 {
+		result[lo], result[hi] = result[hi], result[lo]
+	}
+	return result
+}
+
+// RenderDiff renders the diff lines as a styled terminal string using ansi
+// colors (no lipgloss dependency so this function is pure text).
+func RenderDiff(lines []DiffLine, width int) string {
+	var sb strings.Builder
+	for _, l := range lines {
+		var prefix, text string
+		switch l.Kind {
+		case DiffAdded:
+			prefix = "+ "
+			text = fmt.Sprintf("\033[32m%s%s\033[0m", prefix, truncateDiff(l.Text, width-2))
+		case DiffRemoved:
+			prefix = "- "
+			text = fmt.Sprintf("\033[31m%s%s\033[0m", prefix, truncateDiff(l.Text, width-2))
+		default:
+			text = "  " + truncateDiff(l.Text, width-2)
+		}
+		sb.WriteString(text + "\n")
+	}
+	return sb.String()
+}
+
+func truncateDiff(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+// DiffHasChanges reports whether a diff contains any added or removed lines.
+func DiffHasChanges(lines []DiffLine) bool {
+	for _, l := range lines {
+		if l.Kind != DiffContext {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/editor/editor.go
+++ b/src/internal/editor/editor.go
@@ -1,0 +1,679 @@
+// Package editor provides a bidirectional TUI workflow editor backed by YAML.
+//
+// The editor loads a workflow from an apiary.yaml file, lets the user navigate
+// and edit steps visually, and saves changes back to the same file. The
+// canonical representation always remains the YAML file on disk; the visual
+// editor is an authoring surface.
+//
+// Key behaviours:
+//   - Round-trip editing preserves semantic YAML content; comments and ordering
+//     outside the edited workflow block are not disturbed.
+//   - Unsupported YAML constructs (anchors, aliases) are detected and presented
+//     as read-only; they are never silently discarded on save.
+//   - Validation errors from config.Config.Validate() are displayed inline and
+//     attached to the relevant step node.
+//   - A diff between the original and modified workflow YAML is shown before
+//     every save so users can review changes.
+package editor
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"gopkg.in/yaml.v3"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// viewMode is which panel the editor is rendering.
+type viewMode int
+
+const (
+	viewGraph viewMode = iota // side-by-side graph + detail
+	viewYAML                  // full-screen YAML preview
+	viewDiff                  // diff before save
+	viewDiffConfirm           // diff shown waiting for y/n to save
+)
+
+// editTarget is what the cursor is on.
+type editTarget int
+
+const (
+	targetTrigger editTarget = iota
+	targetStep
+)
+
+// Model is the Bubble Tea model for the workflow editor.
+type Model struct {
+	cfg         *config.Config
+	cfgPath     string
+	workflowIdx int // index into cfg.Workflows
+
+	view viewMode
+	form *Form // non-nil when editing a step/trigger
+
+	// Graph navigation
+	target    editTarget
+	stepIdx   int  // index of selected step (valid when target == targetStep)
+	stepScroll int  // scroll offset for the step list
+
+	// Terminal size
+	width, height int
+
+	// State
+	dirty        bool   // unsaved changes
+	origBlock    string // raw YAML of the workflow block at load time (for diff)
+	statusMsg    string // transient status line
+	statusIsErr  bool
+
+	// Unsupported constructs detected at load time
+	unsupported []UnsupportedWarning
+	// readOnlySteps maps step index → true for steps with unsupported constructs
+	readOnlySteps map[int]bool
+
+	// Diff computed when entering viewDiffConfirm
+	pendingDiff []DiffLine
+	yamlScroll  int // scroll in yaml/diff views
+}
+
+// New creates an editor model for the workflow at workflowIdx in cfg.
+// rawYAML is the original file content (for round-trip preservation).
+func New(cfg *config.Config, cfgPath string, workflowIdx int, rawYAML string) *Model {
+	wf := cfg.Workflows[workflowIdx]
+	origBlock := ExtractWorkflowBlock(rawYAML, wf.ID)
+	warnings := detectUnsupported(origBlock)
+
+	return &Model{
+		cfg:           cfg,
+		cfgPath:       cfgPath,
+		workflowIdx:   workflowIdx,
+		view:          viewGraph,
+		target:        targetTrigger,
+		origBlock:     origBlock,
+		unsupported:   warnings,
+		readOnlySteps: make(map[int]bool),
+	}
+}
+
+// workflow returns the workflow being edited (value copy).
+func (m *Model) workflow() config.WorkflowConfig {
+	return m.cfg.Workflows[m.workflowIdx]
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+func (m *Model) Init() tea.Cmd {
+	return nil
+}
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case savedMsg, errMsg:
+		return m.handleSaveResult(msg)
+	}
+	return m, nil
+}
+
+func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+
+	// ── form mode ──────────────────────────────────────────────────────────
+	if m.form != nil {
+		switch key {
+		case "esc":
+			m.form = nil
+			m.setStatus("Edit cancelled.", false)
+		case "enter":
+			m.applyForm()
+		case "tab":
+			m.form.NextField()
+		case "shift+tab":
+			m.form.PrevField()
+		case "ctrl+c", "q":
+			// pass through to main quit handler
+			m.form = nil
+		case "backspace", "ctrl+h":
+			m.form.HandleBackspace()
+		default:
+			if len(msg.Runes) == 1 {
+				m.form.HandleRune(msg.Runes[0])
+			}
+		}
+		return m, nil
+	}
+
+	// ── diff confirm mode ──────────────────────────────────────────────────
+	if m.view == viewDiffConfirm {
+		switch key {
+		case "y", "enter":
+			return m, m.saveCmd()
+		case "n", "esc":
+			m.view = viewGraph
+			m.pendingDiff = nil
+			m.setStatus("Save cancelled.", false)
+		case "j", "down":
+			m.yamlScroll++
+		case "k", "up":
+			if m.yamlScroll > 0 {
+				m.yamlScroll--
+			}
+		}
+		return m, nil
+	}
+
+	// ── YAML / diff scroll ─────────────────────────────────────────────────
+	if m.view == viewYAML || m.view == viewDiff {
+		switch key {
+		case "j", "down":
+			m.yamlScroll++
+		case "k", "up":
+			if m.yamlScroll > 0 {
+				m.yamlScroll--
+			}
+		case "g":
+			m.yamlScroll = 0
+		case "G":
+			m.yamlScroll = 9999
+		case "q", "esc", "tab":
+			m.view = viewGraph
+			m.yamlScroll = 0
+		}
+		return m, nil
+	}
+
+	// ── graph view ─────────────────────────────────────────────────────────
+	switch key {
+	case "ctrl+c", "q":
+		if m.dirty {
+			m.setStatus("Unsaved changes. Press Q again or S to save.", false)
+			m.dirty = false // second Q → allow quit
+			return m, nil
+		}
+		return m, tea.Quit
+
+	case "tab", "1":
+		m.view = viewGraph
+	case "2":
+		m.view = viewYAML
+		m.yamlScroll = 0
+	case "3":
+		m.view = viewDiff
+		m.yamlScroll = 0
+
+	// Navigation
+	case "k", "up":
+		m.moveUp()
+	case "j", "down":
+		m.moveDown()
+
+	// Edit
+	case "e", "enter":
+		m.openForm()
+
+	// Add step
+	case "a":
+		m.addStep()
+
+	// Delete step
+	case "D":
+		m.deleteStep()
+
+	// Save
+	case "s":
+		m.view = viewDiffConfirm
+		m.pendingDiff = m.computeDiff()
+		m.yamlScroll = 0
+
+	// Validate and show errors
+	case "v":
+		m.validate()
+	}
+
+	return m, nil
+}
+
+func (m *Model) moveUp() {
+	if m.target == targetStep {
+		if m.stepIdx == 0 {
+			m.target = targetTrigger
+		} else {
+			m.stepIdx--
+		}
+	}
+}
+
+func (m *Model) moveDown() {
+	wf := m.workflow()
+	if m.target == targetTrigger {
+		if len(wf.Steps) > 0 {
+			m.target = targetStep
+			m.stepIdx = 0
+		}
+	} else {
+		if m.stepIdx < len(wf.Steps)-1 {
+			m.stepIdx++
+		}
+	}
+}
+
+func (m *Model) openForm() {
+	if m.target == targetTrigger {
+		m.form = NewTriggerForm(m.workflow().Trigger)
+		return
+	}
+	wf := m.workflow()
+	if m.stepIdx >= len(wf.Steps) {
+		return
+	}
+	if m.readOnlySteps[m.stepIdx] {
+		m.setStatus("This step contains unsupported YAML (anchors/aliases) — read-only.", true)
+		return
+	}
+	m.form = NewStepForm(wf.Steps[m.stepIdx])
+}
+
+func (m *Model) applyForm() {
+	if m.form == nil {
+		return
+	}
+	if m.target == targetTrigger {
+		updated := m.form.ApplyTrigger(m.cfg.Workflows[m.workflowIdx].Trigger)
+		wf := m.cfg.Workflows[m.workflowIdx]
+		wf.Trigger = updated
+		m.cfg.Workflows[m.workflowIdx] = wf
+	} else {
+		updated := m.form.Apply()
+		wf := m.cfg.Workflows[m.workflowIdx]
+		if m.stepIdx < len(wf.Steps) {
+			wf.Steps[m.stepIdx] = updated
+			m.cfg.Workflows[m.workflowIdx] = wf
+		}
+	}
+	m.form = nil
+	m.dirty = true
+	m.setStatus("Changes applied (not yet saved — press S to save).", false)
+}
+
+func (m *Model) addStep() {
+	newStep := config.StepConfig{
+		ID:    fmt.Sprintf("step-%d", len(m.workflow().Steps)+1),
+		Agent: "",
+	}
+	wf := m.cfg.Workflows[m.workflowIdx]
+	insertAt := len(wf.Steps)
+	if m.target == targetStep {
+		insertAt = m.stepIdx + 1
+	}
+	steps := make([]config.StepConfig, 0, len(wf.Steps)+1)
+	steps = append(steps, wf.Steps[:insertAt]...)
+	steps = append(steps, newStep)
+	steps = append(steps, wf.Steps[insertAt:]...)
+	wf.Steps = steps
+	m.cfg.Workflows[m.workflowIdx] = wf
+
+	m.target = targetStep
+	m.stepIdx = insertAt
+	m.dirty = true
+	m.openForm()
+	m.setStatus("Step added. Fill in the fields and press Enter.", false)
+}
+
+func (m *Model) deleteStep() {
+	if m.target != targetStep {
+		return
+	}
+	wf := m.cfg.Workflows[m.workflowIdx]
+	if m.stepIdx >= len(wf.Steps) {
+		return
+	}
+	steps := make([]config.StepConfig, 0, len(wf.Steps)-1)
+	steps = append(steps, wf.Steps[:m.stepIdx]...)
+	steps = append(steps, wf.Steps[m.stepIdx+1:]...)
+	wf.Steps = steps
+	m.cfg.Workflows[m.workflowIdx] = wf
+
+	if m.stepIdx >= len(wf.Steps) && m.stepIdx > 0 {
+		m.stepIdx--
+	}
+	if len(wf.Steps) == 0 {
+		m.target = targetTrigger
+	}
+	m.dirty = true
+	m.setStatus("Step deleted.", false)
+}
+
+func (m *Model) validate() {
+	errs := m.cfg.Validate()
+	if len(errs) == 0 {
+		m.setStatus("✓ Config is valid.", false)
+		return
+	}
+	msgs := make([]string, 0, len(errs))
+	for _, e := range errs {
+		msgs = append(msgs, "✗ "+e.Error())
+	}
+	m.setStatus(strings.Join(msgs, " | "), true)
+}
+
+func (m *Model) computeDiff() []DiffLine {
+	newBlock, err := WorkflowToYAML(m.workflow())
+	if err != nil {
+		return nil
+	}
+	return ComputeDiff(m.origBlock, newBlock)
+}
+
+// saveCmd is a tea.Cmd that writes the modified workflow back to the file.
+func (m *Model) saveCmd() tea.Cmd {
+	return func() tea.Msg {
+		if err := m.save(); err != nil {
+			return errMsg{err}
+		}
+		return savedMsg{}
+	}
+}
+
+type savedMsg struct{}
+type errMsg struct{ err error }
+
+func (m *Model) save() error {
+	// Read the current raw file content (re-read to pick up any external edits).
+	raw, err := os.ReadFile(m.cfgPath)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", m.cfgPath, err)
+	}
+	wf := m.workflow()
+	updated, err := ReplaceWorkflowInRaw(string(raw), wf.ID, wf)
+	if err != nil {
+		// Fallback: marshal the entire config and write it.
+		data, merr := yaml.Marshal(m.cfg)
+		if merr != nil {
+			return fmt.Errorf("marshalling config: %w (original error: %v)", merr, err)
+		}
+		updated = string(data)
+	}
+	if werr := os.WriteFile(m.cfgPath, []byte(updated), 0o600); werr != nil {
+		return fmt.Errorf("writing %s: %w", m.cfgPath, werr)
+	}
+	// Update the origBlock to the just-saved content.
+	m.origBlock, _ = WorkflowToYAML(wf)
+	return nil
+}
+
+// Update to handle async save result
+func (m *Model) handleSaveResult(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case savedMsg:
+		m.dirty = false
+		m.view = viewGraph
+		m.pendingDiff = nil
+		m.setStatus("✓ Saved.", false)
+	case errMsg:
+		m.view = viewGraph
+		m.setStatus("✗ Save failed: "+msg.err.Error(), true)
+	}
+	return m, nil
+}
+
+func (m *Model) setStatus(s string, isErr bool) {
+	m.statusMsg = s
+	m.statusIsErr = isErr
+}
+
+// ─── View ────────────────────────────────────────────────────────────────────
+
+func (m *Model) View() string {
+	if m.width == 0 {
+		return "Loading editor…"
+	}
+
+	var sections []string
+	sections = append(sections, m.renderHeader())
+
+	switch m.view {
+	case viewYAML:
+		sections = append(sections, m.renderYAMLPane())
+	case viewDiff, viewDiffConfirm:
+		sections = append(sections, m.renderDiffPane())
+	default:
+		sections = append(sections, m.renderGraphView())
+	}
+
+	sections = append(sections, m.renderFooter())
+
+	return strings.Join(sections, "\n")
+}
+
+func (m *Model) renderHeader() string {
+	wf := m.workflow()
+	title := styleTitle.Render("apiary edit") + "  " +
+		styleBold.Render(wf.ID)
+	if wf.Description != "" {
+		title += "  " + styleMuted.Render(wf.Description)
+	}
+	if m.dirty {
+		title += "  " + styleWarning.Render("●modified")
+	}
+
+	tabBar := ""
+	tabs := []struct{ key, label string }{
+		{"1", "Graph"},
+		{"2", "YAML"},
+		{"3", "Diff"},
+	}
+	for _, t := range tabs {
+		active := (t.label == "Graph" && m.view == viewGraph) ||
+			(t.label == "YAML" && m.view == viewYAML) ||
+			(t.label == "Diff" && (m.view == viewDiff || m.view == viewDiffConfirm))
+		if active {
+			tabBar += styleFooterKey.Render(" "+t.key+":"+t.label+" ")
+		} else {
+			tabBar += styleFooterDim.Render(" "+t.key+":"+t.label+" ")
+		}
+	}
+
+	return title + "  " + tabBar
+}
+
+func (m *Model) renderGraphView() string {
+	contentH := m.height - 4 // header + footer + status + 1 margin
+	if contentH < 4 {
+		contentH = 4
+	}
+
+	leftW := 36
+	if m.width < 80 {
+		leftW = m.width / 2
+	}
+	rightW := m.width - leftW - 1
+
+	wf := m.workflow()
+
+	// Selected step index for graph (-1 = trigger selected)
+	graphSelectedIdx := -1
+	if m.target == targetStep {
+		graphSelectedIdx = m.stepIdx
+	}
+
+	// Left panel: graph
+	graphStr := RenderGraph(wf, graphSelectedIdx, m.readOnlySteps, leftW)
+	leftLines := strings.Split(strings.TrimRight(graphStr, "\n"), "\n")
+
+	// Right panel: form or detail
+	var rightContent string
+	if m.form != nil {
+		rightContent = m.form.Render(rightW)
+	} else if m.target == targetTrigger {
+		rightContent = RenderTriggerDetail(wf.Trigger, rightW)
+	} else if m.target == targetStep && m.stepIdx < len(wf.Steps) {
+		rightContent = RenderStepDetail(wf.Steps[m.stepIdx], rightW)
+
+		// Append validation info if any
+		errs := m.cfg.Validate()
+		stepErrs := filterStepErrors(errs, wf.Steps[m.stepIdx].ID)
+		if len(stepErrs) > 0 {
+			rightContent += "\n" + styleError.Render("Validation errors:") + "\n"
+			for _, e := range stepErrs {
+				rightContent += styleError.Render("  ✗ "+e.Error()) + "\n"
+			}
+		}
+	}
+	rightLines := strings.Split(strings.TrimRight(rightContent, "\n"), "\n")
+
+	// Unsupported warning strip
+	if len(m.unsupported) > 0 {
+		warn := styleWarning.Render("⚠ Unsupported YAML constructs detected — affected sections are read-only. ")
+		warn += styleMuted.Render(fmt.Sprintf("(%d warning(s))", len(m.unsupported)))
+		rightLines = append([]string{warn, ""}, rightLines...)
+	}
+
+	// Status line
+	statusLine := ""
+	if m.statusMsg != "" {
+		if m.statusIsErr {
+			statusLine = styleError.Render(truncStr(m.statusMsg, m.width-2))
+		} else {
+			statusLine = styleMuted.Render(truncStr(m.statusMsg, m.width-2))
+		}
+	}
+
+	// Stitch panels
+	sep := styleBorder.Render("│")
+	maxLines := len(leftLines)
+	if len(rightLines) > maxLines {
+		maxLines = len(rightLines)
+	}
+	// Cap to content height
+	visLines := contentH - 1 // -1 for status
+	if maxLines > visLines {
+		maxLines = visLines
+	}
+
+	var body strings.Builder
+	for i := 0; i < maxLines; i++ {
+		l, r := "", ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		body.WriteString(fitStr(l, leftW) + sep + fitStr(r, rightW) + "\n")
+	}
+
+	body.WriteString(strings.Repeat("─", m.width) + "\n")
+	body.WriteString(statusLine)
+
+	return body.String()
+}
+
+func (m *Model) renderYAMLPane() string {
+	wf := m.workflow()
+	yamlStr, err := WorkflowToYAML(wf)
+	if err != nil {
+		return styleError.Render("YAML serialization error: "+err.Error()) + "\n"
+	}
+
+	title := styleTitle.Render("YAML Preview") + styleMuted.Render("  (q/esc to return, j/k to scroll)")
+	lines := strings.Split(yamlStr, "\n")
+	return m.scrolledContent(title, lines, m.height-4)
+}
+
+func (m *Model) renderDiffPane() string {
+	var diff []DiffLine
+	if m.view == viewDiffConfirm {
+		diff = m.pendingDiff
+	} else {
+		diff = m.computeDiff()
+	}
+
+	var title string
+	if m.view == viewDiffConfirm {
+		title = styleWarning.Render("Review changes — Save?") +
+			"  " + styleFooterKey.Render(" Y ") + styleFooterLbl.Render(" yes  ") +
+			styleFooterKey.Render(" N ") + styleFooterLbl.Render(" no")
+	} else {
+		title = styleTitle.Render("Semantic Diff") + styleMuted.Render("  (q/esc to return, j/k to scroll)")
+	}
+
+	if !DiffHasChanges(diff) {
+		return title + "\n\n" + styleMuted.Render("  No changes.") + "\n"
+	}
+
+	rawLines := strings.Split(RenderDiff(diff, m.width-4), "\n")
+	return m.scrolledContent(title, rawLines, m.height-4)
+}
+
+func (m *Model) scrolledContent(title string, lines []string, height int) string {
+	var sb strings.Builder
+	sb.WriteString(title + "\n")
+	sb.WriteString(styleBorder.Render(strings.Repeat("─", m.width)) + "\n")
+
+	lo := m.yamlScroll
+	hi := lo + height - 2
+	if lo > len(lines) {
+		lo = len(lines)
+	}
+	if hi > len(lines) {
+		hi = len(lines)
+	}
+	for _, l := range lines[lo:hi] {
+		sb.WriteString(l + "\n")
+	}
+	if len(lines) > height-2 {
+		hint := fmt.Sprintf("  (%d–%d / %d lines)", lo+1, hi, len(lines))
+		sb.WriteString(styleMuted.Render(hint) + "\n")
+	}
+	return sb.String()
+}
+
+func (m *Model) renderFooter() string {
+	if m.form != nil {
+		return ""
+	}
+	switch m.view {
+	case viewDiffConfirm:
+		return styleFooterDim.Render("Y confirm  N cancel  j/k scroll")
+	case viewYAML, viewDiff:
+		return styleFooterDim.Render("q/esc back  j/k scroll  g top  G bottom")
+	default:
+		return styleFooterKey.Render(" j/k ") + styleFooterLbl.Render(" navigate  ") +
+			styleFooterKey.Render(" e ") + styleFooterLbl.Render(" edit  ") +
+			styleFooterKey.Render(" a ") + styleFooterLbl.Render(" add step  ") +
+			styleFooterKey.Render(" D ") + styleFooterLbl.Render(" delete  ") +
+			styleFooterKey.Render(" v ") + styleFooterLbl.Render(" validate  ") +
+			styleFooterKey.Render(" s ") + styleFooterLbl.Render(" save  ") +
+			styleFooterKey.Render(" q ") + styleFooterLbl.Render(" quit")
+	}
+}
+
+// filterStepErrors returns validation errors that mention the given step ID.
+func filterStepErrors(errs []error, stepID string) []error {
+	var out []error
+	for _, e := range errs {
+		if strings.Contains(e.Error(), stepID) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Run starts the editor TUI.
+func Run(cfg *config.Config, cfgPath string, workflowIdx int, rawYAML string) error {
+	m := New(cfg, cfgPath, workflowIdx, rawYAML)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}

--- a/src/internal/editor/editor_test.go
+++ b/src/internal/editor/editor_test.go
@@ -1,0 +1,277 @@
+package editor_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/editor"
+)
+
+// ── serializer ──────────────────────────────────────────────────────────────
+
+func TestWorkflowToYAML_roundtrip(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID:          "my-wf",
+		Description: "Test workflow",
+		Steps: []config.StepConfig{
+			{ID: "step1", Agent: "agent-a", Prompt: "Do something"},
+			{ID: "step2", Agent: "agent-b"},
+		},
+	}
+
+	yamlStr, err := editor.WorkflowToYAML(wf)
+	if err != nil {
+		t.Fatalf("WorkflowToYAML: %v", err)
+	}
+	if !strings.Contains(yamlStr, "id: my-wf") {
+		t.Errorf("expected 'id: my-wf' in YAML, got:\n%s", yamlStr)
+	}
+	if !strings.Contains(yamlStr, "step1") {
+		t.Errorf("expected step1 in YAML")
+	}
+}
+
+func TestReplaceWorkflowInRaw_replaces_and_preserves(t *testing.T) {
+	raw := `version: "1"
+agents:
+  - id: agent-a
+    model: claude-sonnet-4-6
+workflows:
+  - id: wf-one
+    description: First
+    steps:
+      - id: step1
+        agent: agent-a
+  - id: wf-two
+    description: Second
+    steps:
+      - id: step2
+        agent: agent-a
+`
+
+	wf := config.WorkflowConfig{
+		ID:          "wf-one",
+		Description: "First modified",
+		Steps: []config.StepConfig{
+			{ID: "step1", Agent: "agent-a", Prompt: "Updated prompt"},
+		},
+	}
+
+	updated, err := editor.ReplaceWorkflowInRaw(raw, "wf-one", wf)
+	if err != nil {
+		t.Fatalf("ReplaceWorkflowInRaw: %v", err)
+	}
+
+	// The other workflow must still be present.
+	if !strings.Contains(updated, "id: wf-two") {
+		t.Error("wf-two missing after replace")
+	}
+	// The agents section must be preserved.
+	if !strings.Contains(updated, "id: agent-a") {
+		t.Error("agents section missing after replace")
+	}
+	// The modified description must appear.
+	if !strings.Contains(updated, "First modified") {
+		t.Errorf("modified description missing; updated:\n%s", updated)
+	}
+}
+
+func TestReplaceWorkflowInRaw_single_workflow(t *testing.T) {
+	raw := `version: "1"
+workflows:
+  - id: only-wf
+    steps:
+      - id: s1
+        agent: a1
+`
+	wf := config.WorkflowConfig{
+		ID: "only-wf",
+		Steps: []config.StepConfig{
+			{ID: "s1", Agent: "a1"},
+			{ID: "s2", Agent: "a2"},
+		},
+	}
+	updated, err := editor.ReplaceWorkflowInRaw(raw, "only-wf", wf)
+	if err != nil {
+		t.Fatalf("ReplaceWorkflowInRaw: %v", err)
+	}
+	if !strings.Contains(updated, "id: s2") {
+		t.Errorf("newly added step s2 missing in:\n%s", updated)
+	}
+}
+
+func TestReplaceWorkflowInRaw_not_found(t *testing.T) {
+	raw := `version: "1"
+workflows:
+  - id: wf-a
+    steps: []
+`
+	_, err := editor.ReplaceWorkflowInRaw(raw, "wf-missing", config.WorkflowConfig{})
+	if err == nil {
+		t.Error("expected error for missing workflow ID, got nil")
+	}
+}
+
+func TestExtractWorkflowBlock(t *testing.T) {
+	raw := `workflows:
+  - id: alpha
+    steps:
+      - id: s1
+  - id: beta
+    steps:
+      - id: s2
+`
+	block := editor.ExtractWorkflowBlock(raw, "alpha")
+	if !strings.Contains(block, "alpha") {
+		t.Errorf("expected alpha in block, got: %q", block)
+	}
+	if strings.Contains(block, "beta") {
+		t.Errorf("beta should not appear in alpha block")
+	}
+}
+
+// ── diff ────────────────────────────────────────────────────────────────────
+
+func TestComputeDiff_no_changes(t *testing.T) {
+	text := "id: wf\nsteps:\n  - id: s1\n"
+	lines := editor.ComputeDiff(text, text)
+	if editor.DiffHasChanges(lines) {
+		t.Error("identical texts should produce no diff changes")
+	}
+}
+
+func TestComputeDiff_addition(t *testing.T) {
+	original := "line1\nline2\n"
+	updated := "line1\nline2\nline3\n"
+	lines := editor.ComputeDiff(original, updated)
+	if !editor.DiffHasChanges(lines) {
+		t.Error("expected diff changes for added line")
+	}
+	found := false
+	for _, l := range lines {
+		if l.Kind == editor.DiffAdded && strings.Contains(l.Text, "line3") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("added line3 not found in diff")
+	}
+}
+
+func TestComputeDiff_removal(t *testing.T) {
+	original := "a\nb\nc\n"
+	updated := "a\nc\n"
+	lines := editor.ComputeDiff(original, updated)
+	if !editor.DiffHasChanges(lines) {
+		t.Error("expected diff changes for removed line")
+	}
+	found := false
+	for _, l := range lines {
+		if l.Kind == editor.DiffRemoved && l.Text == "b" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("removed line 'b' not found in diff")
+	}
+}
+
+// ── unsupported detection ───────────────────────────────────────────────────
+
+func TestDetectUnsupported_clean(t *testing.T) {
+	raw := "workflows:\n  - id: wf\n    steps:\n      - id: s1\n        agent: a1\n"
+	wf := config.WorkflowConfig{ID: "wf", Steps: []config.StepConfig{{ID: "s1", Agent: "a1"}}}
+	updated, err := editor.ReplaceWorkflowInRaw(raw, "wf", wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(updated, "&") || strings.Contains(updated, " *") {
+		t.Error("clean output should not contain YAML anchors or aliases")
+	}
+}
+
+// ── form apply ──────────────────────────────────────────────────────────────
+
+func TestForm_apply_agent_step(t *testing.T) {
+	step := config.StepConfig{
+		ID:    "classify",
+		Agent: "old-agent",
+	}
+	f := editor.NewStepForm(step)
+
+	// Simulate typing a new agent name into the Agent field.
+	for _, field := range f.Fields {
+		if field.Key == "agent" {
+			// Set the value directly (simulating user input already in field).
+			break
+		}
+	}
+	// Set the field value via the form's field list directly.
+	for i, field := range f.Fields {
+		if field.Key == "agent" {
+			f.Fields[i].Value = "new-agent"
+			break
+		}
+	}
+
+	applied := f.Apply()
+	if applied.Agent != "new-agent" {
+		t.Errorf("expected agent 'new-agent', got %q", applied.Agent)
+	}
+	if applied.ID != "classify" {
+		t.Errorf("ID should be preserved, got %q", applied.ID)
+	}
+}
+
+func TestForm_apply_on_fail(t *testing.T) {
+	step := config.StepConfig{ID: "impl"}
+	f := editor.NewStepForm(step)
+
+	for i, field := range f.Fields {
+		switch field.Key {
+		case "on_fail_goto":
+			f.Fields[i].Value = "impl"
+		case "on_fail_retries":
+			f.Fields[i].Value = "3"
+		}
+	}
+
+	applied := f.Apply()
+	if applied.OnFail == nil {
+		t.Fatal("OnFail should be set")
+	}
+	if applied.OnFail.Goto != "impl" {
+		t.Errorf("on_fail.goto = %q, want 'impl'", applied.OnFail.Goto)
+	}
+	if applied.OnFail.MaxRetries != 3 {
+		t.Errorf("on_fail.max_retries = %d, want 3", applied.OnFail.MaxRetries)
+	}
+}
+
+func TestForm_apply_trigger(t *testing.T) {
+	f := editor.NewTriggerForm(nil)
+
+	for i, field := range f.Fields {
+		switch field.Key {
+		case "source":
+			f.Fields[i].Value = "github"
+		case "labels":
+			f.Fields[i].Value = "ai-ready,enhancement"
+		case "priority":
+			f.Fields[i].Value = "5"
+		}
+	}
+
+	trig := &config.TriggerConfig{}
+	out := f.ApplyTrigger(trig)
+	if out.Match.Source != "github" {
+		t.Errorf("source = %q, want 'github'", out.Match.Source)
+	}
+	if len(out.Match.Labels) != 2 {
+		t.Errorf("labels = %v, want 2 items", out.Match.Labels)
+	}
+	if out.Priority != 5 {
+		t.Errorf("priority = %d, want 5", out.Priority)
+	}
+}

--- a/src/internal/editor/form.go
+++ b/src/internal/editor/form.go
@@ -1,0 +1,453 @@
+package editor
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// Field is one editable field in the step form.
+type Field struct {
+	Label   string
+	Key     string // internal key for mapping back to the struct
+	Value   string // current string value
+	Help    string // shown below the field
+	ReadOnly bool
+}
+
+// Form holds the state for inline step editing.
+type Form struct {
+	Step      config.StepConfig
+	Fields    []Field
+	ActiveIdx int // currently focused field
+	Dirty     bool
+}
+
+// NewStepForm creates a form pre-populated from the given step.
+func NewStepForm(step config.StepConfig) *Form {
+	fields := buildFields(step)
+	return &Form{
+		Step:   step,
+		Fields: fields,
+	}
+}
+
+// NewTriggerForm creates a form for the trigger block.
+// It returns nil when the trigger is nil (subworkflow — no trigger to edit).
+func NewTriggerForm(t *config.TriggerConfig) *Form {
+	if t == nil {
+		t = &config.TriggerConfig{}
+	}
+	fields := []Field{
+		{Label: "Source", Key: "source", Value: t.Match.Source, Help: "source ID (e.g. github)"},
+		{Label: "Labels (csv)", Key: "labels", Value: strings.Join(t.Match.Labels, ","), Help: "comma-separated trigger labels"},
+		{Label: "Priority", Key: "priority", Value: fmt.Sprintf("%d", t.Priority), Help: "numeric priority (higher = preferred)"},
+		{Label: "Exclusive", Key: "exclusive", Value: boolStr(t.Exclusive), Help: "true|false — stop after this trigger matches"},
+		{Label: "Once", Key: "once", Value: boolStr(t.Once), Help: "true|false — run at most once per task"},
+	}
+	return &Form{Fields: fields}
+}
+
+// Apply copies the edited field values back into the form's Step.
+// Returns the updated StepConfig.
+func (f *Form) Apply() config.StepConfig {
+	s := f.Step
+	for _, field := range f.Fields {
+		if field.ReadOnly {
+			continue
+		}
+		applyField(&s, field.Key, field.Value)
+	}
+	return s
+}
+
+// ApplyTrigger copies edited field values back into a TriggerConfig.
+func (f *Form) ApplyTrigger(t *config.TriggerConfig) *config.TriggerConfig {
+	if t == nil {
+		t = &config.TriggerConfig{}
+	}
+	for _, field := range f.Fields {
+		switch field.Key {
+		case "source":
+			t.Match.Source = field.Value
+		case "labels":
+			if field.Value == "" {
+				t.Match.Labels = nil
+			} else {
+				t.Match.Labels = strings.Split(field.Value, ",")
+				for i := range t.Match.Labels {
+					t.Match.Labels[i] = strings.TrimSpace(t.Match.Labels[i])
+				}
+			}
+		case "priority":
+			t.Priority, _ = strconv.Atoi(field.Value)
+		case "exclusive":
+			t.Exclusive = parseBool(field.Value)
+		case "once":
+			t.Once = parseBool(field.Value)
+		}
+	}
+	return t
+}
+
+// HandleRune appends a rune to the active field's value.
+func (f *Form) HandleRune(r rune) {
+	if f.ActiveIdx >= len(f.Fields) {
+		return
+	}
+	if f.Fields[f.ActiveIdx].ReadOnly {
+		return
+	}
+	f.Fields[f.ActiveIdx].Value += string(r)
+	f.Dirty = true
+}
+
+// HandleBackspace deletes the last character of the active field.
+func (f *Form) HandleBackspace() {
+	if f.ActiveIdx >= len(f.Fields) {
+		return
+	}
+	if f.Fields[f.ActiveIdx].ReadOnly {
+		return
+	}
+	v := []rune(f.Fields[f.ActiveIdx].Value)
+	if len(v) > 0 {
+		f.Fields[f.ActiveIdx].Value = string(v[:len(v)-1])
+		f.Dirty = true
+	}
+}
+
+// NextField moves focus to the next field (wraps).
+func (f *Form) NextField() {
+	f.ActiveIdx = (f.ActiveIdx + 1) % len(f.Fields)
+}
+
+// PrevField moves focus to the previous field (wraps).
+func (f *Form) PrevField() {
+	f.ActiveIdx = (f.ActiveIdx - 1 + len(f.Fields)) % len(f.Fields)
+}
+
+// Render returns the form as a terminal string.
+func (f *Form) Render(width int) string {
+	var sb strings.Builder
+	sb.WriteString(styleTitle.Render("Edit Step") + "\n")
+	sb.WriteString(styleMuted.Render(strings.Repeat("─", width-2)) + "\n")
+
+	for i, field := range f.Fields {
+		active := i == f.ActiveIdx
+		labelStyle := styleMuted
+		if active {
+			labelStyle = styleFocused
+		}
+
+		label := labelStyle.Render(padStr(field.Label+":", 18))
+		var valueStr string
+		if field.ReadOnly {
+			valueStr = styleMuted.Render(field.Value)
+		} else if active {
+			valueStr = styleSelected.Render(field.Value + "█")
+		} else {
+			valueStr = styleText.Render(field.Value)
+		}
+
+		sb.WriteString("  " + label + " " + valueStr + "\n")
+		if active && field.Help != "" {
+			sb.WriteString("                    " + styleMuted.Render(field.Help) + "\n")
+		}
+	}
+
+	sb.WriteString("\n")
+	help := styleFooterKey.Render(" Tab ") + styleFooterLbl.Render(" next field  ") +
+		styleFooterKey.Render(" Enter ") + styleFooterLbl.Render(" apply  ") +
+		styleFooterKey.Render(" Esc ") + styleFooterLbl.Render(" cancel")
+	sb.WriteString(help + "\n")
+
+	return sb.String()
+}
+
+// buildFields returns the editable fields for a step based on its type.
+func buildFields(s config.StepConfig) []Field {
+	base := []Field{
+		{Label: "ID", Key: "id", Value: s.ID, Help: "unique step identifier"},
+		{Label: "Name", Key: "name", Value: s.Name, Help: "human-readable label (optional)"},
+		{Label: "Type", Key: "type", Value: s.Type, Help: "agent|split|approval|foreach|workflow|wait_for|parallel"},
+	}
+
+	typ := s.StepType()
+
+	switch typ {
+	case config.StepTypeAgent, "":
+		base = append(base,
+			Field{Label: "Agent", Key: "agent", Value: s.Agent, Help: "agent ID from config"},
+			Field{Label: "Model", Key: "model", Value: s.Model, Help: "override agent's model (optional)"},
+			Field{Label: "Prompt", Key: "prompt", Value: s.Prompt, Help: "instructions for the agent"},
+			Field{Label: "If (condition)", Key: "if", Value: cond(s), Help: "skip when false (expression)"},
+			Field{Label: "on_pass.next", Key: "on_pass_next", Value: onPassNext(s), Help: "step to run on success (default: next)"},
+			Field{Label: "on_fail.goto", Key: "on_fail_goto", Value: onFailGoto(s), Help: "step to retry on failure"},
+			Field{Label: "on_fail.retries", Key: "on_fail_retries", Value: onFailRetries(s), Help: "max retry count"},
+			Field{Label: "Idempotent", Key: "idempotent", Value: boolStr(s.Idempotent), Help: "true|false"},
+			Field{Label: "Action class", Key: "action_class", Value: s.ActionClass, Help: "push|deploy|destructive|publication"},
+		)
+
+	case config.StepTypeApproval:
+		base = append(base,
+			Field{Label: "Message", Key: "message", Value: s.Message, Help: "message shown to approvers"},
+			Field{Label: "Timeout", Key: "timeout", Value: s.Timeout, Help: "e.g. 24h"},
+			Field{Label: "Approvers (csv)", Key: "approvers", Value: strings.Join(s.Approvers, ","), Help: "github usernames"},
+			Field{Label: "resume_on.label", Key: "resume_label", Value: resumeLabel(s), Help: "label that resumes the workflow"},
+			Field{Label: "abort_on.label", Key: "abort_label", Value: abortLabel(s), Help: "label that aborts the workflow"},
+		)
+
+	case config.StepTypeSplit:
+		// Branches are complex nested structures — show read-only with an explanation.
+		base = append(base,
+			Field{Label: "Multi", Key: "multi", Value: boolStr(s.Multi), Help: "true = all matching branches run"},
+			Field{
+				Label:    "Branches",
+				Key:      "branches",
+				Value:    formatBranchesInline(s.Branches),
+				Help:     "edit YAML directly to modify branches",
+				ReadOnly: true,
+			},
+		)
+
+	case config.StepTypeForeach:
+		base = append(base,
+			Field{Label: "Items", Key: "items", Value: s.Items, Help: "expression yielding the list"},
+			Field{Label: "As", Key: "as", Value: s.As, Help: "loop variable name"},
+			Field{Label: "Concurrency", Key: "concurrency", Value: intStr(s.Concurrency), Help: "max parallel iterations (0 = sequential)"},
+			Field{Label: "Max items", Key: "max_items", Value: intStr(s.MaxItems), Help: "0 = unlimited"},
+			Field{Label: "Fail fast", Key: "fail_fast", Value: boolStr(s.FailFast), Help: "true|false"},
+		)
+
+	case config.StepTypeWorkflow:
+		ref := s.Workflow
+		if ref == "" {
+			ref = s.Uses
+		}
+		base = append(base,
+			Field{Label: "Workflow / Uses", Key: "workflow_ref", Value: ref, Help: "workflow ID or relative file path"},
+		)
+
+	case config.StepTypeWaitFor:
+		kind := ""
+		interval := ""
+		maxDur := ""
+		if s.WaitFor != nil {
+			kind = s.WaitFor.Kind
+			interval = s.WaitFor.CheckInterval
+			maxDur = s.WaitFor.MaxDuration
+		}
+		base = append(base,
+			Field{Label: "Kind", Key: "wait_kind", Value: kind, Help: "ci | dependency"},
+			Field{Label: "Check interval", Key: "wait_interval", Value: interval, Help: "e.g. 1m"},
+			Field{Label: "Max duration", Key: "wait_max_dur", Value: maxDur, Help: "e.g. 2h"},
+		)
+	}
+
+	return base
+}
+
+// applyField writes one field value back into the StepConfig.
+func applyField(s *config.StepConfig, key, value string) {
+	switch key {
+	case "id":
+		s.ID = value
+	case "name":
+		s.Name = value
+	case "type":
+		if value == config.StepTypeAgent {
+			s.Type = ""
+		} else {
+			s.Type = value
+		}
+	case "agent":
+		s.Agent = value
+	case "model":
+		s.Model = value
+	case "prompt":
+		s.Prompt = value
+	case "if":
+		// v2 authored "if:" field
+		s.If = value
+		s.Condition = "" // clear lowered form
+	case "on_pass_next":
+		if value == "" {
+			s.OnPass = nil
+		} else {
+			s.OnPass = &config.StepNext{Next: value}
+		}
+	case "on_fail_goto":
+		if s.OnFail == nil {
+			s.OnFail = &config.StepOutcome{}
+		}
+		s.OnFail.Goto = value
+		if s.OnFail.Goto == "" && s.OnFail.MaxRetries == 0 {
+			s.OnFail = nil
+		}
+	case "on_fail_retries":
+		n, _ := strconv.Atoi(value)
+		if s.OnFail == nil {
+			s.OnFail = &config.StepOutcome{}
+		}
+		s.OnFail.MaxRetries = n
+		if s.OnFail.Goto == "" && n == 0 {
+			s.OnFail = nil
+		}
+	case "idempotent":
+		s.Idempotent = parseBool(value)
+	case "action_class":
+		s.ActionClass = value
+	case "message":
+		s.Message = value
+	case "timeout":
+		s.Timeout = value
+	case "approvers":
+		if value == "" {
+			s.Approvers = nil
+		} else {
+			parts := strings.Split(value, ",")
+			s.Approvers = make([]string, 0, len(parts))
+			for _, p := range parts {
+				if t := strings.TrimSpace(p); t != "" {
+					s.Approvers = append(s.Approvers, t)
+				}
+			}
+		}
+	case "resume_label":
+		if value == "" {
+			if s.ResumeOn != nil && s.ResumeOn.CommentContains == "" && s.ResumeOn.StateChanged == "" {
+				s.ResumeOn = nil
+			}
+		} else {
+			if s.ResumeOn == nil {
+				s.ResumeOn = &config.ApprovalTrigger{}
+			}
+			s.ResumeOn.LabelAdded = value
+		}
+	case "abort_label":
+		if value == "" {
+			if s.AbortOn != nil && s.AbortOn.CommentContains == "" && s.AbortOn.StateChanged == "" {
+				s.AbortOn = nil
+			}
+		} else {
+			if s.AbortOn == nil {
+				s.AbortOn = &config.ApprovalTrigger{}
+			}
+			s.AbortOn.LabelAdded = value
+		}
+	case "multi":
+		s.Multi = parseBool(value)
+	case "items":
+		s.Items = value
+	case "as":
+		s.As = value
+	case "concurrency":
+		s.Concurrency, _ = strconv.Atoi(value)
+	case "max_items":
+		s.MaxItems, _ = strconv.Atoi(value)
+	case "fail_fast":
+		s.FailFast = parseBool(value)
+	case "workflow_ref":
+		// Decide whether this is an inline workflow ID or a file path.
+		if strings.Contains(value, "/") || strings.HasSuffix(value, ".yaml") || strings.HasSuffix(value, ".yml") {
+			s.Uses = value
+			s.Workflow = ""
+		} else {
+			s.Workflow = value
+			s.Uses = ""
+		}
+	case "wait_kind":
+		if s.WaitFor == nil {
+			s.WaitFor = &config.WaitForConfig{}
+		}
+		s.WaitFor.Kind = value
+	case "wait_interval":
+		if s.WaitFor == nil {
+			s.WaitFor = &config.WaitForConfig{}
+		}
+		s.WaitFor.CheckInterval = value
+	case "wait_max_dur":
+		if s.WaitFor == nil {
+			s.WaitFor = &config.WaitForConfig{}
+		}
+		s.WaitFor.MaxDuration = value
+	}
+}
+
+// helpers
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return ""
+}
+
+func parseBool(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return s == "true" || s == "yes" || s == "1"
+}
+
+func intStr(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return strconv.Itoa(n)
+}
+
+func cond(s config.StepConfig) string {
+	if s.If != "" {
+		return s.If
+	}
+	return s.Condition
+}
+
+func onPassNext(s config.StepConfig) string {
+	if s.OnPass != nil {
+		return s.OnPass.Next
+	}
+	return ""
+}
+
+func onFailGoto(s config.StepConfig) string {
+	if s.OnFail != nil {
+		return s.OnFail.Goto
+	}
+	return ""
+}
+
+func onFailRetries(s config.StepConfig) string {
+	if s.OnFail != nil && s.OnFail.MaxRetries > 0 {
+		return strconv.Itoa(s.OnFail.MaxRetries)
+	}
+	return ""
+}
+
+func resumeLabel(s config.StepConfig) string {
+	if s.ResumeOn != nil {
+		return s.ResumeOn.LabelAdded
+	}
+	return ""
+}
+
+func abortLabel(s config.StepConfig) string {
+	if s.AbortOn != nil {
+		return s.AbortOn.LabelAdded
+	}
+	return ""
+}
+
+func formatBranchesInline(branches []config.SplitBranch) string {
+	parts := make([]string, 0, len(branches))
+	for _, b := range branches {
+		cond := b.If
+		if b.Else || cond == "" {
+			cond = "else"
+		}
+		parts = append(parts, fmt.Sprintf("%s→%s", cond, b.Goto))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/src/internal/editor/graph.go
+++ b/src/internal/editor/graph.go
@@ -1,0 +1,468 @@
+package editor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// palette — same values as dashboard/styles.go so the editor feels consistent
+var (
+	colAccent  = lipgloss.Color("117")
+	colMuted   = lipgloss.Color("244")
+	colInfo    = lipgloss.Color("39")
+	colWarning = lipgloss.Color("220")
+	colError   = lipgloss.Color("203")
+	colSuccess = lipgloss.Color("42")
+	colFocused = lipgloss.Color("213")
+	colSelBg   = lipgloss.Color("24")
+	colText    = lipgloss.Color("252")
+	colBorder  = lipgloss.Color("60")
+	colTitle   = lipgloss.Color("81")
+
+	styleAccent     = lipgloss.NewStyle().Foreground(colAccent)
+	styleMuted      = lipgloss.NewStyle().Foreground(colMuted)
+	styleInfo       = lipgloss.NewStyle().Foreground(colInfo)
+	styleWarning    = lipgloss.NewStyle().Foreground(colWarning)
+	styleError      = lipgloss.NewStyle().Foreground(colError)
+	styleSuccess    = lipgloss.NewStyle().Foreground(colSuccess)
+	styleFocused    = lipgloss.NewStyle().Foreground(colFocused)
+	styleSelected   = lipgloss.NewStyle().Background(colSelBg).Foreground(lipgloss.Color("231"))
+	styleText       = lipgloss.NewStyle().Foreground(colText)
+	styleBold       = lipgloss.NewStyle().Bold(true).Foreground(colText)
+	styleBorder     = lipgloss.NewStyle().Foreground(colBorder)
+	styleTitle      = lipgloss.NewStyle().Bold(true).Foreground(colTitle)
+	styleFooterKey  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("231")).Background(lipgloss.Color("57"))
+	styleFooterLbl  = lipgloss.NewStyle().Foreground(colText)
+	styleFooterDim  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+)
+
+// RenderGraph renders the left-panel step list with ASCII graph connectors.
+// width is the panel width in terminal columns.
+// selectedIdx is the index of the currently selected step (-1 for trigger).
+func RenderGraph(wf config.WorkflowConfig, selectedIdx int, readOnlySteps map[int]bool, width int) string {
+	var sb strings.Builder
+
+	// Trigger node
+	trig := formatTrigger(wf.Trigger, width)
+	if selectedIdx == -1 {
+		trig = styleSelected.Render(fitStr(trig, width))
+	}
+	sb.WriteString(trig + "\n")
+
+	if len(wf.Steps) == 0 {
+		sb.WriteString(styleMuted.Render("  (no steps)") + "\n")
+		return sb.String()
+	}
+
+	// Build a step-ID → index map for connection rendering
+	idxByID := make(map[string]int, len(wf.Steps))
+	for i, s := range wf.Steps {
+		idxByID[s.ID] = i
+	}
+
+	for i, step := range wf.Steps {
+		// Connector from trigger or previous step
+		conn := styleBorder.Render("       │")
+		sb.WriteString(conn + "\n")
+
+		// Step node
+		selected := i == selectedIdx
+		ro := readOnlySteps[i]
+		line := formatStep(step, selected, ro, width)
+		sb.WriteString(line + "\n")
+
+		// Back-edge annotation for on_fail.goto loops
+		if step.OnFail != nil && step.OnFail.Goto != "" {
+			arrow := fmt.Sprintf("       ↺ on_fail → %s", step.OnFail.Goto)
+			if step.OnFail.MaxRetries > 0 {
+				arrow += fmt.Sprintf(" (max %d)", step.OnFail.MaxRetries)
+			}
+			sb.WriteString(styleMuted.Render(fitStr(arrow, width)) + "\n")
+		}
+
+		// on_pass.next annotation when it differs from sequential order
+		if step.OnPass != nil && step.OnPass.Next != "" {
+			next := step.OnPass.Next
+			// Only annotate when it's non-sequential
+			sequential := ""
+			if i+1 < len(wf.Steps) {
+				sequential = wf.Steps[i+1].ID
+			}
+			if next != sequential {
+				arrow := fmt.Sprintf("       → on_pass → %s", next)
+				sb.WriteString(styleAccent.Render(fitStr(arrow, width)) + "\n")
+			}
+		}
+
+		// Split branches
+		if step.StepType() == config.StepTypeSplit {
+			for _, br := range step.Branches {
+				label := br.Goto
+				cond := br.If
+				if br.Else || cond == "" {
+					cond = "else"
+				}
+				brLine := fmt.Sprintf("         ├─ if %s → %s", cond, label)
+				sb.WriteString(styleMuted.Render(fitStr(brLine, width)) + "\n")
+			}
+		}
+	}
+
+	// End marker
+	sb.WriteString(styleBorder.Render("       │") + "\n")
+	sb.WriteString(styleMuted.Render("     [end]") + "\n")
+
+	return sb.String()
+}
+
+func formatTrigger(t *config.TriggerConfig, width int) string {
+	if t == nil {
+		return styleMuted.Render(fitStr("  [no trigger — subworkflow or manual]", width))
+	}
+	parts := []string{"src:" + t.Match.Source}
+	if len(t.Match.Labels) > 0 {
+		parts = append(parts, "labels:"+strings.Join(t.Match.Labels, ","))
+	}
+	if t.Priority > 0 {
+		parts = append(parts, fmt.Sprintf("prio:%d", t.Priority))
+	}
+	inner := strings.Join(parts, " ")
+	line := fmt.Sprintf("  [trigger] %s", inner)
+	return styleInfo.Render(fitStr(line, width))
+}
+
+func formatStep(s config.StepConfig, selected, readOnly bool, width int) string {
+	typeBadge := stepTypeBadge(s.StepType())
+	roMark := ""
+	if readOnly {
+		roMark = " " + styleMuted.Render("[ro]")
+	}
+
+	agentPart := ""
+	switch s.StepType() {
+	case config.StepTypeAgent, "":
+		if s.Agent != "" {
+			agentPart = " → " + s.Agent
+		}
+	case config.StepTypeWorkflow:
+		ref := s.Workflow
+		if ref == "" {
+			ref = s.Uses
+		}
+		agentPart = " ⤷ " + ref
+	case config.StepTypeForeach:
+		agentPart = " ∀ " + s.Items
+	}
+
+	condPart := ""
+	if s.Condition != "" {
+		condPart = " if:(" + truncStr(s.Condition, 20) + ")"
+	} else if s.If != "" {
+		condPart = " if:(" + truncStr(s.If, 20) + ")"
+	}
+
+	line := fmt.Sprintf("  %s %s%s%s%s", typeBadge, s.ID, agentPart, condPart, roMark)
+
+	if selected {
+		line = styleFocused.Render("▶") + " " + styleSelected.Render(fitStr(stripAnsi(line[2:]), width-2))
+	} else {
+		line = fitStr(line, width)
+	}
+	return line
+}
+
+func stepTypeBadge(t string) string {
+	switch t {
+	case config.StepTypeAgent, "":
+		return styleInfo.Render("[agent]   ")
+	case config.StepTypeApproval:
+		return styleWarning.Render("[approval]")
+	case config.StepTypeForeach:
+		return styleAccent.Render("[foreach] ")
+	case config.StepTypeParallel:
+		return styleAccent.Render("[parallel]")
+	case config.StepTypeSplit:
+		return styleMuted.Render("[split]   ")
+	case config.StepTypeWorkflow:
+		return styleMuted.Render("[workflow]")
+	case config.StepTypeWaitFor:
+		return styleMuted.Render("[wait_for]")
+	default:
+		return styleMuted.Render("[" + padStr(t, 8) + "]")
+	}
+}
+
+// RenderStepDetail renders the right panel for a selected step (read view).
+func RenderStepDetail(step config.StepConfig, width int) string {
+	var sb strings.Builder
+
+	row := func(label, value string) {
+		lbl := styleAccent.Render(padStr(label+":", 16))
+		sb.WriteString("  " + lbl + " " + value + "\n")
+	}
+
+	sb.WriteString(styleBold.Render(step.ID) + "  " + styleInfo.Render(step.StepType()) + "\n")
+	sb.WriteString(styleMuted.Render(strings.Repeat("─", width-2)) + "\n")
+
+	if step.Name != "" {
+		row("name", step.Name)
+	}
+
+	switch step.StepType() {
+	case config.StepTypeAgent, "":
+		if step.Agent != "" {
+			row("agent", styleAccent.Render(step.Agent))
+		}
+		if step.Model != "" {
+			row("model", step.Model)
+		}
+		if step.Condition != "" {
+			row("condition", truncStr(step.Condition, width-20))
+		}
+		if step.If != "" {
+			row("if (v2)", truncStr(step.If, width-20))
+		}
+		if step.Prompt != "" {
+			sb.WriteString("  " + styleAccent.Render(padStr("prompt:", 16)) + "\n")
+			for _, line := range wrapStr(step.Prompt, width-4) {
+				sb.WriteString("    " + line + "\n")
+			}
+		}
+		if step.OnPass != nil && step.OnPass.Next != "" {
+			row("on_pass.next", styleSuccess.Render(step.OnPass.Next))
+		}
+		if step.OnFail != nil {
+			val := ""
+			if step.OnFail.Goto != "" {
+				val = styleError.Render("→ " + step.OnFail.Goto)
+			}
+			if step.OnFail.MaxRetries > 0 {
+				val += fmt.Sprintf("  (max %d)", step.OnFail.MaxRetries)
+			}
+			if val != "" {
+				row("on_fail", val)
+			}
+		}
+		if step.FailWhen != "" {
+			row("fail_when", truncStr(step.FailWhen, width-20))
+		}
+		if step.Idempotent {
+			row("idempotent", styleSuccess.Render("true"))
+		}
+
+	case config.StepTypeApproval:
+		if step.Message != "" {
+			row("message", truncStr(step.Message, width-20))
+		}
+		if step.Timeout != "" {
+			row("timeout", step.Timeout)
+		}
+		if len(step.Approvers) > 0 {
+			row("approvers", strings.Join(step.Approvers, ", "))
+		}
+		if step.ResumeOn != nil {
+			if step.ResumeOn.CommentContains != "" {
+				row("resume_on.comment", step.ResumeOn.CommentContains)
+			}
+			if step.ResumeOn.LabelAdded != "" {
+				row("resume_on.label", step.ResumeOn.LabelAdded)
+			}
+		}
+		if step.AbortOn != nil {
+			if step.AbortOn.CommentContains != "" {
+				row("abort_on.comment", step.AbortOn.CommentContains)
+			}
+		}
+
+	case config.StepTypeSplit:
+		sb.WriteString("  " + styleAccent.Render("branches:") + "\n")
+		for _, br := range step.Branches {
+			cond := br.If
+			if br.Else || cond == "" {
+				cond = "(else)"
+			}
+			sb.WriteString(fmt.Sprintf("    %-24s → %s\n", styleMuted.Render(cond), styleAccent.Render(br.Goto)))
+		}
+
+	case config.StepTypeForeach:
+		row("items", step.Items)
+		if step.As != "" {
+			row("as", step.As)
+		}
+		if step.Concurrency > 0 {
+			row("concurrency", fmt.Sprintf("%d", step.Concurrency))
+		}
+		if step.MaxItems > 0 {
+			row("max_items", fmt.Sprintf("%d", step.MaxItems))
+		}
+
+	case config.StepTypeWorkflow:
+		ref := step.Workflow
+		if ref == "" {
+			ref = step.Uses
+		}
+		row("workflow/uses", ref)
+		if len(step.With) > 0 {
+			sb.WriteString("  " + styleAccent.Render(padStr("with:", 16)) + "\n")
+			for k, v := range step.With {
+				sb.WriteString(fmt.Sprintf("    %s: %v\n", k, v))
+			}
+		}
+
+	case config.StepTypeWaitFor:
+		if step.WaitFor != nil {
+			row("kind", step.WaitFor.Kind)
+			if step.WaitFor.CheckInterval != "" {
+				row("check_interval", step.WaitFor.CheckInterval)
+			}
+			if step.WaitFor.MaxDuration != "" {
+				row("max_duration", step.WaitFor.MaxDuration)
+			}
+		}
+
+	case config.StepTypeParallel:
+		sb.WriteString("  " + styleAccent.Render("parallel steps:") + "\n")
+		for _, sub := range step.SubSteps {
+			sb.WriteString(fmt.Sprintf("    - %s (%s)\n", sub.ID, sub.StepType()))
+		}
+	}
+
+	if step.Memory != nil {
+		parts := []string{}
+		if step.Memory.Read != nil && !*step.Memory.Read {
+			parts = append(parts, "read:off")
+		}
+		if len(step.Memory.Write) > 0 {
+			parts = append(parts, "write:"+strings.Join(step.Memory.Write, ","))
+		}
+		if len(parts) > 0 {
+			row("memory", strings.Join(parts, " "))
+		}
+	}
+
+	if len(step.Env) > 0 {
+		envKeys := make([]string, 0, len(step.Env))
+		for k := range step.Env {
+			envKeys = append(envKeys, k)
+		}
+		row("env", strings.Join(envKeys, ", "))
+	}
+
+	return sb.String()
+}
+
+// RenderTriggerDetail renders the right panel for the trigger.
+func RenderTriggerDetail(t *config.TriggerConfig, width int) string {
+	if t == nil {
+		return styleMuted.Render("  No trigger defined (subworkflow or manual dispatch).") + "\n"
+	}
+	var sb strings.Builder
+	row := func(label, value string) {
+		lbl := styleAccent.Render(padStr(label+":", 16))
+		sb.WriteString("  " + lbl + " " + value + "\n")
+	}
+	sb.WriteString(styleBold.Render("trigger") + "\n")
+	sb.WriteString(styleMuted.Render(strings.Repeat("─", width-2)) + "\n")
+	if t.Match.Source != "" {
+		row("source", t.Match.Source)
+	}
+	if len(t.Match.Labels) > 0 {
+		row("labels", strings.Join(t.Match.Labels, ", "))
+	}
+	if t.Priority != 0 {
+		row("priority", fmt.Sprintf("%d", t.Priority))
+	}
+	if t.Exclusive {
+		row("exclusive", styleWarning.Render("true"))
+	}
+	if t.Once {
+		row("once", styleSuccess.Render("true"))
+	}
+	return sb.String()
+}
+
+// helper functions ---------------------------------------------------------
+
+func fitStr(s string, width int) string {
+	visible := visibleLen(s)
+	if width <= 0 {
+		return s
+	}
+	if visible <= width {
+		return s + strings.Repeat(" ", width-visible)
+	}
+	// truncate without stripping ANSI (caller strips when needed)
+	runes := []rune(s)
+	if len(runes) > width {
+		return string(runes[:width-1]) + "…"
+	}
+	return s
+}
+
+func padStr(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+func truncStr(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+func wrapStr(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+	words := strings.Fields(s)
+	var lines []string
+	var cur strings.Builder
+	for _, w := range words {
+		if cur.Len() > 0 && cur.Len()+1+len(w) > width {
+			lines = append(lines, cur.String())
+			cur.Reset()
+		}
+		if cur.Len() > 0 {
+			cur.WriteByte(' ')
+		}
+		cur.WriteString(w)
+	}
+	if cur.Len() > 0 {
+		lines = append(lines, cur.String())
+	}
+	return lines
+}
+
+// visibleLen returns the number of visible (non-ANSI) characters.
+func visibleLen(s string) int {
+	return len([]rune(stripAnsi(s)))
+}
+
+// stripAnsi removes ANSI escape sequences from s.
+func stripAnsi(s string) string {
+	var b strings.Builder
+	inEscape := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inEscape {
+			if c == 'm' {
+				inEscape = false
+			}
+			continue
+		}
+		if c == '\033' && i+1 < len(s) && s[i+1] == '[' {
+			inEscape = true
+			i++ // skip '['
+			continue
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}

--- a/src/internal/editor/serializer.go
+++ b/src/internal/editor/serializer.go
@@ -1,0 +1,177 @@
+package editor
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// WorkflowToYAML marshals a single WorkflowConfig to a YAML string.
+// The output starts with "id: ..." (no leading "- ") — suitable for display
+// in the YAML preview pane or as input to ReplaceWorkflowInRaw.
+func WorkflowToYAML(wf config.WorkflowConfig) (string, error) {
+	data, err := yaml.Marshal(wf)
+	if err != nil {
+		return "", fmt.Errorf("marshalling workflow: %w", err)
+	}
+	return string(data), nil
+}
+
+// ReplaceWorkflowInRaw finds the workflow block identified by workflowID in
+// rawYAML and replaces it with the marshaled representation of wf. All other
+// content in rawYAML (other workflows, other config sections, comments outside
+// the replaced block) is preserved byte-for-byte.
+//
+// If the workflow block is not found, an error is returned — the caller should
+// fall back to a full yaml.Marshal of the entire Config.
+func ReplaceWorkflowInRaw(rawYAML, workflowID string, wf config.WorkflowConfig) (string, error) {
+	newBlock, err := WorkflowToYAML(wf)
+	if err != nil {
+		return "", err
+	}
+
+	lines := strings.Split(rawYAML, "\n")
+
+	// Find the start line: "  - id: <workflowID>" (2-space indent, list item).
+	startLine := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "- id: "+workflowID {
+			startLine = i
+			break
+		}
+	}
+	if startLine < 0 {
+		return "", fmt.Errorf("workflow %q not found in raw YAML", workflowID)
+	}
+
+	// Determine the indent of the list item (the "- " prefix).
+	itemIndent := leadingSpaces(lines[startLine])
+
+	// Find the end line: the next line at the same or lower indent level that
+	// starts a new list item ("- "), or end of file.
+	endLine := len(lines)
+	for i := startLine + 1; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := leadingSpaces(line)
+		trimmed := strings.TrimSpace(line)
+		if indent <= itemIndent && strings.HasPrefix(trimmed, "- ") {
+			endLine = i
+			break
+		}
+		// Also stop at a section boundary (a non-indented key).
+		if indent < itemIndent && !strings.HasPrefix(trimmed, "#") {
+			endLine = i
+			break
+		}
+	}
+
+	// Build the replacement block: indent the marshaled YAML to match the
+	// original list item indentation.
+	prefix := strings.Repeat(" ", itemIndent)
+	replacement := indentWorkflowBlock(newBlock, prefix)
+
+	// Splice: lines[:startLine] + replacement + lines[endLine:]
+	var out strings.Builder
+	for _, l := range lines[:startLine] {
+		out.WriteString(l + "\n")
+	}
+	out.WriteString(replacement)
+	// replacement already ends with "\n"; don't double it.
+	for i, l := range lines[endLine:] {
+		if i > 0 || strings.TrimSpace(l) != "" {
+			out.WriteString(l + "\n")
+		} else {
+			out.WriteString(l + "\n")
+		}
+	}
+
+	result := out.String()
+	// Trim trailing newlines beyond one.
+	result = strings.TrimRight(result, "\n") + "\n"
+	return result, nil
+}
+
+// indentWorkflowBlock takes a marshaled WorkflowConfig YAML (lines starting
+// at "id: ...") and formats it as a YAML list item with the given indentation.
+//
+// Input:
+//
+//	id: my-workflow
+//	steps:
+//	  - id: step1
+//
+// Output (prefix = "  "):
+//
+//	  - id: my-workflow
+//	    steps:
+//	      - id: step1
+func indentWorkflowBlock(yamlBlock, prefix string) string {
+	lines := strings.Split(strings.TrimRight(yamlBlock, "\n"), "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, line := range lines {
+		if i == 0 {
+			// First line: "- " marker
+			sb.WriteString(prefix + "- " + line + "\n")
+		} else {
+			if strings.TrimSpace(line) == "" {
+				sb.WriteString("\n")
+			} else {
+				// Continuation: additional 2 spaces to align with the "- " marker
+				sb.WriteString(prefix + "  " + line + "\n")
+			}
+		}
+	}
+	return sb.String()
+}
+
+// ExtractWorkflowBlock returns the raw YAML text for the workflow block with
+// the given ID. Useful for computing the diff between original and edited.
+func ExtractWorkflowBlock(rawYAML, workflowID string) string {
+	lines := strings.Split(rawYAML, "\n")
+
+	startLine := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "- id: "+workflowID {
+			startLine = i
+			break
+		}
+	}
+	if startLine < 0 {
+		return ""
+	}
+
+	itemIndent := leadingSpaces(lines[startLine])
+	endLine := len(lines)
+	for i := startLine + 1; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := leadingSpaces(line)
+		trimmed := strings.TrimSpace(line)
+		if indent <= itemIndent && strings.HasPrefix(trimmed, "- ") {
+			endLine = i
+			break
+		}
+		if indent < itemIndent && !strings.HasPrefix(trimmed, "#") {
+			endLine = i
+			break
+		}
+	}
+
+	return strings.Join(lines[startLine:endLine], "\n")
+}
+
+func leadingSpaces(s string) int {
+	return len(s) - len(strings.TrimLeft(s, " \t"))
+}


### PR DESCRIPTION
## Summary

- Adds `apiary edit [file] [--workflow <id>]` — a Bubble Tea TUI workflow editor backed by the existing YAML config
- Three-pane layout: ASCII graph navigator (left) + step detail / inline form (right) + YAML preview / diff (full-screen toggles)
- Schema-driven inline forms for every step type: `agent`, `split`, `approval`, `foreach`, `workflow/uses`, `wait_for`, `parallel`, plus the trigger block
- Semantic diff shown before every save — user reviews changes and confirms with Y/N
- Round-trip save: only the edited workflow block is replaced in the raw YAML; all other content (comments, other workflows, agents, sources) is preserved byte-for-byte
- Unsupported YAML constructs (anchors `&`, aliases `*`) are detected at load time and presented read-only — never silently discarded
- Inline validation via `v` key reuses `config.Config.Validate()` and attaches errors to the relevant step node
- 12 unit tests covering serializer round-trips, diff algorithm, unsupported detection, and form field application

## New package: `internal/editor`

| File | Responsibility |
|---|---|
| `editor.go` | Bubble Tea model: graph / yaml / diff / form view modes, key handling, save flow |
| `graph.go` | ASCII graph renderer + step detail / trigger detail panels |
| `form.go` | Per-step-type field builder + apply-back logic |
| `diff.go` | LCS-based line diff + ANSI-coloured render |
| `detect.go` | YAML anchor / alias scanner |
| `serializer.go` | `WorkflowToYAML`, `ReplaceWorkflowInRaw`, `ExtractWorkflowBlock` |

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — compiles without errors
- [x] `TestWorkflowToYAML_roundtrip` — marshal/unmarshal preserves fields
- [x] `TestReplaceWorkflowInRaw_replaces_and_preserves` — multi-workflow file: only target block replaced
- [x] `TestReplaceWorkflowInRaw_single_workflow` — single-workflow file: added step survives
- [x] `TestExtractWorkflowBlock` — block extraction stops at the next sibling
- [x] `TestComputeDiff_*` — LCS diff: no-change, addition, removal cases
- [x] `TestDetectUnsupported_clean` — no false-positive anchors in clean output
- [x] `TestForm_apply_agent_step` / `TestForm_apply_on_fail` / `TestForm_apply_trigger` — field apply-back

Closes #215