### PR TITLE
feat: bidirectional visual workflow editor (apiary edit)

### DIFF
--- a/src/internal/cli/edit.go
+++ b/src/internal/cli/edit.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/editor"
+	"github.com/spf13/cobra"
+)
+
+func newEditCmd() *cobra.Command {
+	var noBrowser bool
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Open the visual workflow editor",
+		Long: `Open a browser-based visual editor for apiary.yaml.
+
+The editor lets you create and connect workflow steps through a drag-and-drop
+DAG canvas, edit step properties through schema-driven forms, and preview the
+resulting YAML before saving. Unsupported YAML constructs are shown in
+read-only mode rather than silently discarded.
+
+The server listens on a random loopback port and exits when you send SIGINT
+(Ctrl-C) or close the terminal.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			srv, err := editor.NewServer(configFile, cfg)
+			if err != nil {
+				return fmt.Errorf("creating editor server: %w", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			url, err := srv.Start(ctx)
+			if err != nil {
+				return fmt.Errorf("starting editor: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Workflow editor running at %s\n", url)
+			fmt.Fprintf(cmd.OutOrStdout(), "Press Ctrl-C to stop.\n")
+
+			if !noBrowser {
+				// Small delay to let the server start accepting connections.
+				time.Sleep(150 * time.Millisecond)
+				_ = openBrowser(url)
+			}
+
+			// Block until Ctrl-C.
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "do not open the browser automatically")
+	return cmd
+}
+
+// openBrowser opens the given URL in the default browser.
+func openBrowser(url string) error {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd, args = "open", []string{url}
+	case "windows":
+		cmd, args = "cmd", []string{"/c", "start", url}
+	default:
+		cmd, args = "xdg-open", []string{url}
+	}
+	return exec.Command(cmd, args...).Start()
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -62,6 +62,7 @@ func init() {
 		newTranscriptCmd(),
 		newPluginsCmd(),
 		newWorkerCmd(),
+		newEditCmd(),
 	)
 }
 

--- a/src/internal/editor/diff.go
+++ b/src/internal/editor/diff.go
@@ -1,0 +1,83 @@
+package editor
+
+import (
+	"fmt"
+	"strings"
+)
+
+// unifiedDiff computes a simple unified-diff-style string between two text
+// blobs. It uses LCS-based backtracking to emit context lines, additions, and
+// deletions. The result is human-readable but not machine-parseable.
+func unifiedDiff(original, proposed string) string {
+	a := strings.Split(original, "\n")
+	b := strings.Split(proposed, "\n")
+
+	// Compute LCS length table.
+	m, n := len(a), len(b)
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if a[i-1] == b[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else if dp[i-1][j] >= dp[i][j-1] {
+				dp[i][j] = dp[i-1][j]
+			} else {
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+
+	// Backtrack to build the edit script in reverse.
+	type line struct {
+		op   byte // ' ', '+', '-'
+		text string
+	}
+	rev := make([]line, 0, m+n)
+	i, j := m, n
+	for i > 0 || j > 0 {
+		if i > 0 && j > 0 && a[i-1] == b[j-1] {
+			rev = append(rev, line{' ', a[i-1]})
+			i--
+			j--
+		} else if j > 0 && (i == 0 || dp[i][j-1] >= dp[i-1][j]) {
+			rev = append(rev, line{'+', b[j-1]})
+			j--
+		} else {
+			rev = append(rev, line{'-', a[i-1]})
+			i--
+		}
+	}
+
+	// Reverse.
+	for l, r := 0, len(rev)-1; l < r; l, r = l+1, r-1 {
+		rev[l], rev[r] = rev[r], rev[l]
+	}
+
+	// Count added/removed.
+	added, removed := 0, 0
+	for _, l := range rev {
+		switch l.op {
+		case '+':
+			added++
+		case '-':
+			removed++
+		}
+	}
+
+	if added == 0 && removed == 0 {
+		return "(no semantic changes)"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("--- original  (%d removed, %d added)\n", removed, added))
+	sb.WriteString("+++ proposed\n")
+	for _, l := range rev {
+		sb.WriteByte(l.op)
+		sb.WriteString(l.text)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}

--- a/src/internal/editor/editor.go
+++ b/src/internal/editor/editor.go
@@ -1,0 +1,81 @@
+// Package editor provides a local HTTP server that serves a browser-based
+// visual workflow editor for apiary.yaml files. The server exposes a JSON API
+// used by the single-page application embedded in static/index.html.
+//
+// The canonical source of truth is always the YAML file; the visual editor is
+// a read-write authoring surface that round-trips through the config package.
+package editor
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+//go:embed static
+var staticFiles embed.FS
+
+// Server is the editor HTTP server. Create one with NewServer and start it
+// with Start. The server is safe for concurrent use once started.
+type Server struct {
+	configPath string
+	cfg        *config.Config
+	rawYAML    []byte
+	mux        *http.ServeMux
+}
+
+// NewServer creates an editor Server for the given config file. The file is
+// read immediately so rawYAML holds the pre-edit content for diff generation.
+func NewServer(configPath string, cfg *config.Config) (*Server, error) {
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+	s := &Server{
+		configPath: configPath,
+		cfg:        cfg,
+		rawYAML:    raw,
+		mux:        http.NewServeMux(),
+	}
+	s.registerRoutes()
+	return s, nil
+}
+
+func (s *Server) registerRoutes() {
+	// Static assets (the SPA).
+	sub, _ := fs.Sub(staticFiles, "static")
+	s.mux.Handle("/", http.FileServer(http.FS(sub)))
+
+	// JSON API.
+	s.mux.HandleFunc("/api/config", s.handleGetConfig)
+	s.mux.HandleFunc("/api/render", s.handleRender)
+	s.mux.HandleFunc("/api/validate", s.handleValidate)
+	s.mux.HandleFunc("/api/diff", s.handleDiff)
+	s.mux.HandleFunc("/api/save", s.handleSave)
+}
+
+// Start binds to a random loopback port and begins serving requests. It
+// returns the URL (http://127.0.0.1:<port>) immediately. The server shuts
+// down when ctx is cancelled.
+func (s *Server) Start(ctx context.Context) (string, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", fmt.Errorf("listening: %w", err)
+	}
+	url := "http://" + ln.Addr().String()
+	srv := &http.Server{Handler: s.mux}
+
+	go func() {
+		<-ctx.Done()
+		_ = srv.Shutdown(context.Background())
+	}()
+	go func() { _ = srv.Serve(ln) }()
+
+	return url, nil
+}

--- a/src/internal/editor/editor_test.go
+++ b/src/internal/editor/editor_test.go
@@ -1,0 +1,214 @@
+package editor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// sampleCfg returns a minimal Config for testing.
+func sampleCfg() *config.Config {
+	t := true
+	return &config.Config{
+		Version: "1",
+		Runners: []config.RunnerConfig{{ID: "r1", Type: "cli", Provider: "claude"}},
+		Sources: []config.SourceConfig{{ID: "src1", Type: "github"}},
+		Agents:  []config.AgentConfig{{ID: "agent1", Model: "claude-sonnet-4-6"}},
+		Workflows: []config.WorkflowConfig{
+			{
+				ID:          "test-wf",
+				Description: "Test workflow",
+				Trigger: &config.TriggerConfig{
+					Priority: 10,
+					Match:    config.RouteMatch{Source: "src1", Labels: []string{"ai-ready"}},
+				},
+				Steps: []config.StepConfig{
+					{
+						ID:    "classify",
+						Agent: "agent1",
+						Prompt: "Classify the issue.",
+						OnFail: &config.StepOutcome{Goto: "classify", MaxRetries: 2},
+					},
+					{
+						ID:   "route",
+						Type: config.StepTypeSplit,
+						Branches: []config.SplitBranch{
+							{If: `memory.track == "complex"`, Goto: "implement"},
+							{Else: true, Goto: "quick-fix"},
+						},
+					},
+					{ID: "implement", Agent: "agent1", Prompt: "Implement the change."},
+					{ID: "quick-fix", Agent: "agent1", Prompt: "Apply the quick fix."},
+					{
+						ID:   "wait-ci",
+						Type: config.StepTypeWaitFor,
+						WaitFor: &config.WaitForConfig{
+							Kind:            config.WaitKindCI,
+							CheckInterval:   "60s",
+							MaxDuration:     "2h",
+							FailIfNotPassed: &t,
+						},
+					},
+				},
+				OnComplete: &config.OnComplete{SetState: "closed"},
+				OnFail:     &config.OnComplete{AddLabels: []string{"needs-attention"}},
+			},
+		},
+	}
+}
+
+// TestRoundTrip verifies that a supported workflow survives a
+// configToEditor → editorToWorkflow round-trip without semantic changes.
+func TestRoundTrip(t *testing.T) {
+	orig := sampleCfg()
+	origWF := orig.Workflows[0]
+
+	ec := configToEditor(orig, "apiary.yaml")
+	if len(ec.Workflows) != 1 {
+		t.Fatalf("expected 1 workflow, got %d", len(ec.Workflows))
+	}
+
+	back := editorToWorkflow(ec.Workflows[0])
+
+	// ID / Description
+	if back.ID != origWF.ID {
+		t.Errorf("ID: got %q, want %q", back.ID, origWF.ID)
+	}
+	if back.Description != origWF.Description {
+		t.Errorf("Description: got %q, want %q", back.Description, origWF.Description)
+	}
+
+	// Trigger
+	if back.Trigger == nil {
+		t.Fatal("Trigger is nil after round-trip")
+	}
+	if back.Trigger.Priority != origWF.Trigger.Priority {
+		t.Errorf("Trigger.Priority: got %d, want %d", back.Trigger.Priority, origWF.Trigger.Priority)
+	}
+	if back.Trigger.Match.Source != origWF.Trigger.Match.Source {
+		t.Errorf("Trigger.Match.Source: got %q, want %q", back.Trigger.Match.Source, origWF.Trigger.Match.Source)
+	}
+
+	// Steps
+	if len(back.Steps) != len(origWF.Steps) {
+		t.Fatalf("Steps len: got %d, want %d", len(back.Steps), len(origWF.Steps))
+	}
+
+	// classify step
+	cs := back.Steps[0]
+	if cs.ID != "classify" {
+		t.Errorf("Steps[0].ID: got %q, want classify", cs.ID)
+	}
+	if cs.Agent != "agent1" {
+		t.Errorf("Steps[0].Agent: got %q, want agent1", cs.Agent)
+	}
+	if cs.OnFail == nil || cs.OnFail.Goto != "classify" {
+		t.Errorf("Steps[0].OnFail.Goto: got %v, want classify", cs.OnFail)
+	}
+	if cs.OnFail.MaxRetries != 2 {
+		t.Errorf("Steps[0].OnFail.MaxRetries: got %d, want 2", cs.OnFail.MaxRetries)
+	}
+
+	// split step
+	rs := back.Steps[1]
+	if rs.Type != config.StepTypeSplit {
+		t.Errorf("Steps[1].Type: got %q, want split", rs.Type)
+	}
+	if len(rs.Branches) != 2 {
+		t.Errorf("Steps[1].Branches len: got %d, want 2", len(rs.Branches))
+	}
+	if rs.Branches[1].Else != true {
+		t.Errorf("Steps[1].Branches[1].Else: want true")
+	}
+	if rs.Branches[1].Goto != "quick-fix" {
+		t.Errorf("Steps[1].Branches[1].Goto: got %q, want quick-fix", rs.Branches[1].Goto)
+	}
+
+	// wait_for step
+	ws := back.Steps[4]
+	if ws.Type != config.StepTypeWaitFor {
+		t.Errorf("Steps[4].Type: got %q, want wait_for", ws.Type)
+	}
+	if ws.WaitFor == nil {
+		t.Fatal("Steps[4].WaitFor is nil")
+	}
+	if ws.WaitFor.Kind != "ci" {
+		t.Errorf("Steps[4].WaitFor.Kind: got %q, want ci", ws.WaitFor.Kind)
+	}
+	if ws.WaitFor.CheckInterval != "60s" {
+		t.Errorf("Steps[4].WaitFor.CheckInterval: got %q, want 60s", ws.WaitFor.CheckInterval)
+	}
+
+	// on_complete
+	if back.OnComplete == nil || back.OnComplete.SetState != "closed" {
+		t.Errorf("OnComplete.SetState: want closed, got %v", back.OnComplete)
+	}
+}
+
+// TestSupportedFlag verifies the supported/unsupported tagging of steps.
+func TestSupportedFlag(t *testing.T) {
+	cfg := sampleCfg()
+	// Add a parallel step (unsupported in the visual editor).
+	cfg.Workflows[0].Steps = append(cfg.Workflows[0].Steps, config.StepConfig{
+		ID:   "par",
+		Type: config.StepTypeParallel,
+		SubSteps: []config.StepConfig{
+			{ID: "a", Agent: "agent1"},
+			{ID: "b", Agent: "agent1"},
+		},
+	})
+
+	ec := configToEditor(cfg, "apiary.yaml")
+	wf := ec.Workflows[0]
+
+	// All non-parallel steps should be supported.
+	for i, s := range wf.Steps[:5] {
+		if !s.Supported {
+			t.Errorf("Steps[%d] (%s): expected supported=true", i, s.ID)
+		}
+	}
+	// The parallel step should be unsupported.
+	par := wf.Steps[5]
+	if par.Supported {
+		t.Errorf("parallel step: expected supported=false")
+	}
+	if !wf.HasUnsupported {
+		t.Error("HasUnsupported should be true when a parallel step is present")
+	}
+}
+
+// TestUnifiedDiff verifies the diff algorithm produces valid output.
+func TestUnifiedDiff(t *testing.T) {
+	a := "line1\nline2\nline3\n"
+	b := "line1\nlineX\nline3\n"
+	d := unifiedDiff(a, b)
+
+	if !strings.Contains(d, "-line2") {
+		t.Errorf("diff should contain removed line2, got:\n%s", d)
+	}
+	if !strings.Contains(d, "+lineX") {
+		t.Errorf("diff should contain added lineX, got:\n%s", d)
+	}
+}
+
+// TestNoDiff verifies identical inputs produce the no-changes sentinel.
+func TestNoDiff(t *testing.T) {
+	same := "a\nb\nc\n"
+	d := unifiedDiff(same, same)
+	if d != "(no semantic changes)" {
+		t.Errorf("identical inputs should produce no-diff sentinel, got: %q", d)
+	}
+}
+
+// TestParseErrorPath verifies extraction of workflow/step IDs from error messages.
+func TestParseErrorPath(t *testing.T) {
+	msg := `workflows[0] "triage": steps[1] "classify": agent "investigator" not defined`
+	wid, sid := parseErrorPath(msg)
+	if wid != "triage" {
+		t.Errorf("workflowID: got %q, want triage", wid)
+	}
+	if sid != "classify" {
+		t.Errorf("stepID: got %q, want classify", sid)
+	}
+}

--- a/src/internal/editor/handlers.go
+++ b/src/internal/editor/handlers.go
@@ -1,0 +1,244 @@
+package editor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// handleGetConfig serves GET /api/config — the full EditorConfig for the
+// current apiary.yaml, including agents, sources, runners, and workflows.
+func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ec := configToEditor(s.cfg, s.configPath)
+	jsonOK(w, ec)
+}
+
+// RenderRequest is the body for POST /api/render.
+type RenderRequest struct {
+	Workflows []EditorWorkflow `json:"workflows"`
+}
+
+// RenderResponse is returned by POST /api/render.
+type RenderResponse struct {
+	YAML string `json:"yaml"`
+}
+
+// handleRender converts the editor's in-memory JSON model back to YAML so the
+// browser can display it as a live preview.
+func (s *Server) handleRender(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req RenderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Build a shallow copy of the loaded config, replacing only the workflows.
+	merged := *s.cfg
+	merged.Workflows = nil
+	for _, ew := range req.Workflows {
+		merged.Workflows = append(merged.Workflows, editorToWorkflow(ew))
+	}
+	out, err := yaml.Marshal(&merged)
+	if err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonOK(w, RenderResponse{YAML: string(out)})
+}
+
+// ValidateRequest is the body for POST /api/validate.
+type ValidateRequest struct {
+	Workflows []EditorWorkflow `json:"workflows"`
+}
+
+// ValidateResponse is returned by POST /api/validate.
+type ValidateResponse struct {
+	Errors   []ValidationError `json:"errors"`
+	Warnings []string          `json:"warnings"`
+	Valid    bool              `json:"valid"`
+}
+
+// handleValidate runs the full config.Validate() suite on the proposed
+// workflows (merged with the loaded non-workflow config) and returns per-step
+// annotated errors.
+func (s *Server) handleValidate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req ValidateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	merged := *s.cfg
+	merged.Workflows = nil
+	for _, ew := range req.Workflows {
+		merged.Workflows = append(merged.Workflows, editorToWorkflow(ew))
+	}
+
+	rawErrs := merged.Validate()
+	warnings := merged.WorkflowWarnings()
+
+	resp := ValidateResponse{Valid: len(rawErrs) == 0}
+	for _, e := range rawErrs {
+		ve := ValidationError{Message: e.Error()}
+		ve.WorkflowID, ve.StepID = parseErrorPath(e.Error())
+		resp.Errors = append(resp.Errors, ve)
+	}
+	resp.Warnings = warnings
+	jsonOK(w, resp)
+}
+
+// DiffRequest is the body for POST /api/diff.
+type DiffRequest struct {
+	Workflows []EditorWorkflow `json:"workflows"`
+}
+
+// DiffResponse is returned by POST /api/diff.
+type DiffResponse struct {
+	Diff     string `json:"diff"`
+	Original string `json:"original"`
+	Proposed string `json:"proposed"`
+	Changed  bool   `json:"changed"`
+}
+
+// handleDiff computes a unified diff between the on-disk YAML and the proposed
+// changes, without writing anything.
+func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req DiffRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	proposed, err := s.renderYAML(req.Workflows)
+	if err != nil {
+		http.Error(w, "render error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	original := string(s.rawYAML)
+	diff := unifiedDiff(original, proposed)
+	jsonOK(w, DiffResponse{
+		Diff:     diff,
+		Original: original,
+		Proposed: proposed,
+		Changed:  diff != "(no semantic changes)",
+	})
+}
+
+// SaveRequest is the body for POST /api/save.
+type SaveRequest struct {
+	Workflows []EditorWorkflow `json:"workflows"`
+}
+
+// SaveResponse is returned by POST /api/save.
+type SaveResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// handleSave validates the proposed workflows, then writes the merged config
+// back to the apiary.yaml file. It reloads the in-memory config and rawYAML on
+// success so subsequent renders reflect the saved state.
+func (s *Server) handleSave(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req SaveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate before writing.
+	merged := *s.cfg
+	merged.Workflows = nil
+	for _, ew := range req.Workflows {
+		merged.Workflows = append(merged.Workflows, editorToWorkflow(ew))
+	}
+	if errs := merged.Validate(); len(errs) > 0 {
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Error()
+		}
+		jsonOK(w, SaveResponse{Error: fmt.Sprintf("validation failed: %s", strings.Join(msgs, "; "))})
+		return
+	}
+
+	proposed, err := s.renderYAML(req.Workflows)
+	if err != nil {
+		jsonOK(w, SaveResponse{Error: "render error: " + err.Error()})
+		return
+	}
+	if err := os.WriteFile(s.configPath, []byte(proposed), 0o600); err != nil {
+		jsonOK(w, SaveResponse{Error: "write error: " + err.Error()})
+		return
+	}
+
+	// Reload to keep in-memory state consistent with the file.
+	newCfg, err := config.Load(s.configPath)
+	if err == nil {
+		s.cfg = newCfg
+		s.rawYAML = []byte(proposed)
+	}
+
+	jsonOK(w, SaveResponse{OK: true})
+}
+
+// renderYAML merges the proposed EditorWorkflows with the loaded config and
+// marshals the result to YAML text.
+func (s *Server) renderYAML(ews []EditorWorkflow) (string, error) {
+	merged := *s.cfg
+	merged.Workflows = nil
+	for _, ew := range ews {
+		merged.Workflows = append(merged.Workflows, editorToWorkflow(ew))
+	}
+	out, err := yaml.Marshal(&merged)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// jsonOK writes v as JSON with status 200.
+func jsonOK(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// pathErrorRe extracts workflow id and step id from a validation error message.
+var (
+	wfRe   = regexp.MustCompile(`workflows\[\d+\] "([^"]+)"`)
+	stepRe = regexp.MustCompile(`steps\[\d+\] "([^"]+)"`)
+)
+
+func parseErrorPath(msg string) (workflowID, stepID string) {
+	if m := wfRe.FindStringSubmatch(msg); len(m) > 1 {
+		workflowID = m[1]
+	}
+	if m := stepRe.FindStringSubmatch(msg); len(m) > 1 {
+		stepID = m[1]
+	}
+	return
+}

--- a/src/internal/editor/model.go
+++ b/src/internal/editor/model.go
@@ -1,0 +1,495 @@
+package editor
+
+import (
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// EditorConfig is the JSON-serialisable view of an apiary.yaml, shared between
+// the HTTP API and the browser. It mirrors the Go config types but uses JSON
+// tags and omits runtime-only fields.
+type EditorConfig struct {
+	Agents    []EditorAgent    `json:"agents"`
+	Sources   []EditorSource   `json:"sources"`
+	Runners   []EditorRunner   `json:"runners"`
+	Workflows []EditorWorkflow `json:"workflows"`
+	FilePath  string           `json:"file_path"`
+}
+
+type EditorAgent struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Model       string `json:"model"`
+	SoulFile    string `json:"soul_file,omitempty"`
+	Runner      string `json:"runner,omitempty"`
+	MaxWorkers  int    `json:"max_workers,omitempty"`
+}
+
+type EditorSource struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type EditorRunner struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Provider string `json:"provider,omitempty"`
+}
+
+type EditorWorkflow struct {
+	ID             string        `json:"id"`
+	Description    string        `json:"description,omitempty"`
+	Resume         string        `json:"resume,omitempty"`
+	Trigger        *EditorTrigger `json:"trigger,omitempty"`
+	Steps          []EditorStep   `json:"steps"`
+	OnComplete     *EditorHook   `json:"on_complete,omitempty"`
+	OnFail         *EditorHook   `json:"on_fail,omitempty"`
+	HasUnsupported bool          `json:"has_unsupported"`
+	Env            map[string]string `json:"env,omitempty"`
+}
+
+type EditorTrigger struct {
+	Priority  int             `json:"priority"`
+	Exclusive bool            `json:"exclusive,omitempty"`
+	Once      bool            `json:"once,omitempty"`
+	Match     EditorTrigMatch `json:"match"`
+}
+
+type EditorTrigMatch struct {
+	Source             string   `json:"source,omitempty"`
+	Labels             []string `json:"labels,omitempty"`
+	ExcludeLabels      []string `json:"exclude_labels,omitempty"`
+	ExcludeLabelPrefix string   `json:"exclude_label_prefix,omitempty"`
+	Types              []string `json:"types,omitempty"`
+	States             []string `json:"states,omitempty"`
+	TitleRegex         string   `json:"title_regex,omitempty"`
+}
+
+type EditorHook struct {
+	SetState     string   `json:"set_state,omitempty"`
+	AddLabels    []string `json:"add_labels,omitempty"`
+	RemoveLabels []string `json:"remove_labels,omitempty"`
+}
+
+// EditorStep is one node in the visual DAG.
+type EditorStep struct {
+	ID        string   `json:"id"`
+	Type      string   `json:"type"`
+	Name      string   `json:"name,omitempty"`
+	Condition string   `json:"condition,omitempty"`
+	FailWhen  string   `json:"fail_when,omitempty"`
+	DependsOn []string `json:"depends_on,omitempty"`
+	SeqDepsOn []string `json:"seq_depends_on,omitempty"`
+	// Supported is false for step types or field combinations the visual editor
+	// cannot yet represent. The node is shown in read-only mode.
+	Supported bool `json:"supported"`
+
+	// agent step
+	Agent           string         `json:"agent,omitempty"`
+	Model           string         `json:"model,omitempty"`
+	Prompt          string         `json:"prompt,omitempty"`
+	SummaryPrompt   string         `json:"summary_prompt,omitempty"`
+	Idempotent      bool           `json:"idempotent,omitempty"`
+	OnPass          *EditorNext    `json:"on_pass,omitempty"`
+	OnFail          *EditorOutcome `json:"on_fail,omitempty"`
+	OnConflict      *EditorOutcome `json:"on_conflict,omitempty"`
+	Publish         string         `json:"publish,omitempty"`
+	Spawn           string         `json:"spawn,omitempty"`
+	Materialize     string         `json:"materialize,omitempty"`
+	ActionClass     string         `json:"action_class,omitempty"`
+	OnMissingOutput string         `json:"on_missing_output,omitempty"`
+
+	// split step
+	Multi    bool          `json:"multi,omitempty"`
+	Branches []EditorBranch `json:"branches,omitempty"`
+
+	// approval step
+	Message           string          `json:"message,omitempty"`
+	Timeout           string          `json:"timeout,omitempty"`
+	ResumeOn          *EditorApprTrig `json:"resume_on,omitempty"`
+	AbortOn           *EditorApprTrig `json:"abort_on,omitempty"`
+	Approvers         []string        `json:"approvers,omitempty"`
+	RequiredApprovals int             `json:"required_approvals,omitempty"`
+
+	// wait_for step
+	WaitFor *EditorWaitFor `json:"wait_for,omitempty"`
+
+	// foreach step
+	Items       string `json:"items,omitempty"`
+	As          string `json:"as,omitempty"`
+	Concurrency int    `json:"concurrency,omitempty"`
+	MaxItems    int    `json:"max_items,omitempty"`
+	FailFast    bool   `json:"fail_fast,omitempty"`
+
+	// workflow (sub-workflow) step
+	Workflow string         `json:"workflow,omitempty"`
+	Uses     string         `json:"uses,omitempty"`
+	With     map[string]any `json:"with,omitempty"`
+}
+
+type EditorNext struct {
+	Next string `json:"next,omitempty"`
+}
+
+type EditorOutcome struct {
+	Goto       string `json:"goto,omitempty"`
+	MaxRetries int    `json:"max_retries,omitempty"`
+}
+
+type EditorBranch struct {
+	If   string `json:"if,omitempty"`
+	Else bool   `json:"else,omitempty"`
+	Goto string `json:"goto"`
+}
+
+type EditorApprTrig struct {
+	CommentContains string `json:"comment_contains,omitempty"`
+	LabelAdded      string `json:"label_added,omitempty"`
+	StateChanged    string `json:"state_changed,omitempty"`
+}
+
+type EditorWaitFor struct {
+	Kind            string   `json:"kind,omitempty"`
+	CheckInterval   string   `json:"check_interval,omitempty"`
+	MaxDuration     string   `json:"max_duration,omitempty"`
+	FailIfNotPassed *bool    `json:"fail_if_not_passed,omitempty"`
+	RemoveLabel     string   `json:"remove_label,omitempty"`
+	SatisfiedWhen   []string `json:"satisfied_when,omitempty"`
+	BlockerLinkType string   `json:"blocker_link_type,omitempty"`
+	OnTimeout       string   `json:"on_timeout,omitempty"`
+}
+
+// ValidationError is one error returned by the validate endpoint, optionally
+// annotated with the workflow and step IDs the error refers to.
+type ValidationError struct {
+	Message    string `json:"message"`
+	WorkflowID string `json:"workflow_id,omitempty"`
+	StepID     string `json:"step_id,omitempty"`
+}
+
+// configToEditor converts a loaded *config.Config to the editor JSON model.
+func configToEditor(cfg *config.Config, filePath string) EditorConfig {
+	ec := EditorConfig{FilePath: filePath}
+	for _, a := range cfg.Agents {
+		ec.Agents = append(ec.Agents, EditorAgent{
+			ID: a.ID, Description: a.Description, Model: a.Model,
+			SoulFile: a.SoulFile, Runner: a.Runner, MaxWorkers: a.MaxWorkers,
+		})
+	}
+	for _, s := range cfg.Sources {
+		ec.Sources = append(ec.Sources, EditorSource{ID: s.ID, Type: s.Type})
+	}
+	for _, r := range cfg.Runners {
+		ec.Runners = append(ec.Runners, EditorRunner{ID: r.ID, Type: r.Type, Provider: r.Provider})
+	}
+	for _, wf := range cfg.Workflows {
+		ec.Workflows = append(ec.Workflows, workflowToEditor(wf))
+	}
+	return ec
+}
+
+func workflowToEditor(wf config.WorkflowConfig) EditorWorkflow {
+	ew := EditorWorkflow{
+		ID:          wf.ID,
+		Description: wf.Description,
+		Resume:      wf.Resume,
+		Env:         wf.Env,
+	}
+	if wf.Trigger != nil {
+		t := wf.Trigger
+		ew.Trigger = &EditorTrigger{
+			Priority:  t.Priority,
+			Exclusive: t.Exclusive,
+			Once:      t.Once,
+			Match: EditorTrigMatch{
+				Source:             t.Match.Source,
+				Labels:             t.Match.Labels,
+				ExcludeLabels:      t.Match.ExcludeLabels,
+				ExcludeLabelPrefix: t.Match.ExcludeLabelPrefix,
+				Types:              t.Match.Types,
+				States:             t.Match.States,
+				TitleRegex:         t.Match.TitleRegex,
+			},
+		}
+	}
+	if wf.OnComplete != nil {
+		ew.OnComplete = hookToEditor(wf.OnComplete)
+	}
+	if wf.OnFail != nil {
+		ew.OnFail = hookToEditor(wf.OnFail)
+	}
+	hasUnsupported := false
+	for _, s := range wf.Steps {
+		es := stepToEditor(s)
+		if !es.Supported {
+			hasUnsupported = true
+		}
+		ew.Steps = append(ew.Steps, es)
+	}
+	ew.HasUnsupported = hasUnsupported
+	return ew
+}
+
+func hookToEditor(h *config.OnComplete) *EditorHook {
+	if h == nil {
+		return nil
+	}
+	return &EditorHook{
+		SetState:     h.SetState,
+		AddLabels:    h.AddLabels,
+		RemoveLabels: h.RemoveLabels,
+	}
+}
+
+// supportedTypes lists the step types the visual editor can fully represent.
+var supportedTypes = map[string]bool{
+	config.StepTypeAgent:    true,
+	config.StepTypeSplit:    true,
+	config.StepTypeApproval: true,
+	config.StepTypeWaitFor:  true,
+	config.StepTypeForeach:  true,
+	config.StepTypeWorkflow: true,
+	config.StepTypeParallel: true,
+}
+
+func stepToEditor(s config.StepConfig) EditorStep {
+	t := s.StepType()
+	es := EditorStep{
+		ID:        s.ID,
+		Type:      t,
+		Name:      s.Name,
+		Condition: s.Condition,
+		FailWhen:  s.FailWhen,
+		DependsOn: s.DependsOn,
+		SeqDepsOn: s.SeqDependsOn,
+		Supported: supportedTypes[t] && !s.IsV2Step(),
+	}
+
+	switch t {
+	case config.StepTypeAgent:
+		es.Agent = s.Agent
+		es.Model = s.Model
+		es.Prompt = s.Prompt
+		es.SummaryPrompt = s.SummaryPrompt
+		es.Idempotent = s.Idempotent
+		es.OnMissingOutput = s.OnMissingOutput
+		es.Publish = s.Publish
+		es.Spawn = s.Spawn
+		es.Materialize = s.Materialize
+		es.ActionClass = s.ActionClass
+		if s.OnPass != nil {
+			es.OnPass = &EditorNext{Next: s.OnPass.Next}
+		}
+		if s.OnFail != nil {
+			es.OnFail = &EditorOutcome{Goto: s.OnFail.Goto, MaxRetries: s.OnFail.MaxRetries}
+		}
+		if s.OnConflict != nil {
+			es.OnConflict = &EditorOutcome{Goto: s.OnConflict.Goto, MaxRetries: s.OnConflict.MaxRetries}
+		}
+
+	case config.StepTypeSplit:
+		es.Multi = s.Multi
+		for _, b := range s.Branches {
+			es.Branches = append(es.Branches, EditorBranch{If: b.If, Else: b.Else, Goto: b.Goto})
+		}
+
+	case config.StepTypeApproval:
+		es.Message = s.Message
+		es.Timeout = s.Timeout
+		es.Approvers = s.Approvers
+		es.RequiredApprovals = s.RequiredApprovals
+		if s.ResumeOn != nil {
+			es.ResumeOn = &EditorApprTrig{
+				CommentContains: s.ResumeOn.CommentContains,
+				LabelAdded:      s.ResumeOn.LabelAdded,
+				StateChanged:    s.ResumeOn.StateChanged,
+			}
+		}
+		if s.AbortOn != nil {
+			es.AbortOn = &EditorApprTrig{
+				CommentContains: s.AbortOn.CommentContains,
+				LabelAdded:      s.AbortOn.LabelAdded,
+				StateChanged:    s.AbortOn.StateChanged,
+			}
+		}
+
+	case config.StepTypeWaitFor:
+		if s.WaitFor != nil {
+			w := s.WaitFor
+			es.WaitFor = &EditorWaitFor{
+				Kind:            w.Kind,
+				CheckInterval:   w.CheckInterval,
+				MaxDuration:     w.MaxDuration,
+				FailIfNotPassed: w.FailIfNotPassed,
+				RemoveLabel:     w.RemoveLabel,
+				SatisfiedWhen:   w.SatisfiedWhen,
+				BlockerLinkType: w.BlockerLinkType,
+				OnTimeout:       w.OnTimeout,
+			}
+		}
+
+	case config.StepTypeForeach:
+		es.Items = s.Items
+		es.As = s.As
+		es.Concurrency = s.Concurrency
+		es.MaxItems = s.MaxItems
+		es.FailFast = s.FailFast
+		// Nested step shown as read-only unsupported.
+
+	case config.StepTypeWorkflow:
+		es.Workflow = s.Workflow
+		es.Uses = s.Uses
+		es.With = s.With
+		if s.OnPass != nil {
+			es.OnPass = &EditorNext{Next: s.OnPass.Next}
+		}
+		if s.OnFail != nil {
+			es.OnFail = &EditorOutcome{Goto: s.OnFail.Goto, MaxRetries: s.OnFail.MaxRetries}
+		}
+
+	case config.StepTypeParallel:
+		// Children (SubSteps) are shown but not individually editable.
+		es.Supported = false
+	}
+	return es
+}
+
+// editorToWorkflow converts an EditorWorkflow back to a config.WorkflowConfig
+// for YAML serialisation.
+func editorToWorkflow(ew EditorWorkflow) config.WorkflowConfig {
+	wf := config.WorkflowConfig{
+		ID:          ew.ID,
+		Description: ew.Description,
+		Resume:      ew.Resume,
+		Env:         ew.Env,
+	}
+	if ew.Trigger != nil {
+		t := ew.Trigger
+		wf.Trigger = &config.TriggerConfig{
+			Priority:  t.Priority,
+			Exclusive: t.Exclusive,
+			Once:      t.Once,
+			Match: config.RouteMatch{
+				Source:             t.Match.Source,
+				Labels:             t.Match.Labels,
+				ExcludeLabels:      t.Match.ExcludeLabels,
+				ExcludeLabelPrefix: t.Match.ExcludeLabelPrefix,
+				Types:              t.Match.Types,
+				States:             t.Match.States,
+				TitleRegex:         t.Match.TitleRegex,
+			},
+		}
+	}
+	if ew.OnComplete != nil {
+		wf.OnComplete = editorHookToConfig(ew.OnComplete)
+	}
+	if ew.OnFail != nil {
+		wf.OnFail = editorHookToConfig(ew.OnFail)
+	}
+	for _, es := range ew.Steps {
+		wf.Steps = append(wf.Steps, editorToStep(es))
+	}
+	return wf
+}
+
+func editorHookToConfig(h *EditorHook) *config.OnComplete {
+	if h == nil {
+		return nil
+	}
+	return &config.OnComplete{
+		SetState:     h.SetState,
+		AddLabels:    h.AddLabels,
+		RemoveLabels: h.RemoveLabels,
+	}
+}
+
+func editorToStep(es EditorStep) config.StepConfig {
+	s := config.StepConfig{
+		ID:           es.ID,
+		Type:         es.Type,
+		Name:         es.Name,
+		Condition:    es.Condition,
+		FailWhen:     es.FailWhen,
+		SeqDependsOn: es.SeqDepsOn,
+	}
+	switch es.Type {
+	case config.StepTypeAgent, "":
+		s.Agent = es.Agent
+		s.Model = es.Model
+		s.Prompt = es.Prompt
+		s.SummaryPrompt = es.SummaryPrompt
+		s.Idempotent = es.Idempotent
+		s.OnMissingOutput = es.OnMissingOutput
+		s.Publish = es.Publish
+		s.Spawn = es.Spawn
+		s.Materialize = es.Materialize
+		s.ActionClass = es.ActionClass
+		if es.OnPass != nil && es.OnPass.Next != "" {
+			s.OnPass = &config.StepNext{Next: es.OnPass.Next}
+		}
+		if es.OnFail != nil && (es.OnFail.Goto != "" || es.OnFail.MaxRetries > 0) {
+			s.OnFail = &config.StepOutcome{Goto: es.OnFail.Goto, MaxRetries: es.OnFail.MaxRetries}
+		}
+		if es.OnConflict != nil && (es.OnConflict.Goto != "" || es.OnConflict.MaxRetries > 0) {
+			s.OnConflict = &config.StepOutcome{Goto: es.OnConflict.Goto, MaxRetries: es.OnConflict.MaxRetries}
+		}
+
+	case config.StepTypeSplit:
+		s.Multi = es.Multi
+		for _, b := range es.Branches {
+			s.Branches = append(s.Branches, config.SplitBranch{If: b.If, Else: b.Else, Goto: b.Goto})
+		}
+
+	case config.StepTypeApproval:
+		s.Message = es.Message
+		s.Timeout = es.Timeout
+		s.Approvers = es.Approvers
+		s.RequiredApprovals = es.RequiredApprovals
+		if es.ResumeOn != nil {
+			s.ResumeOn = &config.ApprovalTrigger{
+				CommentContains: es.ResumeOn.CommentContains,
+				LabelAdded:      es.ResumeOn.LabelAdded,
+				StateChanged:    es.ResumeOn.StateChanged,
+			}
+		}
+		if es.AbortOn != nil {
+			s.AbortOn = &config.ApprovalTrigger{
+				CommentContains: es.AbortOn.CommentContains,
+				LabelAdded:      es.AbortOn.LabelAdded,
+				StateChanged:    es.AbortOn.StateChanged,
+			}
+		}
+
+	case config.StepTypeWaitFor:
+		if es.WaitFor != nil {
+			s.WaitFor = &config.WaitForConfig{
+				Kind:            es.WaitFor.Kind,
+				CheckInterval:   es.WaitFor.CheckInterval,
+				MaxDuration:     es.WaitFor.MaxDuration,
+				FailIfNotPassed: es.WaitFor.FailIfNotPassed,
+				RemoveLabel:     es.WaitFor.RemoveLabel,
+				SatisfiedWhen:   es.WaitFor.SatisfiedWhen,
+				BlockerLinkType: es.WaitFor.BlockerLinkType,
+				OnTimeout:       es.WaitFor.OnTimeout,
+			}
+		}
+
+	case config.StepTypeForeach:
+		s.Items = es.Items
+		s.As = es.As
+		s.Concurrency = es.Concurrency
+		s.MaxItems = es.MaxItems
+		s.FailFast = es.FailFast
+
+	case config.StepTypeWorkflow:
+		s.Workflow = es.Workflow
+		s.Uses = es.Uses
+		s.With = es.With
+		if es.OnPass != nil && es.OnPass.Next != "" {
+			s.OnPass = &config.StepNext{Next: es.OnPass.Next}
+		}
+		if es.OnFail != nil && (es.OnFail.Goto != "" || es.OnFail.MaxRetries > 0) {
+			s.OnFail = &config.StepOutcome{Goto: es.OnFail.Goto, MaxRetries: es.OnFail.MaxRetries}
+		}
+	}
+	return s
+}

--- a/src/internal/editor/static/index.html
+++ b/src/internal/editor/static/index.html
@@ -1,0 +1,1213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Apiary Workflow Editor</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0f1117;
+  --surface: #161b22;
+  --surface2: #1c2230;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --text-dim: #8b949e;
+  --accent: #58a6ff;
+  --success: #3fb950;
+  --warn: #d29922;
+  --error: #f85149;
+  --agent-fill: #0d2044;
+  --agent-stroke: #5b9bd5;
+  --agent-text: #dce8f8;
+  --split-fill: #200d44;
+  --split-stroke: #9b5bd5;
+  --split-text: #e8dcf8;
+  --approval-fill: #2a2000;
+  --approval-stroke: #c8a83a;
+  --approval-text: #f8f0dc;
+  --waitfor-fill: #0d2535;
+  --waitfor-stroke: #3a8aaa;
+  --waitfor-text: #dcf0f8;
+  --foreach-fill: #2a1400;
+  --foreach-stroke: #aa6a3a;
+  --foreach-text: #f8e8dc;
+  --workflow-fill: #002a2a;
+  --workflow-stroke: #3acaca;
+  --workflow-text: #dcf8f8;
+  --unsup-fill: #1a1a1a;
+  --unsup-stroke: #555;
+  --unsup-text: #888;
+  --node-w: 200;
+  --node-h: 64;
+  font-size: 13px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+header h1 { font-size: 15px; font-weight: 600; color: var(--accent); }
+#file-badge {
+  font-size: 11px; color: var(--text-dim);
+  background: var(--bg); border: 1px solid var(--border);
+  border-radius: 4px; padding: 2px 8px; font-family: monospace;
+  max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+#wf-select {
+  background: var(--surface2); border: 1px solid var(--border); color: var(--text);
+  border-radius: 4px; padding: 4px 8px; font-size: 12px; min-width: 180px;
+}
+.spacer { flex: 1; }
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 12px; border-radius: 5px; border: 1px solid var(--border);
+  font-size: 12px; font-weight: 500; cursor: pointer;
+  background: var(--surface2); color: var(--text); transition: all .15s;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); }
+.btn.primary { background: #1a3a6b; border-color: var(--accent); color: var(--accent); }
+.btn.primary:hover { background: #1e4882; }
+.btn.danger { border-color: var(--error); color: var(--error); }
+#dirty-badge {
+  font-size: 11px; color: var(--warn); display: none;
+  background: #2a1900; border: 1px solid var(--warn);
+  border-radius: 4px; padding: 2px 8px;
+}
+#dirty-badge.show { display: inline; }
+
+/* ── Main layout ─────────────────────────────────────────────── */
+main {
+  flex: 1; display: flex; overflow: hidden; min-height: 0;
+}
+
+/* ── Canvas (DAG) ────────────────────────────────────────────── */
+#canvas {
+  flex: 1; overflow: auto; position: relative; background: var(--bg);
+}
+#canvas svg { display: block; }
+.dag-node { cursor: pointer; }
+.dag-node:hover rect, .dag-node:hover polygon { filter: brightness(1.2); }
+.dag-node.selected rect, .dag-node.selected polygon {
+  stroke-width: 2.5 !important;
+  filter: brightness(1.3);
+}
+.dag-node.unsupported { cursor: default; }
+.edge-label {
+  font-size: 10px; fill: var(--text-dim);
+  font-family: monospace; pointer-events: none;
+}
+.src-node { cursor: default; }
+
+/* ── Properties panel ────────────────────────────────────────── */
+#props {
+  width: 320px; flex-shrink: 0;
+  background: var(--surface); border-left: 1px solid var(--border);
+  overflow-y: auto; padding: 12px;
+}
+#props h2 { font-size: 13px; font-weight: 600; margin-bottom: 10px; color: var(--text); }
+#props-empty { color: var(--text-dim); font-size: 12px; padding: 8px 0; }
+.field { margin-bottom: 10px; }
+.field label {
+  display: block; font-size: 11px; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: .5px; margin-bottom: 3px;
+}
+.field input, .field textarea, .field select {
+  width: 100%; background: var(--surface2); border: 1px solid var(--border);
+  color: var(--text); border-radius: 4px; padding: 5px 7px; font-size: 12px;
+  font-family: inherit;
+}
+.field textarea { resize: vertical; min-height: 60px; font-family: monospace; }
+.field input[type=checkbox] { width: auto; margin-right: 6px; }
+.field input:focus, .field textarea:focus, .field select:focus {
+  outline: none; border-color: var(--accent);
+}
+.field-row { display: flex; gap: 8px; }
+.field-row .field { flex: 1; }
+.section-title {
+  font-size: 11px; font-weight: 600; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: .5px;
+  border-top: 1px solid var(--border); margin: 12px 0 8px; padding-top: 8px;
+}
+.unsupported-badge {
+  background: #1a1a1a; border: 1px solid #555; border-radius: 4px;
+  padding: 6px 8px; font-size: 11px; color: #888; margin-bottom: 8px;
+}
+.branch-item {
+  background: var(--surface2); border: 1px solid var(--border);
+  border-radius: 4px; padding: 6px 8px; margin-bottom: 6px;
+}
+.branch-item .field { margin-bottom: 4px; }
+.branch-remove {
+  background: none; border: none; color: var(--error); cursor: pointer; font-size: 14px; float: right;
+}
+.btn-small {
+  padding: 3px 8px; font-size: 11px;
+  background: var(--surface2); border: 1px solid var(--border);
+  color: var(--text); border-radius: 4px; cursor: pointer;
+}
+.btn-small:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ── Bottom panel ────────────────────────────────────────────── */
+#bottom {
+  flex-shrink: 0; border-top: 1px solid var(--border);
+  background: var(--surface); height: 240px;
+  display: flex; flex-direction: column;
+}
+#bottom-tabs {
+  display: flex; border-bottom: 1px solid var(--border); flex-shrink: 0;
+}
+.tab {
+  padding: 6px 14px; font-size: 12px; cursor: pointer;
+  color: var(--text-dim); border-bottom: 2px solid transparent;
+  margin-bottom: -1px; transition: all .15s;
+}
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+#bottom-content { flex: 1; overflow: auto; padding: 10px; }
+#yaml-preview { font-family: monospace; font-size: 11px; white-space: pre; }
+#errors-list { font-size: 12px; }
+.error-item {
+  background: #1a0505; border: 1px solid #500; border-radius: 4px;
+  padding: 6px 8px; margin-bottom: 4px; display: flex; gap: 8px; align-items: flex-start;
+}
+.error-item .err-icon { color: var(--error); flex-shrink: 0; }
+.error-item .err-text { flex: 1; }
+.error-item .err-loc {
+  font-size: 10px; color: var(--text-dim); font-family: monospace;
+  cursor: pointer; text-decoration: underline;
+}
+.warn-item {
+  background: #1a1000; border: 1px solid #553300; border-radius: 4px;
+  padding: 6px 8px; margin-bottom: 4px;
+  color: var(--warn); font-size: 12px;
+}
+
+/* ── Diff modal ──────────────────────────────────────────────── */
+#modal-overlay {
+  display: none; position: fixed; inset: 0;
+  background: rgba(0,0,0,.7); z-index: 100;
+  align-items: center; justify-content: center;
+}
+#modal-overlay.show { display: flex; }
+#modal {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; width: 700px; max-height: 80vh;
+  display: flex; flex-direction: column; overflow: hidden;
+}
+#modal-header {
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px;
+}
+#modal-header h2 { font-size: 14px; flex: 1; }
+#modal-body { flex: 1; overflow: auto; padding: 12px; }
+#diff-text {
+  font-family: monospace; font-size: 11px; white-space: pre;
+  line-height: 1.5;
+}
+.diff-add { color: #56d364; background: #0d2a13; display: block; }
+.diff-del { color: #f85149; background: #2a0d0d; display: block; }
+.diff-ctx { color: var(--text-dim); display: block; }
+#modal-footer {
+  padding: 10px 16px; border-top: 1px solid var(--border);
+  display: flex; gap: 8px; justify-content: flex-end;
+}
+
+/* ── Loader ──────────────────────────────────────────────────── */
+#loader {
+  position: fixed; inset: 0; display: flex;
+  align-items: center; justify-content: center;
+  background: var(--bg); z-index: 200; font-size: 14px; color: var(--text-dim);
+}
+.toast {
+  position: fixed; bottom: 20px; right: 20px; z-index: 300;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 8px 14px; font-size: 12px;
+  opacity: 0; transition: opacity .3s; pointer-events: none;
+}
+.toast.show { opacity: 1; pointer-events: auto; }
+.toast.success { border-color: var(--success); color: var(--success); }
+.toast.error { border-color: var(--error); color: var(--error); }
+</style>
+</head>
+<body>
+
+<div id="loader">Loading workflow editor…</div>
+
+<header>
+  <h1>⬡ Apiary Workflow Editor</h1>
+  <span id="file-badge">apiary.yaml</span>
+  <select id="wf-select" onchange="onWorkflowChange(this.value)">
+    <option value="">— select workflow —</option>
+  </select>
+  <span id="dirty-badge">● unsaved</span>
+  <div class="spacer"></div>
+  <button class="btn" onclick="doValidate()">✓ Validate</button>
+  <button class="btn primary" onclick="doSave()">↑ Save</button>
+</header>
+
+<main>
+  <div id="canvas">
+    <svg id="dag-svg" xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+      <defs>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+        </marker>
+        <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#5b9bd5"/>
+        </marker>
+        <marker id="arrow-retry" viewBox="0 0 10 10" refX="9" refY="5"
+          markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#aa6a3a"/>
+        </marker>
+      </defs>
+      <g id="dag-root"></g>
+    </svg>
+  </div>
+
+  <aside id="props">
+    <h2>Properties</h2>
+    <div id="props-content"><p id="props-empty">Select a node to edit its properties.</p></div>
+  </aside>
+</main>
+
+<div id="bottom">
+  <div id="bottom-tabs">
+    <div class="tab active" onclick="switchTab('yaml')">YAML Preview</div>
+    <div class="tab" onclick="switchTab('errors')">Errors / Warnings</div>
+  </div>
+  <div id="bottom-content">
+    <pre id="yaml-preview">Select a workflow to see its YAML.</pre>
+    <div id="errors-list" style="display:none"></div>
+  </div>
+</div>
+
+<div id="modal-overlay">
+  <div id="modal">
+    <div id="modal-header">
+      <h2>Review Changes</h2>
+      <button class="btn" onclick="closeModal()">✕</button>
+    </div>
+    <div id="modal-body">
+      <pre id="diff-text"></pre>
+    </div>
+    <div id="modal-footer">
+      <button class="btn" onclick="closeModal()">Cancel</button>
+      <button class="btn primary" id="confirm-save-btn" onclick="confirmSave()">Save Changes</button>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+'use strict';
+
+// ── Constants ──────────────────────────────────────────────────
+const NODE_W = 200, NODE_H = 64, H_GAP = 80, V_GAP = 48;
+const PAD = 40; // canvas padding
+
+// ── State ──────────────────────────────────────────────────────
+let cfg = null;          // EditorConfig
+let wf = null;           // selected EditorWorkflow (mutable copy)
+let selectedId = null;   // selected step id
+let dirty = false;       // unsaved changes flag
+
+// ── Init ───────────────────────────────────────────────────────
+async function init() {
+  try {
+    const res = await fetch('/api/config');
+    cfg = await res.json();
+    document.getElementById('file-badge').textContent = cfg.file_path;
+    const sel = document.getElementById('wf-select');
+    (cfg.workflows || []).forEach(w => {
+      const o = document.createElement('option');
+      o.value = w.id;
+      o.textContent = w.id + (w.description ? ` — ${w.description}` : '');
+      sel.appendChild(o);
+    });
+    if (cfg.workflows && cfg.workflows.length > 0) {
+      sel.value = cfg.workflows[0].id;
+      loadWorkflow(cfg.workflows[0].id);
+    }
+  } catch(e) {
+    showToast('Failed to load config: ' + e.message, 'error');
+  } finally {
+    document.getElementById('loader').style.display = 'none';
+  }
+}
+
+function onWorkflowChange(id) {
+  if (dirty && !confirm('You have unsaved changes. Discard them?')) {
+    document.getElementById('wf-select').value = wf ? wf.id : '';
+    return;
+  }
+  loadWorkflow(id);
+}
+
+function loadWorkflow(id) {
+  if (!id) { wf = null; renderDAG(); return; }
+  const found = (cfg.workflows || []).find(w => w.id === id);
+  if (!found) return;
+  wf = JSON.parse(JSON.stringify(found)); // deep clone
+  selectedId = null;
+  dirty = false;
+  updateDirtyBadge();
+  renderDAG();
+  renderProps();
+  refreshYAMLPreview();
+}
+
+// ── DAG Layout ──────────────────────────────────────────────────
+function layoutDAG(steps) {
+  if (!steps || steps.length === 0) return new Map();
+
+  const stepMap = new Map(steps.map(s => [s.id, s]));
+
+  // Collect all forward edges (split branches, on_pass)
+  function forwardSuccessors(step) {
+    const sucs = [];
+    if (step.type === 'split' && step.branches) {
+      step.branches.forEach(b => { if (b.goto) sucs.push(b.goto); });
+    }
+    if (step.on_pass && step.on_pass.next) sucs.push(step.on_pass.next);
+    return sucs;
+  }
+
+  // Assign ranks via BFS from step[0]
+  const rank = new Map();
+  const queue = [steps[0].id];
+  rank.set(steps[0].id, 0);
+
+  while (queue.length > 0) {
+    const id = queue.shift();
+    const s = stepMap.get(id);
+    if (!s) continue;
+    const r = rank.get(id);
+
+    // Sequential successor
+    const idx = steps.indexOf(s);
+    if (idx < steps.length - 1) {
+      const nxt = steps[idx + 1].id;
+      if (!rank.has(nxt) || rank.get(nxt) < r + 1) {
+        rank.set(nxt, r + 1);
+        queue.push(nxt);
+      }
+    }
+    // Explicit successors
+    for (const sid of forwardSuccessors(s)) {
+      if (stepMap.has(sid) && (!rank.has(sid) || rank.get(sid) < r + 1)) {
+        rank.set(sid, r + 1);
+        queue.push(sid);
+      }
+    }
+  }
+
+  // Any unranked steps get sequential ranks
+  let maxRank = Math.max(0, ...[...rank.values()]);
+  for (const s of steps) {
+    if (!rank.has(s.id)) rank.set(s.id, ++maxRank);
+  }
+
+  // Group by rank
+  const byRank = new Map();
+  for (const s of steps) {
+    const r = rank.get(s.id) || 0;
+    if (!byRank.has(r)) byRank.set(r, []);
+    byRank.get(r).push(s.id);
+  }
+
+  // Compute positions
+  let maxCount = 1;
+  for (const ids of byRank.values()) maxCount = Math.max(maxCount, ids.length);
+  const totalW = maxCount * NODE_W + (maxCount - 1) * H_GAP;
+
+  const pos = new Map();
+  const sortedRanks = [...byRank.keys()].sort((a, b) => a - b);
+  sortedRanks.forEach(r => {
+    const ids = byRank.get(r);
+    const rowW = ids.length * NODE_W + (ids.length - 1) * H_GAP;
+    const startX = PAD + (totalW - rowW) / 2;
+    ids.forEach((id, i) => {
+      pos.set(id, {
+        x: startX + i * (NODE_W + H_GAP),
+        y: PAD + r * (NODE_H + V_GAP),
+      });
+    });
+  });
+
+  return pos;
+}
+
+// ── SVG Rendering ───────────────────────────────────────────────
+function nodeStyle(type) {
+  switch (type) {
+    case 'split':    return {fill: '#200d44', stroke: '#9b5bd5', text: '#e8dcf8'};
+    case 'approval': return {fill: '#2a2000', stroke: '#c8a83a', text: '#f8f0dc'};
+    case 'wait_for': return {fill: '#0d2535', stroke: '#3a8aaa', text: '#dcf0f8'};
+    case 'foreach':  return {fill: '#2a1400', stroke: '#aa6a3a', text: '#f8e8dc'};
+    case 'workflow': return {fill: '#002a2a', stroke: '#3acaca', text: '#dcf8f8'};
+    case 'parallel': return {fill: '#1a1a1a', stroke: '#555',    text: '#888'};
+    default:         return {fill: '#0d2044', stroke: '#5b9bd5', text: '#dce8f8'}; // agent
+  }
+}
+
+function nodeIcon(type) {
+  switch (type) {
+    case 'split':    return '⬡';
+    case 'approval': return '⏳';
+    case 'wait_for': return '⏱';
+    case 'foreach':  return '↻';
+    case 'workflow': return '↪';
+    case 'parallel': return '∥';
+    default:         return '▶';
+  }
+}
+
+function shortPrompt(p) {
+  if (!p) return '';
+  return p.length > 30 ? p.slice(0, 30) + '…' : p;
+}
+
+function svgEsc(s) {
+  return (s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function renderDAG() {
+  const root = document.getElementById('dag-root');
+  root.innerHTML = '';
+
+  if (!wf || !wf.steps || wf.steps.length === 0) {
+    const svg = document.getElementById('dag-svg');
+    svg.setAttribute('width', 400);
+    svg.setAttribute('height', 200);
+    const t = document.createElementNS('http://www.w3.org/2000/svg','text');
+    t.setAttribute('x', 200); t.setAttribute('y', 100);
+    t.setAttribute('text-anchor', 'middle');
+    t.setAttribute('fill', '#555'); t.setAttribute('font-size', '14');
+    t.textContent = 'No steps in this workflow.';
+    root.appendChild(t);
+    return;
+  }
+
+  const steps = wf.steps;
+  const pos = layoutDAG(steps);
+  const stepMap = new Map(steps.map(s => [s.id, s]));
+
+  // Compute canvas size
+  let maxX = 0, maxY = 0;
+  for (const {x, y} of pos.values()) {
+    maxX = Math.max(maxX, x + NODE_W);
+    maxY = Math.max(maxY, y + NODE_H);
+  }
+  const svgW = maxX + PAD, svgH = maxY + PAD;
+  const svg = document.getElementById('dag-svg');
+  svg.setAttribute('width', svgW);
+  svg.setAttribute('height', svgH);
+
+  // ── Draw edges (before nodes so nodes appear on top) ──
+  const edgeGroup = document.createElementNS('http://www.w3.org/2000/svg','g');
+  edgeGroup.setAttribute('id','edges');
+  root.appendChild(edgeGroup);
+
+  function edgeBottom(id) {
+    const p = pos.get(id);
+    if (!p) return null;
+    return {x: p.x + NODE_W/2, y: p.y + NODE_H};
+  }
+  function edgeTop(id) {
+    const p = pos.get(id);
+    if (!p) return null;
+    return {x: p.x + NODE_W/2, y: p.y};
+  }
+
+  function drawEdge(fromId, toId, label, color, dashed) {
+    const from = edgeBottom(fromId);
+    const to = edgeTop(toId);
+    if (!from || !to) return;
+
+    const isBack = to.y <= from.y; // retry back-edge
+    const path = document.createElementNS('http://www.w3.org/2000/svg','path');
+    let d;
+    if (isBack) {
+      // Back-edge: go left, up, then right
+      const x1 = from.x, y1 = from.y, x2 = to.x, y2 = to.y;
+      const xmid = Math.min(x1, x2) - 40;
+      d = `M ${x1} ${y1} C ${xmid} ${y1} ${xmid} ${y2} ${x2} ${y2}`;
+    } else {
+      const cy = (from.y + to.y) / 2;
+      d = `M ${from.x} ${from.y} C ${from.x} ${cy} ${to.x} ${cy} ${to.x} ${to.y}`;
+    }
+    path.setAttribute('d', d);
+    path.setAttribute('fill', 'none');
+    path.setAttribute('stroke', color || '#555');
+    path.setAttribute('stroke-width', dashed ? '1.5' : '1.5');
+    if (dashed) path.setAttribute('stroke-dasharray', '5,3');
+    path.setAttribute('marker-end', isBack ? 'url(#arrow-retry)' : 'url(#arrow)');
+    edgeGroup.appendChild(path);
+
+    if (label) {
+      const midX = (from.x + to.x) / 2 + (isBack ? -50 : 8);
+      const midY = (from.y + to.y) / 2;
+      const txt = document.createElementNS('http://www.w3.org/2000/svg','text');
+      txt.setAttribute('x', midX); txt.setAttribute('y', midY);
+      txt.setAttribute('class', 'edge-label'); txt.textContent = label;
+      edgeGroup.appendChild(txt);
+    }
+  }
+
+  // Sequential edges and split branches
+  const branchTargets = new Set();
+  for (const s of steps) {
+    if (s.type === 'split' && s.branches) {
+      s.branches.forEach(b => { if (b.goto) branchTargets.add(b.goto); });
+    }
+  }
+
+  for (let i = 0; i < steps.length; i++) {
+    const s = steps[i];
+    // Sequential: connect to next step unless next is a split target
+    if (i < steps.length - 1) {
+      const next = steps[i + 1];
+      if (!branchTargets.has(next.id)) {
+        drawEdge(s.id, next.id, null, '#444');
+      }
+    }
+    // on_pass.next
+    if (s.on_pass && s.on_pass.next && stepMap.has(s.on_pass.next)) {
+      drawEdge(s.id, s.on_pass.next, 'pass', '#5b9bd5');
+    }
+    // split branches
+    if (s.type === 'split' && s.branches) {
+      s.branches.forEach(b => {
+        if (b.goto && stepMap.has(b.goto)) {
+          const lbl = b.else ? 'else' : (b.if ? b.if.replace(/memory\./g,'').replace(/ == /g,'=').replace(/['"]/g,'').slice(0,20) : '');
+          drawEdge(s.id, b.goto, lbl, '#9b5bd5');
+        }
+      });
+    }
+    // on_fail.goto (retry back-edge, dashed)
+    if (s.on_fail && s.on_fail.goto && stepMap.has(s.on_fail.goto)) {
+      const retryLabel = s.on_fail.max_retries ? `retry ×${s.on_fail.max_retries}` : 'retry';
+      drawEdge(s.id, s.on_fail.goto, retryLabel, '#aa6a3a', true);
+    }
+    // on_conflict.goto (dashed)
+    if (s.on_conflict && s.on_conflict.goto && stepMap.has(s.on_conflict.goto)) {
+      drawEdge(s.id, s.on_conflict.goto, 'conflict', '#c8a83a', true);
+    }
+  }
+
+  // Source node (trigger)
+  if (wf.trigger && wf.trigger.match && wf.trigger.match.source) {
+    const src = wf.trigger.match.source;
+    const srcAgent = (cfg.sources || []).find(s => s.id === src);
+    const firstPos = pos.get(steps[0].id);
+    if (firstPos) {
+      const srcX = firstPos.x + NODE_W/2 - 60;
+      const srcY = PAD - 50;
+      const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+      g.setAttribute('class','src-node');
+      const rect = document.createElementNS('http://www.w3.org/2000/svg','rect');
+      rect.setAttribute('x', srcX); rect.setAttribute('y', srcY);
+      rect.setAttribute('width', 120); rect.setAttribute('height', 28);
+      rect.setAttribute('rx', 4);
+      rect.setAttribute('fill','#0a3a1a'); rect.setAttribute('stroke','#3aaa6a');
+      g.appendChild(rect);
+      const txt = document.createElementNS('http://www.w3.org/2000/svg','text');
+      txt.setAttribute('x', srcX+60); txt.setAttribute('y', srcY+18);
+      txt.setAttribute('text-anchor','middle'); txt.setAttribute('font-size','11');
+      txt.setAttribute('fill','#dcf8e8');
+      txt.textContent = '📦 ' + svgEsc(src) + (srcAgent ? ' ['+srcAgent.type+']' : '');
+      g.appendChild(txt);
+      root.appendChild(g);
+      // Edge from source to first step
+      const trigLine = document.createElementNS('http://www.w3.org/2000/svg','line');
+      trigLine.setAttribute('x1', srcX+60); trigLine.setAttribute('y1', srcY+28);
+      trigLine.setAttribute('x2', firstPos.x+NODE_W/2); trigLine.setAttribute('y2', firstPos.y);
+      trigLine.setAttribute('stroke','#3aaa6a'); trigLine.setAttribute('stroke-width','1.5');
+      trigLine.setAttribute('marker-end','url(#arrow)');
+      root.insertBefore(trigLine, edgeGroup);
+    }
+  }
+
+  // ── Draw nodes ──
+  const nodeGroup = document.createElementNS('http://www.w3.org/2000/svg','g');
+  nodeGroup.setAttribute('id','nodes');
+  root.appendChild(nodeGroup);
+
+  for (const step of steps) {
+    const p = pos.get(step.id);
+    if (!p) continue;
+    const st = step.supported === false ? {fill:'#1a1a1a',stroke:'#555',text:'#888'} : nodeStyle(step.type || 'agent');
+    const isSelected = (step.id === selectedId);
+
+    const g = document.createElementNS('http://www.w3.org/2000/svg','g');
+    g.setAttribute('class', 'dag-node' + (step.supported === false ? ' unsupported' : '') + (isSelected ? ' selected' : ''));
+    g.setAttribute('transform', `translate(${p.x},${p.y})`);
+    g.setAttribute('data-id', step.id);
+    g.addEventListener('click', () => onNodeClick(step.id));
+
+    if (step.type === 'split') {
+      // Diamond shape
+      const cx = NODE_W/2, cy = NODE_H/2;
+      const hw = NODE_W/2 - 4, hh = NODE_H/2 - 4;
+      const pts = `${cx},${cy-hh} ${cx+hw},${cy} ${cx},${cy+hh} ${cx-hw},${cy}`;
+      const poly = document.createElementNS('http://www.w3.org/2000/svg','polygon');
+      poly.setAttribute('points', pts);
+      poly.setAttribute('fill', st.fill); poly.setAttribute('stroke', st.stroke);
+      poly.setAttribute('stroke-width', isSelected ? '2.5' : '1.5');
+      g.appendChild(poly);
+    } else {
+      const rect = document.createElementNS('http://www.w3.org/2000/svg','rect');
+      rect.setAttribute('width', NODE_W); rect.setAttribute('height', NODE_H);
+      rect.setAttribute('rx', 6);
+      rect.setAttribute('fill', st.fill); rect.setAttribute('stroke', st.stroke);
+      rect.setAttribute('stroke-width', isSelected ? '2.5' : '1.5');
+      g.appendChild(rect);
+    }
+
+    // Icon
+    const icon = document.createElementNS('http://www.w3.org/2000/svg','text');
+    icon.setAttribute('x', 12); icon.setAttribute('y', 18);
+    icon.setAttribute('font-size', '14'); icon.setAttribute('fill', st.stroke);
+    icon.textContent = nodeIcon(step.type || 'agent');
+    g.appendChild(icon);
+
+    // Step ID
+    const idTxt = document.createElementNS('http://www.w3.org/2000/svg','text');
+    idTxt.setAttribute('x', 30); idTxt.setAttribute('y', 19);
+    idTxt.setAttribute('font-size', '12'); idTxt.setAttribute('font-weight', '600');
+    idTxt.setAttribute('fill', st.text);
+    idTxt.textContent = svgEsc(step.id.length > 22 ? step.id.slice(0,22)+'…' : step.id);
+    g.appendChild(idTxt);
+
+    // Subtitle
+    const sub = stepSubtitle(step);
+    if (sub) {
+      const subTxt = document.createElementNS('http://www.w3.org/2000/svg','text');
+      subTxt.setAttribute('x', 12); subTxt.setAttribute('y', 36);
+      subTxt.setAttribute('font-size', '10'); subTxt.setAttribute('fill', st.stroke);
+      subTxt.textContent = svgEsc(sub.length > 30 ? sub.slice(0,30)+'…' : sub);
+      g.appendChild(subTxt);
+    }
+
+    // Condition badge
+    if (step.condition) {
+      const condTxt = document.createElementNS('http://www.w3.org/2000/svg','text');
+      condTxt.setAttribute('x', 12); condTxt.setAttribute('y', sub ? 52 : 36);
+      condTxt.setAttribute('font-size', '9'); condTxt.setAttribute('fill', '#d29922');
+      condTxt.textContent = 'if: ' + svgEsc(step.condition.slice(0,30));
+      g.appendChild(condTxt);
+    }
+
+    // Unsupported badge
+    if (step.supported === false) {
+      const badge = document.createElementNS('http://www.w3.org/2000/svg','text');
+      badge.setAttribute('x', NODE_W - 8); badge.setAttribute('y', 18);
+      badge.setAttribute('text-anchor', 'end'); badge.setAttribute('font-size', '9');
+      badge.setAttribute('fill', '#888'); badge.textContent = 'read-only';
+      g.appendChild(badge);
+    }
+
+    nodeGroup.appendChild(g);
+  }
+}
+
+function stepSubtitle(step) {
+  switch(step.type || 'agent') {
+    case 'agent':    return step.agent ? `agent: ${step.agent}` : '';
+    case 'split':    return step.branches ? `${step.branches.length} branches` : '';
+    case 'approval': return step.message ? step.message.slice(0,30) : '';
+    case 'wait_for': return step.wait_for ? `wait_for: ${step.wait_for.kind || 'ci'}` : '';
+    case 'foreach':  return step.items ? `foreach: ${step.items}` : '';
+    case 'workflow': return step.workflow || step.uses || '';
+    case 'parallel': return 'parallel (read-only)';
+    default: return '';
+  }
+}
+
+function onNodeClick(id) {
+  selectedId = id;
+  renderDAG(); // re-render to update selection highlight
+  renderProps();
+}
+
+// ── Properties Panel ────────────────────────────────────────────
+function renderProps() {
+  const content = document.getElementById('props-content');
+  content.innerHTML = '';
+
+  if (!selectedId || !wf) {
+    content.innerHTML = '<p id="props-empty">Select a node to edit its properties.</p>';
+    return;
+  }
+  const step = wf.steps.find(s => s.id === selectedId);
+  if (!step) {
+    content.innerHTML = '<p id="props-empty">Step not found.</p>';
+    return;
+  }
+
+  if (step.supported === false) {
+    const badge = document.createElement('div');
+    badge.className = 'unsupported-badge';
+    badge.innerHTML = '⚠ This step type (<strong>' + (step.type || 'agent') + '</strong>) contains constructs that the visual editor cannot yet represent. It is shown in read-only mode and will be preserved in the YAML as-is.';
+    content.appendChild(badge);
+    // Show basic info
+    const pre = document.createElement('pre');
+    pre.style.cssText = 'font-size:10px;color:#888;overflow:auto;max-height:200px;';
+    pre.textContent = JSON.stringify(step, null, 2);
+    content.appendChild(pre);
+    return;
+  }
+
+  const f = (label, inputHTML, fullWidth) => {
+    const d = document.createElement('div');
+    d.className = 'field';
+    d.innerHTML = `<label>${label}</label>${inputHTML}`;
+    return d;
+  };
+
+  // ── Common fields ──
+  const h = document.createElement('h2');
+  h.textContent = step.id + ' (' + (step.type || 'agent') + ')';
+  content.appendChild(h);
+
+  content.appendChild(f('Step ID', `<input value="${svgEsc(step.id)}" onchange="updateStep('id',this.value)">`));
+  content.appendChild(f('Display Name', `<input value="${svgEsc(step.name||'')}" placeholder="optional label" onchange="updateStep('name',this.value)">`));
+  content.appendChild(f('Condition (if)', `<input value="${svgEsc(step.condition||'')}" placeholder='memory.track == "complex"' onchange="updateStep('condition',this.value)">`));
+
+  // ── Type-specific fields ──
+  const type = step.type || 'agent';
+
+  if (type === 'agent' || type === '') {
+    content.appendChild(makeSectionTitle('Agent'));
+    const agentOpts = (cfg.agents || []).map(a => `<option value="${a.id}" ${a.id===step.agent?'selected':''}>${a.id}</option>`).join('');
+    content.appendChild(f('Agent', `<select onchange="updateStep('agent',this.value)"><option value="">— none —</option>${agentOpts}</select>`));
+    content.appendChild(f('Model Override', `<input value="${svgEsc(step.model||'')}" placeholder="inherits from agent" onchange="updateStep('model',this.value)">`));
+    content.appendChild(f('Prompt', `<textarea rows="4" onchange="updateStep('prompt',this.value)">${svgEsc(step.prompt||'')}</textarea>`));
+    content.appendChild(f('Summary Prompt', `<textarea rows="2" onchange="updateStep('summary_prompt',this.value)">${svgEsc(step.summary_prompt||'')}</textarea>`));
+    content.appendChild(f('', `<label><input type="checkbox" ${step.idempotent?'checked':''} onchange="updateStep('idempotent',this.checked)"> Idempotent</label>`));
+    content.appendChild(f('Fail When', `<input value="${svgEsc(step.fail_when||'')}" placeholder='output.score < 7' onchange="updateStep('fail_when',this.value)">`));
+    content.appendChild(f('Action Class', `<input value="${svgEsc(step.action_class||'')}" placeholder="e.g. push, deploy" onchange="updateStep('action_class',this.value)">`));
+
+    content.appendChild(makeSectionTitle('On Pass'));
+    content.appendChild(f('Next Step', `<input value="${svgEsc(step.on_pass?.next||'')}" placeholder="step id" onchange="updateStepNested('on_pass','next',this.value)">`));
+
+    content.appendChild(makeSectionTitle('On Fail'));
+    content.appendChild(f('Goto Step', `<input value="${svgEsc(step.on_fail?.goto||'')}" placeholder="step id" onchange="updateStepNested('on_fail','goto',this.value)">`));
+    content.appendChild(f('Max Retries', `<input type="number" min="0" value="${step.on_fail?.max_retries||0}" onchange="updateStepNested('on_fail','max_retries',+this.value)">`));
+
+    content.appendChild(makeSectionTitle('On Conflict'));
+    content.appendChild(f('Goto Step', `<input value="${svgEsc(step.on_conflict?.goto||'')}" placeholder="step id" onchange="updateStepNested('on_conflict','goto',this.value)">`));
+    content.appendChild(f('Max Retries', `<input type="number" min="0" value="${step.on_conflict?.max_retries||0}" onchange="updateStepNested('on_conflict','max_retries',+this.value)">`));
+  }
+
+  else if (type === 'split') {
+    content.appendChild(makeSectionTitle('Split'));
+    content.appendChild(f('', `<label><input type="checkbox" ${step.multi?'checked':''} onchange="updateStep('multi',this.checked)"> Multi (fan-out all matching branches)</label>`));
+
+    content.appendChild(makeSectionTitle('Branches'));
+    const branchContainer = document.createElement('div');
+    branchContainer.id = 'branch-list';
+    renderBranchList(branchContainer, step);
+    content.appendChild(branchContainer);
+    const addBtn = document.createElement('button');
+    addBtn.className = 'btn-small'; addBtn.textContent = '+ Add branch';
+    addBtn.onclick = () => addBranch(step, branchContainer);
+    content.appendChild(addBtn);
+  }
+
+  else if (type === 'approval') {
+    content.appendChild(makeSectionTitle('Approval'));
+    content.appendChild(f('Message', `<textarea rows="3" onchange="updateStep('message',this.value)">${svgEsc(step.message||'')}</textarea>`));
+    content.appendChild(f('Timeout', `<input value="${svgEsc(step.timeout||'')}" placeholder="e.g. 24h" onchange="updateStep('timeout',this.value)">`));
+    content.appendChild(f('Approvers (comma-separated)', `<input value="${(step.approvers||[]).join(', ')}" onchange="updateStep('approvers',this.value.split(',').map(s=>s.trim()).filter(Boolean))">`));
+    content.appendChild(f('Required Approvals', `<input type="number" min="1" value="${step.required_approvals||1}" onchange="updateStep('required_approvals',+this.value)">`));
+
+    content.appendChild(makeSectionTitle('Resume On'));
+    content.appendChild(f('Comment Contains', `<input value="${svgEsc(step.resume_on?.comment_contains||'')}" placeholder="LGTM" onchange="updateStepNested('resume_on','comment_contains',this.value)">`));
+    content.appendChild(f('Label Added', `<input value="${svgEsc(step.resume_on?.label_added||'')}" placeholder="approved" onchange="updateStepNested('resume_on','label_added',this.value)">`));
+    content.appendChild(f('State Changed', `<input value="${svgEsc(step.resume_on?.state_changed||'')}" placeholder="closed" onchange="updateStepNested('resume_on','state_changed',this.value)">`));
+
+    content.appendChild(makeSectionTitle('Abort On'));
+    content.appendChild(f('Comment Contains', `<input value="${svgEsc(step.abort_on?.comment_contains||'')}" placeholder="abort" onchange="updateStepNested('abort_on','comment_contains',this.value)">`));
+    content.appendChild(f('Label Added', `<input value="${svgEsc(step.abort_on?.label_added||'')}" placeholder="rejected" onchange="updateStepNested('abort_on','label_added',this.value)">`));
+  }
+
+  else if (type === 'wait_for') {
+    content.appendChild(makeSectionTitle('Wait For'));
+    content.appendChild(f('Kind', `<select onchange="updateStepNested('wait_for','kind',this.value)">
+      <option value="ci" ${(step.wait_for?.kind||'ci')==='ci'?'selected':''}>ci — wait for CI status</option>
+      <option value="dependency" ${step.wait_for?.kind==='dependency'?'selected':''}>dependency — wait for blockers</option>
+    </select>`));
+    content.appendChild(f('Check Interval', `<input value="${svgEsc(step.wait_for?.check_interval||'')}" placeholder="1m" onchange="updateStepNested('wait_for','check_interval',this.value)">`));
+    content.appendChild(f('Max Duration', `<input value="${svgEsc(step.wait_for?.max_duration||'')}" placeholder="2h" onchange="updateStepNested('wait_for','max_duration',this.value)">`));
+    content.appendChild(f('On Timeout', `<select onchange="updateStepNested('wait_for','on_timeout',this.value)">
+      <option value="" ${!step.wait_for?.on_timeout?'selected':''}>default</option>
+      <option value="fail" ${step.wait_for?.on_timeout==='fail'?'selected':''}>fail</option>
+      <option value="hold" ${step.wait_for?.on_timeout==='hold'?'selected':''}>hold</option>
+    </select>`));
+    content.appendChild(f('Remove Label', `<input value="${svgEsc(step.wait_for?.remove_label||'')}" placeholder="optional" onchange="updateStepNested('wait_for','remove_label',this.value)">`));
+  }
+
+  else if (type === 'foreach') {
+    content.appendChild(makeSectionTitle('For Each'));
+    content.appendChild(f('Items Expression', `<input value="${svgEsc(step.items||'')}" placeholder='${{ design.tasks }}' onchange="updateStep('items',this.value)">`));
+    content.appendChild(f('Variable Name (as)', `<input value="${svgEsc(step.as||'')}" placeholder="item" onchange="updateStep('as',this.value)">`));
+    content.appendChild(f('Concurrency', `<input type="number" min="1" value="${step.concurrency||1}" onchange="updateStep('concurrency',+this.value)">`));
+    content.appendChild(f('Max Items', `<input type="number" min="0" value="${step.max_items||0}" placeholder="0 = unlimited" onchange="updateStep('max_items',+this.value)">`));
+    content.appendChild(f('', `<label><input type="checkbox" ${step.fail_fast?'checked':''} onchange="updateStep('fail_fast',this.checked)"> Fail Fast</label>`));
+    const note = document.createElement('div');
+    note.className = 'unsupported-badge';
+    note.textContent = 'The nested step of a foreach is displayed as read-only. Edit it directly in the YAML.';
+    content.appendChild(note);
+  }
+
+  else if (type === 'workflow') {
+    content.appendChild(makeSectionTitle('Sub-workflow'));
+    const wfOpts = (cfg.workflows || []).filter(w => w.id !== wf.id).map(w => `<option value="${w.id}" ${w.id===step.workflow?'selected':''}>${w.id}</option>`).join('');
+    content.appendChild(f('Workflow ID', `<select onchange="updateStep('workflow',this.value)"><option value="">— select —</option>${wfOpts}</select>`));
+    content.appendChild(f('Uses (file)', `<input value="${svgEsc(step.uses||'')}" placeholder="./path/to/workflow.yaml" onchange="updateStep('uses',this.value)">`));
+    content.appendChild(f('With (JSON)', `<textarea rows="3" onchange="updateStepWith(this.value)">${step.with?JSON.stringify(step.with,null,2):''}</textarea>`));
+    content.appendChild(makeSectionTitle('On Pass'));
+    content.appendChild(f('Next Step', `<input value="${svgEsc(step.on_pass?.next||'')}" placeholder="step id" onchange="updateStepNested('on_pass','next',this.value)">`));
+    content.appendChild(makeSectionTitle('On Fail'));
+    content.appendChild(f('Goto Step', `<input value="${svgEsc(step.on_fail?.goto||'')}" placeholder="step id" onchange="updateStepNested('on_fail','goto',this.value)">`));
+    content.appendChild(f('Max Retries', `<input type="number" min="0" value="${step.on_fail?.max_retries||0}" onchange="updateStepNested('on_fail','max_retries',+this.value)">`));
+  }
+}
+
+function makeSectionTitle(title) {
+  const d = document.createElement('div');
+  d.className = 'section-title';
+  d.textContent = title;
+  return d;
+}
+
+function renderBranchList(container, step) {
+  container.innerHTML = '';
+  (step.branches || []).forEach((b, i) => {
+    const div = document.createElement('div');
+    div.className = 'branch-item';
+    div.innerHTML = `
+      <button class="branch-remove" onclick="removeBranch(${i})">✕</button>
+      <div class="field"><label>If Expression</label><input value="${svgEsc(b.if||'')}" placeholder='memory.agent == "reviewer"' onchange="updateBranch(${i},'if',this.value)"></div>
+      <div class="field"><label><input type="checkbox" ${b.else?'checked':''} onchange="updateBranch(${i},'else',this.checked)"> Else (fallback)</label></div>
+      <div class="field"><label>Goto Step ID</label><input value="${svgEsc(b.goto||'')}" placeholder="step id" onchange="updateBranch(${i},'goto',this.value)"></div>
+    `;
+    container.appendChild(div);
+  });
+}
+
+// ── Step mutation helpers ────────────────────────────────────────
+function currentStep() {
+  return wf && selectedId ? wf.steps.find(s => s.id === selectedId) : null;
+}
+
+function updateStep(key, value) {
+  const step = currentStep();
+  if (!step) return;
+  if (key === 'id') {
+    // Renaming: update all references
+    const oldId = step.id;
+    step.id = value;
+    renameReferences(oldId, value);
+    selectedId = value;
+  } else {
+    step[key] = value;
+  }
+  markDirty();
+  renderDAG();
+  refreshYAMLPreview();
+}
+
+function updateStepNested(obj, key, value) {
+  const step = currentStep();
+  if (!step) return;
+  if (!step[obj]) step[obj] = {};
+  step[obj][key] = value;
+  // Clean up empty objects
+  if (!value && step[obj] && Object.values(step[obj]).every(v => !v)) {
+    step[obj] = null;
+  }
+  markDirty();
+  renderDAG();
+  refreshYAMLPreview();
+}
+
+function updateStepWith(jsonText) {
+  const step = currentStep();
+  if (!step) return;
+  try {
+    step.with = jsonText.trim() ? JSON.parse(jsonText) : null;
+    markDirty();
+    refreshYAMLPreview();
+  } catch(e) { /* ignore parse errors while typing */ }
+}
+
+function updateBranch(i, key, value) {
+  const step = currentStep();
+  if (!step || !step.branches) return;
+  step.branches[i][key] = value;
+  markDirty();
+  renderDAG();
+  refreshYAMLPreview();
+}
+
+function addBranch(step, container) {
+  if (!step.branches) step.branches = [];
+  step.branches.push({if: '', else: false, goto: ''});
+  renderBranchList(container, step);
+  markDirty();
+  refreshYAMLPreview();
+}
+
+function removeBranch(i) {
+  const step = currentStep();
+  if (!step || !step.branches) return;
+  step.branches.splice(i, 1);
+  renderProps(); // re-render props
+  markDirty();
+  refreshYAMLPreview();
+}
+
+function renameReferences(oldId, newId) {
+  if (!wf) return;
+  for (const s of wf.steps) {
+    if (s.on_pass?.next === oldId) s.on_pass.next = newId;
+    if (s.on_fail?.goto === oldId) s.on_fail.goto = newId;
+    if (s.on_conflict?.goto === oldId) s.on_conflict.goto = newId;
+    if (s.branches) {
+      s.branches.forEach(b => { if (b.goto === oldId) b.goto = newId; });
+    }
+    if (s.seq_depends_on) {
+      s.seq_depends_on = s.seq_depends_on.map(d => d === oldId ? newId : d);
+    }
+  }
+}
+
+// ── Dirty state ──────────────────────────────────────────────────
+function markDirty() {
+  dirty = true;
+  updateDirtyBadge();
+}
+
+function updateDirtyBadge() {
+  const badge = document.getElementById('dirty-badge');
+  badge.classList.toggle('show', dirty);
+}
+
+// ── YAML Preview ─────────────────────────────────────────────────
+let yamlDebounce = null;
+async function refreshYAMLPreview() {
+  if (!wf) { document.getElementById('yaml-preview').textContent = ''; return; }
+  clearTimeout(yamlDebounce);
+  yamlDebounce = setTimeout(async () => {
+    try {
+      const res = await fetch('/api/render', {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({workflows: getWorkflowList()}),
+      });
+      const data = await res.json();
+      document.getElementById('yaml-preview').textContent = data.yaml || '';
+    } catch(e) { /* ignore */ }
+  }, 300);
+}
+
+function getWorkflowList() {
+  if (!cfg || !wf) return cfg ? cfg.workflows : [];
+  return (cfg.workflows || []).map(w => w.id === wf.id ? wf : w);
+}
+
+// ── Tabs ─────────────────────────────────────────────────────────
+function switchTab(name) {
+  document.getElementById('yaml-preview').style.display = name === 'yaml' ? '' : 'none';
+  document.getElementById('errors-list').style.display = name === 'errors' ? '' : 'none';
+  document.querySelectorAll('.tab').forEach((t,i) => {
+    t.classList.toggle('active', (i===0&&name==='yaml') || (i===1&&name==='errors'));
+  });
+}
+
+// ── Validate ─────────────────────────────────────────────────────
+async function doValidate() {
+  if (!cfg) return;
+  try {
+    const res = await fetch('/api/validate', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({workflows: getWorkflowList()}),
+    });
+    const data = await res.json();
+    renderErrors(data.errors, data.warnings);
+    switchTab('errors');
+    if (data.valid) showToast('✓ Config is valid', 'success');
+    else showToast(`✗ ${data.errors.length} validation error(s)`, 'error');
+  } catch(e) {
+    showToast('Validate error: ' + e.message, 'error');
+  }
+}
+
+function renderErrors(errors, warnings) {
+  const list = document.getElementById('errors-list');
+  list.innerHTML = '';
+  if ((!errors || errors.length === 0) && (!warnings || warnings.length === 0)) {
+    list.innerHTML = '<div style="color:var(--success);font-size:12px;padding:4px 0;">✓ No errors or warnings</div>';
+    return;
+  }
+  (errors || []).forEach(e => {
+    const div = document.createElement('div');
+    div.className = 'error-item';
+    const loc = [e.workflow_id, e.step_id].filter(Boolean).join(' / ');
+    div.innerHTML = `
+      <span class="err-icon">✗</span>
+      <span class="err-text">${e.message}${loc ? ` <span class="err-loc" onclick="selectByPath('${e.workflow_id}','${e.step_id}')">[${loc}]</span>` : ''}</span>
+    `;
+    list.appendChild(div);
+  });
+  (warnings || []).forEach(w => {
+    const div = document.createElement('div');
+    div.className = 'warn-item';
+    div.textContent = '⚠ ' + w;
+    list.appendChild(div);
+  });
+}
+
+function selectByPath(workflowId, stepId) {
+  if (workflowId && workflowId !== (wf?.id)) {
+    document.getElementById('wf-select').value = workflowId;
+    loadWorkflow(workflowId);
+  }
+  if (stepId) {
+    selectedId = stepId;
+    renderDAG();
+    renderProps();
+  }
+}
+
+// ── Save / Diff ──────────────────────────────────────────────────
+let pendingWorkflows = null;
+
+async function doSave() {
+  if (!cfg || !wf) return;
+  const wfs = getWorkflowList();
+  // First validate
+  const vres = await fetch('/api/validate', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({workflows: wfs}),
+  });
+  const vdata = await vres.json();
+  if (!vdata.valid) {
+    renderErrors(vdata.errors, vdata.warnings);
+    switchTab('errors');
+    showToast(`✗ Fix ${vdata.errors.length} error(s) before saving`, 'error');
+    return;
+  }
+
+  // Compute diff
+  const dres = await fetch('/api/diff', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({workflows: wfs}),
+  });
+  const ddata = await dres.json();
+
+  if (!ddata.changed) {
+    showToast('No changes to save', 'success');
+    return;
+  }
+
+  // Show diff modal
+  pendingWorkflows = wfs;
+  renderDiff(ddata.diff);
+  document.getElementById('modal-overlay').classList.add('show');
+}
+
+function renderDiff(diff) {
+  const pre = document.getElementById('diff-text');
+  pre.innerHTML = '';
+  if (!diff) { pre.textContent = '(no changes)'; return; }
+  diff.split('\n').forEach(line => {
+    const span = document.createElement('span');
+    if (line.startsWith('+')) { span.className = 'diff-add'; }
+    else if (line.startsWith('-')) { span.className = 'diff-del'; }
+    else { span.className = 'diff-ctx'; }
+    span.textContent = line;
+    pre.appendChild(span);
+  });
+}
+
+function closeModal() {
+  document.getElementById('modal-overlay').classList.remove('show');
+  pendingWorkflows = null;
+}
+
+async function confirmSave() {
+  if (!pendingWorkflows) return;
+  const wfs = pendingWorkflows;
+  closeModal();
+  try {
+    const res = await fetch('/api/save', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({workflows: wfs}),
+    });
+    const data = await res.json();
+    if (data.ok) {
+      dirty = false;
+      updateDirtyBadge();
+      // Reload config to keep in sync
+      const cfgRes = await fetch('/api/config');
+      cfg = await cfgRes.json();
+      showToast('✓ Saved', 'success');
+      refreshYAMLPreview();
+    } else {
+      showToast('Save failed: ' + (data.error||'unknown'), 'error');
+    }
+  } catch(e) {
+    showToast('Save error: ' + e.message, 'error');
+  }
+}
+
+// ── Toast ────────────────────────────────────────────────────────
+function showToast(msg, type) {
+  const t = document.getElementById('toast');
+  t.textContent = msg;
+  t.className = 'toast show ' + (type||'');
+  clearTimeout(t._timer);
+  t._timer = setTimeout(() => t.className = 'toast', 3000);
+}
+
+// ── Keyboard shortcuts ───────────────────────────────────────────
+document.addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+    e.preventDefault();
+    doSave();
+  }
+  if (e.key === 'Escape') closeModal();
+});
+
+// ── Start ────────────────────────────────────────────────────────
+init();
+</script>
+</body>
+</html>

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -48,7 +48,7 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable)
+	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable, installed.Manifest.Checksum)
 	if err != nil {
 		return nil, err
 	}
@@ -135,9 +135,14 @@ func (c *Client) sanitizeDiagnostic(value string) string {
 }
 
 func (c *Client) environment() []string {
+	sec := c.installed.Manifest.Security
 	allowed := []string{"PATH", "HOME", "TMPDIR", "TEMP", "LANG", "LC_ALL", "TZ"}
-	allowed = append(allowed, c.installed.Manifest.Security.SecretEnv...)
-	env := make([]string, 0, len(allowed)+2)
+	if sec.Network {
+		// Propagate proxy configuration only when the plugin declared network access.
+		allowed = append(allowed, "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy")
+	}
+	allowed = append(allowed, sec.SecretEnv...)
+	env := make([]string, 0, len(allowed)+8)
 	seen := map[string]bool{}
 	for _, key := range allowed {
 		if seen[key] {
@@ -148,7 +153,17 @@ func (c *Client) environment() []string {
 			env = append(env, key+"="+value)
 		}
 	}
-	env = append(env, "APIARY_PLUGIN_ID="+c.ID(), fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion))
+	env = append(env,
+		"APIARY_PLUGIN_ID="+c.ID(),
+		fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion),
+		fmt.Sprintf("APIARY_PLUGIN_NETWORK=%t", sec.Network),
+	)
+	if len(sec.ReadPaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_READ_PATHS="+strings.Join(sec.ReadPaths, string(os.PathListSeparator)))
+	}
+	if len(sec.WritePaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_WRITE_PATHS="+strings.Join(sec.WritePaths, string(os.PathListSeparator)))
+	}
 	return env
 }
 

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,10 @@
 package plugin
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,9 +52,13 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
-	Capabilities  []Capability         `json:"capabilities"`
-	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
-	Security      SecurityRequirements `json:"security,omitempty"`
+	// Checksum is the SHA-256 digest of the plugin executable in the form
+	// "sha256:<64-hex-chars>". Required — plugins without a checksum are refused.
+	// Generate with: sha256sum <executable>
+	Checksum     string               `json:"checksum"`
+	Capabilities []Capability         `json:"capabilities"`
+	ConfigSchema json.RawMessage      `json:"config_schema,omitempty"`
+	Security     SecurityRequirements `json:"security,omitempty"`
 }
 
 type Installed struct {
@@ -135,7 +141,7 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	if _, err := secureExecutable(p.Root, m.Executable, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -180,7 +186,7 @@ func validPluginID(id string) bool {
 	return true
 }
 
-func secureExecutable(root, name string) (string, error) {
+func secureExecutable(root, name, checksum string) (string, error) {
 	if strings.TrimSpace(name) == "" || filepath.IsAbs(name) {
 		return "", fmt.Errorf("executable must be a relative path inside the plugin directory")
 	}
@@ -203,7 +209,39 @@ func secureExecutable(root, name string) (string, error) {
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
 		return "", fmt.Errorf("executable %q is not executable; run chmod +x", name)
 	}
+	if err := verifyChecksum(path, checksum); err != nil {
+		return "", err
+	}
 	return path, nil
+}
+
+// verifyChecksum requires checksum to be "sha256:<64-hex>" and verifies it
+// against the file at path. An empty or malformed checksum is always rejected.
+func verifyChecksum(path, checksum string) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(checksum, prefix) || len(checksum) != len(prefix)+64 {
+		return fmt.Errorf("checksum must be sha256:<64-hex-chars>; generate with: sha256sum <executable> (got %q)", checksum)
+	}
+	hexPart := checksum[len(prefix):]
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return fmt.Errorf("checksum %q contains invalid hex character %q", checksum, string(c))
+		}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("checksum: open executable: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("checksum: read executable: %w", err)
+	}
+	actual := fmt.Sprintf("%x", h.Sum(nil))
+	if actual != hexPart {
+		return fmt.Errorf("executable checksum mismatch: expected sha256:%s, got sha256:%s; update the manifest checksum field", hexPart, actual)
+	}
+	return nil
 }
 
 func validateSecurity(security SecurityRequirements) error {
@@ -216,6 +254,30 @@ func validateSecurity(security SecurityRequirements) error {
 			return fmt.Errorf("security.secret_env contains duplicate %q", name)
 		}
 		seen[name] = true
+	}
+	if err := validatePaths("security.read_paths", security.ReadPaths); err != nil {
+		return err
+	}
+	if err := validatePaths("security.write_paths", security.WritePaths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validatePaths(field string, paths []string) error {
+	seen := map[string]bool{}
+	for _, p := range paths {
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("%s %q must be an absolute path", field, p)
+		}
+		clean := filepath.Clean(p)
+		if clean != p {
+			return fmt.Errorf("%s %q must be a clean absolute path (use %q)", field, p, clean)
+		}
+		if seen[p] {
+			return fmt.Errorf("%s contains duplicate %q", field, p)
+		}
+		seen[p] = true
 	}
 	return nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,7 +2,10 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,7 +24,8 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	execPath := filepath.Join(root, executable)
+	if err := os.WriteFile(execPath, []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	manifest.SchemaVersion = ManifestSchemaVersion
@@ -39,11 +43,28 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if len(manifest.Capabilities) == 0 {
 		manifest.Capabilities = []Capability{CapabilityEventExporter}
 	}
+	if manifest.Checksum == "" {
+		manifest.Checksum = executableChecksum(t, execPath)
+	}
 	raw, _ := json.Marshal(manifest)
 	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
 		t.Fatal(err)
 	}
 	return root
+}
+
+func executableChecksum(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil))
 }
 
 func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
@@ -65,6 +86,174 @@ func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
 	valid := []InstanceConfig{{ID: "dev.apiary.exporter", Config: map[string]any{"path": "events.jsonl"}}}
 	if errs := ValidateConfigured(registry, valid); len(errs) != 0 {
 		t.Fatalf("valid config: %v", errs)
+	}
+}
+
+func TestChecksumVerification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Missing checksum is refused: write the executable manually, then write a
+	// manifest with no checksum field so json.Marshal omits it.
+	nocsRoot := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(nocsRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nocsRoot, "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Use a manifest struct with Checksum omitted — the zero value "" is serialised.
+	nocsManifest := Manifest{
+		SchemaVersion: ManifestSchemaVersion, Protocol: ProtocolVersion,
+		Executable: "plugin.sh", ID: "dev.apiary.nochecksum", Version: "1.0.0",
+		Apiary: ">= 0.10.0-0", Capabilities: []Capability{CapabilityEventExporter},
+	}
+	raw, _ := json.Marshal(nocsManifest)
+	if err := os.WriteFile(filepath.Join(nocsRoot, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(nocsRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "sha256:<64-hex-chars>") {
+		t.Fatalf("missing checksum error = %v", err)
+	}
+
+	// Wrong checksum is refused.
+	wrongRoot := writeTestPlugin(t, parent, "wrongchecksum", "exit 0", Manifest{
+		Checksum: "sha256:" + strings.Repeat("0", 64),
+	})
+	if _, err := Load(wrongRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("wrong checksum error = %v", err)
+	}
+
+	// Correct checksum loads.
+	goodRoot := writeTestPlugin(t, parent, "goodchecksum", "exit 0", Manifest{})
+	if _, err := Load(goodRoot, "v0.10.0"); err != nil {
+		t.Fatalf("good checksum load: %v", err)
+	}
+
+	// Tampered binary after load is caught by NewClient.
+	tamperedRoot := writeTestPlugin(t, parent, "tampered", "exit 0", Manifest{})
+	installed, err := Load(tamperedRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tamperedRoot, "plugin.sh"), []byte("#!/bin/sh\necho tampered\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID}); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("tampered binary error = %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Relative read path is rejected.
+	root := writeTestPlugin(t, parent, "relpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"relative/path"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("relative read_path error = %v", err)
+	}
+
+	// Unclean write path is rejected.
+	root2 := writeTestPlugin(t, parent, "unclean", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{"/tmp//data"}},
+	})
+	if _, err := Load(root2, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "clean absolute path") {
+		t.Fatalf("unclean write_path error = %v", err)
+	}
+
+	// Duplicate read path is rejected.
+	root3 := writeTestPlugin(t, parent, "duppath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp", "/tmp"}},
+	})
+	if _, err := Load(root3, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate read_path error = %v", err)
+	}
+
+	// Valid paths load successfully.
+	root4 := writeTestPlugin(t, parent, "validpaths", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	if _, err := Load(root4, "v0.10.0"); err != nil {
+		t.Fatalf("valid paths load: %v", err)
+	}
+}
+
+func TestPermissionEnvironmentVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Plugin with network=false: APIARY_PLUGIN_NETWORK must be false and
+	// the plugin must NOT receive HTTP_PROXY even if set in the host env.
+	netOffScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s","read":"%s","write":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY" "$APIARY_PLUGIN_READ_PATHS" "$APIARY_PLUGIN_WRITE_PATHS"`
+
+	netOffRoot := writeTestPlugin(t, parent, "netoff", netOffScript, Manifest{
+		Security: SecurityRequirements{Network: false, ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	t.Setenv("HTTP_PROXY", "http://proxy.example.com:3128")
+	installed, err := Load(netOffRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["net"] != "false" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"false\"", result["net"])
+	}
+	if result["proxy"] != "" {
+		t.Errorf("HTTP_PROXY leaked to network=false plugin: %q", result["proxy"])
+	}
+	if result["read"] != "/tmp" {
+		t.Errorf("APIARY_PLUGIN_READ_PATHS = %q, want \"/tmp\"", result["read"])
+	}
+	if result["write"] != "/tmp/out" {
+		t.Errorf("APIARY_PLUGIN_WRITE_PATHS = %q, want \"/tmp/out\"", result["write"])
+	}
+
+	// Plugin with network=true: APIARY_PLUGIN_NETWORK must be true and
+	// HTTP_PROXY from the host must be forwarded.
+	netOnScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY"`
+
+	netOnRoot := writeTestPlugin(t, parent, "neton", netOnScript, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installedOn, err := Load(netOnRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientOn, err := NewClient(installedOn, InstanceConfig{ID: installedOn.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resultOn map[string]string
+	if err := clientOn.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &resultOn); err != nil {
+		t.Fatal(err)
+	}
+	if resultOn["net"] != "true" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"true\"", resultOn["net"])
+	}
+	if resultOn["proxy"] != "http://proxy.example.com:3128" {
+		t.Errorf("HTTP_PROXY not forwarded to network=true plugin: %q", resultOn["proxy"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `apiary edit` — a local browser-based visual editor for `apiary.yaml` workflows. Starts an HTTP server on a random loopback port, opens the browser automatically (suppressed with `--no-browser`), and exits on Ctrl-C.
- New `internal/editor` package: HTTP server with embedded SPA (`static/index.html`), JSON model for the editor ↔ config round-trip, LCS-based semantic diff, and five HTTP API endpoints (`/api/config`, `/api/render`, `/api/validate`, `/api/diff`, `/api/save`).
- The visual DAG canvas renders all supported step types (agent, split, approval, wait_for, foreach, sub-workflow) with type-specific shapes and colours matching the VS Code extension palette. Edges distinguish sequential flow, conditional split branches, retry back-edges (dashed), and conflict loops.
- Unsupported constructs (parallel steps, v2-authored forms not yet lowered) are shown in read-only mode with an explicit notice instead of being silently discarded.
- Validation reuses `config.Validate()` + `WorkflowWarnings()` — the same pipeline as `apiary validate` — and annotates each error with the workflow/step ID so the relevant node can be highlighted.
- Save shows a unified semantic diff before writing; the file is only written if validation passes and the user confirms.
- Renaming a step ID propagates the change to all references (branches, on_pass, on_fail, on_conflict, seq_depends_on).

## Test plan

- [ ] `go build ./...` — clean compile, no new warnings
- [ ] `go vet ./...` — no issues
- [ ] `go test ./internal/editor/...` — 5 tests pass: `TestRoundTrip`, `TestSupportedFlag`, `TestUnifiedDiff`, `TestNoDiff`, `TestParseErrorPath`
- [ ] `apiary edit --help` — command registered and documented
- [ ] `apiary edit --no-browser` with the project `apiary.yaml` — server starts, UI loads, three workflows appear in the dropdown
- [ ] Select the `triage` workflow — DAG renders classify → route (split diamond) → implement / review branches → retry back-edge on classify
- [ ] Click a node → properties panel shows the correct form fields
- [ ] Edit a field → YAML preview updates; unsaved badge appears
- [ ] Click Validate → errors list is empty for the unchanged config
- [ ] Edit an agent step to reference a non-existent agent → Validate shows an annotated error pointing to that step
- [ ] Save → diff modal shows semantic diff → confirm → file on disk is updated
- [ ] Reload the editor → edited values persist (round-trip verified)
- [ ] Add a parallel step to the config directly → reload editor → parallel node shown in grey with "read-only" label

Closes #215