### PR TITLE
feat(source): prometheus adapter — trigger workflows from Alertmanager alerts

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -125,6 +125,25 @@ sources:
       states: [to do, in progress]
       labels: [apiary]
 
+  - id: prod-alerts
+    type: prometheus
+    config:
+      # Alertmanager base URL — /api/v2/alerts is polled (dedup/silences/
+      # inhibitions already applied). Read-only source: alerts have no state,
+      # labels, or comments to write back; publish findings to a ticket source.
+      alertmanager_url: https://alertmanager.internal:9093
+      # bearer_token: ${ALERTMANAGER_TOKEN}   # optional auth
+      # Alert-storm cap: at most this many not-yet-seen alerts become tasks
+      # per poll (oldest first); overflow surfaces on later polls. 0 = off.
+      max_new_per_poll: 10
+      # Flap dampener: alerts must have been firing at least this long.
+      min_age: 1m
+    poll_interval: 30s
+    filters:
+      # Alertmanager matchers, ANDed server-side. key=value, key:value, or a
+      # raw matcher like env=~"prod|staging".
+      labels: ["severity=critical", "team=platform"]
+
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:
   # === Claude-based agents (original design) ===

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -15,7 +15,7 @@ Task System ──► Apiary ──► Agent ──► LLM Model
 | Term | Meaning |
 |---|---|
 | **Hive** | A configured Apiary instance — one `apiary.yaml` plus its `.apiary/` state directory |
-| **Source** | A task-system integration that polls work items and writes results back (GitHub, Plane, …) |
+| **Source** | An integration that polls work items and (where the system supports it) writes results back — ticket systems (GitHub, Jira, Plane) or monitoring signals (Prometheus alerts) |
 | **Task** | A unit of work flowing through the system — born from a source item (an issue) or spawned internally by another task |
 | **Runner** | *How* an agent executes — a CLI subprocess (`claude`, `opencode`, `cursor`) or an API call |
 | **Agent** | A named LLM persona: runner + model + optional soul file, skills, identity, and fallbacks |

--- a/docs/prometheus-source.md
+++ b/docs/prometheus-source.md
@@ -1,0 +1,102 @@
+# Prometheus Source
+
+The `prometheus` source adapter polls **Prometheus Alertmanager**
+(`GET /api/v2/alerts`) and maps each firing alert to an Apiary task — so an
+operational signal, not just a human-filed ticket, can trigger a workflow.
+The canonical pattern: an alert fires (`HighErrorRate` on service X) → an
+investigation workflow dispatches → the agent pulls logs, diagnoses, and
+publishes findings as a GitHub issue or fix PR.
+
+Alertmanager is polled (not the Prometheus rules API) because it has the
+deduplication, silence, and inhibition semantics already applied: silenced
+and inhibited alerts are never ingested.
+
+## Configuration
+
+```yaml
+sources:
+  - id: prod-alerts
+    type: prometheus
+    poll_interval: 30s
+    config:
+      alertmanager_url: https://alertmanager.internal:9093
+      bearer_token: ${ALERTMANAGER_TOKEN}   # optional
+      max_new_per_poll: 10                  # optional, storm cap
+      min_age: 1m                           # optional, flap dampener
+    filters:
+      labels: ["severity=critical", "team=platform"]
+
+workflows:
+  - id: investigate-alert
+    trigger:
+      match: { source: prod-alerts }
+      once: true
+    steps:
+      - id: investigate
+        agent: sre-investigator
+```
+
+### `config` fields
+
+| Field | Required | Description |
+|---|---|---|
+| `alertmanager_url` | yes | Base URL of the Alertmanager instance (`https://host:9093`) |
+| `bearer_token` | no | Sent as `Authorization: Bearer …` on every request |
+| `basic_auth_user` / `basic_auth_password` | no | HTTP Basic auth (ignored when `bearer_token` is set) |
+| `max_new_per_poll` | no | Alert-storm cap: at most this many *not-yet-seen* alerts become tasks per poll; the overflow is logged and surfaces on later polls. `0` disables the cap. Default `10` |
+| `min_age` | no | Flap dampener: an alert must have been firing at least this long before it is ingested (complements the alerting rule's own `for:`). Default `1m` |
+
+### `filters`
+
+| Field | Description |
+|---|---|
+| `labels` | Alertmanager matchers, ANDed and evaluated server-side. Accepts `key=value`, `key:value`, or a raw matcher with operator and quoted value (`env=~"prod|staging"`). A bare word matches `alertname` |
+| `states` | Not applicable — only firing (active, unsilenced, uninhibited) alerts are polled; any value other than `firing` is ignored with a warning |
+
+## Alert → task mapping
+
+| Task field | Alert value |
+|---|---|
+| ID | `fingerprint:startsAt` — stable for the whole fire cycle |
+| Number | first 7 chars of the fingerprint |
+| Title | `alertname` + `summary` annotation |
+| Description | summary/description annotations, full label set, extra annotations, firing-since timestamp, generator URL |
+| Labels | every alert label as `key:value` (e.g. `severity:critical`) — so `trigger.match.labels: [severity:critical]` works verbatim |
+| Type | `alert` |
+| Priority | the `severity` label |
+| State | `firing` |
+| URL | the alert's `generatorURL` |
+| Metadata | raw payload: fingerprint, labels, annotations, startsAt/endsAt, status |
+
+## Behavior
+
+- **Exactly once per fire cycle.** The task ID is the Alertmanager
+  fingerprint plus `startsAt`: while the alert stays firing the ID is
+  constant and the dispatcher's dedup (active-instance drop, `once: true`,
+  persisted task identity) prevents re-dispatch — including across daemon
+  restarts. When the alert resolves and later fires again, `startsAt`
+  changes, producing a new task and a new dispatch.
+- **Storm cap.** One bad deploy can fire 50 alerts in a single poll; each
+  would become a task and an agent run. `max_new_per_poll` bounds how many
+  new alerts are admitted per poll (oldest first); the rest are deferred to
+  subsequent polls and a warning names the deferred count.
+- **Flap dampening.** `min_age` skips alerts younger than the threshold, so
+  firing→resolved→firing blips never dispatch. Combined with the
+  fingerprint+startsAt identity this also means a *resolved-and-refired*
+  alert within the window is a fresh item only once it has stayed firing.
+- **Read-only.** Alerts have no assignable state, labels, or comments to
+  write back to: `Acknowledge` and result write-back are no-ops, and the
+  adapter implements none of the optional write capabilities.
+  `apiary validate` rejects workflows that pin this source and use
+  `on_complete.set_state` / `add_labels`, approval steps, `wait_for` CI
+  steps, or `materialize: sub_issue`.
+- **Resolved while running.** A running investigation is not interrupted
+  when its alert resolves; the workflow finishes normally.
+
+## Where results go
+
+Since the adapter cannot comment on an alert, the natural output of an
+investigation workflow is a *ticket* source: have the agent emit
+`APIARY_PUBLISH` (write findings back to a bound item) or `APIARY_SPAWN`
+(create follow-up work, optionally materialized as a GitHub sub-issue).
+Alert in from Prometheus, findings out as a GitHub issue.

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -42,11 +42,32 @@ Polls Jira Cloud via JQL search. Supports status transitions, blocking relations
 - **Comment rendering:** ADF (Atlassian Document Format) for rich formatting
 - **Setup:** See [Jira Source configuration](jira-source.md)
 
+### Prometheus Alertmanager
+
+**Status:** ✅ Stable | **Auth:** Bearer token or Basic auth (optional)
+
+Polls firing alerts from Prometheus Alertmanager and maps them to tasks, so
+workflows can be triggered by operational signals (an alert fires → an
+investigation agent dispatches). Read-only: alerts have no state, labels, or
+comments to write back — publish findings to a ticket source instead.
+
+- **Requirements:** Reachable Alertmanager `/api/v2/alerts` endpoint
+- **Guardrails:** Alert-storm dispatch cap and flap dampening built in
+- **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
+- **Setup:** See [Prometheus Source configuration](prometheus-source.md)
+
 ### Linear
 
 **Status:** 🔄 Planned | **Auth:** API token
 
 Support for Linear is in development.
+
+### Dynatrace
+
+**Status:** 🔄 Planned | **Auth:** API token
+
+Problem-based monitoring source (`/api/v2/problems`), following the same
+read-only shape as the Prometheus adapter.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - GitHub: github-source.md
       - Jira: jira-source.md
       - Plane: plane-source.md
+      - Prometheus: prometheus-source.md
   - Reference:
       - CLI: cli.md
       - Dashboard: dashboard.md

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -138,7 +138,7 @@
     },
     "sources": {
       "type": "array",
-      "description": "Task sources (github, plane)",
+      "description": "Task sources (github, jira, plane, prometheus)",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -151,11 +151,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "plane", "jira"]
+            "enum": ["github", "jira", "plane", "prometheus"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. plane: workspace, project, api_key, base_url. jira: site, project, email, api_token",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
 	_ "github.com/orlandoburli/apiary/internal/source/plane"
+	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
 
 	_ "github.com/orlandoburli/apiary/internal/runner/providers"
 )

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -32,4 +32,21 @@ func init() {
 		_, ok = a.(source.PREventPoller)
 		return ok
 	}
+	// Same pattern for the write-capability lint: probe a fresh instance for
+	// the optional interfaces, so read-only sources (prometheus alerts) reject
+	// set_state/add_labels/approvals/wait_for-ci workflows at validation time.
+	config.SourceCapabilities = func(sourceType string) config.SourceCaps {
+		a, ok := source.New(sourceType)
+		if !ok {
+			return config.SourceCaps{}
+		}
+		var caps config.SourceCaps
+		_, caps.SetState = a.(source.StateSetter)
+		_, caps.AddLabels = a.(source.LabelAdder)
+		_, caps.RemoveLabels = a.(source.LabelRemover)
+		_, caps.Approvals = a.(source.TaskPoller)
+		_, caps.CIWait = a.(source.CIStatusPoller)
+		_, caps.SubIssues = a.(source.SubIssueCreator)
+		return caps
+	}
 }

--- a/src/internal/config/source_caps_validate.go
+++ b/src/internal/config/source_caps_validate.go
@@ -1,0 +1,112 @@
+package config
+
+import "fmt"
+
+// capNeed is one workflow feature that requires an optional source capability.
+type capNeed struct {
+	feature string // human label for the error message
+	has     func(SourceCaps) bool
+}
+
+// validateSourceCapabilities rejects workflow features that require a write
+// capability (set_state, add_labels, approvals, wait_for ci, materialize)
+// against sources whose adapter does not implement it — e.g. the read-only
+// prometheus alert source. Two rules, mirroring the dependency-wait lint:
+//
+//   - a workflow whose trigger pins match.source to a specific source errors
+//     when THAT source lacks a needed capability (the mismatch is certain);
+//   - a workflow with no source pin errors only when NO configured source
+//     supports the capability (with mixed sources the item's origin is only
+//     known at runtime, where the missing capability degrades to a no-op).
+//
+// Skipped when the SourceCapabilities hook is not injected (configs built in
+// code, isolated tests) or when no sources are configured. Must run after v2
+// lowering so nested/parallel steps are flattened into WorkflowConfig.Steps.
+func (c *Config) validateSourceCapabilities() []error {
+	if SourceCapabilities == nil || len(c.Sources) == 0 {
+		return nil
+	}
+
+	typeByID := map[string]string{}
+	capsByType := map[string]SourceCaps{}
+	for _, s := range c.Sources {
+		typeByID[s.ID] = s.Type
+		if _, ok := capsByType[s.Type]; !ok {
+			capsByType[s.Type] = SourceCapabilities(s.Type)
+		}
+	}
+
+	var errs []error
+	for i, w := range c.Workflows {
+		wctx := fmt.Sprintf("workflows[%d] %q", i, w.ID)
+
+		var pinned string
+		if w.Trigger != nil {
+			pinned = w.Trigger.Match.Source
+		}
+
+		for _, need := range workflowCapNeeds(w) {
+			if pinned != "" {
+				srcType, known := typeByID[pinned]
+				if !known {
+					continue // unknown source id is reported elsewhere
+				}
+				if !need.has(capsByType[srcType]) {
+					errs = append(errs, fmt.Errorf("%s: %s requires a capability that source %q (type %q) does not support — alerts and other read-only sources cannot host it",
+						wctx, need.feature, pinned, srcType))
+				}
+				continue
+			}
+			supported := false
+			for _, caps := range capsByType {
+				if need.has(caps) {
+					supported = true
+					break
+				}
+			}
+			if !supported {
+				errs = append(errs, fmt.Errorf("%s: %s requires a capability that no configured source supports",
+					wctx, need.feature))
+			}
+		}
+	}
+	return errs
+}
+
+// workflowCapNeeds collects the capability-requiring features a workflow uses.
+func workflowCapNeeds(w WorkflowConfig) []capNeed {
+	var needs []capNeed
+
+	addHook := func(scope string, h *OnComplete) {
+		if h == nil {
+			return
+		}
+		if h.SetState != "" {
+			needs = append(needs, capNeed{scope + ".set_state", func(c SourceCaps) bool { return c.SetState }})
+		}
+		if len(h.AddLabels) > 0 || h.AssignFromOutput {
+			needs = append(needs, capNeed{scope + " label writes (add_labels/assign_from_output)", func(c SourceCaps) bool { return c.AddLabels }})
+		}
+		if len(h.RemoveLabels) > 0 {
+			needs = append(needs, capNeed{scope + ".remove_labels", func(c SourceCaps) bool { return c.RemoveLabels }})
+		}
+	}
+	addHook("on_complete", w.OnComplete)
+	addHook("on_fail", w.OnFail)
+
+	for _, s := range w.Steps {
+		sctx := fmt.Sprintf("step %q", s.ID)
+		switch s.StepType() {
+		case StepTypeApproval:
+			needs = append(needs, capNeed{sctx + " (approval)", func(c SourceCaps) bool { return c.Approvals }})
+		case StepTypeWaitFor:
+			if s.WaitFor != nil && (s.WaitFor.Kind == "" || s.WaitFor.Kind == WaitKindCI) {
+				needs = append(needs, capNeed{sctx + " (wait_for ci)", func(c SourceCaps) bool { return c.CIWait }})
+			}
+		}
+		if s.Materialize == MaterializeSubIssue {
+			needs = append(needs, capNeed{sctx + " (materialize: sub_issue)", func(c SourceCaps) bool { return c.SubIssues }})
+		}
+	}
+	return needs
+}

--- a/src/internal/config/source_caps_validate_test.go
+++ b/src/internal/config/source_caps_validate_test.go
@@ -1,0 +1,151 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// withSourceCaps points config.SourceCapabilities at a fake registry where
+// "ticket" supports everything and "alerts" (read-only) supports nothing,
+// restoring the previous hook on cleanup.
+func withSourceCaps(t *testing.T) {
+	t.Helper()
+	prev := config.SourceCapabilities
+	config.SourceCapabilities = func(sourceType string) config.SourceCaps {
+		if sourceType == "ticket" {
+			return config.SourceCaps{SetState: true, AddLabels: true, RemoveLabels: true, Approvals: true, CIWait: true, SubIssues: true}
+		}
+		return config.SourceCaps{}
+	}
+	t.Cleanup(func() { config.SourceCapabilities = prev })
+}
+
+func capsConfig(sources []config.SourceConfig, wf config.WorkflowConfig) *config.Config {
+	return &config.Config{
+		Version:   "1",
+		Sources:   sources,
+		Workflows: []config.WorkflowConfig{wf},
+	}
+}
+
+func errsContain(t *testing.T, errs []error, want string) {
+	t.Helper()
+	for _, e := range errs {
+		if strings.Contains(e.Error(), want) {
+			return
+		}
+	}
+	t.Errorf("expected an error containing %q, got %v", want, errs)
+}
+
+func errsNotContain(t *testing.T, errs []error, fragment string) {
+	t.Helper()
+	for _, e := range errs {
+		if strings.Contains(e.Error(), fragment) {
+			t.Errorf("unexpected error containing %q: %v", fragment, e)
+		}
+	}
+}
+
+func TestSourceCaps_PinnedReadOnlySourceRejectsWrites(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:      "investigate",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "prod-alerts"}},
+			Steps:   []config.StepConfig{{ID: "s1", Agent: "sre"}},
+			OnComplete: &config.OnComplete{
+				SetState:  "done",
+				AddLabels: []string{"triaged"},
+			},
+		},
+	)
+	errs := cfg.Validate()
+	errsContain(t, errs, "on_complete.set_state")
+	errsContain(t, errs, "label writes")
+}
+
+func TestSourceCaps_PinnedReadOnlySourceRejectsApprovalAndCIWait(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:      "investigate",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "prod-alerts"}},
+			Steps: []config.StepConfig{
+				{ID: "gate", Type: config.StepTypeApproval, Message: "ok?", ResumeOn: &config.ApprovalTrigger{CommentContains: "approved"}},
+				{ID: "ci", Type: config.StepTypeWaitFor, WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+			},
+		},
+	)
+	errs := cfg.Validate()
+	errsContain(t, errs, "(approval)")
+	errsContain(t, errs, "(wait_for ci)")
+}
+
+func TestSourceCaps_PinnedTicketSourceAllowsWrites(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "gh", Type: "ticket"}, {ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:         "fix",
+			Trigger:    &config.TriggerConfig{Match: config.RouteMatch{Source: "gh"}},
+			Steps:      []config.StepConfig{{ID: "s1", Agent: "eng"}},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		},
+	)
+	errsNotContain(t, cfg.Validate(), "capability")
+}
+
+func TestSourceCaps_UnpinnedWorkflowAllowedWhenSomeSourceSupports(t *testing.T) {
+	withSourceCaps(t)
+
+	// Mixed sources, no pin: the item's origin is runtime information, so the
+	// lint stays quiet as long as one source supports the feature.
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "gh", Type: "ticket"}, {ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:         "fix",
+			Steps:      []config.StepConfig{{ID: "s1", Agent: "eng"}},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		},
+	)
+	errsNotContain(t, cfg.Validate(), "capability")
+}
+
+func TestSourceCaps_UnpinnedWorkflowRejectedWhenNoSourceSupports(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:         "fix",
+			Steps:      []config.StepConfig{{ID: "s1", Agent: "eng"}},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		},
+	)
+	errsContain(t, cfg.Validate(), "no configured source supports")
+}
+
+func TestSourceCaps_SkippedWhenHookNil(t *testing.T) {
+	prev := config.SourceCapabilities
+	config.SourceCapabilities = nil
+	t.Cleanup(func() { config.SourceCapabilities = prev })
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "prod-alerts", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID:         "fix",
+			Steps:      []config.StepConfig{{ID: "s1", Agent: "eng"}},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		},
+	)
+	errsNotContain(t, cfg.Validate(), "capability")
+	errsNotContain(t, cfg.Validate(), "no configured source supports")
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -24,6 +24,24 @@ var KnownAdapters func() []string
 // isolated tests — expression lint is skipped.
 var LintExpr func(expr string) error
 
+// SourceCaps reports which optional write capabilities a source type's
+// adapter implements. Read-only sources (e.g. prometheus alerts) implement
+// none of them; workflow features that need one are rejected at validation.
+type SourceCaps struct {
+	SetState     bool // source.StateSetter — on_complete/on_fail set_state
+	AddLabels    bool // source.LabelAdder — add_labels, assign_from_output
+	RemoveLabels bool // source.LabelRemover — remove_labels
+	Approvals    bool // source.TaskPoller — approval steps
+	CIWait       bool // source.CIStatusPoller — wait_for kind "ci"
+	SubIssues    bool // source.SubIssueCreator — materialize: sub_issue
+}
+
+// SourceCapabilities reports the SourceCaps of a source type's adapter. The
+// cli package injects it (config cannot import the source package without
+// inverting the dependency direction). When nil — configs built in code,
+// isolated tests — the capability checks are skipped, mirroring KnownAdapters.
+var SourceCapabilities func(sourceType string) SourceCaps
+
 // SourceSupportsDependencyWait reports whether a source type's adapter can
 // enumerate a task's upstream blockers (implements source.BlockerLister), which
 // a wait_for step with kind "dependency" requires. The cli package injects it
@@ -289,6 +307,10 @@ func (c *Config) Validate() []error {
 		errs = append(errs, err)
 	}
 	errs = append(errs, c.validateWorkflows()...)
+
+	// Capability lint: reject workflow features that need a write capability
+	// (set_state, approvals, wait_for ci, …) against sources that lack it.
+	errs = append(errs, c.validateSourceCapabilities()...)
 
 	// Removed-directive and unknown-field checks on the raw text (no-op when the
 	// config was built in code rather than loaded from a file).

--- a/src/internal/source/prometheus/adapter.go
+++ b/src/internal/source/prometheus/adapter.go
@@ -1,0 +1,343 @@
+// Package prometheus provides a read-only source adapter that polls
+// Prometheus Alertmanager (GET /api/v2/alerts) and maps each firing alert to
+// an Apiary SourceItem, so workflow trigger matching (labels, states,
+// title_regex) works against operational signals exactly as it does against
+// tickets.
+//
+// Alerts are read-only work items: the adapter deliberately implements none of
+// the optional write capabilities (StateSetter, LabelAdder, TaskPoller,
+// CIStatusPoller, SubIssueCreator…). Acknowledge and WriteResult are no-ops;
+// config validation rejects workflows that need write capabilities against a
+// source that lacks them (config.SourceCapabilities).
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func init() {
+	source.Register("prometheus", func() source.Adapter { return &Adapter{} })
+}
+
+const (
+	// defaultMaxNewPerPoll caps how many not-yet-seen alerts one poll may
+	// surface — the alert-storm guardrail. One bad deploy can fire dozens of
+	// alerts at once; without a cap each becomes a task + agent run in the same
+	// tick. Overflow alerts are logged and surface on later polls.
+	defaultMaxNewPerPoll = 10
+
+	// defaultMinAge is the flap dampener: an alert must have been firing at
+	// least this long before it is surfaced. Complements the alerting rule's
+	// own `for:` clause; 0 would dispatch on the very first evaluation.
+	defaultMinAge = time.Minute
+)
+
+// Adapter implements source.Adapter for Prometheus Alertmanager.
+type Adapter struct {
+	id     string
+	client *client
+
+	maxNewPerPoll int
+	minAge        time.Duration
+
+	// filters are Alertmanager matcher strings sent as filter= params,
+	// built from SourceFilters.Labels.
+	filters []string
+
+	// seen tracks alert item IDs (fingerprint:startsAt) already surfaced, so
+	// the storm cap only counts genuinely new alerts and an ongoing alert is
+	// re-returned every poll (the dispatcher's active/once dedup relies on
+	// that). Entries are pruned when the alert stops firing. In-memory only:
+	// after a restart every firing alert counts as new again, but re-dispatch
+	// is still prevented downstream by the persisted task/instance dedup.
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+// SetID sets the source ID for this adapter.
+func (a *Adapter) SetID(id string) { a.id = id }
+
+// Connect validates config and creates the HTTP client.
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	baseURL, _ := cfg["alertmanager_url"].(string)
+	if baseURL == "" {
+		return fmt.Errorf("prometheus: config.alertmanager_url is required")
+	}
+
+	bearer, _ := cfg["bearer_token"].(string)
+	basicUser, _ := cfg["basic_auth_user"].(string)
+	basicPass, _ := cfg["basic_auth_password"].(string)
+	a.client = newClient(baseURL, bearer, basicUser, basicPass)
+
+	a.maxNewPerPoll = defaultMaxNewPerPoll
+	if v, ok := cfg["max_new_per_poll"]; ok {
+		n, err := toInt(v)
+		if err != nil || n < 0 {
+			return fmt.Errorf("prometheus: config.max_new_per_poll must be a non-negative integer, got %v", v)
+		}
+		a.maxNewPerPoll = n
+	}
+
+	a.minAge = defaultMinAge
+	if v, ok := cfg["min_age"]; ok {
+		s, _ := v.(string)
+		d, err := time.ParseDuration(s)
+		if err != nil || d < 0 {
+			return fmt.Errorf("prometheus: config.min_age must be a non-negative duration (e.g. \"2m\"), got %v", v)
+		}
+		a.minAge = d
+	}
+
+	a.seen = map[string]struct{}{}
+
+	aplog.Info("prometheus: configured  alertmanager=%s  max_new_per_poll=%d  min_age=%s",
+		baseURL, a.maxNewPerPoll, a.minAge)
+	return nil
+}
+
+// SetFilters maps SourceFilters.Labels to Alertmanager matcher strings.
+// Entries may be "key=value", "key:value", or a raw matcher ("key=~\"re\"").
+// States are not sent to Alertmanager (only firing alerts are polled); a
+// states filter other than "firing" is rejected at Connect-time semantics
+// here to avoid a filter that silently never matches.
+func (a *Adapter) SetFilters(states, labels []string) {
+	for _, l := range labels {
+		a.filters = append(a.filters, toMatcher(l))
+	}
+	for _, s := range states {
+		if !strings.EqualFold(s, "firing") {
+			aplog.Warn("prometheus: filters.states %q ignored — only firing alerts are polled", s)
+		}
+	}
+}
+
+// matcherRe recognises a raw Alertmanager matcher with an explicit operator
+// and quoted value, which is passed through untouched.
+var matcherRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*\s*(=~|!~|!=|=)\s*".*"$`)
+
+// toMatcher normalises a filters.labels entry to an Alertmanager matcher.
+func toMatcher(l string) string {
+	l = strings.TrimSpace(l)
+	if matcherRe.MatchString(l) {
+		return l
+	}
+	if k, v, ok := strings.Cut(l, "="); ok {
+		return fmt.Sprintf("%s=%q", strings.TrimSpace(k), strings.TrimSpace(v))
+	}
+	if k, v, ok := strings.Cut(l, ":"); ok {
+		return fmt.Sprintf("%s=%q", strings.TrimSpace(k), strings.TrimSpace(v))
+	}
+	// A bare word is most useful as an alertname match.
+	return fmt.Sprintf("alertname=%q", l)
+}
+
+// Poll returns the currently firing alerts as SourceItems. The since parameter
+// is ignored on purpose: an ongoing alert must be returned on every poll so
+// the dispatcher's active-instance / once dedup keeps shadowing it; item IDs
+// (fingerprint:startsAt) make re-dispatch impossible while a fire cycle lasts.
+func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, error) {
+	alerts, err := a.client.alerts(ctx, a.filters)
+	if err != nil {
+		return nil, fmt.Errorf("prometheus: polling alerts: %w", err)
+	}
+
+	now := time.Now()
+	var eligible []alert
+	for _, al := range alerts {
+		if al.Fingerprint == "" {
+			aplog.Debug("prometheus: skipping alert without fingerprint (labels=%v)", al.Labels)
+			continue
+		}
+		// Flap dampener: too-young alerts are left for a later poll (not marked
+		// seen), so firing→resolved→firing blips shorter than min_age never
+		// become tasks.
+		if age := now.Sub(al.StartsAt); age < a.minAge {
+			aplog.Debug("prometheus: alert %s age %s < min_age %s — deferred", al.Fingerprint, age.Round(time.Second), a.minAge)
+			continue
+		}
+		eligible = append(eligible, al)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Oldest first so a storm drains deterministically.
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].StartsAt.Before(eligible[j].StartsAt) })
+
+	current := make(map[string]struct{}, len(eligible))
+	var items []model.SourceItem
+	newCount := 0
+	dropped := 0
+	for _, al := range eligible {
+		id := itemID(al)
+		current[id] = struct{}{}
+		if _, ok := a.seen[id]; !ok {
+			if a.maxNewPerPoll > 0 && newCount >= a.maxNewPerPoll {
+				dropped++
+				delete(current, id) // not surfaced: stays unseen for the next poll
+				continue
+			}
+			newCount++
+			a.seen[id] = struct{}{}
+		}
+		items = append(items, a.toSourceItem(al))
+	}
+	if dropped > 0 {
+		aplog.Warn("prometheus: storm cap — %d new alert(s) deferred to next poll (max_new_per_poll=%d)", dropped, a.maxNewPerPoll)
+	}
+
+	// Prune fire cycles that ended so a re-fire (new startsAt) counts as new.
+	for id := range a.seen {
+		if _, ok := current[id]; !ok {
+			delete(a.seen, id)
+		}
+	}
+
+	return items, nil
+}
+
+// itemID is the stable per-fire-cycle identity: the Alertmanager fingerprint
+// (hash of the label set) plus startsAt. While an alert keeps firing the ID is
+// constant — the dispatcher dedups it; after resolve+re-fire startsAt changes
+// and the alert dispatches again as a new item.
+func itemID(al alert) string {
+	return al.Fingerprint + ":" + al.StartsAt.UTC().Format(time.RFC3339)
+}
+
+func (a *Adapter) toSourceItem(al alert) model.SourceItem {
+	name := al.Labels["alertname"]
+	if name == "" {
+		name = "alert " + al.Fingerprint
+	}
+	title := name
+	if s := al.Annotations["summary"]; s != "" {
+		title = fmt.Sprintf("%s: %s", name, s)
+	}
+
+	// Alert labels become routable "key:value" item labels (the router
+	// lowercases both sides), e.g. trigger match `labels: [severity:critical]`.
+	labels := make([]string, 0, len(al.Labels))
+	for k, v := range al.Labels {
+		labels = append(labels, k+":"+v)
+	}
+	sort.Strings(labels)
+
+	number := al.Fingerprint
+	if len(number) > 7 {
+		number = number[:7]
+	}
+
+	return model.SourceItem{
+		ID:          itemID(al),
+		SourceID:    a.ID(),
+		Number:      number,
+		Title:       title,
+		Description: describe(al),
+		Labels:      labels,
+		Type:        "alert",
+		Priority:    al.Labels["severity"],
+		State:       "firing",
+		URL:         al.GeneratorURL,
+		Metadata: map[string]any{
+			"fingerprint":  al.Fingerprint,
+			"labels":       al.Labels,
+			"annotations":  al.Annotations,
+			"startsAt":     al.StartsAt.UTC().Format(time.RFC3339),
+			"endsAt":       al.EndsAt.UTC().Format(time.RFC3339),
+			"generatorURL": al.GeneratorURL,
+			"status":       al.Status.State,
+		},
+		CreatedAt: al.StartsAt,
+		UpdatedAt: al.UpdatedAt,
+	}
+}
+
+// describe renders the full alert payload as the task description, so the
+// investigating agent receives labels, annotations, and the generator link
+// without needing Alertmanager access of its own.
+func describe(al alert) string {
+	var b strings.Builder
+	if s := al.Annotations["summary"]; s != "" {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+	if d := al.Annotations["description"]; d != "" {
+		b.WriteString(d)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("**Labels**\n\n")
+	for _, k := range sortedKeys(al.Labels) {
+		fmt.Fprintf(&b, "- `%s`: `%s`\n", k, al.Labels[k])
+	}
+
+	extra := sortedKeys(al.Annotations)
+	wrote := false
+	for _, k := range extra {
+		if k == "summary" || k == "description" {
+			continue
+		}
+		if !wrote {
+			b.WriteString("\n**Annotations**\n\n")
+			wrote = true
+		}
+		fmt.Fprintf(&b, "- `%s`: %s\n", k, al.Annotations[k])
+	}
+
+	fmt.Fprintf(&b, "\nFiring since %s.", al.StartsAt.UTC().Format(time.RFC3339))
+	if al.GeneratorURL != "" {
+		fmt.Fprintf(&b, "\nSource expression: %s", al.GeneratorURL)
+	}
+	return b.String()
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Acknowledge is a no-op: an alert has no assignable/in-progress state to set.
+// Silencing on dispatch (ack_via_silence) is a possible future opt-in.
+func (a *Adapter) Acknowledge(_ context.Context, cell model.SourceItem, action model.AckAction) error {
+	aplog.Debug("prometheus: acknowledge %s (%s) — no-op for alerts", cell.LogLabel(), action)
+	return nil
+}
+
+// WriteResult is a no-op: Alertmanager has no per-alert comment surface. The
+// intended pattern is a workflow step that publishes findings to a ticket
+// source (APIARY_PUBLISH / APIARY_SPAWN) instead.
+func (a *Adapter) WriteResult(_ context.Context, cell model.SourceItem, result model.RunResult) error {
+	aplog.Debug("prometheus: write result for %s (success=%v) — no-op for alerts", cell.LogLabel(), result.Success)
+	return nil
+}
+
+func (a *Adapter) WebhookHandler() http.Handler { return nil }
+
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	}
+	return 0, fmt.Errorf("not an integer: %v", v)
+}

--- a/src/internal/source/prometheus/adapter_test.go
+++ b/src/internal/source/prometheus/adapter_test.go
@@ -1,0 +1,267 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// newTestServer serves the given alerts on GET /api/v2/alerts and records the
+// last request's query values.
+func newTestServer(t *testing.T, alerts *[]map[string]any, lastQuery *map[string][]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		if lastQuery != nil {
+			*lastQuery = r.URL.Query()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(*alerts)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func mkAlert(fingerprint, name, severity string, startsAt time.Time) map[string]any {
+	return map[string]any{
+		"fingerprint": fingerprint,
+		"labels":      map[string]string{"alertname": name, "severity": severity, "team": "platform"},
+		"annotations": map[string]string{
+			"summary":     "error rate above 5%",
+			"description": "the service is returning 5xx",
+			"runbook_url": "https://runbooks.internal/high-error-rate",
+		},
+		"startsAt":     startsAt.UTC().Format(time.RFC3339),
+		"updatedAt":    startsAt.Add(time.Minute).UTC().Format(time.RFC3339),
+		"generatorURL": "https://prometheus.internal/graph?g0.expr=rate",
+		"status":       map[string]any{"state": "active"},
+	}
+}
+
+func connect(t *testing.T, url string, extra map[string]any) *Adapter {
+	t.Helper()
+	a := &Adapter{}
+	a.SetID("prod-alerts")
+	cfg := map[string]any{"alertmanager_url": url}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	if err := a.Connect(context.Background(), cfg); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	return a
+}
+
+func TestConnectRequiresURL(t *testing.T) {
+	a := &Adapter{}
+	if err := a.Connect(context.Background(), map[string]any{}); err == nil {
+		t.Fatal("expected error for missing alertmanager_url")
+	}
+}
+
+func TestPollMapsAlerts(t *testing.T) {
+	started := time.Now().Add(-10 * time.Minute)
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", started)}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	it := items[0]
+
+	wantID := "abcdef1234567890:" + started.UTC().Format(time.RFC3339)
+	if it.ID != wantID {
+		t.Errorf("ID = %q, want %q", it.ID, wantID)
+	}
+	if it.SourceID != "prod-alerts" {
+		t.Errorf("SourceID = %q", it.SourceID)
+	}
+	if it.Number != "abcdef1" {
+		t.Errorf("Number = %q, want short fingerprint", it.Number)
+	}
+	if it.Title != "HighErrorRate: error rate above 5%" {
+		t.Errorf("Title = %q", it.Title)
+	}
+	if it.State != "firing" {
+		t.Errorf("State = %q, want firing", it.State)
+	}
+	if it.Type != "alert" {
+		t.Errorf("Type = %q, want alert", it.Type)
+	}
+	if it.Priority != "critical" {
+		t.Errorf("Priority = %q, want critical", it.Priority)
+	}
+	wantLabels := []string{"alertname:HighErrorRate", "severity:critical", "team:platform"}
+	if len(it.Labels) != len(wantLabels) {
+		t.Fatalf("Labels = %v, want %v", it.Labels, wantLabels)
+	}
+	for i, l := range wantLabels {
+		if it.Labels[i] != l {
+			t.Errorf("Labels[%d] = %q, want %q", i, it.Labels[i], l)
+		}
+	}
+	if it.Metadata["fingerprint"] != "abcdef1234567890" {
+		t.Errorf("Metadata.fingerprint = %v", it.Metadata["fingerprint"])
+	}
+	for _, want := range []string{"error rate above 5%", "the service is returning 5xx", "`severity`: `critical`", "runbook_url", "Firing since"} {
+		if !strings.Contains(it.Description, want) {
+			t.Errorf("Description missing %q:\n%s", want, it.Description)
+		}
+	}
+}
+
+func TestPollIDStableAcrossPolls(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	alerts := []map[string]any{mkAlert("f1", "HighErrorRate", "critical", started)}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, nil)
+
+	first, _ := a.Poll(context.Background(), time.Time{})
+	second, _ := a.Poll(context.Background(), time.Time{})
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("expected the firing alert on every poll: %d then %d", len(first), len(second))
+	}
+	if first[0].ID != second[0].ID {
+		t.Errorf("ID changed across polls: %q vs %q", first[0].ID, second[0].ID)
+	}
+
+	// A re-fire after resolution (new startsAt) is a NEW item.
+	alerts[0] = mkAlert("f1", "HighErrorRate", "critical", started.Add(30*time.Minute))
+	third, _ := a.Poll(context.Background(), time.Time{})
+	if len(third) != 1 {
+		t.Fatalf("expected 1 item on re-fire, got %d", len(third))
+	}
+	if third[0].ID == first[0].ID {
+		t.Error("re-fired alert kept the old ID — would never re-dispatch")
+	}
+}
+
+func TestPollMinAgeDampensFlaps(t *testing.T) {
+	alerts := []map[string]any{
+		mkAlert("young", "Flappy", "warning", time.Now().Add(-10*time.Second)),
+		mkAlert("old", "Stable", "critical", time.Now().Add(-10*time.Minute)),
+	}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, map[string]any{"min_age": "1m"})
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 || items[0].Metadata["fingerprint"] != "old" {
+		t.Fatalf("expected only the old alert, got %+v", items)
+	}
+}
+
+func TestPollStormCap(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	var alerts []map[string]any
+	for i := 0; i < 5; i++ {
+		alerts = append(alerts, mkAlert(fmt.Sprintf("f%d", i), fmt.Sprintf("Alert%d", i), "critical",
+			started.Add(time.Duration(i)*time.Minute)))
+	}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, map[string]any{"max_new_per_poll": 2})
+
+	// Poll 1: only the 2 oldest new alerts surface.
+	items, _ := a.Poll(context.Background(), time.Time{})
+	if len(items) != 2 {
+		t.Fatalf("poll 1: expected 2 items, got %d", len(items))
+	}
+	if items[0].Metadata["fingerprint"] != "f0" || items[1].Metadata["fingerprint"] != "f1" {
+		t.Errorf("poll 1: expected oldest first, got %v and %v", items[0].Metadata["fingerprint"], items[1].Metadata["fingerprint"])
+	}
+
+	// Poll 2: the 2 already-seen keep flowing plus 2 more new ones.
+	items, _ = a.Poll(context.Background(), time.Time{})
+	if len(items) != 4 {
+		t.Fatalf("poll 2: expected 4 items, got %d", len(items))
+	}
+
+	// Poll 3: all 5.
+	items, _ = a.Poll(context.Background(), time.Time{})
+	if len(items) != 5 {
+		t.Fatalf("poll 3: expected 5 items, got %d", len(items))
+	}
+}
+
+func TestPollSendsFilters(t *testing.T) {
+	alerts := []map[string]any{}
+	var q map[string][]string
+	srv := newTestServer(t, &alerts, &q)
+	a := connect(t, srv.URL, nil)
+	a.SetFilters([]string{"firing"}, []string{"severity=critical", "team:platform", `env=~"prod|staging"`})
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	want := []string{`severity="critical"`, `team="platform"`, `env=~"prod|staging"`}
+	got := q["filter"]
+	if len(got) != len(want) {
+		t.Fatalf("filter params = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("filter[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if v := q["active"]; len(v) != 1 || v[0] != "true" {
+		t.Errorf("active param = %v, want [true]", v)
+	}
+	if v := q["silenced"]; len(v) != 1 || v[0] != "false" {
+		t.Errorf("silenced param = %v, want [false]", v)
+	}
+}
+
+func TestWriteOpsAreNoOps(t *testing.T) {
+	a := &Adapter{}
+	if err := a.Acknowledge(context.Background(), itemStub(), "in_progress"); err != nil {
+		t.Errorf("Acknowledge: %v", err)
+	}
+	if err := a.WriteResult(context.Background(), itemStub(), resultStub()); err != nil {
+		t.Errorf("WriteResult: %v", err)
+	}
+	if a.WebhookHandler() != nil {
+		t.Error("WebhookHandler should be nil for the poll-only adapter")
+	}
+}
+
+func TestToMatcher(t *testing.T) {
+	cases := map[string]string{
+		"severity=critical":   `severity="critical"`,
+		"severity:critical":   `severity="critical"`,
+		" team = platform ":   `team="platform"`,
+		`env=~"prod|staging"`: `env=~"prod|staging"`,
+		`env!="dev"`:          `env!="dev"`,
+		"HighErrorRate":       `alertname="HighErrorRate"`,
+	}
+	for in, want := range cases {
+		if got := toMatcher(in); got != want {
+			t.Errorf("toMatcher(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func itemStub() model.SourceItem {
+	return model.SourceItem{ID: "f1:2026-08-05T00:00:00Z", SourceID: "prod-alerts"}
+}
+
+func resultStub() model.RunResult {
+	return model.RunResult{Success: true}
+}

--- a/src/internal/source/prometheus/client.go
+++ b/src/internal/source/prometheus/client.go
@@ -1,0 +1,144 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+const (
+	maxRetries  = 3
+	baseBackoff = time.Second
+)
+
+type client struct {
+	baseURL     string
+	bearerToken string
+	basicUser   string
+	basicPass   string
+	httpClient  *http.Client
+}
+
+func newClient(baseURL, bearerToken, basicUser, basicPass string) *client {
+	return &client{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		bearerToken: bearerToken,
+		basicUser:   basicUser,
+		basicPass:   basicPass,
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// alerts fetches the currently visible alerts from GET /api/v2/alerts.
+// filters are Alertmanager matcher strings (e.g. `severity="critical"`),
+// passed as repeated filter= params; Alertmanager ANDs them.
+func (c *client) alerts(ctx context.Context, filters []string) ([]alert, error) {
+	params := url.Values{
+		"active":      {"true"},
+		"silenced":    {"false"},
+		"inhibited":   {"false"},
+		"unprocessed": {"false"},
+	}
+	for _, f := range filters {
+		params.Add("filter", f)
+	}
+
+	data, err := c.get(ctx, "/api/v2/alerts", params)
+	if err != nil {
+		return nil, err
+	}
+	var alerts []alert
+	if err := json.Unmarshal(data, &alerts); err != nil {
+		return nil, fmt.Errorf("prometheus: decoding alerts response: %w", err)
+	}
+	return alerts, nil
+}
+
+// get executes the request, retrying on 429/5xx with exponential backoff
+// (honouring Retry-After when present).
+func (c *client) get(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	fullPath := path
+	if len(params) > 0 {
+		fullPath += "?" + params.Encode()
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+fullPath, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		if c.bearerToken != "" {
+			req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+		} else if c.basicUser != "" {
+			req.SetBasicAuth(c.basicUser, c.basicPass)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			aplog.Debug("prometheus: GET %s failed (attempt %d/%d): %v", path, attempt+1, maxRetries, err)
+			if !backoffWait(ctx, nil, attempt) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		aplog.Debug("prometheus: GET %s → %d", path, resp.StatusCode)
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("alertmanager API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+			if !backoffWait(ctx, resp, attempt) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("alertmanager API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("alertmanager API GET %s: exceeded %d retries: %w", path, maxRetries, lastErr)
+}
+
+// backoffWait sleeps for the retry delay (Retry-After header if present,
+// exponential backoff otherwise). Returns false when the context was cancelled.
+func backoffWait(ctx context.Context, resp *http.Response, attempt int) bool {
+	wait := baseBackoff * (1 << attempt)
+	if resp != nil {
+		if h := resp.Header.Get("Retry-After"); h != "" {
+			if secs, err := strconv.Atoi(h); err == nil {
+				wait = time.Duration(secs) * time.Second
+			}
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(wait):
+		return true
+	}
+}
+
+func truncateBody(b []byte) string {
+	const max = 512
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "…"
+}

--- a/src/internal/source/prometheus/types.go
+++ b/src/internal/source/prometheus/types.go
@@ -1,0 +1,22 @@
+package prometheus
+
+import "time"
+
+// alert is one entry of Alertmanager's GET /api/v2/alerts response
+// (openapi GettableAlert). Only the fields the adapter consumes are declared.
+type alert struct {
+	Fingerprint  string            `json:"fingerprint"`
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	StartsAt     time.Time         `json:"startsAt"`
+	EndsAt       time.Time         `json:"endsAt"`
+	UpdatedAt    time.Time         `json:"updatedAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Status       alertStatus       `json:"status"`
+}
+
+type alertStatus struct {
+	State       string   `json:"state"` // "active", "suppressed", "unprocessed"
+	SilencedBy  []string `json:"silencedBy"`
+	InhibitedBy []string `json:"inhibitedBy"`
+}


### PR DESCRIPTION
Implements **Phase 1** of #357: a `prometheus` source adapter that polls Alertmanager and materializes firing alerts as `SourceItem`s, so existing workflow trigger matching works verbatim against operational signals.

## What's in

### New adapter — `src/internal/source/prometheus/`
- Registered via `source.Register("prometheus", …)` like the other adapters; blank-imported in `cmd/apiary/main.go`.
- `Poll` hits `GET /api/v2/alerts` with `active=true&silenced=false&inhibited=false` (Alertmanager, not the Prometheus rules API — dedup/silence/inhibition semantics already applied). `filters.labels` become server-side `filter=` matchers (`key=value`, `key:value`, or raw matchers like `env=~"prod|staging"`).
- **Stable IDs**: `fingerprint:startsAt`. Constant while the alert fires → the dispatcher's existing dedup (`dropActiveMatches` / `dropOnceMatches` / persisted task identity) prevents re-dispatch on every poll, surviving restarts. Resolve + re-fire ⇒ new `startsAt` ⇒ new item ⇒ new dispatch. `since` is deliberately ignored so ongoing alerts keep flowing into the active-match shadow.
- Mapping: title = `alertname` + summary annotation; description = annotations + full label set + firing-since + generatorURL (payload reaches the agent via the task description); item labels = `key:value` pairs so `match: {labels: [severity:critical]}` works; `Priority` = severity; `State` = `firing`; `Type` = `alert`; raw payload in `Metadata`.
- **Guardrails**:
  - `max_new_per_poll` (default 10, `0` = off): storm cap on *not-yet-seen* alerts per poll, oldest first, overflow logged and deferred — one bad deploy firing 50 alerts no longer means 50 simultaneous agent runs.
  - `min_age` (default 1m): flap dampener — firing→resolved→firing blips shorter than the window never dispatch.
- Auth: optional `bearer_token` or `basic_auth_user`/`basic_auth_password`; 429/5xx retried with backoff honouring `Retry-After`.

### Read-only capability lint — `config/validate.go` + `cli/adapters.go`
Alerts are read-only work items: the adapter implements none of the optional write interfaces, and `Acknowledge`/`WriteResult` are no-ops (results should go out via `APIARY_PUBLISH`/`APIARY_SPAWN` to a ticket source).

New `config.SourceCapabilities` hook (same injection pattern as `SourceSupportsDependencyWait`), probed by type assertion in `cli/adapters.go`. `Validate` now rejects, per workflow:
- `on_complete`/`on_fail` `set_state`, `add_labels`/`assign_from_output`, `remove_labels`
- approval steps, `wait_for` kind `ci`, `materialize: sub_issue`

when the trigger **pins** a source lacking the capability (certain mismatch), or — for unpinned workflows — when **no** configured source supports it (mirrors the dependency-wait lint's semantics; with mixed sources the origin is runtime information).

### Schema + docs
- `schema/apiary.json`: `sources[].type` enum now `[github, jira, plane, prometheus]` (the enum was stale and missing `jira`, as noted in the issue).
- New `docs/prometheus-source.md` (+ mkdocs nav), `docs/supported-integrations.md` entry (and a planned Dynatrace stub), `docs/concepts.md` source definition updated, example block in `.apiary/example-apiary-full.yaml`.

## Deliberate scope choices
- Storm guardrail is the rate cap (the issue asked for a cap **and/or** groupKey dispatch): `groupKey` isn't exposed on `/api/v2/alerts`, and group-cycle identity on `/alerts/groups` has no stable fire-cycle epoch — deferred rather than shipping shaky exactly-once semantics.
- `ack_via_silence` opt-in, Dynatrace, webhook push mode, and the plugin-source bridge are Phase 2 (per the issue).
- Resolved-while-running: default behavior (let the investigation finish) — no interrupt option yet.

## Testing
- Adapter tests (httptest-backed): mapping, ID stability across polls + re-fire, storm cap drain, min_age dampening, matcher normalization, filter params, no-op write ops.
- Capability lint tests: pinned read-only source rejects writes/approval/ci-wait; pinned ticket source passes; unpinned mixed-source passes; unpinned alerts-only rejects; nil hook skips.
- `go build ./... && go vet ./... && go test ./...` all green; `gofmt` clean.

Closes nothing — Phase 1 of #357 (Phase 2 items remain).