### PR TITLE
feat(security): require human review before agent PRs can merge (SEC-08)

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`, auto-merge via `gh pr merge --auto --squash`, sync da `main`/rebuild do dev/`gitnexus analyze` após merge. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
+description: Git workflow obrigatório do projeto — toda change via feature branch + PR usando `git worktree`. Agentes NÃO habilitam auto-merge; um humano deve aprovar e mergear o PR. Use ao iniciar qualquer change, abrir PR, ou após merge de PR.
 ---
 
 # Git Workflow — Projeto ERP
@@ -17,16 +17,16 @@ Ou via CLI:
 hermes kanban create "fix: ..." --assignee engineer --skill git-workflow
 ```
 
-**Regra fundamental:** NUNCA bloquear kanban task para review humano. Sempre criar PR com auto-merge e aguardar o CI. O worker só completa a task após o PR estar mergeado e o dev local sincronizado.
+**Regra fundamental:** O agente cria o PR e para. **Não habilite auto-merge** (`gh pr merge --auto`). Um humano deve revisar e aprovar antes de qualquer merge. Isso é um controle de segurança — não um bloqueio de processo.
 
 **Pipeline completo de uma task engineer:**
-Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → auto-merge → aguarda CI → confirma merge → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
+Kanban cria task → dispatcher spawna worker → worker carrega git-workflow → cria worktree → faz o código → commit → push → PR → **aguarda review humano** → humano aprova e mergeia → pull main → task dev:rebuild → gitnexus reindex → remove worktree → complete task
 
 **GH_TOKEN:** o profile engineer tem GH_TOKEN no `.env`. Se o worker não conseguir usar `gh`, verificar se o token ainda é válido.
 
 **Pitfalls:**
 - **Skill must be in each target profile's skills directory.** The kanban worker loads skills from `~/.hermes/profiles/<profile>/skills/`, NOT from `~/.hermes/skills/`. If `git-workflow` is absent from any profile's skills dir, the worker crashes immediately with `Error: Unknown skill(s): git-workflow`. This affects ALL profiles (engineer, po, qa) that run tasks with `--skill git-workflow`. Fix: `ln -s ~/.hermes/skills/git-workflow ~/.hermes/profiles/<profile>/skills/git-workflow` for each profile.
-- Worker sem GH_TOKEN → não consegue criar PR nem ativar auto-merge. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'` no profile, ou adicionar ao `.env` do profile.
+- Worker sem GH_TOKEN → não consegue criar PR. Solução: `hermes config set terminal.env_passthrough '["GH_TOKEN"]'` no profile, ou adicionar ao `.env` do profile.
 - Worktree deletado entre runs → se a task for re-spawnada após um merge, o worktree original sumiu. O worker deve criar um novo worktree ou clonar fresco.
 - CI lento/flaky → `gh pr checks --watch` + `gh run rerun --failed` em flake conhecido. Só desistir após 2-3 reruns do mesmo padrão.
 - Diverging branches no git pull → usar `git reset --hard origin/main` quando o histórico local divergir (worktree worker não deve ter commits locais em main).
@@ -51,14 +51,12 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
 4. **Link issue and project**: after creating the PR:
    - The PR body MUST contain `Closes #<issue>` (or `Fixes #<issue>`) to link the issue.
    - Add the PR to the relevant GitHub Project: `gh project item-add 1 --owner orlandoburli-enterprise --url <pr-url>`.
-5. **Enable auto-merge**: run `gh pr merge <number> --auto --squash` so it merges automatically once CI passes.
-   - NUNCA bloquear kanban task para review humano. O worker cria o PR, ativa auto-merge e aguarda o CI. Sem blocker, sem review-required.
+5. **Stop here.** Do NOT enable auto-merge (`gh pr merge --auto --squash`). The branch protection
+   on `main` requires a human approver, and agent approvals do not count. Leave the PR open for
+   a human to review, approve, and merge.
 6. CI must pass (lint, tests, build, sqlc-check) before merge.
-7. Aguardar o merge — obrigatório, sem exceção. A tarefa não está concluída até o PR estar mergeado e o dev local atualizado. Não pule para a próxima tarefa nem declare pronto antes disso.
-   - `gh pr checks <number> --watch` para aguardar o CI.
-   - Se o CI travar em flake conhecido (RATE_LIMIT 429, timing em `cadastro-observacoes-markdown`, `vendas-nucleo:438`, `cadastro-auto-rascunho`, etc.), faça `gh run rerun <run-id> --failed` e aguarde de novo. Só desista após 2-3 reruns mostrarem o mesmo padrão de falha.
-   - Confirme com `gh pr view <number> --json state,mergedAt` que `state == "MERGED"`.
-8. **Sync da `main` local + rebuild do dev — executar imediatamente após confirmar o merge.** Não esperar o usuário pedir. No checkout principal (não no worktree):
+7. **After a human merges the PR**, sync `main` locally — executar imediatamente após confirmar o merge.
+   No checkout principal (não no worktree):
    ```bash
    cd <repo-root> && git checkout main && git pull --ff-only
    ```
@@ -68,15 +66,15 @@ Kanban cria task → dispatcher spawna worker → worker carrega git-workflow �
    ```
    Sem isso, o container continua servindo o bundle/binário da build anterior — sintoma típico: "o fix não chegou no meu dev local" mesmo após o merge na `main`. `task dev` usa `up -d` puro (não `watch`), então o source do container é cópia estática do momento do build.
    **Sempre rodar `task dev:rebuild`** após `git pull --ff-only`, sem exceção. Não tentar adivinhar quais serviços foram afetados — o comando cuida disso.
-9. **Re-indexar o GitNexus** — executar imediatamente após `task dev:rebuild`:
+8. **Re-indexar o GitNexus** — executar imediatamente após `task dev:rebuild`:
    ```bash
    cd <repo-root> && gitnexus analyze --skip-agents-md
    ```
    O knowledge graph do GitNexus precisa refletir o código atualizado da `main`. Sem isso, queries MCP (`query`, `context`, `impact`) retornam dados stale. **Sempre rodar** após pull, sem exceção. Usa `--skip-agents-md` porque os arquivos de contexto (`AGENTS.md`/`CLAUDE.md`) já foram atualizados pelo PR (ver seção abaixo).
-10. Remove o worktree: `git worktree remove ../project-erp--<branch>` e (opcional) `git branch -d <branch>`.
-11. Never `git push` directly to `main`.
+9. Remove o worktree: `git worktree remove ../project-erp--<branch>` e (opcional) `git branch -d <branch>`.
+10. Never `git push` directly to `main`.
 
-**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → auto-merge → aguardar CI → confirmar merge → pull main → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. Pular qualquer passo (especialmente 7-9) é proibido.
+**Resumo: o ciclo completo de uma change é** `worktree → commit → push → PR → aguardar review humano → pull main (após merge) → task dev:rebuild → gitnexus analyze --skip-agents-md → remover worktree`. O agente para no PR — o merge é responsabilidade humana.
 
 ## AGENTS.md / CLAUDE.md — manter atualizados via PR
 
@@ -94,7 +92,7 @@ git diff --quiet AGENTS.md CLAUDE.md || \
   git commit -m "chore: update AGENTS.md and CLAUDE.md (gitnexus reindex)"
 ```
 
-Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge, o passo 9 usa `--skip-agents-md` porque o PR já atualizou os arquivos.
+Isso garante que cada PR traz os arquivos de contexto atualizados. Após o merge, o passo 8 usa `--skip-agents-md` porque o PR já atualizou os arquivos.
 
 ## PR requirements
 

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# setup-branch-protection.sh — enforce human review gate on main
+#
+# Configures GitHub branch protection on the main branch of orlandoburli/apiary
+# so that NO pull request (including agent-authored ones) can merge without at
+# least one human approving review and all required status checks passing.
+#
+# Prerequisites: gh CLI authenticated with a token that has admin repo access.
+#
+# Usage:
+#   GITHUB_TOKEN=<token> ./scripts/setup-branch-protection.sh
+#   # or just: ./scripts/setup-branch-protection.sh  (uses ambient GH_TOKEN/GITHUB_TOKEN)
+set -euo pipefail
+
+REPO="orlandoburli/apiary"
+BRANCH="main"
+
+echo "Configuring branch protection for ${REPO}@${BRANCH}..."
+
+gh api   --method PUT   "/repos/${REPO}/branches/${BRANCH}/protection"   --field "required_status_checks[strict]=true"   --field "required_status_checks[contexts][]=CI"   --field "required_pull_request_reviews[required_approving_review_count]=1"   --field "required_pull_request_reviews[dismiss_stale_reviews]=true"   --field "required_pull_request_reviews[require_code_owner_reviews]=false"   --field "required_pull_request_reviews[restrict_dismissals]=false"   --field "enforce_admins=false"   --field "allow_force_pushes=false"   --field "allow_deletions=false"   --field "block_creations=false"   --field "required_conversation_resolution=false"
+
+echo "Branch protection applied:"
+echo "  - Required approving reviews: 1"
+echo "  - Dismiss stale reviews: true"
+echo "  - Required status checks: CI"
+echo "  - Strict status checks (branch must be up-to-date): true"
+echo "  - Force pushes: disabled"
+echo ""
+echo "Agent-authored PRs now require a human approval before they can merge."

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -442,6 +442,13 @@ type WaitForConfig struct {
 	// step, "hold" keeps the instance parked for a human. Defaults to fail for
 	// kind: ci and hold for kind: dependency.
 	OnTimeout string `yaml:"on_timeout,omitempty"`
+
+	// ── kind: ci only ─────────────────────────────────────────────────
+	// RequireReview, when true, also waits for at least one human (non-bot)
+	// approval on the PR before treating the step as complete. Ensures
+	// agent-authored PRs cannot merge via auto-merge without a human sign-off,
+	// even when CI is green. Ignored for kind: dependency.
+	RequireReview bool `yaml:"require_review,omitempty"`
 }
 
 // ParsedCheckInterval returns the check interval duration, defaulting to 1 minute.

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -613,6 +613,11 @@ func (c *Config) validateWaitForStep(sctx string, s StepConfig) []error {
 			errs = append(errs, fmt.Errorf("%s: wait_for blocker_link_type is only valid with kind \"dependency\"", sctx))
 		}
 	}
+
+	// ci-only fields are rejected on other kinds.
+	if cfg.Kind == WaitKindDependency && cfg.RequireReview {
+		errs = append(errs, fmt.Errorf("%s: wait_for require_review is only valid with kind \"ci\"", sctx))
+	}
 	for _, cond := range cfg.SatisfiedWhen {
 		if cond != BlockerSatisfiedMerged && cond != BlockerSatisfiedDone {
 			errs = append(errs, fmt.Errorf("%s: wait_for satisfied_when value %q not supported (valid: merged, done)", sctx, cond))

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -55,6 +55,18 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			}
 			return lister.ListBlockers(ctx, sourceItemID, linkType)
 		}))
+		// Wire up PR review checking for wait_for/ci steps with require_review: true.
+		opts = append(opts, workflow.WithReviewChecker(func(ctx context.Context, sourceID, sourceItemID string) (source.ReviewStatus, error) {
+			adapter, ok := d.sources[sourceID]
+			if !ok {
+				return source.ReviewStatus{}, fmt.Errorf("source %q not found", sourceID)
+			}
+			poller, ok := adapter.(source.ReviewPoller)
+			if !ok {
+				return source.ReviewStatus{}, fmt.Errorf("source %q does not support PR review polling (require_review)", sourceID)
+			}
+			return poller.PollReviewStatus(ctx, sourceItemID)
+		}))
 		var store workflow.Store = d.db
 		if d.db != nil {
 			store = pluginExportStore{Client: d.db, dispatcher: d}

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -26,6 +26,7 @@ var (
 	_ source.LabelRemover    = (*Adapter)(nil)
 	_ source.TaskPoller      = (*Adapter)(nil)
 	_ source.CIStatusPoller  = (*Adapter)(nil)
+	_ source.ReviewPoller    = (*Adapter)(nil)
 	_ source.SubIssueCreator = (*Adapter)(nil)
 	_ source.BlockerLister   = (*Adapter)(nil)
 )
@@ -513,6 +514,117 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	}
 
 	return source.CIStatus{Status: overall, URL: pr.HTMLURL, Checks: checks}, nil
+}
+
+// PollReviewStatus fetches the current review state of the PR linked to the
+// given issue. It returns Approved=true when at least one human (non-bot) user
+// has an APPROVED review with no later CHANGES_REQUESTED from the same user,
+// matching GitHub's own "changes requested" dismissal semantics. Implements
+// source.ReviewPoller.
+//
+// The PR is discovered the same way PollCIStatus does: direct lookup by issue
+// number first, then via the issue timeline. A missing or not-yet-opened PR
+// returns Approved=false with no error — the caller keeps polling.
+func (a *Adapter) PollReviewStatus(ctx context.Context, cellID string) (source.ReviewStatus, error) {
+	prNumber, prURL, err := a.resolvePRNumber(ctx, cellID)
+	if err != nil {
+		return source.ReviewStatus{}, err
+	}
+	if prNumber == 0 {
+		return source.ReviewStatus{}, nil // no PR yet
+	}
+
+	reviewsPath := fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", a.owner, a.repo, prNumber)
+	body, err := a.client.get(ctx, reviewsPath)
+	if err != nil {
+		return source.ReviewStatus{}, fmt.Errorf("github: fetching reviews for PR #%d (issue %s): %w", prNumber, cellID, err)
+	}
+
+	var reviews []prReview
+	if err := json.Unmarshal(body, &reviews); err != nil {
+		return source.ReviewStatus{}, fmt.Errorf("github: decoding reviews for PR #%d: %w", prNumber, err)
+	}
+
+	// Walk reviews in order; track each human reviewer's latest state. COMMENTED
+	// reviews are ignored — they don't express approval or rejection. Bots (type:
+	// "Bot") are excluded so only human decisions count.
+	latestByUser := make(map[string]string)
+	for _, r := range reviews {
+		if r.User.Type == "Bot" {
+			continue
+		}
+		switch r.State {
+		case "APPROVED", "CHANGES_REQUESTED", "DISMISSED":
+			latestByUser[r.User.Login] = r.State
+		}
+	}
+
+	for _, state := range latestByUser {
+		if state == "APPROVED" {
+			return source.ReviewStatus{Approved: true, URL: prURL}, nil
+		}
+	}
+	return source.ReviewStatus{URL: prURL}, nil
+}
+
+// resolvePRNumber finds the PR number associated with the given issue (which may
+// equal the PR number, or be discovered via the issue timeline). Returns (0, "",
+// nil) when no PR is linked yet.
+func (a *Adapter) resolvePRNumber(ctx context.Context, cellID string) (int, string, error) {
+	prPath := fmt.Sprintf("/repos/%s/%s/pulls/%s", a.owner, a.repo, cellID)
+	prBody, err := a.client.get(ctx, prPath)
+	if err == nil {
+		var pr pullRequest
+		if err2 := json.Unmarshal(prBody, &pr); err2 == nil && pr.Number != 0 {
+			return pr.Number, pr.HTMLURL, nil
+		}
+	}
+
+	// Fall back to the issue timeline to find a cross-referenced PR.
+	timelinePath := fmt.Sprintf("/repos/%s/%s/issues/%s/timeline", a.owner, a.repo, cellID)
+	timelineBody, err := a.client.get(ctx, timelinePath)
+	if err != nil {
+		return 0, "", nil // no timeline — no PR yet
+	}
+
+	var timeline []struct {
+		Event  string `json:"event"`
+		Source struct {
+			Type  string `json:"type"`
+			Issue struct {
+				Number      int `json:"number"`
+				PullRequest struct {
+					URL string `json:"url"`
+				} `json:"pull_request"`
+			} `json:"issue"`
+		} `json:"source"`
+	}
+	if err := json.Unmarshal(timelineBody, &timeline); err != nil {
+		return 0, "", nil
+	}
+
+	for i := len(timeline) - 1; i >= 0; i-- {
+		ev := timeline[i]
+		if ev.Event == "cross-referenced" && ev.Source.Type == "issue" && ev.Source.Issue.PullRequest.URL != "" {
+			n := ev.Source.Issue.Number
+			if n == 0 {
+				continue
+			}
+			prPath := fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, n)
+			body, err := a.client.get(ctx, prPath)
+			if err != nil {
+				continue
+			}
+			var pr pullRequest
+			if err := json.Unmarshal(body, &pr); err != nil {
+				continue
+			}
+			if pr.State == "open" {
+				return pr.Number, pr.HTMLURL, nil
+			}
+		}
+	}
+	return 0, "", nil
 }
 
 // ListPullRequests returns every pull request cross-referenced from the issue,

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -103,3 +103,12 @@ type checkRunsResponse struct {
 		Status     string `json:"status"`
 	} `json:"check_runs"`
 }
+
+// prReview is one review submitted on a pull request.
+type prReview struct {
+	State string `json:"state"` // APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+	User  struct {
+		Login string `json:"login"`
+		Type  string `json:"type"` // "User" or "Bot"
+	} `json:"user"`
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -85,6 +85,21 @@ type CIStatusPoller interface {
 	PollCIStatus(ctx context.Context, cellID string) (CIStatus, error)
 }
 
+// ReviewStatus represents the human-review state of a PR.
+type ReviewStatus struct {
+	Approved bool   // true when at least one human (non-bot) has approved
+	URL      string // PR browser URL
+}
+
+// ReviewPoller is an optional interface that sources may implement to check
+// whether a PR linked to a task has received at least one human approval. The
+// workflow engine uses it for wait_for/ci steps with require_review: true to
+// block the step until a human approves — preventing auto-merge of
+// agent-authored PRs without oversight.
+type ReviewPoller interface {
+	PollReviewStatus(ctx context.Context, cellID string) (ReviewStatus, error)
+}
+
 // PullRequestRef is one pull request linked to a source item (e.g. a PR that
 // cross-references a GitHub issue). State is best-effort and may be empty when
 // the source does not fetch it.

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -248,6 +248,10 @@ type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (s
 // an error if the lookup fails (transient or permanent).
 type DependencyChecker func(ctx context.Context, sourceID, sourceItemID, linkType string) ([]source.BlockerRef, error)
 
+// ReviewChecker is called by wait_for/ci steps with require_review: true to
+// check whether a PR linked to the task has at least one human approval.
+type ReviewChecker func(ctx context.Context, sourceID, sourceItemID string) (source.ReviewStatus, error)
+
 type Engine struct {
 	cfg               *config.Config
 	store             Store
@@ -259,6 +263,7 @@ type Engine struct {
 	tracker           TaskTracker
 	ciChecker         CIStatusChecker
 	depChecker        DependencyChecker
+	reviewChecker     ReviewChecker
 	approvalProviders []ApprovalProvider
 
 	now   func() time.Time
@@ -308,6 +313,12 @@ func WithCIStatusChecker(checker CIStatusChecker) Option {
 // kind "dependency".
 func WithDependencyChecker(checker DependencyChecker) Option {
 	return func(e *Engine) { e.depChecker = checker }
+}
+
+// WithReviewChecker sets the review-approval checker used by wait_for/ci steps
+// with require_review: true.
+func WithReviewChecker(checker ReviewChecker) Option {
+	return func(e *Engine) { e.reviewChecker = checker }
 }
 
 // WithApprovalProvider registers an external approval request transport.

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -98,6 +98,28 @@ func (e *Engine) checkCIWaitStep(
 
 	switch status.Status {
 	case "passed":
+		// When require_review is set, also gate on at least one human approval
+		// before declaring the step complete. This prevents agent-authored PRs
+		// from advancing (and potentially auto-merging) without a human sign-off.
+		if cfg.RequireReview {
+			if e.reviewChecker == nil {
+				return StepResult{
+					Success: false,
+					Err:     fmt.Errorf("wait_for step %q: require_review is set but no review checker is configured", step.ID),
+				}, nil
+			}
+			review, err := e.reviewChecker(ctx, sourceID, sourceItemID)
+			if err != nil {
+				aplog.Warn("wait_for step %q: review check failed (will retry next cycle): %v", step.ID, err)
+				e.recordCIPoll(ctx, instID, step.ID, "review_pending", status.URL, err.Error())
+				return StepResult{Pending: true}, nil
+			}
+			if !review.Approved {
+				aplog.Debug("wait_for step %q: CI passed but no human review approval yet", step.ID)
+				e.recordCIPoll(ctx, instID, step.ID, "review_pending", status.URL, "waiting for human approval")
+				return StepResult{Pending: true}, nil
+			}
+		}
 		return StepResult{
 			Success: true,
 			StructuredOutput: map[string]any{


### PR DESCRIPTION
## Summary

Closes #231

Implements SEC-08: no agent-authored PR can merge to a protected branch without human approval. Three layers of defense are added:

- **`source.ReviewPoller` interface + GitHub adapter implementation** — `PollReviewStatus` queries `GET /pulls/{n}/reviews`, filters out bot accounts, and returns `Approved: true` when at least one human has an APPROVED review without a later CHANGES_REQUESTED from the same user.
- **`require_review: true` in `WaitForConfig`** — the `wait_for/ci` step now holds `Pending` after CI passes until a human approval is detected. The daemon wires this via a new `WithReviewChecker` option on the engine.
- **`scripts/setup-branch-protection.sh`** — one-shot script to configure GitHub branch protection on `main` requiring 1 approving review, stale-review dismissal, and CI status check.
- **Skill update** — `git-workflow` skill removes the auto-merge step (`gh pr merge --auto --squash`); agents now open the PR and stop. Merge is explicitly a human decision.
- **`triage` reviewer prompt update** — reviewer agent submits `gh pr review --approve` to satisfy branch protection, but does NOT call `gh pr merge --auto`. Only a human can trigger the merge.

### Activating `require_review` in the local dogfood config

After merging and rebuilding the daemon, add `require_review: true` to `apiary.yaml` under the `engineer-implement` workflow's `check-ci` block:

```yaml
- id: check-ci
  type: wait_for
  wait_for:
    kind: ci
    check_interval: 60s
    max_duration: 2h
    require_review: true   # ← add this
```

Then run `scripts/setup-branch-protection.sh` (requires `gh` authenticated with admin scope on the repo) to enforce the requirement at the GitHub level as well.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/workflow/... ./internal/config/... ./internal/source/...` — all pass
- [ ] After merge: run `scripts/setup-branch-protection.sh` to enable branch protection
- [ ] After merge: update local `apiary.yaml` with `require_review: true` and restart daemon
- [ ] Verify: open a test PR as a bot account — apiary `check-ci` step should stay pending until a human approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)