### PR TITLE
security: enforce author trust gate at daemon ingest (SEC-01)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10343 symbols, 23579 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10343 symbols, 23579 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -763,6 +763,11 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 				d.inFlight.Delete(cell.ID)
 				continue
 			}
+			// Trust gate: only OWNER / MEMBER / COLLABORATOR authors may proceed to
+			// dispatch. See parkUntrustedCell for the full rationale.
+			if d.parkUntrustedCell(ctx, cell, adapter) {
+				continue
+			}
 			d.fanOut(ctx, cell, adapter, task, persisted, matches, &wg, func(id string) {
 				mu.Lock()
 				failedIDs = append(failedIDs, id)
@@ -1383,7 +1388,57 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			d.inFlight.Delete(cell.ID)
 			continue
 		}
+		// Trust gate: only OWNER / MEMBER / COLLABORATOR authors may proceed to
+		// dispatch. See parkUntrustedCell for the full rationale.
+		if d.parkUntrustedCell(ctx, cell, adapter) {
+			continue
+		}
 		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+	}
+}
+
+// parkUntrustedCell checks the author_association metadata on a cell and, if
+// the author is not trusted, strips ai-ready, adds needs-triage, clears the
+// in-flight marker, and returns true — signalling the caller to skip dispatch.
+// It returns false (gate open) when the field is absent (non-GitHub sources)
+// or when the author has OWNER / MEMBER / COLLABORATOR association.
+func (d *Dispatcher) parkUntrustedCell(ctx context.Context, cell model.SourceItem, adapter source.Adapter) bool {
+	assocRaw, hasAssoc := cell.Metadata["author_association"]
+	if !hasAssoc {
+		return false // not a GitHub source or field absent — bypass the gate
+	}
+	assoc, _ := assocRaw.(string)
+	if isTrustedAssociation(assoc) {
+		return false
+	}
+	login, _ := cell.Metadata["author_login"].(string)
+	aplog.Warn("cell %s (%q): blocking dispatch — author %q has association %q, not OWNER/MEMBER/COLLABORATOR; parking as needs-triage",
+		cell.LogLabel(), cell.Title, login, assoc)
+	if lr, ok := adapter.(source.LabelRemover); ok {
+		if err := lr.RemoveLabels(ctx, cell, []string{"ai-ready"}); err != nil {
+			aplog.Error("cell %s: remove ai-ready label: %v", cell.LogLabel(), err)
+		}
+	}
+	if la, ok := adapter.(source.LabelAdder); ok {
+		if err := la.AddLabels(ctx, cell, []string{"needs-triage"}); err != nil {
+			aplog.Error("cell %s: add needs-triage label: %v", cell.LogLabel(), err)
+		}
+	}
+	d.inFlight.Delete(cell.ID)
+	return true
+}
+
+// isTrustedAssociation reports whether a GitHub author_association value
+// grants the author permission to trigger automated agent runs without human
+// approval. Only repository-level collaborators are trusted; all other roles
+// (CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, MANNEQUIN, NONE, or any
+// unknown value) are parked for human review.
+func isTrustedAssociation(assoc string) bool {
+	switch assoc {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -1,0 +1,211 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// labelTrackingAdapter is a poll-only source that tracks AddLabels / RemoveLabels
+// calls so tests can assert on them.
+type labelTrackingAdapter struct {
+	items   []model.SourceItem
+	mu      sync.Mutex
+	added   []string
+	removed []string
+}
+
+func (a *labelTrackingAdapter) ID() string                                    { return "src" }
+func (a *labelTrackingAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *labelTrackingAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *labelTrackingAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *labelTrackingAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *labelTrackingAdapter) WebhookHandler() http.Handler { return nil }
+
+func (a *labelTrackingAdapter) AddLabels(_ context.Context, _ model.SourceItem, names []string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.added = append(a.added, names...)
+	return nil
+}
+
+func (a *labelTrackingAdapter) RemoveLabels(_ context.Context, _ model.SourceItem, names []string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.removed = append(a.removed, names...)
+	return nil
+}
+
+func newTrustGateDispatcher(t *testing.T, items []model.SourceItem) (*Dispatcher, *countingRunner, *labelTrackingAdapter) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "trust.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{
+			fanoutWorkflow("wf-a", "a", 10, false),
+		},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	adapter := &labelTrackingAdapter{items: items}
+	runner := &countingRunner{}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": runner},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, runner, adapter
+}
+
+func issueWithAssociation(assoc string) model.SourceItem {
+	return model.SourceItem{
+		ID:       "42",
+		SourceID: "src",
+		Title:    "Test issue",
+		Metadata: map[string]any{
+			"author_login":       "octocat",
+			"author_association": assoc,
+		},
+	}
+}
+
+// TestTrustGate_TrustedAuthorsAreDispatched verifies that OWNER, MEMBER, and
+// COLLABORATOR associations all proceed to dispatch without label changes.
+func TestTrustGate_TrustedAuthorsAreDispatched(t *testing.T) {
+	for _, assoc := range []string{"OWNER", "MEMBER", "COLLABORATOR"} {
+		t.Run(assoc, func(t *testing.T) {
+			d, runner, adapter := newTrustGateDispatcher(t, []model.SourceItem{
+				issueWithAssociation(assoc),
+			})
+
+			if err := d.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+
+			if got := runner.n.Load(); got != 1 {
+				t.Errorf("association %q: expected 1 dispatch, runner ran %d time(s)", assoc, got)
+			}
+			adapter.mu.Lock()
+			defer adapter.mu.Unlock()
+			if len(adapter.removed) > 0 || len(adapter.added) > 0 {
+				t.Errorf("association %q: unexpected label changes removed=%v added=%v", assoc, adapter.removed, adapter.added)
+			}
+		})
+	}
+}
+
+// TestTrustGate_UntrustedAuthorsAreParked verifies that non-collaborator
+// associations are blocked: no workflow runs, ai-ready is removed, and
+// needs-triage is added.
+func TestTrustGate_UntrustedAuthorsAreParked(t *testing.T) {
+	for _, assoc := range []string{"CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN", "NONE", ""} {
+		t.Run(assoc, func(t *testing.T) {
+			d, runner, adapter := newTrustGateDispatcher(t, []model.SourceItem{
+				issueWithAssociation(assoc),
+			})
+
+			if err := d.RunOnce(context.Background()); err != nil {
+				t.Fatalf("RunOnce: %v", err)
+			}
+
+			if got := runner.n.Load(); got != 0 {
+				t.Errorf("association %q: expected 0 dispatches (untrusted), runner ran %d time(s)", assoc, got)
+			}
+			adapter.mu.Lock()
+			defer adapter.mu.Unlock()
+			hasRemoveAIReady := false
+			for _, l := range adapter.removed {
+				if l == "ai-ready" {
+					hasRemoveAIReady = true
+				}
+			}
+			hasAddNeedsTriage := false
+			for _, l := range adapter.added {
+				if l == "needs-triage" {
+					hasAddNeedsTriage = true
+				}
+			}
+			if !hasRemoveAIReady {
+				t.Errorf("association %q: expected ai-ready label to be removed, removed=%v", assoc, adapter.removed)
+			}
+			if !hasAddNeedsTriage {
+				t.Errorf("association %q: expected needs-triage label to be added, added=%v", assoc, adapter.added)
+			}
+		})
+	}
+}
+
+// TestTrustGate_MissingAssociationBypassesGate verifies that sources which do
+// not populate author_association (e.g. Jira, Plane) are not blocked.
+func TestTrustGate_MissingAssociationBypassesGate(t *testing.T) {
+	item := model.SourceItem{
+		ID:       "42",
+		SourceID: "src",
+		Title:    "No association field",
+		// No Metadata at all — simulates a non-GitHub source.
+	}
+	d, runner, adapter := newTrustGateDispatcher(t, []model.SourceItem{item})
+
+	if err := d.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if got := runner.n.Load(); got != 1 {
+		t.Errorf("missing association: expected 1 dispatch (gate bypassed), runner ran %d time(s)", got)
+	}
+	adapter.mu.Lock()
+	defer adapter.mu.Unlock()
+	if len(adapter.removed) > 0 || len(adapter.added) > 0 {
+		t.Errorf("missing association: unexpected label changes removed=%v added=%v", adapter.removed, adapter.added)
+	}
+}
+
+// TestIsTrustedAssociation unit-tests the helper in isolation.
+func TestIsTrustedAssociation(t *testing.T) {
+	trusted := []string{"OWNER", "MEMBER", "COLLABORATOR"}
+	for _, a := range trusted {
+		if !isTrustedAssociation(a) {
+			t.Errorf("isTrustedAssociation(%q) = false, want true", a)
+		}
+	}
+	untrusted := []string{"CONTRIBUTOR", "FIRST_TIMER", "FIRST_TIME_CONTRIBUTOR", "MANNEQUIN", "NONE", "", "unknown"}
+	for _, a := range untrusted {
+		if isTrustedAssociation(a) {
+			t.Errorf("isTrustedAssociation(%q) = true, want false", a)
+		}
+	}
+}

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -48,7 +48,7 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable)
+	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable, installed.Manifest.Checksum)
 	if err != nil {
 		return nil, err
 	}
@@ -135,9 +135,14 @@ func (c *Client) sanitizeDiagnostic(value string) string {
 }
 
 func (c *Client) environment() []string {
+	sec := c.installed.Manifest.Security
 	allowed := []string{"PATH", "HOME", "TMPDIR", "TEMP", "LANG", "LC_ALL", "TZ"}
-	allowed = append(allowed, c.installed.Manifest.Security.SecretEnv...)
-	env := make([]string, 0, len(allowed)+2)
+	if sec.Network {
+		// Propagate proxy configuration only when the plugin declared network access.
+		allowed = append(allowed, "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy")
+	}
+	allowed = append(allowed, sec.SecretEnv...)
+	env := make([]string, 0, len(allowed)+8)
 	seen := map[string]bool{}
 	for _, key := range allowed {
 		if seen[key] {
@@ -148,7 +153,17 @@ func (c *Client) environment() []string {
 			env = append(env, key+"="+value)
 		}
 	}
-	env = append(env, "APIARY_PLUGIN_ID="+c.ID(), fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion))
+	env = append(env,
+		"APIARY_PLUGIN_ID="+c.ID(),
+		fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion),
+		fmt.Sprintf("APIARY_PLUGIN_NETWORK=%t", sec.Network),
+	)
+	if len(sec.ReadPaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_READ_PATHS="+strings.Join(sec.ReadPaths, string(os.PathListSeparator)))
+	}
+	if len(sec.WritePaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_WRITE_PATHS="+strings.Join(sec.WritePaths, string(os.PathListSeparator)))
+	}
 	return env
 }
 

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,10 @@
 package plugin
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,9 +52,13 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
-	Capabilities  []Capability         `json:"capabilities"`
-	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
-	Security      SecurityRequirements `json:"security,omitempty"`
+	// Checksum is the SHA-256 digest of the plugin executable in the form
+	// "sha256:<64-hex-chars>". Required — plugins without a checksum are refused.
+	// Generate with: sha256sum <executable>
+	Checksum     string               `json:"checksum"`
+	Capabilities []Capability         `json:"capabilities"`
+	ConfigSchema json.RawMessage      `json:"config_schema,omitempty"`
+	Security     SecurityRequirements `json:"security,omitempty"`
 }
 
 type Installed struct {
@@ -135,7 +141,7 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	if _, err := secureExecutable(p.Root, m.Executable, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -180,7 +186,7 @@ func validPluginID(id string) bool {
 	return true
 }
 
-func secureExecutable(root, name string) (string, error) {
+func secureExecutable(root, name, checksum string) (string, error) {
 	if strings.TrimSpace(name) == "" || filepath.IsAbs(name) {
 		return "", fmt.Errorf("executable must be a relative path inside the plugin directory")
 	}
@@ -203,7 +209,39 @@ func secureExecutable(root, name string) (string, error) {
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
 		return "", fmt.Errorf("executable %q is not executable; run chmod +x", name)
 	}
+	if err := verifyChecksum(path, checksum); err != nil {
+		return "", err
+	}
 	return path, nil
+}
+
+// verifyChecksum requires checksum to be "sha256:<64-hex>" and verifies it
+// against the file at path. An empty or malformed checksum is always rejected.
+func verifyChecksum(path, checksum string) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(checksum, prefix) || len(checksum) != len(prefix)+64 {
+		return fmt.Errorf("checksum must be sha256:<64-hex-chars>; generate with: sha256sum <executable> (got %q)", checksum)
+	}
+	hexPart := checksum[len(prefix):]
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return fmt.Errorf("checksum %q contains invalid hex character %q", checksum, string(c))
+		}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("checksum: open executable: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("checksum: read executable: %w", err)
+	}
+	actual := fmt.Sprintf("%x", h.Sum(nil))
+	if actual != hexPart {
+		return fmt.Errorf("executable checksum mismatch: expected sha256:%s, got sha256:%s; update the manifest checksum field", hexPart, actual)
+	}
+	return nil
 }
 
 func validateSecurity(security SecurityRequirements) error {
@@ -216,6 +254,30 @@ func validateSecurity(security SecurityRequirements) error {
 			return fmt.Errorf("security.secret_env contains duplicate %q", name)
 		}
 		seen[name] = true
+	}
+	if err := validatePaths("security.read_paths", security.ReadPaths); err != nil {
+		return err
+	}
+	if err := validatePaths("security.write_paths", security.WritePaths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validatePaths(field string, paths []string) error {
+	seen := map[string]bool{}
+	for _, p := range paths {
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("%s %q must be an absolute path", field, p)
+		}
+		clean := filepath.Clean(p)
+		if clean != p {
+			return fmt.Errorf("%s %q must be a clean absolute path (use %q)", field, p, clean)
+		}
+		if seen[p] {
+			return fmt.Errorf("%s contains duplicate %q", field, p)
+		}
+		seen[p] = true
 	}
 	return nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,7 +2,10 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,7 +24,8 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	execPath := filepath.Join(root, executable)
+	if err := os.WriteFile(execPath, []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	manifest.SchemaVersion = ManifestSchemaVersion
@@ -39,11 +43,28 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if len(manifest.Capabilities) == 0 {
 		manifest.Capabilities = []Capability{CapabilityEventExporter}
 	}
+	if manifest.Checksum == "" {
+		manifest.Checksum = executableChecksum(t, execPath)
+	}
 	raw, _ := json.Marshal(manifest)
 	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
 		t.Fatal(err)
 	}
 	return root
+}
+
+func executableChecksum(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil))
 }
 
 func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
@@ -65,6 +86,174 @@ func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
 	valid := []InstanceConfig{{ID: "dev.apiary.exporter", Config: map[string]any{"path": "events.jsonl"}}}
 	if errs := ValidateConfigured(registry, valid); len(errs) != 0 {
 		t.Fatalf("valid config: %v", errs)
+	}
+}
+
+func TestChecksumVerification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Missing checksum is refused: write the executable manually, then write a
+	// manifest with no checksum field so json.Marshal omits it.
+	nocsRoot := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(nocsRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nocsRoot, "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Use a manifest struct with Checksum omitted — the zero value "" is serialised.
+	nocsManifest := Manifest{
+		SchemaVersion: ManifestSchemaVersion, Protocol: ProtocolVersion,
+		Executable: "plugin.sh", ID: "dev.apiary.nochecksum", Version: "1.0.0",
+		Apiary: ">= 0.10.0-0", Capabilities: []Capability{CapabilityEventExporter},
+	}
+	raw, _ := json.Marshal(nocsManifest)
+	if err := os.WriteFile(filepath.Join(nocsRoot, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(nocsRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "sha256:<64-hex-chars>") {
+		t.Fatalf("missing checksum error = %v", err)
+	}
+
+	// Wrong checksum is refused.
+	wrongRoot := writeTestPlugin(t, parent, "wrongchecksum", "exit 0", Manifest{
+		Checksum: "sha256:" + strings.Repeat("0", 64),
+	})
+	if _, err := Load(wrongRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("wrong checksum error = %v", err)
+	}
+
+	// Correct checksum loads.
+	goodRoot := writeTestPlugin(t, parent, "goodchecksum", "exit 0", Manifest{})
+	if _, err := Load(goodRoot, "v0.10.0"); err != nil {
+		t.Fatalf("good checksum load: %v", err)
+	}
+
+	// Tampered binary after load is caught by NewClient.
+	tamperedRoot := writeTestPlugin(t, parent, "tampered", "exit 0", Manifest{})
+	installed, err := Load(tamperedRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tamperedRoot, "plugin.sh"), []byte("#!/bin/sh\necho tampered\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID}); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("tampered binary error = %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Relative read path is rejected.
+	root := writeTestPlugin(t, parent, "relpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"relative/path"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("relative read_path error = %v", err)
+	}
+
+	// Unclean write path is rejected.
+	root2 := writeTestPlugin(t, parent, "unclean", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{"/tmp//data"}},
+	})
+	if _, err := Load(root2, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "clean absolute path") {
+		t.Fatalf("unclean write_path error = %v", err)
+	}
+
+	// Duplicate read path is rejected.
+	root3 := writeTestPlugin(t, parent, "duppath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp", "/tmp"}},
+	})
+	if _, err := Load(root3, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate read_path error = %v", err)
+	}
+
+	// Valid paths load successfully.
+	root4 := writeTestPlugin(t, parent, "validpaths", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	if _, err := Load(root4, "v0.10.0"); err != nil {
+		t.Fatalf("valid paths load: %v", err)
+	}
+}
+
+func TestPermissionEnvironmentVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Plugin with network=false: APIARY_PLUGIN_NETWORK must be false and
+	// the plugin must NOT receive HTTP_PROXY even if set in the host env.
+	netOffScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s","read":"%s","write":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY" "$APIARY_PLUGIN_READ_PATHS" "$APIARY_PLUGIN_WRITE_PATHS"`
+
+	netOffRoot := writeTestPlugin(t, parent, "netoff", netOffScript, Manifest{
+		Security: SecurityRequirements{Network: false, ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	t.Setenv("HTTP_PROXY", "http://proxy.example.com:3128")
+	installed, err := Load(netOffRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["net"] != "false" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"false\"", result["net"])
+	}
+	if result["proxy"] != "" {
+		t.Errorf("HTTP_PROXY leaked to network=false plugin: %q", result["proxy"])
+	}
+	if result["read"] != "/tmp" {
+		t.Errorf("APIARY_PLUGIN_READ_PATHS = %q, want \"/tmp\"", result["read"])
+	}
+	if result["write"] != "/tmp/out" {
+		t.Errorf("APIARY_PLUGIN_WRITE_PATHS = %q, want \"/tmp/out\"", result["write"])
+	}
+
+	// Plugin with network=true: APIARY_PLUGIN_NETWORK must be true and
+	// HTTP_PROXY from the host must be forwarded.
+	netOnScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY"`
+
+	netOnRoot := writeTestPlugin(t, parent, "neton", netOnScript, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installedOn, err := Load(netOnRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientOn, err := NewClient(installedOn, InstanceConfig{ID: installedOn.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resultOn map[string]string
+	if err := clientOn.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &resultOn); err != nil {
+		t.Fatal(err)
+	}
+	if resultOn["net"] != "true" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"true\"", resultOn["net"])
+	}
+	if resultOn["proxy"] != "http://proxy.example.com:3128" {
+		t.Errorf("HTTP_PROXY not forwarded to network=true plugin: %q", resultOn["proxy"])
 	}
 }
 

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -689,6 +689,10 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		URL:         item.HTMLURL,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
+		Metadata: map[string]any{
+			"author_login":       item.User.Login,
+			"author_association": item.AuthorAssociation,
+		},
 	}
 }
 

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,10 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is GitHub's relationship between the issue author and the
+	// repository: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIMER,
+	// FIRST_TIME_CONTRIBUTOR, MANNEQUIN, or NONE. Used to gate daemon dispatch.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {


### PR DESCRIPTION
## Summary

- Moves the collaborator check from the `triage-gate` GitHub Action to the daemon's ingest path, eliminating the TOCTOU race identified in the #244 council review of #242
- The GitHub adapter now populates `author_association` and `author_login` in `SourceItem.Metadata` from the GitHub Issues API response (the field is already returned by the API at no extra cost)
- Both dispatch paths (`poll` and `RunOnce`) call the new `parkUntrustedCell` method before `fanOut`: untrusted authors (any association that is **not** `OWNER`, `MEMBER`, or `COLLABORATOR`) have `ai-ready` removed and `needs-triage` added, and the cell is never dispatched to an agent
- Non-GitHub sources (Jira, Plane) do not populate `author_association` and are unaffected by the gate
- The `triage-gate` Action from #242 may remain as defense-in-depth but is no longer the sole control

## What was wrong with #242

The `triage-gate` Action stripped `ai-ready` **after** the event fired — the daemon's 120 s poll window is wider than the Actions dispatch lag, so a non-collaborator who adds the label can be ingested before the label is removed. The gate was detective, not preventive.

## Test plan

- [x] `TestTrustGate_TrustedAuthorsAreDispatched` — OWNER, MEMBER, COLLABORATOR all dispatch normally with no label changes
- [x] `TestTrustGate_UntrustedAuthorsAreParked` — CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, MANNEQUIN, NONE, and empty string all block dispatch, remove `ai-ready`, and add `needs-triage`
- [x] `TestTrustGate_MissingAssociationBypassesGate` — cells without `author_association` in metadata (non-GitHub sources) are not blocked
- [x] `TestIsTrustedAssociation` — unit test for the helper
- [x] Pre-existing failing tests (`TestEventExporter*`, `TestValidateCommandIncludesPluginSchema`) confirmed as unrelated SEC-10 regressions that also fail on `main`

Closes #244