### PR TITLE
security: sandbox agent execution — filesystem/process containment (SEC-09) [#289]

### DIFF
--- a/docs/runners.md
+++ b/docs/runners.md
@@ -185,6 +185,56 @@ pre-authenticated CLI tool exists on the host.
     capable for implementation work — prefer `cli` runners for coding agents
     and API runners for lightweight classification or as fallback capacity.
 
+## Sandboxing agent execution
+
+A CLI runner can run every agent subprocess inside a Docker container, isolating
+it from the host filesystem. Use it for runners that process issues or comments
+written by people you do not fully trust.
+
+```yaml
+runners:
+  - id: sandboxed-claude
+    type: cli
+    provider: claude
+    config:
+      command: claude
+    sandbox:
+      image: my-org/apiary-agent:latest   # must contain the agent binary
+      # user:    "1000:1000"              # default: the daemon's uid:gid
+      # network: none                     # default: bridge (agents need egress)
+      extra_args: ["--memory", "4g", "--pids-limit", "512"]   # resource limits only
+    env_passthrough: ["MYCORP_*"]         # beyond system + provider credentials
+```
+
+**What it contains:** host filesystem access (only the task working directory is
+mounted), process and capability escalation (`--read-only` rootfs, `--cap-drop
+all`, `--security-opt no-new-privileges`), and unrelated host secrets — the agent
+environment is allow-listed to system variables plus LLM provider credentials,
+with per-task credentials overlaid. Credentials are passed to the container by
+name, so their values never appear in the host process table.
+
+**What it does NOT contain: network exfiltration.** `network` defaults to
+`bridge` because coding agents must reach their LLM API and git remotes, and the
+agent legitimately holds provider keys and a source token. A prompt-injected
+agent can still send data out. Add egress controls at the network layer if your
+trust level requires it.
+
+Notes:
+
+- `extra_args` accepts only resource-limit and labelling flags (`--memory`,
+  `--cpus`, `--pids-limit`, `--ulimit`, `--label`, …). Anything that could weaken
+  the sandbox — `--privileged`, `--cap-add`, extra mounts, `--network`,
+  `--user`, `--read-only=false`, `--entrypoint` — is rejected at config load.
+- `HOME` inside the container points at a writable tmpfs (`mode=1777`, `exec`),
+  since the rootfs is read-only and a numeric `--user` has no passwd entry. Both
+  options are set explicitly because docker *merges* its tmpfs defaults
+  (`nodev,noexec,relatime`) rather than replacing them, and a tmpfs otherwise
+  inherits the mountpoint's mode from the image.
+- **MCP servers are not supported with a sandbox yet.** Their config is written to
+  host paths the container cannot see, so combining them is rejected at config
+  load rather than silently starting an agent with its MCP servers missing.
+
+
 ## MCP servers
 
 Runners (and individual agents) can expose

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -20,6 +20,27 @@
         "additionalProperties": false,
         "required": ["id", "type"],
         "properties": {
+          "sandbox": {
+            "type": "object",
+            "description": "Run this runner's agent subprocesses inside a Docker container isolated from the host filesystem. Contains filesystem/process access; does NOT contain network egress.",
+            "additionalProperties": false,
+            "required": ["image"],
+            "properties": {
+              "image": {"type": "string", "description": "Docker image providing the agent binary"},
+              "user": {"type": "string", "description": "--user value; defaults to the daemon's uid:gid so the bind-mounted workspace stays writable"},
+              "network": {"type": "string", "description": "--network value; defaults to bridge because agents need LLM/git egress. Use \"none\" for agents needing no network"},
+              "extra_args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Additional docker flags. Restricted to resource-limit and labelling flags (e.g. --memory, --cpus, --pids-limit, --ulimit, --label); anything that could weaken the sandbox is rejected"
+              }
+            }
+          },
+          "env_passthrough": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Extra host environment variable names to forward to agents beyond the built-in allow-list (system vars + LLM provider credentials). Exact names or a trailing-* prefix, e.g. MYCORP_*"
+          },
           "id": {
             "type": "string",
             "description": "Unique runner identifier, referenced by agents[].runner and agents[].fallbacks"

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -73,6 +73,39 @@ type RunnerConfig struct {
 	// format/location (see runner/execution). Agent-scope MCPs (AgentConfig.MCPs)
 	// are layered on top of these, overriding by name.
 	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
+	// Sandbox, when set, wraps every agent subprocess for this runner in a Docker
+	// container that isolates it from the host filesystem (only the task working
+	// directory is mounted) and runs it as an unprivileged user. Use it for
+	// runners that process issues/comments from external or untrusted authors, to
+	// contain a successful prompt injection.
+	Sandbox *SandboxConfig `yaml:"sandbox,omitempty"`
+	// EnvPassthrough lists additional host environment variable names to forward to
+	// the agent subprocess beyond the built-in allowlist (system vars + LLM/agent
+	// provider credentials). Entries are exact names or a trailing-"*" prefix
+	// (e.g. "MYCORP_*"). Host variables not covered by the allowlist or this list
+	// are never inherited, so unrelated daemon secrets cannot leak into an agent.
+	EnvPassthrough []string `yaml:"env_passthrough,omitempty"`
+}
+
+// SandboxConfig describes Docker container isolation for a CLI runner's agent
+// subprocesses. Network is left enabled by default because coding agents must
+// reach their LLM API and git remotes; set Network to "none" only for agents
+// that need no network.
+type SandboxConfig struct {
+	// Image is the Docker image providing the agent binary (required).
+	Image string `yaml:"image"`
+	// User is passed as --user (e.g. "1000:1000"). Defaults to the daemon's own
+	// uid:gid so the bind-mounted workspace stays writable — "nobody" would make
+	// every workspace write fail with EACCES.
+	User string `yaml:"user,omitempty"`
+	// Network is the --network value (e.g. "bridge", "none"). Default "bridge".
+	Network string `yaml:"network,omitempty"`
+	// ExtraArgs are appended after the docker flags and before the image. Only
+	// resource-limit and labelling flags are permitted (e.g.
+	// ["--memory", "4g", "--pids-limit", "512"]); anything that could weaken the
+	// sandbox — extra mounts, --privileged, --cap-add, --user, --network,
+	// --read-only=false, --entrypoint — is rejected at config load.
+	ExtraArgs []string `yaml:"extra_args,omitempty"`
 }
 
 // AdapterName returns the runner adapter name as "{provider}-{type}" when both

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -357,7 +357,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			return nil, fmt.Errorf("agent %q: runner type %q not found", ac.ID, rc.Type)
 		}
 
-		if err := ra.Configure(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)); err != nil {
+		if err := ra.Configure(injectRunnerSecurity(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs), rc.Sandbox, rc.EnvPassthrough)); err != nil {
 			return nil, fmt.Errorf("agent %q: configure runner: %w", ac.ID, err)
 		}
 
@@ -389,7 +389,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
 			}
-			if err := fra.Configure(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)); err != nil {
+			if err := fra.Configure(injectRunnerSecurity(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs), frc.Sandbox, frc.EnvPassthrough)); err != nil {
 				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
 			}
 			if fAdapterName == "opencode" {
@@ -1845,6 +1845,39 @@ func runnerConfigWithMCPs(base map[string]any, runnerMCPs, agentMCPs []model.MCP
 	return out
 }
 
+// injectRunnerSecurity folds a runner's sandbox and env-passthrough settings into
+// the config map handed to the runner's Configure. The base map is never mutated;
+// a copy is returned only when there is something to add.
+func injectRunnerSecurity(base map[string]any, sandbox *config.SandboxConfig, envPassthrough []string) map[string]any {
+	if sandbox == nil && len(envPassthrough) == 0 {
+		return base
+	}
+	out := make(map[string]any, len(base)+2)
+	for k, v := range base {
+		out[k] = v
+	}
+	if sandbox != nil {
+		extra := make([]any, len(sandbox.ExtraArgs))
+		for i, v := range sandbox.ExtraArgs {
+			extra[i] = v
+		}
+		out["sandbox"] = map[string]any{
+			"image":      sandbox.Image,
+			"user":       sandbox.User,
+			"network":    sandbox.Network,
+			"extra_args": extra,
+		}
+	}
+	if len(envPassthrough) > 0 {
+		p := make([]any, len(envPassthrough))
+		for i, v := range envPassthrough {
+			p[i] = v
+		}
+		out["env_passthrough"] = p
+	}
+	return out
+}
+
 func workerRunConfig(wc config.WorkerConfig) map[string]any {
 	m := map[string]any{}
 	if wc.RunnerConfig != nil {
@@ -1891,7 +1924,7 @@ func (d *Dispatcher) UpdateAgentConfig(ctx context.Context, agentID, newModel, n
 		if !ok {
 			return fmt.Errorf("runner type %q not registered", rc.Type)
 		}
-		if err := ra.Configure(rc.Config); err != nil {
+		if err := ra.Configure(injectRunnerSecurity(rc.Config, rc.Sandbox, rc.EnvPassthrough)); err != nil {
 			return fmt.Errorf("configure runner %q: %w", newRunner, err)
 		}
 

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -541,11 +541,11 @@ func TestTaskDetailShowsUsageWhenZero(t *testing.T) {
 	a := newTestApp(80, 24)
 	a.model.tasksTab.View = TaskViewDetail
 	a.model.tasksTab.Detail = &TaskItem{
-		TaskID:  "T-2",
-		Number:  "PRJ-6",
-		Title:   "old task",
-		Agent:   "engineer",
-		Status:  "success",
+		TaskID: "T-2",
+		Number: "PRJ-6",
+		Title:  "old task",
+		Agent:  "engineer",
+		Status: "success",
 	}
 	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 20))
 	if !strings.Contains(out, "0 in / 0 out / 0 total") {

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -71,10 +71,10 @@ type Usage struct {
 type FailureKind int
 
 const (
-	FailureNone          FailureKind = iota // no failure; output is usable
-	FailureRateLimited                      // provider rate limit (e.g. 5h session)
-	FailureCreditExhausted                  // out of credits / over quota
-	FailureAborted                          // runner exited early with no useful output (heuristic)
+	FailureNone            FailureKind = iota // no failure; output is usable
+	FailureRateLimited                        // provider rate limit (e.g. 5h session)
+	FailureCreditExhausted                    // out of credits / over quota
+	FailureAborted                            // runner exited early with no useful output (heuristic)
 )
 
 func (k FailureKind) String() string {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -35,6 +35,14 @@ type CliRunner struct {
 	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
 	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
 	mcpRunArgs []string
+	// sandbox, when non-nil, wraps every agent subprocess in a Docker container
+	// that isolates it from the host filesystem and runs it as an unprivileged
+	// user (see sandbox.go). Use it for runners processing untrusted-author input.
+	sandbox *cliSandbox
+	// envPassthrough lists additional host environment variable names (exact, or a
+	// trailing-"*" prefix) to forward to the agent beyond the built-in system and
+	// provider-credential allowlist. Unlisted host secrets are never inherited.
+	envPassthrough []string
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -70,6 +78,16 @@ func (r *CliRunner) Configure(config map[string]any) error {
 	if v, ok := config["mcps"].([]model.MCPServer); ok {
 		r.mcps = v
 	}
+	// Reject sandbox+MCP BEFORE setupMCP runs: setupMCP has side effects (it
+	// writes provider config into $HOME/.cursor, ~/.config/opencode, /tmp), and
+	// those host paths are not visible inside the container — /tmp is masked by
+	// the sandbox tmpfs — so the agent would start with its MCP servers silently
+	// missing. Fail closed, and do it before anything is written.
+	_, sandboxConfigured := config["sandbox"].(map[string]any)
+	if sandboxConfigured && len(r.mcps) > 0 {
+		return fmt.Errorf("cli runner: sandbox is not compatible with MCP servers yet: the MCP config is written to host paths that are not visible inside the container, so the agent would silently lose them; remove the sandbox or the mcps for this runner")
+	}
+
 	// Materialise the provider's MCP config (and any per-run CLI args) once the
 	// servers are known. Configure runs at load time, sequentially across agents,
 	// so the global-config merges (cursor/opencode) are race-free.
@@ -79,6 +97,39 @@ func (r *CliRunner) Configure(config map[string]any) error {
 			return fmt.Errorf("cli runner: setup MCP: %w", err)
 		}
 		r.mcpRunArgs = args
+	}
+	if raw, ok := config["env_passthrough"].([]any); ok {
+		for _, a := range raw {
+			if s, ok := a.(string); ok {
+				r.envPassthrough = append(r.envPassthrough, s)
+			}
+		}
+	}
+	if raw, ok := config["sandbox"].(map[string]any); ok {
+		sc := &cliSandbox{}
+		if v, ok := raw["image"].(string); ok {
+			sc.image = v
+		}
+		if v, ok := raw["user"].(string); ok {
+			sc.user = v
+		}
+		if v, ok := raw["network"].(string); ok {
+			sc.network = v
+		}
+		if extras, ok := raw["extra_args"].([]any); ok {
+			for _, a := range extras {
+				if s, ok := a.(string); ok {
+					sc.extraArgs = append(sc.extraArgs, s)
+				}
+			}
+		}
+		if sc.image == "" {
+			return fmt.Errorf("cli runner: sandbox.image is required when sandbox is configured")
+		}
+		if err := validateExtraArgs(sc.extraArgs); err != nil {
+			return fmt.Errorf("cli runner: %w", err)
+		}
+		r.sandbox = sc
 	}
 	return nil
 }
@@ -103,11 +154,27 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		argv = append(argv, r.promptFlag, prompt)
 	}
 
-	cmd := exec.CommandContext(ctx, r.command, argv...)
-	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
-	for k, v := range req.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
+	var cmd *exec.Cmd
+	if r.sandbox != nil {
+		// Container isolation. Build a scoped environment (allowlisted host vars —
+		// system + provider credentials + configured passthrough — plus the
+		// per-task overlay) so unrelated host secrets never enter the container.
+		// Secrets are forwarded to the container by NAME only (see wrapCommand):
+		// their values live solely in this docker process's environment (cmd.Env),
+		// never in argv/the host process table.
+		scoped, envNames := scopedEnv(os.Environ(), req.Env, r.envPassthrough)
+		binary, sandboxArgv := r.sandbox.wrapCommand(r.command, argv, req.WorkingDir, envNames)
+		cmd = exec.CommandContext(ctx, binary, sandboxArgv...)
+		cmd.Env = scoped
+	} else {
+		// Non-sandbox path: host env is scoped separately by the env-allowlist
+		// change (SEC-07); left as-is here to avoid overlapping that work.
+		cmd = exec.CommandContext(ctx, r.command, argv...)
+		cmd.Dir = req.WorkingDir
+		cmd.Env = os.Environ()
+		for k, v := range req.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
 	}
 	if r.promptFlag == "" && !r.promptPositional {
 		cmd.Stdin = strings.NewReader(prompt)

--- a/src/internal/runner/execution/sandbox.go
+++ b/src/internal/runner/execution/sandbox.go
@@ -1,0 +1,267 @@
+package execution
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Environment handling for agent subprocesses.
+//
+// Two goals, both flagged by review of the first attempt (PR #254):
+//
+//  1. The agent CLI must keep the credentials it legitimately needs — chiefly
+//     its LLM provider key (ANTHROPIC_*, OPENAI_*, opencode, cursor, …). The
+//     first attempt stripped those and broke every run. We retain them via a
+//     curated family prefix list plus an operator-configurable passthrough.
+//  2. Unrelated host secrets the daemon happens to hold (AWS_*, other
+//     integrations' tokens, etc.) must NOT be inherited by the agent — on a
+//     successful prompt injection they would be exfiltratable. Everything not
+//     explicitly allowed is dropped.
+//
+// Per-task credentials (req.Env, e.g. a scoped GITHUB_TOKEN) are always overlaid
+// on top and, in the sandbox path, are passed to the container by NAME only so
+// their values never appear in the host process table (argv).
+
+// systemEnvAllow is the set of non-secret host variables the agent process needs
+// to function (PATH, locale, TLS trust store, CLI config dirs, etc.).
+var systemEnvAllow = map[string]bool{
+	"PATH": true, "HOME": true, "SHELL": true, "USER": true, "LOGNAME": true,
+	"TERM": true, "TZ": true, "LANG": true, "LC_ALL": true, "LC_CTYPE": true,
+	"TMPDIR": true, "TEMP": true, "TMP": true,
+	"SSL_CERT_FILE": true, "SSL_CERT_DIR": true, "CURL_CA_BUNDLE": true,
+	"SSH_AUTH_SOCK": true, "DOCKER_HOST": true,
+	"XDG_CONFIG_HOME": true, "XDG_CACHE_HOME": true, "XDG_DATA_HOME": true,
+}
+
+// providerEnvPrefixes matches whole families of LLM/agent-CLI provider
+// credentials so a newly-added variable in a known family is covered without a
+// code change. Deliberately excludes broad cloud families (AWS_, GCP service
+// keys) that are typically unrelated daemon secrets — those must be opted in via
+// env_passthrough if an agent genuinely needs them.
+var providerEnvPrefixes = []string{
+	"ANTHROPIC_", "CLAUDE_",
+	"OPENAI_", "AZURE_OPENAI_",
+	"OPENCODE_", "CURSOR_",
+	"GEMINI_", "GOOGLE_GENERATIVE_",
+	"OPENROUTER_", "GROQ_", "MISTRAL_", "DEEPSEEK_", "XAI_",
+}
+
+// envAllow decides whether a host variable name may be inherited by the agent.
+// passthrough entries are exact names or a trailing-"*" prefix (e.g. "MYCORP_*").
+func envAllow(name string, passthrough []string) bool {
+	if systemEnvAllow[name] {
+		return true
+	}
+	for _, p := range providerEnvPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	for _, entry := range passthrough {
+		if strings.HasSuffix(entry, "*") {
+			if strings.HasPrefix(name, strings.TrimSuffix(entry, "*")) {
+				return true
+			}
+		} else if name == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// scopedEnv builds the environment for an agent subprocess: the allowed host
+// variables plus the explicit per-task overlay. hostEnv is the raw environment
+// (os.Environ() form "K=V"); overlay wins on key collisions. It returns the
+// "K=V" slice for cmd.Env and, separately, the sorted list of variable names it
+// contains (used to forward names into the sandbox container).
+func scopedEnv(hostEnv []string, overlay map[string]string, passthrough []string) (env []string, names []string) {
+	seen := map[string]string{}
+	for _, kv := range hostEnv {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok && envAllow(k, passthrough) {
+			seen[k] = v
+		}
+	}
+	// Overlay is always trusted/needed for the task; it wins over host values.
+	for k, v := range overlay {
+		seen[k] = v
+	}
+	names = make([]string, 0, len(seen))
+	for k := range seen {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	env = make([]string, 0, len(seen))
+	for _, k := range names {
+		env = append(env, k+"="+seen[k])
+	}
+	return env, names
+}
+
+// cliSandbox describes Docker container isolation applied to a CliRunner. The
+// container isolates the agent from the host filesystem (only the working
+// directory is mounted) and runs it as an unprivileged user. Network is left
+// enabled by default because coding agents must reach their LLM API and git
+// remotes; operators who run agents that need no network may set network:"none".
+const (
+	// sandboxHome is a writable tmpfs mount used as HOME inside the container,
+	// since the rootfs is read-only and a --user uid has no /etc/passwd entry.
+	sandboxHome = "/home/apiary"
+	tmpfsSize   = "512m"
+)
+
+type cliSandbox struct {
+	image     string
+	user      string   // --user; default: the daemon's own uid:gid (workspace is bind-mounted)
+	network   string   // --network; default "bridge" (agents need egress)
+	extraArgs []string // appended after flags, before the image
+}
+
+// wrapCommand rewrites (binary, argv) to run inside the sandbox container.
+//
+// Credentials are forwarded with the NAME-only form `--env NAME` (never
+// `--env NAME=VALUE`): docker reads each value from its own process environment,
+// which the caller sets to the full scoped env. This keeps secret values out of
+// the host process table (argv), closing the leak flagged in review of #254.
+//
+// envNames is the list of variable names to forward (from scopedEnv). Only the
+// working directory is bind-mounted, so the agent cannot read host files outside
+// its task workspace.
+func (s *cliSandbox) wrapCommand(binary string, argv []string, workDir string, envNames []string) (string, []string) {
+	user := s.user
+	if user == "" {
+		// Default to the daemon's own uid:gid, NOT "nobody": the task working
+		// directory is bind-mounted from the host and is owned by this user, so a
+		// mismatched uid makes every workspace write fail with EACCES. Container
+		// isolation here comes from the mount namespace and dropped capabilities,
+		// not from being a different uid than the files the agent must edit.
+		user = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	}
+	network := s.network
+	if network == "" {
+		network = "bridge"
+	}
+	dockerArgs := []string{
+		"run", "--rm",
+		"--network", network,
+		"--user", user,
+		"--read-only",
+		// The rootfs is read-only, so every path the agent must write needs an
+		// explicit tmpfs.
+		//
+		// "exec" must be stated explicitly: docker MERGES its own tmpfs defaults
+		// (nodev,noexec,relatime) rather than replacing them, so omitting it
+		// leaves the mount noexec and breaks npx, node native modules, and git
+		// hooks. "mode=1777" is likewise required because a tmpfs inherits the
+		// mountpoint's existing mode — on any image that pre-creates the
+		// directory as root:0755, an unprivileged --user could not write to it.
+		"--tmpfs", "/tmp:rw,exec,nosuid,mode=1777,size=" + tmpfsSize,
+		"--tmpfs", sandboxHome + ":rw,exec,nosuid,mode=1777,size=" + tmpfsSize,
+		// A uid passed via --user has no /etc/passwd entry, so HOME would resolve
+		// to "/" — which is read-only. Every agent CLI (claude, opencode, cursor)
+		// writes a config directory on startup, so point HOME at the tmpfs above.
+		// Not a secret, so the NAME=VALUE form is fine here.
+		"--env", "HOME=" + sandboxHome,
+		"--cap-drop", "all",
+		"--security-opt", "no-new-privileges",
+	}
+	if workDir != "" {
+		dockerArgs = append(dockerArgs, "-v", workDir+":"+workDir, "-w", workDir)
+	}
+	for _, name := range containerEnvNames(envNames) {
+		dockerArgs = append(dockerArgs, "--env", name) // name-only: value via docker's own env
+	}
+	dockerArgs = append(dockerArgs, s.extraArgs...)
+	dockerArgs = append(dockerArgs, s.image, binary)
+	dockerArgs = append(dockerArgs, argv...)
+	return "docker", dockerArgs
+}
+
+// hostOnlyEnv names must never be forwarded INTO the container. Some are actively
+// dangerous (DOCKER_HOST points at the host Docker socket — forwarding it from an
+// isolation feature would hand the agent a trivial host escape; SSH_AUTH_SOCK is
+// a host agent socket). The rest are host paths or identity that are meaningless
+// or actively wrong inside the image, which supplies its own (HOME under a
+// read-only rootfs is the classic failure).
+var hostOnlyEnv = map[string]bool{
+	"DOCKER_HOST": true, "SSH_AUTH_SOCK": true,
+	"HOME": true, "PATH": true, "SHELL": true, "USER": true, "LOGNAME": true,
+	"TMPDIR": true, "TEMP": true, "TMP": true,
+	"XDG_CONFIG_HOME": true, "XDG_CACHE_HOME": true, "XDG_DATA_HOME": true,
+}
+
+// containerEnvNames filters the scoped env down to the names that should cross
+// the container boundary — credentials and task config, not host wiring.
+func containerEnvNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if !hostOnlyEnv[n] {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// allowedExtraArgs is an ALLOW-list of docker flags permitted in extra_args.
+//
+// A deny-list was tried first and proved unsound: docker uses spf13/pflag, so
+// "-v/:/hostfs" and "-u0:0" are single tokens that never match a "-v"/"-u"
+// entry, and boolean flags accept "--read-only=false", which silently disables
+// the headline protection because later flags win. Enumerating what is safe is
+// the only version of this check that can be reasoned about.
+//
+// Values are accepted after a flag that takes one; anything not listed is
+// refused with a message naming the flag.
+var allowedExtraArgs = map[string]bool{
+	"--memory": true, "-m": true, "--memory-swap": true, "--memory-reservation": true,
+	"--cpus": true, "--cpu-shares": true, "-c": true, "--cpuset-cpus": true, "--cpuset-mems": true,
+	"--pids-limit": true, "--ulimit": true, "--oom-kill-disable": true,
+	"--label": true, "-l": true, "--name": true, "--hostname": true, "-h": true,
+	"--platform": true, "--pull": true, "--quiet": true, "-q": true,
+}
+
+// validateExtraArgs permits only the flags in allowedExtraArgs. It normalizes
+// the "--flag=value" form and rejects pflag attached-shorthand ("-v/:/hostfs")
+// outright, since that form cannot be distinguished from a value safely.
+func validateExtraArgs(args []string) error {
+	expectValue := false
+	for _, a := range args {
+		if expectValue {
+			expectValue = false
+			continue // this token is the previous flag's value
+		}
+		if !strings.HasPrefix(a, "-") {
+			return fmt.Errorf("sandbox.extra_args: unexpected bare value %q; every entry must start with an allowed flag", a)
+		}
+		flag, hasInlineValue := a, false
+		if i := strings.IndexByte(flag, '='); i >= 0 {
+			flag, hasInlineValue = flag[:i], true
+		}
+		// Reject attached shorthand like "-v/:/hostfs" or "-u0:0": a short flag
+		// must be its own token so its value cannot smuggle in a denied option.
+		if !strings.HasPrefix(flag, "--") && len(flag) > 2 {
+			return fmt.Errorf("sandbox.extra_args: %q uses attached shorthand; write the flag and its value as separate entries", a)
+		}
+		if !allowedExtraArgs[flag] {
+			return fmt.Errorf("sandbox.extra_args: %q is not permitted; only resource limits and labelling flags are allowed (e.g. --memory, --cpus, --pids-limit, --ulimit, --label), because anything else can weaken or disable the sandbox", flag)
+		}
+		if !hasInlineValue && flagTakesValue[flag] {
+			expectValue = true
+		}
+	}
+	if expectValue {
+		return fmt.Errorf("sandbox.extra_args: trailing flag is missing its value")
+	}
+	return nil
+}
+
+// flagTakesValue marks allowed flags that consume the following token.
+var flagTakesValue = map[string]bool{
+	"--memory": true, "-m": true, "--memory-swap": true, "--memory-reservation": true,
+	"--cpus": true, "--cpu-shares": true, "-c": true, "--cpuset-cpus": true, "--cpuset-mems": true,
+	"--pids-limit": true, "--ulimit": true,
+	"--label": true, "-l": true, "--name": true, "--hostname": true, "-h": true,
+	"--platform": true, "--pull": true,
+}

--- a/src/internal/runner/execution/sandbox_docker_test.go
+++ b/src/internal/runner/execution/sandbox_docker_test.go
@@ -1,0 +1,165 @@
+package execution
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireDocker skips unless a working docker daemon is reachable. Review of
+// this PR correctly pointed out that argv-shape assertions alone are not
+// evidence the sandbox works; these tests actually run containers.
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if os.Getenv("APIARY_SKIP_DOCKER_TESTS") != "" {
+		t.Skip("APIARY_SKIP_DOCKER_TESTS set")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not installed")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skip("docker daemon not reachable")
+	}
+}
+
+// runSandboxed executes a shell command through the real wrapCommand argv.
+func runSandboxed(t *testing.T, workDir string, envNames []string, script string) (string, error) {
+	t.Helper()
+	s := &cliSandbox{image: "busybox:latest"}
+	bin, args := s.wrapCommand("sh", []string{"-c", script}, workDir, envNames)
+	cmd := exec.Command(bin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// HOME must be writable: with --user <uid> there is no /etc/passwd entry, so a
+// stripped HOME resolves to "/" which is read-only, and every agent CLI writes a
+// config dir on startup. This is the exact runtime break review found.
+func TestSandbox_HomeIsWritable(t *testing.T) {
+	requireDocker(t)
+	out, err := runSandboxed(t, "", nil, `printf %s "$HOME" && mkdir -p "$HOME/.config/agent" && echo ok > "$HOME/.config/agent/x" && cat "$HOME/.config/agent/x"`)
+	if err != nil {
+		t.Fatalf("agent could not write to HOME inside the sandbox: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, sandboxHome) {
+		t.Errorf("expected HOME=%s inside container, got: %s", sandboxHome, out)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Errorf("expected a successful write under HOME, got: %s", out)
+	}
+}
+
+// The bind-mounted workspace must be writable by the container user, which is
+// why --user defaults to the daemon's uid:gid rather than "nobody".
+func TestSandbox_WorkspaceIsWritable(t *testing.T) {
+	requireDocker(t)
+	dir := t.TempDir()
+	out, err := runSandboxed(t, dir, nil, `echo written > ./file.txt && cat ./file.txt`)
+	if err != nil {
+		t.Fatalf("agent could not write its workspace: %v\n%s", err, out)
+	}
+	data, readErr := os.ReadFile(filepath.Join(dir, "file.txt"))
+	if readErr != nil || !strings.Contains(string(data), "written") {
+		t.Errorf("workspace write did not land on the host: err=%v data=%q", readErr, string(data))
+	}
+}
+
+// The rootfs must stay read-only outside the explicit tmpfs mounts.
+func TestSandbox_RootfsIsReadOnly(t *testing.T) {
+	requireDocker(t)
+	out, _ := runSandboxed(t, "", nil, `echo x > /etc/passwd 2>&1 || echo BLOCKED`)
+	if !strings.Contains(out, "BLOCKED") {
+		t.Errorf("expected a write to /etc to be blocked by --read-only, got: %s", out)
+	}
+}
+
+// Credentials cross by NAME only; the value must come from the docker client's
+// own environment and never appear in argv.
+func TestSandbox_CredentialForwardedByNameNotArgv(t *testing.T) {
+	requireDocker(t)
+	t.Setenv("APIARY_TEST_SECRET", "s3cr3t-value")
+	s := &cliSandbox{image: "busybox:latest"}
+	bin, args := s.wrapCommand("sh", []string{"-c", `printf %s "$APIARY_TEST_SECRET"`}, "", []string{"APIARY_TEST_SECRET"})
+	for _, a := range args {
+		if strings.Contains(a, "s3cr3t-value") {
+			t.Fatalf("secret value leaked into argv: %q", a)
+		}
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "s3cr3t-value") {
+		t.Errorf("credential did not reach the container: %q", string(out))
+	}
+}
+
+// Host wiring must not cross the boundary — DOCKER_HOST especially, since it
+// would hand an escaped agent the host Docker socket. Set real values on the
+// host so the assertion is meaningful rather than tautological.
+func TestSandbox_HostWiringNotForwarded(t *testing.T) {
+	requireDocker(t)
+	t.Setenv("SSH_AUTH_SOCK", "/host/ssh-agent.sock")
+	out, err := runSandboxed(t, "", []string{"DOCKER_HOST", "SSH_AUTH_SOCK", "PATH"}, `printf "[%s]" "$SSH_AUTH_SOCK"`)
+	if err != nil {
+		t.Fatalf("run failed: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "/host/ssh-agent.sock") {
+		t.Errorf("host SSH_AUTH_SOCK leaked into the container: %s", out)
+	}
+	if !strings.Contains(out, "[]") {
+		t.Errorf("expected SSH_AUTH_SOCK to be empty inside the container, got: %s", out)
+	}
+}
+
+// buildImageWithHome builds a throwaway image that PRE-CREATES the sandbox HOME
+// as root:0755 — the case where a tmpfs inheriting the mountpoint mode leaves
+// HOME unwritable for an unprivileged --user. busybox happens not to have the
+// directory, which is why the earlier test passed against a broken sandbox.
+func buildImageWithHome(t *testing.T) string {
+	t.Helper()
+	tag := "apiary-sandbox-hometest:latest"
+	dockerfile := "FROM busybox:latest\nRUN mkdir -p " + sandboxHome + " && chmod 0755 " + sandboxHome + "\n"
+	cmd := exec.Command("docker", "build", "-t", tag, "-")
+	cmd.Stdin = strings.NewReader(dockerfile)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not build test image: %v\n%s", err, out)
+	}
+	return tag
+}
+
+// Regression: HOME must be writable even when the image already contains the
+// directory owned by root with restrictive permissions.
+func TestSandbox_HomeWritableWhenImagePreCreatesIt(t *testing.T) {
+	requireDocker(t)
+	tag := buildImageWithHome(t)
+	s := &cliSandbox{image: tag}
+	bin, args := s.wrapCommand("sh", []string{"-c", `touch "$HOME/probe" && echo WROTE`}, "", nil)
+	cmd := exec.Command(bin, args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "WROTE") {
+		t.Fatalf("HOME must be writable even when the image pre-creates it as root:0755: err=%v\n%s", err, out)
+	}
+}
+
+// Docker MERGES its tmpfs defaults (nodev,noexec,relatime), so "exec" has to be
+// stated explicitly or agents cannot run npx/node native modules/git hooks.
+func TestSandbox_TmpfsIsExecutable(t *testing.T) {
+	requireDocker(t)
+	script := `printf '#!/bin/sh\necho RAN\n' > "$HOME/s.sh" && chmod +x "$HOME/s.sh" && "$HOME/s.sh"`
+	out, err := runSandboxed(t, "", nil, script)
+	if err != nil || !strings.Contains(out, "RAN") {
+		t.Fatalf("HOME tmpfs must allow execution (docker merges noexec by default): err=%v\n%s", err, out)
+	}
+	tmpScript := `printf '#!/bin/sh\necho TMPRAN\n' > /tmp/s.sh && chmod +x /tmp/s.sh && /tmp/s.sh`
+	out, err = runSandboxed(t, "", nil, tmpScript)
+	if err != nil || !strings.Contains(out, "TMPRAN") {
+		t.Fatalf("/tmp tmpfs must allow execution: err=%v\n%s", err, out)
+	}
+}

--- a/src/internal/runner/execution/sandbox_test.go
+++ b/src/internal/runner/execution/sandbox_test.go
@@ -1,0 +1,194 @@
+package execution
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func envMap(kvs []string) map[string]string {
+	m := map[string]string{}
+	for _, kv := range kvs {
+		k, v, _ := strings.Cut(kv, "=")
+		m[k] = v
+	}
+	return m
+}
+
+func TestScopedEnv_RetainsProviderKeys_DropsUnrelatedSecrets(t *testing.T) {
+	host := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/apiary",
+		"ANTHROPIC_API_KEY=sk-ant-xxx",  // provider family — must be kept (regression: PR #254 dropped it)
+		"OPENAI_API_KEY=sk-oai-xxx",     // provider family — must be kept
+		"AWS_SECRET_ACCESS_KEY=aws-xxx", // unrelated daemon secret — must be dropped
+		"STRIPE_SECRET_KEY=sk-live-xxx", // unrelated daemon secret — must be dropped
+	}
+	env, names := scopedEnv(host, nil, nil)
+	got := envMap(env)
+
+	for _, keep := range []string{"PATH", "HOME", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"} {
+		if _, ok := got[keep]; !ok {
+			t.Errorf("expected %q to be retained, but it was dropped", keep)
+		}
+	}
+	for _, drop := range []string{"AWS_SECRET_ACCESS_KEY", "STRIPE_SECRET_KEY"} {
+		if _, ok := got[drop]; ok {
+			t.Errorf("expected %q to be dropped, but it was retained", drop)
+		}
+	}
+	// names must mirror env and stay sorted/deduped.
+	if len(names) != len(got) {
+		t.Errorf("names (%d) and env (%d) length mismatch", len(names), len(got))
+	}
+}
+
+func TestScopedEnv_OverlayWinsAndIsRetained(t *testing.T) {
+	host := []string{"PATH=/usr/bin", "GITHUB_TOKEN=host-token"}
+	// Per-task overlay must always be present and win over any host value.
+	env, _ := scopedEnv(host, map[string]string{"GITHUB_TOKEN": "scoped-token"}, nil)
+	got := envMap(env)
+	if got["GITHUB_TOKEN"] != "scoped-token" {
+		t.Errorf("overlay GITHUB_TOKEN not applied: got %q", got["GITHUB_TOKEN"])
+	}
+}
+
+func TestScopedEnv_Passthrough(t *testing.T) {
+	host := []string{"MYCORP_TOKEN=abc", "MYCORP_REGION=us", "OTHER_SECRET=zzz"}
+	env, _ := scopedEnv(host, nil, []string{"MYCORP_*"})
+	got := envMap(env)
+	if _, ok := got["MYCORP_TOKEN"]; !ok {
+		t.Error("MYCORP_TOKEN should pass through via prefix rule")
+	}
+	if _, ok := got["MYCORP_REGION"]; !ok {
+		t.Error("MYCORP_REGION should pass through via prefix rule")
+	}
+	if _, ok := got["OTHER_SECRET"]; ok {
+		t.Error("OTHER_SECRET must not pass through")
+	}
+}
+
+func TestWrapCommand_NoSecretValuesInArgv(t *testing.T) {
+	s := &cliSandbox{image: "apiary/agent:latest"}
+	// Names only — values live in the docker process env, never in argv.
+	_, args := s.wrapCommand("opencode", []string{"run", "--model", "x"}, "/work/task", []string{"GITHUB_TOKEN", "ANTHROPIC_API_KEY"})
+
+	joined := strings.Join(args, " ")
+	// The critical assertion: no "NAME=VALUE" env pair (i.e. no secret value) in argv.
+	for _, a := range args {
+		if strings.HasPrefix(a, "GITHUB_TOKEN=") || strings.HasPrefix(a, "ANTHROPIC_API_KEY=") {
+			t.Fatalf("secret value leaked into argv: %q", a)
+		}
+	}
+	// Name-only --env forwarding must be present.
+	if !strings.Contains(joined, "--env GITHUB_TOKEN") || !strings.Contains(joined, "--env ANTHROPIC_API_KEY") {
+		t.Errorf("expected name-only --env forwarding, got: %s", joined)
+	}
+	// Hardening flags + isolation: unprivileged user, read-only rootfs, no caps, workdir bind mount.
+	for _, want := range []string{
+		"run", "--rm",
+		"--read-only",
+		"--tmpfs", "/tmp:rw,exec,nosuid,mode=1777,size=" + tmpfsSize,
+		"--cap-drop", "all",
+		"--security-opt", "no-new-privileges",
+		"-v", "/work/task:/work/task", "-w", "/work/task",
+		"apiary/agent:latest", "opencode",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected docker args to contain %q, got: %s", want, joined)
+		}
+	}
+}
+
+func TestWrapCommand_NetworkDefaultsToBridge(t *testing.T) {
+	s := &cliSandbox{image: "img"}
+	_, args := s.wrapCommand("bin", nil, "", nil)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--network bridge") {
+		t.Errorf("network should default to bridge so agents keep egress, got: %s", joined)
+	}
+}
+
+// DOCKER_HOST would hand the agent the host Docker socket — a trivial escape
+// from the very sandbox this feature provides. Host paths/identity are likewise
+// wrong inside the image (HOME under a read-only rootfs is the classic break).
+func TestWrapCommand_DoesNotForwardHostWiringIntoContainer(t *testing.T) {
+	names := []string{"ANTHROPIC_API_KEY", "GITHUB_TOKEN", "DOCKER_HOST", "SSH_AUTH_SOCK", "HOME", "PATH", "TMPDIR"}
+	_, args := (&cliSandbox{image: "img"}).wrapCommand("bin", nil, "/w", names)
+	joined := strings.Join(args, " ")
+
+	// The host's values must not cross; note "--env HOME=<path>" (an explicit
+	// container path we set) is different from "--env HOME" (forward host value).
+	for _, leak := range []string{"DOCKER_HOST", "SSH_AUTH_SOCK", "PATH", "TMPDIR"} {
+		if strings.Contains(joined, "--env "+leak+" ") || strings.HasSuffix(joined, "--env "+leak) {
+			t.Errorf("%s must not be forwarded into the container: %s", leak, joined)
+		}
+	}
+	if strings.Contains(joined, "--env HOME ") {
+		t.Errorf("the host HOME value must not be forwarded: %s", joined)
+	}
+	// A writable HOME must be set explicitly, or agent CLIs cannot write config
+	// under the read-only rootfs.
+	if !strings.Contains(joined, "--env HOME="+sandboxHome) {
+		t.Errorf("expected an explicit writable HOME, got: %s", joined)
+	}
+	for _, want := range []string{"ANTHROPIC_API_KEY", "GITHUB_TOKEN"} {
+		if !strings.Contains(joined, "--env "+want) {
+			t.Errorf("credential %s should be forwarded, got: %s", want, joined)
+		}
+	}
+}
+
+// A bind-mounted workspace is owned by the daemon's uid; running as "nobody"
+// makes every write fail with EACCES.
+func TestWrapCommand_DefaultUserCanWriteWorkspace(t *testing.T) {
+	_, args := (&cliSandbox{image: "img"}).wrapCommand("bin", nil, "/w", nil)
+	want := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--user "+want) {
+		t.Errorf("expected --user %s so workspace writes succeed, got: %s", want, joined)
+	}
+	if strings.Contains(joined, "--user nobody") {
+		t.Error("must not default to nobody: bind-mounted workspace writes would EACCES")
+	}
+}
+
+func TestValidateExtraArgs(t *testing.T) {
+	// Every one of these defeats or weakens the sandbox. The last group is why an
+	// allow-list replaced the original deny-list: pflag attached-shorthand and
+	// boolean "=false" forms slipped straight past exact-match matching.
+	for _, bad := range [][]string{
+		{"--privileged"},
+		{"--cap-add", "SYS_ADMIN"},
+		{"--user=0:0"},
+		{"-v", "/:/host"},
+		{"--security-opt", "seccomp=unconfined"},
+		{"--network=host"},
+		{"--read-only=false"},       // silently disables the headline flag (last wins)
+		{"--entrypoint", "/bin/sh"}, // replaces the agent binary
+		{"--cgroupns=host"},
+		{"--group-add", "docker"},
+		{"--tmpfs", "/etc"}, // shadow /etc with a writable mount
+		{"-v/:/hostfs"},     // pflag attached shorthand
+		{"-u0:0"},           // pflag attached shorthand
+		{"--sysctl", "net.ipv4.ip_forward=1"},
+		{"/bin/sh"},  // bare value, not a flag
+		{"--memory"}, // trailing flag with no value
+	} {
+		if err := validateExtraArgs(bad); err == nil {
+			t.Errorf("expected %v to be rejected", bad)
+		}
+	}
+	for _, ok := range [][]string{
+		{"--memory", "2g"},
+		{"--cpus=2"},
+		{"--pids-limit", "256"},
+		{"--ulimit", "nofile=1024:2048"},
+		{"--label", "team=apiary", "--memory", "1g"},
+	} {
+		if err := validateExtraArgs(ok); err != nil {
+			t.Errorf("benign args %v should be allowed, got %v", ok, err)
+		}
+	}
+}

--- a/src/internal/workflow/dag_e2e_test.go
+++ b/src/internal/workflow/dag_e2e_test.go
@@ -235,4 +235,3 @@ func TestE2E_V2ConditionSkipsTrack(t *testing.T) {
 		t.Error("expected complex-impl to be skipped (track=simple)")
 	}
 }
-

--- a/src/internal/workflow/dag_integration_test.go
+++ b/src/internal/workflow/dag_integration_test.go
@@ -52,10 +52,10 @@ func TestDAGIntegration_SequentialMemory(t *testing.T) {
 
 	exec := &fakeExecutor{results: map[string]StepResult{
 		"classify": {
-			Success:         true,
-			Output:          "classified as high-priority",
+			Success:          true,
+			Output:           "classified as high-priority",
 			StructuredOutput: map[string]any{"track": "implement"},
-			Summary:         "track decided",
+			Summary:          "track decided",
 		},
 		"implement": {Success: true, Output: "PR opened"},
 		"review":    {Success: true, Output: "LGTM"},
@@ -208,7 +208,7 @@ func TestDAGIntegration_SplitByMemoryField(t *testing.T) {
 
 	exec := &fakeExecutor{results: map[string]StepResult{
 		"plan": {
-			Success:         true,
+			Success:          true,
 			StructuredOutput: map[string]any{"complexity": "high"},
 		},
 	}}


### PR DESCRIPTION
## Summary
Runs each agent subprocess inside a Docker container, isolated from the host filesystem. Reworked after council review of #254 and of this PR.

## What this actually contains — and what it does not
**Contains:** host filesystem access (only the task working directory is mounted), process/capability escalation (`--read-only`, `--cap-drop all`, `--security-opt no-new-privileges`, tmpfs `/tmp`), and unrelated host secrets (env is allow-listed).

**Does NOT contain: exfiltration.** `network` defaults to `bridge` because coding agents must reach their LLM API and git remotes, and the agent legitimately holds provider keys and a `GITHUB_TOKEN`. An injected agent can still send data out. Egress policy is the missing piece and is tracked as follow-up on #289.

That is why this is `Refs #289`, **not `Closes`** — it narrows the blast radius of a prompt injection but does not shut the rollout gate on its own.

## Fixes from review of #254
- **Provider keys retained.** `scopedEnv` allow-lists system vars plus LLM/agent provider families (`ANTHROPIC_`, `OPENAI_`, `OPENCODE_`, `CURSOR_`, …) by prefix, plus operator-configurable `env_passthrough`. Unrelated host secrets (`AWS_*` etc.) are dropped. #254 stripped provider keys and would have broken every run.
- **No secret values in argv.** Credentials cross with the name-only form `docker run --env NAME`; values live only in the docker process's own env, never the host process table.

## Fixes from review of this PR
- **`--user` defaults to the daemon's uid:gid, not `nobody`.** The workspace is bind-mounted and owned by the daemon user, so `nobody` made every write fail with EACCES — the sandbox was unusable for a coding agent.
- **`DOCKER_HOST` is no longer forwarded into the container** — forwarding the host Docker socket pointer from an isolation feature is a trivial host escape, a hole this PR itself introduced. `SSH_AUTH_SOCK` and host paths/identity (`HOME`/`PATH`/`TMPDIR`/`XDG_*`) are filtered too; `HOME` under a read-only rootfs was also a functional break.
- **Fails closed on MCP + sandbox.** `setupMCP` writes provider config to host paths (`/tmp`, `~/.cursor`, `~/.config`) that the container cannot see (and `/tmp` is masked by tmpfs), so the agent would have started with MCP servers silently missing. Configure now errors instead.
- **`extra_args` is validated** — `--privileged`, `--cap-add`, `--user`, `--network`, extra mounts and friends are refused rather than silently undoing the sandbox.

## Known gaps (deliberate, not oversights)
- Egress/exfiltration, as above.
- MCP is unsupported under a sandbox (fails closed rather than degrading silently).
- Opt-in per runner via `runners[].sandbox`; nothing changes for runners without it.

## Tests
Provider keys retained / unrelated secrets dropped / overlay precedence; no `NAME=VALUE` in argv; host wiring not forwarded while credentials are; writable-workspace uid; `extra_args` rejection. `go build`, `go vet`, and the `execution` + `config` + `daemon` package tests pass.

Refs #289