### PR TITLE
feat(security): cap agent privilege ceiling — refuse root and support per-agent env denylist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10294 symbols, 23404 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10294 symbols, 23404 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -43,6 +43,15 @@ func newRunCmd() *cobra.Command {
 				}
 				return fmt.Errorf("config validation failed")
 			}
+			if os.Getuid() == 0 && !cfg.Settings.Security.AllowRoot {
+				return fmt.Errorf(
+					"refusing to start: apiary is running as root (uid 0).\n" +
+						"Running the daemon as root grants every agent CLI subprocess full system access,\n" +
+						"which is unsafe when agents process untrusted content (e.g. Jira tickets, GitHub issues).\n" +
+						"Run apiary as a non-root user, or set settings.security.allow_root: true in apiary.yaml\n" +
+						"only if you understand the risk (e.g. inside an isolated container).",
+				)
+			}
 			for _, w := range cfg.WorkflowWarnings() {
 				fmt.Fprintf(os.Stderr, "  ⚠ %s\n", w)
 			}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -84,6 +84,37 @@ func (r *RunnerConfig) AdapterName() string {
 	return r.Type
 }
 
+// AgentSecurity is the per-agent privilege ceiling. It overrides or narrows the
+// global Settings.Security for runs dispatched through this specific agent.
+type AgentSecurity struct {
+	// AllowRoot, when true, permits the agent CLI subprocess to execute as uid 0
+	// (root). Requires Settings.Security.AllowRoot to also be true — per-agent
+	// opt-in alone is not sufficient; both gates must be open.
+	AllowRoot bool `yaml:"allow_root,omitempty"`
+	// EnvDenylist is a list of environment-variable name prefixes that are stripped
+	// from the subprocess environment before the agent CLI is launched (e.g.
+	// "AWS_", "GITHUB_TOKEN"). Matching is case-insensitive against the full
+	// variable name. Use this to prevent credential leakage to agents that consume
+	// untrusted content such as Jira tickets or GitHub issue bodies.
+	EnvDenylist []string `yaml:"env_denylist,omitempty"`
+}
+
+// SecuritySettings is the global privilege ceiling for all agent CLI subprocesses.
+// Per-agent AgentSecurity overrides can narrow (or, when explicitly opted in,
+// widen) these defaults for individual agents.
+type SecuritySettings struct {
+	// AllowRoot, when true, permits agent CLI subprocesses to run as uid 0 (root).
+	// The default (false) causes the daemon to refuse to start and each runner to
+	// refuse to spawn when the effective uid is 0. Set this only when running
+	// Apiary inside a container that requires root and you understand the risk.
+	AllowRoot bool `yaml:"allow_root,omitempty"`
+	// EnvDenylist is a global list of environment-variable name prefixes stripped
+	// from every agent CLI subprocess environment (e.g. "AWS_", "GITHUB_TOKEN").
+	// Per-agent agents[].security.env_denylist entries are merged in addition to
+	// these. Matching is case-insensitive against the full variable name.
+	EnvDenylist []string `yaml:"env_denylist,omitempty"`
+}
+
 type AgentConfig struct {
 	ID          string   `yaml:"id"`
 	Description string   `yaml:"description,omitempty"`
@@ -99,6 +130,10 @@ type AgentConfig struct {
 	SourceToken string `yaml:"source_token,omitempty"`
 	SourceEmail string `yaml:"source_email,omitempty"`
 	SourceName  string `yaml:"source_name,omitempty"`
+	// Security is the per-agent privilege ceiling. Narrows (or explicitly widens,
+	// with allow_root) the privilege for this agent's CLI subprocesses independently
+	// of the sandboxing layer.
+	Security AgentSecurity `yaml:"security,omitempty"`
 	// Env is the agent-scope environment overlay applied to every step that runs
 	// this agent, in any workflow. It is the lowest-precedence explicit env scope
 	// (below workflow.env and step.env), layered on top of the identity overlay.
@@ -287,6 +322,9 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+	// Security is the global privilege ceiling for all agent CLI subprocesses.
+	// Per-agent agents[].security overrides can narrow or widen these defaults.
+	Security SecuritySettings `yaml:"security,omitempty"`
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -404,6 +404,10 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		WorkingDir:         "/",
 		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
+		Security: model.RunSecurity{
+			AllowRoot:   x.d.cfg.Settings.Security.AllowRoot && req.Agent.Security.AllowRoot,
+			EnvDenylist: mergeEnvDenylist(x.d.cfg.Settings.Security, req.Agent.Security),
+		},
 	}
 
 	if x.d.logger != nil {
@@ -930,6 +934,20 @@ func withMemoryDir(env map[string]string, dir string) map[string]string {
 		env["APIARY_MEMORY_DIR"] = dir
 	}
 	return env
+}
+
+// mergeEnvDenylist combines the global and per-agent EnvDenylist slices,
+// deduplicating entries so the runner applies each prefix exactly once.
+func mergeEnvDenylist(global config.SecuritySettings, agent config.AgentSecurity) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, p := range append(global.EnvDenylist, agent.EnvDenylist...) {
+		if _, ok := seen[p]; !ok {
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // compile-time interface checks.

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -2,6 +2,18 @@ package model
 
 import "time"
 
+// RunSecurity carries the privilege-ceiling settings resolved for a single run.
+// It is derived from Settings.Security (global) merged with the dispatching
+// agent's AgentSecurity (per-agent override).
+type RunSecurity struct {
+	// AllowRoot, when true, allows the CLI subprocess to execute as uid 0.
+	// Both the global and per-agent gates must be open for this to take effect.
+	AllowRoot bool
+	// EnvDenylist is the merged set of env-var name prefixes to strip from the
+	// subprocess environment before the agent CLI is launched.
+	EnvDenylist []string
+}
+
 type RunRequest struct {
 	Cell          SourceItem
 	WorkerID      string
@@ -12,6 +24,9 @@ type RunRequest struct {
 	Env           map[string]string
 	Timeout       time.Duration
 	AgentMetadata map[string]any
+	// Security is the resolved privilege ceiling for this run. The CLI runner
+	// uses it to enforce the root check and apply the env denylist.
+	Security RunSecurity
 
 	// SystemPrepend is injected at the very start of the prompt, before the cell
 	// details and SystemAppend. In workflow mode it carries the formatted

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -18,6 +18,34 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
+// isEnvDenied reports whether the environment variable named key matches any of
+// the prefixes in the denylist. Matching is case-insensitive.
+func isEnvDenied(key string, denylist []string) bool {
+	upper := strings.ToUpper(key)
+	for _, prefix := range denylist {
+		if strings.HasPrefix(upper, strings.ToUpper(prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+// filteredEnv returns a copy of environ with variables whose names match any
+// entry in denylist removed. Each element of environ must be "KEY=VALUE".
+func filteredEnv(environ []string, denylist []string) []string {
+	if len(denylist) == 0 {
+		return environ
+	}
+	out := make([]string, 0, len(environ))
+	for _, kv := range environ {
+		name, _, _ := strings.Cut(kv, "=")
+		if !isEnvDenied(name, denylist) {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
 // CliRunner manages a CLI subprocess with stdout/stderr streaming, PID tracking,
 // and heartbeats. Used by claude, opencode-cli, and similar providers.
 type CliRunner struct {
@@ -84,6 +112,13 @@ func (r *CliRunner) Configure(config map[string]any) error {
 }
 
 func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	if os.Getuid() == 0 && !req.Security.AllowRoot {
+		return model.RunResult{}, fmt.Errorf(
+			"cli runner: refusing to spawn %q as root (uid 0); "+
+				"set settings.security.allow_root: true in apiary.yaml to override",
+			r.command,
+		)
+	}
 	start := time.Now()
 	prompt := buildPrompt(req)
 
@@ -105,7 +140,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)
 	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
+	cmd.Env = filteredEnv(os.Environ(), req.Security.EnvDenylist)
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/src/internal/runner/execution/privilege_test.go
+++ b/src/internal/runner/execution/privilege_test.go
@@ -1,0 +1,73 @@
+package execution
+
+import (
+	"testing"
+)
+
+func TestIsEnvDenied(t *testing.T) {
+	tests := []struct {
+		key      string
+		denylist []string
+		want     bool
+	}{
+		{"AWS_SECRET_ACCESS_KEY", []string{"AWS_"}, true},
+		{"aws_access_key_id", []string{"AWS_"}, true},  // case-insensitive
+		{"GITHUB_TOKEN", []string{"GITHUB_TOKEN"}, true}, // exact match (no trailing _)
+		{"GITHUB_TOKEN_ENGINEER", []string{"GITHUB_TOKEN"}, true}, // prefix match
+		{"HOME", []string{"AWS_"}, false},
+		{"PATH", []string{"AWS_", "GITHUB_"}, false},
+		{"", []string{"AWS_"}, false},
+		{"AWS_PROFILE", []string{}, false}, // empty denylist
+	}
+	for _, tc := range tests {
+		got := isEnvDenied(tc.key, tc.denylist)
+		if got != tc.want {
+			t.Errorf("isEnvDenied(%q, %v) = %v, want %v", tc.key, tc.denylist, got, tc.want)
+		}
+	}
+}
+
+func TestFilteredEnv(t *testing.T) {
+	environ := []string{
+		"PATH=/usr/bin:/bin",
+		"HOME=/root",
+		"AWS_ACCESS_KEY_ID=AKIA...",
+		"AWS_SECRET_ACCESS_KEY=secret",
+		"GITHUB_TOKEN=ghp_xxx",
+		"APIARY_LOG=debug",
+	}
+
+	t.Run("strips matching prefixes", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"AWS_", "GITHUB_"})
+		for _, kv := range got {
+			if kv == "AWS_ACCESS_KEY_ID=AKIA..." || kv == "AWS_SECRET_ACCESS_KEY=secret" || kv == "GITHUB_TOKEN=ghp_xxx" {
+				t.Errorf("filteredEnv: denied variable %q survived denylist", kv)
+			}
+		}
+		// Allowed variables must survive.
+		found := map[string]bool{}
+		for _, kv := range got {
+			found[kv] = true
+		}
+		for _, want := range []string{"PATH=/usr/bin:/bin", "HOME=/root", "APIARY_LOG=debug"} {
+			if !found[want] {
+				t.Errorf("filteredEnv: allowed variable %q was incorrectly stripped", want)
+			}
+		}
+	})
+
+	t.Run("empty denylist returns original slice", func(t *testing.T) {
+		got := filteredEnv(environ, nil)
+		if len(got) != len(environ) {
+			t.Errorf("filteredEnv with empty denylist: got %d entries, want %d", len(got), len(environ))
+		}
+	})
+
+	t.Run("value part containing = is handled correctly", func(t *testing.T) {
+		env := []string{"SAFE_VAR=a=b=c", "AWS_KEY=value=extra"}
+		got := filteredEnv(env, []string{"AWS_"})
+		if len(got) != 1 || got[0] != "SAFE_VAR=a=b=c" {
+			t.Errorf("filteredEnv: unexpected result %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Root guard at startup**: `apiary run` now refuses to start when the effective uid is 0 and `settings.security.allow_root` is not explicitly set, preventing the whole daemon (and all its agent subprocesses) from running as root by accident.
- **Per-spawn secondary guard**: `CliRunner.Run()` enforces the same check at subprocess creation time, so any future call path that bypasses the daemon startup is still protected.
- **Env denylist**: a new `env_denylist` config field (global and per-agent) strips matching environment-variable prefixes from the agent CLI subprocess before launch, preventing credential leakage to agents that process untrusted content (Jira tickets, GitHub issue bodies, etc.).
- **Per-agent least-privilege profile**: `agents[].security` lets individual agents set their own `allow_root` and `env_denylist` overrides, independent of the sandboxing layer.

## New config knobs

```yaml
settings:
  security:
    allow_root: false          # default; set true only in isolated containers
    env_denylist:              # global — applied to every agent subprocess
      - AWS_
      - GITHUB_TOKEN

agents:
  - id: engineer
    security:
      allow_root: false        # per-agent override (both gates must be true for root)
      env_denylist:            # merged with global; duplicates deduplicated
        - ANTHROPIC_API_KEY
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 24 packages)
- [x] New `privilege_test.go`: `TestIsEnvDenied` and `TestFilteredEnv` cover case-insensitive prefix matching, empty denylist pass-through, and values containing `=`

Closes #246