### PR TITLE
chore: ignore .worktrees/ — canonical location for git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ apiary.yaml.local
 **/.apiary/logs/
 **/.apiary/memory/
 
+# worktrees — single canonical location for all git worktrees
+/.worktrees/
+
 # editor
 .DS_Store
 .idea/


### PR DESCRIPTION
Adds `/.worktrees/` to .gitignore as the single canonical location for git worktrees (`git worktree add .worktrees/<branch>`), replacing the scattered `apiary--*` sibling directories cleaned up today.