### PR TITLE
fix(daemon): embedded worker never advertised runner:<adapter> capabilities — queued jobs stuck forever

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -110,6 +110,7 @@ type Dispatcher struct {
 	// Durable dispatch queue and optional embedded local protocol-1 worker.
 	dispatchQueue  queuepkg.Store
 	localWorker    *workerpkg.Runtime
+	queueWorker    queuepkg.Worker
 	queueProjectID string
 	queueWorkerID  string
 }
@@ -227,9 +228,6 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 	d.eventExporters, pluginErrs = plugin.EnabledClients(registry, cfg.Plugins, plugin.CapabilityEventExporter)
 	if len(pluginErrs) > 0 {
 		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
-	}
-	if err := d.configureDispatchQueue(); err != nil {
-		return nil, err
 	}
 	if dbClient != nil {
 		dbClient.SetEventSensitiveFields(cfg.Settings.Events.SensitiveFields)
@@ -432,6 +430,14 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		d.runners[wc.ID] = ra
 	}
 
+	// Must run after the agent loop above: the embedded worker advertises one
+	// runner:<adapter> capability per entry in d.agentRunner, and enqueued jobs
+	// require them. Configuring the queue before agents are loaded registers a
+	// worker with no runner capabilities, so every job stays queued forever.
+	if err := d.configureDispatchQueue(); err != nil {
+		return nil, err
+	}
+
 	return d, nil
 }
 
@@ -485,6 +491,7 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 			aplog.Info("reconciled %d orphaned step run(s) from a previous run", n)
 		}
 		d.reconcileTerminalQueueJobs(ctx)
+		d.warnUnsatisfiableQueueJobs(ctx)
 
 		// Repair each non-terminal task's outstanding-workflow counter and settle
 		// tasks stranded 'running' with no live instance. The instances just

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -54,8 +54,9 @@ func (d *Dispatcher) configureDispatchQueue() error {
 	for _, adapter := range d.agentRunner {
 		capabilities = append(capabilities, "runner:"+adapter)
 	}
+	d.queueWorker = queue.Worker{ID: workerID, ProtocolVersion: queue.WorkerProtocolVersion, Pool: defaultString(d.cfg.Settings.Queue.WorkerPool, "default"), Labels: uniqueStrings(labels), Capabilities: uniqueStrings(capabilities), Capacity: d.cfg.Settings.Queue.WorkerCapacityValue(), Ready: true}
 	runtimeWorker, err := worker.New(d.dispatchQueue, worker.ExecutorFunc(d.executeQueuedJob), worker.Config{
-		Worker:        queue.Worker{ID: workerID, ProtocolVersion: queue.WorkerProtocolVersion, Pool: defaultString(d.cfg.Settings.Queue.WorkerPool, "default"), Labels: uniqueStrings(labels), Capabilities: uniqueStrings(capabilities), Capacity: d.cfg.Settings.Queue.WorkerCapacityValue(), Ready: true},
+		Worker:        d.queueWorker,
 		LeaseDuration: d.cfg.Settings.Queue.LeaseDurationValue(), HeartbeatInterval: d.cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerHeartbeat: d.cfg.Settings.Queue.HeartbeatIntervalValue(), WorkerTimeout: d.cfg.Settings.Queue.WorkerTimeoutValue(), PollInterval: d.cfg.Settings.Queue.PollIntervalValue(), Policy: d.queuePolicy(),
 		OnError: func(err error) { aplog.Error("embedded worker: %v", err) },
 	})
@@ -209,6 +210,69 @@ func (d *Dispatcher) settleRemoteQueueJob(ctx context.Context, job queue.Job) er
 		taskState = model.TaskStateFailed
 	}
 	return d.db.InternalTasks().UpdateTaskState(ctx, job.TaskID, taskState)
+}
+
+// warnUnsatisfiableQueueJobs logs a warning for queued jobs whose pool, labels,
+// or required capabilities no registered worker (including the embedded one)
+// can satisfy. Without it this failure mode is completely silent: jobs sit
+// queued forever while `apiary status` shows a ready worker with free capacity.
+func (d *Dispatcher) warnUnsatisfiableQueueJobs(ctx context.Context) {
+	if d.dispatchQueue == nil {
+		return
+	}
+	jobs, err := d.dispatchQueue.ListJobs(ctx, queue.JobQueued, 1000)
+	if err != nil {
+		aplog.Error("list queued jobs for capability check: %v", err)
+		return
+	}
+	if len(jobs) == 0 {
+		return
+	}
+	workers, err := d.dispatchQueue.ListWorkers(ctx)
+	if err != nil {
+		aplog.Error("list workers for capability check: %v", err)
+		return
+	}
+	// The embedded worker registers asynchronously in Start; include its spec
+	// so its own jobs are never reported as unsatisfiable during startup.
+	if d.localWorker != nil {
+		workers = append(workers, d.queueWorker)
+	}
+	unsatisfiable := 0
+	for _, job := range jobs {
+		if !jobSatisfiableByAnyWorker(job, workers) {
+			unsatisfiable++
+			aplog.Warn("queued job %s (task %s, workflow %s) is not satisfiable by any registered worker: pool=%q required_labels=%v required_capabilities=%v", job.ID, job.TaskID, job.WorkflowID, job.Pool, job.RequiredLabels, job.RequiredCapabilities)
+		}
+	}
+	if unsatisfiable > 0 {
+		aplog.Warn("%d queued job(s) cannot be leased by any registered worker — they will stay queued until a worker advertising the required pool/labels/capabilities registers", unsatisfiable)
+	}
+}
+
+func jobSatisfiableByAnyWorker(job queue.Job, workers []queue.Worker) bool {
+	for _, w := range workers {
+		if job.Pool != "" && job.Pool != w.Pool {
+			continue
+		}
+		if hasAllStrings(w.Labels, job.RequiredLabels) && hasAllStrings(w.Capabilities, job.RequiredCapabilities) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAllStrings(have, need []string) bool {
+	set := make(map[string]bool, len(have))
+	for _, value := range have {
+		set[value] = true
+	}
+	for _, value := range need {
+		if !set[value] {
+			return false
+		}
+	}
+	return true
 }
 
 func (d *Dispatcher) reconcileTerminalQueueJobs(ctx context.Context) {

--- a/src/internal/daemon/queue_dispatch_test.go
+++ b/src/internal/daemon/queue_dispatch_test.go
@@ -4,11 +4,60 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+	_ "github.com/orlandoburli/apiary/internal/runner/providers"
 )
+
+// Regression for the v0.11.0 ordering bug: configureDispatchQueue ran before
+// agents were loaded, so the embedded worker registered without any
+// runner:<adapter> capability while every enqueued job required one — jobs
+// stayed queued forever with a ready, idle worker.
+func TestEmbeddedWorkerLeasesJobRequiringRunnerCapability(t *testing.T) {
+	ctx := context.Background()
+	client, err := db.New(ctx, filepath.Join(t.TempDir(), "control.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	cfg := &config.Config{
+		Runners: []config.RunnerConfig{{ID: "claude", Type: "claude-cli"}},
+		Agents:  []config.AgentConfig{{ID: "eng", Model: "claude-sonnet-5", Runner: "claude"}},
+	}
+	dispatcher, err := New(ctx, cfg, filepath.Join(t.TempDir(), "apiary.yaml"), client, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dispatcher.localWorker == nil {
+		t.Fatal("expected embedded worker with default queue settings")
+	}
+	// Same requirements the enqueue path computes for a job routed to this agent.
+	pool, labels, capabilities, _ := dispatcher.requirementsForMatch("task-1", router.Match{Route: config.RouteConfig{ID: "build", Agent: "eng"}})
+	if !hasAllStrings(capabilities, []string{"runner:claude-cli"}) {
+		t.Fatalf("expected job to require runner:claude-cli, got %v", capabilities)
+	}
+	job := &queue.Job{IdempotencyKey: "task-1:0:build", ProjectID: dispatcher.queueProjectID, Pool: pool, RequiredLabels: labels, RequiredCapabilities: capabilities, PayloadVersion: 1, Payload: []byte(`{}`), MaxAttempts: 1}
+	if _, err := client.Queue().Enqueue(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	// Register the exact worker spec the embedded worker runs with and lease.
+	embedded := dispatcher.queueWorker
+	if err := client.Queue().RegisterWorker(ctx, &embedded); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := client.Queue().Claim(ctx, queue.ClaimRequest{WorkerID: embedded.ID, LeaseDuration: time.Minute, WorkerTimeout: time.Minute})
+	if err != nil {
+		t.Fatalf("embedded worker (capabilities %v) failed to lease job requiring %v: %v", embedded.Capabilities, capabilities, err)
+	}
+	if claim.Job.ID != job.ID {
+		t.Fatalf("leased job %s, want %s", claim.Job.ID, job.ID)
+	}
+}
 
 func TestSettleRemoteQueueJobIsDurableAndIdempotent(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

Since the durable distributed worker queue (#222, shipped in v0.11.0), with queue mode enabled (the default) and the embedded worker, every enqueued job sits in `queued` forever with `leased: 0`, while `apiary status` shows the worker `ready` with free capacity.

Jobs carry `required_capabilities: ["apiary.workflow", "runner:claude-cli"]`, but the embedded worker registered with only `["apiary.workflow"]`, so `compatible`/`containsAll` never matched.

## Root cause

`configureDispatchQueue` built the embedded worker's capability set by iterating `d.agentRunner` — but it ran near the top of `daemon.New`, before the agent loop populated `d.agentRunner`. No `runner:<adapter>` capability was ever advertised, while the enqueue path (`requirementsForMatch`) correctly required one per agent.

## Fix

- Move `configureDispatchQueue()` to after agent/runner wiring in `New` (with a comment explaining the ordering constraint).
- Keep the built worker spec on the Dispatcher (`queueWorker`).
- **Startup warning**: `warnUnsatisfiableQueueJobs` runs at `Start()` and logs each queued job whose pool/labels/capabilities no registered worker (including the embedded one) can satisfy, plus a summary line — this failure mode was previously completely silent.

## Regression test

`TestEmbeddedWorkerLeasesJobRequiringRunnerCapability`: builds a Dispatcher via `New` with default queue settings and one claude-cli agent, asserts the dispatch path requires `runner:claude-cli`, registers the embedded worker's exact spec, and verifies it leases the job.

## Rollout note

project-erp currently carries a workaround (`settings.queue.worker_capabilities: ["runner:claude-cli"]`, marked "Remover depois") — remove it after the daemon runs a binary with this fix.

Fixes #360
