### PR TITLE
security: extend redaction to stderr logs and add govulncheck + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,28 @@
+name: govulncheck
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        working-directory: src
+        run: govulncheck ./...

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -5,6 +5,8 @@ package log
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 	"sync"
 	"time"
 )
@@ -14,6 +16,11 @@ var (
 	sinkMu  sync.RWMutex
 	sink    func(level, msg string)
 )
+
+// jwtPattern matches JWT-shaped bearer tokens (three base64url segments
+// starting with "eyJ"). Kept out of logs for the same reason it is stripped
+// from transcripts: agents routinely emit tokens in tool call output.
+var jwtPattern = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`)
 
 // Enable turns verbose (debug) output on or off.
 func Enable(v bool) { verbose = v }
@@ -55,7 +62,7 @@ func Error(format string, args ...any) {
 
 func print(level, format string, args ...any) {
 	ts := time.Now().Format("15:04:05")
-	msg := fmt.Sprintf(format, args...)
+	msg := redactMsg(fmt.Sprintf(format, args...))
 	fmt.Fprintf(os.Stderr, "%s  %-5s  %s\n", ts, level, msg)
 
 	sinkMu.RLock()
@@ -64,4 +71,22 @@ func print(level, format string, args ...any) {
 	if f != nil {
 		f(level, msg)
 	}
+}
+
+// redactMsg removes credential-shaped strings from a log message before it
+// reaches stderr or the sink. It mirrors the patterns used in
+// db/execution_event.go (looksLikeSecret) and runner/execution/transcript.go
+// (jwtPattern) so all output surfaces share the same redaction logic.
+func redactMsg(s string) string {
+	s = jwtPattern.ReplaceAllString(s, "[redacted-jwt]")
+	lower := strings.ToLower(s)
+	for _, marker := range []string{"ghp_", "github_pat_", "xoxb-", "xoxp-", "bearer "} {
+		if strings.Contains(lower, marker) {
+			return "[redacted]"
+		}
+	}
+	if strings.Contains(s, "AKIA") {
+		return "[redacted]"
+	}
+	return s
 }

--- a/src/internal/log/log_test.go
+++ b/src/internal/log/log_test.go
@@ -1,0 +1,37 @@
+package log
+
+import "testing"
+
+func TestRedactMsg(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// plain text passes through
+		{"hello world", "hello world"},
+		// JWT is replaced inline
+		{
+			"token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c end",
+			"token [redacted-jwt] end",
+		},
+		// GitHub PAT
+		{"auth ghp_abcdefghijklmnopqrstuvwxyz0123456789", "[redacted]"},
+		// GitHub fine-grained PAT
+		{"using github_pat_ABCD1234", "[redacted]"},
+		// Slack bot token
+		{"header: xoxb-12345-secret", "[redacted]"},
+		// Slack user token
+		{"xoxp-token-value", "[redacted]"},
+		// Bearer header
+		{"Authorization: Bearer sometoken", "[redacted]"},
+		// AWS access key
+		{"key=AKIAIOSFODNN7EXAMPLE", "[redacted]"},
+	}
+
+	for _, tc := range cases {
+		got := redactMsg(tc.input)
+		if got != tc.want {
+			t.Errorf("redactMsg(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Redaction consistency**: `internal/log` stderr output now applies the same JWT regex (`eyJ…`) and credential markers (`ghp_`, `github_pat_`, `xoxb-`, `xoxp-`, `bearer`, `AKIA`) already used in `db/execution_event.go` and `runner/execution/transcript.go`. The new `redactMsg` helper is called in `print()` before writing to stderr and before forwarding to the sink, so tokens are stripped on every log level.
- **Unit test**: `src/internal/log/log_test.go` covers plain text pass-through and each credential class (JWT, GH PAT, GH fine-grained PAT, Slack bot/user tokens, Bearer header, AWS access key).
- **`govulncheck` in CI**: new `.github/workflows/govulncheck.yml` runs `golang.org/x/vuln/cmd/govulncheck ./...` on every push and pull request, flagging dependency CVEs before they reach a release.
- **Dependabot**: `.github/dependabot.yml` schedules weekly scans for both Go modules (`/src`) and GitHub Actions pinned versions.

## Test plan

- [ ] `go test ./internal/log/...` passes locally (verified: `PASS` in `TestRedactMsg`)
- [ ] `go build ./...` compiles cleanly
- [ ] CI govulncheck job runs green on this PR's push
- [ ] Dependabot PRs appear within a week for stale Actions pins / Go deps with known CVEs

Closes #240