### PR TITLE
security: redact credentials in log output and add govulncheck to CI (SEC-17)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /src
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,37 @@
+name: govulncheck
+
+# Scans Go dependencies for known CVEs on every push and PR that touches
+# Go source or module files.
+on:
+  push:
+    paths:
+      - "src/**/*.go"
+      - "src/go.mod"
+      - "src/go.sum"
+      - ".github/workflows/govulncheck.yml"
+  pull_request:
+    paths:
+      - "src/**/*.go"
+      - "src/go.mod"
+      - "src/go.sum"
+      - ".github/workflows/govulncheck.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+        working-directory: src

--- a/src/internal/log/log.go
+++ b/src/internal/log/log.go
@@ -5,6 +5,7 @@ package log
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sync"
 	"time"
 )
@@ -13,7 +14,32 @@ var (
 	verbose bool
 	sinkMu  sync.RWMutex
 	sink    func(level, msg string)
+
+	// redactPatterns matches well-known credential formats embedded in log messages.
+	// Patterns mirror the value heuristics in internal/db/execution_event.go.
+	redactPatterns = []*regexp.Regexp{
+		// JWT: three base64url segments starting with the standard JSON header prefix
+		regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`),
+		// GitHub personal access tokens (classic and fine-grained)
+		regexp.MustCompile(`ghp_[A-Za-z0-9_-]+`),
+		regexp.MustCompile(`github_pat_[A-Za-z0-9_-]+`),
+		// Slack bot/user tokens
+		regexp.MustCompile(`xox[bp]-[A-Za-z0-9-]+`),
+		// AWS access key IDs
+		regexp.MustCompile(`AKIA[A-Z0-9]{16}`),
+	}
+	// bearerPattern keeps the "bearer " prefix so the log line stays readable.
+	bearerPattern = regexp.MustCompile(`(?i)(bearer\s+)\S+`)
 )
+
+// redact removes well-known credential patterns from msg before it reaches
+// stderr or any registered sink.
+func redact(msg string) string {
+	for _, p := range redactPatterns {
+		msg = p.ReplaceAllString(msg, "[REDACTED]")
+	}
+	return bearerPattern.ReplaceAllString(msg, "${1}[REDACTED]")
+}
 
 // Enable turns verbose (debug) output on or off.
 func Enable(v bool) { verbose = v }
@@ -55,7 +81,7 @@ func Error(format string, args ...any) {
 
 func print(level, format string, args ...any) {
 	ts := time.Now().Format("15:04:05")
-	msg := fmt.Sprintf(format, args...)
+	msg := redact(fmt.Sprintf(format, args...))
 	fmt.Fprintf(os.Stderr, "%s  %-5s  %s\n", ts, level, msg)
 
 	sinkMu.RLock()


### PR DESCRIPTION
## Summary

- **`internal/log`: credential redaction** — all messages written to stderr and any registered sink are now scrubbed via `redact()` before they leave the process. Patterns cover JWTs, GitHub PATs (`ghp_`/`github_pat_`), Slack tokens (`xoxb-`/`xoxp-`), AWS access key IDs (`AKIA*`), and Bearer header values. The implementation mirrors the value heuristics already used in `internal/db/execution_event.go` and `internal/runner/execution/transcript.go`, keeping redaction logic consistent across the codebase.
- **govulncheck CI** — new workflow `.github/workflows/govulncheck.yml` installs and runs `govulncheck ./...` on every push and pull request that touches Go source, `go.mod`, or `go.sum`.
- **Dependabot** — `.github/dependabot.yml` schedules weekly automated PRs for Go module and GitHub Actions version updates.

## Files changed

| File | Change |
|---|---|
| `src/internal/log/log.go` | Add `redact()` and apply it in `print()` |
| `.github/workflows/govulncheck.yml` | New vulnerability-scan workflow |
| `.github/dependabot.yml` | New Dependabot config (Go + Actions) |

Closes #240