### PR TITLE
fix(workflow): reject_when/on_reject on parallel and for_each steps were silently dropped

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -237,6 +237,30 @@ func (lc *lowerCtx) lowerParallelStep(s StepConfig, prevID, inheritedCondition s
 	}
 	out.Condition = composeCond(inheritedCondition, ownCond)
 
+	// Lower reject_when + on_reject → fail_when + on_fail, exactly like a leaf
+	// step. The gate lives on the parallel parent because it is evaluated after
+	// the join, over the children's merged outputs — a child-level gate could
+	// only restart_from a sibling within the group.
+	out.FailWhen = s.FailWhen
+	out.OnFail = s.OnFail
+	if s.RejectWhen != "" {
+		rewritten, err := lc.rewriteExpr(s.RejectWhen, s.ID)
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("parallel step %q reject_when: %w", s.ID, err)
+		}
+		out.FailWhen = rewritten
+	}
+	if s.OnReject != nil {
+		if out.OnFail == nil {
+			out.OnFail = &StepOutcome{}
+		}
+		out.OnFail.Goto = s.OnReject.RestartFrom
+		out.OnFail.MaxRetries = s.OnReject.Max
+	}
+
+	// Auto-wire fields referenced by the gate into the emitting steps' memory.write.
+	lc.autoWireMemory(&out)
+
 	// Lower children individually (no implicit chaining — they run concurrently).
 	loweredChildren := make([]StepConfig, 0, len(s.ParallelSteps))
 	for _, child := range s.ParallelSteps {
@@ -271,6 +295,26 @@ func (lc *lowerCtx) lowerForeachStep(s StepConfig, prevID, inheritedCondition st
 		return StepConfig{}, fmt.Errorf("for_each %q if: %w", s.ID, err)
 	}
 	out.Condition = composeCond(inheritedCondition, ownCond)
+
+	// Lower reject_when + on_reject → fail_when + on_fail (same as leaf/parallel
+	// steps) — these were previously dropped silently.
+	out.FailWhen = s.FailWhen
+	out.OnFail = s.OnFail
+	if s.RejectWhen != "" {
+		rewritten, err := lc.rewriteExpr(s.RejectWhen, s.ID)
+		if err != nil {
+			return StepConfig{}, fmt.Errorf("for_each %q reject_when: %w", s.ID, err)
+		}
+		out.FailWhen = rewritten
+	}
+	if s.OnReject != nil {
+		if out.OnFail == nil {
+			out.OnFail = &StepOutcome{}
+		}
+		out.OnFail.Goto = s.OnReject.RestartFrom
+		out.OnFail.MaxRetries = s.OnReject.Max
+	}
+	lc.autoWireMemory(&out)
 
 	// Lower max: → max_items.
 	if s.Max > 0 {

--- a/src/internal/config/lower_v2_parallel_gate_test.go
+++ b/src/internal/config/lower_v2_parallel_gate_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLowerV2_ParallelRejectWhenLowersToFailWhen guards the regression behind
+// project-erp #4140: reject_when/on_reject authored on a parallel: group step
+// were silently dropped by lowerParallelStep, so the gate never fired and the
+// workflow proceeded past a rejected verdict.
+func TestLowerV2_ParallelRejectWhenLowersToFailWhen(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "gate",
+		Steps: []StepConfig{
+			{ID: "implement", Agent: "ag"},
+			{
+				ID:   "gate",
+				Join: "all",
+				ParallelSteps: []StepConfig{
+					{ID: "review", Agent: "ag",
+						Output: &OutputSchema{Type: "object",
+							Properties: map[string]SchemaField{"review_verdict": {Type: "string"}}}},
+					{ID: "validate", Agent: "ag",
+						Output: &OutputSchema{Type: "object",
+							Properties: map[string]SchemaField{"qa_verdict": {Type: "string"}}}},
+				},
+				RejectWhen: `${{ memory.review_verdict == "rejected" or memory.qa_verdict == "rejected" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "implement", Max: 3},
+			},
+			{ID: "merge", Agent: "ag"},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gate := out.Steps[1]
+	if gate.Type != StepTypeParallel {
+		t.Fatalf("gate type = %q, want parallel", gate.Type)
+	}
+	if gate.FailWhen == "" {
+		t.Fatal("FailWhen should be set from RejectWhen on a parallel step")
+	}
+	if !strings.Contains(gate.FailWhen, "memory.qa_verdict") {
+		t.Errorf("FailWhen = %q, want memory.qa_verdict reference preserved", gate.FailWhen)
+	}
+	if gate.OnFail == nil {
+		t.Fatal("OnFail should be set from OnReject on a parallel step")
+	}
+	if gate.OnFail.Goto != "implement" || gate.OnFail.MaxRetries != 3 {
+		t.Errorf("OnFail = %+v, want goto implement, max_retries 3", gate.OnFail)
+	}
+	// Auto-wiring: the referenced fields must land in the children's memory.write
+	// so their outputs actually reach workflow memory.
+	byID := map[string]StepConfig{}
+	for _, c := range gate.SubSteps {
+		byID[c.ID] = c
+	}
+	if rv := byID["review"]; rv.Memory == nil || !memoryWrites(rv.Memory, "review_verdict") {
+		t.Errorf("review child should auto-wire memory.write review_verdict, got %+v", rv.Memory)
+	}
+	if qa := byID["validate"]; qa.Memory == nil || !memoryWrites(qa.Memory, "qa_verdict") {
+		t.Errorf("validate child should auto-wire memory.write qa_verdict, got %+v", qa.Memory)
+	}
+}
+
+// TestLowerV2_ForEachRejectWhenLowersToFailWhen: same silent drop existed on
+// for_each parents.
+func TestLowerV2_ForEachRejectWhenLowersToFailWhen(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "fe",
+		Steps: []StepConfig{
+			{ID: "design", Agent: "ag",
+				Output: &OutputSchema{Type: "object",
+					Properties: map[string]SchemaField{"tasks": {Type: "array"}}}},
+			{
+				ID:          "fanout",
+				ForEachExpr: "${{ design.tasks }}",
+				SubSteps:    []StepConfig{{ID: "worker", Agent: "ag"}},
+				RejectWhen:  `${{ memory.tasks == "" }}`,
+				OnReject:    &OnRejectConfig{RestartFrom: "design", Max: 1},
+			},
+		},
+	}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fanout := out.Steps[1]
+	if fanout.FailWhen == "" {
+		t.Error("FailWhen should be set from RejectWhen on a for_each step")
+	}
+	if fanout.OnFail == nil || fanout.OnFail.Goto != "design" || fanout.OnFail.MaxRetries != 1 {
+		t.Errorf("OnFail = %+v, want goto design, max_retries 1", fanout.OnFail)
+	}
+}
+
+// TestValidateV2_GateOnSequentialGroupRejected: a gate on a plain sequential
+// group has no emitted step to live on (the group dissolves during lowering),
+// so validation must fail loud instead of dropping it silently.
+func TestValidateV2_GateOnSequentialGroupRejected(t *testing.T) {
+	wf := WorkflowConfig{
+		ID: "grp",
+		Steps: []StepConfig{
+			{ID: "implement", Agent: "ag"},
+			{
+				ID: "checks",
+				SubSteps: []StepConfig{
+					{ID: "review", Agent: "ag"},
+					{ID: "validate", Agent: "ag"},
+				},
+				RejectWhen: `${{ memory.verdict == "rejected" }}`,
+				OnReject:   &OnRejectConfig{RestartFrom: "implement", Max: 3},
+			},
+		},
+	}
+	errs := validateV2Workflow("wf", wf)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "sequential group") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a sequential-group gate validation error, got %v", errs)
+	}
+}

--- a/src/internal/config/workflow_validate_v2.go
+++ b/src/internal/config/workflow_validate_v2.go
@@ -61,6 +61,21 @@ func validateV2Steps(ctx string, steps []StepConfig, siblingsBefore []string) []
 			}
 		}
 
+		// A sequential group is dissolved into its children by the lowering pass —
+		// there is no emitted step left to carry a gate, so any gate/outcome field
+		// authored on the group itself would be silently dropped. Fail loud instead.
+		// (Parallel and for_each parents DO keep their node and support these fields;
+		// a lowered parallel node also carries SubSteps, so exclude typed IR nodes.)
+		if len(s.SubSteps) > 0 && s.ForEachExpr == "" && s.Type == "" {
+			if s.RejectWhen != "" || s.OnReject != nil || s.FailWhen != "" || s.OnFail != nil {
+				errs = append(errs, fmt.Errorf(
+					"%s: reject_when/on_reject/fail_when/on_fail on a sequential group are not supported "+
+						"(the group dissolves during lowering and the gate would be dropped) — "+
+						"move the gate to a leaf step, or make the group parallel:",
+					stepCtx))
+			}
+		}
+
 		// Recursively validate group children.
 		if len(s.SubSteps) > 0 {
 			errs = append(errs, validateV2Steps(stepCtx, s.SubSteps, nil)...)

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -349,6 +349,17 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			for field, val := range res.StructuredOutput {
 				transientMem[field] = renderValue(val)
 			}
+			// A parallel step's own StructuredOutput is empty — its children's fresh
+			// contributions are only merged into r.contrib after this check, so
+			// overlay them here (declaration order, last-write-wins) or a gate like
+			// `memory.qa_verdict == "rejected"` would read the stale/empty value.
+			if step.StepType() == config.StepTypeParallel {
+				for _, c := range wr.parallelContribs {
+					for field, val := range c.Structured {
+						transientMem[field] = renderValue(val)
+					}
+				}
+			}
 			evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates}
 			rejected, fwErr := e.evalExpr(step.FailWhen, evalCtx)
 			switch {

--- a/src/internal/workflow/dag_parallel_gate_test.go
+++ b/src/internal/workflow/dag_parallel_gate_test.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// parallelGateWF builds the shape from project-erp #4140: implement → gate
+// (parallel review+validate with a rejection gate) → merge.
+func parallelGateWF(maxRetries int) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "par-gate", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{
+			ID: "gate", Type: config.StepTypeParallel, Join: "all",
+			DependsOn: []string{"implement"},
+			SubSteps: []config.StepConfig{
+				{ID: "review", Agent: "architect",
+					OutputSchema: &config.OutputSchema{Type: "object",
+						Properties: map[string]config.SchemaField{"review_verdict": {Type: "string"}}},
+					Memory: &config.MemoryConfig{Write: []string{"review_verdict"}}},
+				{ID: "validate", Agent: "architect",
+					OutputSchema: &config.OutputSchema{Type: "object",
+						Properties: map[string]config.SchemaField{"qa_verdict": {Type: "string"}}},
+					Memory: &config.MemoryConfig{Write: []string{"qa_verdict"}}},
+			},
+			FailWhen: `memory.review_verdict == "rejected" or memory.qa_verdict == "rejected"`,
+			OnFail:   &config.StepOutcome{Goto: "implement", MaxRetries: maxRetries},
+		},
+		{ID: "merge", Agent: "backend-dev", DependsOn: []string{"gate"}},
+	}}
+}
+
+// TestDAG_ParallelFailWhen_ChildRejectionTriggersLoopback verifies that a
+// rejected verdict emitted by a parallel child is visible to the parent's
+// fail_when at join time and triggers on_fail.goto restart of the outer step.
+// Regression: the children's memory contributions are only merged after the
+// fail_when check, so without the transient overlay the gate read stale/empty
+// memory and passed a rejected result straight through to merge (#4140).
+func TestDAG_ParallelFailWhen_ChildRejectionTriggersLoopback(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["review"] = []StepResult{
+		{Success: true, StructuredOutput: map[string]any{"review_verdict": "approved"}},
+		{Success: true, StructuredOutput: map[string]any{"review_verdict": "approved"}},
+	}
+	// validate: first round rejected, second round approved.
+	exec.scripts["validate"] = []StepResult{
+		{Success: true, StructuredOutput: map[string]any{"qa_verdict": "rejected"}},
+		{Success: true, StructuredOutput: map[string]any{"qa_verdict": "approved"}},
+	}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(), parallelGateWF(3), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected success after loop-back retry")
+	}
+	if exec.ran("implement") != 2 {
+		t.Errorf("expected implement to run twice (loop-back), got %d", exec.ran("implement"))
+	}
+	if exec.ran("validate") != 2 {
+		t.Errorf("expected validate to run twice (reject + approve), got %d", exec.ran("validate"))
+	}
+	if exec.ran("merge") != 1 {
+		t.Errorf("expected merge to run once, after the gate finally passed, got %d", exec.ran("merge"))
+	}
+}
+
+// TestDAG_ParallelFailWhen_ExhaustedRetriesFailsInstance verifies the gate is
+// terminal once on_fail.max_retries is exhausted — merge must never run.
+func TestDAG_ParallelFailWhen_ExhaustedRetriesFailsInstance(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review":   {Success: true, StructuredOutput: map[string]any{"review_verdict": "approved"}},
+		"validate": {Success: true, StructuredOutput: map[string]any{"qa_verdict": "rejected"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID, success, err := eng.RunInstance(context.Background(), parallelGateWF(1), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected failure after exhausted gate retries")
+	}
+	if store.instances[instID].State != "failed" {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+	if countSeen(exec.seen, "merge") != 0 {
+		t.Errorf("merge must not run after a rejected gate, ran %d times", countSeen(exec.seen, "merge"))
+	}
+}


### PR DESCRIPTION
## Problem

Real incident (project-erp #4140 / PR #4141, 2026-08-03): the `implementation` workflow's `gate` step runs `review` + `validate` as a `parallel:` group with `join: all` and a `reject_when` gate over the children's verdicts. QA correctly emitted `qa_verdict: rejected`, yet `merge` was dispatched 34s later — the gate expression was never evaluated.

Two independent bugs:

1. **Lowering drop:** `lowerParallelStep` rebuilt the group's StepConfig copying only ID/Name/Type/Join/DependsOn/Condition/SubSteps — unlike `lowerLeafStep` it never lowered `RejectWhen → FailWhen` nor `OnReject → OnFail`, so the authored gate became a no-op. `lowerForeachStep` had the same drop.
2. **Engine gap:** even with a `fail_when` on a parallel step, the children's memory contributions are only merged into workflow memory *after* the fail_when check in `driveDAG`, so the gate would have evaluated against stale/empty values.

## Fix

- `lower_v2.go`: parallel and for_each parents now lower `reject_when`/`on_reject` exactly like leaf steps (rewriteExpr → FailWhen, OnReject → OnFail.Goto/MaxRetries), pass through authored `fail_when`/`on_fail`, and auto-wire referenced fields into the children's `memory.write`.
- `dag.go`: a parallel step's `fail_when` transiently overlays its children's fresh structured outputs (declaration order, last-write-wins) before evaluation.
- `workflow_validate_v2.go`: a gate authored on a *sequential* group — which dissolves during lowering, leaving no step to carry it — is now a validation error at `apiary validate` time instead of a silent drop.

## Tests

- Lowering: parallel + for_each `reject_when → fail_when` incl. child memory auto-wiring.
- Validation: sequential-group gate is rejected.
- Engine: parallel child's rejected verdict triggers `on_fail.goto` restart of the outer `implement` step (and exhausted retries fail the instance without running `merge`).

Full `go test ./...` green.