### PR TITLE
security: require human review before agent PRs can merge (SEC-08)

### DIFF
--- a/.apiary/apiary.yaml
+++ b/.apiary/apiary.yaml
@@ -130,6 +130,10 @@ workflows:
     steps:
       - id: run
         agent: backend
+        prompt: >-
+          Implement the change following project conventions. Open a PR whose
+          body includes `Closes #<issue>`. IMPORTANT: do NOT enable auto-merge
+          and do NOT merge — stop as soon as the PR is open (SEC-08).
     on_complete:
       set_state: closed
 
@@ -142,6 +146,10 @@ workflows:
     steps:
       - id: run
         agent: frontend
+        prompt: >-
+          Implement the change following project conventions. Open a PR whose
+          body includes `Closes #<issue>`. IMPORTANT: do NOT enable auto-merge
+          and do NOT merge — stop as soon as the PR is open (SEC-08).
     on_complete:
       set_state: closed
 
@@ -154,6 +162,10 @@ workflows:
     steps:
       - id: run
         agent: engineer
+        prompt: >-
+          Implement the change following project conventions. Open a PR whose
+          body includes `Closes #<issue>`. IMPORTANT: do NOT enable auto-merge
+          and do NOT merge — stop as soon as the PR is open (SEC-08).
     on_complete:
       set_state: closed
 

--- a/.apiary/souls/reviewer-council.md
+++ b/.apiary/souls/reviewer-council.md
@@ -1,0 +1,67 @@
+# Code Reviewer Soul — Council (apiary repo)
+
+You do not review as a single voice. You convene a **council of five reviewers**,
+each with a distinct lens, and let them vote. The merge is gated on their verdict.
+
+## The five council members
+
+Review the PR from each lens **independently and in full** before deciding. Do
+not let one lens soften another — each argues its own case as strongly as it can.
+
+1. **Correctness Hawk** — Does the code do what the issue asked, with no logic
+   bugs, broken edge cases, or regressions? Has veto power.
+2. **Security Skeptic** — Does this introduce or fail to fix a vulnerability?
+   Untrusted input, injection, auth, secret handling, unsafe subprocess/plugin
+   behavior. Especially load-bearing for the security-hardening issues. Has veto power.
+3. **Conventions Stickler** — Go idioms, project conventions, English
+   commits/PRs, parameterized SQL, handler error logging, test coverage.
+4. **Simplicity Advocate** — Is this the smallest correct change? Flags needless
+   complexity, dead code, over-engineering, and unrelated scope creep.
+5. **Pragmatist** — Ships value, weighs risk vs. benefit, catches when the other
+   four are bikeshedding. Argues for approving good-enough work.
+
+## Protocol
+
+1. Read the diff and the linked issue. Run/inspect tests where relevant.
+2. For **each** council member, write a 2-4 sentence verdict ending in a bold
+   **APPROVE** or **REJECT**, with a concrete reason.
+3. Apply the decision rule:
+   - **Any REJECT from the Correctness Hawk or Security Skeptic → the PR is rejected**
+     (these two hold veto power; a security fix that doesn't actually fix the issue,
+     or introduces a new hole, must not merge).
+   - Otherwise, **merge requires at least 3 of 5 APPROVE**.
+   - A tie or majority-reject → rejected.
+4. Post the full council verdict as a single PR comment (all five votes + the
+   final decision and rule applied).
+5. Act on the decision:
+   - **Approved**: `gh pr review <n> --approve`, then enable merge with
+     `gh pr merge <n> --auto --squash` (merges once CI passes).
+   - **Rejected**: `gh pr review <n> --request-changes` with the specific,
+     actionable reasons from the dissenting members. Leave the PR open and do
+     NOT enable merge — the workflow escalates it for a human.
+
+Be decisive. The point of the council is a clear approve/reject with reasoning,
+not hedging. A member can disagree with the majority in its written verdict, but
+the decision rule is mechanical.
+
+## Language
+
+Always write everything you produce — commit messages, PR titles and descriptions, issue/sub-task titles and descriptions, and all GitHub comments — in **English**, regardless of the issue's language.
+
+## Memory
+
+You have persistent memory at $APIARY_MEMORY_DIR. Your prompt includes the
+long-term index and this task's notes — read a full entry from
+$APIARY_MEMORY_DIR/global/<name>.md before re-deriving anything it covers.
+
+When you learn something durable (a project gotcha, a tooling quirk, a
+convention), save it:
+
+APIARY_MEMORIZE_BEGIN
+{"scope": "global", "name": "short-kebab-slug", "description": "one-line summary",
+ "content": "the fact, with enough context to act on it cold"}
+APIARY_MEMORIZE_END
+
+For decisions and findings the NEXT step or a retry of THIS task needs, use
+{"content": "..."} alone (task scope, the default). Update a stale fact by
+re-emitting its name. NEVER memorize secrets, tokens, or credentials.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`, auto-merge via `gh pr merge --auto --squash`, sync da `main`/rebuild do dev/`gitnexus analyze` após merge. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
+description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`, PR aberto para review humano (sem auto-merge por agente), sync da `main`/rebuild do dev/`gitnexus analyze` após merge. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
 ---
 
 # Git Workflow — Projeto ERP
@@ -17,10 +17,10 @@ Ou via CLI:
 hermes kanban create "fix: ..." --assignee engineer --skill git-workflow
 ```
 
-**Regra fundamental:** NUNCA bloquear kanban task para review humano. Sempre criar PR com auto-merge e aguardar o CI. O worker só completa a task após o PR estar mergeado e o dev local sincronizado.
+**Regra fundamental (SEC-08):** Agentes NUNCA ativam auto-merge. O engineer cria o PR e para — um revisor humano (ou o reviewer council) deve aprovar explicitamente antes do merge. `gh pr merge --auto --squash` é proibido para agentes engineer.
 
 **Pipeline completo de uma task engineer:**
-Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → auto-merge → aguarda CI → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
+Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR aberto → aguarda review/aprovação humana → merge realizado pelo revisor → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
 
 **GH_TOKEN:** o profile engineer tem GH_TOKEN no `.env`. Se o worker não conseguir usar `gh`, verificar se o token ainda é válido.
 
@@ -51,13 +51,10 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 4. **Link issue and project**: after creating the PR:
    - The PR body MUST contain `Closes #<issue>` (or `Fixes #<issue>`) to link the issue.
    - Add the PR to the relevant GitHub Project: `gh project item-add 1 --owner orlandoburli-enterprise --url <pr-url>`.
-5. **Enable auto-merge**: run `gh pr merge <number> --auto --squash` so it merges automatically once CI passes.
-   - NUNCA bloquear kanban task para review humano. O worker cria o PR, ativa auto-merge e aguarda o CI. Sem blocker, sem review-required.
-6. CI must pass (lint, tests, build, sqlc-check) before merge.
-7. Aguardar o merge — obrigatório, sem exceção. A tarefa não está concluída até o PR estar mergeado e o dev local atualizado. Não pule para a próxima tarefa nem declare pronto antes disso.
-   - `gh pr checks <number> --watch` para aguardar o CI.
-   - Se o CI travar em flake conhecido (RATE_LIMIT 429, timing em `cadastro-observacoes-markdown`, `vendas-nucleo:438`, `cadastro-auto-rascunho`, etc.), faça `gh run rerun <run-id> --failed` e aguarde de novo. Só desista após 2-3 reruns mostrarem o mesmo padrão de falha.
-   - Confirme com `gh pr view <number> --json state,mergedAt` que `state == "MERGED"`.
+5. **Stop here — do NOT enable auto-merge (SEC-08).** An engineer agent MUST NOT run `gh pr merge --auto --squash`. Leave the PR open for a reviewer. A human or the reviewer council will approve and enable merge after inspecting the diff.
+6. CI must pass (lint, tests, build, sqlc-check) before merge — the reviewer verifies this before approving.
+7. After a reviewer approves and enables merge, confirm the merge completed:
+   - `gh pr view <number> --json state,mergedAt` that `state == "MERGED"`.
 8. **Sync da `main` local + rebuild do dev — executar imediatamente após confirmar o merge.** Não esperar o usuário pedir. No checkout principal (não no worktree):
    ```bash
    cd <repo-root> && git checkout main && git pull --ff-only
@@ -76,7 +73,7 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 10. Remove o worktree: `git worktree remove ../project-erp--<branch>` e (opcional) `git branch -d <branch>`.
 11. Never `git push` directly to `main`.
 
-**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → auto-merge → aguardar CI → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 7-9) é proibido.
+**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR aberto → aguardar review humano → merge pelo revisor → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 8-9) é proibido. O agente engineer NUNCA ativa auto-merge.
 
 ## AGENTS.md / CLAUDE.md — manter atualizados via PR
 

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,59 @@
+name: branch-protection
+
+# SEC-08 — Enforce branch protection on main so no agent PR can merge
+# without at least one human approving review.
+#
+# Trigger:
+#   - workflow_dispatch: one-time setup or manual re-enforcement
+#   - push to main touching this file: re-applies rules if the workflow
+#     itself is updated, preventing accidental rule drift
+#
+# Required permission: the GITHUB_TOKEN must have `administration: write`
+# (available to repo admins by default on Actions tokens when the repo
+# grants it, or via a PAT with admin:repo_hook scope stored as a secret).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/branch-protection.yml'
+
+permissions:
+  contents: read
+  # administration write is needed to set branch protection rules.
+  # For org repos this may require an admin PAT in BRANCH_ADMIN_TOKEN.
+  administration: write
+
+jobs:
+  enforce:
+    name: Enforce branch protection on main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply branch protection rules
+        env:
+          # Use BRANCH_ADMIN_TOKEN if set (admin PAT), otherwise fall back
+          # to the default Actions token (works for personal repos where
+          # the Actions token has admin rights).
+          GH_TOKEN: ${{ secrets.BRANCH_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method PUT "/repos/$REPO/branches/main/protection" \
+            --header "Content-Type: application/json" \
+            --input - <<'EOF'
+          {
+            "required_status_checks": null,
+            "enforce_admins": false,
+            "required_pull_request_reviews": {
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": false,
+              "required_approving_review_count": 1,
+              "require_last_push_approval": false
+            },
+            "restrictions": null,
+            "allow_force_pushes": false,
+            "allow_deletions": false
+          }
+          EOF
+          echo "Branch protection applied: main now requires 1 approving review, stale reviews dismissed on new commits."

--- a/apiary.yaml
+++ b/apiary.yaml
@@ -1,0 +1,199 @@
+# Apiary dogfooding config — apiary orchestrating work on apiary itself.
+#
+# This root-level apiary.yaml takes lookup precedence over .apiary/apiary.yaml
+# (which targets project-erp and is left untouched). State still lives under
+# .apiary/ (apiary.db, logs, socket).
+#
+# Requires GITHUB_TOKEN in the environment or in a .env next to this file
+# (classic PAT scope `repo`, or fine-grained: Issues → Read & Write,
+# Metadata → Read, Pull requests → Read & Write for wait_for/ci + reviews).
+
+version: "1"
+
+# ── Runners ────────────────────────────────────────────────────────────────────
+runners:
+  - id: claude-cli
+    type: cli
+    provider: claude
+    mcps:
+      - name: gitnexus
+        command: npx
+        args: ["-y", "gitnexus@latest", "mcp"]
+
+default_runner: claude-cli
+
+# ── Sources ────────────────────────────────────────────────────────────────────
+sources:
+  - id: apiary
+    type: github
+    config:
+      repo: orlandoburli/apiary
+      api_key: ${GITHUB_TOKEN}
+    poll_interval: 120s
+    filters:
+      states: [open]
+      # Only issues explicitly handed to the swarm — the apiary tracker also
+      # holds planning/discussion issues that agents must not pick up.
+      labels: [ai-ready]
+
+# ── Agents ─────────────────────────────────────────────────────────────────────
+agents:
+  - id: investigator
+    description: "Classifies incoming apiary issues and picks the right agent"
+    soul_file: .apiary/souls/investigator.md
+    model: claude-opus-4-8
+    skills: [gitnexus-codebase]
+    max_workers: 1
+
+  - id: engineer
+    description: "Implements apiary changes (Go daemon, dashboard, docs)"
+    soul_file: .apiary/souls/engineer.md
+    model: claude-sonnet-4-6
+    skills: [git-workflow, gitnexus-codebase]
+    max_workers: 5
+
+  - id: reviewer
+    description: "Reviews apiary pull requests for correctness and conventions"
+    soul_file: .apiary/souls/reviewer-council.md
+    model: claude-sonnet-4-6
+    skills: [git-workflow, gitnexus-codebase]
+    max_workers: 2
+
+# ── Workflows ──────────────────────────────────────────────────────────────────
+workflows:
+  # Direct routes when a human pre-labels the issue.
+  - id: engineer-implement
+    # SEC-08: engineer opens the PR but does NOT enable auto-merge.
+    # The reviewer council gates the merge, just like the triage flow.
+    resume: allowed
+    trigger:
+      priority: 20
+      match:
+        source: apiary
+        labels: [agent:engineer]
+    steps:
+      - id: implement
+        agent: engineer
+        prompt: >-
+          Implement the change following apiary project conventions (Go, English
+          commits/PRs). Open a PR whose body includes `Closes #<issue>`.
+          IMPORTANT: do NOT enable auto-merge and do NOT merge or wait for the
+          merge — stop as soon as the PR is open. A reviewer will approve and
+          enable the merge. This overrides the git-workflow skill's auto-merge step.
+        on_pass:
+          next: review
+
+      - id: review
+        agent: reviewer
+        prompt: >-
+          Convene the five-member review council (per your soul) on the open PR
+          the engineer created for this issue. Post the full council verdict as
+          a PR comment, then apply the decision rule: on approval, approve and
+          enable merge (`gh pr merge <n> --auto --squash`); on rejection, request
+          changes with the dissenters' reasons, leave the PR open, and do NOT
+          enable merge.
+
+    # Issue closes via `Closes #<issue>` in the PR body when the PR merges.
+    on_fail:
+      add_labels: [needs-attention]
+
+  - id: code-review
+    trigger:
+      priority: 25
+      match:
+        source: apiary
+        types: [pull_request]
+        labels: [agent:reviewer]
+    steps:
+      - id: review
+        agent: reviewer
+    on_complete:
+      add_labels: [reviewed]
+
+  # Triage — unlabeled ai-ready issues get classified and handled in one instance.
+  - id: triage
+    description: "Classify an apiary issue and route it to the right agent."
+    resume: allowed
+    trigger:
+      priority: 100
+      match:
+        source: apiary
+        exclude_label_prefix: "agent:"
+        exclude_labels: [draft]
+    steps:
+      - id: classify
+        agent: investigator
+        summary_prompt: "One line: which agent you chose and the key reason."
+        output_schema:
+          type: object
+          properties:
+            agent: {type: string, enum: [engineer, reviewer]}
+          required: [agent]
+        memory:
+          write: [agent]
+
+      - id: route
+        type: split
+        branches:
+          - if: 'memory.agent == "reviewer"'
+            goto: review
+          - else: true
+            goto: implement
+
+      - id: implement
+        agent: engineer
+        prompt: >-
+          Implement the change following apiary project conventions (Go, English
+          commits/PRs). Open a PR whose body includes `Closes #<issue>`.
+          IMPORTANT: do NOT enable auto-merge and do NOT merge or wait for the
+          merge — stop as soon as the PR is open. A reviewer will approve and
+          enable the merge. This overrides the git-workflow skill's auto-merge step.
+        # Chain into the council review. `review` is a split target (reviewer
+        # branch), so without this explicit edge the engineer path would settle
+        # after `implement` and the PR would never be reviewed/merged.
+        on_pass:
+          next: review
+
+      - id: review
+        agent: reviewer
+        prompt: >-
+          Convene the five-member review council (per your soul) on the open PR
+          the engineer created for this issue. Post the full council verdict as
+          a PR comment, then apply the decision rule: on approval, approve and
+          enable merge (`gh pr merge <n> --auto --squash`); on rejection, request
+          changes with the dissenters' reasons, leave the PR open, and do NOT
+          enable merge.
+
+    # No forced set_state here: an approved PR carries `Closes #<issue>` and
+    # auto-closes the issue when it merges. A rejected/unmerged PR leaves the
+    # issue open so it can be picked up again.
+    on_fail:
+      add_labels: [needs-attention]
+
+# ── Settings ───────────────────────────────────────────────────────────────────
+settings:
+  concurrency: 7
+  log_level: info
+  state_lock: true
+  max_attempts: 3
+  log_max_size_mb: 50
+  log_max_backups: 5
+  log_max_age_days: 30
+  memory:
+    enabled: true   # agents accumulate apiary-specific facts via APIARY_MEMORIZE
+
+# ── Task completion hook ───────────────────────────────────────────────────────
+tasks:
+  on_complete:
+    add_labels: [ai-complete]
+  on_fail:
+    add_labels: [ai-failed, needs-attention]
+
+# ── Escalation notifications ───────────────────────────────────────────────────
+# Uncomment and pick a channel to get pinged when a flow parks with
+# needs-attention instead of freezing silently.
+# notifications:
+#   on_labels: [needs-attention]
+#   channels:
+#     - type: command
+#       run: osascript -e 'display notification {{summary}} with title "apiary #{{number}} escalated"'


### PR DESCRIPTION
## Summary

SEC-08 interim mitigation: closes the window where an injected agent could open a PR that auto-merges on CI green with no human in the loop.

Three independent layers, each sufficient to block fully-automated merge:

- **Branch protection** — new `.github/workflows/branch-protection.yml` enforces branch protection on `main` via the GitHub API (1 approving review required, stale reviews dismissed on new commits). Run it once via `workflow_dispatch`; thereafter it self-re-enforces whenever the file is updated. Accepts an optional `BRANCH_ADMIN_TOKEN` secret for org repos where the default `GITHUB_TOKEN` lacks admin rights.

- **git-workflow skill** — removes `gh pr merge --auto --squash` as the default for engineer agents. The skill now explicitly states that agents open the PR and stop; `gh pr merge` is prohibited for engineer agents. A human or the reviewer council must approve and enable merge.

- **Workflow configs** — both `apiary.yaml` (dogfood, now committed for the first time alongside its `reviewer-council.md` soul) and `.apiary/apiary.yaml` (project-erp) gain explicit `IMPORTANT: do NOT enable auto-merge` prompt overrides on every `agent:engineer` / `agent:backend` / `agent:frontend` step. The dogfood `engineer-implement` workflow is restructured to chain into the reviewer council after the engineer opens the PR, mirroring the existing `triage` flow.

## Test plan

- [ ] Run `.github/workflows/branch-protection.yml` via `workflow_dispatch` and verify `main` shows "1 required reviewer" in branch protection settings
- [ ] Dispatch an `agent:engineer` issue on the apiary repo and confirm the engineer agent opens a PR but does **not** call `gh pr merge`
- [ ] Verify the reviewer council step fires after the engineer step in `engineer-implement`
- [ ] Attempt to merge a test PR without a review and confirm GitHub blocks it

Closes #231