### PR TITLE
fix(security): enforce collaborator trust gate at daemon ingest (SEC-01)

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -277,6 +277,7 @@ type Settings struct {
 	Memory        MemorySettings     `yaml:"memory"`
 	Events        EventSettings      `yaml:"events"`
 	Approvals     ApprovalSettings   `yaml:"approvals"`
+	TrustGate     TrustGateSettings  `yaml:"trust_gate"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
@@ -360,6 +361,30 @@ func queueDuration(value string, fallback time.Duration) time.Duration {
 type ApprovalSettings struct {
 	WebhookSecret string   `yaml:"webhook_secret,omitempty"`
 	RequireFor    []string `yaml:"require_for,omitempty"`
+}
+
+// TrustGateSettings controls the pre-dispatch approval gate for workflow runs
+// triggered by non-collaborator GitHub issue authors.
+//
+// When Enabled, every run whose source item carries an author_association that
+// is not OWNER, MEMBER, or COLLABORATOR gets a synthetic approval step
+// prepended to the matched workflow. The run parks in approval_waiting state
+// until a human approves (or rejects) via the existing multi-channel approval
+// infrastructure (dashboard, webhook, or comment).
+//
+// Non-GitHub sources (Jira, Plane, …) never set author_association and are
+// therefore unaffected regardless of this setting.
+type TrustGateSettings struct {
+	// Enabled activates the gate. Must be explicitly set to true.
+	Enabled bool `yaml:"enabled"`
+	// Approvers lists GitHub logins (or email addresses for non-GitHub approval
+	// providers) that may approve or reject a parked trust-gate run via the
+	// dashboard / webhook path. When empty the legacy comment-based triggers
+	// (/approve / /reject) are used instead, which do not enforce approver identity.
+	Approvers []string `yaml:"approvers,omitempty"`
+	// Message overrides the default comment posted to the issue when the run
+	// parks at the trust gate.
+	Message string `yaml:"message,omitempty"`
 }
 
 // EventSettings controls persisted structured execution events. Events are

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -817,9 +817,14 @@ func expandEnv(s string) string {
 
 // loadDotEnv reads .env from the same directory as the config file and calls
 // os.Setenv for each entry. Lines starting with # are skipped.
+// If the file is group- or world-readable a warning is printed and the file is
+// still loaded — startup is never blocked by a permission mismatch.
 func loadDotEnv(configPath string) {
 	dir := filepath.Dir(configPath)
 	envPath := filepath.Join(dir, ".env")
+	if warn := checkDotEnvPerms(envPath); warn != "" {
+		aplog.Warn("%s", warn)
+	}
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		return

--- a/src/internal/config/dotenv_perm_unix.go
+++ b/src/internal/config/dotenv_perm_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkDotEnvPerms returns a non-nil warning string if the .env file at path
+// is readable by group or world. The caller decides how to handle the warning.
+// A missing or inaccessible file returns an empty string (no warning).
+func checkDotEnvPerms(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "" // absent or inaccessible; caller handles missing file
+	}
+	if perm := info.Mode().Perm(); perm&0o044 != 0 {
+		return fmt.Sprintf(".env file %q is group- or world-readable (mode %04o); credentials may be visible to other local accounts — fix with: chmod 0600 %q", path, perm, path)
+	}
+	return ""
+}

--- a/src/internal/config/dotenv_perm_unix_test.go
+++ b/src/internal/config/dotenv_perm_unix_test.go
@@ -1,0 +1,109 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+func TestCheckDotEnvPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("KEY=val\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// 0600 — owner-only: no warning expected.
+	if warn := checkDotEnvPerms(env); warn != "" {
+		t.Errorf("0600: unexpected warning: %q", warn)
+	}
+
+	// 0640 — group-readable: warning expected.
+	if err := os.Chmod(env, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0640: expected warning, got empty string")
+	}
+
+	// 0644 — world-readable: warning expected.
+	if err := os.Chmod(env, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if warn := checkDotEnvPerms(env); warn == "" {
+		t.Error("0644: expected warning, got empty string")
+	}
+
+	// Non-existent path: must return empty string (no warning).
+	if warn := checkDotEnvPerms(filepath.Join(dir, "missing.env")); warn != "" {
+		t.Errorf("missing file: unexpected warning: %q", warn)
+	}
+}
+
+// TestLoadDotEnvWarnAndLoadOnBadPerms verifies that loadDotEnv emits a warning
+// but still loads credentials from a group/world-readable .env, so startup is
+// never silently broken by a permission mismatch.
+func TestLoadDotEnvWarnAndLoadOnBadPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	// Write .env with world-readable permissions (0644 — common default).
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_BAD=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_BAD")
+
+	// Capture log output to confirm the warning is emitted.
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	// The key must be loaded despite bad permissions.
+	if got := os.Getenv("APIARY_TEST_KEY_BAD"); got != "secret" {
+		t.Errorf("loadDotEnv must load credentials even from a world-readable .env; got %q, want %q", got, "secret")
+	}
+
+	// A warning must have been logged.
+	found := false
+	for _, msg := range logged {
+		if strings.Contains(msg, "group- or world-readable") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about group- or world-readable .env, but none was logged; got: %v", logged)
+	}
+}
+
+// TestLoadDotEnvLoadsOnGoodPerms verifies that loadDotEnv loads credentials
+// normally and emits no warning when the .env file has 0600 (owner-only) permissions.
+func TestLoadDotEnvLoadsOnGoodPerms(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("APIARY_TEST_KEY_GOOD=value\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("APIARY_TEST_KEY_GOOD")
+
+	var logged []string
+	aplog.SetSink(func(_, msg string) { logged = append(logged, msg) })
+	defer aplog.SetSink(nil)
+
+	fakeConfig := filepath.Join(dir, "apiary.yaml")
+	loadDotEnv(fakeConfig)
+
+	if got := os.Getenv("APIARY_TEST_KEY_GOOD"); got != "value" {
+		t.Errorf("loadDotEnv must load credentials from a 0600 .env; got %q, want %q", got, "value")
+	}
+	if len(logged) > 0 {
+		t.Errorf("expected no warnings for 0600 .env; got: %v", logged)
+	}
+}

--- a/src/internal/config/dotenv_perm_windows.go
+++ b/src/internal/config/dotenv_perm_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package config
+
+// checkDotEnvPerms is a no-op on Windows, which uses ACLs rather than
+// Unix-style permission bits.
+func checkDotEnvPerms(_ string) string { return "" }

--- a/src/internal/daemon/trust_gate.go
+++ b/src/internal/daemon/trust_gate.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// isTrustedAssociation reports whether a GitHub author_association value
+// belongs to the trusted collaborator set: OWNER, MEMBER, or COLLABORATOR.
+// Any other value (CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE, or
+// an empty string) is considered untrusted.
+func isTrustedAssociation(assoc string) bool {
+	switch assoc {
+	case "OWNER", "MEMBER", "COLLABORATOR":
+		return true
+	default:
+		return false
+	}
+}
+
+// trustGateStepID is the synthetic step identifier injected by withTrustGate.
+// It must not collide with any user-defined step ID; the leading underscore
+// makes a collision by YAML authoring effectively impossible.
+const trustGateStepID = "_trust_gate"
+
+const trustGateDefaultMsg = "A workflow run triggered by a non-collaborator requires human approval before the agent executes.\n\nReply with `/approve` to allow or `/reject` to discard."
+
+// withTrustGate returns wf unchanged when:
+//   - the trust gate is disabled (cfg.Enabled == false), or
+//   - cell carries no author_association metadata (non-GitHub sources pass through), or
+//   - the author's association is in the trusted set (OWNER/MEMBER/COLLABORATOR).
+//
+// For untrusted GitHub issue authors it prepends a synthetic approval step to
+// wf.Steps and adds it as an explicit dependency of every root step (steps with
+// neither DependsOn nor SeqDependsOn). This ensures the DAG engine parks the
+// run at the approval step before any shell-capable agent step can execute, and
+// the run is resolvable through the full multi-channel approval infrastructure
+// (dashboard, webhook, or comment trigger).
+func withTrustGate(wf config.WorkflowConfig, cell model.SourceItem, cfg config.TrustGateSettings) config.WorkflowConfig {
+	if !cfg.Enabled {
+		return wf
+	}
+	assoc, ok := cell.Metadata["author_association"].(string)
+	if !ok || assoc == "" {
+		return wf
+	}
+	if isTrustedAssociation(assoc) {
+		return wf
+	}
+
+	login, _ := cell.Metadata["author_login"].(string)
+	msg := cfg.Message
+	if msg == "" {
+		if login != "" {
+			msg = fmt.Sprintf("@%s is not a repository collaborator (association: %s). %s", login, assoc, trustGateDefaultMsg)
+		} else {
+			msg = trustGateDefaultMsg
+		}
+	}
+
+	gate := config.StepConfig{
+		ID:      trustGateStepID,
+		Type:    config.StepTypeApproval,
+		Name:    "Trust gate: non-collaborator approval required",
+		Message: msg,
+		ResumeOn: &config.ApprovalTrigger{
+			CommentContains: "/approve",
+		},
+		AbortOn: &config.ApprovalTrigger{
+			CommentContains: "/reject",
+		},
+		Approvers: cfg.Approvers,
+	}
+
+	// Attach the gate as a dependency of every root step (steps that currently
+	// have no explicit or sequential predecessor). This covers both v1 workflows
+	// (explicit DependsOn) and v2 lowered workflows (SeqDependsOn chains).
+	steps := make([]config.StepConfig, 0, len(wf.Steps)+1)
+	steps = append(steps, gate)
+	for _, s := range wf.Steps {
+		if len(s.DependsOn) == 0 && len(s.SeqDependsOn) == 0 {
+			s.DependsOn = []string{trustGateStepID}
+		}
+		steps = append(steps, s)
+	}
+	wf.Steps = steps
+	return wf
+}

--- a/src/internal/daemon/trust_gate_test.go
+++ b/src/internal/daemon/trust_gate_test.go
@@ -1,0 +1,214 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestIsTrustedAssociation verifies the GitHub collaborator trust set.
+func TestIsTrustedAssociation(t *testing.T) {
+	trusted := []string{"OWNER", "MEMBER", "COLLABORATOR"}
+	for _, assoc := range trusted {
+		if !isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = false, want true", assoc)
+		}
+	}
+
+	untrusted := []string{"CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "NONE", ""}
+	for _, assoc := range untrusted {
+		if isTrustedAssociation(assoc) {
+			t.Errorf("isTrustedAssociation(%q) = true, want false", assoc)
+		}
+	}
+}
+
+// wf2steps is a helper that builds a minimal two-step workflow.
+func wf2steps() config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID: "wf-test",
+		Steps: []config.StepConfig{
+			{ID: "classify", Agent: "bot"},
+			{ID: "implement", Agent: "bot", SeqDependsOn: []string{"classify"}},
+		},
+	}
+}
+
+// untrustedCell returns a SourceItem whose author_association is NONE.
+func untrustedCell(login string) model.SourceItem {
+	return model.SourceItem{
+		ID:       "42",
+		SourceID: "gh",
+		Title:    "Untrusted issue",
+		Metadata: map[string]any{
+			"author_association": "NONE",
+			"author_login":       login,
+		},
+	}
+}
+
+// trustedCell returns a SourceItem whose author_association is MEMBER.
+func trustedCell() model.SourceItem {
+	return model.SourceItem{
+		ID:       "43",
+		SourceID: "gh",
+		Title:    "Trusted issue",
+		Metadata: map[string]any{
+			"author_association": "MEMBER",
+			"author_login":       "team-member",
+		},
+	}
+}
+
+// noAssocCell returns a SourceItem with no Metadata (non-GitHub source).
+func noAssocCell() model.SourceItem {
+	return model.SourceItem{ID: "44", SourceID: "jira", Title: "Jira ticket"}
+}
+
+func enabledGate() config.TrustGateSettings {
+	return config.TrustGateSettings{Enabled: true}
+}
+
+// TestWithTrustGate_Disabled verifies withTrustGate is a no-op when disabled.
+func TestWithTrustGate_Disabled(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), config.TrustGateSettings{Enabled: false})
+	if len(got.Steps) != 2 {
+		t.Errorf("disabled gate: got %d steps, want 2", len(got.Steps))
+	}
+}
+
+// TestWithTrustGate_TrustedPassThrough verifies that trusted authors are not gated.
+func TestWithTrustGate_TrustedPassThrough(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, trustedCell(), enabledGate())
+	if len(got.Steps) != 2 {
+		t.Errorf("trusted author: got %d steps, want 2", len(got.Steps))
+	}
+	if got.Steps[0].ID == trustGateStepID {
+		t.Errorf("trusted author: unexpected trust gate step prepended")
+	}
+}
+
+// TestWithTrustGate_NoAssocPassThrough verifies that items without author_association pass through.
+func TestWithTrustGate_NoAssocPassThrough(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, noAssocCell(), enabledGate())
+	if len(got.Steps) != 2 {
+		t.Errorf("no-assoc cell: got %d steps, want 2", len(got.Steps))
+	}
+}
+
+// TestWithTrustGate_PrependsApprovalStep verifies that an untrusted author
+// gets a trust gate approval step prepended before the workflow's own steps.
+func TestWithTrustGate_PrependsApprovalStep(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	if len(got.Steps) != 3 {
+		t.Fatalf("untrusted author: got %d steps, want 3", len(got.Steps))
+	}
+	gate := got.Steps[0]
+	if gate.ID != trustGateStepID {
+		t.Errorf("step[0].ID = %q, want %q", gate.ID, trustGateStepID)
+	}
+	if gate.Type != config.StepTypeApproval {
+		t.Errorf("step[0].Type = %q, want %q", gate.Type, config.StepTypeApproval)
+	}
+	if gate.ResumeOn == nil || gate.ResumeOn.CommentContains != "/approve" {
+		t.Errorf("gate.ResumeOn = %+v, want CommentContains=/approve", gate.ResumeOn)
+	}
+	if gate.AbortOn == nil || gate.AbortOn.CommentContains != "/reject" {
+		t.Errorf("gate.AbortOn = %+v, want CommentContains=/reject", gate.AbortOn)
+	}
+}
+
+// TestWithTrustGate_RootStepDependsOnGate verifies that the first step of the
+// original workflow is wired to depend on the trust gate step so the DAG engine
+// cannot dispatch it before the approval resolves.
+func TestWithTrustGate_RootStepDependsOnGate(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	// The original first step (classify) had no deps; it should now depend on gate.
+	classify := got.Steps[1]
+	if classify.ID != "classify" {
+		t.Fatalf("got.Steps[1].ID = %q, want %q", classify.ID, "classify")
+	}
+	foundGateDep := false
+	for _, dep := range classify.DependsOn {
+		if dep == trustGateStepID {
+			foundGateDep = true
+		}
+	}
+	if !foundGateDep {
+		t.Errorf("classify.DependsOn = %v, want %q in there", classify.DependsOn, trustGateStepID)
+	}
+}
+
+// TestWithTrustGate_NonRootStepUnchanged verifies that a step that already has
+// deps is not modified — only root steps get the gate wired in.
+func TestWithTrustGate_NonRootStepUnchanged(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+
+	// implement depends on classify, so it is not a root step.
+	implement := got.Steps[2]
+	if implement.ID != "implement" {
+		t.Fatalf("got.Steps[2].ID = %q, want %q", implement.ID, "implement")
+	}
+	for _, dep := range implement.DependsOn {
+		if dep == trustGateStepID {
+			t.Errorf("implement.DependsOn = %v: non-root step should not have gate dep", implement.DependsOn)
+		}
+	}
+}
+
+// TestWithTrustGate_MessageContainsLogin verifies the default approval message
+// mentions the author login when one is provided.
+func TestWithTrustGate_MessageContainsLogin(t *testing.T) {
+	wf := wf2steps()
+	got := withTrustGate(wf, untrustedCell("ext-user"), enabledGate())
+	gate := got.Steps[0]
+	if gate.Message == "" {
+		t.Fatal("gate.Message is empty")
+	}
+	if !strings.Contains(gate.Message, "ext-user") {
+		t.Errorf("gate.Message = %q, want it to contain %q", gate.Message, "ext-user")
+	}
+}
+
+// TestWithTrustGate_CustomMessage verifies a configured message is used verbatim.
+func TestWithTrustGate_CustomMessage(t *testing.T) {
+	wf := wf2steps()
+	cfg := config.TrustGateSettings{Enabled: true, Message: "custom approval needed"}
+	got := withTrustGate(wf, untrustedCell("outsider"), cfg)
+	gate := got.Steps[0]
+	if gate.Message != "custom approval needed" {
+		t.Errorf("gate.Message = %q, want %q", gate.Message, "custom approval needed")
+	}
+}
+
+// TestWithTrustGate_ApproversForwarded verifies that configured approvers are
+// forwarded to the synthetic approval step.
+func TestWithTrustGate_ApproversForwarded(t *testing.T) {
+	wf := wf2steps()
+	cfg := config.TrustGateSettings{Enabled: true, Approvers: []string{"alice", "bob"}}
+	got := withTrustGate(wf, untrustedCell("outsider"), cfg)
+	gate := got.Steps[0]
+	if len(gate.Approvers) != 2 || gate.Approvers[0] != "alice" || gate.Approvers[1] != "bob" {
+		t.Errorf("gate.Approvers = %v, want [alice bob]", gate.Approvers)
+	}
+}
+
+// TestWithTrustGate_OriginalWorkflowUnmutated verifies that the original
+// WorkflowConfig is not mutated in place.
+func TestWithTrustGate_OriginalWorkflowUnmutated(t *testing.T) {
+	wf := wf2steps()
+	_ = withTrustGate(wf, untrustedCell("outsider"), enabledGate())
+	if len(wf.Steps) != 2 {
+		t.Errorf("original wf.Steps length changed to %d; withTrustGate must not mutate the caller's slice", len(wf.Steps))
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -215,6 +215,7 @@ func (d *Dispatcher) dispatchWorkflow(ctx context.Context, cell model.SourceItem
 	}
 
 	wf := d.resolveWorkflow(match)
+	wf = withTrustGate(wf, cell, d.cfg.Settings.TrustGate)
 	instID, success, err := d.workflowEngine().RunInstance(ctx, wf, task)
 	if err != nil {
 		aplog.Error("cell %s: workflow run failed: %v", cell.LogLabel(), err)

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -689,6 +689,10 @@ func (a *Adapter) toSourceItem(item issue) model.SourceItem {
 		URL:         item.HTMLURL,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
+		Metadata: map[string]any{
+			"author_association": item.AuthorAssociation,
+			"author_login":       item.User.Login,
+		},
 	}
 }
 

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -14,6 +14,11 @@ type issue struct {
 	UpdatedAt   string    `json:"updated_at"`
 	PullRequest *struct{} `json:"pull_request,omitempty"`
 	User        user      `json:"user"`
+	// AuthorAssociation is the relationship of the issue author to the
+	// repository: OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR,
+	// FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, or NONE. GitHub returns this
+	// field on every issue list response at no extra API cost.
+	AuthorAssociation string `json:"author_association"`
 }
 
 type user struct {


### PR DESCRIPTION
## Summary

Closes #244

Supersedes the Action-only approach merged in #242, which had a TOCTOU race: the `triage-gate` Action fires on the GitHub event but the daemon may poll and ingest an issue with `ai-ready` before the Action strips it. This PR moves the trust check **inside the daemon at dispatch time**, eliminating the race entirely.

- **`source/github`**: populate `Metadata["author_association"]` and `Metadata["author_login"]` from the GitHub REST API's `author_association` field (included in every issue list response at no extra API cost; no new API calls).
- **`config`**: add `TrustGateSettings` struct (`enabled`, `approvers`, `message`) exposed under `settings.trust_gate` in YAML.
- **`daemon/trust_gate.go`**: `isTrustedAssociation` (OWNER/MEMBER/COLLABORATOR → trusted) and `withTrustGate` (pure function, no I/O). When the gate is enabled and the issue author is untrusted, it prepends a synthetic `_trust_gate` approval step to the matched workflow before `RunInstance` is called. The run parks at `approval_waiting` immediately — no agent shell command executes until a human approves via `/approve` comment or the dashboard/webhook path. Trusted authors and non-GitHub sources (no `author_association` metadata) pass through unchanged.
- **`daemon/workflow.go`**: wire `withTrustGate` between `resolveWorkflow` and `RunInstance` in `dispatchWorkflow`.
- **`daemon/trust_gate_test.go`**: 11 unit tests covering: trusted/untrusted/no-assoc paths, approval step injection, DAG root-step wiring, non-root step unchanged, message formatting with login, custom message, approvers forwarded, and original WorkflowConfig immutability.

The `triage-gate` GitHub Action from #242 remains as defense-in-depth (removes `ai-ready` label to prevent repeated polling of a gated issue), but is no longer the sole control.

## How to enable

```yaml
settings:
  trust_gate:
    enabled: true
    approvers:            # optional; leave empty for comment-only /approve / /reject
      - maintainer-login
    message: ""           # optional; omit to use the default message
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/...` — all packages pass (24 packages, 0 failures)
- [x] `go test ./internal/daemon/ -run TestIsTrusted\|TestWithTrustGate -v` — 11/11 pass
- [ ] Integration: enable `trust_gate.enabled: true` in a test config, create an issue as a non-collaborator, verify the daemon parks the run at `_trust_gate` approval step without dispatching the agent; post `/approve` and verify the run proceeds