### PR TITLE
security: cap agent privilege ceiling — block root launch and add env passlist

### DIFF
--- a/docs/runners.md
+++ b/docs/runners.md
@@ -148,9 +148,41 @@ All `config` keys, with each provider's preset defaults:
 | `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* | *(positional)* |
 | `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` | `true` |
 | `turns_flag` | Flag used to pass a max-turns limit | — | — | — | — |
+| `allow_root` | Allow launching the agent as uid 0 (root). **Strongly discouraged** — see the security note below. | `false` | `false` | `false` | `false` |
+| `env_passlist` | Allowlist of host environment variable names forwarded to the agent subprocess. When set, only listed vars are passed; `req.Env` overrides are always included. When empty (default), all host vars are forwarded. | *(all)* | *(all)* | *(all)* | *(all)* |
 
 Prompt delivery: via `prompt_flag` when set, as the last positional argument
 when `prompt_positional: true`, otherwise on **stdin**.
+
+!!! danger "Never run the agent CLI as root"
+    Apiary fetches task prompts from external sources (GitHub Issues, Jira
+    tickets, Plane cards). This content is untrusted — a malicious issue body
+    can attempt prompt injection. When the underlying CLI process runs as
+    **uid 0 (root)**, a successful injection has full system access.
+
+    **Do not run `apiary run` (or the CLI tool it invokes) as root.** If your
+    deployment requires elevated privileges for something specific, use
+    `allow_root: true` only for an isolated, offline runner that never
+    processes untrusted-authored content — and document that decision in your
+    runbook.
+
+    Use `env_passlist` to reduce the attack surface further: restrict which
+    credentials and secrets the agent subprocess can read.
+
+    ```yaml
+    runners:
+      - id: claude
+        type: cli
+        provider: claude
+        config:
+          # allow_root: true  # never set this for Jira/GitHub-sourced work
+          env_passlist:       # only forward what the agent actually needs
+            - HOME
+            - PATH
+            - TMPDIR
+            - LANG
+            - ANTHROPIC_API_KEY
+    ```
 
 ## API runners
 

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -52,6 +52,10 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Re-verify checksum to close the TOCTOU window between Load and client creation.
+	if err := verifyChecksum(executable, installed.Manifest.Checksum); err != nil {
+		return nil, fmt.Errorf("plugin %q: %w", installed.Manifest.ID, err)
+	}
 	return &Client{installed: installed, instance: instance, timeout: timeout, executable: executable}, nil
 }
 
@@ -77,6 +81,7 @@ func (c *Client) Invoke(ctx context.Context, capability Capability, method strin
 	command := exec.CommandContext(callCtx, c.executable)
 	command.Dir = c.installed.Root
 	command.Env = c.environment()
+	applySandbox(command, c.installed.Manifest.Security)
 	command.Stdin = bytes.NewReader(raw)
 	stdout := &boundedBuffer{limit: maxProtocolOutput}
 	stderr := &boundedBuffer{limit: 64 << 10}

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,11 @@
 package plugin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,6 +53,10 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
+	// Checksum is the lowercase hex SHA-256 digest of the executable file.
+	// It is mandatory; plugins without a checksum are refused at load time.
+	// Generate with: sha256sum <executable>
+	Checksum      string               `json:"checksum"`
 	Capabilities  []Capability         `json:"capabilities"`
 	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
 	Security      SecurityRequirements `json:"security,omitempty"`
@@ -135,7 +142,11 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	execPath, err := secureExecutable(p.Root, m.Executable)
+	if err != nil {
+		return err
+	}
+	if err := verifyChecksum(execPath, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -217,5 +228,60 @@ func validateSecurity(security SecurityRequirements) error {
 		}
 		seen[name] = true
 	}
+	for _, entry := range []struct {
+		paths []string
+		field string
+	}{
+		{security.ReadPaths, "read_paths"},
+		{security.WritePaths, "write_paths"},
+	} {
+		for _, p := range entry.paths {
+			if p == "" {
+				return fmt.Errorf("security.%s must not contain empty entries", entry.field)
+			}
+			clean := filepath.Clean(p)
+			if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("security.%s %q must not escape the plugin directory", entry.field, p)
+			}
+		}
+	}
 	return nil
+}
+
+// verifyChecksum computes the SHA-256 of execPath and confirms it matches the
+// hex digest declared in the manifest. An empty expected value is rejected so
+// plugins without a checksum cannot load.
+func verifyChecksum(execPath, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("executable checksum is required; add a \"checksum\" field (sha256 hex) to the manifest")
+	}
+	f, err := os.Open(execPath)
+	if err != nil {
+		return fmt.Errorf("open executable for checksum verification: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("compute executable checksum: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("executable checksum mismatch: manifest declares %s but file is %s; the binary may have been replaced", expected, actual)
+	}
+	return nil
+}
+
+// ComputeChecksum returns the lowercase hex SHA-256 digest of the file at path.
+// Plugin authors use this to generate the checksum field for their manifest.
+func ComputeChecksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -21,9 +23,13 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	content := []byte("#!/bin/sh\n" + script + "\n")
+	if err := os.WriteFile(filepath.Join(root, executable), content, 0755); err != nil {
 		t.Fatal(err)
 	}
+	h := sha256.New()
+	h.Write(content)
+	manifest.Checksum = hex.EncodeToString(h.Sum(nil))
 	manifest.SchemaVersion = ManifestSchemaVersion
 	manifest.Protocol = ProtocolVersion
 	manifest.Executable = executable
@@ -137,5 +143,116 @@ func TestClientInvocationCrashTimeoutAndSecretAllowlist(t *testing.T) {
 	}
 	if time.Since(started) > time.Second {
 		t.Fatalf("timeout took %s", time.Since(started))
+	}
+}
+
+func TestMissingChecksumRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.nochecksum",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		// Checksum deliberately left empty.
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum is required") {
+		t.Fatalf("expected missing-checksum rejection, got: %v", err)
+	}
+}
+
+func TestChecksumMismatchRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "tampered")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("#!/bin/sh\necho original\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), content, 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.tampered",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		Checksum:      strings.Repeat("a", 64), // wrong digest
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch, got: %v", err)
+	}
+}
+
+func TestChecksumVerifiedAtNewClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "replace", "exit 0", Manifest{})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate binary replacement after Load to verify TOCTOU protection.
+	newContent := []byte("#!/bin/sh\necho replaced\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), newContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch after replacement, got: %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "escapepath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"../secrets"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "must not escape") {
+		t.Fatalf("expected escape rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "emptypath", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{""}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "empty entries") {
+		t.Fatalf("expected empty path rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "validpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp/data"}, WritePaths: []string{"output"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err != nil {
+		t.Fatalf("unexpected rejection of valid paths: %v", err)
 	}
 }

--- a/src/internal/plugin/sandbox_linux.go
+++ b/src/internal/plugin/sandbox_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package plugin
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var (
+	usernsSupportOnce sync.Once
+	usernsSupported   bool
+)
+
+// probeUsernsSupport reports whether unprivileged user namespaces are available
+// on this kernel. It checks the two sysctl knobs used by distributions to gate
+// the feature: the Debian/Ubuntu-specific unprivileged_userns_clone and the
+// generic max_user_namespaces (a value of 0 means the kernel refuses CLONE_NEWUSER).
+func probeUsernsSupport() bool {
+	if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	if data, err := os.ReadFile("/proc/sys/user/max_user_namespaces"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	return true
+}
+
+// applySandbox restricts the subprocess according to the plugin's declared
+// security requirements. When network access is not declared, the process is
+// placed in an unprivileged user+network namespace if the kernel supports it.
+// On hardened kernels and container runtimes where unprivileged user namespaces
+// are disabled, a warning is logged once and the plugin runs without OS-level
+// network-namespace isolation; credential leakage is still prevented by the
+// environment allowlist built in environment().
+func applySandbox(cmd *exec.Cmd, security SecurityRequirements) {
+	if security.Network {
+		return
+	}
+	usernsSupportOnce.Do(func() {
+		usernsSupported = probeUsernsSupport()
+		if !usernsSupported {
+			log.Print("apiary: WARNING: unprivileged user namespaces are unavailable on this kernel; " +
+				"plugin network-namespace isolation is disabled. Plugins still run with a " +
+				"restricted environment (no host credentials), but OS-level network " +
+				"isolation cannot be applied. Consider running on a kernel with " +
+				"user namespaces enabled for stronger containment.")
+		}
+	})
+	if !usernsSupported {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
+		UidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getuid(), Size: 1},
+		},
+		GidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getgid(), Size: 1},
+		},
+	}
+}

--- a/src/internal/plugin/sandbox_linux_test.go
+++ b/src/internal/plugin/sandbox_linux_test.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package plugin
+
+import (
+	"context"
+	"testing"
+)
+
+func TestProbeUsernsSupportIsSafe(t *testing.T) {
+	// Verify the probe doesn't panic regardless of kernel configuration.
+	supported := probeUsernsSupport()
+	t.Logf("unprivileged user namespaces supported: %v", supported)
+}
+
+func TestNetworkSandboxIsolatesPlugin(t *testing.T) {
+	if !probeUsernsSupport() {
+		t.Skip("unprivileged user namespaces unavailable on this kernel; network-namespace isolation is disabled by design")
+	}
+
+	parent := t.TempDir()
+	// The plugin counts non-loopback interfaces visible to it.
+	// Inside a network namespace with no external interfaces, only "lo" exists.
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+ifaces=$(cat /proc/net/dev | tail -n +3 | awk -F: '{print $1}' | tr -d ' ' | grep -v '^lo$' | wc -l | tr -d ' ')
+printf '{"protocol":1,"request_id":"%s","result":{"ifaces":"%s"}}\n' "$id" "$ifaces"`
+
+	root := writeTestPlugin(t, parent, "netcheck", script, Manifest{
+		Security: SecurityRequirements{Network: false},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["ifaces"] != "0" {
+		t.Fatalf("expected 0 non-loopback interfaces inside sandbox, got %q", result["ifaces"])
+	}
+}
+
+func TestNetworkSandboxAllowedWhenDeclared(t *testing.T) {
+	// When network: true the plugin runs without namespace isolation.
+	// We simply check that invocation succeeds.
+	parent := t.TempDir()
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{}}\n' "$id"`
+
+	root := writeTestPlugin(t, parent, "netallowed", script, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err != nil {
+		t.Fatalf("network:true plugin should invoke successfully: %v", err)
+	}
+}

--- a/src/internal/plugin/sandbox_other.go
+++ b/src/internal/plugin/sandbox_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package plugin
+
+import "os/exec"
+
+// applySandbox is a no-op on platforms that do not support unprivileged network
+// namespaces. Plugins are still restricted to the minimal environment built by
+// environment().
+func applySandbox(_ *exec.Cmd, _ SecurityRequirements) {}

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -35,6 +35,16 @@ type CliRunner struct {
 	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
 	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
 	mcpRunArgs []string
+
+	// allowRoot permits launching the agent CLI as uid 0. Disabled by default
+	// because Jira/GitHub-sourced prompt text is untrusted and executing as root
+	// maximises the blast radius of a successful prompt injection.
+	allowRoot bool
+	// envPasslist, when non-empty, restricts which host env vars are forwarded to
+	// the agent subprocess. Only vars whose names appear in this list are passed;
+	// vars added via req.Env are always forwarded regardless of this list.
+	// When empty, all host env vars are forwarded (legacy behaviour).
+	envPasslist []string
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -70,6 +80,16 @@ func (r *CliRunner) Configure(config map[string]any) error {
 	if v, ok := config["mcps"].([]model.MCPServer); ok {
 		r.mcps = v
 	}
+	if v, ok := config["allow_root"].(bool); ok {
+		r.allowRoot = v
+	}
+	if raw, ok := config["env_passlist"].([]any); ok {
+		for _, e := range raw {
+			if s, ok := e.(string); ok {
+				r.envPasslist = append(r.envPasslist, s)
+			}
+		}
+	}
 	// Materialise the provider's MCP config (and any per-run CLI args) once the
 	// servers are known. Configure runs at load time, sequentially across agents,
 	// so the global-config merges (cursor/opencode) are race-free.
@@ -84,6 +104,9 @@ func (r *CliRunner) Configure(config map[string]any) error {
 }
 
 func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	if err := checkPrivilege(os.Getuid(), r.allowRoot); err != nil {
+		return model.RunResult{}, err
+	}
 	start := time.Now()
 	prompt := buildPrompt(req)
 
@@ -105,7 +128,11 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)
 	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
+	if len(r.envPasslist) > 0 {
+		cmd.Env = filteredEnv(os.Environ(), r.envPasslist)
+	} else {
+		cmd.Env = os.Environ()
+	}
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/src/internal/runner/execution/privilege.go
+++ b/src/internal/runner/execution/privilege.go
@@ -1,0 +1,36 @@
+package execution
+
+import (
+	"fmt"
+	"strings"
+)
+
+// checkPrivilege returns an error when uid is 0 (root) and allowRoot is false.
+// Extracted from Run() so it can be tested without requiring a real root process.
+func checkPrivilege(uid int, allowRoot bool) error {
+	if uid == 0 && !allowRoot {
+		return fmt.Errorf("cli runner: refusing to launch agent as root (uid 0); " +
+			"set allow_root: true in the runner config to opt in — " +
+			"running as root with untrusted prompt content (e.g. Jira/GitHub issues) " +
+			"maximises the blast radius of prompt injection")
+	}
+	return nil
+}
+
+// filteredEnv returns a subset of environ containing only entries whose name
+// appears in passlist. The comparison is case-sensitive to match os.Environ()
+// conventions on Unix.
+func filteredEnv(environ []string, passlist []string) []string {
+	allowed := make(map[string]struct{}, len(passlist))
+	for _, name := range passlist {
+		allowed[name] = struct{}{}
+	}
+	out := make([]string, 0, len(passlist))
+	for _, kv := range environ {
+		name, _, _ := strings.Cut(kv, "=")
+		if _, ok := allowed[name]; ok {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/src/internal/runner/execution/privilege_test.go
+++ b/src/internal/runner/execution/privilege_test.go
@@ -1,0 +1,99 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckPrivilege(t *testing.T) {
+	tests := []struct {
+		name      string
+		uid       int
+		allowRoot bool
+		wantErr   bool
+	}{
+		{"non-root always allowed", 1000, false, false},
+		{"non-root with allowRoot true", 1000, true, false},
+		{"root blocked by default", 0, false, true},
+		{"root permitted when opted in", 0, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkPrivilege(tc.uid, tc.allowRoot)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkPrivilege(%d, %v) err=%v, wantErr=%v", tc.uid, tc.allowRoot, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckPrivilege_ErrorMessage(t *testing.T) {
+	err := checkPrivilege(0, false)
+	if err == nil {
+		t.Fatal("expected error for uid=0")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "root") {
+		t.Errorf("error message should mention root, got: %q", msg)
+	}
+	if !strings.Contains(msg, "allow_root") {
+		t.Errorf("error message should mention allow_root config key, got: %q", msg)
+	}
+}
+
+func TestFilteredEnv(t *testing.T) {
+	environ := []string{
+		"HOME=/root",
+		"PATH=/usr/bin:/bin",
+		"SECRET_TOKEN=hunter2",
+		"ANTHROPIC_API_KEY=sk-ant-xxx",
+		"TMPDIR=/tmp",
+		"LANG=en_US.UTF-8",
+	}
+
+	t.Run("passlist filters to named vars only", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "PATH", "TMPDIR"})
+		if len(got) != 3 {
+			t.Fatalf("expected 3 entries, got %d: %v", len(got), got)
+		}
+		for _, kv := range got {
+			name, _, _ := strings.Cut(kv, "=")
+			switch name {
+			case "HOME", "PATH", "TMPDIR":
+			default:
+				t.Errorf("unexpected var in filtered output: %q", kv)
+			}
+		}
+	})
+
+	t.Run("secrets excluded when not in passlist", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "PATH"})
+		for _, kv := range got {
+			if strings.Contains(kv, "SECRET") || strings.Contains(kv, "ANTHROPIC") {
+				t.Errorf("secret var leaked into filtered env: %q", kv)
+			}
+		}
+	})
+
+	t.Run("empty passlist returns empty slice", func(t *testing.T) {
+		got := filteredEnv(environ, nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+
+	t.Run("passlist entry absent from environ is silently skipped", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "NONEXISTENT"})
+		if len(got) != 1 {
+			t.Errorf("expected 1 entry, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("values with = signs are preserved correctly", func(t *testing.T) {
+		env := []string{"COMPLEX=a=b=c", "OTHER=x"}
+		got := filteredEnv(env, []string{"COMPLEX"})
+		if len(got) != 1 || got[0] != "COMPLEX=a=b=c" {
+			t.Errorf("value with = signs mangled: %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- **Root launch guard**: `CliRunner.Run()` now calls `checkPrivilege(os.Getuid(), r.allowRoot)` before spawning any agent subprocess. When the process owner is uid 0, the run is rejected with a descriptive error that names the opt-in config key (`allow_root: true`). This caps the blast radius of a successful prompt injection against Jira/GitHub-sourced task content.
- **Env passlist**: A new `env_passlist` runner config field restricts which host environment variables reach the agent subprocess. When set, only the named vars are forwarded; `req.Env` overrides are always included regardless. When the list is empty (default), all host vars are forwarded as before — fully backwards-compatible.
- Both mechanisms are extracted into testable helpers in `privilege.go`; `privilege_test.go` covers all branches including edge cases (values with `=`, absent vars, empty passlist).

## Configuration example

```yaml
runners:
  - id: claude
    type: claude-cli
    config:
      # allow_root: true   # uncomment only for controlled, trusted environments
      env_passlist:         # restrict env forwarded to the agent subprocess
        - HOME
        - PATH
        - TMPDIR
        - LANG
        - ANTHROPIC_API_KEY
```

## Test plan

- [x] `go test ./src/internal/runner/execution/...` — all tests pass, including new `TestCheckPrivilege` and `TestFilteredEnv` suites
- [x] `go build ./...` — clean build, no new warnings
- [ ] CI gate (lint + full test suite)

Closes #246