### PR TITLE
fix: skip CI wait immediately when no PR was opened

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10268 symbols, 23366 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10268 symbols, 23366 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -365,7 +365,11 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 		}
 
 		if len(candidates) == 0 {
-			return source.CIStatus{Status: "pending"}, nil // No PR found yet; still pending
+			// No PR has been cross-referenced on the issue's timeline. This happens
+			// when the engineer step finished as a no-op (e.g. blocked by a dep) and
+			// never opened a PR. Return "no_pr" so the wait_for step can short-circuit
+			// instead of polling until the max-duration timeout.
+			return source.CIStatus{Status: "no_pr"}, nil
 		}
 
 		// Fetch candidate PRs until an open one is found. A fetch failure is NOT

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -69,7 +69,7 @@ type TaskPoller interface {
 // CIStatus represents the result of a CI status check. Used by poll steps waiting
 // for CI to complete.
 type CIStatus struct {
-	Status string // "passed", "failed", "pending", "conflict"
+	Status string // "passed", "failed", "pending", "conflict", "no_pr" (no PR associated with the issue)
 	URL    string // Link to the CI run
 	Checks []struct {
 		Name   string // Check name (e.g., "test", "lint")

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -403,3 +403,32 @@ func countID(seen []StepRequest, id string) int {
 	}
 	return n
 }
+
+// TestWaitFor_NoPREndsAsNoOp is the regression for issue #200: when the CI
+// poller returns "no_pr" (no PR was ever opened — the implement step was a
+// no-op), the wait_for step must complete successfully on the first check
+// instead of parking the instance until the max-duration timeout expires.
+func TestWaitFor_NoPREndsAsNoOp(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "no_pr"}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, success, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
+
+	// The instance must complete successfully — not park waiting for a PR that never comes.
+	if !success {
+		t.Fatal("no_pr should resolve to success (no-op implement)")
+	}
+	if got := store.instances[instID].State; got != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done (no PR means no CI to wait for)", got)
+	}
+	if len(eng.ParkedWaits()) != 0 {
+		t.Error("instance must not be parked when no PR was opened")
+	}
+	// The "no_pr" outcome must be recorded so the history is auditable.
+	if statuses := store.pollStatuses(); len(statuses) != 1 || statuses[0] != "no_pr" {
+		t.Errorf("recorded poll statuses = %v, want [no_pr]", statuses)
+	}
+}

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -137,6 +137,20 @@ func (e *Engine) checkCIWaitStep(
 			},
 		}, nil
 
+	case "no_pr":
+		// The source found no PR associated with this issue. The implement step most
+		// likely finished as a no-op (e.g. blocked by a dependency) and never opened
+		// a PR. Treat the CI wait as satisfied so the instance ends cleanly instead
+		// of polling until the max-duration timeout expires.
+		aplog.Info("wait_for step %q: no PR found for this issue — skipping CI wait (no-op implement)", step.ID)
+		return StepResult{
+			Success: true,
+			StructuredOutput: map[string]any{
+				"ci_status": "no_pr",
+				"reason":    "no PR was opened; implement step was a no-op",
+			},
+		}, nil
+
 	case "pending":
 		aplog.Debug("wait_for step %q: CI still pending", step.ID)
 		return StepResult{Pending: true}, nil
@@ -288,7 +302,7 @@ func checksToMap(checks []struct {
 // recorded poll always carries a meaningful, non-empty status.
 func normalizeCIStatus(s string) string {
 	switch s {
-	case "passed", "failed", "pending", "conflict":
+	case "passed", "failed", "pending", "conflict", "no_pr":
 		return s
 	default:
 		return "unknown"


### PR DESCRIPTION
## Summary

- `source/github`: return `status="no_pr"` when an issue timeline has **zero** cross-referenced PR candidates, instead of `"pending"` (which looped forever)
- `workflow`: handle `"no_pr"` as a terminal **success** in `checkCIWaitStep` — the instance ends cleanly as a no-op (no `on_fail` noise)
- `workflow`: add `"no_pr"` to `normalizeCIStatus` so every poll is auditable from the dashboard
- `workflow/test`: `TestWaitFor_NoPREndsAsNoOp` covers the regression

**Root cause:** when an engineer step finishes without opening a PR (e.g. it commented "blocked by #3704" and exited), `PollCIStatus` found no PR in the GitHub timeline and returned `{Status: "pending"}` each cycle. The engine parked at `check-ci` until `apiary restart` or the 2-hour `max_duration` timeout — whichever came first.

**Fix contract:** `"no_pr"` is now a distinct terminal result from the source, not a polling artefact. The engine routes it to success so downstream steps (review, QA) are not run and the cell is returned to the pool immediately.

## Test plan

- [x] `go test ./internal/workflow/... -run TestWaitFor_` — all passing, including new `TestWaitFor_NoPREndsAsNoOp`
- [x] Existing timeout / conflict / rehydrate tests unchanged

Closes #200