### PR TITLE
fix(security): enforce collaborator trust gate at daemon ingest (SEC-01)

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1383,7 +1383,55 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			d.inFlight.Delete(cell.ID)
 			continue
 		}
+		// Trust gate: block dispatch for issues whose author is not a repository
+		// collaborator. The GitHub /issues endpoint returns author_association on
+		// every item, so no extra API call is required. Only items that carry an
+		// explicit association string are subject to this check — non-GitHub
+		// sources (which never set the key) pass through unchanged.
+		//
+		// A TOCTOU race exists between issue creation and the triage-gate Action
+		// removing the trigger label: this daemon-side check closes that window by
+		// refusing to dispatch regardless of which labels are currently set.
+		if assoc, ok := cell.Metadata["author_association"].(string); ok && assoc != "" {
+			if !isTrustedAssociation(assoc) {
+				login, _ := cell.Metadata["author_login"].(string)
+				aplog.Warn("cell %s (%q): author %q has association %q — parking as needs-triage, dispatch blocked",
+					cell.LogLabel(), cell.Title, login, assoc)
+				d.parkUntrustedCell(ctx, cell, adapter, sc.Filters.Labels)
+				d.inFlight.Delete(cell.ID)
+				continue
+			}
+		}
 		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+	}
+}
+
+// isTrustedAssociation reports whether the GitHub author_association value
+// represents a repository insider. Mirrors the trust set in triage-gate.yml.
+func isTrustedAssociation(assoc string) bool {
+	switch assoc {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+// parkUntrustedCell marks a cell whose author is not trusted: it adds the
+// "needs-triage" label and strips the source filter labels that caused it to
+// be polled, preventing re-dispatch on the next poll cycle before the
+// triage-gate Action fires. Both operations are best-effort — a failure is
+// logged but never fatal.
+func (d *Dispatcher) parkUntrustedCell(ctx context.Context, cell model.SourceItem, adapter source.Adapter, triggerLabels []string) {
+	if la, ok := adapter.(source.LabelAdder); ok {
+		if err := la.AddLabels(ctx, cell, []string{"needs-triage"}); err != nil {
+			aplog.Error("cell %s: trust gate: adding needs-triage: %v", cell.LogLabel(), err)
+		}
+	}
+	if lr, ok := adapter.(source.LabelRemover); ok && len(triggerLabels) > 0 {
+		if err := lr.RemoveLabels(ctx, cell, triggerLabels); err != nil {
+			aplog.Error("cell %s: trust gate: removing trigger labels %v: %v", cell.LogLabel(), triggerLabels, err)
+		}
 	}
 }
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -763,6 +763,18 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 				d.inFlight.Delete(cell.ID)
 				continue
 			}
+			// Trust gate: same check as in poll() — block untrusted authors before
+			// any shell-capable agent can be dispatched.
+			if assoc, ok := cell.Metadata["author_association"].(string); ok && assoc != "" {
+				if !isTrustedAssociation(assoc) {
+					login, _ := cell.Metadata["author_login"].(string)
+					aplog.Warn("cell %s (%q): author %q has association %q — parking as needs-triage, dispatch blocked",
+						cell.LogLabel(), cell.Title, login, assoc)
+					d.parkUntrustedCell(ctx, cell, adapter, sc.Filters.Labels)
+					d.inFlight.Delete(cell.ID)
+					continue
+				}
+			}
 			d.fanOut(ctx, cell, adapter, task, persisted, matches, &wg, func(id string) {
 				mu.Lock()
 				failedIDs = append(failedIDs, id)

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -1,0 +1,233 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// TestIsTrustedAssociation verifies the GitHub collaborator trust set.
+func TestIsTrustedAssociation(t *testing.T) {
+	trusted := []string{"OWNER", "MEMBER", "COLLABORATOR"}
+	for _, assoc := range trusted {
+		if !isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = false, want true", assoc)
+		}
+	}
+
+	untrusted := []string{"CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "NONE", ""}
+	for _, assoc := range untrusted {
+		if isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = true, want false", assoc)
+		}
+	}
+}
+
+// trustAdapter is a source that implements LabelAdder and LabelRemover so the
+// trust gate can inspect what label operations were requested.
+type trustAdapter struct {
+	items         []model.SourceItem
+	addedLabels   []string
+	removedLabels []string
+}
+
+func (a *trustAdapter) ID() string                                    { return "gh-trust" }
+func (a *trustAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *trustAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *trustAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *trustAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *trustAdapter) WebhookHandler() http.Handler { return nil }
+func (a *trustAdapter) AddLabels(_ context.Context, _ model.SourceItem, labels []string) error {
+	a.addedLabels = append(a.addedLabels, labels...)
+	return nil
+}
+func (a *trustAdapter) RemoveLabels(_ context.Context, _ model.SourceItem, labels []string) error {
+	a.removedLabels = append(a.removedLabels, labels...)
+	return nil
+}
+
+func newTrustDispatcher(t *testing.T, triggerLabels []string) (*Dispatcher, *countingRunner, *db.Client) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "trust.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{
+			ID:   "gh-trust",
+			Type: "gh-trust",
+			Filters: config.SourceFilters{
+				Labels: triggerLabels,
+			},
+		}},
+		Agents: []config.AgentConfig{
+			{ID: "bot", Model: "test/model"},
+		},
+		Workflows: []config.WorkflowConfig{{
+			ID: "wf-trust",
+			Trigger: &config.TriggerConfig{
+				Match: config.RouteMatch{
+					Source: "gh-trust",
+					Labels: triggerLabels,
+				},
+			},
+			Steps: []config.StepConfig{{ID: "run", Agent: "bot"}},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	runner := &countingRunner{}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{},
+		runners:     map[string]runnerpkg.Runner{"agent-bot": runner},
+		agentRunner: map[string]string{"bot": "test"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"gh-trust": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, runner, dbc
+}
+
+// TestTrustGate_BlocksUntrustedAuthor verifies that poll() refuses to dispatch
+// when author_association is not in the trusted set, and instead applies the
+// "needs-triage" label and removes the trigger labels.
+func TestTrustGate_BlocksUntrustedAuthor(t *testing.T) {
+	d, runner, _ := newTrustDispatcher(t, []string{"ai-ready"})
+
+	adapter := &trustAdapter{
+		items: []model.SourceItem{
+			{
+				ID:       "99",
+				SourceID: "gh-trust",
+				Title:    "Untrusted issue",
+				Labels:   []string{"ai-ready"},
+				Metadata: map[string]any{
+					"author_association": "NONE",
+					"author_login":       "outsider",
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	d.sources["gh-trust"] = adapter
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	if got := runner.n.Load(); got != 0 {
+		t.Errorf("dispatch count = %d, want 0: untrusted author must be blocked", got)
+	}
+
+	foundNeedsTriage := false
+	for _, l := range adapter.addedLabels {
+		if l == "needs-triage" {
+			foundNeedsTriage = true
+		}
+	}
+	if !foundNeedsTriage {
+		t.Errorf("added labels = %v, want needs-triage to be added", adapter.addedLabels)
+	}
+
+	foundAiReady := false
+	for _, l := range adapter.removedLabels {
+		if l == "ai-ready" {
+			foundAiReady = true
+		}
+	}
+	if !foundAiReady {
+		t.Errorf("removed labels = %v, want ai-ready to be stripped", adapter.removedLabels)
+	}
+}
+
+// TestTrustGate_AllowsTrustedAuthor verifies that a MEMBER is dispatched normally.
+func TestTrustGate_AllowsTrustedAuthor(t *testing.T) {
+	d, runner, _ := newTrustDispatcher(t, []string{"ai-ready"})
+
+	adapter := &trustAdapter{
+		items: []model.SourceItem{
+			{
+				ID:       "77",
+				SourceID: "gh-trust",
+				Title:    "Trusted member issue",
+				Labels:   []string{"ai-ready"},
+				Metadata: map[string]any{
+					"author_association": "MEMBER",
+					"author_login":       "team-member",
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	d.sources["gh-trust"] = adapter
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	// Give dispatch goroutines time to run.
+	time.Sleep(300 * time.Millisecond)
+
+	if got := runner.n.Load(); got == 0 {
+		t.Error("dispatch count = 0: trusted MEMBER must be dispatched")
+	}
+	if len(adapter.addedLabels) != 0 {
+		t.Errorf("added labels = %v for trusted author, want none", adapter.addedLabels)
+	}
+}
+
+// TestTrustGate_SourceWithoutAssociation verifies that a SourceItem with no
+// author_association metadata (Jira/Plane) passes through unblocked.
+func TestTrustGate_SourceWithoutAssociation(t *testing.T) {
+	d, runner, _ := newTrustDispatcher(t, []string{"ai-ready"})
+
+	adapter := &trustAdapter{
+		items: []model.SourceItem{
+			{
+				ID:        "55",
+				SourceID:  "gh-trust",
+				Title:     "Plane task without association",
+				Labels:    []string{"ai-ready"},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+				// No Metadata — simulates a non-GitHub source.
+			},
+		},
+	}
+	d.sources["gh-trust"] = adapter
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	time.Sleep(300 * time.Millisecond)
+
+	if got := runner.n.Load(); got == 0 {
+		t.Error("dispatch count = 0: items without author_association must be dispatched")
+	}
+}

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -231,3 +231,45 @@ func TestTrustGate_SourceWithoutAssociation(t *testing.T) {
 		t.Error("dispatch count = 0: items without author_association must be dispatched")
 	}
 }
+
+// TestTrustGate_RunOnce_BlocksUntrustedAuthor verifies that RunOnce() enforces
+// the trust gate on the same code path as poll().
+func TestTrustGate_RunOnce_BlocksUntrustedAuthor(t *testing.T) {
+	d, runner, _ := newTrustDispatcher(t, []string{"ai-ready"})
+
+	adapter := &trustAdapter{
+		items: []model.SourceItem{
+			{
+				ID:       "100",
+				SourceID: "gh-trust",
+				Title:    "Untrusted via RunOnce",
+				Labels:   []string{"ai-ready"},
+				Metadata: map[string]any{
+					"author_association": "CONTRIBUTOR",
+					"author_login":       "external",
+				},
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+		},
+	}
+	d.sources["gh-trust"] = adapter
+
+	if err := d.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if got := runner.n.Load(); got != 0 {
+		t.Errorf("dispatch count = %d via RunOnce, want 0: untrusted author must be blocked", got)
+	}
+
+	foundNeedsTriage := false
+	for _, l := range adapter.addedLabels {
+		if l == "needs-triage" {
+			foundNeedsTriage = true
+		}
+	}
+	if !foundNeedsTriage {
+		t.Errorf("RunOnce added labels = %v, want needs-triage", adapter.addedLabels)
+	}
+}

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -689,6 +689,10 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		URL:         item.HTMLURL,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
+		Metadata: map[string]any{
+			"author_association": item.AuthorAssociation,
+			"author_login":       item.User.Login,
+		},
 	}
 }
 

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -380,3 +380,46 @@ func TestAddLabels_AppendsWithoutReplacing(t *testing.T) {
 		t.Errorf("posted body must not replay the snapshot labels: %s", postedBody)
 	}
 }
+
+// TestToCell_AuthorAssociation verifies that toSourceItem carries author_association
+// and author_login from the raw issue into SourceItem.Metadata, so the daemon
+// trust gate can read them without an extra API call.
+func TestToCell_AuthorAssociation(t *testing.T) {
+	a := &Adapter{id: "gh-test"}
+	item := issue{
+		Number:            10,
+		Title:             "Security report",
+		AuthorAssociation: "COLLABORATOR",
+		User:              user{Login: "trusted-dev"},
+	}
+
+	cell := a.toSourceItem(item)
+
+	if cell.Metadata == nil {
+		t.Fatal("Metadata must not be nil")
+	}
+	if got := cell.Metadata["author_association"]; got != "COLLABORATOR" {
+		t.Errorf("author_association = %q, want %q", got, "COLLABORATOR")
+	}
+	if got := cell.Metadata["author_login"]; got != "trusted-dev" {
+		t.Errorf("author_login = %q, want %q", got, "trusted-dev")
+	}
+}
+
+// TestToCell_AuthorAssociation_None verifies that NONE (external contributor)
+// is captured verbatim — the trust gate decides what to do with it.
+func TestToCell_AuthorAssociation_None(t *testing.T) {
+	a := &Adapter{id: "gh-test"}
+	item := issue{
+		Number:            11,
+		Title:             "Spam issue",
+		AuthorAssociation: "NONE",
+		User:              user{Login: "random-user"},
+	}
+
+	cell := a.toSourceItem(item)
+
+	if got := cell.Metadata["author_association"]; got != "NONE" {
+		t.Errorf("author_association = %q, want %q", got, "NONE")
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,11 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is GitHub's trust level for the issue author relative to
+	// the repository: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR,
+	// FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, or NONE. Populated by the /issues
+	// REST endpoint with no extra API call.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {


### PR DESCRIPTION
## Summary

- **TOCTOU race closed**: PR #242 added a GitHub Actions `triage-gate` to strip `ai-ready` from untrusted authors, but the daemon polls on a 120 s tick and can ingest an issue in the window before the Action fires. This PR closes that race by enforcing the trust check **inside the daemon's ingest paths**, before `fanOut()` is ever called.
- **`author_association` decoded at ingest**: GitHub already returns `author_association` (OWNER / MEMBER / COLLABORATOR / CONTRIBUTOR / NONE / …) on every item from the `/repos/orlandoburli/apiary/issues` endpoint — no extra API call. The field is decoded by the GitHub adapter and carried in `SourceItem.Metadata`.
- **Both ingest paths protected**: `poll()` and `RunOnce()` both call the trust gate check before `fanOut()`.
- **Untrusted authors are parked, not dispatched**: when `author_association` is not in `{OWNER, MEMBER, COLLABORATOR}`, the daemon adds `needs-triage` and removes the trigger labels, then skips `fanOut()`. No shell-capable agent runs.
- **Non-GitHub sources unaffected**: Jira/Plane items have no `author_association` key and pass through unchanged — fully backwards compatible.
- **`triage-gate` Action retained as defence-in-depth** — now secondary, no longer the sole control.

## Changed files

| File | Change |
|------|--------|
| `src/internal/source/github/types.go` | Add `AuthorAssociation string` to `issue` struct |
| `src/internal/source/github/adapter.go` | Populate `Metadata["author_association"]` and `Metadata["author_login"]` in `toSourceItem()` |
| `src/internal/daemon/dispatcher.go` | Trust gate in `poll()` and `RunOnce()` + `isTrustedAssociation()` + `parkUntrustedCell()` |
| `src/internal/source/github/adapter_test.go` | Two new tests for Metadata propagation |
| `src/internal/daemon/trust_gate_test.go` | Five new tests covering block / allow / non-GitHub passthrough / RunOnce |

## Test plan

- [x] `go test ./...` — all packages green
- [x] `TestTrustGate_BlocksUntrustedAuthor` — NONE author: dispatch=0, needs-triage added, ai-ready removed
- [x] `TestTrustGate_AllowsTrustedAuthor` — MEMBER: dispatched normally, no label mutation
- [x] `TestTrustGate_SourceWithoutAssociation` — no `author_association` key: dispatched normally
- [x] `TestTrustGate_RunOnce_BlocksUntrustedAuthor` — CONTRIBUTOR via RunOnce: dispatch=0, needs-triage added
- [x] `TestIsTrustedAssociation` — trusted/untrusted sets verified exhaustively
- [x] `TestToCell_AuthorAssociation` / `_None` — Metadata populated correctly in adapter

Closes #244