### PR TITLE
security: check each plugin sub-root for writable permissions (SEC-04 follow-up)

### DIFF
--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -53,6 +53,10 @@ func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error
 		}
 		sort.Strings(roots)
 		for _, root := range roots {
+			if warn := checkDirOwnerOnly(root); warn != nil {
+				errs = append(errs, warn)
+				continue
+			}
 			if _, err := os.Stat(filepath.Join(root, ManifestFilename)); err != nil {
 				continue
 			}

--- a/src/internal/plugin/discovery_unix_test.go
+++ b/src/internal/plugin/discovery_unix_test.go
@@ -42,3 +42,30 @@ func TestDiscoverSkipsGroupAndWorldWritableDirs(t *testing.T) {
 		t.Fatal("safe plugin from good path should still load")
 	}
 }
+
+func TestDiscoverSkipsWritableChildPluginDir(t *testing.T) {
+	// Parent dir has correct permissions (0700); one child plugin dir is
+	// group-writable — discovery must skip that child and warn, while still
+	// loading a sibling child with safe permissions.
+	parent := t.TempDir() // 0700 by default
+
+	writeTestPlugin(t, parent, "bad", "exit 0", Manifest{})
+	if err := os.Chmod(filepath.Join(parent, "bad"), 0o775); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(parent, "bad"), 0o755) })
+
+	writeTestPlugin(t, parent, "good", "exit 0", Manifest{})
+
+	registry, errs := Discover([]string{parent}, parent, "v0.10.0")
+
+	if _, ok := registry.Get("dev.apiary.bad"); ok {
+		t.Fatal("group-writable child plugin dir must not be loaded")
+	}
+	if _, ok := registry.Get("dev.apiary.good"); !ok {
+		t.Fatal("sibling with safe permissions must still load")
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "group- or world-writable") {
+		t.Fatalf("expected exactly 1 permission warning for the bad child, got errs=%v", errs)
+	}
+}


### PR DESCRIPTION
## Summary

- `plugin.Discover()` previously called `checkDirOwnerOnly` only on the top-level configured path. In the common `plugins/<plugin-a>/`, `plugins/<plugin-b>/` layout the per-plugin subdirectories were never checked — a group/world-writable child dir under a safe parent was still loaded.
- This PR applies `checkDirOwnerOnly` to **each root** inside the roots loop, so the permission gate fires on the directory that actually contains the plugin executable.
- Adds `TestDiscoverSkipsWritableChildPluginDir` which reproduces the missed case: clean parent (0700) + one group-writable child + one safe sibling. The safe sibling still loads; the writable child is skipped with a warning.

## Test plan

- [x] `TestDiscoverSkipsGroupAndWorldWritableDirs` — existing top-level case, still passes
- [x] `TestDiscoverSkipsWritableChildPluginDir` — new test covering the sub-root case (was the missed scenario)
- [x] Full plugin package test suite passes (`go test ./internal/plugin/...` — 6/6)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)