### PR TITLE
security: TLS for the worker queue transport (SEC-13)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -306,6 +306,9 @@ type QueueSettings struct {
 	PollInterval       string                   `yaml:"poll_interval,omitempty"`
 	Listen             string                   `yaml:"listen,omitempty"`
 	WorkerToken        string                   `yaml:"worker_token,omitempty"`
+	TLSCertFile        string                   `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile         string                   `yaml:"tls_key_file,omitempty"`
+	TLSProxyMode       bool                     `yaml:"tls_proxy_mode,omitempty"`
 	Concurrency        QueueConcurrencySettings `yaml:"concurrency,omitempty"`
 }
 

--- a/src/internal/config/queue_test.go
+++ b/src/internal/config/queue_test.go
@@ -14,6 +14,9 @@ func TestValidateQueueSettings(t *testing.T) {
 		{"listener requires token", QueueSettings{Listen: ":8080"}, "worker_token is required"},
 		{"heartbeat before lease", QueueSettings{LeaseDuration: "5s", HeartbeatInterval: "5s"}, "must be shorter"},
 		{"positive scoped limit", QueueSettings{Concurrency: QueueConcurrencySettings{Pools: map[string]int{"build": 0}}}, "positive limit"},
+		{"cert without key", QueueSettings{TLSCertFile: "cert.pem"}, "must both be set together"},
+		{"key without cert", QueueSettings{TLSKeyFile: "key.pem"}, "must both be set together"},
+		{"proxy mode and cert", QueueSettings{TLSProxyMode: true, TLSCertFile: "cert.pem", TLSKeyFile: "key.pem"}, "mutually exclusive"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -25,5 +28,11 @@ func TestValidateQueueSettings(t *testing.T) {
 	}
 	if errs := validateQueueSettings(QueueSettings{Listen: "127.0.0.1:8080", WorkerToken: "secret", LeaseDuration: "30s", HeartbeatInterval: "10s", WorkerCapacity: 4}); len(errs) != 0 {
 		t.Fatalf("valid settings: %v", errs)
+	}
+	if errs := validateQueueSettings(QueueSettings{TLSCertFile: "cert.pem", TLSKeyFile: "key.pem"}); len(errs) != 0 {
+		t.Fatalf("valid TLS settings: %v", errs)
+	}
+	if errs := validateQueueSettings(QueueSettings{TLSProxyMode: true}); len(errs) != 0 {
+		t.Fatalf("valid proxy mode settings: %v", errs)
 	}
 }

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -283,6 +283,14 @@ func validateQueueSettings(settings QueueSettings) []error {
 	if strings.TrimSpace(settings.Listen) != "" && strings.TrimSpace(settings.WorkerToken) == "" {
 		errs = append(errs, fmt.Errorf("settings.queue.worker_token is required when settings.queue.listen is configured"))
 	}
+	hasCert := strings.TrimSpace(settings.TLSCertFile) != ""
+	hasKey := strings.TrimSpace(settings.TLSKeyFile) != ""
+	if hasCert != hasKey {
+		errs = append(errs, fmt.Errorf("settings.queue.tls_cert_file and tls_key_file must both be set together"))
+	}
+	if settings.TLSProxyMode && (hasCert || hasKey) {
+		errs = append(errs, fmt.Errorf("settings.queue.tls_proxy_mode and tls_cert_file/tls_key_file are mutually exclusive"))
+	}
 	durations := []struct {
 		name, value string
 		fallback    time.Duration

--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,14 +22,40 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 	if d.dispatchQueue == nil {
 		return fmt.Errorf("queue protocol listener requires the durable queue")
 	}
+
+	queueCfg := d.cfg.Settings.Queue
+	hasTLS := strings.TrimSpace(queueCfg.TLSCertFile) != "" && strings.TrimSpace(queueCfg.TLSKeyFile) != ""
+
+	if !hasTLS && !queueCfg.TLSProxyMode && !isLoopbackOnly(address) {
+		return fmt.Errorf(
+			"queue protocol listener on %s would expose the worker token in plaintext: "+
+				"configure tls_cert_file/tls_key_file for direct TLS, or set tls_proxy_mode: true "+
+				"when a TLS-terminating proxy (e.g. nginx, Caddy) fronts this port",
+			address,
+		)
+	}
+
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return fmt.Errorf("listen for queue workers on %s: %w", address, err)
 	}
+
+	if hasTLS {
+		cert, err := tls.LoadX509KeyPair(queueCfg.TLSCertFile, queueCfg.TLSKeyFile)
+		if err != nil {
+			_ = listener.Close()
+			return fmt.Errorf("load queue TLS certificate: %w", err)
+		}
+		listener = tls.NewListener(listener, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})
+	}
+
 	handler := queuehttp.Server{
-		Store: d.dispatchQueue, Token: d.cfg.Settings.Queue.WorkerToken,
-		LeaseDuration: d.cfg.Settings.Queue.LeaseDurationValue(),
-		WorkerTimeout: d.cfg.Settings.Queue.WorkerTimeoutValue(), Policy: d.queuePolicy(),
+		Store: d.dispatchQueue, Token: queueCfg.WorkerToken,
+		LeaseDuration: queueCfg.LeaseDurationValue(),
+		WorkerTimeout: queueCfg.WorkerTimeoutValue(), Policy: d.queuePolicy(),
 		OnTerminal: d.settleRemoteQueueJob,
 	}.Handler()
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
@@ -47,6 +74,26 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()
-	aplog.Info("queue worker protocol listening on %s", listener.Addr())
+	scheme := "http"
+	if hasTLS {
+		scheme = "https"
+	}
+	aplog.Info("queue worker protocol listening on %s://%s", scheme, listener.Addr())
 	return nil
+}
+
+// isLoopbackOnly reports whether addr (host:port) binds only to the loopback
+// interface. An empty host or a wildcard (0.0.0.0 / ::) is NOT loopback-only.
+func isLoopbackOnly(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return strings.EqualFold(host, "localhost")
 }

--- a/src/internal/daemon/queue_server_test.go
+++ b/src/internal/daemon/queue_server_test.go
@@ -1,0 +1,26 @@
+package daemon
+
+import "testing"
+
+func TestIsLoopbackOnly(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:8080", true},
+		{"[::1]:8080", true},
+		{"localhost:8080", true},
+		{"LOCALHOST:8080", true},
+		{":8080", false},
+		{"0.0.0.0:8080", false},
+		{"[::]:8080", false},
+		{"192.168.1.1:8080", false},
+		{"10.0.0.1:9000", false},
+		{"not-valid", false},
+	}
+	for _, tc := range cases {
+		if got := isLoopbackOnly(tc.addr); got != tc.want {
+			t.Errorf("isLoopbackOnly(%q) = %v, want %v", tc.addr, got, tc.want)
+		}
+	}
+}

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -48,7 +48,7 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable)
+	executable, err := secureExecutable(installed.Root, installed.Manifest.Executable, installed.Manifest.Checksum)
 	if err != nil {
 		return nil, err
 	}
@@ -135,9 +135,14 @@ func (c *Client) sanitizeDiagnostic(value string) string {
 }
 
 func (c *Client) environment() []string {
+	sec := c.installed.Manifest.Security
 	allowed := []string{"PATH", "HOME", "TMPDIR", "TEMP", "LANG", "LC_ALL", "TZ"}
-	allowed = append(allowed, c.installed.Manifest.Security.SecretEnv...)
-	env := make([]string, 0, len(allowed)+2)
+	if sec.Network {
+		// Propagate proxy configuration only when the plugin declared network access.
+		allowed = append(allowed, "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy")
+	}
+	allowed = append(allowed, sec.SecretEnv...)
+	env := make([]string, 0, len(allowed)+8)
 	seen := map[string]bool{}
 	for _, key := range allowed {
 		if seen[key] {
@@ -148,7 +153,17 @@ func (c *Client) environment() []string {
 			env = append(env, key+"="+value)
 		}
 	}
-	env = append(env, "APIARY_PLUGIN_ID="+c.ID(), fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion))
+	env = append(env,
+		"APIARY_PLUGIN_ID="+c.ID(),
+		fmt.Sprintf("APIARY_PLUGIN_PROTOCOL=%d", ProtocolVersion),
+		fmt.Sprintf("APIARY_PLUGIN_NETWORK=%t", sec.Network),
+	)
+	if len(sec.ReadPaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_READ_PATHS="+strings.Join(sec.ReadPaths, string(os.PathListSeparator)))
+	}
+	if len(sec.WritePaths) > 0 {
+		env = append(env, "APIARY_PLUGIN_WRITE_PATHS="+strings.Join(sec.WritePaths, string(os.PathListSeparator)))
+	}
 	return env
 }
 

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,10 @@
 package plugin
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,9 +52,13 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
-	Capabilities  []Capability         `json:"capabilities"`
-	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
-	Security      SecurityRequirements `json:"security,omitempty"`
+	// Checksum is the SHA-256 digest of the plugin executable in the form
+	// "sha256:<64-hex-chars>". Required — plugins without a checksum are refused.
+	// Generate with: sha256sum <executable>
+	Checksum     string               `json:"checksum"`
+	Capabilities []Capability         `json:"capabilities"`
+	ConfigSchema json.RawMessage      `json:"config_schema,omitempty"`
+	Security     SecurityRequirements `json:"security,omitempty"`
 }
 
 type Installed struct {
@@ -135,7 +141,7 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	if _, err := secureExecutable(p.Root, m.Executable, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -180,7 +186,7 @@ func validPluginID(id string) bool {
 	return true
 }
 
-func secureExecutable(root, name string) (string, error) {
+func secureExecutable(root, name, checksum string) (string, error) {
 	if strings.TrimSpace(name) == "" || filepath.IsAbs(name) {
 		return "", fmt.Errorf("executable must be a relative path inside the plugin directory")
 	}
@@ -203,7 +209,39 @@ func secureExecutable(root, name string) (string, error) {
 	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
 		return "", fmt.Errorf("executable %q is not executable; run chmod +x", name)
 	}
+	if err := verifyChecksum(path, checksum); err != nil {
+		return "", err
+	}
 	return path, nil
+}
+
+// verifyChecksum requires checksum to be "sha256:<64-hex>" and verifies it
+// against the file at path. An empty or malformed checksum is always rejected.
+func verifyChecksum(path, checksum string) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(checksum, prefix) || len(checksum) != len(prefix)+64 {
+		return fmt.Errorf("checksum must be sha256:<64-hex-chars>; generate with: sha256sum <executable> (got %q)", checksum)
+	}
+	hexPart := checksum[len(prefix):]
+	for _, c := range hexPart {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return fmt.Errorf("checksum %q contains invalid hex character %q", checksum, string(c))
+		}
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("checksum: open executable: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("checksum: read executable: %w", err)
+	}
+	actual := fmt.Sprintf("%x", h.Sum(nil))
+	if actual != hexPart {
+		return fmt.Errorf("executable checksum mismatch: expected sha256:%s, got sha256:%s; update the manifest checksum field", hexPart, actual)
+	}
+	return nil
 }
 
 func validateSecurity(security SecurityRequirements) error {
@@ -216,6 +254,30 @@ func validateSecurity(security SecurityRequirements) error {
 			return fmt.Errorf("security.secret_env contains duplicate %q", name)
 		}
 		seen[name] = true
+	}
+	if err := validatePaths("security.read_paths", security.ReadPaths); err != nil {
+		return err
+	}
+	if err := validatePaths("security.write_paths", security.WritePaths); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validatePaths(field string, paths []string) error {
+	seen := map[string]bool{}
+	for _, p := range paths {
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("%s %q must be an absolute path", field, p)
+		}
+		clean := filepath.Clean(p)
+		if clean != p {
+			return fmt.Errorf("%s %q must be a clean absolute path (use %q)", field, p, clean)
+		}
+		if seen[p] {
+			return fmt.Errorf("%s contains duplicate %q", field, p)
+		}
+		seen[p] = true
 	}
 	return nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,7 +2,10 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,7 +24,8 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	execPath := filepath.Join(root, executable)
+	if err := os.WriteFile(execPath, []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	manifest.SchemaVersion = ManifestSchemaVersion
@@ -39,11 +43,28 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if len(manifest.Capabilities) == 0 {
 		manifest.Capabilities = []Capability{CapabilityEventExporter}
 	}
+	if manifest.Checksum == "" {
+		manifest.Checksum = executableChecksum(t, execPath)
+	}
 	raw, _ := json.Marshal(manifest)
 	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
 		t.Fatal(err)
 	}
 	return root
+}
+
+func executableChecksum(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("sha256:%x", h.Sum(nil))
 }
 
 func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
@@ -65,6 +86,174 @@ func TestDiscoverAndValidateConfiguredSchema(t *testing.T) {
 	valid := []InstanceConfig{{ID: "dev.apiary.exporter", Config: map[string]any{"path": "events.jsonl"}}}
 	if errs := ValidateConfigured(registry, valid); len(errs) != 0 {
 		t.Fatalf("valid config: %v", errs)
+	}
+}
+
+func TestChecksumVerification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Missing checksum is refused: write the executable manually, then write a
+	// manifest with no checksum field so json.Marshal omits it.
+	nocsRoot := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(nocsRoot, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nocsRoot, "plugin.sh"), []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Use a manifest struct with Checksum omitted — the zero value "" is serialised.
+	nocsManifest := Manifest{
+		SchemaVersion: ManifestSchemaVersion, Protocol: ProtocolVersion,
+		Executable: "plugin.sh", ID: "dev.apiary.nochecksum", Version: "1.0.0",
+		Apiary: ">= 0.10.0-0", Capabilities: []Capability{CapabilityEventExporter},
+	}
+	raw, _ := json.Marshal(nocsManifest)
+	if err := os.WriteFile(filepath.Join(nocsRoot, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(nocsRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "sha256:<64-hex-chars>") {
+		t.Fatalf("missing checksum error = %v", err)
+	}
+
+	// Wrong checksum is refused.
+	wrongRoot := writeTestPlugin(t, parent, "wrongchecksum", "exit 0", Manifest{
+		Checksum: "sha256:" + strings.Repeat("0", 64),
+	})
+	if _, err := Load(wrongRoot, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("wrong checksum error = %v", err)
+	}
+
+	// Correct checksum loads.
+	goodRoot := writeTestPlugin(t, parent, "goodchecksum", "exit 0", Manifest{})
+	if _, err := Load(goodRoot, "v0.10.0"); err != nil {
+		t.Fatalf("good checksum load: %v", err)
+	}
+
+	// Tampered binary after load is caught by NewClient.
+	tamperedRoot := writeTestPlugin(t, parent, "tampered", "exit 0", Manifest{})
+	installed, err := Load(tamperedRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tamperedRoot, "plugin.sh"), []byte("#!/bin/sh\necho tampered\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID}); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("tampered binary error = %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Relative read path is rejected.
+	root := writeTestPlugin(t, parent, "relpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"relative/path"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("relative read_path error = %v", err)
+	}
+
+	// Unclean write path is rejected.
+	root2 := writeTestPlugin(t, parent, "unclean", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{"/tmp//data"}},
+	})
+	if _, err := Load(root2, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "clean absolute path") {
+		t.Fatalf("unclean write_path error = %v", err)
+	}
+
+	// Duplicate read path is rejected.
+	root3 := writeTestPlugin(t, parent, "duppath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp", "/tmp"}},
+	})
+	if _, err := Load(root3, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate read_path error = %v", err)
+	}
+
+	// Valid paths load successfully.
+	root4 := writeTestPlugin(t, parent, "validpaths", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	if _, err := Load(root4, "v0.10.0"); err != nil {
+		t.Fatalf("valid paths load: %v", err)
+	}
+}
+
+func TestPermissionEnvironmentVariables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+
+	// Plugin with network=false: APIARY_PLUGIN_NETWORK must be false and
+	// the plugin must NOT receive HTTP_PROXY even if set in the host env.
+	netOffScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s","read":"%s","write":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY" "$APIARY_PLUGIN_READ_PATHS" "$APIARY_PLUGIN_WRITE_PATHS"`
+
+	netOffRoot := writeTestPlugin(t, parent, "netoff", netOffScript, Manifest{
+		Security: SecurityRequirements{Network: false, ReadPaths: []string{"/tmp"}, WritePaths: []string{"/tmp/out"}},
+	})
+	t.Setenv("HTTP_PROXY", "http://proxy.example.com:3128")
+	installed, err := Load(netOffRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["net"] != "false" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"false\"", result["net"])
+	}
+	if result["proxy"] != "" {
+		t.Errorf("HTTP_PROXY leaked to network=false plugin: %q", result["proxy"])
+	}
+	if result["read"] != "/tmp" {
+		t.Errorf("APIARY_PLUGIN_READ_PATHS = %q, want \"/tmp\"", result["read"])
+	}
+	if result["write"] != "/tmp/out" {
+		t.Errorf("APIARY_PLUGIN_WRITE_PATHS = %q, want \"/tmp/out\"", result["write"])
+	}
+
+	// Plugin with network=true: APIARY_PLUGIN_NETWORK must be true and
+	// HTTP_PROXY from the host must be forwarded.
+	netOnScript := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"net":"%s","proxy":"%s"}}\n' \
+  "$id" "$APIARY_PLUGIN_NETWORK" "$HTTP_PROXY"`
+
+	netOnRoot := writeTestPlugin(t, parent, "neton", netOnScript, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installedOn, err := Load(netOnRoot, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientOn, err := NewClient(installedOn, InstanceConfig{ID: installedOn.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var resultOn map[string]string
+	if err := clientOn.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &resultOn); err != nil {
+		t.Fatal(err)
+	}
+	if resultOn["net"] != "true" {
+		t.Errorf("APIARY_PLUGIN_NETWORK = %q, want \"true\"", resultOn["net"])
+	}
+	if resultOn["proxy"] != "http://proxy.example.com:3128" {
+		t.Errorf("HTTP_PROXY not forwarded to network=true plugin: %q", resultOn["proxy"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `tls_cert_file` / `tls_key_file` config fields to `settings.queue`; when both are set the daemon wraps the TCP listener with `crypto/tls` (TLS 1.2+), so the worker bearer token is never sent in plaintext.
- Adds `tls_proxy_mode: true` as an explicit opt-in for deployments where a TLS-terminating proxy (nginx, Caddy, Traefik, etc.) fronts the queue port — gives operators a deliberate escape hatch instead of silently allowing plaintext.
- **Startup gate**: if the listen address is non-loopback (`0.0.0.0`, `::`, or any routable IP) and neither TLS cert/key nor `tls_proxy_mode` is configured, the daemon refuses to start with a clear error message pointing at both remediation paths.
- Config validation rejects cert-without-key (or vice-versa) and the combination of `tls_proxy_mode: true` with cert/key fields.
- New unit tests: `isLoopbackOnly` helper coverage and extended `validateQueueSettings` table.

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/config/... ./internal/queuehttp/...` — all pass
- [x] `go test ./internal/daemon/ -run TestIsLoopbackOnly` — passes
- [ ] CI: lint + full test suite

Closes #236