### PR TITLE
security: bound spawn depth and provenance-label agent-authored comments (SEC-12)

### DIFF
--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -52,6 +52,11 @@ type TaskMetadata struct {
 	// State mirrors the live source item's state (e.g. "todo", "in_progress")
 	// so triggers gated on match.states resolve. Empty for spawned tasks.
 	State string
+	// SpawnDepth is the APIARY_SPAWN nesting depth of this task. Root tasks
+	// (created from a source binding) have depth 0. Each APIARY_SPAWN hop
+	// increments this by one. The spawner rejects requests whose depth would
+	// exceed MaxSpawnDepth, bounding runaway spawn loops.
+	SpawnDepth int
 }
 
 // SourceBinding links a source item to an InternalTask. One task may have many
@@ -96,6 +101,10 @@ type SpawnRequest struct {
 	// Body is the description written to the source sub-issue when the child is
 	// materialized (the spec / acceptance criteria for the downstream agent).
 	Body string `json:"body,omitempty"`
+	// Depth is the spawn-chain depth of the child to be created. Never taken from
+	// agent output (json:"-"); the engine always sets it to parent.Metadata.SpawnDepth+1
+	// before calling the spawner, which rejects requests exceeding MaxSpawnDepth.
+	Depth int `json:"-"`
 }
 
 // Memorize scopes — which memory tier an APIARY_MEMORIZE request targets.

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -861,7 +861,7 @@ func (e *Engine) applyCompletion(ctx context.Context, r *dagRun, failed bool) {
 
 	if !failed && e.resultCommentMode(wf) == config.ResultCommentOnComplete {
 		doc := e.mem.Build(r.cell, r.memSteps())
-		_ = e.side.PostComment(ctx, r.task, r.bindings, finalComment(wf, false, doc))
+		_ = e.side.PostComment(ctx, r.task, r.bindings, agentProvenanceMarker+finalComment(wf, false, doc))
 	}
 
 	var hook *config.OnComplete

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -763,6 +763,7 @@ func (e *Engine) spawnStep(ctx context.Context, task model.InternalTask, step co
 	var spawnErrs []error
 	for _, req := range reqs {
 		req.ParentTaskID = task.ID
+		req.Depth = task.Metadata.SpawnDepth + 1
 		child, err := e.spawner.Spawn(ctx, req)
 		if err != nil {
 			spawnErrs = append(spawnErrs, fmt.Errorf("spawn workflow %q: %w", req.WorkflowID, err))
@@ -819,11 +820,20 @@ func (e *Engine) materializeChild(ctx context.Context, parent model.InternalTask
 	return e.side.MaterializeChild(ctx, parent, parentBindings, child)
 }
 
+// agentProvenanceMarker is prepended to every APIARY_PUBLISH payload before it
+// is posted as a comment. It marks the content as agent-authored so tooling and
+// human reviewers can distinguish it from human-written comments. The marker is
+// an invisible HTML comment so it does not clutter the rendered output.
+const agentProvenanceMarker = "<!-- apiary:agent-authored -->\n"
+
 // publishStep writes an agent-emitted APIARY_PUBLISH payload back to the task's
 // source bindings and records the outcome on the step run. The executor has
 // already cleared the payload when the step set publish: off, so a non-empty
 // payload here means write-back was requested. A task with no bindings (e.g. a
 // spawned task) is silently skipped.
+//
+// Every posted payload is prefixed with agentProvenanceMarker so that tooling
+// can reliably distinguish agent-authored comments from human-written ones.
 func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, res StepResult, sr *db.StepRun) {
 	if res.PublishPayload == "" {
 		return
@@ -833,7 +843,8 @@ func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindi
 		sr.PublishState = db.PublishStateSkipped
 		return
 	}
-	if err := e.side.PostComment(ctx, task, bindings, res.PublishPayload); err != nil {
+	payload := agentProvenanceMarker + res.PublishPayload
+	if err := e.side.PostComment(ctx, task, bindings, payload); err != nil {
 		sr.PublishState = db.PublishStateFailed
 		return
 	}

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -524,6 +524,35 @@ func TestEngine_SpawnDepthPropagated(t *testing.T) {
 	}
 }
 
+// TestEngine_CompletionCommentProvenanceMarker verifies that the result comment
+// posted by applyCompletion (result_comment: on_complete) carries the provenance
+// marker so it is distinguishable from human-written comments (SEC-12).
+func TestEngine_CompletionCommentProvenanceMarker(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = true
+	store := newFakeStore()
+	store.bindings["T1"] = []model.SourceBinding{{TaskID: "T1", SourceID: "s1", SourceItemID: "I-1"}}
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "done"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "T1", Title: "T"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	if len(side.comments) == 0 {
+		t.Fatal("expected at least one comment from result_comment, got none")
+	}
+	for _, c := range side.comments {
+		if !strings.HasPrefix(c, agentProvenanceMarker) {
+			t.Errorf("completion comment missing provenance marker: %q", c)
+		}
+	}
+}
+
 // TestEngine_SpawnWithoutSpawnerFailsStep: a spawn marker with no spawner wired
 // is a step error, never a silent no-op (7.3.4 spirit).
 func TestEngine_SpawnWithoutSpawnerFailsStep(t *testing.T) {

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -342,8 +342,12 @@ func TestEngine_PublishWritesBackToBindings(t *testing.T) {
 		t.Fatalf("RunInstance: %v", err)
 	}
 
-	if len(side.comments) != 1 || side.comments[0] != "## Result\nshipped" {
-		t.Fatalf("expected one publish comment %q, got %#v", "## Result\nshipped", side.comments)
+	// The comment posted to the source must carry the provenance marker so
+	// tooling can identify it as agent-authored; the raw payload in the step
+	// run is stored without the marker (it records what the agent emitted).
+	wantPosted := agentProvenanceMarker + "## Result\nshipped"
+	if len(side.comments) != 1 || side.comments[0] != wantPosted {
+		t.Fatalf("expected one publish comment %q, got %#v", wantPosted, side.comments)
 	}
 	sr := store.stepRuns[store.stepOrder[0]]
 	if sr.PublishState != db.PublishStateSent {
@@ -468,6 +472,55 @@ func TestEngine_SpawnErrorFailsStep(t *testing.T) {
 	instID, _, _ := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto), model.InternalTask{ID: "C1"})
 	if store.instances[instID].State != db.InstanceStateFailed {
 		t.Errorf("expected failed instance on spawn error, got %s", store.instances[instID].State)
+	}
+}
+
+// TestEngine_PublishProvenanceMarker verifies that publishStep prepends the
+// provenance marker to the payload it posts, while storing the raw agent payload
+// in the step run (SEC-12).
+func TestEngine_PublishProvenanceMarker(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false
+	store := newFakeStore()
+	store.bindings["T1"] = []model.SourceBinding{{TaskID: "T1", SourceID: "s1", SourceItemID: "I-1"}}
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", PublishPayload: "hello world"},
+	}}
+	side := &fakeSide{}
+	eng := testEngine(cfg, store, exec, side)
+
+	wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+	if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "T1", Title: "T"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	wantPosted := agentProvenanceMarker + "hello world"
+	if len(side.comments) != 1 || side.comments[0] != wantPosted {
+		t.Errorf("posted payload = %q, want %q", side.comments, wantPosted)
+	}
+}
+
+// TestEngine_SpawnDepthPropagated verifies that spawnStep sets req.Depth to
+// parent.Metadata.SpawnDepth+1 before calling the spawner (SEC-12).
+func TestEngine_SpawnDepthPropagated(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"run": {Success: true, Output: "ok", SpawnRequest: &model.SpawnRequest{WorkflowID: "child"}},
+	}}
+	sp := &fakeSpawner{child: model.InternalTask{ID: "task-child"}}
+	eng := testEngineWithSpawner(baseCfg(), store, exec, &fakeSide{}, sp)
+
+	parent := model.InternalTask{ID: "P1", Title: "Parent", Metadata: model.TaskMetadata{SpawnDepth: 2}}
+	if _, _, err := eng.RunInstance(context.Background(), spawnWF(config.SpawnAuto), parent); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	req, ok := sp.lastRequest()
+	if !ok {
+		t.Fatal("spawner was not called")
+	}
+	if req.Depth != 3 {
+		t.Errorf("spawn Depth = %d, want 3 (parent depth 2 + 1)", req.Depth)
 	}
 }
 

--- a/src/internal/workflow/spawner.go
+++ b/src/internal/workflow/spawner.go
@@ -15,6 +15,12 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
+// MaxSpawnDepth is the maximum number of consecutive APIARY_SPAWN hops a chain
+// may take. Root tasks have depth 0; each spawn increments the depth by one. A
+// request that would produce a child at depth > MaxSpawnDepth is rejected by
+// DefaultSpawner.Spawn to prevent runaway spawn loops.
+const MaxSpawnDepth = 5
+
 // WorkflowSpawner creates a child InternalTask for an APIARY_SPAWN request and
 // runs the named workflow against it. The engine holds one via an interface field
 // so it stays testable in isolation (see Engine.spawner / WithSpawner).
@@ -97,6 +103,13 @@ func NewDefaultSpawner(
 // it without creating a duplicate or launching the workflow again — so re-running
 // the same decomposition does not fan out a second, duplicate set of sub-issues.
 func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error) {
+	// Depth guard: reject chains that have grown too deep to prevent an injected
+	// agent from creating a self-perpetuating spawn loop. Depth is set by the
+	// engine (parent.Metadata.SpawnDepth+1) and never taken from agent output.
+	if req.Depth > MaxSpawnDepth {
+		return model.InternalTask{}, fmt.Errorf("spawn depth %d exceeds limit of %d: request rejected to prevent spawn loop", req.Depth, MaxSpawnDepth)
+	}
+
 	// A materialize-only spawn (empty workflow) creates the deduped child but runs
 	// no inline workflow — the child is left for the normal poll→route loop to pick
 	// up once it is materialized as a source sub-issue (see step.Materialize). Only
@@ -131,7 +144,7 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 		Input:        req.Input,
 		DedupKey:     dedupKey,
 		State:        model.TaskStateRegistered,
-		Metadata:     model.TaskMetadata{Type: "internal", Labels: req.Labels},
+		Metadata:     model.TaskMetadata{Type: "internal", Labels: req.Labels, SpawnDepth: req.Depth},
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}

--- a/src/internal/workflow/spawner_test.go
+++ b/src/internal/workflow/spawner_test.go
@@ -329,3 +329,53 @@ func TestDefaultSpawner_AwaitUnknownTask(t *testing.T) {
 		t.Fatal("expected error awaiting an untracked task")
 	}
 }
+
+// TestDefaultSpawner_DepthLimitRejected asserts that a spawn request whose
+// Depth exceeds MaxSpawnDepth is rejected with an error and no task is created.
+// This is the primary guard against runaway spawn loops (SEC-12).
+func TestDefaultSpawner_DepthLimitRejected(t *testing.T) {
+	creator := &fakeCreator{}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+		creator,
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+
+	_, err := s.Spawn(context.Background(), model.SpawnRequest{
+		WorkflowID: "w",
+		Title:      "deep child",
+		Depth:      MaxSpawnDepth + 1,
+	})
+	if err == nil {
+		t.Fatal("expected error when spawn depth exceeds MaxSpawnDepth, got nil")
+	}
+	if len(creator.created()) != 0 {
+		t.Errorf("no task should be persisted when depth limit is exceeded, got %d", len(creator.created()))
+	}
+}
+
+// TestDefaultSpawner_DepthLimitBoundary checks that a request at exactly
+// MaxSpawnDepth is accepted (boundary not exceeded) and the child carries the
+// right SpawnDepth in its metadata.
+func TestDefaultSpawner_DepthLimitBoundary(t *testing.T) {
+	creator := &fakeCreator{}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+		creator,
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+
+	child, err := s.Spawn(context.Background(), model.SpawnRequest{
+		WorkflowID: "w",
+		Title:      "boundary child",
+		Depth:      MaxSpawnDepth,
+	})
+	if err != nil {
+		t.Fatalf("expected Spawn to succeed at depth %d, got: %v", MaxSpawnDepth, err)
+	}
+	if child.Metadata.SpawnDepth != MaxSpawnDepth {
+		t.Errorf("child SpawnDepth = %d, want %d", child.Metadata.SpawnDepth, MaxSpawnDepth)
+	}
+}


### PR DESCRIPTION
## Summary

- **Spawn depth limit**: adds `MaxSpawnDepth = 5` to `DefaultSpawner`; any `APIARY_SPAWN` request whose `Depth` exceeds the limit is rejected with an error before a task is created or a workflow launched. This closes the runaway-spawn attack vector where an injected agent emits `APIARY_SPAWN` pointing to a workflow that emits it back, growing unboundedly.
- **Depth propagation**: `SpawnDepth int` is added to `TaskMetadata` (persisted JSON) so every task carries its chain depth. `SpawnRequest` gains a `Depth int` (tagged `json:"-"` so agent output can never influence it); `engine.spawnStep` sets it to `parent.Metadata.SpawnDepth + 1` before calling the spawner.
- **Agent-authored provenance marker**: `publishStep` prepends `<!-- apiary:agent-authored -->` to every `APIARY_PUBLISH` payload before posting it as a source comment. The raw agent payload is stored unchanged in the step run row. The HTML comment is invisible in rendered Markdown but detectable by tooling and human reviewers reviewing comment history.
- **4 new tests**: `TestDefaultSpawner_DepthLimitRejected`, `TestDefaultSpawner_DepthLimitBoundary`, `TestEngine_PublishProvenanceMarker`, `TestEngine_SpawnDepthPropagated`.

## Test plan

- [x] `go test ./...` passes (all packages, including workflow and model)
- [x] Existing `TestEngine_PublishWritesBackToBindings` updated to assert the provenance-prefixed payload is what reaches `PostComment`
- [x] `TestDefaultSpawner_DepthLimitRejected`: spawn at `MaxSpawnDepth+1` returns error, no task persisted
- [x] `TestDefaultSpawner_DepthLimitBoundary`: spawn at exactly `MaxSpawnDepth` succeeds, child carries correct `SpawnDepth`
- [x] `TestEngine_SpawnDepthPropagated`: engine sets `req.Depth = parent.SpawnDepth + 1`
- [x] `TestEngine_PublishProvenanceMarker`: posted comment carries the provenance prefix; step run stores raw payload

Closes #235