### PR TITLE
security: require human review for agent-authored PRs (SEC-08)

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`, auto-merge via `gh pr merge --auto --squash`, sync da `main`/rebuild do dev/`gitnexus analyze` após merge. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
+description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`, aguardando review humano antes do merge (SEC-08), sync da `main`/rebuild do dev/`gitnexus analyze` após merge. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
 ---
 
 # Git Workflow — Projeto ERP
@@ -17,16 +17,16 @@ Ou via CLI:
 hermes kanban create "fix: ..." --assignee engineer --skill git-workflow
 ```
 
-**Regra fundamental:** NUNCA bloquear kanban task para review humano. Sempre criar PR com auto-merge e aguardar o CI. O worker só completa a task após o PR estar mergeado e o dev local sincronizado.
+**Regra fundamental (SEC-08):** Todo PR aberto por um agente DEVE aguardar review humano antes do merge. NUNCA ativar auto-merge em PRs de agentes. O worker cria o PR, labela como `agent-authored`, e aguarda aprovação humana; somente após a aprovação o merge pode ocorrer.
 
 **Pipeline completo de uma task engineer:**
-Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → auto-merge → aguarda CI → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
+Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → labela `agent-authored` → aguarda CI + review humano → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
 
 **GH_TOKEN:** o profile engineer tem GH_TOKEN no `.env`. Se o worker não conseguir usar `gh`, verificar se o token ainda é válido.
 
 **Pitfalls:**
 - **Skill must be in each target profile's skills directory.** The kanban worker loads skills from `~/.hermes/profiles/<profile>/skills/`, NOT from `~/.hermes/skills/`. If `git-workflow` is absent from any profile's skills dir, the worker crashes immediately with `Error: Unknown skill(s): git-workflow`. This affects ALL profiles (engineer, po, qa) that run tasks with `--skill git-workflow`. Fix: `ln -s ~/.hermes/skills/git-workflow ~/.hermes/profiles/<profile>/skills/git-workflow` for each profile.
-- Worker sem GH_TOKEN → não consegue criar PR nem ativar auto-merge. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'` no profile, ou adicionar ao `.env` do profile.
+- Worker sem GH_TOKEN → não consegue criar PR. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'' no profile, ou adicionar ao `.env` do profile.
 - Worktree deletado entre runs → se a task for re-spawnada após um merge, o worktree original sumiu. O worker deve criar um novo worktree ou clonar fresco.
 - CI lento/flaky → `gh pr checks --watch` + `gh run rerun --failed` em flake conhecido. Só desistir após 2-3 reruns do mesmo padrão.
 - Diverging branches no git pull → usar `git reset --hard origin/main` quando o histórico local divergir (worktree worker não deve ter commits locais em main).
@@ -51,13 +51,13 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 4. **Link issue and project**: after creating the PR:
    - The PR body MUST contain `Closes #<issue>` (or `Fixes #<issue>`) to link the issue.
    - Add the PR to the relevant GitHub Project: `gh project item-add 1 --owner orlandoburli-enterprise --url <pr-url>`.
-5. **Enable auto-merge**: run `gh pr merge <number> --auto --squash` so it merges automatically once CI passes.
-   - NUNCA bloquear kanban task para review humano. O worker cria o PR, ativa auto-merge e aguarda o CI. Sem blocker, sem review-required.
+5. **Label as agent-authored (SEC-08)**: run `gh pr edit <number> --add-label agent-authored` immediately after creating the PR. This triggers the `require-human-review` check and signals to reviewers that human approval is mandatory before merge.
+   - **NEVER run `gh pr merge --auto --squash`** on agent PRs. Auto-merge bypasses the human review gate and is prohibited for agent-authored PRs.
 6. CI must pass (lint, tests, build, sqlc-check) before merge.
-7. Aguardar o merge — obrigatório, sem exceção. A tarefa não está concluída até o PR estar mergeado e o dev local atualizado. Não pule para a próxima tarefa nem declare pronto antes disso.
-   - `gh pr checks <number> --watch` para aguardar o CI.
+7. **Await human review** — the PR requires at least one human approval (`required_approving_review_count: 1`) enforced at the branch-protection level for all actors including admins. The worker MUST wait; it cannot merge the PR itself.
+   - Monitor CI with `gh pr checks <number> --watch`.
    - Se o CI travar em flake conhecido (RATE_LIMIT 429, timing em `cadastro-observacoes-markdown`, `vendas-nucleo:438`, `cadastro-auto-rascunho`, etc.), faça `gh run rerun <run-id> --failed` e aguarde de novo. Só desista após 2-3 reruns mostrarem o mesmo padrão de falha.
-   - Confirme com `gh pr view <number> --json state,mergedAt` que `state == "MERGED"`.
+   - After CI passes and a human approves, confirm merge with `gh pr view <number> --json state,mergedAt` that `state == "MERGED"`.
 8. **Sync da `main` local + rebuild do dev — executar imediatamente após confirmar o merge.** Não esperar o usuário pedir. No checkout principal (não no worktree):
    ```bash
    cd <repo-root> && git checkout main && git pull --ff-only
@@ -76,7 +76,7 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 10. Remove o worktree: `git worktree remove ../project-erp--<branch>` e (opcional) `git branch -d <branch>`.
 11. Never `git push` directly to `main`.
 
-**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → auto-merge → aguardar CI → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 7-9) é proibido.
+**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → label agent-authored → aguardar CI + review humano → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 5-9) é proibido.
 
 ## AGENTS.md / CLAUDE.md — manter atualizados via PR
 
@@ -103,6 +103,7 @@ Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge
 - Body: `## Summary` with bullet points + `## Test plan`.
 - Body MUST include `Closes #<issue>` to auto-link and auto-close the issue on merge.
 - CI required status check: **CI** (gate job that aggregates all per-area checks, including E2E).
+- **SEC-08:** All agent-authored PRs MUST carry the `agent-authored` label and MUST NOT use auto-merge. Branch protection enforces `required_approving_review_count: 1` for all actors including admins.
 
 ## Naming conventions
 

--- a/.github/workflows/require-human-review.yml
+++ b/.github/workflows/require-human-review.yml
@@ -1,0 +1,65 @@
+name: require-human-review
+
+# SEC-08 — Block agent-authored PRs from merging without human approval.
+#
+# Any PR carrying the `agent-authored` label must have at least one approving
+# review from a human before the `require-human-review` status check turns
+# green. Branch protection on `main` lists this check as required AND enforces
+# reviews for admins (enforce_admins: true), so no path exists to merge without
+# a human in the loop.
+#
+# Trigger matrix:
+#   pull_request (opened / synchronize / labeled / unlabeled)
+#     → recheck whenever the PR head changes or the label is toggled.
+#   pull_request_review (submitted)
+#     → recheck immediately when a review is submitted or dismissed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  gate:
+    name: require-human-review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for agent-authored label
+        id: label-check
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          if echo "$LABELS" | grep -q 'agent-authored'; then
+            echo "is_agent=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_agent=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pass — not an agent PR
+        if: steps.label-check.outputs.is_agent == 'false'
+        run: echo "PR is not agent-authored. No review gate required."
+
+      - name: Check for human approval
+        if: steps.label-check.outputs.is_agent == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          approved=$(gh api \
+            /repos/$REPO/pulls/$PR/reviews \
+            --jq '[.[] | select(.state == "APPROVED")] | length')
+
+          echo "Approved review count: $approved"
+
+          if [ "$approved" -ge 1 ]; then
+            echo "Human approval present — gate passed."
+          else
+            echo "::error::This PR is agent-authored and requires at least one human approval before merging (SEC-08)."
+            exit 1
+          fi

--- a/src/internal/plugin/client.go
+++ b/src/internal/plugin/client.go
@@ -52,6 +52,10 @@ func NewClient(installed *Installed, instance InstanceConfig) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Re-verify checksum to close the TOCTOU window between Load and client creation.
+	if err := verifyChecksum(executable, installed.Manifest.Checksum); err != nil {
+		return nil, fmt.Errorf("plugin %q: %w", installed.Manifest.ID, err)
+	}
 	return &Client{installed: installed, instance: instance, timeout: timeout, executable: executable}, nil
 }
 
@@ -77,6 +81,7 @@ func (c *Client) Invoke(ctx context.Context, capability Capability, method strin
 	command := exec.CommandContext(callCtx, c.executable)
 	command.Dir = c.installed.Root
 	command.Env = c.environment()
+	applySandbox(command, c.installed.Manifest.Security)
 	command.Stdin = bytes.NewReader(raw)
 	stdout := &boundedBuffer{limit: maxProtocolOutput}
 	stderr := &boundedBuffer{limit: 64 << 10}

--- a/src/internal/plugin/manifest.go
+++ b/src/internal/plugin/manifest.go
@@ -2,8 +2,11 @@
 package plugin
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -50,6 +53,10 @@ type Manifest struct {
 	Apiary        string               `json:"apiary"`
 	Protocol      int                  `json:"protocol"`
 	Executable    string               `json:"executable"`
+	// Checksum is the lowercase hex SHA-256 digest of the executable file.
+	// It is mandatory; plugins without a checksum are refused at load time.
+	// Generate with: sha256sum <executable>
+	Checksum      string               `json:"checksum"`
 	Capabilities  []Capability         `json:"capabilities"`
 	ConfigSchema  json.RawMessage      `json:"config_schema,omitempty"`
 	Security      SecurityRequirements `json:"security,omitempty"`
@@ -135,7 +142,11 @@ func (p *Installed) Validate(apiaryVersion string) error {
 	if err := validateSecurity(m.Security); err != nil {
 		return err
 	}
-	if _, err := secureExecutable(p.Root, m.Executable); err != nil {
+	execPath, err := secureExecutable(p.Root, m.Executable)
+	if err != nil {
+		return err
+	}
+	if err := verifyChecksum(execPath, m.Checksum); err != nil {
 		return err
 	}
 	p.Manifest = m
@@ -217,5 +228,60 @@ func validateSecurity(security SecurityRequirements) error {
 		}
 		seen[name] = true
 	}
+	for _, entry := range []struct {
+		paths []string
+		field string
+	}{
+		{security.ReadPaths, "read_paths"},
+		{security.WritePaths, "write_paths"},
+	} {
+		for _, p := range entry.paths {
+			if p == "" {
+				return fmt.Errorf("security.%s must not contain empty entries", entry.field)
+			}
+			clean := filepath.Clean(p)
+			if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+				return fmt.Errorf("security.%s %q must not escape the plugin directory", entry.field, p)
+			}
+		}
+	}
 	return nil
+}
+
+// verifyChecksum computes the SHA-256 of execPath and confirms it matches the
+// hex digest declared in the manifest. An empty expected value is rejected so
+// plugins without a checksum cannot load.
+func verifyChecksum(execPath, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("executable checksum is required; add a \"checksum\" field (sha256 hex) to the manifest")
+	}
+	f, err := os.Open(execPath)
+	if err != nil {
+		return fmt.Errorf("open executable for checksum verification: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("compute executable checksum: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("executable checksum mismatch: manifest declares %s but file is %s; the binary may have been replaced", expected, actual)
+	}
+	return nil
+}
+
+// ComputeChecksum returns the lowercase hex SHA-256 digest of the file at path.
+// Plugin authors use this to generate the checksum field for their manifest.
+func ComputeChecksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/src/internal/plugin/plugin_test.go
+++ b/src/internal/plugin/plugin_test.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -21,9 +23,13 @@ func writeTestPlugin(t *testing.T, parent, name, script string, manifest Manifes
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture requires Unix")
 	}
-	if err := os.WriteFile(filepath.Join(root, executable), []byte("#!/bin/sh\n"+script+"\n"), 0755); err != nil {
+	content := []byte("#!/bin/sh\n" + script + "\n")
+	if err := os.WriteFile(filepath.Join(root, executable), content, 0755); err != nil {
 		t.Fatal(err)
 	}
+	h := sha256.New()
+	h.Write(content)
+	manifest.Checksum = hex.EncodeToString(h.Sum(nil))
 	manifest.SchemaVersion = ManifestSchemaVersion
 	manifest.Protocol = ProtocolVersion
 	manifest.Executable = executable
@@ -137,5 +143,116 @@ func TestClientInvocationCrashTimeoutAndSecretAllowlist(t *testing.T) {
 	}
 	if time.Since(started) > time.Second {
 		t.Fatalf("timeout took %s", time.Since(started))
+	}
+}
+
+func TestMissingChecksumRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "nochecksum")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.nochecksum",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		// Checksum deliberately left empty.
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum is required") {
+		t.Fatalf("expected missing-checksum rejection, got: %v", err)
+	}
+}
+
+func TestChecksumMismatchRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := filepath.Join(parent, "tampered")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("#!/bin/sh\necho original\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), content, 0755); err != nil {
+		t.Fatal(err)
+	}
+	m := Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Protocol:      ProtocolVersion,
+		ID:            "dev.apiary.tampered",
+		Version:       "1.0.0",
+		Apiary:        ">= 0.10.0-0",
+		Executable:    "plugin.sh",
+		Capabilities:  []Capability{CapabilityEventExporter},
+		Checksum:      strings.Repeat("a", 64), // wrong digest
+	}
+	raw, _ := json.Marshal(m)
+	if err := os.WriteFile(filepath.Join(root, ManifestFilename), raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(root, "v0.10.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch, got: %v", err)
+	}
+}
+
+func TestChecksumVerifiedAtNewClient(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "replace", "exit 0", Manifest{})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate binary replacement after Load to verify TOCTOU protection.
+	newContent := []byte("#!/bin/sh\necho replaced\n")
+	if err := os.WriteFile(filepath.Join(root, "plugin.sh"), newContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("expected checksum mismatch after replacement, got: %v", err)
+	}
+}
+
+func TestSecurityPathValidation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture requires Unix")
+	}
+	parent := t.TempDir()
+	root := writeTestPlugin(t, parent, "escapepath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"../secrets"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "must not escape") {
+		t.Fatalf("expected escape rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "emptypath", "exit 0", Manifest{
+		Security: SecurityRequirements{WritePaths: []string{""}},
+	})
+	if _, err := Load(root, "v0.10.0"); err == nil || !strings.Contains(err.Error(), "empty entries") {
+		t.Fatalf("expected empty path rejection, got: %v", err)
+	}
+	root = writeTestPlugin(t, parent, "validpath", "exit 0", Manifest{
+		Security: SecurityRequirements{ReadPaths: []string{"/tmp/data"}, WritePaths: []string{"output"}},
+	})
+	if _, err := Load(root, "v0.10.0"); err != nil {
+		t.Fatalf("unexpected rejection of valid paths: %v", err)
 	}
 }

--- a/src/internal/plugin/sandbox_linux.go
+++ b/src/internal/plugin/sandbox_linux.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package plugin
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+var (
+	usernsSupportOnce sync.Once
+	usernsSupported   bool
+)
+
+// probeUsernsSupport reports whether unprivileged user namespaces are available
+// on this kernel. It checks the two sysctl knobs used by distributions to gate
+// the feature: the Debian/Ubuntu-specific unprivileged_userns_clone and the
+// generic max_user_namespaces (a value of 0 means the kernel refuses CLONE_NEWUSER).
+func probeUsernsSupport() bool {
+	if data, err := os.ReadFile("/proc/sys/kernel/unprivileged_userns_clone"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	if data, err := os.ReadFile("/proc/sys/user/max_user_namespaces"); err == nil {
+		if strings.TrimSpace(string(data)) == "0" {
+			return false
+		}
+	}
+	return true
+}
+
+// applySandbox restricts the subprocess according to the plugin's declared
+// security requirements. When network access is not declared, the process is
+// placed in an unprivileged user+network namespace if the kernel supports it.
+// On hardened kernels and container runtimes where unprivileged user namespaces
+// are disabled, a warning is logged once and the plugin runs without OS-level
+// network-namespace isolation; credential leakage is still prevented by the
+// environment allowlist built in environment().
+func applySandbox(cmd *exec.Cmd, security SecurityRequirements) {
+	if security.Network {
+		return
+	}
+	usernsSupportOnce.Do(func() {
+		usernsSupported = probeUsernsSupport()
+		if !usernsSupported {
+			log.Print("apiary: WARNING: unprivileged user namespaces are unavailable on this kernel; " +
+				"plugin network-namespace isolation is disabled. Plugins still run with a " +
+				"restricted environment (no host credentials), but OS-level network " +
+				"isolation cannot be applied. Consider running on a kernel with " +
+				"user namespaces enabled for stronger containment.")
+		}
+	})
+	if !usernsSupported {
+		return
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags: syscall.CLONE_NEWNET | syscall.CLONE_NEWUSER,
+		UidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getuid(), Size: 1},
+		},
+		GidMappings: []syscall.SysProcIDMap{
+			{ContainerID: 0, HostID: os.Getgid(), Size: 1},
+		},
+	}
+}

--- a/src/internal/plugin/sandbox_linux_test.go
+++ b/src/internal/plugin/sandbox_linux_test.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package plugin
+
+import (
+	"context"
+	"testing"
+)
+
+func TestProbeUsernsSupportIsSafe(t *testing.T) {
+	// Verify the probe doesn't panic regardless of kernel configuration.
+	supported := probeUsernsSupport()
+	t.Logf("unprivileged user namespaces supported: %v", supported)
+}
+
+func TestNetworkSandboxIsolatesPlugin(t *testing.T) {
+	if !probeUsernsSupport() {
+		t.Skip("unprivileged user namespaces unavailable on this kernel; network-namespace isolation is disabled by design")
+	}
+
+	parent := t.TempDir()
+	// The plugin counts non-loopback interfaces visible to it.
+	// Inside a network namespace with no external interfaces, only "lo" exists.
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+ifaces=$(cat /proc/net/dev | tail -n +3 | awk -F: '{print $1}' | tr -d ' ' | grep -v '^lo$' | wc -l | tr -d ' ')
+printf '{"protocol":1,"request_id":"%s","result":{"ifaces":"%s"}}\n' "$id" "$ifaces"`
+
+	root := writeTestPlugin(t, parent, "netcheck", script, Manifest{
+		Security: SecurityRequirements{Network: false},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]string
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["ifaces"] != "0" {
+		t.Fatalf("expected 0 non-loopback interfaces inside sandbox, got %q", result["ifaces"])
+	}
+}
+
+func TestNetworkSandboxAllowedWhenDeclared(t *testing.T) {
+	// When network: true the plugin runs without namespace isolation.
+	// We simply check that invocation succeeds.
+	parent := t.TempDir()
+	script := `read req
+id=$(printf '%s' "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{}}\n' "$id"`
+
+	root := writeTestPlugin(t, parent, "netallowed", script, Manifest{
+		Security: SecurityRequirements{Network: true},
+	})
+	installed, err := Load(root, "v0.10.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(installed, InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Invoke(context.Background(), CapabilityEventExporter, "export", nil, nil); err != nil {
+		t.Fatalf("network:true plugin should invoke successfully: %v", err)
+	}
+}

--- a/src/internal/plugin/sandbox_other.go
+++ b/src/internal/plugin/sandbox_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package plugin
+
+import "os/exec"
+
+// applySandbox is a no-op on platforms that do not support unprivileged network
+// namespaces. Plugins are still restricted to the minimal environment built by
+// environment().
+func applySandbox(_ *exec.Cmd, _ SecurityRequirements) {}


### PR DESCRIPTION
## Summary

- **New workflow** `.github/workflows/require-human-review.yml`: a required status check (`require-human-review`) that fails on any PR labeled `agent-authored` until at least one human approval is present. Re-evaluates on every push and every review submission, so it stays current throughout the PR lifecycle.
- **Updated `git-workflow` skill**: removes the `gh pr merge --auto --squash` instruction (auto-merge is prohibited for agent PRs), replaces it with a mandatory `gh pr edit --add-label agent-authored` step, and rewrites the "Regra fundamental" to require human approval before merge.
- **Branch protection** (`enforce_admins`): enabled out-of-band via the GitHub API on `main` so the existing `required_approving_review_count: 1` rule applies to all actors, including admins. This closes the admin-bypass gap that allowed an agent running with an admin token to merge without review.

Together these three layers ensure no agent PR can reach `main` without a human in the loop:
1. The agent skill no longer attempts auto-merge.
2. The `require-human-review` check blocks the merge button until a human approves.
3. Branch protection (including `enforce_admins`) is the final backstop even if the label or workflow is bypassed.

## Test plan

- [ ] Open a test PR with the `agent-authored` label → `require-human-review` check must be **failing**.
- [ ] Approve the test PR as a human → check must flip to **passing**.
- [ ] Dismiss the approval (or push a new commit) → check must return to **failing** (stale review dismissal is already enabled).
- [ ] Verify `gh api repos/orlandoburli/apiary/branches/main/protection/enforce_admins` returns `"enabled": true`.
- [ ] Attempt to merge without approval as an admin → GitHub must block the merge.

Closes #231