### PR TITLE
security: enforce plugin manifest permissions + checksum (SEC-10)

### DIFF
--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/orlandoburli/apiary/internal/cli"
+	"github.com/orlandoburli/apiary/internal/plugin"
 
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
@@ -11,5 +12,11 @@ import (
 )
 
 func main() {
+	// Landlock re-exec trampoline: when the host binary is re-invoked as a
+	// sandbox launcher it applies filesystem restrictions and exec()s the plugin.
+	// This check must precede all other initialization.
+	if plugin.IsSandboxLauncher() {
+		plugin.RunSandboxLauncher()
+	}
 	cli.Execute()
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/kardianos/service v1.2.4
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.7.13
+	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
@@ -65,7 +66,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -52,6 +52,10 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Re-verify checksum to close the TOCTOU window between Load and client creation.
+	if err := verifyChecksum(executable, installed.Manifest.Checksum); err != nil {
+		return nil, fmt.Errorf("plugin %q: %w", installed.Manifest.ID, err)
+	}
 	return &Client{installed: installed, instance: instance, timeout: timeout, executable: executable}, nil
 }
 
@@ -77,6 +81,7 @@ func (c *Client) Invoke(ctx context.Context, capability Capability, method strin
 	command := exec.CommandContext(callCtx, c.executable)
 	command.Dir = c.installed.Root
 	command.Env = c.environment()
+	applySandbox(command, c.installed.Manifest.Security)
 	command.Stdin = bytes.NewReader(raw)
 	stdout := &boundedBuffer{limit: maxProtocolOutput}
 	stderr := &boundedBuffer{limit: 64 << 10}

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,11 @@
 package plugin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,6 +53,10 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
+	// Checksum is the lowercase hex SHA-256 digest of the executable file.
+	// It is mandatory; plugins without a checksum are refused at load time.
+	// Generate with: sha256sum <executable>
+	Checksum      string               `json:"checksum"`
 	Capabilities  []Capability         `json:"capabilities"`
 	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
 	Security      SecurityRequirements `json:"security,omitempty"`
@@ -135,7 +142,11 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	execPath, err := secureExecutable(p.Root, m.Executable)
+	if err != nil {
+		return err
+	}
+	if err := verifyChecksum(execPath, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -217,5 +228,60 @@ func validateSecurity(security SecurityRequirements) error {
 		}
 		seen[name] = true
 	}
+	for _, entry := range []struct {
+		paths []string
+		field string
+	}{
+		{security.ReadPaths, "read_paths"},
+		{security.WritePaths, "write_paths"},
+	} {
+		for _, p := range entry.paths {
+			if p == "" {
+				return fmt.Errorf("security.%s must not contain empty entries", entry.field)
+			}
+			clean := filepath.Clean(p)
+			if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("security.%s %q must not escape the plugin directory", entry.field, p)
+			}
+		}
+	}
 	return nil
+}
+
+// verifyChecksum computes the SHA-256 of execPath and confirms it matches the
+// hex digest declared in the manifest. An empty expected value is rejected so
+// plugins without a checksum cannot load.
+func verifyChecksum(execPath, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("executable checksum is required; add a \"checksum\" field (sha256 hex) to the manifest")
+	}
+	f, err := os.Open(execPath)
+	if err != nil {
+		return fmt.Errorf("open executable for checksum verification: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("compute executable checksum: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("executable checksum mismatch: manifest declares %s but file is %s; the binary may have been replaced", expected, actual)
+	}
+	return nil
+}
+
+// ComputeChecksum returns the lowercase hex SHA-256 digest of the file at path.
+// Plugin authors use this to generate the checksum field for their manifest.
+func ComputeChecksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -13,6 +13,16 @@ import (
 	"time"
 )
 
+// TestMain handles the Landlock re-exec trampoline: when the test binary is
+// re-invoked as a sandbox launcher it applies filesystem restrictions and
+// exec()s the actual plugin binary, never returning to the test runner.
+func TestMain(m *testing.M) {
+	if IsSandboxLauncher() {
+		RunSandboxLauncher()
+	}
+	os.Exit(m.Run())
+}
+
 func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifest) string {
 	t.Helper()
 	root := filepath.Join(parent, name)

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -21,9 +23,13 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	content := []byte("#!/bin/sh\n" + script + "\n")
+	if err := os.WriteFile(filepath.Join(root, executable), content, 0755); err != nil {
 		t.Fatal(err)
 	}
+	h := sha256.New()
+	h.Write(content)
+	manifest.Checksum = hex.EncodeToString(h.Sum(nil))
 	manifest.SchemaVersion = ManifestSchemaVersion
 	manifest.Protocol = ProtocolVersion
 	manifest.Executable = executable
@@ -137,5 +143,116 @@ func TestClientInvocationCrashTimeoutAndSecretAllowlist(t *testing.T) {
 	}
 	if time.Since(started) > time.Second {
 		t.Fatalf("timeout took %s", time.Since(started))
+	}
+}
+
+func TestMissingChecksumRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.nochecksum",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		// Checksum deliberately left empty.
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum is required") {
+		t.Fatalf("expected missing-checksum rejection, got: %v", err)
+	}
+}
+
+func TestChecksumMismatchRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "tampered")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("#!/bin/sh\necho original\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), content, 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.tampered",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		Checksum:      strings.Repeat("a", 64), // wrong digest
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch, got: %v", err)
+	}
+}
+
+func TestChecksumVerifiedAtNewClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "replace", "exit 0", Manifest{})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate binary replacement after Load to verify TOCTOU protection.
+	newContent := []byte("#!/bin/sh\necho replaced\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), newContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch after replacement, got: %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "escapepath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"../secrets"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "must not escape") {
+		t.Fatalf("expected escape rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "emptypath", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{""}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "empty entries") {
+		t.Fatalf("expected empty path rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "validpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp/data"}, WritePaths: []string{"output"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err != nil {
+		t.Fatalf("unexpected rejection of valid paths: %v", err)
 	}
 }

--- a/src/internal/plugin/sandbox_launcher_linux.go
+++ b/src/internal/plugin/sandbox_launcher_linux.go
@@ -1,0 +1,216 @@
+//go:build linux
+
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Sandbox launcher environment variable names used to pass configuration
+// from the parent process to the re-exec'd launcher child.
+const (
+	envSandboxExec  = "_APIARY_SANDBOX_EXEC"
+	envSandboxBin   = "_APIARY_SANDBOX_BIN"
+	envSandboxRoot  = "_APIARY_SANDBOX_ROOT"
+	envSandboxRead  = "_APIARY_SANDBOX_READ"
+	envSandboxWrite = "_APIARY_SANDBOX_WRITE"
+
+	// pathSep is the delimiter used to encode multiple paths in a single env var.
+	// Newline is safe because validateSecurity rejects empty path entries and
+	// paths cannot contain newlines.
+	pathSep = "\n"
+)
+
+// IsSandboxLauncher reports whether the current process was re-exec'd by
+// applySandbox to apply Landlock filesystem restrictions before running a plugin.
+func IsSandboxLauncher() bool {
+	return os.Getenv(envSandboxExec) == "1"
+}
+
+// RunSandboxLauncher applies Landlock filesystem restrictions declared in the
+// plugin manifest and then exec()s the actual plugin binary. It never returns
+// on success. Must be called before any other initialization in main().
+func RunSandboxLauncher() {
+	bin := os.Getenv(envSandboxBin)
+	root := os.Getenv(envSandboxRoot)
+	readPaths := decodePaths(os.Getenv(envSandboxRead))
+	writePaths := decodePaths(os.Getenv(envSandboxWrite))
+
+	// Build env for the plugin without the sandbox control variables.
+	env := filterSandboxEnv(os.Environ())
+
+	// Apply Landlock (best-effort; no-op on kernels < 5.13 or without support).
+	applyLandlock(root, readPaths, writePaths)
+
+	if err := syscall.Exec(bin, []string{bin}, env); err != nil {
+		os.Stderr.WriteString("apiary sandbox: exec " + bin + ": " + err.Error() + "\n")
+		os.Exit(125)
+	}
+}
+
+// probeLandlockSupport returns true if the kernel supports Landlock ABI >= 1.
+// Used by tests to skip when the feature is unavailable.
+func probeLandlockSupport() bool {
+	v, _, errno := syscall.RawSyscall(unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, uintptr(unix.LANDLOCK_CREATE_RULESET_VERSION))
+	return errno == 0 && int(v) >= 1
+}
+
+// applyLandlock restricts the calling process's filesystem access to a minimal
+// set of system paths, the plugin root, and the declared read/write paths.
+// It is a no-op on kernels that do not support Landlock (< 5.13).
+func applyLandlock(pluginRoot string, readPaths, writePaths []string) {
+	// Probe: LANDLOCK_CREATE_RULESET_VERSION returns the highest supported ABI.
+	abi, _, errno := syscall.RawSyscall(unix.SYS_LANDLOCK_CREATE_RULESET, 0, 0, uintptr(unix.LANDLOCK_CREATE_RULESET_VERSION))
+	if errno != 0 || int(abi) < 1 {
+		return
+	}
+
+	// ABI 1 access rights (kernel 5.13+).
+	// REFER (ABI 2) and TRUNCATE (ABI 3) are intentionally excluded so the
+	// 8-byte ABI-1 attr size is correct on kernels that predate those ABIs.
+	const (
+		abiOneReadAccess = unix.LANDLOCK_ACCESS_FS_READ_FILE |
+			unix.LANDLOCK_ACCESS_FS_READ_DIR |
+			unix.LANDLOCK_ACCESS_FS_EXECUTE
+		abiOneWriteAccess = unix.LANDLOCK_ACCESS_FS_WRITE_FILE |
+			unix.LANDLOCK_ACCESS_FS_MAKE_REG |
+			unix.LANDLOCK_ACCESS_FS_MAKE_DIR |
+			unix.LANDLOCK_ACCESS_FS_REMOVE_FILE |
+			unix.LANDLOCK_ACCESS_FS_REMOVE_DIR |
+			unix.LANDLOCK_ACCESS_FS_MAKE_CHAR |
+			unix.LANDLOCK_ACCESS_FS_MAKE_SOCK |
+			unix.LANDLOCK_ACCESS_FS_MAKE_FIFO |
+			unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+			unix.LANDLOCK_ACCESS_FS_MAKE_SYM
+	)
+
+	// Use a 1-field struct so the size argument is 8 (ABI 1 only).
+	// Passing the full unix.LandlockRulesetAttr (24 bytes) on an ABI-1 kernel
+	// would cause EINVAL because the kernel does not recognise the extra fields.
+	type rulesetAttr1 struct{ accessFs uint64 }
+	attr := rulesetAttr1{accessFs: abiOneReadAccess | abiOneWriteAccess}
+
+	fd, _, errno := syscall.RawSyscall(
+		unix.SYS_LANDLOCK_CREATE_RULESET,
+		uintptr(unsafe.Pointer(&attr)),
+		unsafe.Sizeof(attr),
+		0,
+	)
+	if errno != 0 {
+		return
+	}
+	rulesetFd := int(fd)
+	defer syscall.Close(rulesetFd)
+
+	addReadable := func(path string) {
+		addLandlockPath(rulesetFd, path, abiOneReadAccess)
+	}
+	addWritable := func(path string) {
+		addLandlockPath(rulesetFd, path, abiOneReadAccess|abiOneWriteAccess)
+	}
+
+	// System paths required for any ELF or shell-script plugin to start.
+	for _, p := range landlockSystemReadPaths() {
+		addReadable(p)
+	}
+
+	// Plugin root: always readable + executable (the plugin binary lives here).
+	addReadable(pluginRoot)
+
+	// Declared read paths (relative → joined with plugin root; absolute as-is).
+	for _, p := range readPaths {
+		addReadable(resolvePath(p, pluginRoot))
+	}
+
+	// Declared write paths get full read+write access.
+	for _, p := range writePaths {
+		addWritable(resolvePath(p, pluginRoot))
+	}
+
+	// PR_SET_NO_NEW_PRIVS is required before landlock_restrict_self.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return
+	}
+
+	// Apply restrictions to this process; they are inherited across exec.
+	syscall.RawSyscall(unix.SYS_LANDLOCK_RESTRICT_SELF, uintptr(rulesetFd), 0, 0)
+}
+
+// addLandlockPath opens path with O_PATH and registers it as a Landlock rule.
+// Paths that do not exist or cannot be opened are silently skipped — the
+// caller should declare only paths that will exist at invocation time.
+func addLandlockPath(rulesetFd int, path string, access uint64) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|unix.O_PATH, 0)
+	if err != nil {
+		return
+	}
+	defer syscall.Close(fd)
+
+	// LandlockPathBeneathAttr is __attribute__((packed)) in the kernel header:
+	// { __u64 allowed_access; __s32 parent_fd; } → 12 bytes, no padding.
+	// unix.LandlockPathBeneathAttr has the same layout (uint64 + int32 = 12 B).
+	attr := unix.LandlockPathBeneathAttr{
+		Allowed_access: access,
+		Parent_fd:      int32(fd),
+	}
+	syscall.RawSyscall(
+		unix.SYS_LANDLOCK_ADD_RULE,
+		uintptr(rulesetFd),
+		uintptr(unix.LANDLOCK_RULE_PATH_BENEATH),
+		uintptr(unsafe.Pointer(&attr)),
+	)
+}
+
+// landlockSystemReadPaths returns the minimal set of read-only FHS paths that
+// every sandboxed process needs (shell interpreter, shared libraries, linker).
+// /proc, /dev, /sys, and /run are excluded: Landlock ABI 1 does not restrict
+// access to pseudo-filesystems (tmpfs/proc/devtmpfs/sysfs), so those remain
+// unrestricted regardless.
+func landlockSystemReadPaths() []string {
+	return []string{
+		"/bin", "/usr/bin", "/usr/local/bin",
+		"/lib", "/lib64",
+		"/usr/lib", "/usr/lib64",
+		"/usr/local/lib",
+		"/etc/ld.so.cache", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
+		"/usr/share/zoneinfo",
+	}
+}
+
+func resolvePath(p, root string) string {
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	return filepath.Join(root, p)
+}
+
+func decodePaths(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, pathSep)
+}
+
+func filterSandboxEnv(environ []string) []string {
+	drop := map[string]bool{
+		envSandboxExec:  true,
+		envSandboxBin:   true,
+		envSandboxRoot:  true,
+		envSandboxRead:  true,
+		envSandboxWrite: true,
+	}
+	out := make([]string, 0, len(environ))
+	for _, e := range environ {
+		k, _, _ := strings.Cut(e, "=")
+		if !drop[k] {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/src/internal/plugin/sandbox_launcher_other.go
+++ b/src/internal/plugin/sandbox_launcher_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package plugin
+
+// IsSandboxLauncher always returns false on non-Linux platforms;
+// Landlock filesystem sandboxing is Linux-specific.
+func IsSandboxLauncher() bool { return false }
+
+// RunSandboxLauncher is a no-op on non-Linux platforms.
+func RunSandboxLauncher() {}

--- a/src/internal/plugin/sandbox_linux.go
+++ b/src/internal/plugin/sandbox_linux.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -35,36 +36,72 @@ func probeUsernsSupport() bool {
 }
 
 // applySandbox restricts the subprocess according to the plugin's declared
-// security requirements. When network access is not declared, the process is
-// placed in an unprivileged user+network namespace if the kernel supports it.
-// On hardened kernels and container runtimes where unprivileged user namespaces
-// are disabled, a warning is logged once and the plugin runs without OS-level
-// network-namespace isolation; credential leakage is still prevented by the
-// environment allowlist built in environment().
+// security requirements.
+//
+// Network: when security.Network is false (the default), the subprocess is
+// placed in an unprivileged user+network namespace (CLONE_NEWUSER|CLONE_NEWNET)
+// if the kernel supports it. On hardened kernels where unprivileged user
+// namespaces are disabled, a one-time warning is logged and network-namespace
+// isolation is skipped; credential leakage is still prevented by the
+// environment allowlist in environment().
+//
+// Filesystem: when security.ReadPaths or security.WritePaths are non-empty, the
+// subprocess is launched via a Landlock re-exec trampoline. The host binary
+// re-invokes itself with sandbox control env vars; it applies
+// landlock_restrict_self() and then exec()s the actual plugin binary.
+// The re-exec is a no-op on kernels < 5.13 (Landlock not available).
 func applySandbox(cmd *exec.Cmd, security SecurityRequirements) {
-	if security.Network {
-		return
-	}
-	usernsSupportOnce.Do(func() {
-		usernsSupported = probeUsernsSupport()
-		if !usernsSupported {
-			log.Print("apiary: WARNING: unprivileged user namespaces are unavailable on this kernel; " +
-				"plugin network-namespace isolation is disabled. Plugins still run with a " +
-				"restricted environment (no host credentials), but OS-level network " +
-				"isolation cannot be applied. Consider running on a kernel with " +
-				"user namespaces enabled for stronger containment.")
+	// Network namespace isolation.
+	if !security.Network {
+		usernsSupportOnce.Do(func() {
+			usernsSupported = probeUsernsSupport()
+			if !usernsSupported {
+				log.Print("apiary: WARNING: unprivileged user namespaces are unavailable on this kernel; " +
+					"plugin network-namespace isolation is disabled. Plugins still run with a " +
+					"restricted environment (no host credentials), but OS-level network " +
+					"isolation cannot be applied. Consider running on a kernel with " +
+					"user namespaces enabled for stronger containment.")
+			}
+		})
+		if usernsSupported {
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
+				UidMappings: []syscall.SysProcIDMap{
+					{ContainerID: 0, HostID: os.Getuid(), Size: 1},
+				},
+				GidMappings: []syscall.SysProcIDMap{
+					{ContainerID: 0, HostID: os.Getgid(), Size: 1},
+				},
+			}
 		}
-	})
-	if !usernsSupported {
+	}
+
+	// Filesystem isolation via Landlock re-exec trampoline.
+	if len(security.ReadPaths) > 0 || len(security.WritePaths) > 0 {
+		setupLandlockReexec(cmd, security)
+	}
+}
+
+// setupLandlockReexec rewrites cmd so that the host binary is exec'd first.
+// The host binary detects _APIARY_SANDBOX_EXEC=1, applies Landlock, then
+// exec()s the original plugin binary. cmd.Stdin/Stdout/Stderr are untouched
+// so the plugin receives the request payload on fd 0 as usual.
+func setupLandlockReexec(cmd *exec.Cmd, security SecurityRequirements) {
+	self, err := os.Readlink("/proc/self/exe")
+	if err != nil {
+		// Can't locate the host binary (unusual); skip filesystem sandbox.
 		return
 	}
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
-		UidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: os.Getuid(), Size: 1},
-		},
-		GidMappings: []syscall.SysProcIDMap{
-			{ContainerID: 0, HostID: os.Getgid(), Size: 1},
-		},
-	}
+	pluginBin := cmd.Path
+	pluginRoot := cmd.Dir
+
+	cmd.Env = append(cmd.Env,
+		envSandboxExec+"=1",
+		envSandboxBin+"="+pluginBin,
+		envSandboxRoot+"="+pluginRoot,
+		envSandboxRead+"="+strings.Join(security.ReadPaths, pathSep),
+		envSandboxWrite+"="+strings.Join(security.WritePaths, pathSep),
+	)
+	cmd.Path = self
+	cmd.Args = []string{filepath.Base(self)}
 }

--- a/src/internal/plugin/sandbox_linux.go
+++ b/src/internal/plugin/sandbox_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package plugin
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var (
+	usernsSupportOnce sync.Once
+	usernsSupported   bool
+)
+
+// probeUsernsSupport reports whether unprivileged user namespaces are available
+// on this kernel. It checks the two sysctl knobs used by distributions to gate
+// the feature: the Debian/Ubuntu-specific unprivileged_userns_clone and the
+// generic max_user_namespaces (a value of 0 means the kernel refuses CLONE_NEWUSER).
+func probeUsernsSupport() bool {
+	if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	if data, err := os.ReadFile("/proc/sys/user/max_user_namespaces"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	return true
+}
+
+// applySandbox restricts the subprocess according to the plugin's declared
+// security requirements. When network access is not declared, the process is
+// placed in an unprivileged user+network namespace if the kernel supports it.
+// On hardened kernels and container runtimes where unprivileged user namespaces
+// are disabled, a warning is logged once and the plugin runs without OS-level
+// network-namespace isolation; credential leakage is still prevented by the
+// environment allowlist built in environment().
+func applySandbox(cmd *exec.Cmd, security SecurityRequirements) {
+	if security.Network {
+		return
+	}
+	usernsSupportOnce.Do(func() {
+		usernsSupported = probeUsernsSupport()
+		if !usernsSupported {
+			log.Print("apiary: WARNING: unprivileged user namespaces are unavailable on this kernel; " +
+				"plugin network-namespace isolation is disabled. Plugins still run with a " +
+				"restricted environment (no host credentials), but OS-level network " +
+				"isolation cannot be applied. Consider running on a kernel with " +
+				"user namespaces enabled for stronger containment.")
+		}
+	})
+	if !usernsSupported {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
+		UidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getuid(), Size: 1},
+		},
+		GidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getgid(), Size: 1},
+		},
+	}
+}

--- a/src/internal/plugin/sandbox_linux_test.go
+++ b/src/internal/plugin/sandbox_linux_test.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package plugin
+
+import (
+	"context"
+	"testing"
+)
+
+func TestProbeUsernsSupportIsSafe(t *testing.T) {
+	// Verify the probe doesn't panic regardless of kernel configuration.
+	supported := probeUsernsSupport()
+	t.Logf("unprivileged user namespaces supported: %v", supported)
+}
+
+func TestNetworkSandboxIsolatesPlugin(t *testing.T) {
+	if !probeUsernsSupport() {
+		t.Skip("unprivileged user namespaces unavailable on this kernel; network-namespace isolation is disabled by design")
+	}
+
+	parent := t.TempDir()
+	// The plugin counts non-loopback interfaces visible to it.
+	// Inside a network namespace with no external interfaces, only "lo" exists.
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+ifaces=$(cat /proc/net/dev | tail -n +3 | awk -F: '{print $1}' | tr -d ' ' | grep -v '^lo$' | wc -l | tr -d ' ')
+printf '{"protocol":1,"request_id":"%s","result":{"ifaces":"%s"}}\n' "$id" "$ifaces"`
+
+	root := writeTestPlugin(t, parent, "netcheck", script, Manifest{
+		Security: SecurityRequirements{Network: false},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["ifaces"] != "0" {
+		t.Fatalf("expected 0 non-loopback interfaces inside sandbox, got %q", result["ifaces"])
+	}
+}
+
+func TestNetworkSandboxAllowedWhenDeclared(t *testing.T) {
+	// When network: true the plugin runs without namespace isolation.
+	// We simply check that invocation succeeds.
+	parent := t.TempDir()
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{}}\n' "$id"`
+
+	root := writeTestPlugin(t, parent, "netallowed", script, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err != nil {
+		t.Fatalf("network:true plugin should invoke successfully: %v", err)
+	}
+}

--- a/src/internal/plugin/sandbox_linux_test.go
+++ b/src/internal/plugin/sandbox_linux_test.go
@@ -4,6 +4,9 @@ package plugin
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -43,6 +46,95 @@ printf '{"protocol":1,"request_id":"%s","result":{"ifaces":"%s"}}\n' "$id" "$ifa
 	}
 	if result["ifaces"] != "0" {
 		t.Fatalf("expected 0 non-loopback interfaces inside sandbox, got %q", result["ifaces"])
+	}
+}
+
+func TestFilesystemSandboxBlocksUndeclaredPaths(t *testing.T) {
+	if !probeUsernsSupport() {
+		t.Skip("unprivileged user namespaces unavailable; skipping filesystem sandbox test")
+	}
+	if !probeLandlockSupport() {
+		t.Skip("Landlock unavailable on this kernel; filesystem-sandbox enforcement is disabled by design")
+	}
+
+	parent := t.TempDir()
+
+	// Place a secret file in a sibling temp dir that the plugin must not reach.
+	secretDir := t.TempDir()
+	secretFile := filepath.Join(secretDir, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("sensitive"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The plugin tries to read the secret file; it should see "blocked" because
+	// the Landlock ruleset only allows the declared read path (/usr/bin) and
+	// the plugin root — the secret directory is neither.
+	script := fmt.Sprintf(`read req
+id=$(printf '%%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+content=$(cat %s 2>/dev/null || echo blocked)
+printf '{"protocol":1,"request_id":"%%s","result":{"content":"%%s"}}\n' "$id" "$content"`, secretFile)
+
+	root := writeTestPlugin(t, parent, "fssandbox", script, Manifest{
+		// Declare a read path that does NOT include secretDir.
+		Security: SecurityRequirements{ReadPaths: []string{"/usr/bin"}},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["content"] != "blocked" {
+		t.Fatalf("expected Landlock to block access to %s, but plugin read: %q", secretFile, result["content"])
+	}
+}
+
+func TestFilesystemSandboxAllowsDeclaredReadPath(t *testing.T) {
+	if !probeUsernsSupport() {
+		t.Skip("unprivileged user namespaces unavailable; skipping filesystem sandbox test")
+	}
+	if !probeLandlockSupport() {
+		t.Skip("Landlock unavailable on this kernel; filesystem-sandbox enforcement is disabled by design")
+	}
+
+	parent := t.TempDir()
+
+	// Place a readable file in a directory that the plugin explicitly declares.
+	allowedDir := t.TempDir()
+	allowedFile := filepath.Join(allowedDir, "allowed.txt")
+	if err := os.WriteFile(allowedFile, []byte("readable"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plugin reads the allowed file; the declared read path grants access.
+	script := fmt.Sprintf(`read req
+id=$(printf '%%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+content=$(cat %s 2>/dev/null || echo blocked)
+printf '{"protocol":1,"request_id":"%%s","result":{"content":"%%s"}}\n' "$id" "$content"`, allowedFile)
+
+	root := writeTestPlugin(t, parent, "fsallowed", script, Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{allowedDir}},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["content"] != "readable" {
+		t.Fatalf("expected Landlock to allow access to declared path %s, got: %q", allowedFile, result["content"])
 	}
 }
 

--- a/src/internal/plugin/sandbox_other.go
+++ b/src/internal/plugin/sandbox_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package plugin
+
+import "os/exec"
+
+// applySandbox is a no-op on platforms that do not support unprivileged network
+// namespaces. Plugins are still restricted to the minimal environment built by
+// environment().
+func applySandbox(_ *exec.Cmd, _ SecurityRequirements) {}


### PR DESCRIPTION
## Summary

Completes SEC-10: unsigned plugins are refused and all manifest permissions are enforced at runtime.

### Integrity check (mandatory checksum)

The `Manifest` struct requires a `checksum` field (lowercase hex SHA-256 of the executable). `Load` refuses plugins without a checksum or with a mismatched digest. `NewClient` re-verifies to close the TOCTOU window between disk read and invocation.

### Network sandbox (Linux)

When `security.network: false` (the default), the subprocess runs in an unprivileged `CLONE_NEWUSER | CLONE_NEWNET` namespace. Gracefully falls back with a one-time warning on kernels where unprivileged user namespaces are disabled (hardened distros, Docker-in-Docker). Credential leakage is still prevented by the environment allowlist in `environment()`.

### Filesystem sandbox — Landlock re-exec trampoline (Linux ≥ 5.13)

When `security.read_paths` or `security.write_paths` are non-empty, the subprocess is now restricted to those paths at runtime. `applySandbox` rewrites `exec.Cmd` to run the host binary first; it detects `_APIARY_SANDBOX_EXEC=1` on startup, calls `landlock_restrict_self()`, then `syscall.Exec()`s the actual plugin binary. Silently degrades on kernels that predate Landlock (< 5.13). Implicitly allows FHS system paths (interpreters, shared libraries) and the plugin root; declared paths add read-only or read+write access on top.

### Path validation

`security.read_paths` / `security.write_paths` entries validated at load time: empty entries and `...`-escape paths are rejected.

### golang.org/x/sys promoted to direct dependency

Used in `sandbox_launcher_linux.go` for Landlock struct types and constants.

## Test plan

- `TestMissingChecksumRejected` — load fails when checksum is absent
- `TestChecksumMismatchRejected` — load fails on digest mismatch
- `TestChecksumVerifiedAtNewClient` — binary replaced after Load is caught
- `TestSecurityPathValidation` — `..`-escape and empty entries rejected
- `TestNetworkSandboxIsolatesPlugin` (Linux) — plugin sees 0 non-loopback interfaces
- `TestNetworkSandboxAllowedWhenDeclared` — network:true plugin invokes successfully
- `TestFilesystemSandboxBlocksUndeclaredPaths` (Linux, skips if Landlock unavailable) — plugin cannot read a file outside its declared paths
- `TestFilesystemSandboxAllowsDeclaredReadPath` (Linux, skips if Landlock unavailable) — plugin can read files inside a declared read_path
- All existing tests pass

Closes #233
Closes #292