### PR TITLE
feat(queuehttp): add optional TLS for the worker queue transport (SEC-13)

### DIFF
--- a/src/internal/cli/worker.go
+++ b/src/internal/cli/worker.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -38,7 +41,8 @@ func newWorkerCmd() *cobra.Command {
 				return fmt.Errorf("config validation failed: %v", errs)
 			}
 			if controlPlane == "" {
-				controlPlane = queueControlPlaneURL(cfg.Settings.Queue.Listen)
+				tlsEnabled := strings.TrimSpace(cfg.Settings.Queue.TLSCertFile) != ""
+				controlPlane = queueControlPlaneURL(cfg.Settings.Queue.Listen, tlsEnabled)
 			}
 			if controlPlane == "" {
 				return fmt.Errorf("--control-plane is required (for example http://apiary-control:8080)")
@@ -96,7 +100,11 @@ func newWorkerCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("initialize worker runners: %w", err)
 			}
-			remote := &queuehttp.Client{BaseURL: controlPlane, Token: token}
+			httpClient, err := workerHTTPClient(cfg.Settings.Queue.TLSCAFile)
+			if err != nil {
+				return fmt.Errorf("configure TLS for control-plane connection: %w", err)
+			}
+			remote := &queuehttp.Client{BaseURL: controlPlane, Token: token, HTTPClient: httpClient}
 			runtimeWorker, err := worker.New(remote, worker.ExecutorFunc(func(execCtx context.Context, job queue.Job) queue.FinishResult {
 				return dispatcher.ExecuteQueuedJob(execCtx, job, workerID)
 			}), worker.Config{
@@ -121,7 +129,7 @@ func newWorkerCmd() *cobra.Command {
 	return cmd
 }
 
-func queueControlPlaneURL(listen string) string {
+func queueControlPlaneURL(listen string, tlsEnabled bool) string {
 	listen = strings.TrimSpace(listen)
 	if listen == "" {
 		return ""
@@ -129,16 +137,44 @@ func queueControlPlaneURL(listen string) string {
 	if strings.HasPrefix(listen, "http://") || strings.HasPrefix(listen, "https://") {
 		return listen
 	}
+	scheme := "http"
+	if tlsEnabled {
+		scheme = "https"
+	}
 	if strings.HasPrefix(listen, ":") {
-		return "http://127.0.0.1" + listen
+		return scheme + "://127.0.0.1" + listen
 	}
 	if strings.HasPrefix(listen, "0.0.0.0:") {
-		return "http://127.0.0.1:" + strings.TrimPrefix(listen, "0.0.0.0:")
+		return scheme + "://127.0.0.1:" + strings.TrimPrefix(listen, "0.0.0.0:")
 	}
 	if strings.HasPrefix(listen, "[") || strings.Count(listen, ":") == 1 {
-		return "http://" + listen
+		return scheme + "://" + listen
 	}
 	return listen
+}
+
+// workerHTTPClient returns an *http.Client suitable for connecting to the
+// control-plane. When caFile is set the returned client trusts only that CA,
+// enabling mutual verification against self-signed certificates. When caFile
+// is empty the system root pool is used.
+func workerHTTPClient(caFile string) (*http.Client, error) {
+	caFile = strings.TrimSpace(caFile)
+	if caFile == "" {
+		return http.DefaultClient, nil
+	}
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read TLS CA file %q: %w", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("TLS CA file %q contains no valid PEM certificates", caFile)
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}, nil
 }
 
 func normalizedValues(values []string) []string {

--- a/src/internal/cli/worker_test.go
+++ b/src/internal/cli/worker_test.go
@@ -3,14 +3,23 @@ package cli
 import "testing"
 
 func TestQueueControlPlaneURL(t *testing.T) {
-	for input, want := range map[string]string{
-		":8080":                  "http://127.0.0.1:8080",
-		"0.0.0.0:8080":           "http://127.0.0.1:8080",
-		"apiary.local:8080":      "http://apiary.local:8080",
-		"https://apiary.example": "https://apiary.example",
-	} {
-		if got := queueControlPlaneURL(input); got != want {
-			t.Errorf("queueControlPlaneURL(%q)=%q, want %q", input, got, want)
+	tests := []struct {
+		input      string
+		tlsEnabled bool
+		want       string
+	}{
+		{":8080", false, "http://127.0.0.1:8080"},
+		{"0.0.0.0:8080", false, "http://127.0.0.1:8080"},
+		{"apiary.local:8080", false, "http://apiary.local:8080"},
+		{"https://apiary.example", false, "https://apiary.example"},
+		{":8080", true, "https://127.0.0.1:8080"},
+		{"0.0.0.0:8080", true, "https://127.0.0.1:8080"},
+		{"apiary.local:8080", true, "https://apiary.local:8080"},
+		{"https://apiary.example", true, "https://apiary.example"},
+	}
+	for _, tc := range tests {
+		if got := queueControlPlaneURL(tc.input, tc.tlsEnabled); got != tc.want {
+			t.Errorf("queueControlPlaneURL(%q, %v)=%q, want %q", tc.input, tc.tlsEnabled, got, tc.want)
 		}
 	}
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -306,6 +306,9 @@ type QueueSettings struct {
 	PollInterval       string                   `yaml:"poll_interval,omitempty"`
 	Listen             string                   `yaml:"listen,omitempty"`
 	WorkerToken        string                   `yaml:"worker_token,omitempty"`
+	TLSCertFile        string                   `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile         string                   `yaml:"tls_key_file,omitempty"`
+	TLSCAFile          string                   `yaml:"tls_ca_file,omitempty"`
 	Concurrency        QueueConcurrencySettings `yaml:"concurrency,omitempty"`
 }
 

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -283,6 +283,14 @@ func validateQueueSettings(settings QueueSettings) []error {
 	if strings.TrimSpace(settings.Listen) != "" && strings.TrimSpace(settings.WorkerToken) == "" {
 		errs = append(errs, fmt.Errorf("settings.queue.worker_token is required when settings.queue.listen is configured"))
 	}
+	hasCert := strings.TrimSpace(settings.TLSCertFile) != ""
+	hasKey := strings.TrimSpace(settings.TLSKeyFile) != ""
+	if hasCert != hasKey {
+		errs = append(errs, fmt.Errorf("settings.queue.tls_cert_file and settings.queue.tls_key_file must both be set or both be empty"))
+	}
+	if strings.TrimSpace(settings.TLSCAFile) != "" && !hasCert {
+		errs = append(errs, fmt.Errorf("settings.queue.tls_ca_file requires tls_cert_file and tls_key_file to be set"))
+	}
 	durations := []struct {
 		name, value string
 		fallback    time.Duration

--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -32,11 +32,20 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 		OnTerminal: d.settleRemoteQueueJob,
 	}.Handler()
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+	certFile := strings.TrimSpace(d.cfg.Settings.Queue.TLSCertFile)
+	keyFile := strings.TrimSpace(d.cfg.Settings.Queue.TLSKeyFile)
+	tlsEnabled := certFile != "" && keyFile != ""
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			aplog.Error("queue protocol server: %v", err)
+		var serveErr error
+		if tlsEnabled {
+			serveErr = server.ServeTLS(listener, certFile, keyFile)
+		} else {
+			serveErr = server.Serve(listener)
+		}
+		if serveErr != nil && serveErr != http.ErrServerClosed {
+			aplog.Error("queue protocol server: %v", serveErr)
 		}
 	}()
 	wg.Add(1)
@@ -47,6 +56,10 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()
-	aplog.Info("queue worker protocol listening on %s", listener.Addr())
+	if tlsEnabled {
+		aplog.Info("queue worker protocol listening on %s (TLS)", listener.Addr())
+	} else {
+		aplog.Info("queue worker protocol listening on %s", listener.Addr())
+	}
 	return nil
 }

--- a/src/internal/queuehttp/protocol_test.go
+++ b/src/internal/queuehttp/protocol_test.go
@@ -71,6 +71,45 @@ func TestAuthenticatedWorkerLifecycle(t *testing.T) {
 	}
 }
 
+func TestTLSWorkerLifecycle(t *testing.T) {
+	ctx := context.Background()
+	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = clientDB.Close() })
+	store := clientDB.Queue()
+
+	// httptest.NewTLSServer uses a self-signed cert; server.Client() has the
+	// matching trust pool, simulating a client that trusts the server's CA.
+	server := httptest.NewTLSServer(queuehttp.Server{Store: store, Token: "tls-secret", LeaseDuration: time.Minute, WorkerTimeout: time.Minute}.Handler())
+	t.Cleanup(server.Close)
+	remote := &queuehttp.Client{BaseURL: server.URL, Token: "tls-secret", HTTPClient: server.Client()}
+
+	w := &queue.Worker{ID: "tls-worker-1", ProtocolVersion: queue.WorkerProtocolVersion, Pool: "build", Labels: []string{"linux"}, Capabilities: []string{"runner:codex"}, Capacity: 1, Ready: true}
+	if err := remote.RegisterWorker(ctx, w); err != nil {
+		t.Fatalf("RegisterWorker over TLS: %v", err)
+	}
+	job := &queue.Job{IdempotencyKey: "tls:1", Pool: "build", RequiredLabels: []string{"linux"}, RequiredCapabilities: []string{"runner:codex"}, PayloadVersion: 1, Payload: []byte(`{"task":"tls"}`), MaxAttempts: 1}
+	if created, err := store.Enqueue(ctx, job); err != nil || !created {
+		t.Fatalf("enqueue created=%v err=%v", created, err)
+	}
+	claim, err := remote.Claim(ctx, queue.ClaimRequest{WorkerID: w.ID})
+	if err != nil {
+		t.Fatalf("Claim over TLS: %v", err)
+	}
+	if err := remote.Finish(ctx, job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatalf("Finish over TLS: %v", err)
+	}
+	got, err := remote.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != queue.JobSucceeded {
+		t.Fatalf("state=%s, want succeeded", got.State)
+	}
+}
+
 func TestProtocolRejectsInvalidAuthenticationAndVersion(t *testing.T) {
 	ctx := context.Background()
 	clientDB, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))


### PR DESCRIPTION
## Summary

- Adds `tls_cert_file`, `tls_key_file`, and `tls_ca_file` fields to `QueueSettings` so operators can opt in to TLS without breaking existing plain-HTTP deployments.
- The queue protocol server switches from `http.Server.Serve` to `ServeTLS` when cert+key paths are configured; the log line distinguishes the two modes.
- The worker CLI auto-derives `https://` control-plane URLs when TLS is enabled on the same node, and builds a custom-CA `http.Client` when `tls_ca_file` is set (self-signed cert support).
- Config validation rejects mismatched cert/key pairs and an orphaned `tls_ca_file` without cert+key.
- New `TestTLSWorkerLifecycle` test exercises a full register→claim→finish round-trip through `httptest.NewTLSServer`; existing `TestQueueControlPlaneURL` table is extended to cover the TLS/non-TLS scheme branches.

## Test plan

- [x] `go test -count=1 ./internal/queuehttp/... ./internal/config/... ./internal/daemon/... ./internal/cli/...` — all green
- [x] `TestTLSWorkerLifecycle` — new test verifies end-to-end TLS worker flow
- [x] `TestQueueControlPlaneURL` — extended to assert `https://` scheme when TLS enabled
- [ ] Smoke: run `apiary worker --control-plane https://<host>:PORT` against a daemon with `tls_cert_file`/`tls_key_file` set

Closes #236