### PR TITLE
security: check per-plugin subdirectory permissions in Discover (SEC-04 follow-up)

### DIFF
--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -53,6 +53,15 @@ func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error
 		}
 		sort.Strings(roots)
 		for _, root := range roots {
+			if root != path {
+				// Per-plugin subdirectory: enforce owner-only permissions just like
+				// the parent. A writable child dir is the common attack surface —
+				// it bypasses the top-level check when the parent is correctly locked.
+				if warn := checkDirOwnerOnly(root); warn != nil {
+					errs = append(errs, warn)
+					continue
+				}
+			}
 			if _, err := os.Stat(filepath.Join(root, ManifestFilename)); err != nil {
 				continue
 			}

--- a/src/internal/plugin/discovery_unix_test.go
+++ b/src/internal/plugin/discovery_unix_test.go
@@ -10,35 +10,67 @@ import (
 )
 
 func TestDiscoverSkipsGroupAndWorldWritableDirs(t *testing.T) {
-	parent := t.TempDir()
+	t.Run("writable parent dir is refused entirely", func(t *testing.T) {
+		parent := t.TempDir()
 
-	// Write a valid plugin so we can confirm it is NOT loaded.
-	writeTestPlugin(t, parent, "legit", "exit 0", Manifest{})
+		// Write a valid plugin so we can confirm it is NOT loaded.
+		writeTestPlugin(t, parent, "legit", "exit 0", Manifest{})
 
-	// Make the plugin directory group-writable — discovery must refuse it.
-	if err := os.Chmod(parent, 0o775); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+		// Make the plugin directory group-writable — discovery must refuse it.
+		if err := os.Chmod(parent, 0o775); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
 
-	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
-	if len(registry.List()) != 0 {
-		t.Fatalf("expected 0 plugins loaded from writable dir, got %d", len(registry.List()))
-	}
-	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
-		t.Fatalf("expected permission warning, got errs=%v", errs)
-	}
+		registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+		if len(registry.List()) != 0 {
+			t.Fatalf("expected 0 plugins loaded from writable dir, got %d", len(registry.List()))
+		}
+		if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+			t.Fatalf("expected permission warning, got errs=%v", errs)
+		}
 
-	// A second path with correct permissions should still load fine.
-	safeParent := t.TempDir() // TempDir creates 0700 — passes the check
-	writeTestPlugin(t, safeParent, "safe", "exit 0", Manifest{})
-	_ = os.WriteFile(filepath.Join(safeParent, "safe", "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
+		// A second path with correct permissions should still load fine.
+		safeParent := t.TempDir() // TempDir creates 0700 — passes the check
+		writeTestPlugin(t, safeParent, "safe", "exit 0", Manifest{})
+		_ = os.WriteFile(filepath.Join(safeParent, "safe", "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755)
 
-	registry2, errs2 := Discover([]string{parent, safeParent}, safeParent, "v0.10.0")
-	if len(errs2) != 1 || !strings.Contains(errs2[0].Error(), "group- or world-writable") {
-		t.Fatalf("expected exactly 1 warning for the bad path, got errs=%v", errs2)
-	}
-	if _, ok := registry2.Get("dev.apiary.safe"); !ok {
-		t.Fatal("safe plugin from good path should still load")
-	}
+		registry2, errs2 := Discover([]string{parent, safeParent}, safeParent, "v0.10.0")
+		if len(errs2) != 1 || !strings.Contains(errs2[0].Error(), "group- or world-writable") {
+			t.Fatalf("expected exactly 1 warning for the bad path, got errs=%v", errs2)
+		}
+		if _, ok := registry2.Get("dev.apiary.safe"); !ok {
+			t.Fatal("safe plugin from good path should still load")
+		}
+	})
+
+	t.Run("writable child plugin dir is skipped, sibling is loaded", func(t *testing.T) {
+		// Parent is owner-only (0700) — passes the top-level check.
+		parent := t.TempDir()
+
+		writeTestPlugin(t, parent, "good", "exit 0", Manifest{})
+		writeTestPlugin(t, parent, "bad", "exit 0", Manifest{})
+
+		// Make the "bad" plugin subdirectory group-writable.
+		badDir := filepath.Join(parent, "bad")
+		if err := os.Chmod(badDir, 0o775); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(badDir, 0o755) })
+
+		registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+
+		// The writable child must produce exactly one permission warning.
+		if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+			t.Fatalf("expected 1 permission warning for writable child, got errs=%v", errs)
+		}
+		// The safe sibling must still be loaded.
+		if _, ok := registry.Get("dev.apiary.good"); !ok {
+			t.Fatal("good plugin from secure sibling dir should load")
+		}
+		// The writable plugin must be rejected.
+		if _, ok := registry.Get("dev.apiary.bad"); ok {
+			t.Fatal("bad plugin from writable dir must not load")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Extends the plugin directory permission check from #241 to cover the standard multi-plugin layout (`plugins/<a>/`, `plugins/<b>/`).
- Before this fix, `checkDirOwnerOnly` was called only on the configured top-level path; each per-plugin subdirectory entered the load loop unchecked. A correctly-locked parent containing a group/world-writable child still served any executable planted there.
- Fix: inside the roots loop, call `checkDirOwnerOnly(root)` for every root that is a subdirectory (`root != path`); skip and warn on failure, mirroring the existing top-level guard.
- Test: splits `TestDiscoverSkipsGroupAndWorldWritableDirs` into two named sub-tests and adds a new one — owner-only parent with one writable child and one safe sibling — verifying the writable child is skipped and the safe sibling loads.

## Test plan

- [x] `go test ./internal/plugin/...` passes (both sub-tests green)
- [x] New sub-test `writable child plugin dir is skipped, sibling is loaded` fails before the fix and passes after
- [x] Existing `writable parent dir is refused entirely` behaviour unchanged

Closes #245