### PR TITLE
security: stop persisting full prompts and scrub existing rows (SEC-15)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -287,6 +287,13 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+	// PersistPrompts controls whether the full composed prompt sent to the agent
+	// is saved to the database (task_logs "prompt sent to agent" entries,
+	// task_executions.input_prompt, step_runs.input_prompt). Prompts can contain
+	// the entire ticket body including PII and confidential data, so persistence
+	// is off by default. Set to true only when prompt auditing is explicitly
+	// required.
+	PersistPrompts bool `yaml:"persist_prompts"`
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -404,6 +404,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		WorkingDir:         "/",
 		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
+		LogPrompts:         x.d.cfg.Settings.PersistPrompts,
 	}
 
 	if x.d.logger != nil {

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -427,6 +427,9 @@ func InitSchema(ctx context.Context, db *sql.DB) error {
 	if err := repairSupersededFailedTasks(ctx, db); err != nil {
 		return fmt.Errorf("repair superseded failed tasks: %w", err)
 	}
+	if err := scrubPersistedPrompts(ctx, db); err != nil {
+		return fmt.Errorf("scrub persisted prompts: %w", err)
+	}
 	return nil
 }
 
@@ -454,6 +457,25 @@ func repairSupersededFailedTasks(ctx context.Context, db *sql.DB) error {
 		  ) = 'done'
 	`, time.Now())
 	return err
+}
+
+// scrubPersistedPrompts removes full prompt text that was persisted by older
+// builds. Prompts can contain the entire ticket body including PII and
+// confidential data; the new default (persist_prompts: false) stops writing
+// them, but existing rows must also be cleared. The function is idempotent —
+// re-runs on an already-scrubbed database affect zero rows and are cheap.
+func scrubPersistedPrompts(ctx context.Context, db *sql.DB) error {
+	stmts := []string{
+		`UPDATE task_executions SET input_prompt = NULL WHERE input_prompt IS NOT NULL`,
+		`UPDATE step_runs SET input_prompt = NULL WHERE input_prompt IS NOT NULL`,
+		`DELETE FROM task_logs WHERE message LIKE 'prompt sent to agent:%'`,
+	}
+	for _, s := range stmts {
+		if _, err := db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("%s: %w", s, err)
+		}
+	}
+	return nil
 }
 
 // legacyTimestampColumns lists every TIMESTAMP column written from a time.Time.

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -32,6 +32,11 @@ type RunRequest struct {
 	// logging/tracing (empty for plain routes).
 	WorkflowInstanceID string
 
+	// LogPrompts, when true, causes the runner to emit the full composed prompt
+	// as a debug log entry and include it in RunResult.InputPrompt for DB
+	// persistence. Off by default; mirrors settings.persist_prompts.
+	LogPrompts bool
+
 	// LogSink receives log entries in real time as the runner produces them.
 	// Must be safe to call from multiple goroutines.
 	LogSink func(LogEntry) `json:"-"`

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -139,7 +139,9 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	}
 
 	emit("debug", fmt.Sprintf("$ %s %s", r.command, strings.Join(argv, " ")))
-	emit("debug", "prompt sent to agent:\n"+prompt)
+	if req.LogPrompts {
+		emit("debug", "prompt sent to agent:\n"+prompt)
+	}
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -236,6 +238,10 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	if usage.TotalTokens == 0 && usage.NumTurns == 0 && usage.CostUSD == 0 {
 		usagePtr = nil
 	}
+	var inputPrompt string
+	if req.LogPrompts {
+		inputPrompt = prompt
+	}
 	result := model.RunResult{
 		WorkerID:    req.WorkerID,
 		Success:     runErr == nil,
@@ -243,7 +249,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		Logs:        logs,
 		Duration:    time.Since(start),
 		Usage:       usagePtr,
-		InputPrompt: prompt,
+		InputPrompt: inputPrompt,
 		RateLimited: rateLimited,
 	}
 	if rateLimited && rateLimitResetsAt > 0 {


### PR DESCRIPTION
## Summary

- Add `settings.persist_prompts` (default `false`) — full prompts are no longer persisted unless explicitly opted in.
- Gate the `"prompt sent to agent"` debug log entry in `cli.go` behind `RunRequest.LogPrompts`, which the daemon sets from the config flag.
- Gate `RunResult.InputPrompt` so `task_executions.input_prompt` and `step_runs.input_prompt` stay NULL when the flag is off.
- Add `scrubPersistedPrompts()` called at schema init: NULLs existing `input_prompt` columns in `task_executions` and `step_runs`, and deletes matching `task_logs` rows (those starting with `"prompt sent to agent:"`). Idempotent — re-runs on an already-scrubbed DB touch zero rows.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/...` — all 24 packages pass
- [ ] Upgrade an existing install and confirm `task_executions.input_prompt` and `step_runs.input_prompt` are NULL after startup
- [ ] Set `settings.persist_prompts: true` and verify prompts are recorded again

Closes #238