### PR TITLE
security: sandbox agent execution to contain prompt injection (SEC-09)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -73,6 +73,31 @@ type RunnerConfig struct {
 	// format/location (see runner/execution). Agent-scope MCPs (AgentConfig.MCPs)
 	// are layered on top of these, overriding by name.
 	MCPs []model.MCPServer `yaml:"mcps,omitempty"`
+	// Sandbox, when set, wraps every agent subprocess in a Docker container with
+	// the specified image, restricted user, and network policy. Apply to runners
+	// that process issues from external/untrusted authors to contain
+	// prompt-injection escapes. Per-task credentials (agent.env) are injected
+	// into the container via docker's env mechanism, not host inheritance.
+	Sandbox *SandboxConfig `yaml:"sandbox,omitempty"`
+}
+
+// SandboxConfig describes container isolation applied to every subprocess
+// spawned by a CliRunner. When present on a RunnerConfig, the daemon wraps
+// each agent invocation in `docker run --rm` with the specified image,
+// user, and network policy.
+type SandboxConfig struct {
+	// Image is the Docker image providing the agent binary (required).
+	Image string `yaml:"image"`
+	// User is passed as --user to docker run (e.g. "nobody", "1000:1000").
+	// Defaults to "nobody" when empty.
+	User string `yaml:"user,omitempty"`
+	// Network is the --network value for docker run (e.g. "none", "host", or a
+	// named bridge). Defaults to "none" when empty.
+	Network string `yaml:"network,omitempty"`
+	// ExtraArgs are appended verbatim between the security flags and the image
+	// name, e.g. ["-v", "/data:/data:ro"] for read-only bind mounts. These are
+	// trusted operator overrides; do not allow untrusted user input here.
+	ExtraArgs []string `yaml:"extra_args,omitempty"`
 }
 
 // AdapterName returns the runner adapter name as "{provider}-{type}" when both
@@ -128,6 +153,11 @@ type AgentConfig struct {
 	// WorkspaceAffinity pins retries/resumes to the first worker that claims the
 	// task, preserving a local checkout or other non-portable environment.
 	WorkspaceAffinity bool `yaml:"workspace_affinity,omitempty"`
+	// Permissions overrides the default tool permissions written into the OpenCode
+	// agent file. Keys are tool names ("bash", "edit", "webfetch", etc.); values
+	// are "allow" or "deny". Absent keys use least-privilege defaults:
+	// read/glob/grep/task → allow; bash/edit/webfetch → deny.
+	Permissions map[string]string `yaml:"permissions,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -357,7 +357,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			return nil, fmt.Errorf("agent %q: runner type %q not found", ac.ID, rc.Type)
 		}
 
-		if err := ra.Configure(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)); err != nil {
+		if err := ra.Configure(injectSandbox(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs), rc.Sandbox)); err != nil {
 			return nil, fmt.Errorf("agent %q: configure runner: %w", ac.ID, err)
 		}
 
@@ -389,7 +389,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
 			}
-			if err := fra.Configure(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)); err != nil {
+			if err := fra.Configure(injectSandbox(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs), frc.Sandbox)); err != nil {
 				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
 			}
 			if fAdapterName == "opencode" {
@@ -1733,18 +1733,16 @@ func (d *Dispatcher) writeOpencodeAgent(ctx context.Context, ac config.AgentConf
 		}
 	}
 
+	perms := opencodeDefaultPerms(ac)
+
 	var b strings.Builder
 	b.WriteString("---\n")
 	fmt.Fprintf(&b, "description: %s\n", ac.Description)
 	b.WriteString("mode: primary\n")
 	b.WriteString("permission:\n")
-	b.WriteString("  edit: allow\n")
-	b.WriteString("  bash: allow\n")
-	b.WriteString("  read: allow\n")
-	b.WriteString("  glob: allow\n")
-	b.WriteString("  grep: allow\n")
-	b.WriteString("  webfetch: allow\n")
-	b.WriteString("  task: allow\n")
+	for _, tool := range []string{"read", "glob", "grep", "task", "edit", "bash", "webfetch"} {
+		fmt.Fprintf(&b, "  %s: %s\n", tool, perms[tool])
+	}
 	b.WriteString("---\n")
 	if promptBody != "" {
 		b.WriteString("\n")
@@ -1797,20 +1795,19 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		_ = json.Unmarshal(data, &cfg)
 	}
 
+	perms := opencodeDefaultPerms(ac)
+	permMap := make(map[string]any, len(perms))
+	for k, v := range perms {
+		permMap[k] = v
+	}
+
 	// Use a relative reference from the global config directory
 	agentEntry := map[string]any{
 		"description": ac.Description,
 		"mode":        "primary",
 		"prompt":      "{file:./agents/" + ac.ID + ".md}",
 		"skills":      ac.Skills,
-		"permission": map[string]any{
-			"edit": "allow",
-			"bash": "allow",
-			"read": "allow",
-			"glob": "allow",
-			"grep": "allow",
-			"task": "allow",
-		},
+		"permission":  permMap,
 	}
 
 	agents, _ := cfg["agent"].(map[string]any)
@@ -1825,6 +1822,49 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		return err
 	}
 	return os.WriteFile(globalConfigPath, raw, 0644)
+}
+
+// opencodeDefaultPerms returns the OpenCode permission map for an agent, applying
+// least-privilege defaults (bash/edit/webfetch: deny; read/glob/grep/task: allow)
+// overridden by the agent's explicit Permissions.
+func opencodeDefaultPerms(ac config.AgentConfig) map[string]string {
+	perms := map[string]string{
+		"read":     "allow",
+		"glob":     "allow",
+		"grep":     "allow",
+		"task":     "allow",
+		"edit":     "deny",
+		"bash":     "deny",
+		"webfetch": "deny",
+	}
+	for k, v := range ac.Permissions {
+		perms[k] = v
+	}
+	return perms
+}
+
+// injectSandbox folds a RunnerConfig.Sandbox into the config map passed to
+// CliRunner.Configure. The base map is never mutated; a copy is returned only
+// when a sandbox is present.
+func injectSandbox(base map[string]any, s *config.SandboxConfig) map[string]any {
+	if s == nil {
+		return base
+	}
+	out := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	extras := make([]any, len(s.ExtraArgs))
+	for i, v := range s.ExtraArgs {
+		extras[i] = v
+	}
+	out["sandbox"] = map[string]any{
+		"image":      s.Image,
+		"user":       s.User,
+		"network":    s.Network,
+		"extra_args": extras,
+	}
+	return out
 }
 
 // runnerConfigWithMCPs returns the runner's config map augmented with the

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -35,6 +35,104 @@ type CliRunner struct {
 	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
 	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
 	mcpRunArgs []string
+	// sandbox, when non-nil, wraps every agent subprocess in a Docker container
+	// with the given image, restricted user, and network policy. Prevents
+	// prompt-injection escapes from reaching the host or other services.
+	sandbox *cliSandbox
+}
+
+// cliSandbox describes the Docker container isolation layer for a CliRunner.
+type cliSandbox struct {
+	image     string
+	user      string   // defaults to "nobody"
+	network   string   // defaults to "none"
+	extraArgs []string // operator-controlled; trusted config only
+}
+
+// hostEnvAllowList is the set of host environment variable names that the
+// docker host process (the docker CLI binary itself) needs to operate. These
+// do not flow into the container unless they also appear in req.Env. All other
+// host vars (API keys, AWS credentials, etc.) are excluded so that daemon
+// secrets cannot reach the sandboxed agent.
+var hostEnvAllowList = map[string]bool{
+	"PATH":          true,
+	"HOME":          true,
+	"TMPDIR":        true,
+	"TEMP":          true,
+	"TMP":           true,
+	"TERM":          true,
+	"USER":          true,
+	"LOGNAME":       true,
+	"LANG":          true,
+	"LC_ALL":        true,
+	"LC_CTYPE":      true,
+	"SSL_CERT_FILE": true,
+	"SSL_CERT_DIR":  true,
+	"SSH_AUTH_SOCK": true,
+	"DOCKER_HOST":   true, // docker daemon socket; needed by the docker CLI
+}
+
+// filteredHostEnv returns a subset of os.Environ() that matches hostEnvAllowList
+// plus every entry in overlay. Used for the docker host process env so that
+// secrets present in the daemon process do not reach the docker CLI argv/env.
+func filteredHostEnv(overlay map[string]string) []string {
+	env := make([]string, 0, len(hostEnvAllowList)+len(overlay))
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if ok && hostEnvAllowList[name] {
+			env = append(env, kv)
+		}
+	}
+	for k, v := range overlay {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// wrapCommand rewrites (binary, argv) to execute inside the sandbox container.
+// Per-task credentials in overlay are injected via `--env KEY` (without the
+// value in argv) and are placed in the docker host process's environment so
+// Docker passes them into the container. This prevents secrets from appearing
+// in the host process table (/proc/<pid>/cmdline / `ps`).
+// Returns (dockerBinary, dockerArgv, dockerHostEnv).
+func (s *cliSandbox) wrapCommand(binary string, argv []string, workDir string, overlay map[string]string) (string, []string, []string) {
+	user := s.user
+	if user == "" {
+		user = "nobody"
+	}
+	network := s.network
+	if network == "" {
+		network = "none"
+	}
+
+	dockerArgs := []string{
+		"run", "--rm",
+		"--network", network,
+		"--user", user,
+		"--read-only",
+		"--tmpfs", "/tmp:rw,noexec,nosuid,size=64m",
+		"--cap-drop", "all",
+		"--security-opt", "no-new-privileges",
+	}
+	if workDir != "" {
+		dockerArgs = append(dockerArgs, "-v", workDir+":"+workDir, "-w", workDir)
+	}
+
+	// Inject per-task credentials as --env KEY (no value in argv).
+	// Docker resolves the value from its own process environment, keeping
+	// secrets out of the host process table.
+	for k := range overlay {
+		dockerArgs = append(dockerArgs, "--env", k)
+	}
+
+	// extraArgs are trusted operator additions (e.g. read-only cache mounts).
+	dockerArgs = append(dockerArgs, s.extraArgs...)
+	dockerArgs = append(dockerArgs, s.image, binary)
+	dockerArgs = append(dockerArgs, argv...)
+
+	// Build the docker host process env: safe subset of host + per-task creds.
+	hostEnv := filteredHostEnv(overlay)
+	return "docker", dockerArgs, hostEnv
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -80,6 +178,29 @@ func (r *CliRunner) Configure(config map[string]any) error {
 		}
 		r.mcpRunArgs = args
 	}
+	if raw, ok := config["sandbox"].(map[string]any); ok {
+		sc := &cliSandbox{}
+		if v, ok := raw["image"].(string); ok {
+			sc.image = v
+		}
+		if v, ok := raw["user"].(string); ok {
+			sc.user = v
+		}
+		if v, ok := raw["network"].(string); ok {
+			sc.network = v
+		}
+		if extras, ok := raw["extra_args"].([]any); ok {
+			for _, a := range extras {
+				if s, ok := a.(string); ok {
+					sc.extraArgs = append(sc.extraArgs, s)
+				}
+			}
+		}
+		if sc.image == "" {
+			return fmt.Errorf("cli runner: sandbox.image is required when sandbox is configured")
+		}
+		r.sandbox = sc
+	}
 	return nil
 }
 
@@ -103,11 +224,25 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		argv = append(argv, r.promptFlag, prompt)
 	}
 
-	cmd := exec.CommandContext(ctx, r.command, argv...)
-	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
-	for k, v := range req.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
+	var cmd *exec.Cmd
+	if r.sandbox != nil {
+		// Container isolation: run the agent CLI inside Docker. Per-task
+		// credentials are injected via --env KEY (no value in argv) to keep
+		// them out of the host process table. The docker host process inherits
+		// only the safe allowlist of host env vars.
+		dockerBin, dockerArgv, dockerEnv := r.sandbox.wrapCommand(r.command, argv, req.WorkingDir, req.Env)
+		cmd = exec.CommandContext(ctx, dockerBin, dockerArgv...)
+		cmd.Env = dockerEnv
+	} else {
+		// Non-sandbox: inherit the full daemon env so provider CLI tools
+		// (claude, opencode, etc.) can pick up ANTHROPIC_API_KEY and other
+		// credentials from the host environment. req.Env overlays on top.
+		cmd = exec.CommandContext(ctx, r.command, argv...)
+		cmd.Dir = req.WorkingDir
+		cmd.Env = os.Environ()
+		for k, v := range req.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
 	}
 	if r.promptFlag == "" && !r.promptPositional {
 		cmd.Stdin = strings.NewReader(prompt)

--- a/src/internal/runner/execution/sandbox_test.go
+++ b/src/internal/runner/execution/sandbox_test.go
@@ -1,0 +1,226 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFilteredHostEnv_AllowlistedKeysPass verifies that keys in hostEnvAllowList
+// are forwarded and unrecognised keys are dropped.
+func TestFilteredHostEnv_AllowlistedKeysPass(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv("HOME", "/home/test")
+	t.Setenv("ANTHROPIC_API_KEY", "secret")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "other-secret")
+
+	env := filteredHostEnv(nil)
+
+	got := make(map[string]string)
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		got[k] = v
+	}
+
+	if got["PATH"] != "/usr/bin" {
+		t.Errorf("PATH should pass through; got %q", got["PATH"])
+	}
+	if got["HOME"] != "/home/test" {
+		t.Errorf("HOME should pass through; got %q", got["HOME"])
+	}
+	if _, found := got["ANTHROPIC_API_KEY"]; found {
+		t.Error("ANTHROPIC_API_KEY must not pass through the filter")
+	}
+	if _, found := got["AWS_SECRET_ACCESS_KEY"]; found {
+		t.Error("AWS_SECRET_ACCESS_KEY must not pass through the filter")
+	}
+}
+
+// TestFilteredHostEnv_OverlayAdded verifies that overlay keys appear in the
+// output even when they are not in the allowlist.
+func TestFilteredHostEnv_OverlayAdded(t *testing.T) {
+	overlay := map[string]string{"CUSTOM_TOKEN": "tok123"}
+	env := filteredHostEnv(overlay)
+
+	got := make(map[string]string)
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		got[k] = v
+	}
+
+	if got["CUSTOM_TOKEN"] != "tok123" {
+		t.Errorf("overlay key CUSTOM_TOKEN should appear; got %q", got["CUSTOM_TOKEN"])
+	}
+}
+
+// TestFilteredHostEnv_OverlayPrecedence verifies that when an overlay key
+// collides with a host allowlist key the overlay value is the one present
+// (both entries appear because we append; the last one wins in exec, but
+// we verify the overlay value is in the slice).
+func TestFilteredHostEnv_OverlayPrecedence(t *testing.T) {
+	t.Setenv("HOME", "/home/daemon")
+	overlay := map[string]string{"HOME": "/home/task"}
+	env := filteredHostEnv(overlay)
+
+	// Find the last occurrence of HOME — that's what exec uses.
+	last := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HOME=") {
+			last = kv
+		}
+	}
+	if last != "HOME=/home/task" {
+		t.Errorf("overlay HOME should win; last entry was %q", last)
+	}
+}
+
+// TestWrapCommand_NoSecretsInArgv verifies that credentials in the overlay do
+// NOT appear as --env KEY=VALUE in the docker argv (which would expose them via
+// /proc/<pid>/cmdline). Instead only --env KEY is emitted, with the value
+// delivered through the returned hostEnv.
+func TestWrapCommand_NoSecretsInArgv(t *testing.T) {
+	s := &cliSandbox{image: "myimage:latest", user: "nobody", network: "none"}
+	overlay := map[string]string{"ANTHROPIC_API_KEY": "sk-secret"}
+
+	_, dockerArgv, hostEnv := s.wrapCommand("claude", []string{"--model", "claude-3"}, "/work", overlay)
+
+	// argv must contain --env ANTHROPIC_API_KEY but NOT --env ANTHROPIC_API_KEY=sk-secret
+	for i, arg := range dockerArgv {
+		if arg == "--env" && i+1 < len(dockerArgv) {
+			val := dockerArgv[i+1]
+			if strings.Contains(val, "=") && strings.HasPrefix(val, "ANTHROPIC_API_KEY") {
+				t.Errorf("secret must not appear as KEY=VALUE in argv; found %q", val)
+			}
+		}
+	}
+
+	// The secret must be present in the returned hostEnv so docker can inject it.
+	found := false
+	for _, kv := range hostEnv {
+		if kv == "ANTHROPIC_API_KEY=sk-secret" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("ANTHROPIC_API_KEY=sk-secret must be in hostEnv so docker resolves --env KEY")
+	}
+}
+
+// TestWrapCommand_SecurityFlags verifies that the hardened docker flags are
+// always present regardless of sandbox config.
+func TestWrapCommand_SecurityFlags(t *testing.T) {
+	s := &cliSandbox{image: "myimage:latest"}
+	dockerBin, dockerArgv, _ := s.wrapCommand("opencode", []string{"run", "task"}, "/repo", nil)
+
+	if dockerBin != "docker" {
+		t.Errorf("expected binary=docker; got %q", dockerBin)
+	}
+
+	required := []string{"--read-only", "--cap-drop", "all", "--security-opt", "no-new-privileges"}
+	joined := strings.Join(dockerArgv, " ")
+	for _, flag := range required {
+		if !strings.Contains(joined, flag) {
+			t.Errorf("expected docker arg %q in argv %v", flag, dockerArgv)
+		}
+	}
+}
+
+// TestWrapCommand_DefaultUserAndNetwork verifies defaults.
+func TestWrapCommand_DefaultUserAndNetwork(t *testing.T) {
+	s := &cliSandbox{image: "myimage:latest"} // user and network left empty
+	_, dockerArgv, _ := s.wrapCommand("claude", nil, "", nil)
+
+	joined := strings.Join(dockerArgv, " ")
+	if !strings.Contains(joined, "--user nobody") {
+		t.Errorf("expected --user nobody in %v", dockerArgv)
+	}
+	if !strings.Contains(joined, "--network none") {
+		t.Errorf("expected --network none in %v", dockerArgv)
+	}
+}
+
+// TestWrapCommand_WorkdirMount verifies the working directory is bind-mounted.
+func TestWrapCommand_WorkdirMount(t *testing.T) {
+	s := &cliSandbox{image: "myimage:latest"}
+	_, dockerArgv, _ := s.wrapCommand("claude", nil, "/repo/workspace", nil)
+
+	joined := strings.Join(dockerArgv, " ")
+	if !strings.Contains(joined, "-v /repo/workspace:/repo/workspace") {
+		t.Errorf("expected workdir bind mount in argv %v", dockerArgv)
+	}
+	if !strings.Contains(joined, "-w /repo/workspace") {
+		t.Errorf("expected -w /repo/workspace in argv %v", dockerArgv)
+	}
+}
+
+// TestWrapCommand_ImageAndBinaryLast verifies image and binary appear at the
+// end (after all docker flags).
+func TestWrapCommand_ImageAndBinaryLast(t *testing.T) {
+	s := &cliSandbox{image: "myimage:latest"}
+	_, dockerArgv, _ := s.wrapCommand("claude", []string{"-p", "hello"}, "", nil)
+
+	// image should come before binary which comes before forwarded args
+	imageIdx, binaryIdx, promptIdx := -1, -1, -1
+	for i, a := range dockerArgv {
+		switch a {
+		case "myimage:latest":
+			imageIdx = i
+		case "claude":
+			binaryIdx = i
+		case "hello":
+			promptIdx = i
+		}
+	}
+	if imageIdx < 0 || binaryIdx < 0 || promptIdx < 0 {
+		t.Fatalf("image=%d binary=%d prompt=%d; argv=%v", imageIdx, binaryIdx, promptIdx, dockerArgv)
+	}
+	if !(imageIdx < binaryIdx && binaryIdx < promptIdx) {
+		t.Errorf("expected image < binary < args; positions image=%d binary=%d prompt=%d", imageIdx, binaryIdx, promptIdx)
+	}
+}
+
+// TestConfigureSandbox_RequiresImage verifies that Configure rejects a sandbox
+// block with no image.
+func TestConfigureSandbox_RequiresImage(t *testing.T) {
+	r := &CliRunner{}
+	err := r.Configure(map[string]any{
+		"command": "claude",
+		"sandbox": map[string]any{
+			"user": "nobody",
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "sandbox.image") {
+		t.Errorf("expected error about sandbox.image; got %v", err)
+	}
+}
+
+// TestConfigureSandbox_ParsesFields verifies that Configure reads all sandbox fields.
+func TestConfigureSandbox_ParsesFields(t *testing.T) {
+	r := &CliRunner{}
+	err := r.Configure(map[string]any{
+		"command": "opencode",
+		"sandbox": map[string]any{
+			"image":      "myimage:v1",
+			"user":       "1000:1000",
+			"network":    "bridge",
+			"extra_args": []any{"-v", "/cache:/cache:ro"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	if r.sandbox == nil {
+		t.Fatal("expected sandbox to be set")
+	}
+	if r.sandbox.image != "myimage:v1" {
+		t.Errorf("image: want myimage:v1 got %q", r.sandbox.image)
+	}
+	if r.sandbox.user != "1000:1000" {
+		t.Errorf("user: want 1000:1000 got %q", r.sandbox.user)
+	}
+	if r.sandbox.network != "bridge" {
+		t.Errorf("network: want bridge got %q", r.sandbox.network)
+	}
+	if len(r.sandbox.extraArgs) != 2 || r.sandbox.extraArgs[0] != "-v" {
+		t.Errorf("extra_args: want [\"-v\",\"/cache:/cache:ro\"] got %v", r.sandbox.extraArgs)
+	}
+}


### PR DESCRIPTION
## Summary

Rework of rejected PR #254. Addresses all four council objections:

- **Correctness (was: veto)**: Non-sandbox path fully restored to `os.Environ()` + overlay — provider CLI tools keep their API key access unchanged. `filteredHostEnv` only applies to the docker host process when sandbox is enabled.

- **Security (was: veto)**: Per-task credentials are no longer passed as `--env KEY=VALUE` on argv. Instead the sandbox emits `--env KEY` (no value in argv) and delivers the value through the docker host process environment (`filteredHostEnv(overlay)`). Docker resolves the value from its own env — secrets never appear in `/proc/<pid>/cmdline` or `ps`.

- **Simplification (was: reject)**: `opencodeDefaultPerms()` is a single shared helper called by both `writeOpencodeAgent` and `registerAgentInConfig`. No duplication.

- **Hardening**: Default sandbox flags now include `--read-only`, `--tmpfs /tmp:rw,noexec,nosuid,size=64m`, `--cap-drop all`, `--security-opt no-new-privileges` in addition to `--user` and `--network`.

### Changes

- **`config/config.go`** — new `SandboxConfig` struct on `RunnerConfig`; new `Permissions map[string]string` on `AgentConfig`
- **`runner/execution/cli.go`** — `cliSandbox.wrapCommand()` returns `(binary, argv, hostEnv)`; sandbox path uses `filteredHostEnv(overlay)`; non-sandbox path unchanged
- **`daemon/dispatcher.go`** — `opencodeDefaultPerms()` shared helper; `injectSandbox()` folds config into runner map; both OpenCode registration paths use least-privilege defaults (bash/edit/webfetch: deny by default)
- **`runner/execution/sandbox_test.go`** — 9 new unit tests covering: allowlist filtering, overlay injection, no-secrets-in-argv, security flags, default user/network, workdir mount, image/binary ordering, Configure validation

### Config example

```yaml
runners:
  - id: opencode-sandboxed
    type: cli
    provider: opencode
    sandbox:
      image: "ghcr.io/org/opencode-agent:latest"
      user: "nobody"
      network: "none"
    config:
      command: opencode
      working_dir: /workspace

agents:
  - id: engineer
    runner: opencode-sandboxed
    # Explicit credential injection for sandboxed runners:
    env:
      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
    # Opt in to bash + edit only when needed:
    permissions:
      bash: allow
      edit: allow
```

## Test plan

- [x] 9 new unit tests in `sandbox_test.go` — all pass
- [x] Full test suite passes (`go test ./...` — 23 packages, 0 failures)
- [x] `go build ./...` clean
- [x] GitNexus re-indexed (`gitnexus analyze --skip-agents-md`)

Fixes #289
Closes #232