### PR TITLE
security: warn (not refuse) on loosely-permissioned .env (rework #269) [#293]

### DIFF
--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -824,6 +824,15 @@ func loadDotEnv(configPath string) {
 	if err != nil {
 		return
 	}
+	// The .env commonly holds real secrets (e.g. a Jira API key). Warn — but do
+	// NOT refuse to load — if it is group- or world-accessible, so other local
+	// accounts could read those secrets. Warn-and-load avoids breaking startup for
+	// existing setups while still surfacing the risk (SEC #293).
+	if info, statErr := os.Stat(envPath); statErr == nil {
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			aplog.Warn("%s is group/world-accessible (mode %04o) and may contain secrets; run: chmod 600 %q", envPath, perm, envPath)
+		}
+	}
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/src/internal/config/dotenv_perms_test.go
+++ b/src/internal/config/dotenv_perms_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadDotEnv must always load the file (warn-and-load), regardless of perms —
+// the value must reach the environment even when the file is loosely permissioned.
+func TestLoadDotEnv_LoadsRegardlessOfPerms(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("SEC293_TOKEN=abc123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A group/world-readable .env (0644) must still be loaded, not refused.
+	t.Setenv("SEC293_TOKEN", "")
+	loadDotEnv(filepath.Join(dir, "apiary.yaml"))
+	if got := os.Getenv("SEC293_TOKEN"); got != "abc123" {
+		t.Fatalf("warn-and-load: expected value to be loaded even with 0644 perms, got %q", got)
+	}
+}
+
+func TestLoadDotEnv_LoadsWith0600(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("SEC293_SECURE=xyz\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SEC293_SECURE", "")
+	loadDotEnv(filepath.Join(dir, "apiary.yaml"))
+	if got := os.Getenv("SEC293_SECURE"); got != "xyz" {
+		t.Fatalf("expected 0600 .env to load, got %q", got)
+	}
+}


### PR DESCRIPTION
Reworks council-rejected #269 (issue #293). #269 did an early `return` that **refused to load** a group/world-readable `.env` while claiming to only warn — a silent startup-breaking regression.

`loadDotEnv` now **warns loudly** (with a `chmod 600` remediation hint) when the `.env` is group/world-accessible, but **always loads it** — matching the warn-and-load intent and never breaking startup for existing default-perm setups.

Tests: a 0644 .env still loads (value reaches env); a 0600 .env loads. `go build` + config tests pass.

Closes #293