### PR TITLE
security: enforce collaborator gate at daemon ingest time (rework #242)

### DIFF
--- a/src/internal/daemon/author_gate_test.go
+++ b/src/internal/daemon/author_gate_test.go
@@ -1,0 +1,116 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// gateSource is a minimal source.Adapter that also implements source.AuthorGate,
+// controlled by test-supplied callbacks.
+type gateSource struct {
+	trusted  bool
+	trustErr error
+	parked   []model.SourceItem
+	parkErr  error
+}
+
+func (g *gateSource) ID() string                                    { return "gate" }
+func (g *gateSource) Connect(context.Context, map[string]any) error { return nil }
+func (g *gateSource) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (g *gateSource) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (g *gateSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (g *gateSource) WebhookHandler() http.Handler { return nil }
+
+func (g *gateSource) IsAuthorTrusted(_ context.Context, _ model.SourceItem) (bool, error) {
+	return g.trusted, g.trustErr
+}
+func (g *gateSource) ParkUntrusted(_ context.Context, item model.SourceItem) error {
+	g.parked = append(g.parked, item)
+	return g.parkErr
+}
+
+// Ensure gateSource satisfies the interface at compile time.
+var _ source.AuthorGate = (*gateSource)(nil)
+
+// TestCheckAndParkUntrusted_TrustedAuthor verifies that a trusted author passes
+// through: checkAndParkUntrusted returns false and nothing is parked.
+func TestCheckAndParkUntrusted_TrustedAuthor(t *testing.T) {
+	g := &gateSource{trusted: true}
+	d := &Dispatcher{}
+	cell := model.SourceItem{ID: "1", Title: "safe issue"}
+
+	if skip := d.checkAndParkUntrusted(context.Background(), cell, g); skip {
+		t.Error("want skip=false for trusted author, got true")
+	}
+	if len(g.parked) != 0 {
+		t.Errorf("want no parked items, got %d", len(g.parked))
+	}
+}
+
+// TestCheckAndParkUntrusted_UntrustedAuthor verifies that an untrusted author
+// causes the item to be parked and checkAndParkUntrusted returns true.
+func TestCheckAndParkUntrusted_UntrustedAuthor(t *testing.T) {
+	g := &gateSource{trusted: false}
+	d := &Dispatcher{}
+	cell := model.SourceItem{ID: "7", Title: "untrusted issue"}
+
+	if skip := d.checkAndParkUntrusted(context.Background(), cell, g); !skip {
+		t.Error("want skip=true for untrusted author, got false")
+	}
+	if len(g.parked) != 1 || g.parked[0].ID != "7" {
+		t.Errorf("want item 7 parked, got %v", g.parked)
+	}
+}
+
+// TestCheckAndParkUntrusted_TrustCheckError verifies fail-open: when the trust
+// check returns an error, the item is NOT parked and skip=false so dispatch
+// proceeds rather than blocking legitimate work.
+func TestCheckAndParkUntrusted_TrustCheckError(t *testing.T) {
+	g := &gateSource{trusted: false, trustErr: errors.New("API timeout")}
+	d := &Dispatcher{}
+	cell := model.SourceItem{ID: "3", Title: "flaky check"}
+
+	if skip := d.checkAndParkUntrusted(context.Background(), cell, g); skip {
+		t.Error("want skip=false on trust-check error (fail-open), got true")
+	}
+	if len(g.parked) != 0 {
+		t.Errorf("want no parked items on trust-check error, got %d", len(g.parked))
+	}
+}
+
+// TestCheckAndParkUntrusted_NoGateInterface verifies that an adapter without
+// the AuthorGate interface is a no-op: checkAndParkUntrusted returns false.
+func TestCheckAndParkUntrusted_NoGateInterface(t *testing.T) {
+	bare := &fakeBareSource{}
+	d := &Dispatcher{}
+	cell := model.SourceItem{ID: "5"}
+
+	if skip := d.checkAndParkUntrusted(context.Background(), cell, bare); skip {
+		t.Error("want skip=false when adapter has no AuthorGate interface, got true")
+	}
+}
+
+// TestCheckAndParkUntrusted_ParkErrorDoesNotPreventSkip verifies that even
+// when ParkUntrusted returns an error, the item is still skipped (we don't
+// want to dispatch an untrusted item just because the label update failed).
+func TestCheckAndParkUntrusted_ParkErrorDoesNotPreventSkip(t *testing.T) {
+	g := &gateSource{trusted: false, parkErr: errors.New("label API down")}
+	d := &Dispatcher{}
+	cell := model.SourceItem{ID: "9", Title: "park fails"}
+
+	if skip := d.checkAndParkUntrusted(context.Background(), cell, g); !skip {
+		t.Error("want skip=true even when ParkUntrusted errors, got false")
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -755,6 +755,11 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 			if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
 				continue
 			}
+			// Author trust gate: same check as in poll(). See checkAndParkUntrusted.
+			if d.checkAndParkUntrusted(ctx, cell, adapter) {
+				d.inFlight.Delete(cell.ID)
+				continue
+			}
 			task, persisted := d.bindItem(ctx, cell)
 			d.recordRouteEvents(ctx, task)
 			matches := d.router.RouteAll(task)
@@ -1366,6 +1371,15 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			aplog.Debug("cell %s: already in-flight, skipping", cell.LogLabel())
 			continue
 		}
+		// Author trust gate: if the source enforces require_collaborator and the
+		// item's author is not a trusted collaborator, park the item (remove
+		// trigger labels, add needs-triage) and skip dispatch. This check happens
+		// before bindItem so untrusted items are never persisted as tasks.
+		// The check is synchronous at poll time — no TOCTOU window exists.
+		if d.checkAndParkUntrusted(ctx, cell, adapter) {
+			d.inFlight.Delete(cell.ID)
+			continue
+		}
 		task, persisted := d.bindItem(ctx, cell)
 		d.recordRouteEvents(ctx, task)
 		matches := d.router.RouteAll(task)
@@ -1666,6 +1680,31 @@ func (d *Dispatcher) parkCappedTask(ctx context.Context, task model.InternalTask
 	if err := (&wfSideEffects{d: d}).ApplyHook(ctx, task, bindings, *onFail); err != nil {
 		aplog.Error("park capped task %s: apply on_fail: %v", task.ID, err)
 	}
+}
+
+// checkAndParkUntrusted applies the per-source author trust gate if the adapter
+// implements source.AuthorGate. Returns true when the item must be skipped
+// (author not trusted, item parked). Errors from the trust check are logged and
+// cause a fail-open return of false (dispatch proceeds) so a transient API
+// failure cannot permanently block legitimate work.
+func (d *Dispatcher) checkAndParkUntrusted(ctx context.Context, cell model.SourceItem, adapter source.Adapter) bool {
+	ag, ok := adapter.(source.AuthorGate)
+	if !ok {
+		return false
+	}
+	trusted, err := ag.IsAuthorTrusted(ctx, cell)
+	if err != nil {
+		aplog.Error("cell %s: author trust check: %v — dispatching anyway (fail-open)", cell.LogLabel(), err)
+		return false
+	}
+	if trusted {
+		return false
+	}
+	aplog.Warn("cell %s (%q): author association not trusted — parking for triage", cell.LogLabel(), cell.Title)
+	if err := ag.ParkUntrusted(ctx, cell); err != nil {
+		aplog.Error("cell %s: park untrusted: %v", cell.LogLabel(), err)
+	}
+	return true
 }
 
 // dispatch acknowledges, runs, and writes the result for a single task.

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -21,13 +21,14 @@ func init() {
 // Compile-time checks: the GitHub adapter supports the optional source
 // capabilities used by the dispatcher and the workflow engine.
 var (
-	_ source.StateSetter     = (*Adapter)(nil)
-	_ source.LabelAdder      = (*Adapter)(nil)
-	_ source.LabelRemover    = (*Adapter)(nil)
-	_ source.TaskPoller      = (*Adapter)(nil)
+	_ source.StateSetter  = (*Adapter)(nil)
+	_ source.LabelAdder   = (*Adapter)(nil)
+	_ source.LabelRemover = (*Adapter)(nil)
+	_ source.TaskPoller   = (*Adapter)(nil)
 	_ source.CIStatusPoller  = (*Adapter)(nil)
 	_ source.SubIssueCreator = (*Adapter)(nil)
 	_ source.BlockerLister   = (*Adapter)(nil)
+	_ source.AuthorGate      = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -39,6 +40,12 @@ type Adapter struct {
 
 	filterStates []string
 	filterLabels []string
+
+	// requireCollaborator, when true, enables the daemon-side author trust gate:
+	// items whose author_association is not OWNER/MEMBER/COLLABORATOR are
+	// parked (trigger labels removed, needs-triage added) instead of being
+	// dispatched. Configured via require_collaborator in the source config.
+	requireCollaborator bool
 }
 
 func (a *Adapter) ID() string { return a.id }
@@ -58,10 +65,12 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 
 	apiKey, _ := cfg["api_key"].(string)
 	baseURL, _ := cfg["base_url"].(string)
+	requireCollaborator, _ := cfg["require_collaborator"].(bool)
 
 	a.owner = parts[0]
 	a.repo = parts[1]
 	a.client = newClient(baseURL, apiKey)
+	a.requireCollaborator = requireCollaborator
 
 	if baseURL == "" || baseURL == defaultBaseURL {
 		a.webBaseURL = "https://github.com"
@@ -74,7 +83,11 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 		}
 	}
 
-	aplog.Info("github: configured  repo=%s/%s  host=%s", a.owner, a.repo, a.webBaseURL)
+	if requireCollaborator {
+		aplog.Info("github: configured  repo=%s/%s  host=%s  require_collaborator=true", a.owner, a.repo, a.webBaseURL)
+	} else {
+		aplog.Info("github: configured  repo=%s/%s  host=%s", a.owner, a.repo, a.webBaseURL)
+	}
 	return nil
 }
 
@@ -677,6 +690,8 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 	updatedAt, _ := time.Parse(time.RFC3339, item.UpdatedAt)
 
 	// Poll skips pull requests, so every ingested item is a plain issue.
+	// author_association is included in list responses so no extra API call is
+	// needed; the dispatcher uses it to enforce the trust gate at ingest time.
 	return model.SourceItem{
 		ID:          fmt.Sprintf("%d", item.Number),
 		SourceID:    a.ID(),
@@ -687,9 +702,47 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		Type:        "issue",
 		State:       item.State,
 		URL:         item.HTMLURL,
+		Metadata:    map[string]any{"author_association": item.AuthorAssociation},
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 	}
+}
+
+// IsAuthorTrusted implements source.AuthorGate. When require_collaborator is
+// false (the default), every author is trusted and the gate is a no-op. When
+// true, the item's author_association (stored in Metadata by toSourceItem) must
+// be OWNER, MEMBER, or COLLABORATOR; anything else is untrusted. An absent or
+// empty association is treated as trusted so that a transient metadata gap never
+// blocks legitimate work (fail-open).
+func (a *Adapter) IsAuthorTrusted(_ context.Context, item model.SourceItem) (bool, error) {
+	if !a.requireCollaborator {
+		return true, nil
+	}
+	assoc, _ := item.Metadata["author_association"].(string)
+	if assoc == "" {
+		return true, nil // fail-open: no association data
+	}
+	switch strings.ToUpper(assoc) {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// ParkUntrusted implements source.AuthorGate. It removes the configured
+// trigger labels (e.g. "ai-ready") so the item exits the poll filter set, then
+// adds "needs-triage" to signal that a maintainer must review and re-authorize
+// the item before it can be dispatched. Both steps are best-effort: a label
+// removal failure is logged but does not prevent the triage label from being
+// added.
+func (a *Adapter) ParkUntrusted(ctx context.Context, item model.SourceItem) error {
+	if len(a.filterLabels) > 0 {
+		if err := a.RemoveLabels(ctx, item, a.filterLabels); err != nil {
+			aplog.Warn("github: park untrusted %s: remove trigger labels %v: %v", item.LogLabel(), a.filterLabels, err)
+		}
+	}
+	return a.AddLabels(ctx, item, []string{"needs-triage"})
 }
 
 func formatComment(result model.RunResult) string {

--- a/src/internal/source/github/author_gate_test.go
+++ b/src/internal/source/github/author_gate_test.go
@@ -1,0 +1,221 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// itemWithAssoc builds a minimal SourceItem whose Metadata contains the given
+// author_association value, as toSourceItem would populate it.
+func itemWithAssoc(assoc string) model.SourceItem {
+	return model.SourceItem{
+		ID:       "1",
+		Metadata: map[string]any{"author_association": assoc},
+	}
+}
+
+// TestIsAuthorTrusted_GateDisabled verifies that when require_collaborator is
+// false (the default), every author — including NONE and CONTRIBUTOR — is
+// treated as trusted and the gate is a no-op.
+func TestIsAuthorTrusted_GateDisabled(t *testing.T) {
+	a := &Adapter{requireCollaborator: false}
+	for _, assoc := range []string{"OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "NONE", ""} {
+		trusted, err := a.IsAuthorTrusted(context.Background(), itemWithAssoc(assoc))
+		if err != nil {
+			t.Errorf("assoc=%q: unexpected error: %v", assoc, err)
+		}
+		if !trusted {
+			t.Errorf("assoc=%q: want trusted=true when gate disabled, got false", assoc)
+		}
+	}
+}
+
+// TestIsAuthorTrusted_TrustedAssociations verifies that OWNER, MEMBER, and
+// COLLABORATOR pass the gate when require_collaborator is true.
+func TestIsAuthorTrusted_TrustedAssociations(t *testing.T) {
+	a := &Adapter{requireCollaborator: true}
+	for _, assoc := range []string{"OWNER", "MEMBER", "COLLABORATOR"} {
+		trusted, err := a.IsAuthorTrusted(context.Background(), itemWithAssoc(assoc))
+		if err != nil {
+			t.Errorf("assoc=%q: unexpected error: %v", assoc, err)
+		}
+		if !trusted {
+			t.Errorf("assoc=%q: want trusted=true, got false", assoc)
+		}
+	}
+}
+
+// TestIsAuthorTrusted_UntrustedAssociations verifies that associations other
+// than OWNER/MEMBER/COLLABORATOR are blocked by the gate.
+func TestIsAuthorTrusted_UntrustedAssociations(t *testing.T) {
+	a := &Adapter{requireCollaborator: true}
+	for _, assoc := range []string{"CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "NONE", "MANNEQUIN"} {
+		trusted, err := a.IsAuthorTrusted(context.Background(), itemWithAssoc(assoc))
+		if err != nil {
+			t.Errorf("assoc=%q: unexpected error: %v", assoc, err)
+		}
+		if trusted {
+			t.Errorf("assoc=%q: want trusted=false, got true", assoc)
+		}
+	}
+}
+
+// TestIsAuthorTrusted_EmptyAssociation verifies fail-open: when author_association
+// is absent or empty, the item is treated as trusted so a metadata gap never
+// blocks legitimate work.
+func TestIsAuthorTrusted_EmptyAssociation(t *testing.T) {
+	a := &Adapter{requireCollaborator: true}
+
+	for _, item := range []model.SourceItem{
+		{ID: "1", Metadata: map[string]any{"author_association": ""}},
+		{ID: "2", Metadata: nil},
+		{ID: "3"},
+	} {
+		trusted, err := a.IsAuthorTrusted(context.Background(), item)
+		if err != nil {
+			t.Errorf("item %s: unexpected error: %v", item.ID, err)
+		}
+		if !trusted {
+			t.Errorf("item %s: want trusted=true (fail-open on missing data), got false", item.ID)
+		}
+	}
+}
+
+// TestIsAuthorTrusted_CaseInsensitive verifies that association values are
+// compared case-insensitively (GitHub documents uppercase but defensive).
+func TestIsAuthorTrusted_CaseInsensitive(t *testing.T) {
+	a := &Adapter{requireCollaborator: true}
+	for _, assoc := range []string{"owner", "Member", "collaborator"} {
+		trusted, err := a.IsAuthorTrusted(context.Background(), itemWithAssoc(assoc))
+		if err != nil {
+			t.Errorf("assoc=%q: unexpected error: %v", assoc, err)
+		}
+		if !trusted {
+			t.Errorf("assoc=%q: want trusted=true (case-insensitive), got false", assoc)
+		}
+	}
+}
+
+// TestParkUntrusted_RemovesTriggerLabelsAndAddsTriage verifies that
+// ParkUntrusted removes the configured filter labels and adds "needs-triage".
+func TestParkUntrusted_RemovesTriggerLabelsAndAddsTriage(t *testing.T) {
+	var deletedLabels []string
+	var addedLabels string
+	var ensuredLabels []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/labels/"):
+			idx := strings.LastIndex(r.URL.Path, "/labels/")
+			deletedLabels = append(deletedLabels, r.URL.Path[idx+len("/labels/"):])
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/labels") && !strings.Contains(r.URL.Path, "/repos/o/r/labels"):
+			b := make([]byte, 512)
+			n, _ := r.Body.Read(b)
+			addedLabels = string(b[:n])
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/labels":
+			// ensureLabel
+			b := make([]byte, 512)
+			n, _ := r.Body.Read(b)
+			ensuredLabels = append(ensuredLabels, string(b[:n]))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{
+		id:           "gh",
+		owner:        "o",
+		repo:         "r",
+		client:       newClient(srv.URL, ""),
+		filterLabels: []string{"ai-ready"},
+	}
+	cell := model.SourceItem{ID: "7", Labels: []string{"ai-ready"}}
+
+	if err := a.ParkUntrusted(context.Background(), cell); err != nil {
+		t.Fatalf("ParkUntrusted: %v", err)
+	}
+	if len(deletedLabels) != 1 || deletedLabels[0] != "ai-ready" {
+		t.Errorf("deleted labels = %v, want [ai-ready]", deletedLabels)
+	}
+	if !strings.Contains(addedLabels, "needs-triage") {
+		t.Errorf("added labels body = %q, want needs-triage", addedLabels)
+	}
+}
+
+// TestParkUntrusted_NoFilterLabels verifies that ParkUntrusted still adds
+// "needs-triage" even when the adapter has no configured filter labels.
+func TestParkUntrusted_NoFilterLabels(t *testing.T) {
+	var ensuredLabels, addedBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/o/r/labels":
+			b := make([]byte, 512)
+			n, _ := r.Body.Read(b)
+			ensuredLabels = string(b[:n])
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/issues/5/labels"):
+			b := make([]byte, 512)
+			n, _ := r.Body.Read(b)
+			addedBody = string(b[:n])
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := &Adapter{
+		id:     "gh",
+		owner:  "o",
+		repo:   "r",
+		client: newClient(srv.URL, ""),
+		// No filterLabels configured.
+	}
+	if err := a.ParkUntrusted(context.Background(), model.SourceItem{ID: "5"}); err != nil {
+		t.Fatalf("ParkUntrusted: %v", err)
+	}
+	if !strings.Contains(addedBody, "needs-triage") {
+		t.Errorf("added labels body = %q, want needs-triage", addedBody)
+	}
+	_ = ensuredLabels
+}
+
+// TestPoll_PopulatesAuthorAssociation verifies that Poll stores the
+// author_association from the GitHub response in SourceItem.Metadata so the
+// dispatcher can use it for the trust gate without an extra API call.
+func TestPoll_PopulatesAuthorAssociation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"number": 10, "title": "Collab issue", "state": "open",
+			 "author_association": "COLLABORATOR"},
+			{"number": 11, "title": "External issue", "state": "open",
+			 "author_association": "NONE"}
+		]`))
+	}))
+	defer srv.Close()
+
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if got, _ := items[0].Metadata["author_association"].(string); got != "COLLABORATOR" {
+		t.Errorf("items[0] author_association = %q, want COLLABORATOR", got)
+	}
+	if got, _ := items[1].Metadata["author_association"].(string); got != "NONE" {
+		t.Errorf("items[1] author_association = %q, want NONE", got)
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,11 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is GitHub's relationship of the issue author to the
+	// repo: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR,
+	// FIRST_TIMER, MANNEQUIN, or NONE. Included in list responses, so no
+	// extra API call is needed to retrieve it.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -142,6 +142,27 @@ type SubIssueCreator interface {
 	CreateSubIssue(ctx context.Context, parent, child model.SourceItem) (model.SourceItem, error)
 }
 
+// AuthorGate is an optional interface a source may implement to enforce a
+// trust check at daemon ingest time. When the dispatcher encounters an item
+// from a source that implements this interface, it calls IsAuthorTrusted
+// before routing or dispatching. Untrusted items are parked (trigger labels
+// removed, a triage label added) so they leave the poll filter set without
+// ever reaching an agent — closing the TOCTOU window that an Actions-only
+// check leaves open.
+type AuthorGate interface {
+	// IsAuthorTrusted reports whether the item's author may be dispatched
+	// automatically. Returns (true, nil) for trusted authors, (false, nil)
+	// for untrusted, or (true, err) on errors so that transient failures
+	// never block legitimate work (fail-open).
+	IsAuthorTrusted(ctx context.Context, item model.SourceItem) (bool, error)
+
+	// ParkUntrusted applies source-side side-effects for items whose author
+	// is not trusted: removes trigger labels so the item exits the dispatch
+	// filter set, and adds a triage label signalling that human review is
+	// required before the item may be re-authorized for dispatch.
+	ParkUntrusted(ctx context.Context, item model.SourceItem) error
+}
+
 // Factory creates a new, unconfigured Adapter instance.
 type Factory func() Adapter
 


### PR DESCRIPTION
## Summary

- **Closes the TOCTOU race in #242**: the previous triage-gate GitHub Action removed `ai-ready` after the event fired, but the Apiary daemon could poll in the 120s window before Actions dispatch and ingest the issue. The gate was detective, not preventive.
- **Daemon-level trust check** (`source.AuthorGate` interface): `poll()` and `RunOnce()` now call `IsAuthorTrusted()` synchronously before binding or dispatching any item. Untrusted items are parked via `ParkUntrusted()` — trigger labels are removed and `needs-triage` is added — so they leave the poll filter set without ever reaching an agent.
- **No extra API call**: `author_association` is already included in GitHub's issue list response and is stored in `SourceItem.Metadata` by `toSourceItem()`.
- **Opt-in per source**: set `require_collaborator: true` in the source config block. Default is `false` (backward-compatible).
- **Fail-open design**: empty/missing association and API errors both return trusted=true so a transient gap never blocks legitimate work.
- **triage-gate Action kept** as defense-in-depth; it's no longer the sole control.

```yaml
# apiary.yaml
sources:
  - id: github
    type: github
    config:
      repo: owner/repo
      api_key: $GITHUB_TOKEN
      require_collaborator: true  # NEW
    filters:
      labels: [ai-ready]
```

## Test plan

- [x] `TestIsAuthorTrusted_GateDisabled` — gate off → all associations trusted
- [x] `TestIsAuthorTrusted_TrustedAssociations` — OWNER/MEMBER/COLLABORATOR pass
- [x] `TestIsAuthorTrusted_UntrustedAssociations` — CONTRIBUTOR/NONE/etc. blocked
- [x] `TestIsAuthorTrusted_EmptyAssociation` — fail-open on missing data
- [x] `TestIsAuthorTrusted_CaseInsensitive` — lowercase associations handled
- [x] `TestParkUntrusted_RemovesTriggerLabelsAndAddsTriage` — correct label ops
- [x] `TestParkUntrusted_NoFilterLabels` — still adds needs-triage even with no filter labels
- [x] `TestPoll_PopulatesAuthorAssociation` — Metadata populated from list response
- [x] `TestCheckAndParkUntrusted_TrustedAuthor` — trusted passes through, nothing parked
- [x] `TestCheckAndParkUntrusted_UntrustedAuthor` — skip=true, item parked
- [x] `TestCheckAndParkUntrusted_TrustCheckError` — fail-open, skip=false
- [x] `TestCheckAndParkUntrusted_NoGateInterface` — no-op for adapters without the interface
- [x] `TestCheckAndParkUntrusted_ParkErrorDoesNotPreventSkip` — park error still skips dispatch
- [x] Full `go test ./...` passes

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)