### PR TITLE
fix(config): warn-and-load .env with loose permissions instead of refusing

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }


### PR DESCRIPTION
## Summary

- Fixes the behavior rejected in PR #269: the old code did an early `return` on a group/world-readable `.env`, silently skipping all credentials and breaking startup for users with common default file permissions (0644/0640).
- New behavior: **warn-and-load**. A `WARN` log message is emitted (including the `chmod 0600` remediation hint) and loading continues normally. Startup is never blocked by a permission mismatch.
- Adds `checkDotEnvPerms` as a platform-specific helper (returns a warning string; no-op stub on Windows which uses ACLs).
- Three new tests: 0600 (no warning, file loaded), 0644 world-readable (warning emitted, file still loaded), 0640 group-readable (warning emitted), missing file (no warning).

## Test plan

- [ ] `go test github.com/orlandoburli/apiary/internal/config` passes (all existing + new tests green).
- [ ] Run with a 0644 `.env` alongside `apiary.yaml` and confirm the WARN appears but vars are set.
- [ ] Run with a 0600 `.env` and confirm no warning and vars are set.

Closes #293