### PR TITLE
security(daemon): authenticate Unix-socket control plane (SEC-11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10318 symbols, 23615 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10318 symbols, 23615 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/src/internal/cli/dashboard_cmd.go
+++ b/src/internal/cli/dashboard_cmd.go
@@ -44,8 +44,10 @@ func runDashboard(ctx context.Context) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	socketPath := daemon.SocketPath(config.DataDir(configFile))
-	app := dashboard.New(dbConn, socketPath, cfg, getLogDir())
+	dataDir := config.DataDir(configFile)
+	socketPath := daemon.SocketPath(dataDir)
+	socketToken, _ := daemon.ReadSocketToken(dataDir)
+	app := dashboard.New(dbConn, socketPath, socketToken, cfg, getLogDir())
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("dashboard error: %w", err)
 	}

--- a/src/internal/cli/delete.go
+++ b/src/internal/cli/delete.go
@@ -52,7 +52,8 @@ func newDeleteCmd() *cobra.Command {
 				}
 			}
 
-			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			dataDir := config.DataDir(configFile)
+			socketPath := daemon.SocketPath(dataDir)
 			transport := &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -60,8 +61,14 @@ func newDeleteCmd() *cobra.Command {
 			}
 			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 
-			url := fmt.Sprintf("http://apiary/tasks/delete/%s", taskID)
-			resp, err := client.Post(url, "application/json", nil)
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/tasks/delete/%s", taskID), nil)
+			if err != nil {
+				return fmt.Errorf("building request: %w", err)
+			}
+			if token, err := daemon.ReadSocketToken(dataDir); err == nil {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("cannot reach daemon: %w", err)
 			}

--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -32,7 +32,8 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 				return fmt.Errorf("cell id is required")
 			}
 
-			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			dataDir := config.DataDir(configFile)
+			socketPath := daemon.SocketPath(dataDir)
 			transport := &http.Transport{
 				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -40,8 +41,14 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 			}
 			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 
-			url := fmt.Sprintf("http://apiary/restart/%s", cellID)
-			resp, err := client.Post(url, "application/json", nil)
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/restart/%s", cellID), nil)
+			if err != nil {
+				return fmt.Errorf("building request: %w", err)
+			}
+			if token, err := daemon.ReadSocketToken(dataDir); err == nil {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("cannot reach daemon: %w", err)
 			}

--- a/src/internal/cli/resume.go
+++ b/src/internal/cli/resume.go
@@ -166,7 +166,8 @@ func confirm(prompt string) bool {
 // JSON response into out (when non-nil). It returns the HTTP status code (0 on
 // transport failure) so callers can map distinct exit codes.
 func ipcDo(method, path string, out any) (int, error) {
-	socketPath := daemon.SocketPath(config.DataDir(configFile))
+	dataDir := config.DataDir(configFile)
+	socketPath := daemon.SocketPath(dataDir)
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
@@ -177,6 +178,9 @@ func ipcDo(method, path string, out any) (int, error) {
 	req, err := http.NewRequest(method, "http://apiary"+path, nil)
 	if err != nil {
 		return 0, err
+	}
+	if token, err := daemon.ReadSocketToken(dataDir); err == nil {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -995,6 +996,28 @@ func (d *Dispatcher) controlLabels(cell model.SourceItem) []string {
 	return out
 }
 
+// socketAuthMiddleware enforces Bearer token authentication on all mutating
+// (non-GET, non-HEAD) requests to the IPC socket. Read-only endpoints remain
+// accessible without credentials so that health checks and status queries work
+// even when the token file is temporarily unavailable.
+//
+// The token is written to <dataDir>/apiary.token (mode 0600) at daemon startup.
+// Clients read it with daemon.ReadSocketToken before sending mutating requests.
+func socketAuthMiddleware(token string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet || r.Method == http.MethodHead {
+			next.ServeHTTP(w, r)
+			return
+		}
+		provided := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if len(provided) == 0 || len(provided) != len(token) || subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
+			http.Error(w, "unauthorized: valid socket token required", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // StartServer starts an HTTP server on the Unix socket for IPC.
 // It removes any stale socket file before binding.
 func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error {
@@ -1004,6 +1027,11 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	}
 	// remove stale socket
 	_ = os.Remove(path)
+
+	token, err := writeSocketToken(config.DataDir(d.configFile))
+	if err != nil {
+		return fmt.Errorf("socket auth: %w", err)
+	}
 
 	ln, err := net.Listen("unix", path)
 	if err != nil {
@@ -1284,7 +1312,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		_ = json.NewEncoder(w).Encode(map[string]any{"deleted": taskRef})
 	})
 
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: socketAuthMiddleware(token, mux)}
 
 	wg.Add(1)
 	go func() {

--- a/src/internal/daemon/socket.go
+++ b/src/internal/daemon/socket.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -17,6 +20,43 @@ func SocketPath(dataDir string) string {
 		return "/tmp/apiary.sock"
 	}
 	return filepath.Join(dataDir, "apiary.sock")
+}
+
+// TokenPath returns the path for the socket auth token file. The file is
+// written with mode 0600 so only the daemon owner can read it.
+func TokenPath(dataDir string) string {
+	if dataDir == "" {
+		return "/tmp/apiary.token"
+	}
+	return filepath.Join(dataDir, "apiary.token")
+}
+
+// writeSocketToken generates a fresh 32-byte random token, writes it to the
+// token file (mode 0600), and returns the hex-encoded token string.
+func writeSocketToken(dataDir string) (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generating socket token: %w", err)
+	}
+	token := hex.EncodeToString(raw)
+	path := TokenPath(dataDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", fmt.Errorf("creating token dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(token), 0600); err != nil {
+		return "", fmt.Errorf("writing socket token: %w", err)
+	}
+	return token, nil
+}
+
+// ReadSocketToken reads the socket auth token from the token file. CLI commands
+// call this before sending mutating requests to the IPC server.
+func ReadSocketToken(dataDir string) (string, error) {
+	data, err := os.ReadFile(TokenPath(dataDir))
+	if err != nil {
+		return "", fmt.Errorf("reading socket token: %w", err)
+	}
+	return string(data), nil
 }
 
 // ensureSocketDir creates the directory that will hold the socket file.

--- a/src/internal/daemon/socket_auth_test.go
+++ b/src/internal/daemon/socket_auth_test.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSocketAuthMiddlewareAllowsGET(t *testing.T) {
+	token := "testtoken"
+	handler := socketAuthMiddleware(token, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// GET without any Authorization header must pass through.
+	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET without token: expected 200, got %d", w.Code)
+	}
+}
+
+func TestSocketAuthMiddlewareBlocksMutatingWithoutToken(t *testing.T) {
+	token := "testtoken"
+	handler := socketAuthMiddleware(token, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodDelete, http.MethodPut} {
+		req := httptest.NewRequest(method, "/restart/cell-1", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s without token: expected 401, got %d", method, w.Code)
+		}
+	}
+}
+
+func TestSocketAuthMiddlewareBlocksWrongToken(t *testing.T) {
+	token := "correcttoken"
+	handler := socketAuthMiddleware(token, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/restart/cell-1", nil)
+	req.Header.Set("Authorization", "Bearer wrongtoken")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("POST with wrong token: expected 401, got %d", w.Code)
+	}
+}
+
+func TestSocketAuthMiddlewareAllowsCorrectToken(t *testing.T) {
+	token := "correcttoken"
+	handler := socketAuthMiddleware(token, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/restart/cell-1", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST with correct token: expected 200, got %d", w.Code)
+	}
+}
+
+func TestWriteAndReadSocketToken(t *testing.T) {
+	dir := t.TempDir()
+
+	token, err := writeSocketToken(dir)
+	if err != nil {
+		t.Fatalf("writeSocketToken: %v", err)
+	}
+	if len(token) != 64 { // 32 bytes → 64 hex chars
+		t.Fatalf("unexpected token length %d", len(token))
+	}
+
+	got, err := ReadSocketToken(dir)
+	if err != nil {
+		t.Fatalf("ReadSocketToken: %v", err)
+	}
+	if got != token {
+		t.Fatalf("token mismatch: wrote %q, read %q", token, got)
+	}
+}
+
+func TestSocketAuthMiddlewareDashboardApprovalRequiresToken(t *testing.T) {
+	token := "securetoken"
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	})
+	handler := socketAuthMiddleware(token, inner)
+
+	// Dashboard approval path without token must be rejected.
+	req := httptest.NewRequest(http.MethodPost, "/approvals/req-1/respond", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("approval without token: expected 401, got %d", w.Code)
+	}
+	if called {
+		t.Fatal("inner handler should not have been called without token")
+	}
+
+	// With correct token it must reach the inner handler.
+	req2 := httptest.NewRequest(http.MethodPost, "/approvals/req-1/respond", nil)
+	req2.Header.Set("Authorization", "Bearer "+token)
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusAccepted {
+		t.Fatalf("approval with token: expected 202, got %d", w2.Code)
+	}
+}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -53,10 +53,11 @@ const logPrefixWidth = 15
 // event-loop goroutine) is allowed to mutate the model. This is what keeps
 // the data-fetching goroutines from racing with View.
 type App struct {
-	model      *Model
-	dbConn     *db.Client
-	socketPath string
-	cfg        *config.Config
+	model       *Model
+	dbConn      *db.Client
+	socketPath  string
+	socketToken string
+	cfg         *config.Config
 	// logDir is the daemon's log directory, used to locate per-task markdown
 	// transcripts (logDir/transcripts/<task>/...).
 	logDir string
@@ -74,13 +75,14 @@ type App struct {
 	logMDWidth   int
 }
 
-func New(dbConn *db.Client, socketPath string, cfg *config.Config, logDir string) *App {
+func New(dbConn *db.Client, socketPath, socketToken string, cfg *config.Config, logDir string) *App {
 	return &App{
-		model:      NewModel(),
-		dbConn:     dbConn,
-		socketPath: socketPath,
-		cfg:        cfg,
-		logDir:     logDir,
+		model:       NewModel(),
+		dbConn:      dbConn,
+		socketPath:  socketPath,
+		socketToken: socketToken,
+		cfg:         cfg,
+		logDir:      logDir,
 	}
 }
 
@@ -1570,8 +1572,14 @@ func (a *App) restartTaskCmd(taskID string) tea.Cmd {
 			},
 		}
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/restart/%s", taskID)
-		resp, err := client.Post(url, "application/json", nil)
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/restart/%s", taskID), nil)
+		if err != nil {
+			return nil
+		}
+		if a.socketToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.socketToken)
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1597,8 +1605,14 @@ func (a *App) refreshTaskPullsCmd(internalTaskID string) tea.Cmd {
 			},
 		}
 		client := &http.Client{Transport: transport, Timeout: 8 * time.Second}
-		url := fmt.Sprintf("http://apiary/tasks/pulls/refresh/%s", internalTaskID)
-		resp, err := client.Post(url, "application/json", nil)
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/tasks/pulls/refresh/%s", internalTaskID), nil)
+		if err != nil {
+			return nil
+		}
+		if a.socketToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.socketToken)
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1619,8 +1633,14 @@ func (a *App) clearLogsCmd(taskID string) tea.Cmd {
 			},
 		}
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/clearlogs/%s", taskID)
-		resp, err := client.Post(url, "application/json", nil)
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/clearlogs/%s", taskID), nil)
+		if err != nil {
+			return nil
+		}
+		if a.socketToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.socketToken)
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1639,8 +1659,14 @@ func (a *App) stopInstanceCmd(instanceID string) tea.Cmd {
 			},
 		}
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/instances/stop/%s", instanceID)
-		resp, err := client.Post(url, "application/json", nil)
+		req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://apiary/instances/stop/%s", instanceID), nil)
+		if err != nil {
+			return nil
+		}
+		if a.socketToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.socketToken)
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil
 		}
@@ -1662,6 +1688,9 @@ func (a *App) approvalResponseCmd(requestID, decision string) tea.Cmd {
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 		req, _ := http.NewRequest(http.MethodPost, "http://apiary/approvals/"+requestID+"/respond", bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
+		if a.socketToken != "" {
+			req.Header.Set("Authorization", "Bearer "+a.socketToken)
+		}
 		resp, err := client.Do(req)
 		if err == nil {
 			resp.Body.Close()
@@ -1946,6 +1975,9 @@ func (a *App) patchAgentViaSocket(agentID, model, runner string, maxWorkers int)
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if a.socketToken != "" {
+		req.Header.Set("Authorization", "Bearer "+a.socketToken)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Writes a 32-byte random token to `<dataDir>/apiary.token` (mode `0600`) at daemon startup; clients read it via `daemon.ReadSocketToken` before sending mutating requests.
- Adds `socketAuthMiddleware` that enforces `Authorization: Bearer <token>` on every non-GET/HEAD endpoint of the IPC socket. Read-only endpoints (`/status`, `/health`, `/events`, instance/workflow queries) remain open.
- Fixes the dashboard approval bypass: `POST /approvals/{id}/respond` (dashboard path) previously had no authentication while the webhook path enforced HMAC. The middleware now gates both paths identically at the transport layer.
- Updates all CLI commands (`restart`, `delete`, `resume/ipcDo`) and the dashboard (`restartTaskCmd`, `clearLogsCmd`, `refreshTaskPullsCmd`, `stopInstanceCmd`, `approvalResponseCmd`, `patchAgentViaSocket`) to attach the Bearer token.
- Adds 5 unit tests covering: GET pass-through, mutating-method rejection without token, wrong token rejection, correct token acceptance, and the approval bypass fix.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/daemon/... ./internal/cli/... ./internal/dashboard/...` — all pass
- [x] New tests in `socket_auth_test.go` cover all middleware branches and the token file round-trip

Closes #234