### PR TITLE
fix(security): enforce collaborator trust gate at daemon ingest (SEC-01)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -47,6 +47,16 @@ type SourceConfig struct {
 	Config       map[string]any `yaml:"config"`
 	PollInterval string         `yaml:"poll_interval"`
 	Filters      SourceFilters  `yaml:"filters"`
+	Security     SourceSecurity `yaml:"security,omitempty"`
+}
+
+// SourceSecurity holds ingest-time trust controls for a source.
+type SourceSecurity struct {
+	// RequireTrustedAuthor, when true, prevents dispatch of items whose author
+	// is not a repository OWNER, MEMBER, or COLLABORATOR. Untrusted items are
+	// labelled needs-triage and skipped. Only effective for sources that carry
+	// author association information (e.g. GitHub).
+	RequireTrustedAuthor bool `yaml:"require_trusted_author"`
 }
 
 func (s SourceConfig) ParsedPollInterval() (time.Duration, error) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1366,6 +1366,15 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			aplog.Debug("cell %s: already in-flight, skipping", cell.LogLabel())
 			continue
 		}
+		// Trust gate: when the source requires trusted authors, refuse to dispatch
+		// items from non-collaborators. The check runs before bindItem so untrusted
+		// items are never persisted as tasks — eliminating the TOCTOU window that
+		// exists when relying solely on the triage-gate GitHub Action.
+		if sc.Security.RequireTrustedAuthor && !isTrustedAuthor(cell) {
+			d.parkUntrustedItem(ctx, cell, sc.ID)
+			d.inFlight.Delete(cell.ID)
+			continue
+		}
 		task, persisted := d.bindItem(ctx, cell)
 		d.recordRouteEvents(ctx, task)
 		matches := d.router.RouteAll(task)

--- a/src/internal/daemon/trust_gate.go
+++ b/src/internal/daemon/trust_gate.go
@@ -1,0 +1,59 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// trustedAssociations are the GitHub author_association values that are
+// considered trusted: the repository owner, an org member, or an explicitly
+// invited collaborator. Every other value (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR,
+// FIRST_TIMER, MANNEQUIN, NONE) is untrusted.
+var trustedAssociations = map[string]bool{
+	"OWNER":        true,
+	"MEMBER":       true,
+	"COLLABORATOR": true,
+}
+
+// isTrustedAuthor reports whether a source item's author carries a trusted
+// association. Items with an empty AuthorAssociation are treated as trusted so
+// that sources that don't carry this field (Plane, Jira, …) are unaffected.
+func isTrustedAuthor(item model.SourceItem) bool {
+	if item.AuthorAssociation == "" {
+		return true
+	}
+	return trustedAssociations[strings.ToUpper(item.AuthorAssociation)]
+}
+
+// parkUntrustedItem labels the item as needs-triage, removes the ai-ready
+// label (best-effort), and logs the decision. It does not bind the item to the
+// DB so untrusted items leave no task footprint.
+func (d *Dispatcher) parkUntrustedItem(ctx context.Context, cell model.SourceItem, sourceID string) {
+	aplog.Info("trust-gate: source %s item %s (%q): author_association=%q is not trusted — labelling needs-triage and skipping dispatch",
+		sourceID, cell.LogLabel(), cell.Title, cell.AuthorAssociation)
+
+	adapter, ok := d.sources[sourceID]
+	if !ok {
+		return
+	}
+
+	// Strip the ai-ready label so the item leaves the filter set and stops
+	// being re-polled as a dispatch candidate. This is the same label removed
+	// by the triage-gate GitHub Action (defense-in-depth layer). Best-effort.
+	if remover, ok := adapter.(source.LabelRemover); ok {
+		if err := remover.RemoveLabels(ctx, cell, []string{"ai-ready"}); err != nil {
+			aplog.Warn("trust-gate: source %s item %s: remove ai-ready: %v", sourceID, cell.LogLabel(), err)
+		}
+	}
+
+	// Mark the item as needing human triage.
+	if adder, ok := adapter.(source.LabelAdder); ok {
+		if err := adder.AddLabels(ctx, cell, []string{"needs-triage"}); err != nil {
+			aplog.Warn("trust-gate: source %s item %s: add needs-triage: %v", sourceID, cell.LogLabel(), err)
+		}
+	}
+}

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -1,0 +1,269 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// --- isTrustedAuthor unit tests ---
+
+func TestIsTrustedAuthor(t *testing.T) {
+	cases := []struct {
+		assoc string
+		want  bool
+	}{
+		{"OWNER", true},
+		{"MEMBER", true},
+		{"COLLABORATOR", true},
+		{"owner", true},                  // case-insensitive
+		{"member", true},                 // case-insensitive
+		{"CONTRIBUTOR", false},
+		{"FIRST_TIME_CONTRIBUTOR", false},
+		{"FIRST_TIMER", false},
+		{"NONE", false},
+		{"MANNEQUIN", false},
+		{"", true}, // empty = source doesn't carry association; pass through
+	}
+
+	for _, tc := range cases {
+		item := model.SourceItem{AuthorAssociation: tc.assoc}
+		if got := isTrustedAuthor(item); got != tc.want {
+			t.Errorf("isTrustedAuthor(%q) = %v, want %v", tc.assoc, got, tc.want)
+		}
+	}
+}
+
+// --- stub adapter that records label mutations ---
+
+type trustGateAdapter struct {
+	mu            sync.Mutex
+	items         []model.SourceItem
+	removedLabels map[string][]string
+	addedLabels   map[string][]string
+}
+
+func (a *trustGateAdapter) ID() string                                    { return "tg" }
+func (a *trustGateAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *trustGateAdapter) Poll(_ context.Context, _ time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *trustGateAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *trustGateAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *trustGateAdapter) WebhookHandler() http.Handler { return nil }
+
+func (a *trustGateAdapter) RemoveLabels(_ context.Context, cell model.SourceItem, names []string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.removedLabels == nil {
+		a.removedLabels = map[string][]string{}
+	}
+	a.removedLabels[cell.ID] = append(a.removedLabels[cell.ID], names...)
+	return nil
+}
+
+func (a *trustGateAdapter) AddLabels(_ context.Context, cell model.SourceItem, names []string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.addedLabels == nil {
+		a.addedLabels = map[string][]string{}
+	}
+	a.addedLabels[cell.ID] = append(a.addedLabels[cell.ID], names...)
+	return nil
+}
+
+var (
+	_ source.LabelRemover = (*trustGateAdapter)(nil)
+	_ source.LabelAdder   = (*trustGateAdapter)(nil)
+)
+
+// newTrustGateDispatcher builds a minimal Dispatcher for trust-gate tests.
+// The source type "fake" is already registered (via fanout_test.go's init);
+// we swap in a trustGateAdapter instance after construction.
+func newTrustGateDispatcher(t *testing.T, requireTrustedAuthor bool) (*Dispatcher, *countingRunner, *trustGateAdapter) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "tg.db"))
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{
+			ID:   "src",
+			Type: "fake",
+			Security: config.SourceSecurity{
+				RequireTrustedAuthor: requireTrustedAuthor,
+			},
+		}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Workers: nil,
+		Workflows: []config.WorkflowConfig{{
+			ID: "do-work",
+			Trigger: &config.TriggerConfig{
+				Match: config.RouteMatch{Source: "src", Labels: []string{"ai-ready"}},
+			},
+			Steps: []config.StepConfig{{ID: "run", Agent: "a"}},
+		}},
+	}
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+
+	runner := &countingRunner{}
+	adapter := &trustGateAdapter{}
+
+	d := &Dispatcher{
+		cfg:             cfg,
+		db:              dbc,
+		binder:          source.NewSourceBinder(dbc),
+		router:          r,
+		sources:         map[string]source.Adapter{"src": adapter},
+		runners:         map[string]runnerpkg.Runner{"agent-a": runner},
+		agentRunner:     map[string]string{"a": "test"},
+		agentFallbacks:  map[string][]runnerCandidate{},
+		rateLimitPaused: map[string]time.Time{},
+		agentSem:        map[string]chan struct{}{"a": make(chan struct{}, 1)},
+		stats:           map[string]*sourceStat{"src": {}},
+		sem:             make(chan struct{}, 1),
+	}
+
+	return d, runner, adapter
+}
+
+// TestTrustGate_UntrustedNotDispatched verifies that when RequireTrustedAuthor
+// is enabled, items with a non-collaborator association are never dispatched,
+// their ai-ready label is removed, and needs-triage is applied.
+func TestTrustGate_UntrustedNotDispatched(t *testing.T) {
+	d, runner, adapter := newTrustGateDispatcher(t, true)
+	adapter.items = []model.SourceItem{{
+		ID:                "1",
+		SourceID:          "src",
+		Title:             "Untrusted issue",
+		Labels:            []string{"ai-ready"},
+		AuthorAssociation: "NONE",
+		State:             "open",
+	}}
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	if runner.n.Load() != 0 {
+		t.Errorf("dispatch count = %d, want 0 (untrusted item must not be dispatched)", runner.n.Load())
+	}
+
+	adapter.mu.Lock()
+	removed := adapter.removedLabels["1"]
+	added := adapter.addedLabels["1"]
+	adapter.mu.Unlock()
+
+	if !sliceContains(removed, "ai-ready") {
+		t.Errorf("ai-ready not removed from untrusted item; removed=%v", removed)
+	}
+	if !sliceContains(added, "needs-triage") {
+		t.Errorf("needs-triage not added to untrusted item; added=%v", added)
+	}
+}
+
+// TestTrustGate_TrustedIsNotBlocked verifies that trusted authors pass through
+// the gate without label changes. The item may or may not dispatch (routing
+// rules apply after the gate), but ai-ready must not be stripped.
+func TestTrustGate_TrustedIsNotBlocked(t *testing.T) {
+	d, _, adapter := newTrustGateDispatcher(t, true)
+	adapter.items = []model.SourceItem{{
+		ID:                "2",
+		SourceID:          "src",
+		Title:             "Collaborator issue",
+		Labels:            []string{"ai-ready"},
+		AuthorAssociation: "COLLABORATOR",
+		State:             "open",
+	}}
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	adapter.mu.Lock()
+	removed := adapter.removedLabels["2"]
+	adapter.mu.Unlock()
+
+	if sliceContains(removed, "ai-ready") {
+		t.Error("ai-ready was stripped from a trusted COLLABORATOR item — gate must not block them")
+	}
+}
+
+// TestTrustGate_DisabledAllowsAll verifies that with RequireTrustedAuthor=false
+// even items with NONE association are not stripped by the gate.
+func TestTrustGate_DisabledAllowsAll(t *testing.T) {
+	d, _, adapter := newTrustGateDispatcher(t, false)
+	adapter.items = []model.SourceItem{{
+		ID:                "3",
+		SourceID:          "src",
+		Title:             "Gate-disabled issue",
+		Labels:            []string{"ai-ready"},
+		AuthorAssociation: "NONE",
+		State:             "open",
+	}}
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	adapter.mu.Lock()
+	removed := adapter.removedLabels["3"]
+	adapter.mu.Unlock()
+
+	if sliceContains(removed, "ai-ready") {
+		t.Error("ai-ready was removed even though RequireTrustedAuthor=false")
+	}
+}
+
+// TestTrustGate_EmptyAssociationPassesThrough verifies that an item without an
+// AuthorAssociation (e.g. from a Plane or Jira source) is never blocked.
+func TestTrustGate_EmptyAssociationPassesThrough(t *testing.T) {
+	d, _, adapter := newTrustGateDispatcher(t, true)
+	adapter.items = []model.SourceItem{{
+		ID:                "4",
+		SourceID:          "src",
+		Title:             "Non-GitHub issue",
+		Labels:            []string{"ai-ready"},
+		AuthorAssociation: "",
+		State:             "open",
+	}}
+
+	sc := d.cfg.Sources[0]
+	d.poll(context.Background(), sc, adapter, time.Time{})
+
+	adapter.mu.Lock()
+	removed := adapter.removedLabels["4"]
+	adapter.mu.Unlock()
+
+	if sliceContains(removed, "ai-ready") {
+		t.Error("empty AuthorAssociation was treated as untrusted; it should pass through the gate")
+	}
+}
+
+func sliceContains(s []string, target string) bool {
+	for _, v := range s {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}

--- a/src/internal/model/source_item.go
+++ b/src/internal/model/source_item.go
@@ -25,6 +25,10 @@ type SourceItem struct {
 	Metadata    map[string]any
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// AuthorAssociation is the author's relationship to the source repository.
+	// Populated by adapters that carry this information (e.g. GitHub). Empty
+	// string means unknown / not provided by the source.
+	AuthorAssociation string
 	// Comments is populated only by a TaskPoller (per-task fetch used for
 	// approval steps), not by Poll. It holds comments relevant to evaluating an
 	// approval condition.

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -678,17 +678,18 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 
 	// Poll skips pull requests, so every ingested item is a plain issue.
 	return model.SourceItem{
-		ID:          fmt.Sprintf("%d", item.Number),
-		SourceID:    a.ID(),
-		Number:      fmt.Sprintf("#%d", item.Number),
-		Title:       item.Title,
-		Description: item.Body,
-		Labels:      labels,
-		Type:        "issue",
-		State:       item.State,
-		URL:         item.HTMLURL,
-		CreatedAt:   createdAt,
-		UpdatedAt:   updatedAt,
+		ID:                fmt.Sprintf("%d", item.Number),
+		SourceID:          a.ID(),
+		Number:            fmt.Sprintf("#%d", item.Number),
+		Title:             item.Title,
+		Description:       item.Body,
+		Labels:            labels,
+		Type:              "issue",
+		State:             item.State,
+		URL:               item.HTMLURL,
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+		AuthorAssociation: item.AuthorAssociation,
 	}
 }
 

--- a/src/internal/source/github/adapter_test.go
+++ b/src/internal/source/github/adapter_test.go
@@ -380,3 +380,14 @@ func TestAddLabels_AppendsWithoutReplacing(t *testing.T) {
 		t.Errorf("posted body must not replay the snapshot labels: %s", postedBody)
 	}
 }
+
+func TestToCell_MapsAuthorAssociation(t *testing.T) {
+	a := &Adapter{id: "gh"}
+	for _, assoc := range []string{"OWNER", "MEMBER", "COLLABORATOR", "NONE", ""} {
+		item := issue{Number: 1, AuthorAssociation: assoc}
+		cell := a.toSourceItem(item)
+		if cell.AuthorAssociation != assoc {
+			t.Errorf("assoc %q: toSourceItem set AuthorAssociation=%q", assoc, cell.AuthorAssociation)
+		}
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,9 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is the issue author's relationship to the repository:
+	// OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE, etc.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {


### PR DESCRIPTION
## Summary

- **Closes the TOCTOU race** from #242: the triage-gate GitHub Action is detective (fires after the label event) — the daemon's 120 s poll window lets a non-collaborator's item be ingested before the Action strips `ai-ready`. This PR moves the trust check _inside_ the daemon's `poll` loop, _before_ `bindItem`, so the race is physically impossible.
- `model.SourceItem` gains `AuthorAssociation string`; the GitHub adapter decodes `author_association` from the issue JSON and populates it.
- `config.SourceConfig` gains `security.require_trusted_author` (opt-in). When `true`, the daemon rejects ingest of any item whose author is not `OWNER`, `MEMBER`, or `COLLABORATOR`: it removes `ai-ready`, adds `needs-triage`, and continues — no task is written to the DB, no workflow is dispatched.
- Empty `AuthorAssociation` (non-GitHub sources: Plane, Jira …) is treated as trusted, so the gate is a no-op for those sources.
- The `triage-gate` GitHub Action from #242 remains as defence-in-depth.

## Test plan

- [x] `TestIsTrustedAuthor` — all trusted/untrusted association values, case-insensitive, empty passthrough
- [x] `TestTrustGate_UntrustedNotDispatched` — runner count stays 0; `ai-ready` removed; `needs-triage` added
- [x] `TestTrustGate_TrustedIsNotBlocked` — `COLLABORATOR` items flow through the gate normally
- [x] `TestTrustGate_DisabledAllowsAll` — gate off (`require_trusted_author: false`) → no label changes
- [x] `TestTrustGate_EmptyAssociationPassesThrough` — non-GitHub sources unaffected
- [x] `TestToCell_MapsAuthorAssociation` — adapter correctly threads the field through `toSourceItem`
- [x] Full `go test ./...` — all existing tests pass, no regressions

Closes #244