### PR TITLE
security: add privilege ceiling for agent CLI subprocesses (SEC-14)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -84,6 +84,21 @@ func (r *RunnerConfig) AdapterName() string {
 	return r.Type
 }
 
+// PrivilegeConfig constrains the privilege level of the agent CLI subprocess
+// launched for an agent or step. It maps directly to model.PrivilegeProfile.
+type PrivilegeConfig struct {
+	// AllowRoot permits starting the agent CLI when the orchestrator process is
+	// running as root (uid 0). False by default; must be explicitly opted into.
+	AllowRoot bool `yaml:"allow_root,omitempty"`
+	// StripEnv lists environment-variable key names (case-insensitive) to
+	// remove from the subprocess environment before launch.
+	StripEnv []string `yaml:"strip_env,omitempty"`
+	// EnvAllowlist, when non-empty, restricts the subprocess to only the listed
+	// environment-variable key names (case-insensitive). StripEnv keys are
+	// always removed even when also listed here.
+	EnvAllowlist []string `yaml:"env_allowlist,omitempty"`
+}
+
 type AgentConfig struct {
 	ID          string   `yaml:"id"`
 	Description string   `yaml:"description,omitempty"`
@@ -128,6 +143,10 @@ type AgentConfig struct {
 	// WorkspaceAffinity pins retries/resumes to the first worker that claims the
 	// task, preserving a local checkout or other non-portable environment.
 	WorkspaceAffinity bool `yaml:"workspace_affinity,omitempty"`
+	// Privilege sets the agent-scope privilege ceiling applied to every
+	// subprocess started for this agent. A nil value uses safe defaults
+	// (AllowRoot=false, no env filtering). Step-level privilege overrides this.
+	Privilege *PrivilegeConfig `yaml:"privilege,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -179,6 +179,10 @@ type StepConfig struct {
 	// ActionClass lets settings.approvals.require_for enforce an approval gate
 	// before sensitive work such as push, deploy, destructive, or publication.
 	ActionClass string `yaml:"action_class,omitempty"`
+	// Privilege overrides the agent-scope privilege ceiling for this step only.
+	// When set, it replaces (not merges) the agent's privilege config. A nil
+	// value inherits the agent-level privilege setting.
+	Privilege *PrivilegeConfig `yaml:"privilege,omitempty"`
 
 	// ── split step ────────────────────────────────────────────────
 	Multi    bool          `yaml:"multi,omitempty"`

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -404,6 +404,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		WorkingDir:         "/",
 		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
+		Privilege:          mergePrivilege(req.Agent.Privilege, req.Step.Privilege),
 	}
 
 	if x.d.logger != nil {
@@ -930,6 +931,25 @@ func withMemoryDir(env map[string]string, dir string) map[string]string {
 		env["APIARY_MEMORY_DIR"] = dir
 	}
 	return env
+}
+
+// mergePrivilege resolves the effective privilege profile for a step. The step-
+// level config takes precedence: if set it completely replaces the agent-level
+// config (no merging). When both are nil, a nil profile is returned (callers
+// treat nil as "safe defaults", i.e. AllowRoot=false, no env filtering).
+func mergePrivilege(agent, step *config.PrivilegeConfig) *model.PrivilegeProfile {
+	src := agent
+	if step != nil {
+		src = step
+	}
+	if src == nil {
+		return nil
+	}
+	return &model.PrivilegeProfile{
+		AllowRoot:    src.AllowRoot,
+		StripEnv:     src.StripEnv,
+		EnvAllowlist: src.EnvAllowlist,
+	}
 }
 
 // compile-time interface checks.

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -2,6 +2,25 @@ package model
 
 import "time"
 
+// PrivilegeProfile caps the privilege level of an agent subprocess and
+// restricts which environment variables are forwarded to it. An absent (nil)
+// profile uses safe defaults: root execution is rejected, no env filtering.
+type PrivilegeProfile struct {
+	// AllowRoot, when true, permits the agent CLI to start even when the current
+	// process is running as root (uid 0). Must be explicitly opted into per-agent
+	// or per-step; the default is false (reject).
+	AllowRoot bool
+	// StripEnv is a list of environment-variable key names (case-insensitive
+	// exact match) to remove before the subprocess inherits the environment.
+	// Use it to prevent credentials that the orchestrator needs but the agent
+	// should not see from leaking into the subprocess.
+	StripEnv []string
+	// EnvAllowlist, when non-empty, restricts the subprocess environment to only
+	// the listed key names (case-insensitive exact match). Keys in StripEnv are
+	// still removed even when listed here.
+	EnvAllowlist []string
+}
+
 type RunRequest struct {
 	Cell          SourceItem
 	WorkerID      string
@@ -12,6 +31,10 @@ type RunRequest struct {
 	Env           map[string]string
 	Timeout       time.Duration
 	AgentMetadata map[string]any
+	// Privilege, when set, is applied by CLI runners before starting the agent
+	// subprocess: root-execution guard + env filtering. A nil profile uses
+	// safe defaults (AllowRoot=false, no env filtering).
+	Privilege *PrivilegeProfile
 
 	// SystemPrepend is injected at the very start of the prompt, before the cell
 	// details and SystemAppend. In workflow mode it carries the formatted

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -84,6 +84,9 @@ func (r *CliRunner) Configure(config map[string]any) error {
 }
 
 func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	if err := checkPrivilege(req.Privilege); err != nil {
+		return model.RunResult{}, err
+	}
 	start := time.Now()
 	prompt := buildPrompt(req)
 
@@ -105,7 +108,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)
 	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
+	cmd.Env = applyPrivilegeEnv(os.Environ(), req.Privilege)
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/src/internal/runner/execution/privilege.go
+++ b/src/internal/runner/execution/privilege.go
@@ -1,0 +1,87 @@
+package execution
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// checkPrivilege enforces the privilege ceiling declared in the profile before
+// the agent CLI subprocess is started. It returns an error when:
+//   - the current process is root (uid 0) and AllowRoot is false, or
+//   - the profile is nil and the process is root (safe default: reject root).
+//
+// On platforms where os.Getuid() returns -1 (Windows) the root check is
+// skipped — there is no uid 0 concept there.
+func checkPrivilege(profile *model.PrivilegeProfile) error {
+	allowRoot := false
+	if profile != nil {
+		allowRoot = profile.AllowRoot
+	}
+	if uid := os.Getuid(); uid == 0 && !allowRoot {
+		return fmt.Errorf(
+			"privilege ceiling: agent CLI refused to start as root (uid 0); " +
+				"set privilege.allow_root: true in the agent or step config to opt in, " +
+				"or run apiary as a non-root user (strongly recommended for untrusted-content workflows)",
+		)
+	}
+	return nil
+}
+
+// applyPrivilegeEnv filters env (a slice of "KEY=VALUE" strings) according to
+// the privilege profile and returns the filtered copy. The original slice is not
+// modified.
+//
+// Filtering rules (applied in order):
+//  1. If profile.EnvAllowlist is non-empty, only keys in the allowlist pass.
+//  2. Any key in profile.StripEnv is removed (even if it is in the allowlist).
+//
+// Both EnvAllowlist and StripEnv comparisons are case-insensitive key matches.
+// A nil profile returns env unmodified.
+func applyPrivilegeEnv(env []string, profile *model.PrivilegeProfile) []string {
+	if profile == nil || (len(profile.EnvAllowlist) == 0 && len(profile.StripEnv) == 0) {
+		return env
+	}
+
+	// Build lookup sets for O(1) membership tests.
+	strip := make(map[string]struct{}, len(profile.StripEnv))
+	for _, k := range profile.StripEnv {
+		strip[strings.ToLower(k)] = struct{}{}
+	}
+	var allowlist map[string]struct{}
+	if len(profile.EnvAllowlist) > 0 {
+		allowlist = make(map[string]struct{}, len(profile.EnvAllowlist))
+		for _, k := range profile.EnvAllowlist {
+			allowlist[strings.ToLower(k)] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key := envKey(entry)
+		lower := strings.ToLower(key)
+
+		// 1. Allowlist filter: skip unless the key is listed.
+		if allowlist != nil {
+			if _, ok := allowlist[lower]; !ok {
+				continue
+			}
+		}
+		// 2. Strip: remove even if it passed the allowlist.
+		if _, ok := strip[lower]; ok {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// envKey returns the key portion of a "KEY=VALUE" string.
+func envKey(entry string) string {
+	if i := strings.IndexByte(entry, '='); i >= 0 {
+		return entry[:i]
+	}
+	return entry
+}

--- a/src/internal/runner/execution/privilege_test.go
+++ b/src/internal/runner/execution/privilege_test.go
@@ -1,0 +1,121 @@
+package execution
+
+import (
+	"os"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestCheckPrivilege_NonRoot verifies that a non-root process (uid != 0) is
+// always allowed, regardless of the AllowRoot setting.
+func TestCheckPrivilege_NonRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test must run as non-root")
+	}
+	for _, tc := range []struct {
+		name    string
+		profile *model.PrivilegeProfile
+	}{
+		{"nil profile", nil},
+		{"allow_root false", &model.PrivilegeProfile{AllowRoot: false}},
+		{"allow_root true", &model.PrivilegeProfile{AllowRoot: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := checkPrivilege(tc.profile); err != nil {
+				t.Errorf("expected nil error for non-root process, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestCheckPrivilege_Root verifies the root guard logic. Because unit tests
+// cannot change uid, this test is skipped unless already running as root.
+func TestCheckPrivilege_Root(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("test requires root (uid 0)")
+	}
+	t.Run("nil profile rejects root", func(t *testing.T) {
+		if err := checkPrivilege(nil); err == nil {
+			t.Error("expected error for root execution with nil profile")
+		}
+	})
+	t.Run("allow_root false rejects root", func(t *testing.T) {
+		if err := checkPrivilege(&model.PrivilegeProfile{AllowRoot: false}); err == nil {
+			t.Error("expected error for root execution with allow_root=false")
+		}
+	})
+	t.Run("allow_root true permits root", func(t *testing.T) {
+		if err := checkPrivilege(&model.PrivilegeProfile{AllowRoot: true}); err != nil {
+			t.Errorf("expected nil error with allow_root=true, got: %v", err)
+		}
+	})
+}
+
+func TestApplyPrivilegeEnv_NilProfile(t *testing.T) {
+	env := []string{"HOME=/root", "PATH=/usr/bin", "SECRET=abc"}
+	got := applyPrivilegeEnv(env, nil)
+	if len(got) != len(env) {
+		t.Errorf("nil profile: want %d entries, got %d", len(env), len(got))
+	}
+}
+
+func TestApplyPrivilegeEnv_StripEnv(t *testing.T) {
+	env := []string{"HOME=/root", "SECRET=abc", "PATH=/usr/bin", "TOKEN=xyz"}
+	profile := &model.PrivilegeProfile{
+		StripEnv: []string{"secret", "TOKEN"}, // case-insensitive
+	}
+	got := applyPrivilegeEnv(env, profile)
+	for _, entry := range got {
+		key := envKey(entry)
+		if key == "SECRET" || key == "TOKEN" {
+			t.Errorf("strip_env: key %q must not appear in output, got entries: %v", key, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("strip_env: want 2 entries (HOME, PATH), got %d: %v", len(got), got)
+	}
+}
+
+func TestApplyPrivilegeEnv_Allowlist(t *testing.T) {
+	env := []string{"HOME=/root", "PATH=/usr/bin", "SECRET=abc", "RUNNER=claude"}
+	profile := &model.PrivilegeProfile{
+		EnvAllowlist: []string{"path", "RUNNER"}, // case-insensitive
+	}
+	got := applyPrivilegeEnv(env, profile)
+	for _, entry := range got {
+		key := envKey(entry)
+		if key != "PATH" && key != "RUNNER" {
+			t.Errorf("allowlist: unexpected key %q in output: %v", key, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("allowlist: want 2 entries, got %d: %v", len(got), got)
+	}
+}
+
+func TestApplyPrivilegeEnv_AllowlistAndStrip(t *testing.T) {
+	env := []string{"HOME=/root", "PATH=/usr/bin", "SECRET=abc", "RUNNER=claude"}
+	profile := &model.PrivilegeProfile{
+		EnvAllowlist: []string{"PATH", "SECRET"},
+		StripEnv:     []string{"SECRET"},
+	}
+	got := applyPrivilegeEnv(env, profile)
+	// SECRET is in both allowlist and strip_env — strip wins
+	for _, entry := range got {
+		if envKey(entry) == "SECRET" {
+			t.Errorf("strip_env must take precedence over allowlist, but SECRET appeared: %v", got)
+		}
+	}
+	if len(got) != 1 || envKey(got[0]) != "PATH" {
+		t.Errorf("want [PATH=/usr/bin], got %v", got)
+	}
+}
+
+func TestApplyPrivilegeEnv_EmptyProfile(t *testing.T) {
+	env := []string{"A=1", "B=2"}
+	got := applyPrivilegeEnv(env, &model.PrivilegeProfile{})
+	if len(got) != len(env) {
+		t.Errorf("empty profile: want %d entries, got %d", len(env), len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- **Root guard**: `CliRunner.Run` now rejects execution when the orchestrator process is uid 0 unless `privilege.allow_root: true` is explicitly set in the agent or step config. This caps the blast radius of a successful prompt injection — untrusted Jira/GitHub ticket text can no longer execute as root even when the daemon is misconfigured.
- **Per-agent/per-step least-privilege profile**: new `privilege:` block in `AgentConfig` and `StepConfig` (YAML) carrying `allow_root`, `strip_env`, and `env_allowlist` fields. The step-level config overrides the agent-level config. Existing configs without a `privilege:` block use safe defaults (root rejected, no env filtering).
- **Env filtering**: `applyPrivilegeEnv` strips named env vars (`strip_env`) and/or allowlists the subprocess environment to a declared set (`env_allowlist`) before `exec.CommandContext`. Prevents orchestrator-held credentials from leaking into the agent subprocess.
- **Unit tests**: `privilege_test.go` covers root guard logic (non-root, root-with-opt-in) and all env-filtering combinations (nil, strip, allowlist, both).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all 25 packages pass
- [x] `TestCheckPrivilege_NonRoot` passes (non-root host)
- [x] `TestApplyPrivilegeEnv_*` — 5 table-driven cases, all green
- [ ] Integration: start `apiary run` as root → verify startup error mentioning `privilege ceiling`
- [ ] Integration: set `privilege.allow_root: true` on an agent → verify agent starts normally as root

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)