### PR TITLE
security: cap agent privilege ceiling — refuse root execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10299 symbols, 23575 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **apiary** (10299 symbols, 23575 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
-- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -335,6 +335,34 @@ shared directory — editing a script updates every repo at once. Note that
 `core.hooksPath` replaces the per-repo `.git/hooks` directory entirely for
 the configured repos.
 
+### Privilege ceiling (`security`)
+
+Apiary adds no privilege of its own — agent subprocesses inherit the OS user
+that runs the daemon. If that user is **root (uid 0)**, a successful
+prompt-injection attack via untrusted task content (a GitHub issue body, a
+Jira ticket description, a PR comment) executes with full system access.
+
+To guard against this, the daemon **refuses to launch agent subprocesses when
+running as root** unless explicitly overridden:
+
+```yaml
+settings:
+  security:
+    allow_root: false   # default — refuse root execution
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `allow_root` | `false` | Set `true` to permit agent launches as root. Strongly discouraged — prefer running Apiary as a dedicated unprivileged service account |
+
+**Recommended setup:** create a dedicated OS user (`apiary` or similar) with
+access to only the repositories the daemon manages. Do not run the daemon or
+the underlying CLI (`claude`, `opencode`, `codex`) as root.
+
+**One-off override:** set `APIARY_ALLOW_ROOT=1` in the environment to bypass
+the check for a single run without editing `apiary.yaml`. This is intended for
+troubleshooting, not production use.
+
 ### Cursor cost back-fill (`cursor_cost`)
 
 The Cursor agent CLI streams token counts but **no dollar cost** — unlike the

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -287,6 +287,21 @@ type Settings struct {
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+	// Security controls privilege and execution-boundary settings.
+	Security SecuritySettings `yaml:"security,omitempty"`
+}
+
+// SecuritySettings caps the privilege at which agent subprocesses are allowed
+// to run and documents the recommended secure configuration.
+type SecuritySettings struct {
+	// AllowRoot, when true, permits Apiary to launch agent CLI subprocesses
+	// as root (uid 0). Default false: root execution is refused because a
+	// successful prompt-injection via untrusted task content (Jira/GitHub issue
+	// text, PR descriptions, etc.) would then run at full system privilege.
+	// Set APIARY_ALLOW_ROOT=1 for a one-off override without editing config.
+	// Both options are strongly discouraged — prefer running as a dedicated
+	// unprivileged service account.
+	AllowRoot bool `yaml:"allow_root,omitempty"`
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -357,7 +357,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			return nil, fmt.Errorf("agent %q: runner type %q not found", ac.ID, rc.Type)
 		}
 
-		if err := ra.Configure(runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)); err != nil {
+		agentRunConf := runnerConfigWithMCPs(rc.Config, rc.MCPs, ac.MCPs)
+		agentRunConf["allow_root"] = cfg.Settings.Security.AllowRoot
+		if err := ra.Configure(agentRunConf); err != nil {
 			return nil, fmt.Errorf("agent %q: configure runner: %w", ac.ID, err)
 		}
 
@@ -389,7 +391,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			if !ok {
 				return nil, fmt.Errorf("agent %q: fallback runner type %q not found", ac.ID, fAdapterName)
 			}
-			if err := fra.Configure(runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)); err != nil {
+			fbRunConf := runnerConfigWithMCPs(frc.Config, frc.MCPs, ac.MCPs)
+			fbRunConf["allow_root"] = cfg.Settings.Security.AllowRoot
+			if err := fra.Configure(fbRunConf); err != nil {
 				return nil, fmt.Errorf("agent %q: configure fallback runner %q: %w", ac.ID, fb.Runner, err)
 			}
 			if fAdapterName == "opencode" {
@@ -415,7 +419,9 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		if !ok {
 			return nil, fmt.Errorf("worker %q: unknown runner type %q", wc.ID, wc.Runner)
 		}
-		if err := ra.Configure(workerRunConfig(wc)); err != nil {
+		wrcConf := workerRunConfig(wc)
+		wrcConf["allow_root"] = cfg.Settings.Security.AllowRoot
+		if err := ra.Configure(wrcConf); err != nil {
 			return nil, fmt.Errorf("worker %q: configure runner: %w", wc.ID, err)
 		}
 		d.runners[wc.ID] = ra
@@ -1891,7 +1897,12 @@ func (d *Dispatcher) UpdateAgentConfig(ctx context.Context, agentID, newModel, n
 		if !ok {
 			return fmt.Errorf("runner type %q not registered", rc.Type)
 		}
-		if err := ra.Configure(rc.Config); err != nil {
+		hotConf := make(map[string]any, len(rc.Config)+1)
+		for k, v := range rc.Config {
+			hotConf[k] = v
+		}
+		hotConf["allow_root"] = d.cfg.Settings.Security.AllowRoot
+		if err := ra.Configure(hotConf); err != nil {
 			return fmt.Errorf("configure runner %q: %w", newRunner, err)
 		}
 

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -35,6 +35,9 @@ type CliRunner struct {
 	// mcpRunArgs are extra CLI args injected into every run to activate the MCP
 	// config written by setupMCP (e.g. claude's "--mcp-config <path>").
 	mcpRunArgs []string
+	// allowRoot, when true, permits launching the agent subprocess as root (uid 0).
+	// Injected from settings.security.allow_root by the dispatcher. Default false.
+	allowRoot bool
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -70,6 +73,9 @@ func (r *CliRunner) Configure(config map[string]any) error {
 	if v, ok := config["mcps"].([]model.MCPServer); ok {
 		r.mcps = v
 	}
+	if v, ok := config["allow_root"].(bool); ok {
+		r.allowRoot = v
+	}
 	// Materialise the provider's MCP config (and any per-run CLI args) once the
 	// servers are known. Configure runs at load time, sequentially across agents,
 	// so the global-config merges (cursor/opencode) are race-free.
@@ -101,6 +107,10 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		argv = append(argv, prompt)
 	} else if r.promptFlag != "" {
 		argv = append(argv, r.promptFlag, prompt)
+	}
+
+	if err := checkPrivilege(r.allowRoot); err != nil {
+		return model.RunResult{}, err
 	}
 
 	cmd := exec.CommandContext(ctx, r.command, argv...)

--- a/src/internal/runner/execution/privilege_test.go
+++ b/src/internal/runner/execution/privilege_test.go
@@ -1,0 +1,39 @@
+package execution
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCheckPrivilege_AllowRoot(t *testing.T) {
+	// When allowRoot is true the call must not error regardless of uid.
+	if err := checkPrivilege(true); err != nil {
+		t.Fatalf("checkPrivilege(allowRoot=true): unexpected error: %v", err)
+	}
+}
+
+func TestCheckPrivilege_EnvOverride(t *testing.T) {
+	t.Setenv("APIARY_ALLOW_ROOT", "1")
+	if err := checkPrivilege(false); err != nil {
+		t.Fatalf("checkPrivilege with APIARY_ALLOW_ROOT=1: unexpected error: %v", err)
+	}
+}
+
+func TestCheckPrivilege_NonRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test must run as non-root")
+	}
+	if err := checkPrivilege(false); err != nil {
+		t.Fatalf("checkPrivilege on non-root process: unexpected error: %v", err)
+	}
+}
+
+func TestCheckPrivilege_RootRefused(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("test requires root uid")
+	}
+	os.Unsetenv("APIARY_ALLOW_ROOT")
+	if err := checkPrivilege(false); err == nil {
+		t.Fatal("checkPrivilege(allowRoot=false) on root: expected error, got nil")
+	}
+}

--- a/src/internal/runner/execution/privilege_unix.go
+++ b/src/internal/runner/execution/privilege_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package execution
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkPrivilege returns an error when the current process is running as root
+// (uid 0) and the caller has not explicitly opted in. Running Apiary as root
+// means a successful prompt-injection attack in any untrusted task body
+// (Jira/GitHub issue text, PR description, etc.) executes at full-system
+// privilege. Opt in only via the security.allow_root config setting or the
+// APIARY_ALLOW_ROOT=1 env var — both are documented as strongly discouraged.
+func checkPrivilege(allowRoot bool) error {
+	if os.Getuid() != 0 {
+		return nil
+	}
+	if allowRoot || os.Getenv("APIARY_ALLOW_ROOT") == "1" {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to launch agent as root (uid 0): running Apiary as root gives " +
+			"untrusted task content full system access; run as an unprivileged user " +
+			"or set security.allow_root: true in apiary.yaml (strongly discouraged) " +
+			"/ APIARY_ALLOW_ROOT=1 to override",
+	)
+}

--- a/src/internal/runner/execution/privilege_windows.go
+++ b/src/internal/runner/execution/privilege_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package execution
+
+// checkPrivilege is a no-op on Windows; privilege ceiling on Windows is
+// enforced via token integrity levels and ACLs, not Unix uid 0.
+func checkPrivilege(_ bool) error { return nil }


### PR DESCRIPTION
## Summary

- Adds `execution.checkPrivilege()` (platform-split: `privilege_unix.go` / `privilege_windows.go`) called in `CliRunner.Run()` before `cmd.Start()` — returns an actionable error when the current process runs as root (uid 0) and no opt-in is configured.
- Adds `CliRunner.allowRoot bool` field, populated from the runner config map in `Configure()`.
- Adds `config.SecuritySettings` with `allow_root bool` (default `false`) under `settings.security:` in `apiary.yaml`.
- Dispatcher injects `allow_root` from `settings.security.allow_root` into every runner config (primary, fallback, legacy workers) so one setting controls all launch paths.
- Opt-in escapes: `security.allow_root: true` in config or `APIARY_ALLOW_ROOT=1` env var (both documented as strongly discouraged).
- Docs: new **Privilege ceiling (`security`)** section in `docs/configuration.md` with recommended setup and one-off override instructions.

## Test plan

- [ ] `go test ./internal/runner/execution/...` — `TestCheckPrivilege_AllowRoot`, `TestCheckPrivilege_EnvOverride`, `TestCheckPrivilege_NonRoot` all pass; `TestCheckPrivilege_RootRefused` is exercised in a root-uid CI environment (skipped otherwise).
- [ ] `go build ./...` — no compile errors on both linux/amd64 and darwin/arm64 (the platform split is build-tag gated).
- [ ] Running `apiary run` as a non-root user: no change in behaviour.
- [ ] Running as root without `allow_root: true`: startup logs an actionable error and refuses to launch the agent subprocess.
- [ ] `APIARY_ALLOW_ROOT=1` overrides the check for a one-off test without editing config.

Closes #246