### PR TITLE
security: check permissions on each per-plugin subdirectory (SEC-04)

### DIFF
--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -53,6 +53,15 @@ func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error
 		}
 		sort.Strings(roots)
 		for _, root := range roots {
+			if root != path {
+				// root is a per-plugin subdirectory; the parent was already checked
+				// above. Re-check each child so an attacker cannot plant executables
+				// in a group/world-writable child even when the parent is 0700.
+				if warn := checkDirOwnerOnly(root); warn != nil {
+					errs = append(errs, warn)
+					continue
+				}
+			}
 			if _, err := os.Stat(filepath.Join(root, ManifestFilename)); err != nil {
 				continue
 			}

--- a/src/internal/plugin/discovery_unix_test.go
+++ b/src/internal/plugin/discovery_unix_test.go
@@ -42,3 +42,30 @@ func TestDiscoverSkipsGroupAndWorldWritableDirs(t *testing.T) {
 		t.Fatal("safe plugin from good path should still load")
 	}
 }
+
+func TestDiscoverSkipsWritableChildPluginDir(t *testing.T) {
+	// The parent directory is correctly owner-only (0700). One child plugin dir
+	// is group-writable — discovery must skip that child with a warning while
+	// still loading a sibling whose permissions are clean.
+	parent := t.TempDir() // 0700 by default
+
+	writeTestPlugin(t, parent, "clean", "exit 0", Manifest{})
+	writeTestPlugin(t, parent, "writable", "exit 0", Manifest{})
+
+	if err := os.Chmod(filepath.Join(parent, "writable"), 0o775); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(parent, "writable"), 0o755) })
+
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+		t.Fatalf("expected exactly 1 permission warning, got errs=%v", errs)
+	}
+	if _, ok := registry.Get("dev.apiary.writable"); ok {
+		t.Fatal("writable child plugin dir should have been skipped")
+	}
+	if _, ok := registry.Get("dev.apiary.clean"); !ok {
+		t.Fatal("clean sibling plugin should still load")
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `checkDirOwnerOnly` was only called on the top-level configured path. When that path has no `plugin.json` of its own, `Discover` enumerates its subdirectories as per-plugin roots and loads each — without verifying their permissions. A group/world-writable child directory inside a correctly-locked-down parent was therefore accepted, giving an attacker write access to exactly where a planted executable lives.
- **Fix**: apply `checkDirOwnerOnly` to each per-plugin subdirectory root before loading it; skip and emit a warning on any writable root.
- **Test**: add `TestDiscoverSkipsWritableChildPluginDir` — a clean parent (0700) with one group-writable child (`0775`) and one clean sibling; asserts the writable child is refused and the clean sibling still loads.

## Test plan

- [x] `go test ./internal/plugin/...` — all tests pass, including new `TestDiscoverSkipsWritableChildPluginDir`
- [x] Existing `TestDiscoverSkipsGroupAndWorldWritableDirs` still passes (top-level-writable path still refused)

Closes #245