### PR TITLE
security: strip host env vars from agent subprocesses (SEC-07)

### DIFF
--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -873,9 +873,9 @@ func readSoulFile(agent config.AgentConfig, cellID string) string {
 // the agent runs itself authenticate as the agent, not the daemon's inherited
 // default account). The `gh` CLI honours both variables; we set both for safety.
 //
-// These overlay os.Environ() at the call site (Env on the RunRequest, applied
-// after the inherited environment in the runner), so the agent's token wins over
-// any GITHUB_TOKEN the daemon inherited.
+// These are passed as req.Env and applied after the runner's host-env allow-list
+// (hostEnvPasslist in the execution package), so the per-agent token always wins
+// and the daemon's own GITHUB_TOKEN is never inherited by the subprocess.
 func agentIdentityEnv(agent config.AgentConfig) map[string]string {
 	env := map[string]string{}
 	if agent.SourceName != "" {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -105,7 +105,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)
 	cmd.Dir = req.WorkingDir
-	cmd.Env = os.Environ()
+	cmd.Env = filteredEnv(os.Environ(), hostEnvPasslist)
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, k+"="+v)
 	}

--- a/src/internal/runner/execution/privilege.go
+++ b/src/internal/runner/execution/privilege.go
@@ -1,0 +1,86 @@
+package execution
+
+import (
+	"fmt"
+	"strings"
+)
+
+// checkPrivilege returns an error when uid is 0 (root) and allowRoot is false.
+// Extracted from Run() so it can be tested without requiring a real root process.
+func checkPrivilege(uid int, allowRoot bool) error {
+	if uid == 0 && !allowRoot {
+		return fmt.Errorf("cli runner: refusing to launch agent as root (uid 0); " +
+			"set allow_root: true in the runner config to opt in — " +
+			"running as root with untrusted prompt content (e.g. Jira/GitHub issues) " +
+			"maximises the blast radius of prompt injection")
+	}
+	return nil
+}
+
+// hostEnvPasslist is the explicit set of host environment variables forwarded
+// to every agent subprocess. Anything not listed here is stripped before the
+// process is spawned, limiting the exfiltration surface of a successful
+// prompt-injection attack.
+//
+// Operator-configured AI credentials (e.g. ANTHROPIC_API_KEY) appear here so
+// the CLI subprocess can authenticate without requiring every agent config to
+// repeat the key. Per-agent GitHub credentials are never inherited from the
+// host — they arrive exclusively via req.Env (populated by agentIdentityEnv /
+// stepEnv in the workflow layer), so a broad host GITHUB_TOKEN cannot bleed
+// into an agent's git context.
+var hostEnvPasslist = []string{
+	// Runtime path and identity
+	"PATH",
+	"HOME",
+	"USER",
+	"LOGNAME",
+	"SHELL",
+	// Temporary directories
+	"TMPDIR",
+	"TMP",
+	"TEMP",
+	// Terminal type (needed by some interactive sub-tools)
+	"TERM",
+	"COLORTERM",
+	// Locale
+	"LANG",
+	"LC_ALL",
+	"LC_CTYPE",
+	"LC_COLLATE",
+	"LC_MESSAGES",
+	"LC_MONETARY",
+	"LC_NUMERIC",
+	"LC_TIME",
+	// SSH agent forwarding (git operations)
+	"SSH_AUTH_SOCK",
+	"SSH_AGENT_PID",
+	"GIT_SSH_COMMAND",
+	"GIT_SSH",
+	// XDG base directories
+	"XDG_RUNTIME_DIR",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_CACHE_HOME",
+	// Anthropic CLI credentials (required by the Claude CLI subprocess)
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"ANTHROPIC_BASE_URL",
+}
+
+// filteredEnv returns a subset of environ containing only entries whose name
+// appears in passlist. The comparison is case-sensitive to match os.Environ()
+// conventions on Unix.
+func filteredEnv(environ []string, passlist []string) []string {
+	allowed := make(map[string]struct{}, len(passlist))
+	for _, name := range passlist {
+		allowed[name] = struct{}{}
+	}
+	out := make([]string, 0, len(passlist))
+	for _, kv := range environ {
+		name, _, _ := strings.Cut(kv, "=")
+		if _, ok := allowed[name]; ok {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/src/internal/runner/execution/privilege_test.go
+++ b/src/internal/runner/execution/privilege_test.go
@@ -1,0 +1,99 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckPrivilege(t *testing.T) {
+	tests := []struct {
+		name      string
+		uid       int
+		allowRoot bool
+		wantErr   bool
+	}{
+		{"non-root always allowed", 1000, false, false},
+		{"non-root with allowRoot true", 1000, true, false},
+		{"root blocked by default", 0, false, true},
+		{"root permitted when opted in", 0, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkPrivilege(tc.uid, tc.allowRoot)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkPrivilege(%d, %v) err=%v, wantErr=%v", tc.uid, tc.allowRoot, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckPrivilege_ErrorMessage(t *testing.T) {
+	err := checkPrivilege(0, false)
+	if err == nil {
+		t.Fatal("expected error for uid=0")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "root") {
+		t.Errorf("error message should mention root, got: %q", msg)
+	}
+	if !strings.Contains(msg, "allow_root") {
+		t.Errorf("error message should mention allow_root config key, got: %q", msg)
+	}
+}
+
+func TestFilteredEnv(t *testing.T) {
+	environ := []string{
+		"HOME=/root",
+		"PATH=/usr/bin:/bin",
+		"SECRET_TOKEN=hunter2",
+		"ANTHROPIC_API_KEY=sk-ant-xxx",
+		"TMPDIR=/tmp",
+		"LANG=en_US.UTF-8",
+	}
+
+	t.Run("passlist filters to named vars only", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "PATH", "TMPDIR"})
+		if len(got) != 3 {
+			t.Fatalf("expected 3 entries, got %d: %v", len(got), got)
+		}
+		for _, kv := range got {
+			name, _, _ := strings.Cut(kv, "=")
+			switch name {
+			case "HOME", "PATH", "TMPDIR":
+			default:
+				t.Errorf("unexpected var in filtered output: %q", kv)
+			}
+		}
+	})
+
+	t.Run("secrets excluded when not in passlist", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "PATH"})
+		for _, kv := range got {
+			if strings.Contains(kv, "SECRET") || strings.Contains(kv, "ANTHROPIC") {
+				t.Errorf("secret var leaked into filtered env: %q", kv)
+			}
+		}
+	})
+
+	t.Run("empty passlist returns empty slice", func(t *testing.T) {
+		got := filteredEnv(environ, nil)
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+
+	t.Run("passlist entry absent from environ is silently skipped", func(t *testing.T) {
+		got := filteredEnv(environ, []string{"HOME", "NONEXISTENT"})
+		if len(got) != 1 {
+			t.Errorf("expected 1 entry, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("values with = signs are preserved correctly", func(t *testing.T) {
+		env := []string{"COMPLEX=a=b=c", "OTHER=x"}
+		got := filteredEnv(env, []string{"COMPLEX"})
+		if len(got) != 1 || got[0] != "COMPLEX=a=b=c" {
+			t.Errorf("value with = signs mangled: %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Replaces `cmd.Env = os.Environ()` in the CLI runner with `filteredEnv(os.Environ(), hostEnvPasslist)`, so agent subprocesses inherit only an explicit set of safe host variables instead of the entire daemon environment.
- Defines `hostEnvPasslist` in a new `privilege.go` file (same package as `filteredEnv`): runtime essentials (`PATH`, `HOME`, `USER`, `SHELL`), temp dirs, locale vars, SSH agent sockets, XDG base dirs, and Anthropic CLI credentials (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`).
- Per-agent GitHub credentials (`GITHUB_TOKEN` / `GH_TOKEN`) are **not** on the passlist — they arrive exclusively via `req.Env` from `agentIdentityEnv`/`stepEnv`, so the daemon's broad token cannot bleed into a subprocess.
- Updates the stale comment in `workflow.go` that referenced `os.Environ()` inheritance.
- Adds `privilege.go` + `privilege_test.go` with unit tests covering `filteredEnv` semantics (secret exclusion, empty passlist, absent vars, values containing `=`).

**Token scoping guidance:** operators should use per-repository fine-grained GitHub PATs (scoped to `Issues: Read & Write` + `Pull requests: Read & Write` + `Metadata: Read`) rather than broad classic PATs. A leaked fine-grained token is bounded to one repository instead of the entire account.

## Test plan

- [x] `go test ./internal/runner/execution/...` — all tests pass including the new `TestFilteredEnv` cases
- [x] `go build ./...` — compiles cleanly
- [x] `go vet ./...` — no issues

Closes #230