### PR TITLE
security: require human review of agent-authored PRs (SEC-08)

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -17,16 +17,16 @@ Ou via CLI:
 hermes kanban create "fix: ..." --assignee engineer --skill git-workflow
 ```
 
-**Regra fundamental:** NUNCA bloquear kanban task para review humano. Sempre criar PR com auto-merge e aguardar o CI. O worker só completa a task após o PR estar mergeado e o dev local sincronizado.
+**Regra fundamental (SEC-08):** Todo PR de agente requer aprovação humana antes do merge. NUNCA ativar auto-merge em PRs de agente — branch protection rejeita merges sem review. O agente cria o PR e aguarda o CI; um humano aprova e realiza o merge. O worker só completa a task após o PR estar mergeado e o dev local sincronizado.
 
 **Pipeline completo de uma task engineer:**
-Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → auto-merge → aguarda CI → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
+Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → aguarda CI + aprovação humana → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
 
 **GH_TOKEN:** o profile engineer tem GH_TOKEN no `.env`. Se o worker não conseguir usar `gh`, verificar se o token ainda é válido.
 
 **Pitfalls:**
 - **Skill must be in each target profile's skills directory.** The kanban worker loads skills from `~/.hermes/profiles/<profile>/skills/`, NOT from `~/.hermes/skills/`. If `git-workflow` is absent from any profile's skills dir, the worker crashes immediately with `Error: Unknown skill(s): git-workflow`. This affects ALL profiles (engineer, po, qa) that run tasks with `--skill git-workflow`. Fix: `ln -s ~/.hermes/skills/git-workflow ~/.hermes/profiles/<profile>/skills/git-workflow` for each profile.
-- Worker sem GH_TOKEN → não consegue criar PR nem ativar auto-merge. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'` no profile, ou adicionar ao `.env` do profile.
+- Worker sem GH_TOKEN → não consegue criar PR. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'` no profile, ou adicionar ao `.env` do profile.
 - Worktree deletado entre runs → se a task for re-spawnada após um merge, o worktree original sumiu. O worker deve criar um novo worktree ou clonar fresco.
 - CI lento/flaky → `gh pr checks --watch` + `gh run rerun --failed` em flake conhecido. Só desistir após 2-3 reruns do mesmo padrão.
 - Diverging branches no git pull → usar `git reset --hard origin/main` quando o histórico local divergir (worktree worker não deve ter commits locais em main).
@@ -51,10 +51,9 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 4. **Link issue and project**: after creating the PR:
    - The PR body MUST contain `Closes #<issue>` (or `Fixes #<issue>`) to link the issue.
    - Add the PR to the relevant GitHub Project: `gh project item-add 1 --owner orlandoburli-enterprise --url <pr-url>`.
-5. **Enable auto-merge**: run `gh pr merge <number> --auto --squash` so it merges automatically once CI passes.
-   - NUNCA bloquear kanban task para review humano. O worker cria o PR, ativa auto-merge e aguarda o CI. Sem blocker, sem review-required.
+5. **Do NOT enable auto-merge** (SEC-08). Branch protection on `main` requires at least one human approval; `--auto` without an approval would be rejected. Open the PR and stop — a human reviewer will approve and merge.
 6. CI must pass (lint, tests, build, sqlc-check) before merge.
-7. Aguardar o merge — obrigatório, sem exceção. A tarefa não está concluída até o PR estar mergeado e o dev local atualizado. Não pule para a próxima tarefa nem declare pronto antes disso.
+7. Aguardar o merge — obrigatório, sem exceção. A tarefa não está concluída até o PR estar aprovado por um humano, mergeado, e o dev local atualizado. Não pule para a próxima tarefa nem declare pronto antes disso.
    - `gh pr checks <number> --watch` para aguardar o CI.
    - Se o CI travar em flake conhecido (RATE_LIMIT 429, timing em `cadastro-observacoes-markdown`, `vendas-nucleo:438`, `cadastro-auto-rascunho`, etc.), faça `gh run rerun <run-id> --failed` e aguarde de novo. Só desista após 2-3 reruns mostrarem o mesmo padrão de falha.
    - Confirme com `gh pr view <number> --json state,mergedAt` que `state == "MERGED"`.
@@ -76,7 +75,7 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 10. Remove o worktree: `git worktree remove ../project-erp--<branch>` e (opcional) `git branch -d <branch>`.
 11. Never `git push` directly to `main`.
 
-**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → auto-merge → aguardar CI → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 7-9) é proibido.
+**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → aguardar CI + aprovação humana → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 7-9) é proibido.
 
 ## AGENTS.md / CLAUDE.md — manter atualizados via PR
 

--- a/.github/workflows/agent-pr-guard.yml
+++ b/.github/workflows/agent-pr-guard.yml
@@ -1,0 +1,75 @@
+name: agent-pr-guard
+
+# SEC-08 — Require human review of agent-authored PRs.
+#
+# When a PR is opened or synchronised by the apiary bot or carries an
+# agent-authorship label, this workflow:
+#   1. Disables auto-merge so CI-green alone cannot land the PR.
+#   2. Posts a one-time comment reminding reviewers that the change was
+#      agent-generated and must be read before approving.
+#
+# Branch protection (required_pull_request_reviews ≥ 1) is the hard gate;
+# this workflow is a defence-in-depth layer that strips the auto-merge flag
+# before any race can occur.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    # Fire only for PRs that carry an agent-authorship label.
+    # Labels set by apiary workflows: agent:engineer, ai-complete, ai-ready.
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'agent:engineer') ||
+      contains(github.event.pull_request.labels.*.name, 'ai-complete') ||
+      contains(github.event.pull_request.labels.*.name, 'ai-ready')
+
+    steps:
+      - name: Disable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.node_id }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Disable auto-merge via GraphQL mutation (idempotent — safe to repeat).
+          gh api graphql -f query='
+            mutation($pr: ID!) {
+              disablePullRequestAutoMerge(input: { pullRequestId: $pr }) {
+                clientMutationId
+              }
+            }
+          ' -f pr="$PR" --silent || true
+
+          echo "Auto-merge disabled for PR #${PR_NUMBER}"
+
+      - name: Post review notice (once)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          # Only post the notice on the first open, not on every push.
+          if [ "$EVENT_ACTION" != "opened" ]; then
+            echo "Skipping notice (action=${EVENT_ACTION})"
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+          "🤖 **Agent-authored PR — human review required (SEC-08)**
+
+          This pull request was opened by an automated agent. Auto-merge has been
+          disabled: the PR will not merge until a human reviewer explicitly approves
+          it, regardless of CI status.
+
+          Please read the diff carefully before approving — agent PRs can contain
+          plausible-looking but incorrect or injected changes.
+
+          _This is an automated message from the agent-pr-guard workflow (SEC-08)._"

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SEC-08 — Enable branch protection on main requiring human review.
+#
+# Run once by a repository admin:
+#   GITHUB_TOKEN=<admin-pat> ./scripts/setup-branch-protection.sh
+#
+# Requirements:
+#   - gh CLI authenticated as a repo admin
+#   - Fine-grained token with Administration: Write (or classic with `repo`)
+#
+# What this script does:
+#   1. Enables required pull request reviews (≥1 approving review from a
+#      non-author reviewer) on the main branch.
+#   2. Dismisses stale approvals on every new push so an injected commit
+#      cannot ride an earlier human approval.
+#   3. Does NOT enforce for administrators so maintainers can make emergency
+#      fixes; revisit once sandboxed agent environments land (SEC-09+).
+#
+# This is idempotent — safe to re-run after any settings drift.
+
+set -euo pipefail
+
+REPO="${REPO:-orlandoburli/apiary}"
+BRANCH="main"
+
+echo "Applying branch protection to ${REPO}@${BRANCH} ..."
+
+gh api \
+  --method PUT \
+  "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --input - <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+
+echo "Branch protection applied successfully."
+echo ""
+echo "Verify with:"
+echo "  gh api repos/${REPO}/branches/${BRANCH}/protection | jq '.required_pull_request_reviews'"


### PR DESCRIPTION
## Summary

- **Branch protection enabled** on `main`: requires ≥1 approving human review before any PR can merge (`dismiss_stale_reviews: true`, applied immediately via the included script).
- **`agent-pr-guard` workflow** (`.github/workflows/agent-pr-guard.yml`): fires on every PR carrying `agent:engineer`, `ai-complete`, or `ai-ready` labels; disables auto-merge via GraphQL mutation and posts a reviewer notice — defence-in-depth so the auto-merge flag is stripped before any race condition.
- **`git-workflow` skill updated**: removed the `gh pr merge --auto --squash` instruction that previously told agents to enable auto-merge; updated the pipeline description and "Regra fundamental" to reflect SEC-08's requirement for human approval.
- **`scripts/setup-branch-protection.sh`**: idempotent admin script documenting and reproducing the branch protection settings — run by a repo admin once (already applied as part of this PR).

The combination of (1) GitHub-enforced branch protection and (2) the guard workflow means an injected or compromised agent PR cannot land without a human reading and approving the diff, even if CI is green.

## Test plan

- [ ] Verify `gh api repos/orlandoburli/apiary/branches/main/protection | jq '.required_pull_request_reviews'` returns `required_approving_review_count: 1, dismiss_stale_reviews: true`.
- [ ] Open a test PR with `ai-ready` label — confirm `agent-pr-guard` fires, auto-merge is disabled, and the reviewer notice appears.
- [ ] Attempt to merge without an approval — confirm GitHub blocks the merge.
- [ ] Add an approval — confirm merge is then allowed.

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)