### PR TITLE
fix(plugin): check dir permissions on each plugin root subdir (SEC-04)

### DIFF
--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -53,6 +53,10 @@ func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error
 		}
 		sort.Strings(roots)
 		for _, root := range roots {
+			if warn := checkDirOwnerOnly(root); warn != nil {
+				errs = append(errs, warn)
+				continue
+			}
 			if _, err := os.Stat(filepath.Join(root, ManifestFilename)); err != nil {
 				continue
 			}

--- a/src/internal/plugin/discovery_unix_test.go
+++ b/src/internal/plugin/discovery_unix_test.go
@@ -42,3 +42,32 @@ func TestDiscoverSkipsGroupAndWorldWritableDirs(t *testing.T) {
 		t.Fatal("safe plugin from good path should still load")
 	}
 }
+
+func TestDiscoverSkipsWritableChildPluginDir(t *testing.T) {
+	// Parent directory is owner-only (0700); one child plugin subdir is
+	// group-writable. The writable child must be skipped with a warning
+	// while a sibling with correct permissions still loads.
+	parent := t.TempDir() // TempDir creates 0700
+
+	writeTestPlugin(t, parent, "bad-plugin", "exit 0", Manifest{})
+	writeTestPlugin(t, parent, "good-plugin", "exit 0", Manifest{})
+
+	// Make only the bad-plugin subdir group-writable.
+	badRoot := filepath.Join(parent, "bad-plugin")
+	if err := os.Chmod(badRoot, 0o775); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badRoot, 0o755) })
+
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+
+	if _, ok := registry.Get("dev.apiary.good-plugin"); !ok {
+		t.Fatal("good-plugin with safe permissions should load")
+	}
+	if _, ok := registry.Get("dev.apiary.bad-plugin"); ok {
+		t.Fatal("bad-plugin with group-writable dir must not load")
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+		t.Fatalf("expected exactly 1 permission warning for bad-plugin, got errs=%v", errs)
+	}
+}


### PR DESCRIPTION
## Summary

- `plugin.Discover()` previously called `checkDirOwnerOnly` only on the top-level configured path, so the common `plugins/<a>/`, `plugins/<b>/` multi-plugin layout was unprotected: a group/world-writable child subdir would load even when the parent was `0700`.
- Adds a `checkDirOwnerOnly(root)` call at the top of the per-root loop so every plugin subdirectory is validated before loading — a writable root is skipped with a warning and remaining sibling roots continue loading normally.
- Extends the test suite with `TestDiscoverSkipsWritableChildPluginDir` covering the previously-missed case: owner-only parent, group-writable child subdir, clean sibling still loads.

## Test plan

- [x] `go test ./internal/plugin/...` — all pass including the new test
- [x] Existing `TestDiscoverSkipsGroupAndWorldWritableDirs` unchanged and still passes

Closes #245