### PR TITLE
fix(sec-03): bind worker queue to loopback by default

### DIFF
--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -13,6 +13,26 @@ import (
 	"github.com/orlandoburli/apiary/internal/queuehttp"
 )
 
+// resolveQueueListenAddress ensures the queue protocol server binds to loopback
+// by default. When address has no host component, 127.0.0.1 is used. When the
+// host is non-loopback a warning is logged so operators know they have opted in
+// to a network-exposed binding.
+func resolveQueueListenAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port)
+	}
+	ip := net.ParseIP(host)
+	isLoopback := host == "localhost" || (ip != nil && ip.IsLoopback())
+	if !isLoopback {
+		aplog.Warn("queue worker protocol is bound to a non-loopback address %q; set settings.queue.listen to a loopback address (e.g. 127.0.0.1:<port>) unless remote workers are required", address)
+	}
+	return address
+}
+
 func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.WaitGroup) error {
 	address := strings.TrimSpace(d.cfg.Settings.Queue.Listen)
 	if address == "" {
@@ -21,6 +41,7 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 	if d.dispatchQueue == nil {
 		return fmt.Errorf("queue protocol listener requires the durable queue")
 	}
+	address = resolveQueueListenAddress(address)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return fmt.Errorf("listen for queue workers on %s: %w", address, err)

--- a/src/internal/daemon/queue_server_test.go
+++ b/src/internal/daemon/queue_server_test.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestResolveQueueListenAddress(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{":8080", "127.0.0.1:8080"},
+		{":0", "127.0.0.1:0"},
+		{"127.0.0.1:8080", "127.0.0.1:8080"},
+		{"localhost:8080", "localhost:8080"},
+		{"[::1]:8080", "[::1]:8080"},
+		// non-loopback passes through unchanged (warning is logged separately)
+		{"0.0.0.0:8080", "0.0.0.0:8080"},
+		{"192.168.1.1:8080", "192.168.1.1:8080"},
+		// unparseable — pass through and let net.Listen report the error
+		{"not-an-address", "not-an-address"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := resolveQueueListenAddress(tc.input)
+			if got != tc.want {
+				t.Errorf("resolveQueueListenAddress(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `settings.queue.listen` values without a host (e.g. `":8080"`) now bind to `127.0.0.1` instead of all network interfaces.
- Binding to a non-loopback address (e.g. `0.0.0.0:8080`) still works but emits a `WARN` log so operators know they have opted in to a network-exposed queue endpoint.
- `localhost` and IPv6 loopback `[::1]` are treated as loopback and do not trigger the warning.
- Added `TestResolveQueueListenAddress` covering all address forms (no-host, loopback, non-loopback, unparseable).

TLS for the queue transport is tracked separately in SEC-13.

## Test plan

- [x] `go test ./internal/daemon/ -run TestResolveQueueListenAddress` — all 8 cases pass
- [x] `go vet ./internal/daemon/` — clean
- [x] `gitnexus detect_changes` — risk LOW, no affected processes

Closes #226