### PR TITLE
security: redact secrets from log stderr + add govulncheck/Dependabot to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,32 @@
+name: govulncheck
+
+on:
+  push:
+    paths:
+      - "src/**"
+      - ".github/workflows/govulncheck.yml"
+  pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/govulncheck.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Run govulncheck
+        working-directory: src
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10265 symbols, 23355 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10265 symbols, 23355 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -5,6 +5,7 @@ package log
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -14,6 +15,27 @@ var (
 	sinkMu  sync.RWMutex
 	sink    func(level, msg string)
 )
+
+// Patterns that identify secrets which must never appear in log output.
+var (
+	reJWT    = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`)
+	reGHPAT  = regexp.MustCompile(`ghp_[A-Za-z0-9]{10,}`)
+	reGHFine = regexp.MustCompile(`github_pat_[A-Za-z0-9_]{10,}`)
+	reSlack  = regexp.MustCompile(`xox[bp]-[A-Za-z0-9\-]{10,}`)
+	reAWS    = regexp.MustCompile(`AKIA[A-Z0-9]{16}`)
+	reBearer = regexp.MustCompile(`(?i)(bearer\s+)\S{8,}`)
+)
+
+// redact replaces known secret patterns in s with [REDACTED].
+func redact(s string) string {
+	s = reJWT.ReplaceAllString(s, "[REDACTED]")
+	s = reGHPAT.ReplaceAllString(s, "[REDACTED]")
+	s = reGHFine.ReplaceAllString(s, "[REDACTED]")
+	s = reSlack.ReplaceAllString(s, "[REDACTED]")
+	s = reAWS.ReplaceAllString(s, "[REDACTED]")
+	s = reBearer.ReplaceAllString(s, "${1}[REDACTED]")
+	return s
+}
 
 // Enable turns verbose (debug) output on or off.
 func Enable(v bool) { verbose = v }
@@ -55,7 +77,7 @@ func Error(format string, args ...any) {
 
 func print(level, format string, args ...any) {
 	ts := time.Now().Format("15:04:05")
-	msg := fmt.Sprintf(format, args...)
+	msg := redact(fmt.Sprintf(format, args...))
 	fmt.Fprintf(os.Stderr, "%s  %-5s  %s\n", ts, level, msg)
 
 	sinkMu.RLock()

--- a/src/internal/log/log_test.go
+++ b/src/internal/log/log_test.go
@@ -1,0 +1,79 @@
+package log
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildToken joins parts with sep to prevent static secret scanners from
+// flagging test fixtures as real credentials.
+func buildToken(sep string, parts ...string) string {
+	return strings.Join(parts, sep)
+}
+
+func TestRedact(t *testing.T) {
+	// Slack-shaped token split across parts to avoid push-protection false positives.
+	slackBot  := buildToken("-", "xoxb", "12345678901", "12345678901", "abcdefghijklmnop")
+	slackUser := buildToken("-", "xoxp", "12345678901", "12345678901", "abcdefghijklmnop")
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "JWT token",
+			input: "auth eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			want:  "auth [REDACTED]",
+		},
+		{
+			name:  "GitHub PAT ghp_",
+			input: "token ghp_ABCDEFGHIJ1234567890",
+			want:  "token [REDACTED]",
+		},
+		{
+			name:  "GitHub fine-grained PAT",
+			input: "using github_pat_ABCDEFGHIJ1234567890",
+			want:  "using [REDACTED]",
+		},
+		{
+			name:  "Slack bot token",
+			input: "slack " + slackBot,
+			want:  "slack [REDACTED]",
+		},
+		{
+			name:  "Slack user token",
+			input: "slack " + slackUser,
+			want:  "slack [REDACTED]",
+		},
+		{
+			name:  "AWS access key",
+			input: "key AKIAIOSFODNN7EXAMPLE",
+			want:  "key [REDACTED]",
+		},
+		{
+			name:  "Bearer header",
+			input: "Authorization: Bearer supersecrettoken123",
+			want:  "Authorization: Bearer [REDACTED]",
+		},
+		{
+			name:  "Bearer header case-insensitive",
+			input: "authorization: bearer supersecrettoken123",
+			want:  "authorization: bearer [REDACTED]",
+		},
+		{
+			name:  "no secret",
+			input: "hello world",
+			want:  "hello world",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redact(tc.input)
+			if got != tc.want {
+				t.Errorf("redact(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Log redaction**: `internal/log` now applies the same secret-pattern heuristic used in `execution_event.go` and `transcript.go` to every message before it reaches stderr (and the operational sink). Patterns covered: JWT, GitHub PATs (`ghp_`, `github_pat_`), Slack tokens (`xoxb-`, `xoxp-`), AWS access key IDs (`AKIA…`), and `Authorization: Bearer <token>` values.
- **govulncheck CI**: new workflow `.github/workflows/govulncheck.yml` runs `golang.org/x/vuln/cmd/govulncheck ./...` on every push/PR that touches `src/`.
- **Dependabot**: new `.github/dependabot.yml` schedules weekly dependency updates for both Go modules (`/src`) and GitHub Actions.
- **Tests**: `src/internal/log/log_test.go` covers all 6 redaction pattern families plus a no-op case.

## Test plan

- [x] `go test ./internal/log/...` passes locally (9/9 cases)
- [x] `go vet ./...` clean
- [ ] CI govulncheck job runs green on this PR

Closes #240