### PR TITLE
fix(sec-03): bind worker queue to loopback by default

### DIFF
--- a/src/internal/daemon/queue_server.go
+++ b/src/internal/daemon/queue_server.go
@@ -21,6 +21,7 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 	if d.dispatchQueue == nil {
 		return fmt.Errorf("queue protocol listener requires the durable queue")
 	}
+	address = resolveQueueListenAddress(address)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return fmt.Errorf("listen for queue workers on %s: %w", address, err)
@@ -49,4 +50,22 @@ func (d *Dispatcher) startQueueProtocolServer(ctx context.Context, wg *sync.Wait
 	}()
 	aplog.Info("queue worker protocol listening on %s", listener.Addr())
 	return nil
+}
+
+// resolveQueueListenAddress enforces a loopback-first default: a bare :PORT
+// address is rewritten to 127.0.0.1:PORT, and any non-loopback host triggers
+// a warning because the queue protocol uses plaintext HTTP.
+func resolveQueueListenAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port)
+	}
+	ip := net.ParseIP(host)
+	if host != "localhost" && (ip == nil || !ip.IsLoopback()) {
+		aplog.Warn("queue worker protocol bound to %s exposes plaintext HTTP to the network; bind to 127.0.0.1 or enable TLS (SEC-13)", address)
+	}
+	return address
 }

--- a/src/internal/daemon/queue_server_test.go
+++ b/src/internal/daemon/queue_server_test.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestResolveQueueListenAddress(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// Bare port: host defaults to 127.0.0.1
+		{":8080", "127.0.0.1:8080"},
+		{":0", "127.0.0.1:0"},
+		// Explicit loopback — kept as-is
+		{"127.0.0.1:9000", "127.0.0.1:9000"},
+		{"[::1]:9000", "[::1]:9000"},
+		{"localhost:9000", "localhost:9000"},
+		// Non-loopback — kept as-is (warning is emitted, not testable without log capture)
+		{"0.0.0.0:8080", "0.0.0.0:8080"},
+		{"192.168.1.1:8080", "192.168.1.1:8080"},
+		// Unparseable — returned unchanged
+		{"not-valid", "not-valid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := resolveQueueListenAddress(tc.input)
+			if got != tc.want {
+				t.Errorf("resolveQueueListenAddress(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Bare-host addresses (e.g. `:8080`) now resolve to `127.0.0.1:8080` instead of binding on all interfaces, preventing accidental network exposure of the plaintext HTTP queue protocol.
- Explicit loopback addresses (`127.0.0.1`, `[::1]`, `localhost`) pass through unchanged.
- Non-loopback addresses (e.g. `0.0.0.0`, a LAN IP) still work but emit a `WARN` log so operators know they have opted in to a network-exposed endpoint.
- TLS for the queue transport is tracked separately in SEC-13.

## Test plan

- [x] `TestResolveQueueListenAddress` — 8 cases (bare port, explicit loopback variants, non-loopback, unparseable) all pass
- [x] `go vet ./internal/daemon/` — clean
- [x] Warning log emits correctly for `0.0.0.0` and LAN IP cases

Closes #226