### PR TITLE
security: gate non-collaborator runs behind approval before dispatch (SEC-05)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -277,6 +277,7 @@ type Settings struct {
 	Memory        MemorySettings     `yaml:"memory"`
 	Events        EventSettings      `yaml:"events"`
 	Approvals     ApprovalSettings   `yaml:"approvals"`
+	TrustGate     TrustGateSettings  `yaml:"trust_gate"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
@@ -360,6 +361,30 @@ func queueDuration(value string, fallback time.Duration) time.Duration {
 type ApprovalSettings struct {
 	WebhookSecret string   `yaml:"webhook_secret,omitempty"`
 	RequireFor    []string `yaml:"require_for,omitempty"`
+}
+
+// TrustGateSettings controls the pre-dispatch approval gate for workflow runs
+// triggered by non-collaborator GitHub issue authors.
+//
+// When Enabled, every run whose source item carries an author_association that
+// is not OWNER, MEMBER, or COLLABORATOR gets a synthetic approval step
+// prepended to the matched workflow. The run parks in approval_waiting state
+// until a human approves (or rejects) via the existing multi-channel approval
+// infrastructure (dashboard, webhook, or comment).
+//
+// Non-GitHub sources (Jira, Plane, …) never set author_association and are
+// therefore unaffected regardless of this setting.
+type TrustGateSettings struct {
+	// Enabled activates the gate. Must be explicitly set to true.
+	Enabled bool `yaml:"enabled"`
+	// Approvers lists GitHub logins (or email addresses for non-GitHub approval
+	// providers) that may approve or reject a parked trust-gate run via the
+	// dashboard / webhook path. When empty the legacy comment-based triggers
+	// (/approve / /reject) are used instead, which do not enforce approver identity.
+	Approvers []string `yaml:"approvers,omitempty"`
+	// Message overrides the default comment posted to the issue when the run
+	// parks at the trust gate.
+	Message string `yaml:"message,omitempty"`
 }
 
 // EventSettings controls persisted structured execution events. Events are

--- a/src/internal/daemon/trust_gate.go
+++ b/src/internal/daemon/trust_gate.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// isTrustedAssociation reports whether a GitHub author_association value
+// belongs to the trusted collaborator set: OWNER, MEMBER, or COLLABORATOR.
+// Any other value (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE, or
+// an empty string) is considered untrusted.
+func isTrustedAssociation(assoc string) bool {
+	switch assoc {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+// trustGateStepID is the synthetic step identifier injected by withTrustGate.
+// It must not collide with any user-defined step ID; the leading underscore
+// makes a collision by YAML authoring effectively impossible.
+const trustGateStepID = "_trust_gate"
+
+const trustGateDefaultMsg = "A workflow run triggered by a non-collaborator requires human approval before the agent executes.\n\nReply with `/approve` to allow or `/reject` to discard."
+
+// withTrustGate returns wf unchanged when:
+//   - the trust gate is disabled (cfg.Enabled == false), or
+//   - cell carries no author_association metadata (non-GitHub sources pass through), or
+//   - the author's association is in the trusted set (OWNER/MEMBER/COLLABORATOR).
+//
+// For untrusted GitHub issue authors it prepends a synthetic approval step to
+// wf.Steps and adds it as an explicit dependency of every root step (steps with
+// neither DependsOn nor SeqDependsOn). This ensures the DAG engine parks the
+// run at the approval step before any shell-capable agent step can execute, and
+// the run is resolvable through the full multi-channel approval infrastructure
+// (dashboard, webhook, or comment trigger).
+func withTrustGate(wf config.WorkflowConfig, cell model.SourceItem, cfg config.TrustGateSettings) config.WorkflowConfig {
+	if !cfg.Enabled {
+		return wf
+	}
+	assoc, ok := cell.Metadata["author_association"].(string)
+	if !ok || assoc == "" {
+		return wf
+	}
+	if isTrustedAssociation(assoc) {
+		return wf
+	}
+
+	login, _ := cell.Metadata["author_login"].(string)
+	msg := cfg.Message
+	if msg == "" {
+		if login != "" {
+			msg = fmt.Sprintf("@%s is not a repository collaborator (association: %s). %s", login, assoc, trustGateDefaultMsg)
+		} else {
+			msg = trustGateDefaultMsg
+		}
+	}
+
+	gate := config.StepConfig{
+		ID:      trustGateStepID,
+		Type:    config.StepTypeApproval,
+		Name:    "Trust gate: non-collaborator approval required",
+		Message: msg,
+		ResumeOn: &config.ApprovalTrigger{
+			CommentContains: "/approve",
+		},
+		AbortOn: &config.ApprovalTrigger{
+			CommentContains: "/reject",
+		},
+		Approvers: cfg.Approvers,
+	}
+
+	// Attach the gate as a dependency of every root step (steps that currently
+	// have no explicit or sequential predecessor). This covers both v1 workflows
+	// (explicit DependsOn) and v2 lowered workflows (SeqDependsOn chains).
+	steps := make([]config.StepConfig, 0, len(wf.Steps)+1)
+	steps = append(steps, gate)
+	for _, s := range wf.Steps {
+		if len(s.DependsOn) == 0 && len(s.SeqDependsOn) == 0 {
+			s.DependsOn = []string{trustGateStepID}
+		}
+		steps = append(steps, s)
+	}
+	wf.Steps = steps
+	return wf
+}

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -1,0 +1,215 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestIsTrustedAssociation verifies the GitHub collaborator trust set.
+func TestIsTrustedAssociation(t *testing.T) {
+	trusted := []string{"OWNER", "MEMBER", "COLLABORATOR"}
+	for _, assoc := range trusted {
+		if !isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = false, want true", assoc)
+		}
+	}
+
+	untrusted := []string{"CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "NONE", ""}
+	for _, assoc := range untrusted {
+		if isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = true, want false", assoc)
+		}
+	}
+}
+
+// wf2steps is a helper that builds a minimal two-step workflow.
+func wf2steps() config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: "wf-test",
+		Steps: []config.StepConfig{
+			{ID: "classify", Agent: "bot"},
+			{ID: "implement", Agent: "bot", SeqDependsOn: []string{"classify"}},
+		},
+	}
+}
+
+// untrustedCell returns a SourceItem whose author_association is NONE.
+func untrustedCell(login string) model.SourceItem {
+	return model.SourceItem{
+		ID:       "42",
+		SourceID: "gh",
+		Title:    "Untrusted issue",
+		Metadata: map[string]any{
+			"author_association": "NONE",
+			"author_login":       login,
+		},
+	}
+}
+
+// trustedCell returns a SourceItem whose author_association is MEMBER.
+func trustedCell() model.SourceItem {
+	return model.SourceItem{
+		ID:       "43",
+		SourceID: "gh",
+		Title:    "Trusted issue",
+		Metadata: map[string]any{
+			"author_association": "MEMBER",
+			"author_login":       "team-member",
+		},
+	}
+}
+
+// noAssocCell returns a SourceItem with no Metadata (non-GitHub source).
+func noAssocCell() model.SourceItem {
+	return model.SourceItem{ID: "44", SourceID: "jira", Title: "Jira ticket"}
+}
+
+func enabledGate() config.TrustGateSettings {
+	return config.TrustGateSettings{Enabled: true}
+}
+
+// TestWithTrustGate_Disabled verifies withTrustGate is a no-op when disabled.
+func TestWithTrustGate_Disabled(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), config.TrustGateSettings{Enabled: false})
+	if len(got.Steps) != 2 {
+		t.Errorf("disabled gate: got %d steps, want 2", len(got.Steps))
+	}
+}
+
+// TestWithTrustGate_TrustedPassThrough verifies that trusted authors are not gated.
+func TestWithTrustGate_TrustedPassThrough(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, trustedCell(), enabledGate())
+	if len(got.Steps) != 2 {
+		t.Errorf("trusted author: got %d steps, want 2", len(got.Steps))
+	}
+	if got.Steps[0].ID == trustGateStepID {
+		t.Errorf("trusted author: unexpected trust gate step prepended")
+	}
+}
+
+// TestWithTrustGate_NoAssocPassThrough verifies that items without author_association pass through.
+func TestWithTrustGate_NoAssocPassThrough(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, noAssocCell(), enabledGate())
+	if len(got.Steps) != 2 {
+		t.Errorf("no-assoc cell: got %d steps, want 2", len(got.Steps))
+	}
+}
+
+// TestWithTrustGate_PrependsApprovalStep verifies that an untrusted author
+// gets a trust gate approval step prepended before the workflow's own steps.
+func TestWithTrustGate_PrependsApprovalStep(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	if len(got.Steps) != 3 {
+		t.Fatalf("untrusted author: got %d steps, want 3", len(got.Steps))
+	}
+	gate := got.Steps[0]
+	if gate.ID != trustGateStepID {
+		t.Errorf("step[0].ID = %q, want %q", gate.ID, trustGateStepID)
+	}
+	if gate.Type != config.StepTypeApproval {
+		t.Errorf("step[0].Type = %q, want %q", gate.Type, config.StepTypeApproval)
+	}
+	if gate.ResumeOn == nil || gate.ResumeOn.CommentContains != "/approve" {
+		t.Errorf("gate.ResumeOn = %+v, want CommentContains=/approve", gate.ResumeOn)
+	}
+	if gate.AbortOn == nil || gate.AbortOn.CommentContains != "/reject" {
+		t.Errorf("gate.AbortOn = %+v, want CommentContains=/reject", gate.AbortOn)
+	}
+}
+
+// TestWithTrustGate_RootStepDependsOnGate verifies that the first step of the
+// original workflow is wired to depend on the trust gate step so the DAG engine
+// cannot dispatch it before the approval resolves.
+func TestWithTrustGate_RootStepDependsOnGate(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	// The original first step (classify) had no deps; it should now depend on gate.
+	classify := got.Steps[1]
+	if classify.ID != "classify" {
+		t.Fatalf("got.Steps[1].ID = %q, want %q", classify.ID, "classify")
+	}
+	foundGateDep := false
+	for _, dep := range classify.DependsOn {
+		if dep == trustGateStepID {
+			foundGateDep = true
+		}
+	}
+	if !foundGateDep {
+		t.Errorf("classify.DependsOn = %v, want %q in there", classify.DependsOn, trustGateStepID)
+	}
+}
+
+// TestWithTrustGate_NonRootStepUnchanged verifies that a step that already has
+// deps is not modified — only root steps get the gate wired in.
+func TestWithTrustGate_NonRootStepUnchanged(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	// implement depends on classify, so it is not a root step.
+	implement := got.Steps[2]
+	if implement.ID != "implement" {
+		t.Fatalf("got.Steps[2].ID = %q, want %q", implement.ID, "implement")
+	}
+	for _, dep := range implement.DependsOn {
+		if dep == trustGateStepID {
+			t.Errorf("implement.DependsOn = %v: non-root step should not have gate dep", implement.DependsOn)
+		}
+	}
+}
+
+// TestWithTrustGate_MessageContainsLogin verifies the default approval message
+// mentions the author login when one is provided.
+func TestWithTrustGate_MessageContainsLogin(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("ext-user"), enabledGate())
+	gate := got.Steps[0]
+	if gate.Message == "" {
+		t.Fatal("gate.Message is empty")
+	}
+	if !strings.Contains(gate.Message, "ext-user") {
+		t.Errorf("gate.Message = %q, want it to contain %q", gate.Message, "ext-user")
+	}
+}
+
+// TestWithTrustGate_CustomMessage verifies a configured message is used verbatim.
+func TestWithTrustGate_CustomMessage(t *testing.T) {
+	wf := wf2steps()
+	cfg := config.TrustGateSettings{Enabled: true, Message: "custom approval needed"}
+	got := withTrustGate(wf, untrustedCell("outsider"), cfg)
+	gate := got.Steps[0]
+	if gate.Message != "custom approval needed" {
+		t.Errorf("gate.Message = %q, want %q", gate.Message, "custom approval needed")
+	}
+}
+
+// TestWithTrustGate_ApproversForwarded verifies that configured approvers are
+// forwarded to the synthetic approval step.
+func TestWithTrustGate_ApproversForwarded(t *testing.T) {
+	wf := wf2steps()
+	cfg := config.TrustGateSettings{Enabled: true, Approvers: []string{"alice", "bob"}}
+	got := withTrustGate(wf, untrustedCell("outsider"), cfg)
+	gate := got.Steps[0]
+	if len(gate.Approvers) != 2 || gate.Approvers[0] != "alice" || gate.Approvers[1] != "bob" {
+		t.Errorf("gate.Approvers = %v, want [alice bob]", gate.Approvers)
+	}
+}
+
+// TestWithTrustGate_OriginalWorkflowUnmutated verifies that the original
+// WorkflowConfig is not mutated in place.
+func TestWithTrustGate_OriginalWorkflowUnmutated(t *testing.T) {
+	wf := wf2steps()
+	_ = withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+	if len(wf.Steps) != 2 {
+		t.Errorf("original wf.Steps length changed to %d; withTrustGate must not mutate the caller's slice", len(wf.Steps))
+	}
+}
+

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -215,6 +215,7 @@ func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem
 	}
 
 	wf := d.resolveWorkflow(match)
+	wf = withTrustGate(wf, cell, d.cfg.Settings.TrustGate)
 	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
 	if err != nil {
 		aplog.Error("cell %s: workflow run failed: %v", cell.LogLabel(), err)

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -689,6 +689,10 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		URL:         item.HTMLURL,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
+		Metadata: map[string]any{
+			"author_association": item.AuthorAssociation,
+			"author_login":       item.User.Login,
+		},
 	}
 }
 

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,11 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is the relationship of the issue author to the
+	// repository: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR,
+	// FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, or NONE. GitHub returns this
+	// field on every issue list response at no extra API cost.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {


### PR DESCRIPTION
## Summary

- GitHub's `author_association` field (returned for free on every issues REST response) is now mapped into `SourceItem.Metadata` so the dispatcher can inspect it without extra API calls.
- New `settings.trust_gate` config block (`enabled`, `approvers`, `message`) controls the gate.
- `withTrustGate` in `daemon/trust_gate.go` prepends a synthetic `_trust_gate` approval step to the resolved workflow when the trigger is a GitHub issue from a non-collaborator (any association that is not `OWNER`, `MEMBER`, or `COLLABORATOR`). The gate is wired as a `DependsOn` predecessor of every root step so the DAG engine cannot advance to any shell-capable agent step until a human approves.
- Runs park in `approval_waiting` state and are resolvable through the existing multi-channel approval infrastructure: dashboard (`POST /approvals/{id}/respond`), webhook (`POST /approvals/{id}/webhook`), or comment-based triggers (`/approve` / `/reject`).
- Non-GitHub sources (Jira, Plane, …) never set `author_association` and pass through untouched.

## Test plan

- [ ] `go test ./internal/daemon/ -run TestIsTrustedAssociation` — trust classification
- [ ] `go test ./internal/daemon/ -run TestWithTrustGate` — 9 unit tests covering: disabled gate, trusted pass-through, non-GitHub pass-through, step prepend, root-step dependency wiring, non-root step unchanged, login in message, custom message, approvers forwarded, no mutation of original workflow

## Configuration example

```yaml
settings:
  trust_gate:
    enabled: true
    approvers:
      - owner-login
    # message: optional override; defaults to a comment mentioning the author login
```

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)