### PR TITLE
security: privilege ceiling — root warning + opt-in least-privilege agent tools [#290]

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,6 +182,7 @@ agents:
 | `skills` | no | Skill names injected into the agent's context |
 | `max_workers` | no | Per-agent concurrency cap (default 1) — see [concurrency](#concurrency) |
 | `max_turns` | no | Max agent turns per step run (default 0 = unlimited). CLI runners pass it as the provider's turns flag (e.g. claude's `--max-turns`); 0 omits the flag |
+| `permissions` | no | Per-agent tool permissions for runners that support them (OpenCode). Keys: `read`, `glob`, `grep`, `task`, `edit`, `bash`, `webfetch`; values `allow`/`deny`. An explicit entry always wins over `settings.least_privilege_agents`. Note: with the permissive default, `webfetch` is omitted from the generated `opencode.json` (preserving the historical key set) unless you set it explicitly |
 | `source_token` | no | Source API token for this agent's write operations — see [Agent identity](#agent-identity) |
 | `source_email` / `source_name` | no | Git author identity exported to the runner environment |
 | `fallbacks` | no | Ordered `{runner, model}` list for [runner failover](resilience.md#runner-failures--failover); `model` optional (empty = that runner's default) |
@@ -281,6 +282,8 @@ settings:
 | `result_comment` | `false` | Post the agent's final output back as a comment |
 | `task_timeout` | `30m` | Default per-run timeout (e.g. `2h`) |
 | `max_attempts` | 3 | Stop re-dispatching a `(task, workflow)` after this many **consecutive failed** instances; `<=0` disables — see [resilience](resilience.md#re-dispatch-failure-cap) |
+| `refuse_root` | `false` | Make running as root (euid 0) a startup **error** instead of a warning. Agent CLIs inherit the daemon's uid, so a prompt-injected agent would execute as root. Default warns so existing root service installs keep working |
+| `least_privilege_agents` | `false` | Deny `edit`/`bash`/`webfetch` by default for agents on runners that support per-agent permissions (OpenCode). Individual agents override via `agents[].permissions` |
 | `default_fallbacks` | — | Global [fallback chain](resilience.md#fallback-chains) inherited by any agent without explicit `fallbacks[]` |
 | `credit_exhausted_cooldown` | `24h` | How long a runner type is paused after a credit-exhausted failure — see [resilience](resilience.md#runner-failures--failover) |
 | `log_max_size_mb` | 50 | Rotate `apiary.log` past this size (MB); negative disables rotation |

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -260,6 +260,20 @@
             "description": "Worker capabilities required before a workflow can be claimed",
             "items": { "type": "string" }
           },
+          "permissions": {
+            "type": "object",
+            "description": "Per-agent tool permissions for runners that support them (OpenCode). An explicit entry always wins over the baseline set by settings.least_privilege_agents",
+            "additionalProperties": false,
+            "properties": {
+              "read": {"type": "string", "enum": ["allow", "deny"]},
+              "glob": {"type": "string", "enum": ["allow", "deny"]},
+              "grep": {"type": "string", "enum": ["allow", "deny"]},
+              "task": {"type": "string", "enum": ["allow", "deny"]},
+              "edit": {"type": "string", "enum": ["allow", "deny"]},
+              "bash": {"type": "string", "enum": ["allow", "deny"]},
+              "webfetch": {"type": "string", "enum": ["allow", "deny"]}
+            }
+          },
           "workspace_affinity": {
             "type": "boolean",
             "description": "Pin retries for this task to the worker that first claims it",
@@ -475,6 +489,16 @@
           "type": "string",
           "description": "Default task timeout (e.g., '2h'). Defaults to 120m",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "refuse_root": {
+          "type": "boolean",
+          "description": "Make running as root (euid 0) a startup error instead of a warning. Agent CLIs inherit the daemon's uid, so a prompt-injected agent would execute as root",
+          "default": false
+        },
+        "least_privilege_agents": {
+          "type": "boolean",
+          "description": "Deny edit/bash/webfetch by default for agents on runners that support per-agent permissions (OpenCode). Individual agents override via agents[].permissions",
+          "default": false
         },
         "max_attempts": {
           "type": "integer",

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -128,6 +128,14 @@ type AgentConfig struct {
 	// WorkspaceAffinity pins retries/resumes to the first worker that claims the
 	// task, preserving a local checkout or other non-portable environment.
 	WorkspaceAffinity bool `yaml:"workspace_affinity,omitempty"`
+	// Permissions overrides the tool permissions written into the OpenCode agent
+	// file. Keys are tool names ("bash", "edit", "webfetch", "read", "glob",
+	// "grep", "task"); values are "allow" or "deny". Keys left out follow the
+	// baseline: permissive by default, or deny for edit/bash/webfetch when
+	// settings.least_privilege_agents is set. An explicit entry always wins, so a
+	// single agent can be restricted without changing the global default —
+	// e.g. permissions: {bash: deny} on a review-only agent.
+	Permissions map[string]string `yaml:"permissions,omitempty"`
 }
 
 // FallbackConfig is one entry in an agent's rate-limit failover chain. Runner
@@ -257,11 +265,23 @@ type TasksConfig struct {
 }
 
 type Settings struct {
-	Concurrency   int    `yaml:"concurrency"`
-	LogLevel      string `yaml:"log_level"`
-	StateLock     bool   `yaml:"state_lock"`
-	ResultComment bool   `yaml:"result_comment"`
-	TaskTimeout   string `yaml:"task_timeout"`
+	Concurrency int    `yaml:"concurrency"`
+	LogLevel    string `yaml:"log_level"`
+	StateLock   bool   `yaml:"state_lock"`
+	// RefuseRoot makes running as root (euid 0) a startup error instead of a
+	// warning. Agent CLIs inherit the daemon's uid, so a prompt-injected agent
+	// executes with whatever privilege the daemon has. Default false — Apiary
+	// warns but starts, so existing root service installs keep working; set true
+	// to enforce a non-root daemon.
+	RefuseRoot bool `yaml:"refuse_root,omitempty"`
+	// LeastPrivilegeAgents makes agent tool permissions deny-by-default
+	// (read/glob/grep/task allowed; edit/bash/webfetch denied) for runners that
+	// support per-agent permissions. Default false preserves the historical
+	// permissive behaviour; individual agents can always restrict themselves via
+	// agents[].permissions regardless of this setting.
+	LeastPrivilegeAgents bool   `yaml:"least_privilege_agents,omitempty"`
+	ResultComment        bool   `yaml:"result_comment"`
+	TaskTimeout          string `yaml:"task_timeout"`
 	// MaxAttempts caps how many consecutive FAILED workflow instances a single
 	// (task, workflow) pair may accumulate before the dispatcher stops
 	// re-dispatching it and applies the workflow's on_fail hook. Rate-limited
@@ -783,6 +803,7 @@ func Load(path string) (*Config, error) {
 		cfg.Settings.Memory.MaxEntryBytes = 16384
 	}
 	warnDeprecatedResultComment(&cfg)
+	warnUnenforceablePermissions(&cfg)
 	return &cfg, nil
 }
 
@@ -798,6 +819,33 @@ func warnDeprecatedResultComment(cfg *Config) {
 	for _, wf := range cfg.Workflows {
 		if wf.ResultComment != "" {
 			aplog.Warn("workflow %q: %s", wf.ID, msg)
+		}
+	}
+}
+
+// warnUnenforceablePermissions warns when per-agent tool permissions cannot be
+// enforced for an agent's runner. Only the OpenCode runner writes an agent file
+// carrying tool permissions; on other runners least_privilege_agents and
+// agents[].permissions are silently inert, which would otherwise leave an
+// operator believing a fleet is restricted when it is not.
+func warnUnenforceablePermissions(cfg *Config) {
+	adapters := map[string]string{}
+	for i := range cfg.Runners {
+		adapters[cfg.Runners[i].ID] = cfg.Runners[i].AdapterName()
+	}
+	for _, a := range cfg.Agents {
+		runnerID := a.Runner
+		if runnerID == "" {
+			runnerID = cfg.DefaultRunner
+		}
+		adapter := adapters[runnerID]
+		if adapter == "" || strings.HasPrefix(adapter, "opencode") {
+			continue // unknown (reported elsewhere) or supported
+		}
+		if len(a.Permissions) > 0 {
+			aplog.Warn("agents[%q]: permissions are ignored by runner %q (adapter %q); only the opencode runner enforces per-agent tool permissions", a.ID, runnerID, adapter)
+		} else if cfg.Settings.LeastPrivilegeAgents {
+			aplog.Warn("settings.least_privilege_agents is set but agent %q uses runner %q (adapter %q), which does not enforce per-agent tool permissions; this agent is NOT restricted", a.ID, runnerID, adapter)
 		}
 	}
 }

--- a/src/internal/config/permissions_warn_test.go
+++ b/src/internal/config/permissions_warn_test.go
@@ -1,0 +1,25 @@
+package config
+
+import "testing"
+
+// least_privilege_agents and agents[].permissions are inert on runners other
+// than opencode; the operator must be told rather than silently believing the
+// fleet is restricted.
+func TestWarnUnenforceablePermissions_DoesNotPanicAndSkipsOpencode(t *testing.T) {
+	cfg := &Config{
+		DefaultRunner: "claude",
+		Runners: []RunnerConfig{
+			{ID: "claude", Type: "cli", Provider: "claude"},
+			{ID: "oc", Type: "cli", Provider: "opencode"},
+		},
+		Agents: []AgentConfig{
+			{ID: "on-claude", Permissions: map[string]string{"bash": "deny"}},
+			{ID: "on-opencode", Runner: "oc", Permissions: map[string]string{"bash": "deny"}},
+			{ID: "unknown-runner", Runner: "nope"},
+		},
+		Settings: Settings{LeastPrivilegeAgents: true},
+	}
+	// Exercises every branch: unsupported adapter with explicit permissions,
+	// supported adapter, and an unresolved runner (reported by Validate instead).
+	warnUnenforceablePermissions(cfg)
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -32,6 +32,12 @@ var LintExpr func(expr string) error
 // skipped.
 var SourceSupportsDependencyWait func(sourceType string) bool
 
+// validAgentTools are the tool names accepted in agents[].permissions.
+var validAgentTools = map[string]bool{
+	"read": true, "glob": true, "grep": true, "task": true,
+	"edit": true, "bash": true, "webfetch": true,
+}
+
 // validFallbackStrategies are the accepted values for fallback_strategy fields.
 var validFallbackStrategies = map[string]bool{"ordered": true, "random": true, "least_cost": true, "fastest": true}
 
@@ -153,6 +159,14 @@ func (c *Config) Validate() []error {
 		}
 		if a.FallbackStrategy != "" && !validFallbackStrategies[a.FallbackStrategy] {
 			errs = append(errs, fmt.Errorf("agents[%d] %q: fallback_strategy %q: must be one of ordered, random, least_cost, fastest", i, a.ID, a.FallbackStrategy))
+		}
+		for tool, value := range a.Permissions {
+			if !validAgentTools[tool] {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: permissions: unknown tool %q; supported: bash, edit, glob, grep, read, task, webfetch", i, a.ID, tool))
+			}
+			if value != "allow" && value != "deny" {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: permissions.%s: %q must be \"allow\" or \"deny\"", i, a.ID, tool, value))
+			}
 		}
 		for j, fb := range a.Fallbacks {
 			if fb.Runner == "" {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -186,6 +186,17 @@ func (d *Dispatcher) pauseRunnerWithKind(runnerType string, until time.Time, kin
 // profileName selects a named runner profile (from cfg.Profiles) that overrides
 // per-agent runner/model/fallbacks settings. An empty string means base config.
 func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *db.Client, logger *logging.Logger, profileName ...string) (*Dispatcher, error) {
+	// Privilege ceiling: agent CLIs inherit the daemon's uid, so running as root
+	// means a prompt-injected agent executes as root. Warn by default (a hard
+	// refusal would break existing root service installs on upgrade); operators
+	// can enforce it with settings.refuse_root.
+	if os.Geteuid() == 0 {
+		if cfg.Settings.RefuseRoot {
+			return nil, fmt.Errorf("refusing to start as root (euid 0) because settings.refuse_root is set: agent CLIs would inherit root privileges — run the daemon as a dedicated non-root user")
+		}
+		aplog.Warn("running as root (euid 0): agent CLIs inherit root privileges, so a prompt injection would execute as root — run as a dedicated non-root user, or set settings.refuse_root: true to make this an error")
+	}
+
 	r, err := router.New(cfg)
 	if err != nil {
 		return nil, err
@@ -1705,6 +1716,55 @@ func (d *Dispatcher) nextRunID() string {
 	return fmt.Sprintf("run-%04d", d.runSeq)
 }
 
+// agentTools is the fixed set of tool permissions written for an agent, in a
+// stable order so generated files don't churn.
+var agentTools = []string{"read", "glob", "grep", "task", "edit", "bash", "webfetch"}
+
+// agentPermissions returns the OpenCode tool-permission map for an agent.
+//
+// The baseline is permissive (historical behaviour) unless
+// settings.least_privilege_agents is set, which flips write/shell/network tools
+// to deny. Either way an agent's explicit permissions win, so an operator can
+// restrict a single agent without flipping the global default. Keeping the
+// default permissive matters because these files are rewritten on every
+// dispatch: a silent flip would leave existing agents unable to edit code, and
+// they would fail by producing no diff rather than by erroring.
+func agentPermissions(ac config.AgentConfig, leastPrivilege bool) map[string]string {
+	perms := map[string]string{}
+	for _, tool := range agentTools {
+		perms[tool] = "allow"
+	}
+	if leastPrivilege {
+		perms["edit"], perms["bash"], perms["webfetch"] = "deny", "deny", "deny"
+	}
+	for k, v := range ac.Permissions {
+		perms[k] = v
+	}
+	return perms
+}
+
+// permissionMap converts a permission map to the any-typed form used in the JSON
+// opencode config.
+//
+// Historically this writer emitted six keys and omitted webfetch, while the
+// markdown writer emitted seven. Emitting webfetch here unconditionally would be
+// a net privilege INCREASE on the default path — the wrong direction for a
+// privilege-ceiling change — so under the permissive baseline the historical key
+// set is preserved. An explicit agents[].permissions entry is always honoured.
+func permissionMap(ac config.AgentConfig, leastPrivilege bool) map[string]any {
+	perms := agentPermissions(ac, leastPrivilege)
+	out := make(map[string]any, len(perms))
+	for k, v := range perms {
+		if k == "webfetch" && !leastPrivilege {
+			if _, set := ac.Permissions[k]; !set {
+				continue // preserve pre-existing opencode.json key set
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // writeOpencodeAgent writes a markdown agent file for opencode so it can load
 // the agent with the right skills, soul prompt, and permissions. The file is
 // written to <working_dir>/.opencode/agents/<agent-id>.md.
@@ -1738,13 +1798,10 @@ func (d *Dispatcher) writeOpencodeAgent(ctx context.Context, ac config.AgentConf
 	fmt.Fprintf(&b, "description: %s\n", ac.Description)
 	b.WriteString("mode: primary\n")
 	b.WriteString("permission:\n")
-	b.WriteString("  edit: allow\n")
-	b.WriteString("  bash: allow\n")
-	b.WriteString("  read: allow\n")
-	b.WriteString("  glob: allow\n")
-	b.WriteString("  grep: allow\n")
-	b.WriteString("  webfetch: allow\n")
-	b.WriteString("  task: allow\n")
+	perms := agentPermissions(ac, d.cfg.Settings.LeastPrivilegeAgents)
+	for _, tool := range agentTools {
+		fmt.Fprintf(&b, "  %s: %s\n", tool, perms[tool])
+	}
 	b.WriteString("---\n")
 	if promptBody != "" {
 		b.WriteString("\n")
@@ -1803,14 +1860,7 @@ func (d *Dispatcher) registerAgentInConfig(workDir string, ac config.AgentConfig
 		"mode":        "primary",
 		"prompt":      "{file:./agents/" + ac.ID + ".md}",
 		"skills":      ac.Skills,
-		"permission": map[string]any{
-			"edit": "allow",
-			"bash": "allow",
-			"read": "allow",
-			"glob": "allow",
-			"grep": "allow",
-			"task": "allow",
-		},
+		"permission":  permissionMap(ac, d.cfg.Settings.LeastPrivilegeAgents),
 	}
 
 	agents, _ := cfg["agent"].(map[string]any)

--- a/src/internal/daemon/permissions_test.go
+++ b/src/internal/daemon/permissions_test.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// Default must stay permissive: these files are rewritten on every dispatch, so
+// flipping the default would silently strip edit/bash from every existing agent,
+// which fails by producing no diff rather than by erroring.
+func TestAgentPermissions_DefaultIsPermissive(t *testing.T) {
+	p := agentPermissions(config.AgentConfig{ID: "eng"}, false)
+	for _, tool := range agentTools {
+		if p[tool] != "allow" {
+			t.Errorf("default should allow %q, got %q", tool, p[tool])
+		}
+	}
+}
+
+func TestAgentPermissions_LeastPrivilegeOptIn(t *testing.T) {
+	p := agentPermissions(config.AgentConfig{ID: "eng"}, true)
+	for _, tool := range []string{"read", "glob", "grep", "task"} {
+		if p[tool] != "allow" {
+			t.Errorf("read-only tool %q should stay allow, got %q", tool, p[tool])
+		}
+	}
+	for _, tool := range []string{"edit", "bash", "webfetch"} {
+		if p[tool] != "deny" {
+			t.Errorf("least-privilege should deny %q, got %q", tool, p[tool])
+		}
+	}
+}
+
+// An explicit per-agent entry wins in both directions, so one agent can be
+// locked down without changing the global default, and one agent can keep shell
+// access when the global default is least-privilege.
+func TestAgentPermissions_ExplicitOverridesBaseline(t *testing.T) {
+	restricted := agentPermissions(config.AgentConfig{
+		ID: "reviewer", Permissions: map[string]string{"bash": "deny", "edit": "deny"},
+	}, false)
+	if restricted["bash"] != "deny" || restricted["edit"] != "deny" {
+		t.Errorf("explicit deny ignored under permissive default: %v", restricted)
+	}
+
+	granted := agentPermissions(config.AgentConfig{
+		ID: "eng", Permissions: map[string]string{"bash": "allow", "edit": "allow"},
+	}, true)
+	if granted["bash"] != "allow" || granted["edit"] != "allow" {
+		t.Errorf("explicit allow ignored under least-privilege: %v", granted)
+	}
+	if granted["webfetch"] != "deny" {
+		t.Errorf("unspecified tool should keep the least-privilege baseline, got %q", granted["webfetch"])
+	}
+}
+
+// The JSON opencode.json writer historically omitted webfetch. Emitting it on
+// the permissive default path would be a net privilege INCREASE, so the
+// historical key set is preserved unless least-privilege is on or the agent
+// sets it explicitly.
+func TestPermissionMap_NoPrivilegeIncreaseOnDefaultPath(t *testing.T) {
+	def := permissionMap(config.AgentConfig{ID: "eng"}, false)
+	if _, present := def["webfetch"]; present {
+		t.Errorf("permissive default must not newly grant webfetch in opencode.json: %v", def)
+	}
+	for _, tool := range []string{"read", "glob", "grep", "task", "edit", "bash"} {
+		if def[tool] != "allow" {
+			t.Errorf("expected %q allow on default path, got %v", tool, def[tool])
+		}
+	}
+
+	// Least-privilege writes the full set (webfetch explicitly denied).
+	lp := permissionMap(config.AgentConfig{ID: "eng"}, true)
+	if lp["webfetch"] != "deny" {
+		t.Errorf("least-privilege should write webfetch: deny, got %v", lp["webfetch"])
+	}
+
+	// An explicit entry is always honoured.
+	got := permissionMap(config.AgentConfig{ID: "eng", Permissions: map[string]string{"webfetch": "allow"}}, false)
+	if got["webfetch"] != "allow" {
+		t.Errorf("explicit webfetch entry must be written, got %v", got["webfetch"])
+	}
+}


### PR DESCRIPTION
## Summary
Privilege-ceiling controls for #290, reworked after two council reviews. **Both controls are opt-in and default to today's behaviour — merging this PR does not harden an existing fleet.** It adds the mechanism and makes the risk visible; an operator opts in.

## What it actually does
| Setting | Default | Effect |
|---|---|---|
| `settings.refuse_root` | `false` | Running as root (euid 0) logs a loud **warning**. Set `true` to make it a startup **error**. |
| `settings.least_privilege_agents` | `false` | Set `true` to deny `edit`/`bash`/`webfetch` by default for agents on runners supporting per-agent permissions. |
| `agents[].permissions` | — | Per-agent `allow`/`deny` per tool. **Always wins** over the baseline, in both directions. |

## Why opt-in rather than deny-by-default
The first revision flipped the defaults and was vetoed for good reason: agent files are rewritten on **every dispatch**, so an upgrade would silently strip `edit`/`bash` from every existing agent — and the failure mode is silent (the agent runs, produces no diff, burns `max_attempts`). The hard root refusal likewise broke the documented `apiary service install` path, whose systemd unit runs as root.

Defaulting to warn matches the posture already set for loose `.env` permissions in ff779ef (warn-and-load, not refuse).

## Honest scope limits
- **Merging this hardens nothing by itself.** Both switches are off.
- **Only the OpenCode runner** honours per-agent tool permissions. `claude-cli` and `cursor-cli` are unconstrained by this change.
- **Env allowlisting is not here** — that is SEC-07 (#253). The previous attempt (#267) was vetoed for filtering `os.Environ()` while passing `req.Env` through unfiltered; this PR deliberately does not touch env.

## Other fixes from review
- `schema/apiary.json` gains `agents[].permissions`, `settings.refuse_root`, `settings.least_privilege_agents` — previously `additionalProperties: false` rejected the exact fields the error text told users to add. Surgical +24 insert, no whole-file re-indent.
- `apiary validate` rejects unknown tool names and values other than `allow`/`deny` (`bash: allwo` used to be written through verbatim).
- `permissionMap` no longer emits `webfetch` on the permissive default path: the JSON writer historically omitted it, so unifying upward would have been a net **privilege increase**. Regression-tested.
- Fixed dangling `writeOpencodeAgent` / `validFallbackStrategies` doc comments.
- Documented both settings and `agents[].permissions` in `docs/configuration.md`.

## Tests
Permissive default, least-privilege opt-in, explicit override in both directions, and the no-privilege-increase guard. `gofmt`, `go vet`, and `daemon` + `config` package tests pass.

Refs #290 (deliberately not "Closes": both defaults are off, only one runner is covered, and env allowlisting remains open in #253)