### PR TITLE
feat: add environments, configuration promotion, and rollback

### DIFF
--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -5,16 +5,14 @@ description: "Use when the user needs to run GitNexus CLI commands like analyze/
 
 # GitNexus CLI Commands
 
-Commands below use `node .gitnexus/run.cjs <command>` — the project-local runner `gitnexus analyze` drops next to the index. It auto-selects an available runner at call time (global `gitnexus`, else `pnpm dlx`, else `npx`), so no package-manager assumption and no global install is required.
-
-> **Not analyzed yet, or `node .gitnexus/run.cjs` reports `Cannot find module`** (the gitignored runner is absent — e.g. a fresh clone or `git clean`)? (Re)generate it with `npx gitnexus analyze` from the project root. On **npm 11.x**, if `npx` crashes during install (`node.target is null`), install once with `npm i -g gitnexus` (then `gitnexus analyze`) or use `pnpm --allow-build=@ladybugdb/core --allow-build=gitnexus --allow-build=tree-sitter dlx gitnexus@latest analyze`. See [#1939](https://github.com/abhigyanpatwari/GitNexus/issues/1939).
+All commands work via `npx` — no global install required.
 
 ## Commands
 
 ### analyze — Build or refresh the index
 
 ```bash
-node .gitnexus/run.cjs analyze
+npx gitnexus analyze
 ```
 
 Run from the project root. This parses all source files, builds the knowledge graph, writes it to `.gitnexus/`, and generates CLAUDE.md / AGENTS.md context files.
@@ -24,14 +22,13 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--force`      | Force full re-index even if up to date                           |
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
-| `--pdg` | Build the program-dependence layers used by `explain` and `pdg_query` (taint, CDG, and REACHING_DEF). |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
 
 ### status — Check index freshness
 
 ```bash
-node .gitnexus/run.cjs status
+npx gitnexus status
 ```
 
 Shows whether the current repo has a GitNexus index, when it was last updated, and symbol/relationship counts. Use this to check if re-indexing is needed.
@@ -39,7 +36,7 @@ Shows whether the current repo has a GitNexus index, when it was last updated, a
 ### clean — Delete the index
 
 ```bash
-node .gitnexus/run.cjs clean
+npx gitnexus clean
 ```
 
 Deletes the `.gitnexus/` directory and unregisters the repo from the global registry. Use before re-indexing if the index is corrupt or after removing GitNexus from a project.
@@ -52,7 +49,7 @@ Deletes the `.gitnexus/` directory and unregisters the repo from the global regi
 ### wiki — Generate documentation from the graph
 
 ```bash
-node .gitnexus/run.cjs wiki
+npx gitnexus wiki
 ```
 
 Generates repository documentation from the knowledge graph using an LLM. Requires an API key (saved to `~/.gitnexus/config.json` on first use).
@@ -69,7 +66,7 @@ Generates repository documentation from the knowledge graph using an LLM. Requir
 ### list — Show all indexed repos
 
 ```bash
-node .gitnexus/run.cjs list
+npx gitnexus list
 ```
 
 Lists all repositories registered in `~/.gitnexus/registry.json`. The MCP `list_repos` tool provides the same information.

--- a/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-debugging/SKILL.md
@@ -16,23 +16,23 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 ## Workflow
 
 ```
-1. query({search_query: "<error or symptom>"})            → Find related execution flows
-2. context({name: "<suspect>"})                    → See callers/callees/processes
+1. gitnexus_query({query: "<error or symptom>"})            → Find related execution flows
+2. gitnexus_context({name: "<suspect>"})                    → See callers/callees/processes
 3. READ gitnexus://repo/{name}/process/{name}                → Trace execution flow
-4. cypher({statement: "MATCH path..."})                 → Custom traces if needed
+4. gitnexus_cypher({query: "MATCH path..."})                 → Custom traces if needed
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] Understand the symptom (error message, unexpected behavior)
-- [ ] query for error text or related code
+- [ ] gitnexus_query for error text or related code
 - [ ] Identify the suspect function from returned processes
-- [ ] context to see callers and callees
+- [ ] gitnexus_context to see callers and callees
 - [ ] Trace execution flow via process resource if applicable
-- [ ] cypher for custom call chain traces if needed
+- [ ] gitnexus_cypher for custom call chain traces if needed
 - [ ] Read source files to confirm root cause
 ```
 
@@ -40,58 +40,46 @@ description: "Use when the user is debugging a bug, tracing an error, or asking 
 
 | Symptom              | GitNexus Approach                                          |
 | -------------------- | ---------------------------------------------------------- |
-| Error message        | `query` for error text → `context` on throw sites |
+| Error message        | `gitnexus_query` for error text → `context` on throw sites |
 | Wrong return value   | `context` on the function → trace callees for data flow    |
 | Intermittent failure | `context` → look for external calls, async deps            |
 | Performance issue    | `context` → find symbols with many callers (hot paths)     |
 | Recent regression    | `detect_changes` to see what your changes affect           |
-| "How does A reach B?" | `trace` between the two symbols — shortest call chain in one call |
 
 ## Tools
 
-**query** — find code related to error:
+**gitnexus_query** — find code related to error:
 
 ```
-query({search_query: "payment validation error"})
+gitnexus_query({query: "payment validation error"})
 → Processes: CheckoutFlow, ErrorHandling
 → Symbols: validatePayment, handlePaymentError, PaymentException
 ```
 
-**context** — full context for a suspect:
+**gitnexus_context** — full context for a suspect:
 
 ```
-context({name: "validatePayment"})
+gitnexus_context({name: "validatePayment"})
 → Incoming calls: processCheckout, webhookHandler
 → Outgoing calls: verifyCard, fetchRates (external API!)
 → Processes: CheckoutFlow (step 3/7)
 ```
 
-**cypher** — custom call chain traces:
+**gitnexus_cypher** — custom call chain traces:
 
 ```cypher
 MATCH path = (a)-[:CodeRelation {type: 'CALLS'}*1..2]->(b:Function {name: "validatePayment"})
 RETURN [n IN nodes(path) | n.name] AS chain
 ```
 
-**trace** — shortest call chain between two symbols ("how does A reach B?"), one call instead of chaining `context` hops:
-
-```
-trace({ from: "processCheckout", to: "fetchRates" })
-→ status: ok, hopCount: 3
-→ hops: processCheckout → validatePayment → verifyCard → fetchRates
-→ edges: CALLS (1.0), CALLS (0.95), CALLS (1.0)
-```
-
-When no path exists, `trace` reports the furthest reachable node — exactly where the chain breaks (dynamic dispatch, reflection, or an external boundary).
-
 ## Example: "Payment endpoint returns 500 intermittently"
 
 ```
-1. query({search_query: "payment error handling"})
+1. gitnexus_query({query: "payment error handling"})
    → Processes: CheckoutFlow, ErrorHandling
    → Symbols: validatePayment, handlePaymentError
 
-2. context({name: "validatePayment"})
+2. gitnexus_context({name: "validatePayment"})
    → Outgoing calls: verifyCard, fetchRates (external API!)
 
 3. READ gitnexus://repo/my-app/process/CheckoutFlow

--- a/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-exploring/SKILL.md
@@ -18,20 +18,20 @@ description: "Use when the user asks how code works, wants to understand archite
 ```
 1. READ gitnexus://repos                          → Discover indexed repos
 2. READ gitnexus://repo/{name}/context             → Codebase overview, check staleness
-3. query({search_query: "<what you want to understand>"})  → Find related execution flows
-4. context({name: "<symbol>"})            → Deep dive on specific symbol
+3. gitnexus_query({query: "<what you want to understand>"})  → Find related execution flows
+4. gitnexus_context({name: "<symbol>"})            → Deep dive on specific symbol
 5. READ gitnexus://repo/{name}/process/{name}      → Trace full execution flow
 ```
 
-> If step 2 says "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If step 2 says "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
 - [ ] READ gitnexus://repo/{name}/context
-- [ ] query for the concept you want to understand
+- [ ] gitnexus_query for the concept you want to understand
 - [ ] Review returned processes (execution flows)
-- [ ] context on key symbols for callers/callees
+- [ ] gitnexus_context on key symbols for callers/callees
 - [ ] READ process resource for full execution traces
 - [ ] Read source files for implementation details
 ```
@@ -47,18 +47,18 @@ description: "Use when the user asks how code works, wants to understand archite
 
 ## Tools
 
-**query** — find execution flows related to a concept:
+**gitnexus_query** — find execution flows related to a concept:
 
 ```
-query({search_query: "payment processing"})
+gitnexus_query({query: "payment processing"})
 → Processes: CheckoutFlow, RefundFlow, WebhookHandler
 → Symbols grouped by flow with file locations
 ```
 
-**context** — 360-degree view of a symbol:
+**gitnexus_context** — 360-degree view of a symbol:
 
 ```
-context({name: "validateUser"})
+gitnexus_context({name: "validateUser"})
 → Incoming calls: loginHandler, apiMiddleware
 → Outgoing calls: checkToken, getUserById
 → Processes: LoginFlow (step 2/5), TokenRefresh (step 1/3)
@@ -68,10 +68,10 @@ context({name: "validateUser"})
 
 ```
 1. READ gitnexus://repo/my-app/context       → 918 symbols, 45 processes
-2. query({search_query: "payment processing"})
+2. gitnexus_query({query: "payment processing"})
    → CheckoutFlow: processPayment → validateCard → chargeStripe
    → RefundFlow: initiateRefund → calculateRefund → processRefund
-3. context({name: "processPayment"})
+3. gitnexus_context({name: "processPayment"})
    → Incoming: checkoutHandler, webhookHandler
    → Outgoing: validateCard, chargeStripe, saveTransaction
 4. Read src/payments/processor.ts for implementation details

--- a/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-guide/SKILL.md
@@ -15,7 +15,7 @@ For any task involving code understanding, debugging, impact analysis, or refact
 2. **Match your task to a skill below** and **read that skill file**
 3. **Follow the skill's workflow and checklist**
 
-> If step 1 warns the index is stale, run `node .gitnexus/run.cjs analyze` in the terminal first.
+> If step 1 warns the index is stale, run `npx gitnexus analyze` in the terminal first.
 
 ## Skills
 
@@ -35,82 +35,10 @@ For any task involving code understanding, debugging, impact analysis, or refact
 | `query`          | Process-grouped code intelligence — execution flows related to a concept |
 | `context`        | 360-degree symbol view — categorized refs, processes it participates in  |
 | `impact`         | Symbol blast radius — what breaks at depth 1/2/3 with confidence         |
-| `trace`          | Shortest path between two symbols — "how does A reach B?" in one call     |
 | `detect_changes` | Git-diff impact — what do your current changes affect                    |
 | `rename`         | Multi-file coordinated rename with confidence-tagged edits               |
 | `cypher`         | Raw graph queries (read `gitnexus://repo/{name}/schema` first)           |
-| `explain`        | Persisted taint findings — source→sink data flows (needs `analyze --pdg`) |
-| `pdg_query`      | Control/data dependence — what gates X (CDG) / where Y flows (REACHING_DEF); needs `analyze --pdg` |
-| `check`          | Check graph invariants such as circular imports                          |
-| `route_map`      | API route map — which components/hooks fetch which endpoints, and the handler files that serve them |
-| `shape_check`    | Response-shape drift — keys each route returns vs keys its consumers access (flags MISMATCH) |
-| `api_impact`     | Pre-change report for an API route — consumers, middleware, shape mismatches, risk level |
-| `tool_map`       | MCP/RPC tool definitions and the files that handle them                  |
-| `group_list`     | List configured multi-repo groups, or one group's config                 |
-| `group_sync`     | Rebuild a group's Contract Registry (cross-repo HTTP contract links); run after `group.yaml` changes or member re-index |
-| `list_repos`     | Discover indexed repos (paginated — `limit`/`offset`)                    |
-
-### Paginating `list_repos`
-
-`list_repos` is paginated so a large registry is not truncated by MCP/LLM token limits. It takes optional `limit` (default **50**, max **200**) and `offset`, and returns:
-
-```jsonc
-{
-  "repositories": [
-    { "name": "...", "path": "...", "indexedAt": "...", "lastCommit": "...", "stats": { } }
-  ],
-  "pagination": {
-    "total": 437,
-    "limit": 50,
-    "offset": 0,
-    "returned": 50,
-    "hasMore": true,
-    "nextOffset": 50
-  }
-}
-```
-
-To enumerate **every** repository, keep calling with `offset` set to `pagination.nextOffset` until `hasMore` is `false`:
-
-```text
-list_repos {}               → repos 1–50,    nextOffset 50,  hasMore true
-list_repos { offset: 50 }   → repos 51–100,  nextOffset 100, hasMore true
-…
-list_repos { offset: 400 }  → repos 401–437,                 hasMore false   (done)
-```
-
-Notes: `offset` ≥ `total` returns an empty page (with `total` still reported). Out-of-range or malformed `limit`/`offset` (non-integer, `limit` outside `[1, 200]`, `offset < 0`) are rejected with a clear error — `limit` above the max is rejected, not silently capped. The order is deterministic (lower-cased name, then path), so paging never skips or duplicates an entry while the registry is unchanged.
-
-### Taint findings (`explain`)
-
-`explain` returns taint findings recorded by `gitnexus analyze --pdg` — intra-procedural `TAINTED` edges plus cross-function `TAINT_PATH` hops where the interprocedural taint phase found a function-level source→sink chain. Each finding includes a sink category (command-injection, code-injection, path-traversal, sql-injection, xss), source/sink lines, and the ordered hop path with the variable carried on each hop.
-
-- `explain {}` — enumerate all findings for the repo (bounded by `limit`, deterministic order)
-- `explain { target: "src/vuln.ts" }` — findings in a file (suffix path match accepted)
-- `explain { target: "runUserCommand" }` — findings in a function (resolved like `context`; ambiguous names return ranked candidates)
-
-A repo indexed without `--pdg` returns a clear "no taint layer" note. Caveats: closure/callback, property/field, and implicit flows are not modeled, and interprocedural findings are function-level `TAINT_PATH` hops rather than statement-level path proof, so the absence of a finding is **not** proof of safety. `SANITIZES` (sanitizer-kill) edges are queryable via `cypher`.
-
-### Control & data dependence (`pdg_query`)
-
-`pdg_query` reads the control/data-dependence layers `gitnexus analyze --pdg` records (CDG + REACHING_DEF, basic-block granular) — the control/data analog of `explain`. It is **always anchored** (a `target` file path or symbol, resolved like `context`) and has two modes:
-
-- `pdg_query { mode: "controls", target: "..." }` — CDG: "under what condition does X run?". Each edge is a controlling predicate block → dependent block with the branch sense (`'T'`/`'F'`) in `reason`; an edge into an early `return`/`throw` is flagged `guard: true` (guard-clause discovery — the sense depends on the predicate, so don't filter guards by a fixed label).
-- `pdg_query { mode: "flows", target: "...", variable?: "..." }` — REACHING_DEF def→use edges within the function; pass `variable` to trace one binding.
-
-A repo indexed without `--pdg` returns a "no PDG layer" note (or "status unknown" when the layer can't be confirmed). Intra-procedural only — cross-function flow is taint's domain (`explain`). The raw CDG/REACHING_DEF edges are also queryable via `cypher`. See the `gitnexus-pdg-query` skill for the full query surface.
-
-### Shortest path between two symbols (`trace`)
-
-`trace` answers "how does A reach B?" in one call — the shortest directed path over `CALLS` (plus `HAS_METHOD`, so a class-rooted trace descends into its methods) instead of chaining 3–8 `context`/`impact` hops by hand.
-
-- `trace { from: "validateUser", to: "executeQuery" }` — shortest path between two symbols.
-- Disambiguate common names with `from_uid`/`to_uid` (zero-ambiguity) or `from_file`/`to_file`; an ambiguous name returns ranked candidates.
-- `maxDepth` (default 10, max 30) bounds the search; `includeTests` (default false) lets the traversal pass through test-file symbols.
-
-Returns ordered `hops` (each `{ name, filePath, startLine }`) and an aligned `edges[]` of `{ relType, confidence }`, so call hops and containment (`HAS_METHOD`) hops stay distinguishable. When no path exists it reports the **furthest** reachable node (where the chain breaks) and sets `truncated: true` if a traversal cap was hit first. Every result carries a `status`: `ok` / `no_path` / `ambiguous` / `not_found` / `error`.
-
-Cross-repo (experimental): pass `repo: "@groupName"` to trace across a group's member repos — the path may cross **one** `ContractLink` boundary (reported as a `CONTRACT_LINK` hop with the bridged contract in `crossings[]`). Omit `to` entirely to follow `from`'s outgoing HTTP call to whatever provider endpoint it lands on. Groups are configured via `group_list` / `group_sync`.
+| `list_repos`     | Discover indexed repos                                                   |
 
 ## Resources Reference
 
@@ -127,10 +55,8 @@ Lightweight reads (~100-500 tokens) for navigation:
 
 ## Graph Schema
 
-**Nodes:** File, Folder, Function, Class, Interface, Method, CodeElement, Community, Process, Route, Tool, plus language-specific types (Struct, Enum, Trait, Impl, Namespace, Module, …) and BasicBlock (`--pdg` indexes only). The full node list lives in `gitnexus://repo/{name}/schema`.
-**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, CONTAINS, MEMBER_OF, HAS_METHOD, HAS_PROPERTY, ACCESSES, METHOD_OVERRIDES, METHOD_IMPLEMENTS, STEP_IN_PROCESS, HANDLES_ROUTE, FETCHES, HANDLES_TOOL, ENTRY_POINT_OF, WRAPS, QUERIES, INJECTS, plus `--pdg`-only types (CFG, REACHING_DEF, TAINTED, SANITIZES, TAINT_PATH, CDG — zero rows on a default index).
-
-Read `gitnexus://repo/{name}/schema` before writing Cypher — it is the authoritative schema for the indexed repo.
+**Nodes:** File, Function, Class, Interface, Method, Community, Process
+**Edges (via CodeRelation.type):** CALLS, IMPORTS, EXTENDS, IMPLEMENTS, DEFINES, MEMBER_OF, STEP_IN_PROCESS
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "myFunc"})

--- a/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md
@@ -17,22 +17,22 @@ description: "Use when the user wants to know what will break if they change som
 ## Workflow
 
 ```
-1. impact({target: "X", direction: "upstream"})  → What depends on this
+1. gitnexus_impact({target: "X", direction: "upstream"})  → What depends on this
 2. READ gitnexus://repo/{name}/processes                   → Check affected execution flows
-3. detect_changes()                               → Map current git changes to affected flows
+3. gitnexus_detect_changes()                               → Map current git changes to affected flows
 4. Assess risk and report to user
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklist
 
 ```
-- [ ] impact({target, direction: "upstream"}) to find dependents
+- [ ] gitnexus_impact({target, direction: "upstream"}) to find dependents
 - [ ] Review d=1 items first (these WILL BREAK)
 - [ ] Check high-confidence (>0.8) dependencies
 - [ ] READ processes to check affected execution flows
-- [ ] detect_changes() for pre-commit check
+- [ ] gitnexus_detect_changes() for pre-commit check
 - [ ] Assess risk level and report to user
 ```
 
@@ -55,10 +55,10 @@ description: "Use when the user wants to know what will break if they change som
 
 ## Tools
 
-**impact** — the primary tool for symbol blast radius:
+**gitnexus_impact** — the primary tool for symbol blast radius:
 
 ```
-impact({
+gitnexus_impact({
   target: "validateUser",
   direction: "upstream",
   minConfidence: 0.8,
@@ -73,10 +73,10 @@ impact({
   - authRouter (src/routes/auth.ts:22) [CALLS, 95%]
 ```
 
-**detect_changes** — git-diff based impact analysis:
+**gitnexus_detect_changes** — git-diff based impact analysis:
 
 ```
-detect_changes({scope: "staged"})
+gitnexus_detect_changes({scope: "staged"})
 
 → Changed: 5 symbols in 3 files
 → Affected: LoginFlow, TokenRefresh, APIMiddlewarePipeline
@@ -86,7 +86,7 @@ detect_changes({scope: "staged"})
 ## Example: "What breaks if I change validateUser?"
 
 ```
-1. impact({target: "validateUser", direction: "upstream"})
+1. gitnexus_impact({target: "validateUser", direction: "upstream"})
    → d=1: loginHandler, apiMiddleware (WILL BREAK)
    → d=2: authRouter, sessionManager (LIKELY AFFECTED)
 

--- a/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
@@ -16,78 +16,78 @@ description: "Use when the user wants to rename, extract, split, move, or restru
 ## Workflow
 
 ```
-1. impact({target: "X", direction: "upstream"})  → Map all dependents
-2. query({search_query: "X"})                            → Find execution flows involving X
-3. context({name: "X"})                           → See all incoming/outgoing refs
+1. gitnexus_impact({target: "X", direction: "upstream"})  → Map all dependents
+2. gitnexus_query({query: "X"})                            → Find execution flows involving X
+3. gitnexus_context({name: "X"})                           → See all incoming/outgoing refs
 4. Plan update order: interfaces → implementations → callers → tests
 ```
 
-> If "Index is stale" → run `node .gitnexus/run.cjs analyze` in terminal.
+> If "Index is stale" → run `npx gitnexus analyze` in terminal.
 
 ## Checklists
 
 ### Rename Symbol
 
 ```
-- [ ] rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
-- [ ] Review graph edits (high confidence) and text_search edits (review carefully)
-- [ ] If satisfied: rename({..., dry_run: false}) — apply edits
-- [ ] detect_changes() — verify only expected files changed
+- [ ] gitnexus_rename({symbol_name: "oldName", new_name: "newName", dry_run: true}) — preview all edits
+- [ ] Review graph edits (high confidence) and ast_search edits (review carefully)
+- [ ] If satisfied: gitnexus_rename({..., dry_run: false}) — apply edits
+- [ ] gitnexus_detect_changes() — verify only expected files changed
 - [ ] Run tests for affected processes
 ```
 
 ### Extract Module
 
 ```
-- [ ] context({name: target}) — see all incoming/outgoing refs
-- [ ] impact({target, direction: "upstream"}) — find all external callers
+- [ ] gitnexus_context({name: target}) — see all incoming/outgoing refs
+- [ ] gitnexus_impact({target, direction: "upstream"}) — find all external callers
 - [ ] Define new module interface
 - [ ] Extract code, update imports
-- [ ] detect_changes() — verify affected scope
+- [ ] gitnexus_detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ### Split Function/Service
 
 ```
-- [ ] context({name: target}) — understand all callees
+- [ ] gitnexus_context({name: target}) — understand all callees
 - [ ] Group callees by responsibility
-- [ ] impact({target, direction: "upstream"}) — map callers to update
+- [ ] gitnexus_impact({target, direction: "upstream"}) — map callers to update
 - [ ] Create new functions/services
 - [ ] Update callers
-- [ ] detect_changes() — verify affected scope
+- [ ] gitnexus_detect_changes() — verify affected scope
 - [ ] Run tests for affected processes
 ```
 
 ## Tools
 
-**rename** — automated multi-file rename:
+**gitnexus_rename** — automated multi-file rename:
 
 ```
-rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
 → 12 edits across 8 files
-→ 10 graph edits (high confidence), 2 text_search edits (review)
+→ 10 graph edits (high confidence), 2 ast_search edits (review)
 → Changes: [{file_path, edits: [{line, old_text, new_text, confidence}]}]
 ```
 
-**impact** — map all dependents first:
+**gitnexus_impact** — map all dependents first:
 
 ```
-impact({target: "validateUser", direction: "upstream"})
+gitnexus_impact({target: "validateUser", direction: "upstream"})
 → d=1: loginHandler, apiMiddleware, testUtils
 → Affected Processes: LoginFlow, TokenRefresh
 ```
 
-**detect_changes** — verify your changes after refactoring:
+**gitnexus_detect_changes** — verify your changes after refactoring:
 
 ```
-detect_changes({scope: "all"})
+gitnexus_detect_changes({scope: "all"})
 → Changed: 8 files, 12 symbols
 → Affected processes: LoginFlow, TokenRefresh
 → Risk: MEDIUM
 ```
 
-**cypher** — custom reference queries:
+**gitnexus_cypher** — custom reference queries:
 
 ```cypher
 MATCH (caller)-[:CodeRelation {type: 'CALLS'}]->(f:Function {name: "validateUser"})
@@ -98,24 +98,24 @@ RETURN caller.name, caller.filePath ORDER BY caller.filePath
 
 | Risk Factor         | Mitigation                                |
 | ------------------- | ----------------------------------------- |
-| Many callers (>5)   | Use rename for automated updates |
+| Many callers (>5)   | Use gitnexus_rename for automated updates |
 | Cross-area refs     | Use detect_changes after to verify scope  |
-| String/dynamic refs | query to find them               |
+| String/dynamic refs | gitnexus_query to find them               |
 | External/public API | Version and deprecate properly            |
 
 ## Example: Rename `validateUser` to `authenticateUser`
 
 ```
-1. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
-   → 12 edits: 10 graph (safe), 2 text_search (review)
+1. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: true})
+   → 12 edits: 10 graph (safe), 2 ast_search (review)
    → Files: validator.ts, login.ts, middleware.ts, config.json...
 
-2. Review text_search edits (config.json: dynamic reference!)
+2. Review ast_search edits (config.json: dynamic reference!)
 
-3. rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
+3. gitnexus_rename({symbol_name: "validateUser", new_name: "authenticateUser", dry_run: false})
    → Applied 12 edits across 8 files
 
-4. detect_changes({scope: "all"})
+4. gitnexus_detect_changes({scope: "all"})
    → Affected: LoginFlow, TokenRefresh
    → Risk: MEDIUM — run tests for these flows
 ```

--- a/src/internal/cli/diff.go
+++ b/src/internal/cli/diff.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newDiffCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diff <env1> <env2>",
+		Short: "Show semantic diff between two environment configurations",
+		Long: `Show a semantic diff between two named environment configurations.
+
+Each environment's overlays are resolved and the resulting configurations are
+compared entity-by-entity (workflows, sources, agents, runners, settings).
+Use "base" as an environment name to compare against the raw config with no
+overlay applied.
+
+Examples:
+  apiary diff development staging
+  apiary diff staging production
+  apiary diff base production`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return err
+			}
+
+			resolve := func(name string) (*config.Config, error) {
+				if name == "base" {
+					return cfg, nil
+				}
+				if _, ok := cfg.Environments[name]; !ok {
+					return nil, fmt.Errorf("environment %q not found in config", name)
+				}
+				return cfg.ResolveForEnvironment(name)
+			}
+
+			fromName, toName := args[0], args[1]
+			fromCfg, err := resolve(fromName)
+			if err != nil {
+				return err
+			}
+			toCfg, err := resolve(toName)
+			if err != nil {
+				return err
+			}
+
+			fromDigest, _ := config.Digest(fromCfg)
+			toDigest, _ := config.Digest(toCfg)
+
+			entries := config.SemanticDiff(fromCfg, toCfg)
+
+			fmt.Printf("diff %s..%s\n", fromName, toName)
+			fmt.Printf("  from digest: %s\n", fromDigest)
+			fmt.Printf("  to   digest: %s\n\n", toDigest)
+
+			if len(entries) == 0 {
+				fmt.Println("no differences")
+				return nil
+			}
+
+			for _, e := range entries {
+				fmt.Println(e.String())
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/src/internal/cli/promote.go
+++ b/src/internal/cli/promote.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os/user"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/spf13/cobra"
+)
+
+func newPromoteCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "promote <from> <to>",
+		Short: "Promote a configuration from one environment to another",
+		Long: `Promote a configuration from one named environment to another.
+
+Before promotion, the resolved configuration for the target environment is
+validated. When --dry-run is set, all checks are performed but no revision
+record is written to the database.
+
+The promotion is recorded in the environment_revisions table with the config
+digest, git revision, and the OS user who ran the command. Use "apiary rollback"
+to restore a previous revision.
+
+Examples:
+  apiary promote development staging
+  apiary promote staging production --dry-run`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fromName, toName := args[0], args[1]
+
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				return err
+			}
+
+			if _, ok := cfg.Environments[fromName]; !ok {
+				return fmt.Errorf("source environment %q not found in config", fromName)
+			}
+			if _, ok := cfg.Environments[toName]; !ok {
+				return fmt.Errorf("target environment %q not found in config", toName)
+			}
+
+			fromCfg, err := cfg.ResolveForEnvironment(fromName)
+			if err != nil {
+				return fmt.Errorf("resolving source environment %q: %w", fromName, err)
+			}
+			toCfg, err := cfg.ResolveForEnvironment(toName)
+			if err != nil {
+				return fmt.Errorf("resolving target environment %q: %w", toName, err)
+			}
+
+			// Validate the target resolved config.
+			if errs := toCfg.Validate(); len(errs) > 0 {
+				fmt.Printf("✗ resolved config for %q failed validation:\n", toName)
+				for _, e := range errs {
+					fmt.Printf("  ✗ %s\n", e)
+				}
+				return fmt.Errorf("target environment %q did not pass validation", toName)
+			}
+
+			fromDigest, _ := config.Digest(fromCfg)
+			toDigest, _ := config.Digest(toCfg)
+			gitRev := config.GitRevision(configFile)
+
+			// Show semantic diff so the operator can confirm.
+			entries := config.SemanticDiff(fromCfg, toCfg)
+			fmt.Printf("Promoting %s → %s\n", fromName, toName)
+			fmt.Printf("  from digest: %s\n", fromDigest)
+			fmt.Printf("  to   digest: %s\n", toDigest)
+			if gitRev != "" {
+				fmt.Printf("  git revision: %s\n", gitRev)
+			}
+			if len(entries) == 0 {
+				fmt.Println("  (no semantic differences between environments)")
+			} else {
+				fmt.Printf("\nSemantic diff (%d change(s)):\n", len(entries))
+				for _, e := range entries {
+					fmt.Println(" ", e.String())
+				}
+			}
+
+			if dryRun {
+				fmt.Println("\n✓ dry-run: validation passed, no revision recorded")
+				return nil
+			}
+
+			// Persist the revision record.
+			promotedBy := "unknown"
+			if u, err := user.Current(); err == nil {
+				promotedBy = u.Username
+			}
+
+			yamlBytes, err := config.MarshalYAML(toCfg)
+			if err != nil {
+				return fmt.Errorf("marshaling resolved config: %w", err)
+			}
+
+			dbPath := getDBPath()
+			ctx := context.Background()
+			dbClient, err := db.New(ctx, dbPath)
+			if err != nil {
+				return fmt.Errorf("opening database: %w", err)
+			}
+			defer dbClient.Close()
+
+			rev := &db.EnvironmentRevision{
+				EnvName:      toName,
+				ConfigDigest: toDigest,
+				GitRevision:  gitRev,
+				ConfigYAML:   string(yamlBytes),
+				PromotedBy:   promotedBy,
+			}
+			id, err := dbClient.SaveEnvironmentRevision(ctx, rev)
+			if err != nil {
+				return fmt.Errorf("saving revision: %w", err)
+			}
+
+			fmt.Printf("\n✓ promoted to %q (revision id %d, digest %s)\n", toName, id, toDigest)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate and diff without writing a revision record")
+	return cmd
+}

--- a/src/internal/cli/rollback.go
+++ b/src/internal/cli/rollback.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/spf13/cobra"
+)
+
+func newRollbackCmd() *cobra.Command {
+	var (
+		envName string
+		digest  string
+		list    bool
+		limit   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Restore a previously promoted environment configuration",
+		Long: `Restore a previously recorded environment configuration revision.
+
+Use --list to show recent revisions for an environment without rolling back.
+Use --env and --digest to roll back to a specific revision. When --digest is
+omitted, the second-most-recent revision is restored (i.e. one step back).
+
+Rollback writes the stored config YAML to stdout — redirect it to apiary.yaml
+or a staging copy, review the diff, then reload the daemon.
+
+Examples:
+  apiary rollback --env production --list
+  apiary rollback --env production --digest a1b2c3d4e5f60708`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dbPath := getDBPath()
+			ctx := context.Background()
+			dbClient, err := db.New(ctx, dbPath)
+			if err != nil {
+				return fmt.Errorf("opening database: %w", err)
+			}
+			defer dbClient.Close()
+
+			if list {
+				revs, err := dbClient.ListEnvironmentRevisions(ctx, envName, limit)
+				if err != nil {
+					return err
+				}
+				if len(revs) == 0 {
+					if envName != "" {
+						fmt.Printf("no revisions found for environment %q\n", envName)
+					} else {
+						fmt.Println("no revisions recorded yet")
+					}
+					return nil
+				}
+				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "ID\tENV\tDIGEST\tGIT REV\tPROMOTED BY\tCREATED AT")
+				for _, r := range revs {
+					fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\n",
+						r.ID, r.EnvName, r.ConfigDigest, r.GitRevision,
+						r.PromotedBy, r.CreatedAt.Format("2006-01-02 15:04:05"))
+				}
+				return w.Flush()
+			}
+
+			if envName == "" {
+				return fmt.Errorf("--env is required for rollback (use --list to see available revisions)")
+			}
+
+			var target *db.EnvironmentRevision
+
+			if digest != "" {
+				target, err = dbClient.GetEnvironmentRevisionByDigest(ctx, envName, digest)
+				if err != nil {
+					return err
+				}
+				if target == nil {
+					return fmt.Errorf("no revision with digest %q found for environment %q", digest, envName)
+				}
+			} else {
+				// No digest — restore the previous revision (second-most-recent).
+				revs, err := dbClient.ListEnvironmentRevisions(ctx, envName, 2)
+				if err != nil {
+					return err
+				}
+				if len(revs) < 2 {
+					return fmt.Errorf("need at least 2 revisions to roll back; use --digest to target a specific one")
+				}
+				target = &revs[1]
+			}
+
+			fmt.Fprintf(os.Stderr, "Rolling back environment %q to revision %d (digest %s, git %s)\n",
+				envName, target.ID, target.ConfigDigest, target.GitRevision)
+			fmt.Fprintf(os.Stderr, "Promoted by %q at %s\n\n",
+				target.PromotedBy, target.CreatedAt.Format("2006-01-02 15:04:05"))
+
+			// Print the stored YAML to stdout so the operator can review and redirect.
+			fmt.Print(target.ConfigYAML)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&envName, "env", "", "target environment name")
+	cmd.Flags().StringVar(&digest, "digest", "", "specific config digest to restore (omit for one-step rollback)")
+	cmd.Flags().BoolVar(&list, "list", false, "list recent revisions instead of rolling back")
+	cmd.Flags().IntVar(&limit, "limit", 20, "number of revisions to show with --list")
+	return cmd
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -62,6 +62,9 @@ func init() {
 		newTranscriptCmd(),
 		newPluginsCmd(),
 		newWorkerCmd(),
+		newDiffCmd(),
+		newPromoteCmd(),
+		newRollbackCmd(),
 	)
 }
 

--- a/src/internal/cli/run.go
+++ b/src/internal/cli/run.go
@@ -27,6 +27,7 @@ func newRunCmd() *cobra.Command {
 		src     string
 		worker  string
 		profile string
+		envName string
 	)
 
 	cmd := &cobra.Command{
@@ -101,7 +102,7 @@ func newRunCmd() *cobra.Command {
 			})
 			defer aplog.SetSink(nil)
 
-			disp, err := daemon.New(ctx, cfg, configFile, dbClient, logger, profile)
+			disp, err := daemon.New(ctx, cfg, configFile, dbClient, logger, profile, envName)
 			if err != nil {
 				return fmt.Errorf("initialising dispatcher: %w", err)
 			}
@@ -153,6 +154,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&src, "source", "", "restrict to a single source id")
 	cmd.Flags().StringVar(&worker, "worker", "", "restrict to a single worker id")
 	cmd.Flags().StringVar(&profile, "profile", "", "activate a named runner profile from config profiles.<name>")
+	cmd.Flags().StringVar(&envName, "env", "", "activate a named environment overlay from config environments.<name>")
 
 	return cmd
 }

--- a/src/internal/cli/validate.go
+++ b/src/internal/cli/validate.go
@@ -8,20 +8,37 @@ import (
 )
 
 func newValidateCmd() *cobra.Command {
-	var connectivity bool
+	var (
+		connectivity bool
+		envName      string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate apiary.yaml",
+		Long: `Validate the apiary.yaml configuration file.
+
+When --env is provided, the named environment's overlays are applied first and
+the resolved configuration is validated. This catches overlay errors such as
+references to undefined source IDs or invalid rollout percentages.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(configFile)
 			if err != nil {
 				return err
 			}
 
-			errs := cfg.Validate()
+			resolved := cfg
+			if envName != "" {
+				resolved, err = cfg.ResolveForEnvironment(envName)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Validating resolved config for environment %q\n", envName)
+			}
+
+			errs := resolved.Validate()
 			if len(errs) == 0 {
-				_, pluginErrs := configuredPlugins(cfg)
+				_, pluginErrs := configuredPlugins(resolved)
 				errs = append(errs, pluginErrs...)
 			}
 			if len(errs) > 0 {
@@ -31,11 +48,16 @@ func newValidateCmd() *cobra.Command {
 				return fmt.Errorf("%d validation error(s)", len(errs))
 			}
 
-			for _, w := range cfg.WorkflowWarnings() {
+			for _, w := range resolved.WorkflowWarnings() {
 				fmt.Fprintf(cmd.ErrOrStderr(), "  ⚠ %s\n", w)
 			}
 
-			fmt.Println("✓ config is valid")
+			if envName != "" {
+				digest, _ := config.Digest(resolved)
+				fmt.Printf("✓ config is valid for environment %q (digest: %s)\n", envName, digest)
+			} else {
+				fmt.Println("✓ config is valid")
+			}
 
 			if connectivity {
 				fmt.Println("connectivity checks not yet implemented")
@@ -45,5 +67,6 @@ func newValidateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&connectivity, "connectivity", false, "also test source connectivity")
+	cmd.Flags().StringVar(&envName, "env", "", "validate the resolved configuration for this named environment")
 	return cmd
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -22,7 +22,11 @@ type Config struct {
 	Agents        []AgentConfig                       `yaml:"agents"`
 	Workers       []WorkerConfig                      `yaml:"workers"`
 	Workflows     []WorkflowConfig                    `yaml:"workflows"`
-	Profiles      map[string]map[string]ProfileConfig `yaml:"profiles,omitempty"` // NEW: named runner profiles
+	Profiles      map[string]map[string]ProfileConfig `yaml:"profiles,omitempty"` // named runner profiles
+	// Environments defines named overlays (development, staging, production, …).
+	// Activate one with `apiary run --env <name>`, validate with
+	// `apiary validate --env <name>`, and compare two with `apiary diff <a> <b>`.
+	Environments  map[string]EnvironmentConfig        `yaml:"environments,omitempty"`
 	Settings      Settings                            `yaml:"settings"`
 	Tasks         *TasksConfig                        `yaml:"tasks"`
 	Notifications *NotificationsConfig                `yaml:"notifications"`

--- a/src/internal/config/environment.go
+++ b/src/internal/config/environment.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// EnvironmentConfig defines one named environment (e.g. development, staging,
+// production). It holds overlays applied on top of the base configuration when
+// that environment is active. Secret values must not be stored here; use
+// ${VAR} references that resolve from per-environment .env files instead.
+type EnvironmentConfig struct {
+	// Sources selectively overrides source settings by source ID. Only listed
+	// sources are affected; unlisted sources are inherited unchanged.
+	Sources []EnvironmentSourceOverride `yaml:"sources,omitempty"`
+	// Settings overrides top-level daemon runtime settings for this environment.
+	Settings *EnvironmentSettingsOverride `yaml:"settings,omitempty"`
+	// Rollout restricts dispatch to a subset of eligible tasks, enabling
+	// gradual rollout before promoting a workflow to full production traffic.
+	Rollout *RolloutConfig `yaml:"rollout,omitempty"`
+}
+
+// EnvironmentSourceOverride selectively overrides one source's config.
+// Only the keys listed in Config are merged; unmentioned config keys are kept.
+type EnvironmentSourceOverride struct {
+	// ID is the source id to override (required).
+	ID string `yaml:"id"`
+	// Enabled, when set to false, disables the source entirely for this
+	// environment — it will not be polled and no tasks are dispatched from it.
+	Enabled *bool `yaml:"enabled,omitempty"`
+	// Config is a partial map of source config keys to override. Values support
+	// ${VAR} expansion the same way the top-level config does.
+	Config map[string]any `yaml:"config,omitempty"`
+}
+
+// EnvironmentSettingsOverride overrides per-environment runtime settings.
+// Zero values mean "inherit from the base config".
+type EnvironmentSettingsOverride struct {
+	Concurrency int    `yaml:"concurrency,omitempty"`
+	LogLevel    string `yaml:"log_level,omitempty"`
+	MaxAttempts int    `yaml:"max_attempts,omitempty"`
+}
+
+// RolloutConfig gates dispatch to a subset of eligible tasks, enabling
+// gradual rollout. All non-empty fields are ANDed: a task must satisfy every
+// active filter to be dispatched. An empty RolloutConfig dispatches everything.
+type RolloutConfig struct {
+	// Sources restricts dispatch to tasks originating from these source IDs.
+	// Empty means all sources are eligible.
+	Sources []string `yaml:"sources,omitempty"`
+	// Labels restricts dispatch to tasks that carry at least one of these
+	// labels. Empty means any label set is eligible.
+	Labels []string `yaml:"labels,omitempty"`
+	// Percent restricts dispatch to this percentage (1–100) of eligible tasks.
+	// The selection is deterministic: the same task ID always produces the same
+	// decision across daemon restarts. 0 means no percentage filter.
+	Percent int `yaml:"percent,omitempty"`
+}
+
+// ResolveForEnvironment applies the named environment's overlays to a
+// deep-copy of c and returns the resolved config. The original is never
+// modified. If name is empty the original is returned unchanged.
+// Returns an error when name is non-empty but not defined in environments:.
+func (c *Config) ResolveForEnvironment(name string) (*Config, error) {
+	if name == "" {
+		return c, nil
+	}
+	env, ok := c.Environments[name]
+	if !ok {
+		available := make([]string, 0, len(c.Environments))
+		for k := range c.Environments {
+			available = append(available, k)
+		}
+		if len(available) == 0 {
+			return nil, fmt.Errorf("environment %q not defined (no environments: block configured)", name)
+		}
+		return nil, fmt.Errorf("environment %q not defined; available: %s", name, strings.Join(available, ", "))
+	}
+
+	out, err := cloneConfig(c)
+	if err != nil {
+		return nil, fmt.Errorf("resolving environment %q: %w", name, err)
+	}
+
+	// Build a set of explicitly disabled source IDs.
+	disabledSources := map[string]bool{}
+	// Build a map of source overrides for fast lookup.
+	overrideByID := make(map[string]EnvironmentSourceOverride, len(env.Sources))
+	for _, o := range env.Sources {
+		overrideByID[o.ID] = o
+		if o.Enabled != nil && !*o.Enabled {
+			disabledSources[o.ID] = true
+		}
+	}
+
+	// Remove disabled sources and apply config overlays.
+	filtered := out.Sources[:0]
+	for _, src := range out.Sources {
+		if disabledSources[src.ID] {
+			continue
+		}
+		if o, ok := overrideByID[src.ID]; ok {
+			for k, v := range o.Config {
+				if src.Config == nil {
+					src.Config = map[string]any{}
+				}
+				src.Config[k] = v
+			}
+		}
+		filtered = append(filtered, src)
+	}
+	out.Sources = filtered
+
+	// Apply settings overlay.
+	if s := env.Settings; s != nil {
+		if s.Concurrency > 0 {
+			out.Settings.Concurrency = s.Concurrency
+		}
+		if s.LogLevel != "" {
+			out.Settings.LogLevel = s.LogLevel
+		}
+		if s.MaxAttempts > 0 {
+			out.Settings.MaxAttempts = s.MaxAttempts
+		}
+	}
+
+	return out, nil
+}
+
+// ActiveRollout returns the RolloutConfig for the named environment, or nil
+// when no environment is active or the environment has no rollout: block.
+func (c *Config) ActiveRollout(envName string) *RolloutConfig {
+	if envName == "" || c.Environments == nil {
+		return nil
+	}
+	env, ok := c.Environments[envName]
+	if !ok || env.Rollout == nil {
+		return nil
+	}
+	r := *env.Rollout
+	return &r
+}
+
+// Digest computes a short hex digest of the resolved configuration. The digest
+// is stable for identical configs and is recorded on every workflow instance for
+// audit purposes. It is not intended for cryptographic use.
+func Digest(cfg *Config) (string, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("config digest: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:8]), nil
+}
+
+// GitRevision returns the abbreviated Git commit hash at the HEAD of the
+// repository containing configPath. Returns an empty string when configPath is
+// not inside a Git repository or when git is unavailable — callers must treat
+// an empty string as "unknown" and continue normally.
+func GitRevision(configPath string) string {
+	dir := filepath.Dir(configPath)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--short=12", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// MarshalYAML returns the YAML encoding of cfg. Used by CLI commands that need
+// the serialized form of a resolved environment configuration (e.g. promote,
+// rollback).
+func MarshalYAML(cfg *Config) ([]byte, error) {
+	return yaml.Marshal(cfg)
+}
+
+// cloneConfig deep-copies a Config via YAML round-trip so that struct slices
+// are not aliased between the original and the copy.
+func cloneConfig(c *Config) (*Config, error) {
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	var out Config
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	// rawContent is used by Save(); propagate it so callers can still persist.
+	out.rawContent = c.rawContent
+	return &out, nil
+}

--- a/src/internal/config/environment_diff.go
+++ b/src/internal/config/environment_diff.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DiffEntry describes one semantic difference between two resolved configs.
+type DiffEntry struct {
+	// Kind is the entity type: "workflow", "source", "agent", "runner", "setting".
+	Kind string
+	// Name is the entity ID or setting key.
+	Name string
+	// Op is the change operation: "added", "removed", or "changed".
+	Op string
+	// Detail is a human-readable description of what changed (only for "changed").
+	Detail string
+}
+
+func (d DiffEntry) String() string {
+	switch d.Op {
+	case "changed":
+		return fmt.Sprintf("%s %s: %s (%s)", d.Kind, d.Name, d.Op, d.Detail)
+	default:
+		return fmt.Sprintf("%s %s: %s", d.Kind, d.Name, d.Op)
+	}
+}
+
+// SemanticDiff computes the differences between two resolved configurations.
+// The diff is entity-aware: it understands workflows, sources, agents, runners,
+// and settings rather than treating the config as raw YAML text. This makes it
+// meaningful across environments where the same entity may have different
+// credentials or concurrency limits.
+func SemanticDiff(from, to *Config) []DiffEntry {
+	var entries []DiffEntry
+	entries = append(entries, diffWorkflows(from, to)...)
+	entries = append(entries, diffSources(from, to)...)
+	entries = append(entries, diffAgents(from, to)...)
+	entries = append(entries, diffRunners(from, to)...)
+	entries = append(entries, diffSettings(from, to)...)
+	return entries
+}
+
+func diffWorkflows(from, to *Config) []DiffEntry {
+	fromMap := make(map[string]WorkflowConfig, len(from.Workflows))
+	for _, w := range from.Workflows {
+		fromMap[w.ID] = w
+	}
+	toMap := make(map[string]WorkflowConfig, len(to.Workflows))
+	for _, w := range to.Workflows {
+		toMap[w.ID] = w
+	}
+	var out []DiffEntry
+	for id := range fromMap {
+		if _, ok := toMap[id]; !ok {
+			out = append(out, DiffEntry{Kind: "workflow", Name: id, Op: "removed"})
+		}
+	}
+	for id, tw := range toMap {
+		fw, ok := fromMap[id]
+		if !ok {
+			out = append(out, DiffEntry{Kind: "workflow", Name: id, Op: "added"})
+			continue
+		}
+		var changes []string
+		if len(fw.Steps) != len(tw.Steps) {
+			changes = append(changes, fmt.Sprintf("steps: %d → %d", len(fw.Steps), len(tw.Steps)))
+		}
+		if fw.Trigger.Priority != tw.Trigger.Priority {
+			changes = append(changes, fmt.Sprintf("trigger.priority: %d → %d", fw.Trigger.Priority, tw.Trigger.Priority))
+		}
+		if len(changes) > 0 {
+			out = append(out, DiffEntry{Kind: "workflow", Name: id, Op: "changed",
+				Detail: strings.Join(changes, "; ")})
+		}
+	}
+	return out
+}
+
+func diffSources(from, to *Config) []DiffEntry {
+	fromMap := make(map[string]SourceConfig, len(from.Sources))
+	for _, s := range from.Sources {
+		fromMap[s.ID] = s
+	}
+	toMap := make(map[string]SourceConfig, len(to.Sources))
+	for _, s := range to.Sources {
+		toMap[s.ID] = s
+	}
+	var out []DiffEntry
+	for id := range fromMap {
+		if _, ok := toMap[id]; !ok {
+			out = append(out, DiffEntry{Kind: "source", Name: id, Op: "removed"})
+		}
+	}
+	for id, ts := range toMap {
+		fs, ok := fromMap[id]
+		if !ok {
+			out = append(out, DiffEntry{Kind: "source", Name: id, Op: "added"})
+			continue
+		}
+		var changes []string
+		if fs.Type != ts.Type {
+			changes = append(changes, fmt.Sprintf("type: %s → %s", fs.Type, ts.Type))
+		}
+		if fs.PollInterval != ts.PollInterval {
+			changes = append(changes, fmt.Sprintf("poll_interval: %s → %s", fs.PollInterval, ts.PollInterval))
+		}
+		if len(changes) > 0 {
+			out = append(out, DiffEntry{Kind: "source", Name: id, Op: "changed",
+				Detail: strings.Join(changes, "; ")})
+		}
+	}
+	return out
+}
+
+func diffAgents(from, to *Config) []DiffEntry {
+	fromMap := make(map[string]AgentConfig, len(from.Agents))
+	for _, a := range from.Agents {
+		fromMap[a.ID] = a
+	}
+	toMap := make(map[string]AgentConfig, len(to.Agents))
+	for _, a := range to.Agents {
+		toMap[a.ID] = a
+	}
+	var out []DiffEntry
+	for id := range fromMap {
+		if _, ok := toMap[id]; !ok {
+			out = append(out, DiffEntry{Kind: "agent", Name: id, Op: "removed"})
+		}
+	}
+	for id, ta := range toMap {
+		fa, ok := fromMap[id]
+		if !ok {
+			out = append(out, DiffEntry{Kind: "agent", Name: id, Op: "added"})
+			continue
+		}
+		var changes []string
+		if fa.Model != ta.Model {
+			changes = append(changes, fmt.Sprintf("model: %s → %s", fa.Model, ta.Model))
+		}
+		if fa.Runner != ta.Runner {
+			changes = append(changes, fmt.Sprintf("runner: %s → %s", fa.Runner, ta.Runner))
+		}
+		if fa.MaxWorkers != ta.MaxWorkers {
+			changes = append(changes, fmt.Sprintf("max_workers: %d → %d", fa.MaxWorkers, ta.MaxWorkers))
+		}
+		if len(changes) > 0 {
+			out = append(out, DiffEntry{Kind: "agent", Name: id, Op: "changed",
+				Detail: strings.Join(changes, "; ")})
+		}
+	}
+	return out
+}
+
+func diffRunners(from, to *Config) []DiffEntry {
+	fromMap := make(map[string]RunnerConfig, len(from.Runners))
+	for _, r := range from.Runners {
+		fromMap[r.ID] = r
+	}
+	toMap := make(map[string]RunnerConfig, len(to.Runners))
+	for _, r := range to.Runners {
+		toMap[r.ID] = r
+	}
+	var out []DiffEntry
+	for id := range fromMap {
+		if _, ok := toMap[id]; !ok {
+			out = append(out, DiffEntry{Kind: "runner", Name: id, Op: "removed"})
+		}
+	}
+	for id, tr := range toMap {
+		fr, ok := fromMap[id]
+		if !ok {
+			out = append(out, DiffEntry{Kind: "runner", Name: id, Op: "added"})
+			continue
+		}
+		if fr.Type != tr.Type || fr.Provider != tr.Provider {
+			out = append(out, DiffEntry{Kind: "runner", Name: id, Op: "changed",
+				Detail: fmt.Sprintf("type/provider: %s/%s → %s/%s", fr.Type, fr.Provider, tr.Type, tr.Provider)})
+		}
+	}
+	return out
+}
+
+func diffSettings(from, to *Config) []DiffEntry {
+	var out []DiffEntry
+	if from.Settings.Concurrency != to.Settings.Concurrency {
+		out = append(out, DiffEntry{Kind: "setting", Name: "concurrency", Op: "changed",
+			Detail: fmt.Sprintf("%d → %d", from.Settings.Concurrency, to.Settings.Concurrency)})
+	}
+	if from.Settings.LogLevel != to.Settings.LogLevel {
+		out = append(out, DiffEntry{Kind: "setting", Name: "log_level", Op: "changed",
+			Detail: fmt.Sprintf("%q → %q", from.Settings.LogLevel, to.Settings.LogLevel)})
+	}
+	if from.Settings.MaxAttempts != to.Settings.MaxAttempts {
+		out = append(out, DiffEntry{Kind: "setting", Name: "max_attempts", Op: "changed",
+			Detail: fmt.Sprintf("%d → %d", from.Settings.MaxAttempts, to.Settings.MaxAttempts)})
+	}
+	if from.Settings.StateLock != to.Settings.StateLock {
+		out = append(out, DiffEntry{Kind: "setting", Name: "state_lock", Op: "changed",
+			Detail: fmt.Sprintf("%v → %v", from.Settings.StateLock, to.Settings.StateLock)})
+	}
+	return out
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -274,6 +274,7 @@ func (c *Config) Validate() []error {
 	errs = append(errs, c.lint()...)
 
 	errs = append(errs, c.validateNotifications()...)
+	errs = append(errs, c.validateEnvironments(sourceIDs)...)
 
 	return errs
 }
@@ -321,6 +322,44 @@ func validateQueueSettings(settings QueueSettings) []error {
 		for key, value := range values {
 			if strings.TrimSpace(key) == "" || value <= 0 {
 				errs = append(errs, fmt.Errorf("settings.queue.concurrency.%s[%q] must have a non-empty key and positive limit", name, key))
+			}
+		}
+	}
+	return errs
+}
+
+// validateEnvironments checks the environments: block. sourceIDs is the set of
+// already-validated source ids, used to catch overrides that reference unknown
+// sources.
+func (c *Config) validateEnvironments(sourceIDs map[string]bool) []error {
+	if len(c.Environments) == 0 {
+		return nil
+	}
+	var errs []error
+	for name, env := range c.Environments {
+		scope := fmt.Sprintf("environments.%s", name)
+		seen := map[string]bool{}
+		for i, so := range env.Sources {
+			if so.ID == "" {
+				errs = append(errs, fmt.Errorf("%s.sources[%d]: id is required", scope, i))
+				continue
+			}
+			if !sourceIDs[so.ID] {
+				errs = append(errs, fmt.Errorf("%s.sources[%d]: source id %q not defined in sources:", scope, i, so.ID))
+			}
+			if seen[so.ID] {
+				errs = append(errs, fmt.Errorf("%s.sources[%d]: duplicate source override for %q", scope, i, so.ID))
+			}
+			seen[so.ID] = true
+		}
+		if r := env.Rollout; r != nil {
+			if r.Percent < 0 || r.Percent > 100 {
+				errs = append(errs, fmt.Errorf("%s.rollout.percent must be between 0 and 100, got %d", scope, r.Percent))
+			}
+			for i, src := range r.Sources {
+				if !sourceIDs[src] {
+					errs = append(errs, fmt.Errorf("%s.rollout.sources[%d]: source id %q not defined in sources:", scope, i, src))
+				}
 			}
 		}
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -49,6 +49,14 @@ type Dispatcher struct {
 	configFile string
 	startedAt  time.Time
 
+	// configDigest and gitRevision are the effective config revision at
+	// daemon startup. Written to every workflow instance via the engine.
+	configDigest string
+	gitRevision  string
+	// rollout is the active environment's rollout filter, or nil when no
+	// environment is active or the environment has no rollout: block.
+	rollout *config.RolloutConfig
+
 	router      *router.Router
 	sources     map[string]source.Adapter
 	runners     map[string]runnerimpl.Runner
@@ -185,16 +193,31 @@ func (d *Dispatcher) pauseRunnerWithKind(runnerType string, until time.Time, kin
 // Pass nil for db and logger to skip state persistence and logging to SQLite.
 // profileName selects a named runner profile (from cfg.Profiles) that overrides
 // per-agent runner/model/fallbacks settings. An empty string means base config.
-func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger, profileName ...string) (*Dispatcher, error) {
+func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger, profileAndEnv ...string) (*Dispatcher, error) {
 	r, err := router.New(cfg)
 	if err != nil {
 		return nil, err
 	}
 
+	// Extract profile name (positional 0) and env name (positional 1).
+	var profileName, envName string
+	if len(profileAndEnv) > 0 {
+		profileName = profileAndEnv[0]
+	}
+	if len(profileAndEnv) > 1 {
+		envName = profileAndEnv[1]
+	}
+	// Compute the config revision at startup for audit trail on every instance.
+	digest, _ := config.Digest(cfg)
+	gitRev := config.GitRevision(configFile)
+
 	d := &Dispatcher{
 		cfg:             cfg,
 		configFile:      configFile,
 		startedAt:       time.Now(),
+		configDigest:    digest,
+		gitRevision:     gitRev,
+		rollout:         cfg.ActiveRollout(envName),
 		router:          r,
 		sources:         make(map[string]source.Adapter),
 		runners:         make(map[string]runnerimpl.Runner),
@@ -295,10 +318,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 	// Apply the active profile overlay (if any) before building runners.
 	// Profiles override per-agent runner/model/fallbacks/fallback_strategy from
 	// the named entry in cfg.Profiles, selected via --profile=<name>.
-	var activeProfile string
-	if len(profileName) > 0 {
-		activeProfile = profileName[0]
-	}
+	activeProfile := profileName
 	if activeProfile != "" {
 		profile, ok := cfg.Profiles[activeProfile]
 		if !ok {
@@ -1378,6 +1398,14 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			matches = d.dropOnceMatches(ctx, task.ID, matches)
 			matches = d.dropCappedMatches(ctx, task, matches)
 		}
+		// Apply the active environment's rollout filter. When a rollout is
+		// configured, only tasks that pass the source/label/percent filters are
+		// dispatched; the rest are skipped for this poll cycle.
+		if d.rollout != nil && !d.rolloutMatches(cell, d.rollout) {
+			aplog.Debug("cell %s (%q): excluded by rollout filter", cell.LogLabel(), cell.Title)
+			d.inFlight.Delete(cell.ID)
+			continue
+		}
 		if len(matches) == 0 {
 			aplog.Debug("cell %s (%q): no matching route, skipping", cell.LogLabel(), cell.Title)
 			d.inFlight.Delete(cell.ID)
@@ -1385,6 +1413,68 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		}
 		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
 	}
+}
+
+// rolloutMatches reports whether a cell passes the active environment's rollout
+// filter. All non-empty criteria must match (they are ANDed).
+func (d *Dispatcher) rolloutMatches(cell model.SourceItem, r *config.RolloutConfig) bool {
+	// Source filter.
+	if len(r.Sources) > 0 {
+		found := false
+		for _, src := range r.Sources {
+			if src == cell.SourceID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Label filter — at least one of r.Labels must appear in the cell's labels.
+	if len(r.Labels) > 0 {
+		labelSet := make(map[string]bool, len(cell.Labels))
+		for _, l := range cell.Labels {
+			labelSet[strings.ToLower(l)] = true
+		}
+		found := false
+		for _, wanted := range r.Labels {
+			if labelSet[strings.ToLower(wanted)] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Percentage filter — deterministic hash of the cell ID.
+	if r.Percent > 0 && r.Percent < 100 {
+		h := rolloutHash(cell.ID)
+		if h%100 >= uint64(r.Percent) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// rolloutHash computes a stable, uniform-looking hash of a string for the
+// percentage rollout filter. We use a simple FNV-1a 64-bit hash; the modulo
+// distribution is good enough for rollout decisions.
+func rolloutHash(s string) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	h := uint64(offset64)
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
 }
 
 // fanOut dispatches every workflow matched for a polled cell. One InternalTask

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -59,6 +59,7 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 		if d.db != nil {
 			store = pluginExportStore{Client: d.db, dispatcher: d}
 		}
+		opts = append(opts, workflow.WithConfigRevision(d.configDigest, d.gitRevision))
 		d.engine = workflow.NewEngine(d.cfg, store, &wfStepExecutor{d: d}, opts...)
 	})
 	return d.engine

--- a/src/internal/db/environment_store.go
+++ b/src/internal/db/environment_store.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+// EnvironmentRevision records one promoted configuration revision for a named
+// environment. Written by "apiary promote" after validation and dry-run checks
+// pass; read by "apiary rollback" to restore a previous revision.
+type EnvironmentRevision struct {
+	ID           int64
+	EnvName      string
+	ConfigDigest string
+	GitRevision  string
+	// ConfigYAML is the full resolved YAML of the promoted configuration so
+	// rollback does not need to reconstruct it from the current config file.
+	ConfigYAML string
+	PromotedBy string
+	CreatedAt  time.Time
+}
+
+// SaveEnvironmentRevision appends a new revision record and returns its id.
+func (c *Client) SaveEnvironmentRevision(ctx context.Context, r *EnvironmentRevision) (int64, error) {
+	res, err := c.db.ExecContext(ctx, `
+		INSERT INTO environment_revisions
+		  (env_name, config_digest, git_revision, config_yaml, promoted_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, r.EnvName, r.ConfigDigest, r.GitRevision, r.ConfigYAML, r.PromotedBy, time.Now())
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// ListEnvironmentRevisions returns the most recent revisions for the given
+// environment, newest first. If envName is empty all environments are returned.
+func (c *Client) ListEnvironmentRevisions(ctx context.Context, envName string, limit int) ([]EnvironmentRevision, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if envName != "" {
+		rows, err = c.db.QueryContext(ctx, `
+			SELECT id, env_name, config_digest, COALESCE(git_revision,''),
+			       config_yaml, COALESCE(promoted_by,''), created_at
+			FROM environment_revisions
+			WHERE env_name = ?
+			ORDER BY created_at DESC LIMIT ?
+		`, envName, limit)
+	} else {
+		rows, err = c.db.QueryContext(ctx, `
+			SELECT id, env_name, config_digest, COALESCE(git_revision,''),
+			       config_yaml, COALESCE(promoted_by,''), created_at
+			FROM environment_revisions
+			ORDER BY created_at DESC LIMIT ?
+		`, limit)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []EnvironmentRevision
+	for rows.Next() {
+		var r EnvironmentRevision
+		if err := rows.Scan(&r.ID, &r.EnvName, &r.ConfigDigest, &r.GitRevision,
+			&r.ConfigYAML, &r.PromotedBy, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetEnvironmentRevisionByDigest returns the most recent revision whose digest
+// matches, or (nil, nil) when not found.
+func (c *Client) GetEnvironmentRevisionByDigest(ctx context.Context, envName, digest string) (*EnvironmentRevision, error) {
+	row := c.db.QueryRowContext(ctx, `
+		SELECT id, env_name, config_digest, COALESCE(git_revision,''),
+		       config_yaml, COALESCE(promoted_by,''), created_at
+		FROM environment_revisions
+		WHERE env_name = ? AND config_digest = ?
+		ORDER BY created_at DESC LIMIT 1
+	`, envName, digest)
+	var r EnvironmentRevision
+	if err := row.Scan(&r.ID, &r.EnvName, &r.ConfigDigest, &r.GitRevision,
+		&r.ConfigYAML, &r.PromotedBy, &r.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &r, nil
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -326,6 +326,21 @@ CREATE INDEX IF NOT EXISTS idx_internal_tasks_parent ON internal_tasks(parent_ta
 CREATE INDEX IF NOT EXISTS idx_source_bindings_task ON source_bindings(task_id);
 CREATE INDEX IF NOT EXISTS idx_source_bindings_item ON source_bindings(source_id, source_item_id);
 CREATE INDEX IF NOT EXISTS idx_task_pull_requests_task ON task_pull_requests(task_id);
+
+-- Auditable record of every promoted configuration revision. Written by
+-- "apiary promote" after validation and dry-run checks pass. Each row carries
+-- the full resolved YAML so "apiary rollback" can restore any prior revision
+-- without consulting the Git history of the config file.
+CREATE TABLE IF NOT EXISTS environment_revisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  env_name TEXT NOT NULL,
+  config_digest TEXT NOT NULL,
+  git_revision TEXT NOT NULL DEFAULT '',
+  config_yaml TEXT NOT NULL,
+  promoted_by TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_env_revisions_env ON environment_revisions(env_name, created_at DESC);
 `
 
 // migrations are idempotent ALTER statements applied to databases created
@@ -406,6 +421,13 @@ var migrations = []string{
 	// "aborted".
 	`ALTER TABLE task_executions ADD COLUMN credit_exhausted INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN failure_kind TEXT`,
+	// Config revision tracking: record the effective configuration digest and
+	// Git revision on every workflow instance so promotions and rollbacks are
+	// fully auditable. config_digest is a short SHA256 of the resolved YAML;
+	// git_revision is the HEAD commit hash at the time of dispatch (empty when
+	// the config is not inside a Git repository or git is unavailable).
+	`ALTER TABLE workflow_instances ADD COLUMN config_digest TEXT`,
+	`ALTER TABLE workflow_instances ADD COLUMN git_revision TEXT`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -50,8 +50,16 @@ type WorkflowInstance struct {
 	State            string
 	ParentInstanceID string
 	ResumedFrom      string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	// ConfigDigest is the short SHA256 of the resolved configuration YAML at
+	// the time this instance was dispatched. Empty for instances created before
+	// this feature was added. Set by the workflow engine from the active config.
+	ConfigDigest string
+	// GitRevision is the abbreviated HEAD commit hash of the config's Git
+	// repository at dispatch time. Empty when git is unavailable or the config
+	// is not inside a repository.
+	GitRevision string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // StepRun records one step execution within a workflow instance.
@@ -104,13 +112,18 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO workflow_instances
 		  (id, workflow_id, task_id, cell_id, source_id, state, parent_instance_id, resumed_from,
-		   task_generation, created_at, updated_at)
+		   task_generation, config_digest, git_revision, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
-		        COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0), ?, ?)
+		        COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0), ?, ?, ?, ?)
 	`, inst.ID, inst.WorkflowID, nullStr(inst.TaskID), inst.CellID, nullStr(inst.SourceID), inst.State,
-		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.TaskID, inst.CreatedAt, inst.UpdatedAt)
+		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.TaskID,
+		nullStr(inst.ConfigDigest), nullStr(inst.GitRevision), inst.CreatedAt, inst.UpdatedAt)
 	if err == nil {
-		c.recordWorkflowEvent(ctx, inst, "workflow.started", map[string]any{"state": inst.State})
+		c.recordWorkflowEvent(ctx, inst, "workflow.started", map[string]any{
+			"state":         inst.State,
+			"config_digest": inst.ConfigDigest,
+			"git_revision":  inst.GitRevision,
+		})
 		if inst.ResumedFrom != "" {
 			c.recordWorkflowEvent(ctx, inst, "workflow.resumed", map[string]any{"resumed_from": inst.ResumedFrom})
 		}
@@ -140,7 +153,8 @@ func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state stri
 func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances WHERE id = ?
 	`, id)
 	inst, err := scanInstance(row)
@@ -234,7 +248,8 @@ func (c *Client) HasCompletedInstanceForRoute(ctx context.Context, taskID, workf
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances WHERE state = ? ORDER BY created_at ASC
 	`, state)
 	if err != nil {
@@ -251,7 +266,8 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 	}
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances ORDER BY created_at DESC LIMIT ?
 	`, limit)
 	if err != nil {
@@ -266,7 +282,8 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC LIMIT 1
 	`, cellID)
 	inst, err := scanInstance(row)
@@ -282,7 +299,8 @@ func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*W
 func (c *Client) ListWorkflowInstancesByCell(ctx context.Context, cellID string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC
 	`, cellID)
 	if err != nil {
@@ -298,7 +316,8 @@ func (c *Client) ListWorkflowInstancesByCell(ctx context.Context, cellID string)
 func (c *Client) ListWorkflowInstancesByTask(ctx context.Context, taskID string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances WHERE task_id = ? ORDER BY created_at DESC
 	`, taskID)
 	if err != nil {
@@ -313,7 +332,8 @@ func (c *Client) ListWorkflowInstancesByTask(ctx context.Context, taskID string)
 func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
 		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
-		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at,
+		       COALESCE(task_id,''), COALESCE(config_digest,''), COALESCE(git_revision,'')
 		FROM workflow_instances
 		WHERE workflow_id = ? AND state IN ('failed','interrupted')
 		ORDER BY created_at DESC LIMIT 1
@@ -341,7 +361,8 @@ func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowI
 	q := `
 		SELECT wi.id, wi.workflow_id, wi.cell_id, COALESCE(wi.source_id,''), wi.state,
 		       COALESCE(wi.parent_instance_id,''), COALESCE(wi.resumed_from,''),
-		       wi.created_at, wi.updated_at, COALESCE(wi.task_id,''), COALESCE(t.title,'')
+		       wi.created_at, wi.updated_at, COALESCE(wi.task_id,''),
+		       COALESCE(wi.config_digest,''), COALESCE(wi.git_revision,''), COALESCE(t.title,'')
 		FROM workflow_instances wi
 		LEFT JOIN tasks t ON t.id = wi.cell_id
 		WHERE 1=1`
@@ -367,7 +388,8 @@ func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowI
 	for rows.Next() {
 		var v WorkflowInstanceView
 		if err := rows.Scan(&v.ID, &v.WorkflowID, &v.CellID, &v.SourceID, &v.State,
-			&v.ParentInstanceID, &v.ResumedFrom, &v.CreatedAt, &v.UpdatedAt, &v.TaskID, &v.Title); err != nil {
+			&v.ParentInstanceID, &v.ResumedFrom, &v.CreatedAt, &v.UpdatedAt,
+			&v.TaskID, &v.ConfigDigest, &v.GitRevision, &v.Title); err != nil {
 			return nil, err
 		}
 		out = append(out, v)
@@ -691,7 +713,8 @@ type scanner interface {
 func scanInstance(s scanner) (*WorkflowInstance, error) {
 	var inst WorkflowInstance
 	err := s.Scan(&inst.ID, &inst.WorkflowID, &inst.CellID, &inst.SourceID, &inst.State,
-		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt, &inst.TaskID)
+		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt,
+		&inst.TaskID, &inst.ConfigDigest, &inst.GitRevision)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -261,6 +261,12 @@ type Engine struct {
 	depChecker        DependencyChecker
 	approvalProviders []ApprovalProvider
 
+	// configDigest and gitRevision are recorded on every workflow instance for
+	// audit purposes. Set via WithConfigRevision; empty strings are stored as
+	// NULLs in the database.
+	configDigest string
+	gitRevision  string
+
 	now   func() time.Time
 	newID func(prefix string) string
 
@@ -319,6 +325,16 @@ func WithApprovalProvider(provider ApprovalProvider) Option {
 	}
 }
 
+// WithConfigRevision records the effective configuration digest and Git revision
+// on every workflow instance this engine creates, providing a full audit trail
+// of which configuration version was active at dispatch time.
+func WithConfigRevision(digest, gitRevision string) Option {
+	return func(e *Engine) {
+		e.configDigest = digest
+		e.gitRevision = gitRevision
+	}
+}
+
 // NewEngine builds an Engine. cfg, store, and exec are required.
 func NewEngine(cfg *config.Config, store Store, exec StepExecutor, opts ...Option) *Engine {
 	e := &Engine{
@@ -354,13 +370,15 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task
 
 	instID := e.newID("wf")
 	inst := &db.WorkflowInstance{
-		ID:         instID,
-		WorkflowID: wf.ID,
-		TaskID:     task.ID,
-		CellID:     cell.ID,
-		SourceID:   cell.SourceID,
-		State:      db.InstanceStateRunning,
-		CreatedAt:  e.now(),
+		ID:           instID,
+		WorkflowID:   wf.ID,
+		TaskID:       task.ID,
+		CellID:       cell.ID,
+		SourceID:     cell.SourceID,
+		State:        db.InstanceStateRunning,
+		ConfigDigest: e.configDigest,
+		GitRevision:  e.gitRevision,
+		CreatedAt:    e.now(),
 	}
 	if err := e.store.CreateWorkflowInstance(ctx, inst); err != nil {
 		return "", false, fmt.Errorf("create workflow instance: %w", err)


### PR DESCRIPTION
## Summary

Implements named environment overlays (development/staging/production) with the full promotion/rollback workflow described in issue #216.

**Config layer:**
- New `environments:` map in `apiary.yaml` — each entry holds source overrides (enable/disable + config key merges), settings overrides (concurrency, log level, max_attempts), and a gradual rollout block (by source list, label list, or deterministic percentage)
- `ResolveForEnvironment(name)` deep-copies the base config and applies overlays; original is never mutated
- `Digest(cfg)` — 16-char SHA256 hex for audit stamping; `GitRevision(configPath)` — abbreviated HEAD hash via `git -C`
- `SemanticDiff(from, to)` — entity-aware diff across workflows, sources, agents, runners, and settings
- `validateEnvironments()` added to `Validate()` — catches unknown source IDs and invalid rollout percents at startup

**Persistence layer:**
- New `environment_revisions` table records promoted configs (env name, digest, git rev, full YAML, promotedBy, timestamp)
- `workflow_instances` gains `config_digest` and `git_revision` columns (idempotent `ALTER TABLE` migrations)
- `WorkflowInstance` struct and all SELECT/INSERT queries updated accordingly

**Daemon layer:**
- `Dispatcher` resolves env name at startup, computes digest + git rev, stores rollout config
- Rollout filter applied in the `poll()` loop after routing (FNV-1a 64-bit hash for deterministic percentage)
- `Engine` receives `WithConfigRevision(digest, gitRev)` and stamps every new `WorkflowInstance`

**CLI layer:**
- `apiary validate --env <name>` — resolves overlay then validates; prints digest on success
- `apiary run --env <name>` — activates environment overlay for the running daemon
- `apiary diff <env1> <env2>` — semantic diff between two resolved configs (use `base` for no overlay)
- `apiary promote <from> <to> [--dry-run]` — validates target, shows diff, writes revision record
- `apiary rollback [--env] [--digest] [--list]` — lists or restores a previously promoted revision (prints YAML to stdout for operator review before reload)

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./...` — all 23 packages pass
- [ ] Manual: add `environments:` block to a local `apiary.yaml` and run `apiary validate --env staging`
- [ ] Manual: `apiary diff development staging` shows semantic diff
- [ ] Manual: `apiary promote development staging` writes a revision row
- [ ] Manual: `apiary rollback --env staging --list` shows the revision; `--digest` restores it

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)