### PR TITLE
security: constrain agent output side-effects (SEC-12)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -287,6 +287,13 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+	// AgentPublishSources is an optional allow-list of source IDs that agent
+	// steps are permitted to post APIARY_PUBLISH comments to. When non-empty,
+	// publish write-backs targeting any other source are silently skipped — the
+	// payload is still recorded on the step run for auditing, but the comment is
+	// not posted. When empty (the default) there is no restriction and all bound
+	// sources may receive agent-authored comments.
+	AgentPublishSources []string `yaml:"agent_publish_sources,omitempty"`
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -823,7 +823,9 @@ func (e *Engine) materializeChild(ctx context.Context, parent model.InternalTask
 // source bindings and records the outcome on the step run. The executor has
 // already cleared the payload when the step set publish: off, so a non-empty
 // payload here means write-back was requested. A task with no bindings (e.g. a
-// spawned task) is silently skipped.
+// spawned task) is silently skipped. When settings.agent_publish_sources is
+// non-empty, only bindings whose source ID appears in the allow-list receive the
+// comment; others are silently dropped (payload still recorded for auditing).
 func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, res StepResult, sr *db.StepRun) {
 	if res.PublishPayload == "" {
 		return
@@ -833,11 +835,37 @@ func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindi
 		sr.PublishState = db.PublishStateSkipped
 		return
 	}
+	// Enforce the publish allow-list: if configured, filter out bindings for
+	// sources not in the list. A fully-filtered result skips the write-back
+	// without error so the step does not fail due to a config restriction.
+	if allowed := e.cfg.Settings.AgentPublishSources; len(allowed) > 0 {
+		bindings = filterAllowedBindings(bindings, allowed)
+		if len(bindings) == 0 {
+			sr.PublishState = db.PublishStateSkipped
+			return
+		}
+	}
 	if err := e.side.PostComment(ctx, task, bindings, res.PublishPayload); err != nil {
 		sr.PublishState = db.PublishStateFailed
 		return
 	}
 	sr.PublishState = db.PublishStateSent
+}
+
+// filterAllowedBindings returns the subset of bindings whose SourceID appears
+// in allowed. The original slice is never mutated.
+func filterAllowedBindings(bindings []model.SourceBinding, allowed []string) []model.SourceBinding {
+	set := make(map[string]struct{}, len(allowed))
+	for _, s := range allowed {
+		set[s] = struct{}{}
+	}
+	out := make([]model.SourceBinding, 0, len(bindings))
+	for _, b := range bindings {
+		if _, ok := set[b.SourceID]; ok {
+			out = append(out, b)
+		}
+	}
+	return out
 }
 
 // applyCompletion applies the on_complete/on_fail hook and posts the on_complete

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -737,6 +737,96 @@ func TestEngine_StructuredOutputPersisted(t *testing.T) {
 	}
 }
 
+// TestEngine_PublishAllowList verifies that settings.agent_publish_sources
+// restricts APIARY_PUBLISH write-backs: a binding in the allow-list receives
+// the comment; a binding not in the list is silently skipped while the payload
+// is still recorded on the step run for auditing.
+func TestEngine_PublishAllowList(t *testing.T) {
+	t.Run("binding in allow-list posts comment", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.Settings.ResultComment = false
+		cfg.Settings.AgentPublishSources = []string{"allowed-source"}
+		store := newFakeStore()
+		store.bindings["T1"] = []model.SourceBinding{
+			{TaskID: "T1", SourceID: "allowed-source", SourceItemID: "ISSUE-10"},
+		}
+		exec := &fakeExecutor{results: map[string]StepResult{
+			"run": {Success: true, Output: "done", PublishPayload: "allowed comment"},
+		}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "T1", Title: "T"}); err != nil {
+			t.Fatalf("RunInstance: %v", err)
+		}
+		if len(side.comments) != 1 || side.comments[0] != "allowed comment" {
+			t.Errorf("expected comment to allowed-source, got %#v", side.comments)
+		}
+		sr := store.stepRuns[store.stepOrder[0]]
+		if sr.PublishState != db.PublishStateSent {
+			t.Errorf("publish_state = %q, want %q", sr.PublishState, db.PublishStateSent)
+		}
+		if sr.PublishPayload != "allowed comment" {
+			t.Errorf("publish_payload not persisted: %q", sr.PublishPayload)
+		}
+	})
+
+	t.Run("binding not in allow-list is skipped", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.Settings.ResultComment = false
+		cfg.Settings.AgentPublishSources = []string{"allowed-source"}
+		store := newFakeStore()
+		store.bindings["T2"] = []model.SourceBinding{
+			{TaskID: "T2", SourceID: "blocked-source", SourceItemID: "ISSUE-20"},
+		}
+		exec := &fakeExecutor{results: map[string]StepResult{
+			"run": {Success: true, Output: "done", PublishPayload: "should be blocked"},
+		}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "T2", Title: "T"}); err != nil {
+			t.Fatalf("RunInstance: %v", err)
+		}
+		if len(side.comments) != 0 {
+			t.Errorf("expected no comment for blocked source, got %#v", side.comments)
+		}
+		sr := store.stepRuns[store.stepOrder[0]]
+		if sr.PublishState != db.PublishStateSkipped {
+			t.Errorf("publish_state = %q, want %q", sr.PublishState, db.PublishStateSkipped)
+		}
+		// Payload still persisted for auditing even when skipped.
+		if sr.PublishPayload != "should be blocked" {
+			t.Errorf("publish_payload not persisted: %q", sr.PublishPayload)
+		}
+	})
+
+	t.Run("empty allow-list permits all sources", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.Settings.ResultComment = false
+		// AgentPublishSources is nil → no restriction.
+		store := newFakeStore()
+		store.bindings["T3"] = []model.SourceBinding{
+			{TaskID: "T3", SourceID: "any-source", SourceItemID: "ISSUE-30"},
+		}
+		exec := &fakeExecutor{results: map[string]StepResult{
+			"run": {Success: true, Output: "done", PublishPayload: "open comment"},
+		}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "T3", Title: "T"}); err != nil {
+			t.Fatalf("RunInstance: %v", err)
+		}
+		if len(side.comments) != 1 {
+			t.Errorf("expected comment when allow-list is empty, got %#v", side.comments)
+		}
+	})
+}
+
 func TestSynthWF(t *testing.T) {
 	route := config.RouteConfig{
 		ID: "backend-bugs", Priority: 10, Agent: "backend-dev",

--- a/src/internal/workflow/spawner.go
+++ b/src/internal/workflow/spawner.go
@@ -15,6 +15,35 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
+// maxSpawnDepth is the maximum number of times an agent-driven APIARY_SPAWN
+// chain may nest before the engine refuses to create further children. It
+// prevents runaway self-propagating spawn loops triggered by prompt injection.
+// Depth is tracked via the spawn context; the root caller has depth 0 and each
+// spawned child increments it by one.
+const maxSpawnDepth = 10
+
+// ProvenanceLabel is automatically appended to every child task created by an
+// agent APIARY_SPAWN request so agent-authored artifacts are distinguishable
+// from human-authored work in logs, routing rules, and source sub-issues.
+const ProvenanceLabel = "apiary:agent-spawned"
+
+// spawnDepthKey is the unexported context key used to track the current spawn
+// nesting depth across goroutine boundaries.
+type spawnDepthKey struct{}
+
+// spawnDepth returns the spawn depth embedded in ctx, or 0 when absent.
+func spawnDepth(ctx context.Context) int {
+	if v, ok := ctx.Value(spawnDepthKey{}).(int); ok {
+		return v
+	}
+	return 0
+}
+
+// withSpawnDepth returns a child context carrying the given spawn depth.
+func withSpawnDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, spawnDepthKey{}, depth)
+}
+
 // WorkflowSpawner creates a child InternalTask for an APIARY_SPAWN request and
 // runs the named workflow against it. The engine holds one via an interface field
 // so it stays testable in isolation (see Engine.spawner / WithSpawner).
@@ -97,6 +126,15 @@ func NewDefaultSpawner(
 // it without creating a duplicate or launching the workflow again — so re-running
 // the same decomposition does not fan out a second, duplicate set of sub-issues.
 func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (model.InternalTask, error) {
+	// Enforce the spawn depth limit before any work: an injected agent can emit
+	// APIARY_SPAWN to create a child that itself spawns more children, forming a
+	// self-propagating loop. Rejecting requests beyond maxSpawnDepth stops the
+	// chain at a safe bound regardless of how the injection was crafted.
+	depth := spawnDepth(ctx)
+	if depth >= maxSpawnDepth {
+		return model.InternalTask{}, fmt.Errorf("spawn depth limit (%d) exceeded — refusing to create child task (possible injection loop)", maxSpawnDepth)
+	}
+
 	// A materialize-only spawn (empty workflow) creates the deduped child but runs
 	// no inline workflow — the child is left for the normal poll→route loop to pick
 	// up once it is materialized as a source sub-issue (see step.Materialize). Only
@@ -122,6 +160,13 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 		return *existing, nil
 	}
 
+	// Attach the provenance label to every agent-authored child so it is
+	// distinguishable from human-authored work in logs, routing rules, and source
+	// sub-issues without requiring callers to add it explicitly.
+	labels := make([]string, 0, len(req.Labels)+1)
+	labels = append(labels, req.Labels...)
+	labels = append(labels, ProvenanceLabel)
+
 	now := s.now()
 	child := model.InternalTask{
 		ID:           s.newID("task"),
@@ -131,7 +176,7 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 		Input:        req.Input,
 		DedupKey:     dedupKey,
 		State:        model.TaskStateRegistered,
-		Metadata:     model.TaskMetadata{Type: "internal", Labels: req.Labels},
+		Metadata:     model.TaskMetadata{Type: "internal", Labels: labels},
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -162,11 +207,13 @@ func (s *DefaultSpawner) Spawn(ctx context.Context, req model.SpawnRequest) (mod
 	s.running[child.ID] = h
 	s.mu.Unlock()
 
-	// Fire-and-forget: the child workflow runs on its own goroutine with a context
-	// detached from the parent step, so cancelling the step does not abort the
-	// spawned work. spawn:await callers observe completion through Await.
+	// Pass depth+1 into the child context so any further APIARY_SPAWN inside the
+	// child's workflow is counted against the limit. WithoutCancel preserves
+	// context values (including the depth key) while detaching from the parent
+	// cancellation, so the spawned work outlives the parent step.
+	childCtx := withSpawnDepth(context.WithoutCancel(ctx), depth+1)
 	go func() {
-		success, err := s.run(context.WithoutCancel(ctx), wf, child)
+		success, err := s.run(childCtx, wf, child)
 		h.success = success && err == nil
 		close(h.done)
 	}()

--- a/src/internal/workflow/spawner_test.go
+++ b/src/internal/workflow/spawner_test.go
@@ -152,8 +152,13 @@ func TestDefaultSpawner_MaterializeOnly(t *testing.T) {
 	if child.Description != "GIVEN ... THEN ..." {
 		t.Errorf("child Description = %q, want body", child.Description)
 	}
-	if len(child.Metadata.Labels) != 1 || child.Metadata.Labels[0] != "agent:backend" {
-		t.Errorf("child labels = %v, want [agent:backend]", child.Metadata.Labels)
+	// Caller-supplied labels plus the automatic provenance label must be present.
+	wantLabels := map[string]bool{"agent:backend": true, ProvenanceLabel: true}
+	for _, l := range child.Metadata.Labels {
+		delete(wantLabels, l)
+	}
+	if len(wantLabels) != 0 {
+		t.Errorf("child labels = %v, missing: %v", child.Metadata.Labels, wantLabels)
 	}
 	if child.DedupKey != "customer-crud-endpoint" {
 		t.Errorf("child DedupKey = %q, want explicit key", child.DedupKey)
@@ -327,5 +332,117 @@ func TestDefaultSpawner_AwaitUnknownTask(t *testing.T) {
 	)
 	if _, err := s.Await(context.Background(), "never-spawned"); err == nil {
 		t.Fatal("expected error awaiting an untracked task")
+	}
+}
+
+// TestDefaultSpawner_SpawnDepthLimit verifies that Spawn rejects requests once
+// the context depth reaches maxSpawnDepth, preventing runaway injection loops.
+func TestDefaultSpawner_SpawnDepthLimit(t *testing.T) {
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+		&fakeCreator{},
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+	req := model.SpawnRequest{WorkflowID: "w", Title: "child"}
+
+	// One below the limit must succeed.
+	belowCtx := withSpawnDepth(context.Background(), maxSpawnDepth-1)
+	if _, err := s.Spawn(belowCtx, req); err != nil {
+		t.Fatalf("Spawn at depth %d: unexpected error: %v", maxSpawnDepth-1, err)
+	}
+
+	// At the limit must be rejected.
+	atCtx := withSpawnDepth(context.Background(), maxSpawnDepth)
+	_, err := s.Spawn(atCtx, req)
+	if err == nil {
+		t.Fatalf("Spawn at depth %d: expected error, got nil", maxSpawnDepth)
+	}
+}
+
+// TestDefaultSpawner_ProvenanceLabel verifies that every agent-spawned child
+// carries ProvenanceLabel regardless of what labels the spawn request supplied.
+func TestDefaultSpawner_ProvenanceLabel(t *testing.T) {
+	creator := &fakeCreator{}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+		creator,
+		func(context.Context, config.WorkflowConfig, model.InternalTask) (bool, error) { return true, nil },
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+
+	for _, tc := range []struct {
+		name   string
+		labels []string
+	}{
+		{"no caller labels", nil},
+		{"with caller labels", []string{"agent:backend", "priority:high"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			creator.mu.Lock()
+			creator.tasks = nil
+			creator.mu.Unlock()
+
+			child, err := s.Spawn(context.Background(), model.SpawnRequest{
+				WorkflowID: "w",
+				Title:      "task-" + tc.name,
+				Labels:     tc.labels,
+				Key:        tc.name, // unique key per sub-test
+			})
+			if err != nil {
+				t.Fatalf("Spawn: %v", err)
+			}
+
+			found := false
+			for _, l := range child.Metadata.Labels {
+				if l == ProvenanceLabel {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("child labels %v missing ProvenanceLabel %q", child.Metadata.Labels, ProvenanceLabel)
+			}
+			// Caller-supplied labels must still be present.
+			for _, want := range tc.labels {
+				present := false
+				for _, got := range child.Metadata.Labels {
+					if got == want {
+						present = true
+						break
+					}
+				}
+				if !present {
+					t.Errorf("child labels %v missing caller label %q", child.Metadata.Labels, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDefaultSpawner_DepthPropagates verifies that the depth embedded in the
+// child's run context is one greater than the parent's, so cascading spawns
+// accumulate correctly toward the limit.
+func TestDefaultSpawner_DepthPropagates(t *testing.T) {
+	var capturedDepth int
+	run := func(ctx context.Context, _ config.WorkflowConfig, _ model.InternalTask) (bool, error) {
+		capturedDepth = spawnDepth(ctx)
+		return true, nil
+	}
+	s := NewDefaultSpawner(
+		func(string) (config.WorkflowConfig, bool) { return config.WorkflowConfig{ID: "w"}, true },
+		&fakeCreator{},
+		run,
+		testIDGen(), func() time.Time { return time.Unix(1000, 0) },
+	)
+
+	parentCtx := withSpawnDepth(context.Background(), 3)
+	if _, err := s.Spawn(parentCtx, model.SpawnRequest{WorkflowID: "w", Title: "child"}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	// Give the goroutine a moment to run.
+	time.Sleep(50 * time.Millisecond)
+	if capturedDepth != 4 {
+		t.Errorf("child context depth = %d, want 4 (parent 3 + 1)", capturedDepth)
 	}
 }


### PR DESCRIPTION
## Summary

- **Spawn depth limit**: `DefaultSpawner.Spawn` checks a depth counter embedded in the context and rejects APIARY_SPAWN requests at or beyond `maxSpawnDepth = 10`. The child goroutine receives a context with `depth+1`, so every level of a spawn chain accumulates correctly toward the cap — stopping runaway injection loops before they can fan out exponentially.
- **Provenance label**: every `InternalTask` created via APIARY_SPAWN automatically receives the label `apiary:agent-spawned` in `Metadata.Labels`. Agent-authored artifacts are now distinguishable from human-authored work in logs, routing rules, and source sub-issues without any extra workflow configuration.
- **Publish allow-list**: a new `settings.agent_publish_sources: [source-id, ...]` field in config. When non-empty, `publishStep` filters source bindings and only posts APIARY_PUBLISH comments to listed sources. Non-listed bindings are silently skipped (payload still recorded on the step run for auditing). Empty list (the default) preserves current unrestricted behaviour.

## Test plan

- [x] `TestDefaultSpawner_SpawnDepthLimit` — depth at `maxSpawnDepth-1` succeeds; at `maxSpawnDepth` returns error
- [x] `TestDefaultSpawner_DepthPropagates` — child workflow context carries `parent_depth + 1`
- [x] `TestDefaultSpawner_ProvenanceLabel` — `apiary:agent-spawned` present with and without caller-supplied labels
- [x] `TestEngine_PublishAllowList/binding_in_allow-list_posts_comment` — allowed source receives comment
- [x] `TestEngine_PublishAllowList/binding_not_in_allow-list_is_skipped` — blocked source skipped; payload still persisted
- [x] `TestEngine_PublishAllowList/empty_allow-list_permits_all_sources` — default behaviour unchanged
- [x] Full test suite (`go test ./...`) — all packages green

Closes #235