### PR TITLE
fix: default queue listen address to loopback and warn on non-loopback bind (SEC-03)

### DIFF
--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -13,17 +13,42 @@ import (
 	"github.com/orlandoburli/apiary/internal/queuehttp"
 )
 
+// resolveQueueListenAddress normalises a raw listen address so that the queue
+// server defaults to loopback when no host is specified, and returns whether
+// the resolved host is non-loopback (requiring a warning).
+func resolveQueueListenAddress(address string) (resolved string, nonLoopback bool) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		// Not a standard host:port pair — pass through unchanged.
+		return address, false
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port), false
+	}
+	if host == "localhost" {
+		return address, false
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return address, false
+	}
+	return address, true
+}
+
 func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.WaitGroup) error {
 	address := strings.TrimSpace(d.cfg.Settings.Queue.Listen)
 	if address == "" {
 		return nil
 	}
+	resolved, nonLoopback := resolveQueueListenAddress(address)
+	if nonLoopback {
+		aplog.Warn("queue worker protocol is binding on a non-loopback address (%s); set settings.queue.listen to 127.0.0.1:<port> to restrict access to local connections only", resolved)
+	}
 	if d.dispatchQueue == nil {
 		return fmt.Errorf("queue protocol listener requires the durable queue")
 	}
-	listener, err := net.Listen("tcp", address)
+	listener, err := net.Listen("tcp", resolved)
 	if err != nil {
-		return fmt.Errorf("listen for queue workers on %s: %w", address, err)
+		return fmt.Errorf("listen for queue workers on %s: %w", resolved, err)
 	}
 	handler := queuehttp.Server{
 		Store: d.dispatchQueue, Token: d.cfg.Settings.Queue.WorkerToken,

--- a/src/internal/daemon/queue_server_test.go
+++ b/src/internal/daemon/queue_server_test.go
@@ -1,0 +1,29 @@
+package daemon
+
+import "testing"
+
+func TestResolveQueueListenAddress(t *testing.T) {
+	cases := []struct {
+		in          string
+		want        string
+		nonLoopback bool
+	}{
+		{":8080", "127.0.0.1:8080", false},
+		{"127.0.0.1:8080", "127.0.0.1:8080", false},
+		{"::1]:8080", "::1]:8080", false}, // malformed — pass through
+		{"localhost:8080", "localhost:8080", false},
+		{"[::1]:8080", "[::1]:8080", false},
+		{"0.0.0.0:8080", "0.0.0.0:8080", true},
+		{"192.168.1.10:9000", "192.168.1.10:9000", true},
+		{"0.0.0.0:0", "0.0.0.0:0", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, nonLoopback := resolveQueueListenAddress(tc.in)
+			if got != tc.want || nonLoopback != tc.nonLoopback {
+				t.Fatalf("resolveQueueListenAddress(%q) = (%q, %v), want (%q, %v)",
+					tc.in, got, nonLoopback, tc.want, tc.nonLoopback)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Default `settings.queue.listen` to `127.0.0.1` when only a port is given (e.g. `:8080` → `127.0.0.1:8080`), preventing accidental exposure of the worker protocol server on all interfaces.
- Explicit `localhost` / loopback IP addresses pass through unchanged and are treated as safe.
- Any non-loopback host (e.g. `0.0.0.0`, a LAN IP) is still accepted but now emits a `Warn` log so operators are aware of the network exposure.
- TLS transport is tracked separately (SEC-13).

## Test plan

- [ ] New unit test `TestResolveQueueListenAddress` covers: no-host port (→ loopback), explicit `127.0.0.1`, `localhost`, `[::1]`, `0.0.0.0` (warn), and a LAN IP (warn).
- [ ] All existing `internal/daemon` tests still pass (`go test ./internal/daemon/`).
- [ ] `go vet` clean on affected packages.

Closes #226