### PR TITLE
feat(workflow): trigger workflows from PR events (comments, review approvals, changes requested)

### DIFF
--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -126,6 +126,29 @@ workflows:
     on_fail:
       add_labels: [needs-attention]
 
+  # ── PR event trigger (trigger.on) ─────────────────────────────────────────
+  # Fires on pull-request activity instead of polled work items. Each event
+  # (comment / review) dispatches exactly once, persisted across restarts.
+  # Author gating defaults to collaborators-only; the daemon's own comments and
+  # bot comments never trigger. The step environment carries APIARY_EVENT_KIND,
+  # APIARY_EVENT_AUTHOR, APIARY_EVENT_BODY, APIARY_PR_NUMBER, APIARY_PR_URL,
+  # and expressions can read ${{ event.* }}.
+  - id: react-to-pr-comment
+    description: "Address reviewer feedback left as a PR comment mentioning @apiary"
+    trigger:
+      on: pr_comment                  # pr_comment | pr_review_approved | pr_review_changes_requested
+      comment_contains: "@apiary"     # pr_comment only
+      max_dispatches: 5               # per-PR runaway-loop budget (0 = unlimited)
+      # authors: [orlandoburli]       # explicit allow-list (overrides association gate)
+      # authors_association: [OWNER, MEMBER, COLLABORATOR]   # the default gate
+    steps:
+      - id: address
+        agent: engineer
+        prompt: |
+          A reviewer commented on PR ${{ event.pr_number }} ($APIARY_PR_URL).
+          Address the request in $APIARY_EVENT_BODY, push to the PR branch, and
+          reply on the PR when done.
+
 settings:
   concurrency: 2
   state_lock: true

--- a/.apiary/example-workflow.yaml
+++ b/.apiary/example-workflow.yaml
@@ -137,7 +137,7 @@ workflows:
     description: "Address reviewer feedback left as a PR comment mentioning @apiary"
     trigger:
       on: pr_comment                  # pr_comment | pr_review_approved | pr_review_changes_requested
-      comment_contains: "@apiary"     # pr_comment only
+      comment_matches: "(?i)@apiary"  # pr_comment only; Go regexp, validated at load
       max_dispatches: 5               # per-PR runaway-loop budget (0 = unlimited)
       # authors: [orlandoburli]       # explicit allow-list (overrides association gate)
       # authors_association: [OWNER, MEMBER, COLLABORATOR]   # the default gate

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -50,6 +50,36 @@ GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
 them out during polling — only plain issues become cells (always
 `Type: "issue"`).
 
+## PR event polling (`trigger.on: pr_*`)
+
+When any workflow declares a [PR event trigger](workflows.md#pr-event-triggers-on),
+the adapter additionally polls pull-request activity every cycle:
+
+| Event | GitHub API call |
+|---|---|
+| `pr_comment` (conversation) | `GET /repos/{o}/{r}/issues/comments?sort=updated&since=<watermark>` (PRs picked out by `html_url`) |
+| `pr_comment` (inline review comment) | `GET /repos/{o}/{r}/pulls/comments?sort=updated&since=<watermark>` |
+| `pr_review_approved` / `pr_review_changes_requested` | `GET /repos/{o}/{r}/pulls/{n}/reviews` for PRs updated since the watermark |
+
+Details:
+
+- The **watermark** is persisted per source in SQLite; the first poll after
+  enabling event triggers baselines it to "now", so historical comments never
+  dispatch. Each event dispatches a matching workflow **exactly once**, even
+  across daemon restarts.
+- Events authored by the **adapter's own token identity** (`GET /user`) and by
+  **bot accounts** are dropped — an agent commenting through the daemon's
+  account can never re-trigger a workflow.
+- The **originating issue** of a PR is resolved from the PR body's closing
+  reference (`Closes #42`, `Fixes #42`, …; first plain `#N` as fallback), and
+  the workflow instance binds to that issue's task. PRs without a discoverable
+  parent issue get a standalone per-PR task.
+- Edited comments do not re-fire (events are gated on `created_at`), and
+  review states other than `APPROVED` / `CHANGES_REQUESTED` are ignored.
+
+The token needs **Pull requests: Read** for review/comment polling (already
+required for `wait_for: ci`).
+
 ## Token permissions
 
 The `api_key` is a GitHub personal access token. Without it, the adapter falls

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -93,7 +93,7 @@ workflows:
   - id: react-to-pr-comment
     trigger:
       on: pr_comment
-      comment_contains: "@apiary"        # only comments mentioning @apiary
+      comment_matches: "(?i)@apiary"     # only comments mentioning @apiary
     steps:
       - id: fix
         agent: engineer
@@ -115,7 +115,7 @@ workflows:
 | Field | Description |
 |---|---|
 | `on` | `item` (default) or `pr_comment`, `pr_review_approved`, `pr_review_changes_requested` |
-| `comment_contains` | `pr_comment` only: comment body must contain this substring (case-insensitive) |
+| `comment_matches` | `pr_comment` only: comment body must match this Go regexp (case-sensitive — prefix `(?i)` for case-insensitive). Validated at config load |
 | `authors` | Only fire for these author logins (case-insensitive); overrides `authors_association` |
 | `authors_association` | Only fire for authors with one of these repo associations. **Default: `[OWNER, MEMBER, COLLABORATOR]`** — drive-by comments from strangers never spawn agents |
 | `max_dispatches` | Cap dispatches per (workflow, PR) — a runaway-loop budget. `0` = unlimited |

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -81,6 +81,67 @@ that:
   runs are not blocked; they stay eligible for retry up to
   `settings.max_attempts`.
 
+### PR event triggers (`on:`)
+
+By default a trigger matches **work items** (issues/tickets polled from a
+source). Setting `on:` to a pull-request event kind makes the trigger fire on
+PR activity instead, polled from sources that support PR events (currently
+`github`):
+
+```yaml
+workflows:
+  - id: react-to-pr-comment
+    trigger:
+      on: pr_comment
+      comment_contains: "@apiary"        # only comments mentioning @apiary
+    steps:
+      - id: fix
+        agent: engineer
+        prompt: |
+          A reviewer commented on PR ${{ event.pr_number }}. Address it:
+          the comment body is in $APIARY_EVENT_BODY.
+
+  - id: fix-review-feedback
+    trigger:
+      on: pr_review_changes_requested
+      match:
+        source: github
+        labels: [apiary]                 # of the PR's originating issue
+    steps:
+      - id: address
+        agent: engineer
+```
+
+| Field | Description |
+|---|---|
+| `on` | `item` (default) or `pr_comment`, `pr_review_approved`, `pr_review_changes_requested` |
+| `comment_contains` | `pr_comment` only: comment body must contain this substring (case-insensitive) |
+| `authors` | Only fire for these author logins (case-insensitive); overrides `authors_association` |
+| `authors_association` | Only fire for authors with one of these repo associations. **Default: `[OWNER, MEMBER, COLLABORATOR]`** — drive-by comments from strangers never spawn agents |
+| `max_dispatches` | Cap dispatches per (workflow, PR) — a runaway-loop budget. `0` = unlimited |
+
+Semantics:
+
+- **Exactly once.** Each event (a comment or review) dispatches a matching
+  workflow exactly once, persisted in SQLite — a daemon restart or poll
+  overlap never re-dispatches it. First-time enablement baselines to "now":
+  historical comments are ignored.
+- **Task binding.** The instance binds to the InternalTask of the PR's
+  originating issue when one exists (resolved from the PR body's `Closes #N`
+  reference), so lineage, dashboard, and transcripts work unchanged.
+  Otherwise a standalone per-PR task is bound.
+- **Loop prevention.** Events authored by the daemon's own source token
+  identity and by bot accounts are dropped at the adapter, so an agent's own
+  PR comments can never re-trigger a workflow. `max_dispatches` is the
+  backstop for multi-account ping-pong.
+- **`match` on event triggers.** `match.source` applies to the event's
+  source; the item-shaped fields (`labels`, `states`, …) apply to the
+  originating issue's task and only match when that task exists.
+- **Event payload.** Every step of an event-triggered instance gets
+  `APIARY_EVENT_KIND`, `APIARY_EVENT_AUTHOR`, `APIARY_EVENT_BODY`,
+  `APIARY_PR_NUMBER`, and `APIARY_PR_URL` in its environment, and expressions
+  can read `event.*` (see [Accessors](#accessors)).
+
 ## Steps
 
 Steps run **sequentially in the order written**. Each step has an `id`
@@ -317,6 +378,16 @@ Precedence is `not` > `and` > `or`, and `and`/`or` short-circuit.
 | `steps.<id>.state` | string | `passed` or `failed` |
 | `steps.<id>.output` | string | the step's output text |
 | `steps.<id>.exit_code` | number | the step's exit code |
+| `event.kind` | string | PR event kind (`pr_comment`, `pr_review_approved`, `pr_review_changes_requested`) |
+| `event.body` | string | comment / review body |
+| `event.author` | string | event author's login |
+| `event.author_association` | string | author's repo association (e.g. `COLLABORATOR`) |
+| `event.pr_number` | string | pull request number |
+| `event.pr_url` | string | pull request URL |
+
+`event.*` is populated only on instances started by a [PR event
+trigger](#pr-event-triggers-on); elsewhere (and on instances rehydrated after
+a daemon restart) it resolves as missing (`""`).
 
 A `memory.<key>` that was never written — and a `steps.<id>` that has not
 run — resolves to the empty string, so `memory.flag == ""` is the idiom for

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -151,11 +151,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "plane"]
+            "enum": ["github", "plane", "jira"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. plane: workspace, project, api_key, base_url",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. plane: workspace, project, api_key, base_url. jira: site, project, email, api_token",
             "additionalProperties": true
           },
           "poll_interval": {
@@ -453,6 +453,35 @@
               },
               "match": {
                 "$ref": "#/definitions/RouteMatch"
+              },
+              "on": {
+                "type": "string",
+                "description": "Trigger event axis: item (default — polled work items) or a PR event kind polled from a source that supports PR events (currently github)",
+                "enum": ["item", "pr_comment", "pr_review_approved", "pr_review_changes_requested"],
+                "default": "item"
+              },
+              "comment_contains": {
+                "type": "string",
+                "description": "Only with on: pr_comment — require the comment body to contain this substring (case-insensitive), e.g. \"@apiary\""
+              },
+              "authors": {
+                "type": "array",
+                "description": "Event triggers only: restrict to events authored by one of these source logins (case-insensitive). Takes precedence over authors_association",
+                "items": { "type": "string" }
+              },
+              "authors_association": {
+                "type": "array",
+                "description": "Event triggers only: restrict to authors whose repository association is in this list. Default when neither authors nor authors_association is set: [OWNER, MEMBER, COLLABORATOR] (collaborators-only)",
+                "items": {
+                  "type": "string",
+                  "enum": ["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", "MANNEQUIN", "NONE"]
+                }
+              },
+              "max_dispatches": {
+                "type": "integer",
+                "description": "Event triggers only: cap how many times this trigger may dispatch for the same pull request (runaway-loop budget). 0 = unlimited",
+                "minimum": 0,
+                "default": 0
               }
             }
           },

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -460,9 +460,10 @@
                 "enum": ["item", "pr_comment", "pr_review_approved", "pr_review_changes_requested"],
                 "default": "item"
               },
-              "comment_contains": {
+              "comment_matches": {
                 "type": "string",
-                "description": "Only with on: pr_comment — require the comment body to contain this substring (case-insensitive), e.g. \"@apiary\""
+                "description": "Only with on: pr_comment — require the comment body to match this Go regexp (case-sensitive; use (?i) for case-insensitive), e.g. \"(?i)@apiary\\\\s+(fix|update)\"",
+                "format": "regex"
               },
               "authors": {
                 "type": "array",

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -24,4 +24,12 @@ func init() {
 		_, ok = a.(source.BlockerLister)
 		return ok
 	}
+	config.SourceSupportsPREvents = func(sourceType string) bool {
+		a, ok := source.New(sourceType)
+		if !ok {
+			return false
+		}
+		_, ok = a.(source.PREventPoller)
+		return ok
+	}
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -228,9 +228,9 @@ type RouteConfig struct {
 	// polled work items, or a pr_* event kind). Set by the Router from the
 	// workflow trigger; event routes are evaluated by RouteEvent only.
 	On string `yaml:"-"`
-	// CommentContains / Authors / AuthorsAssociation / MaxDispatches mirror the
+	// CommentMatches / Authors / AuthorsAssociation / MaxDispatches mirror the
 	// same TriggerConfig fields for event routes. Set by the Router.
-	CommentContains    string   `yaml:"-"`
+	CommentMatches     string   `yaml:"-"`
 	Authors            []string `yaml:"-"`
 	AuthorsAssociation []string `yaml:"-"`
 	MaxDispatches      int      `yaml:"-"`

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -224,6 +224,22 @@ type RouteConfig struct {
 	// once the task already has a completed instance of it, so a run-at-most-once
 	// workflow does not re-dispatch. Set by the Router from the workflow trigger.
 	Once bool `yaml:"-"`
+	// On mirrors TriggerConfig.On: the trigger's event axis ("" / "item" for
+	// polled work items, or a pr_* event kind). Set by the Router from the
+	// workflow trigger; event routes are evaluated by RouteEvent only.
+	On string `yaml:"-"`
+	// CommentContains / Authors / AuthorsAssociation / MaxDispatches mirror the
+	// same TriggerConfig fields for event routes. Set by the Router.
+	CommentContains    string   `yaml:"-"`
+	Authors            []string `yaml:"-"`
+	AuthorsAssociation []string `yaml:"-"`
+	MaxDispatches      int      `yaml:"-"`
+}
+
+// IsEventRoute reports whether this route was synthesized from an event trigger
+// (trigger.on: pr_*) rather than an item trigger.
+func (r RouteConfig) IsEventRoute() bool {
+	return r.On != "" && r.On != TriggerOnItem
 }
 
 type RouteMatch struct {

--- a/src/internal/config/trigger_events_test.go
+++ b/src/internal/config/trigger_events_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// eventCfg builds a minimal config with one workflow whose trigger is t.
+func eventCfg(t TriggerConfig) *Config {
+	return &Config{
+		Version: "1",
+		Sources: []SourceConfig{{ID: "github", Type: "github"}, {ID: "board", Type: "plane"}},
+		Agents:  []AgentConfig{{ID: "eng", Model: "m"}},
+		Workflows: []WorkflowConfig{{
+			ID:      "wf",
+			Trigger: &t,
+			Steps:   []StepConfig{{ID: "s1", Agent: "eng"}},
+		}},
+	}
+}
+
+func errsContain(errs []error, substr string) bool {
+	for _, e := range errs {
+		if strings.Contains(e.Error(), substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateTriggerEvents_OnWhitelist(t *testing.T) {
+	if errs := eventCfg(TriggerConfig{On: "pr_merged"}).Validate(); !errsContain(errs, "trigger on \"pr_merged\" not supported") {
+		t.Errorf("unknown on: value must be rejected, got %v", errs)
+	}
+	for _, on := range []string{"", "item", "pr_comment", "pr_review_approved", "pr_review_changes_requested"} {
+		if errs := eventCfg(TriggerConfig{On: on}).Validate(); errsContain(errs, "trigger on") {
+			t.Errorf("on=%q must be accepted, got %v", on, errs)
+		}
+	}
+}
+
+func TestValidateTriggerEvents_EventOnlyFieldsOnItemTrigger(t *testing.T) {
+	if errs := eventCfg(TriggerConfig{CommentContains: "@apiary"}).Validate(); !errsContain(errs, "comment_contains requires on") {
+		t.Errorf("comment_contains on item trigger must be rejected, got %v", errs)
+	}
+	if errs := eventCfg(TriggerConfig{Authors: []string{"me"}}).Validate(); !errsContain(errs, "authors/authors_association are only valid") {
+		t.Errorf("authors on item trigger must be rejected, got %v", errs)
+	}
+	if errs := eventCfg(TriggerConfig{MaxDispatches: 3}).Validate(); !errsContain(errs, "max_dispatches is only valid") {
+		t.Errorf("max_dispatches on item trigger must be rejected, got %v", errs)
+	}
+}
+
+func TestValidateTriggerEvents_CommentContainsScoping(t *testing.T) {
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRReviewApproved, CommentContains: "@apiary"}).Validate(); !errsContain(errs, "comment_contains is only valid with on: pr_comment") {
+		t.Errorf("comment_contains on a review trigger must be rejected, got %v", errs)
+	}
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, CommentContains: "@apiary"}).Validate(); len(errs) != 0 {
+		t.Errorf("comment_contains on pr_comment must be accepted, got %v", errs)
+	}
+}
+
+func TestValidateTriggerEvents_OnceRejectedAndAssociationEnum(t *testing.T) {
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, Once: true}).Validate(); !errsContain(errs, "once is not valid on an event trigger") {
+		t.Errorf("once on event trigger must be rejected, got %v", errs)
+	}
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, AuthorsAssociation: []string{"FRIEND"}}).Validate(); !errsContain(errs, "authors_association value \"FRIEND\"") {
+		t.Errorf("bad authors_association must be rejected, got %v", errs)
+	}
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, AuthorsAssociation: []string{"owner", "MEMBER"}}).Validate(); len(errs) != 0 {
+		t.Errorf("case-insensitive association values must be accepted, got %v", errs)
+	}
+}
+
+func TestValidateTriggerEvents_SourceCapability(t *testing.T) {
+	prev := SourceSupportsPREvents
+	defer func() { SourceSupportsPREvents = prev }()
+	SourceSupportsPREvents = func(sourceType string) bool { return sourceType == "github" }
+
+	// Scoped to a capable source: OK.
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, Match: RouteMatch{Source: "github"}}).Validate(); len(errs) != 0 {
+		t.Errorf("capable source must pass, got %v", errs)
+	}
+	// Scoped to an incapable source: rejected.
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, Match: RouteMatch{Source: "board"}}).Validate(); !errsContain(errs, "does not support it") {
+		t.Errorf("incapable source must be rejected, got %v", errs)
+	}
+	// Unscoped with at least one capable source: OK.
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment}).Validate(); len(errs) != 0 {
+		t.Errorf("unscoped trigger with a capable source must pass, got %v", errs)
+	}
+	// No capable source at all: rejected.
+	SourceSupportsPREvents = func(string) bool { return false }
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment}).Validate(); !errsContain(errs, "no configured source supports it") {
+		t.Errorf("no capable source must be rejected, got %v", errs)
+	}
+}

--- a/src/internal/config/trigger_events_test.go
+++ b/src/internal/config/trigger_events_test.go
@@ -40,8 +40,8 @@ func TestValidateTriggerEvents_OnWhitelist(t *testing.T) {
 }
 
 func TestValidateTriggerEvents_EventOnlyFieldsOnItemTrigger(t *testing.T) {
-	if errs := eventCfg(TriggerConfig{CommentContains: "@apiary"}).Validate(); !errsContain(errs, "comment_contains requires on") {
-		t.Errorf("comment_contains on item trigger must be rejected, got %v", errs)
+	if errs := eventCfg(TriggerConfig{CommentMatches: "@apiary"}).Validate(); !errsContain(errs, "comment_matches requires on") {
+		t.Errorf("comment_matches on item trigger must be rejected, got %v", errs)
 	}
 	if errs := eventCfg(TriggerConfig{Authors: []string{"me"}}).Validate(); !errsContain(errs, "authors/authors_association are only valid") {
 		t.Errorf("authors on item trigger must be rejected, got %v", errs)
@@ -51,12 +51,16 @@ func TestValidateTriggerEvents_EventOnlyFieldsOnItemTrigger(t *testing.T) {
 	}
 }
 
-func TestValidateTriggerEvents_CommentContainsScoping(t *testing.T) {
-	if errs := eventCfg(TriggerConfig{On: TriggerOnPRReviewApproved, CommentContains: "@apiary"}).Validate(); !errsContain(errs, "comment_contains is only valid with on: pr_comment") {
-		t.Errorf("comment_contains on a review trigger must be rejected, got %v", errs)
+func TestValidateTriggerEvents_CommentMatchesScoping(t *testing.T) {
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRReviewApproved, CommentMatches: "@apiary"}).Validate(); !errsContain(errs, "comment_matches is only valid with on: pr_comment") {
+		t.Errorf("comment_matches on a review trigger must be rejected, got %v", errs)
 	}
-	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, CommentContains: "@apiary"}).Validate(); len(errs) != 0 {
-		t.Errorf("comment_contains on pr_comment must be accepted, got %v", errs)
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, CommentMatches: `(?i)@apiary\s+(fix|update)`}).Validate(); len(errs) != 0 {
+		t.Errorf("comment_matches on pr_comment must be accepted, got %v", errs)
+	}
+	// An invalid pattern fails validate, not runtime.
+	if errs := eventCfg(TriggerConfig{On: TriggerOnPRComment, CommentMatches: "@apiary["}).Validate(); !errsContain(errs, "invalid regexp") {
+		t.Errorf("invalid comment_matches regexp must be rejected, got %v", errs)
 	}
 }
 

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -32,6 +32,13 @@ var LintExpr func(expr string) error
 // skipped.
 var SourceSupportsDependencyWait func(sourceType string) bool
 
+// SourceSupportsPREvents reports whether a source type's adapter can poll
+// pull-request events (implements source.PREventPoller), which a workflow
+// trigger with an `on:` event kind requires. The cli package injects it (config
+// cannot import the source package without inverting the dependency direction).
+// When nil — configs built in code, isolated tests — the check is skipped.
+var SourceSupportsPREvents func(sourceType string) bool
+
 // validAgentTools are the tool names accepted in agents[].permissions.
 var validAgentTools = map[string]bool{
 	"read": true, "glob": true, "grep": true, "task": true,

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -153,10 +153,11 @@ type TriggerConfig struct {
 	// or a PR event kind (pr_comment, pr_review_approved,
 	// pr_review_changes_requested) polled from a PREventPoller-capable source.
 	On string `yaml:"on,omitempty"`
-	// CommentContains, valid only with on: pr_comment, requires the comment body
-	// to contain this substring (case-insensitive) — same vocabulary as
-	// ApprovalTrigger. E.g. "@apiary".
-	CommentContains string `yaml:"comment_contains,omitempty"`
+	// CommentMatches, valid only with on: pr_comment, requires the comment body
+	// to match this Go regexp — the title_regex convention (case-sensitive; use
+	// (?i) for case-insensitive). E.g. "(?i)@apiary\\s+(fix|update)". Compiled
+	// at config load; an invalid pattern fails validation.
+	CommentMatches string `yaml:"comment_matches,omitempty"`
 	// Authors, when set, restricts an event trigger to events authored by one of
 	// these source logins (case-insensitive). Takes precedence over
 	// AuthorsAssociation.

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -98,6 +98,39 @@ func (w WorkflowConfig) ResumePolicy() string {
 	return w.Resume
 }
 
+// Trigger event kinds for TriggerConfig.On. The default (empty) is "item":
+// today's behavior, where polled work items are matched against the trigger.
+// The pr_* kinds instead match pull-request events polled from sources that
+// implement PREventPoller.
+const (
+	TriggerOnItem                   = "item"
+	TriggerOnPRComment              = "pr_comment"
+	TriggerOnPRReviewApproved       = "pr_review_approved"
+	TriggerOnPRReviewChangesRequest = "pr_review_changes_requested"
+)
+
+// TriggerEventKinds lists the PR event kinds accepted in trigger.on (everything
+// except the implicit default "item").
+var TriggerEventKinds = []string{
+	TriggerOnPRComment,
+	TriggerOnPRReviewApproved,
+	TriggerOnPRReviewChangesRequest,
+}
+
+// validAuthorAssociations are the source author-association values accepted in
+// trigger.authors_association (GitHub's vocabulary; other forges map onto it).
+var validAuthorAssociations = map[string]bool{
+	"OWNER": true, "MEMBER": true, "COLLABORATOR": true,
+	"CONTRIBUTOR": true, "FIRST_TIME_CONTRIBUTOR": true, "FIRST_TIMER": true,
+	"MANNEQUIN": true, "NONE": true,
+}
+
+// DefaultEventAuthorAssociations is the default actor gate for event triggers
+// when neither authors nor authors_association is declared: collaborators-only,
+// so drive-by comments from strangers cannot spawn agents. This is a security
+// boundary, not a convenience.
+var DefaultEventAuthorAssociations = []string{"OWNER", "MEMBER", "COLLABORATOR"}
+
 // TriggerConfig selects which tasks start a workflow. It mirrors route matching:
 // priority ordering plus a RouteMatch condition.
 type TriggerConfig struct {
@@ -115,6 +148,42 @@ type TriggerConfig struct {
 	// remain eligible for retry up to settings.max_attempts).
 	Once  bool       `yaml:"once"`
 	Match RouteMatch `yaml:"match"`
+
+	// On selects the trigger's event axis: "item" (default — polled work items)
+	// or a PR event kind (pr_comment, pr_review_approved,
+	// pr_review_changes_requested) polled from a PREventPoller-capable source.
+	On string `yaml:"on,omitempty"`
+	// CommentContains, valid only with on: pr_comment, requires the comment body
+	// to contain this substring (case-insensitive) — same vocabulary as
+	// ApprovalTrigger. E.g. "@apiary".
+	CommentContains string `yaml:"comment_contains,omitempty"`
+	// Authors, when set, restricts an event trigger to events authored by one of
+	// these source logins (case-insensitive). Takes precedence over
+	// AuthorsAssociation.
+	Authors []string `yaml:"authors,omitempty"`
+	// AuthorsAssociation restricts an event trigger to authors whose repository
+	// association is in this list (e.g. OWNER, MEMBER, COLLABORATOR). When both
+	// this and Authors are empty the default is collaborators-only
+	// (DefaultEventAuthorAssociations).
+	AuthorsAssociation []string `yaml:"authors_association,omitempty"`
+	// MaxDispatches caps how many times this trigger may dispatch for the same
+	// pull request (a runaway-loop budget, analogous to on_conflict's own
+	// budget). 0 means unlimited.
+	MaxDispatches int `yaml:"max_dispatches,omitempty"`
+}
+
+// EventKind returns the trigger's event axis, defaulting to TriggerOnItem.
+func (t TriggerConfig) EventKind() string {
+	if t.On == "" {
+		return TriggerOnItem
+	}
+	return t.On
+}
+
+// IsEventTrigger reports whether this trigger fires on PR events rather than
+// polled work items.
+func (t TriggerConfig) IsEventTrigger() bool {
+	return t.EventKind() != TriggerOnItem
 }
 
 // StepConfig is one node in a workflow graph. The active fields depend on Type.

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -82,6 +82,11 @@ func (c *Config) validateWorkflow(
 		errs = append(errs, fmt.Errorf("%s: trigger source %q not defined", ctx, wf.Trigger.Match.Source))
 	}
 
+	// Trigger event axis (on: pr_* / item).
+	if wf.Trigger != nil {
+		errs = append(errs, c.validateTriggerEvents(ctx, *wf.Trigger)...)
+	}
+
 	if len(wf.Steps) == 0 {
 		errs = append(errs, fmt.Errorf("%s: at least one step is required", ctx))
 		return errs
@@ -142,6 +147,82 @@ func (c *Config) validateWorkflow(
 			if s.StepType() == StepTypeAgent && !s.Idempotent {
 				errs = append(errs, fmt.Errorf("%s: resume: auto requires all steps idempotent, but step %q is not", ctx, s.ID))
 			}
+		}
+	}
+
+	return errs
+}
+
+// validateTriggerEvents validates the event axis of a trigger: the on: value
+// whitelist, event-only fields on item triggers, comment_contains scoping, and
+// that some configured source can actually poll PR events (via the injected
+// SourceSupportsPREvents capability hook — skipped when nil, mirroring
+// SourceSupportsDependencyWait).
+func (c *Config) validateTriggerEvents(ctx string, t TriggerConfig) []error {
+	var errs []error
+
+	valid := t.EventKind() == TriggerOnItem
+	for _, k := range TriggerEventKinds {
+		if t.EventKind() == k {
+			valid = true
+		}
+	}
+	if !valid {
+		errs = append(errs, fmt.Errorf("%s: trigger on %q not supported (valid: item, %s)",
+			ctx, t.On, strings.Join(TriggerEventKinds, ", ")))
+		return errs
+	}
+
+	if !t.IsEventTrigger() {
+		// Event-only fields are a config mistake on an item trigger: they would
+		// silently never apply.
+		if t.CommentContains != "" {
+			errs = append(errs, fmt.Errorf("%s: trigger comment_contains requires on: %s", ctx, TriggerOnPRComment))
+		}
+		if len(t.Authors) > 0 || len(t.AuthorsAssociation) > 0 {
+			errs = append(errs, fmt.Errorf("%s: trigger authors/authors_association are only valid on an event trigger (on: %s)",
+				ctx, strings.Join(TriggerEventKinds, "|")))
+		}
+		if t.MaxDispatches != 0 {
+			errs = append(errs, fmt.Errorf("%s: trigger max_dispatches is only valid on an event trigger", ctx))
+		}
+		return errs
+	}
+
+	if t.CommentContains != "" && t.EventKind() != TriggerOnPRComment {
+		errs = append(errs, fmt.Errorf("%s: trigger comment_contains is only valid with on: %s", ctx, TriggerOnPRComment))
+	}
+	if t.MaxDispatches < 0 {
+		errs = append(errs, fmt.Errorf("%s: trigger max_dispatches must be >= 0", ctx))
+	}
+	if t.Once {
+		errs = append(errs, fmt.Errorf("%s: trigger once is not valid on an event trigger (each event dispatches exactly once already)", ctx))
+	}
+	for _, a := range t.AuthorsAssociation {
+		if !validAuthorAssociations[strings.ToUpper(a)] {
+			errs = append(errs, fmt.Errorf("%s: trigger authors_association value %q not supported (e.g. OWNER, MEMBER, COLLABORATOR)", ctx, a))
+		}
+	}
+
+	// The trigger's source (or, when unscoped, at least one configured source)
+	// must be able to poll PR events.
+	if SourceSupportsPREvents != nil && len(c.Sources) > 0 {
+		supported := false
+		for _, src := range c.Sources {
+			if t.Match.Source != "" && src.ID != t.Match.Source {
+				continue
+			}
+			if SourceSupportsPREvents(src.Type) {
+				supported = true
+				break
+			}
+		}
+		if !supported {
+			where := "no configured source supports it"
+			if t.Match.Source != "" {
+				where = fmt.Sprintf("source %q does not support it", t.Match.Source)
+			}
+			errs = append(errs, fmt.Errorf("%s: trigger on: %s requires a source whose adapter can poll PR events, but %s", ctx, t.EventKind(), where))
 		}
 	}
 

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -176,8 +177,8 @@ func (c *Config) validateTriggerEvents(ctx string, t TriggerConfig) []error {
 	if !t.IsEventTrigger() {
 		// Event-only fields are a config mistake on an item trigger: they would
 		// silently never apply.
-		if t.CommentContains != "" {
-			errs = append(errs, fmt.Errorf("%s: trigger comment_contains requires on: %s", ctx, TriggerOnPRComment))
+		if t.CommentMatches != "" {
+			errs = append(errs, fmt.Errorf("%s: trigger comment_matches requires on: %s", ctx, TriggerOnPRComment))
 		}
 		if len(t.Authors) > 0 || len(t.AuthorsAssociation) > 0 {
 			errs = append(errs, fmt.Errorf("%s: trigger authors/authors_association are only valid on an event trigger (on: %s)",
@@ -189,8 +190,13 @@ func (c *Config) validateTriggerEvents(ctx string, t TriggerConfig) []error {
 		return errs
 	}
 
-	if t.CommentContains != "" && t.EventKind() != TriggerOnPRComment {
-		errs = append(errs, fmt.Errorf("%s: trigger comment_contains is only valid with on: %s", ctx, TriggerOnPRComment))
+	if t.CommentMatches != "" {
+		if t.EventKind() != TriggerOnPRComment {
+			errs = append(errs, fmt.Errorf("%s: trigger comment_matches is only valid with on: %s", ctx, TriggerOnPRComment))
+		}
+		if _, err := regexp.Compile(t.CommentMatches); err != nil {
+			errs = append(errs, fmt.Errorf("%s: trigger comment_matches %q: invalid regexp: %w", ctx, t.CommentMatches, err))
+		}
 	}
 	if t.MaxDispatches < 0 {
 		errs = append(errs, fmt.Errorf("%s: trigger max_dispatches must be >= 0", ctx))

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1396,6 +1396,10 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		}
 		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
 	}
+
+	// PR events (trigger.on: pr_*) ride the same poll cadence, after item
+	// dispatch. Capability-gated inside; a no-event config is a no-op.
+	d.pollPREvents(ctx, sc, adapter)
 }
 
 // fanOut dispatches every workflow matched for a polled cell. One InternalTask

--- a/src/internal/daemon/pr_events.go
+++ b/src/internal/daemon/pr_events.go
@@ -1,0 +1,241 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// prEventOverlap is re-fetched behind the watermark on every event poll, so a
+// comment that landed while the previous poll ran is never missed. The
+// persistent dispatch claim (pr_event_dispatches) makes the overlap safe: a
+// re-fetched event can never dispatch twice.
+const prEventOverlap = 2 * time.Minute
+
+// pollPREvents fetches and routes pull-request events for one source, called
+// from the poll cycle after item polling. Capability-gated: sources that do not
+// implement PREventPoller — or configs with no event trigger — skip it entirely.
+//
+// The watermark is persisted per source. A source with no watermark yet is
+// baselined to "now" without dispatching, so enabling event triggers on a repo
+// with years of comments does not storm over history. The watermark only
+// advances after a successful poll, so a transient API failure retries the same
+// window on the next cycle.
+func (d *Dispatcher) pollPREvents(ctx context.Context, sc config.SourceConfig, adapter source.Adapter) {
+	poller, ok := adapter.(source.PREventPoller)
+	if !ok || d.db == nil || !d.router.HasEventRoutes() {
+		return
+	}
+
+	wm, err := d.db.GetPREventWatermark(ctx, sc.ID)
+	if err != nil {
+		aplog.Error("source %s: read PR event watermark: %v", sc.ID, err)
+		return
+	}
+	pollStart := time.Now()
+	if wm.IsZero() {
+		if err := d.db.SetPREventWatermark(ctx, sc.ID, pollStart); err != nil {
+			aplog.Error("source %s: baseline PR event watermark: %v", sc.ID, err)
+			return
+		}
+		aplog.Info("source %s: PR event polling baselined — events before now are ignored", sc.ID)
+		return
+	}
+
+	events, err := poller.PollPREvents(ctx, wm.Add(-prEventOverlap))
+	if err != nil {
+		aplog.Error("source %s: poll PR events: %v", sc.ID, err)
+		return
+	}
+	if len(events) > 0 {
+		aplog.Info("source %s: found %d PR event(s)", sc.ID, len(events))
+	}
+	for _, ev := range events {
+		d.routePREvent(ctx, ev)
+	}
+	if err := d.db.SetPREventWatermark(ctx, sc.ID, pollStart); err != nil {
+		aplog.Error("source %s: advance PR event watermark: %v", sc.ID, err)
+	}
+}
+
+// routePREvent routes one PR event through the event triggers and dispatches
+// every match exactly once (guarded by the persistent per-(event, workflow)
+// claim). The workflow instance binds to the InternalTask of the originating
+// issue when one exists; otherwise a standalone per-PR task is bound, so
+// lineage, dashboard, and transcripts work unchanged.
+func (d *Dispatcher) routePREvent(ctx context.Context, ev model.SourceEvent) {
+	// Resolve the related task (originating issue) via its source binding.
+	var related *model.InternalTask
+	if ev.RelatedItemID != "" {
+		if b, _ := d.db.SourceBindings().GetBindingBySourceItem(ctx, ev.SourceID, ev.RelatedItemID); b != nil {
+			if t, _ := d.db.InternalTasks().GetTask(ctx, b.TaskID); t != nil {
+				related = t
+			}
+		}
+	}
+
+	matches := d.router.RouteEvent(ev, related)
+	if len(matches) == 0 {
+		aplog.Debug("event %s (%s on PR #%d by %s): no matching trigger", ev.ID, ev.Kind, ev.PRNumber, ev.Author)
+		return
+	}
+
+	var task model.InternalTask
+	var persisted bool
+	if related != nil {
+		task, persisted = *related, true
+	} else {
+		// No originating issue: bind a standalone per-PR task. The synthetic item
+		// id is stable per PR, so every event on the same PR resolves to the same
+		// task (the binder is keyed on source_id + source_item_id).
+		task, persisted = d.bindItem(ctx, model.SourceItem{
+			ID:       fmt.Sprintf("pr-%d", ev.PRNumber),
+			SourceID: ev.SourceID,
+			Number:   fmt.Sprintf("#%d", ev.PRNumber),
+			Title:    fmt.Sprintf("PR #%d", ev.PRNumber),
+			URL:      ev.PRURL,
+			Type:     "pr",
+			State:    "open",
+		})
+	}
+
+	for _, m := range matches {
+		// Runaway-loop budget: cap dispatches per (workflow, PR). Fail closed on a
+		// count error — skip this poll, the claim below still prevents duplicates.
+		if budget := m.Route.MaxDispatches; budget > 0 {
+			n, err := d.db.CountPREventDispatches(ctx, ev.SourceID, m.Route.ID, ev.PRNumber)
+			if err != nil {
+				aplog.Error("event %s: count dispatches for workflow %s: %v — skipping this poll", ev.ID, m.Route.ID, err)
+				continue
+			}
+			if n >= budget {
+				aplog.Warn("event %s: workflow %s hit max_dispatches (%d/%d) for PR #%d, not dispatching",
+					ev.ID, m.Route.ID, n, budget, ev.PRNumber)
+				continue
+			}
+		}
+
+		// Exactly-once claim: the insert either wins (dispatch now) or the event
+		// already dispatched this workflow — on this or any previous daemon run.
+		claimed, err := d.db.ClaimPREventDispatch(ctx, ev.SourceID, ev.ID, m.Route.ID, ev.PRNumber)
+		if err != nil {
+			aplog.Error("event %s: claim dispatch for workflow %s: %v — skipping this poll", ev.ID, m.Route.ID, err)
+			continue
+		}
+		if !claimed {
+			aplog.Debug("event %s: workflow %s already dispatched, skipping", ev.ID, m.Route.ID)
+			continue
+		}
+		d.dispatchPREvent(ctx, ev, task, persisted, m)
+	}
+}
+
+// dispatchPREvent launches one workflow for one claimed PR event, mirroring
+// fanOut's admission (per-agent semaphore, active-run tracking, outstanding
+// counter) for a single match. The event payload rides in on the workflow env
+// overlay (APIARY_EVENT_* / APIARY_PR_*) and the engine's event scope
+// (${{ event.* }}).
+func (d *Dispatcher) dispatchPREvent(ctx context.Context, ev model.SourceEvent, task model.InternalTask, persisted bool, match router.Match) {
+	if persisted && d.db != nil {
+		if _, err := d.db.InternalTasks().IncrementOutstanding(ctx, task.ID, 1); err != nil {
+			aplog.Error("task %s: increment outstanding: %v", task.ID, err)
+		}
+	}
+
+	agentCh := d.agentSem[match.Route.Agent]
+	runID := d.nextRunID()
+	cell := model.SourceItem{
+		ID:       ev.RelatedItemID,
+		SourceID: ev.SourceID,
+		Number:   fmt.Sprintf("#%d", ev.PRNumber),
+		Title:    fmt.Sprintf("%s on PR #%d", ev.Kind, ev.PRNumber),
+		URL:      ev.PRURL,
+	}
+	if cell.ID == "" {
+		cell.ID = fmt.Sprintf("pr-%d", ev.PRNumber)
+	}
+
+	go func() {
+		if agentCh != nil {
+			select {
+			case agentCh <- struct{}{}:
+			case <-ctx.Done():
+				return // shutting down before a slot freed; never acquired
+			}
+			defer func() { <-agentCh }()
+		}
+
+		d.active.Add(1)
+		defer d.active.Add(-1)
+		d.activeRuns.Store(runID, model.ActiveRun{
+			ID:        runID,
+			Cell:      cell,
+			WorkerID:  match.Route.Agent,
+			Status:    model.RunStatusRunning,
+			StartedAt: time.Now(),
+		})
+		defer d.activeRuns.Delete(runID)
+
+		aplog.Info("dispatching PR event %s (%s on PR #%d by %s) → workflow %s [agent %s]",
+			ev.ID, ev.Kind, ev.PRNumber, ev.Author, match.Route.ID, match.Route.Agent)
+		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "pr_event.dispatched", TaskID: task.ID, WorkflowID: match.Route.ID,
+			Metadata: map[string]any{"event_id": ev.ID, "kind": ev.Kind, "pr_number": ev.PRNumber, "author": ev.Author}})
+
+		wf := d.resolveWorkflow(match)
+		wf.Env = overlayEnv(wf.Env, prEventEnv(ev))
+
+		instID, success, err := d.workflowEngine().RunInstanceForEvent(ctx, wf, task, prEventScope(ev))
+		if err != nil {
+			aplog.Error("event %s: workflow run failed: %v", ev.ID, err)
+			return
+		}
+		aplog.Info("event %s: workflow instance %s started (success=%v)", ev.ID, instID, success)
+	}()
+}
+
+// prEventEnv is the environment payload exported to every step of an
+// event-triggered workflow instance (overlaid on workflow-scope env, still
+// overridable per step).
+func prEventEnv(ev model.SourceEvent) map[string]string {
+	return map[string]string{
+		"APIARY_EVENT_KIND":   ev.Kind,
+		"APIARY_EVENT_AUTHOR": ev.Author,
+		"APIARY_EVENT_BODY":   ev.Body,
+		"APIARY_PR_NUMBER":    strconv.Itoa(ev.PRNumber),
+		"APIARY_PR_URL":       ev.PRURL,
+	}
+}
+
+// prEventScope is the ${{ event.* }} expression scope for an event-triggered
+// instance.
+func prEventScope(ev model.SourceEvent) map[string]string {
+	return map[string]string{
+		"kind":               ev.Kind,
+		"body":               ev.Body,
+		"author":             ev.Author,
+		"author_association": ev.AuthorAssociation,
+		"pr_number":          strconv.Itoa(ev.PRNumber),
+		"pr_url":             ev.PRURL,
+	}
+}
+
+// overlayEnv returns base with overlay applied on top, without mutating base
+// (the workflow config's Env map is shared with the live config).
+func overlayEnv(base, overlay map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		out[k] = v
+	}
+	return out
+}

--- a/src/internal/daemon/pr_events_test.go
+++ b/src/internal/daemon/pr_events_test.go
@@ -46,7 +46,7 @@ func newEventDispatcher(t *testing.T) (*Dispatcher, *db.Client, *envRecordingRun
 		Agents:  []config.AgentConfig{{ID: "eng", Model: "test/model"}},
 		Workflows: []config.WorkflowConfig{{
 			ID:      "fix-feedback",
-			Trigger: &config.TriggerConfig{On: config.TriggerOnPRComment, CommentContains: "@apiary", MaxDispatches: 2},
+			Trigger: &config.TriggerConfig{On: config.TriggerOnPRComment, CommentMatches: "(?i)@apiary", MaxDispatches: 2},
 			Steps:   []config.StepConfig{{ID: "run", Agent: "eng"}},
 		}},
 	}

--- a/src/internal/daemon/pr_events_test.go
+++ b/src/internal/daemon/pr_events_test.go
@@ -1,0 +1,188 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// envRecordingRunner records the env of every RunRequest it executes, so the
+// test can assert the event payload reached the agent step.
+type envRecordingRunner struct {
+	mu   sync.Mutex
+	envs []map[string]string
+}
+
+func (r *envRecordingRunner) ID() string                     { return "recording" }
+func (r *envRecordingRunner) Configure(map[string]any) error { return nil }
+func (r *envRecordingRunner) Run(_ context.Context, rr model.RunRequest) (model.RunResult, error) {
+	r.mu.Lock()
+	r.envs = append(r.envs, rr.Env)
+	r.mu.Unlock()
+	return model.RunResult{Success: true}, nil
+}
+
+func newEventDispatcher(t *testing.T) (*Dispatcher, *db.Client, *envRecordingRunner) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "events.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "github", Type: "github"}},
+		Agents:  []config.AgentConfig{{ID: "eng", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "fix-feedback",
+			Trigger: &config.TriggerConfig{On: config.TriggerOnPRComment, CommentContains: "@apiary", MaxDispatches: 2},
+			Steps:   []config.StepConfig{{ID: "run", Agent: "eng"}},
+		}},
+	}
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &envRecordingRunner{}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{},
+		runners:     map[string]runnerpkg.Runner{"agent-eng": runner},
+		agentRunner: map[string]string{"eng": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, dbc, runner
+}
+
+func testEvent(id string) model.SourceEvent {
+	return model.SourceEvent{
+		ID: id, SourceID: "github", Kind: model.EventPRComment,
+		PRNumber: 7, PRURL: "https://github.com/o/r/pull/7",
+		Author: "alice", AuthorAssociation: "COLLABORATOR",
+		Body: "@apiary fix the lint errors", SubmittedAt: time.Now(),
+	}
+}
+
+// waitForInstances polls until the workflow_instances count reaches want (the
+// dispatch runs on its own goroutine) or the deadline passes.
+func waitForInstances(t *testing.T, dbc *db.Client, want int) []db.WorkflowInstance {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		insts, err := dbc.ListWorkflowInstances(context.Background(), 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(insts) >= want || time.Now().After(deadline) {
+			if len(insts) != want {
+				t.Fatalf("expected %d workflow instance(s), got %d", want, len(insts))
+			}
+			return insts
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestRoutePREvent_ExactlyOnceAndEnvPayload drives one PR comment event through
+// routing twice (simulating the watermark overlap / a restart re-fetch) and
+// asserts: exactly one workflow instance dispatches, the agent step receives the
+// APIARY_EVENT_* / APIARY_PR_* payload, and a standalone per-PR task is bound.
+func TestRoutePREvent_ExactlyOnceAndEnvPayload(t *testing.T) {
+	ctx := context.Background()
+	d, dbc, runner := newEventDispatcher(t)
+
+	ev := testEvent("comment-1")
+	d.routePREvent(ctx, ev)
+	d.routePREvent(ctx, ev) // duplicate delivery must be a no-op
+
+	insts := waitForInstances(t, dbc, 1)
+	if insts[0].WorkflowID != "fix-feedback" {
+		t.Errorf("instance workflow = %q", insts[0].WorkflowID)
+	}
+
+	// The standalone per-PR task is bound via the synthetic pr-<n> item.
+	b, err := dbc.SourceBindings().GetBindingBySourceItem(ctx, "github", "pr-7")
+	if err != nil || b == nil {
+		t.Fatalf("expected a binding for pr-7, got %v (%v)", b, err)
+	}
+	if insts[0].TaskID != b.TaskID {
+		t.Errorf("instance task %q != bound task %q", insts[0].TaskID, b.TaskID)
+	}
+
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	if len(runner.envs) != 1 {
+		t.Fatalf("expected 1 agent run, got %d", len(runner.envs))
+	}
+	env := runner.envs[0]
+	for k, want := range map[string]string{
+		"APIARY_EVENT_KIND":   "pr_comment",
+		"APIARY_EVENT_AUTHOR": "alice",
+		"APIARY_EVENT_BODY":   "@apiary fix the lint errors",
+		"APIARY_PR_NUMBER":    "7",
+		"APIARY_PR_URL":       "https://github.com/o/r/pull/7",
+	} {
+		if env[k] != want {
+			t.Errorf("env[%s] = %q, want %q", k, env[k], want)
+		}
+	}
+}
+
+// TestRoutePREvent_MaxDispatchesBudget sends distinct events on the same PR past
+// the trigger's max_dispatches and asserts the budget caps dispatch.
+func TestRoutePREvent_MaxDispatchesBudget(t *testing.T) {
+	ctx := context.Background()
+	d, dbc, _ := newEventDispatcher(t)
+
+	d.routePREvent(ctx, testEvent("comment-1"))
+	waitForInstances(t, dbc, 1)
+	d.routePREvent(ctx, testEvent("comment-2"))
+	waitForInstances(t, dbc, 2)
+
+	// Budget is 2: the third event on the same PR must not dispatch.
+	d.routePREvent(ctx, testEvent("comment-3"))
+	time.Sleep(150 * time.Millisecond)
+	waitForInstances(t, dbc, 2)
+}
+
+// TestRoutePREvent_BindsRelatedTask pre-binds an issue task and asserts an event
+// whose RelatedItemID points at it dispatches on that task (lineage preserved),
+// with no standalone pr-<n> task created.
+func TestRoutePREvent_BindsRelatedTask(t *testing.T) {
+	ctx := context.Background()
+	d, dbc, _ := newEventDispatcher(t)
+
+	issueTask, persisted := d.bindItem(ctx, model.SourceItem{
+		ID: "42", SourceID: "github", Number: "#42", Title: "Fix login", State: "open",
+	})
+	if !persisted {
+		t.Fatal("issue task must persist")
+	}
+
+	ev := testEvent("comment-9")
+	ev.RelatedItemID = "42"
+	d.routePREvent(ctx, ev)
+
+	insts := waitForInstances(t, dbc, 1)
+	if insts[0].TaskID != issueTask.ID {
+		t.Errorf("instance task = %q, want the originating issue's task %q", insts[0].TaskID, issueTask.ID)
+	}
+	if b, _ := dbc.SourceBindings().GetBindingBySourceItem(ctx, "github", "pr-7"); b != nil {
+		t.Error("no standalone pr-7 task must be bound when the related task exists")
+	}
+}

--- a/src/internal/db/pr_event_store.go
+++ b/src/internal/db/pr_event_store.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// GetPREventWatermark returns the PR event watermark for a source, or the zero
+// time when the source has never polled events.
+func (c *Client) GetPREventWatermark(ctx context.Context, sourceID string) (time.Time, error) {
+	var wm time.Time
+	err := c.db.QueryRowContext(ctx,
+		`SELECT watermark FROM pr_event_watermarks WHERE source_id = ?`, sourceID).Scan(&wm)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	return wm, nil
+}
+
+// SetPREventWatermark upserts the PR event watermark for a source.
+func (c *Client) SetPREventWatermark(ctx context.Context, sourceID string, watermark time.Time) error {
+	_, err := c.db.ExecContext(ctx, `
+		INSERT INTO pr_event_watermarks (source_id, watermark) VALUES (?, ?)
+		ON CONFLICT(source_id) DO UPDATE SET watermark = excluded.watermark
+	`, sourceID, watermark)
+	return err
+}
+
+// ClaimPREventDispatch atomically claims the (source, event, workflow) dispatch:
+// it returns true when this call inserted the claim (the caller must dispatch)
+// and false when the claim already existed (already dispatched — skip). The
+// insert-or-ignore against the primary key is what makes an event dispatch a
+// given workflow exactly once, across poll overlaps and daemon restarts.
+func (c *Client) ClaimPREventDispatch(ctx context.Context, sourceID, eventID, workflowID string, prNumber int) (bool, error) {
+	res, err := c.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO pr_event_dispatches (source_id, event_id, workflow_id, pr_number)
+		VALUES (?, ?, ?, ?)
+	`, sourceID, eventID, workflowID, prNumber)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// CountPREventDispatches returns how many events have dispatched the workflow
+// for one pull request — the denominator of the trigger's max_dispatches
+// runaway-loop budget.
+func (c *Client) CountPREventDispatches(ctx context.Context, sourceID, workflowID string, prNumber int) (int, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM pr_event_dispatches
+		WHERE source_id = ? AND workflow_id = ? AND pr_number = ?
+	`, sourceID, workflowID, prNumber).Scan(&n)
+	return n, err
+}

--- a/src/internal/db/pr_event_store_test.go
+++ b/src/internal/db/pr_event_store_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPREventWatermarkRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	c, err := New(ctx, filepath.Join(t.TempDir(), "wm.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	wm, err := c.GetPREventWatermark(ctx, "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !wm.IsZero() {
+		t.Errorf("unset watermark must be zero, got %v", wm)
+	}
+
+	want := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	if err := c.SetPREventWatermark(ctx, "github", want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.GetPREventWatermark(ctx, "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(want) {
+		t.Errorf("watermark = %v, want %v", got, want)
+	}
+
+	// Upsert advances in place.
+	later := want.Add(time.Hour)
+	if err := c.SetPREventWatermark(ctx, "github", later); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := c.GetPREventWatermark(ctx, "github"); !got.Equal(later) {
+		t.Errorf("watermark after upsert = %v, want %v", got, later)
+	}
+}
+
+func TestClaimPREventDispatch_ExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	c, err := New(ctx, filepath.Join(t.TempDir(), "claims.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	claimed, err := c.ClaimPREventDispatch(ctx, "github", "comment-1", "wf-a", 7)
+	if err != nil || !claimed {
+		t.Fatalf("first claim = (%v, %v), want (true, nil)", claimed, err)
+	}
+	claimed, err = c.ClaimPREventDispatch(ctx, "github", "comment-1", "wf-a", 7)
+	if err != nil || claimed {
+		t.Fatalf("second claim = (%v, %v), want (false, nil)", claimed, err)
+	}
+	// Same event may claim a different workflow.
+	if claimed, _ := c.ClaimPREventDispatch(ctx, "github", "comment-1", "wf-b", 7); !claimed {
+		t.Error("a different workflow must claim the same event independently")
+	}
+	// Different event on the same PR claims fresh.
+	if claimed, _ := c.ClaimPREventDispatch(ctx, "github", "comment-2", "wf-a", 7); !claimed {
+		t.Error("a different event must claim independently")
+	}
+
+	// max_dispatches denominator counts per (source, workflow, PR).
+	if n, _ := c.CountPREventDispatches(ctx, "github", "wf-a", 7); n != 2 {
+		t.Errorf("wf-a dispatches on PR 7 = %d, want 2", n)
+	}
+	if n, _ := c.CountPREventDispatches(ctx, "github", "wf-b", 7); n != 1 {
+		t.Errorf("wf-b dispatches on PR 7 = %d, want 1", n)
+	}
+	if n, _ := c.CountPREventDispatches(ctx, "github", "wf-a", 99); n != 0 {
+		t.Errorf("dispatches on another PR = %d, want 0", n)
+	}
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -218,6 +218,31 @@ CREATE TABLE IF NOT EXISTS task_pull_requests (
   UNIQUE(task_id, source_id, pr_number)
 );
 
+-- PR event polling state (trigger.on: pr_*). One watermark per source: events
+-- submitted before it have already been fetched and evaluated. A source with no
+-- row has never polled events — the first poll baselines to "now" and dispatches
+-- nothing, so enabling event triggers on an old repo does not storm over its
+-- comment history.
+CREATE TABLE IF NOT EXISTS pr_event_watermarks (
+  source_id TEXT PRIMARY KEY,
+  watermark TIMESTAMP NOT NULL
+);
+
+-- Exactly-once dispatch claims for PR events. A row is inserted (INSERT OR
+-- IGNORE) when a workflow is dispatched for an event; the primary key makes the
+-- claim atomic, so an event re-fetched inside the watermark overlap — or after a
+-- daemon restart — can never dispatch the same workflow twice. pr_number backs
+-- the per-trigger max_dispatches budget.
+CREATE TABLE IF NOT EXISTS pr_event_dispatches (
+  source_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  workflow_id TEXT NOT NULL,
+  pr_number INTEGER NOT NULL DEFAULT 0,
+  dispatched_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (source_id, event_id, workflow_id)
+);
+CREATE INDEX IF NOT EXISTS idx_pr_event_dispatches_pr ON pr_event_dispatches(source_id, workflow_id, pr_number);
+
 -- Create indices
 CREATE INDEX IF NOT EXISTS idx_executions_task ON task_executions(task_id);
 CREATE INDEX IF NOT EXISTS idx_executions_retry ON task_executions(next_retry_at) WHERE status='failed';

--- a/src/internal/model/source_event.go
+++ b/src/internal/model/source_event.go
@@ -1,0 +1,42 @@
+package model
+
+import "time"
+
+// PR event kinds emitted by a source adapter's PollPREvents. They mirror the
+// trigger `on:` vocabulary in config (config.TriggerOn*).
+const (
+	EventPRComment              = "pr_comment"
+	EventPRReviewApproved       = "pr_review_approved"
+	EventPRReviewChangesRequest = "pr_review_changes_requested"
+)
+
+// SourceEvent is a normalized, source-agnostic pull-request event (a comment or
+// a review submission) returned by a source adapter's PollPREvents. Unlike a
+// SourceItem it is not a unit of work by itself: the dispatcher routes it
+// through event triggers (`trigger.on:`) and binds the resulting workflow
+// instance to the InternalTask of the originating issue when one exists.
+type SourceEvent struct {
+	// ID is a stable, source-native identifier for the event (e.g. a comment id
+	// or review id, prefixed by kind). It is the dedup key: an event ID must
+	// dispatch a given workflow at most once, across daemon restarts.
+	ID       string
+	SourceID string
+	// Kind is one of the EventPR* constants.
+	Kind     string
+	PRNumber int
+	PRURL    string
+	// Author is the source-native login of the user who wrote the comment or
+	// submitted the review.
+	Author string
+	// AuthorAssociation is the author's relationship to the repository as
+	// reported by the source (e.g. GitHub's OWNER / MEMBER / COLLABORATOR /
+	// CONTRIBUTOR / NONE). Used for default actor gating.
+	AuthorAssociation string
+	// Body is the comment body or the review's summary text.
+	Body        string
+	SubmittedAt time.Time
+	// RelatedItemID is the source-native id of the originating work item (e.g.
+	// the issue a PR closes), resolved best-effort by the adapter. Empty when the
+	// PR has no discoverable parent item.
+	RelatedItemID string
+}

--- a/src/internal/router/event.go
+++ b/src/internal/router/event.go
@@ -1,0 +1,121 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// HasEventRoutes reports whether any workflow trigger declares an event axis
+// (on: pr_*). The dispatcher uses it to skip PR event polling entirely when no
+// workflow could ever consume an event.
+func (r *Router) HasEventRoutes() bool {
+	for _, route := range r.routes {
+		if route.IsEventRoute() {
+			return true
+		}
+	}
+	return false
+}
+
+// RouteEvent evaluates every event trigger against a PR event in priority order
+// and returns all matches — mirroring RouteAll's fan-out and Exclusive
+// semantics, but over the event axis. task is the InternalTask bound to the
+// event's originating work item, or nil when the event has no related item; a
+// route whose Match declares item criteria (labels, types, states, priority,
+// title_regex) can only match when a related task exists to evaluate them
+// against.
+func (r *Router) RouteEvent(event model.SourceEvent, task *model.InternalTask) []Match {
+	var matches []Match
+	for _, route := range r.routes {
+		if !route.IsEventRoute() {
+			continue
+		}
+		ok, _ := r.evaluateEvent(route, event, task)
+		if !ok {
+			continue
+		}
+		m, ok := r.resolveMatch(route)
+		if !ok {
+			continue
+		}
+		matches = append(matches, m)
+		if route.Exclusive {
+			break
+		}
+	}
+	return matches
+}
+
+// evaluateEvent reports whether an event route matches the event (and its
+// related task, when bound) plus a human-readable reason for the decision.
+func (r *Router) evaluateEvent(route config.RouteConfig, event model.SourceEvent, task *model.InternalTask) (bool, string) {
+	if route.On != event.Kind {
+		return false, fmt.Sprintf("event kind %q != trigger on %q", event.Kind, route.On)
+	}
+	if route.Match.Source != "" && event.SourceID != route.Match.Source {
+		return false, fmt.Sprintf("source %q != required %q", event.SourceID, route.Match.Source)
+	}
+	if route.CommentContains != "" &&
+		!strings.Contains(strings.ToLower(event.Body), strings.ToLower(route.CommentContains)) {
+		return false, fmt.Sprintf("comment does not contain %q", route.CommentContains)
+	}
+	if ok, reason := authorAllowed(route, event); !ok {
+		return false, reason
+	}
+
+	// Item-shaped criteria apply to the related task. A route that declares them
+	// but has no related task to evaluate them against must not match — matching
+	// would silently ignore a declared condition.
+	if hasItemCriteria(route.Match) {
+		if task == nil {
+			return false, "trigger declares item match criteria but the event has no related work item"
+		}
+		// Source was already checked against the event; clear it so evaluateTarget
+		// does not re-require it on the task (whose Metadata.Source equals the
+		// event's source anyway for bound items).
+		m := route.Match
+		m.Source = ""
+		scoped := route
+		scoped.Match = m
+		if ok, reason := r.evaluateTarget(scoped, targetFromTask(*task)); !ok {
+			return false, reason
+		}
+	}
+
+	return true, fmt.Sprintf("matched event %s by %s", event.Kind, event.Author)
+}
+
+// authorAllowed applies the trigger's actor gate: an explicit authors list wins;
+// otherwise the author's repository association must be in authors_association,
+// defaulting to collaborators-only (config.DefaultEventAuthorAssociations).
+func authorAllowed(route config.RouteConfig, event model.SourceEvent) (bool, string) {
+	if len(route.Authors) > 0 {
+		for _, a := range route.Authors {
+			if strings.EqualFold(a, event.Author) {
+				return true, ""
+			}
+		}
+		return false, fmt.Sprintf("author %q not in trigger authors %v", event.Author, route.Authors)
+	}
+	allowed := route.AuthorsAssociation
+	if len(allowed) == 0 {
+		allowed = config.DefaultEventAuthorAssociations
+	}
+	for _, a := range allowed {
+		if strings.EqualFold(a, event.AuthorAssociation) {
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("author %q association %q not in %v", event.Author, event.AuthorAssociation, allowed)
+}
+
+// hasItemCriteria reports whether a match declares any criterion that must be
+// evaluated against a work item (everything except source, which is an event
+// attribute too).
+func hasItemCriteria(m config.RouteMatch) bool {
+	return len(m.Labels) > 0 || len(m.ExcludeLabels) > 0 || m.ExcludeLabelPrefix != "" ||
+		len(m.Types) > 0 || len(m.Priority) > 0 || len(m.States) > 0 || m.TitleRegex != ""
+}

--- a/src/internal/router/event.go
+++ b/src/internal/router/event.go
@@ -58,9 +58,10 @@ func (r *Router) evaluateEvent(route config.RouteConfig, event model.SourceEvent
 	if route.Match.Source != "" && event.SourceID != route.Match.Source {
 		return false, fmt.Sprintf("source %q != required %q", event.SourceID, route.Match.Source)
 	}
-	if route.CommentContains != "" &&
-		!strings.Contains(strings.ToLower(event.Body), strings.ToLower(route.CommentContains)) {
-		return false, fmt.Sprintf("comment does not contain %q", route.CommentContains)
+	if re, ok := r.commentRegexes[route.ID]; ok {
+		if !re.MatchString(event.Body) {
+			return false, fmt.Sprintf("comment does not match /%s/", route.CommentMatches)
+		}
 	}
 	if ok, reason := authorAllowed(route, event); !ok {
 		return false, reason

--- a/src/internal/router/event_test.go
+++ b/src/internal/router/event_test.go
@@ -1,0 +1,131 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func eventRouterConfig(triggers map[string]*config.TriggerConfig) *config.Config {
+	cfg := &config.Config{Version: "1"}
+	for id, tr := range triggers {
+		cfg.Workflows = append(cfg.Workflows, config.WorkflowConfig{
+			ID:      id,
+			Trigger: tr,
+			Steps:   []config.StepConfig{{ID: "s", Agent: "eng"}},
+		})
+	}
+	return cfg
+}
+
+func collabEvent(kind, body string) model.SourceEvent {
+	return model.SourceEvent{
+		ID: "comment-1", SourceID: "github", Kind: kind, PRNumber: 7,
+		Author: "alice", AuthorAssociation: "COLLABORATOR", Body: body,
+	}
+}
+
+func TestRouteEvent_KindAndCommentContains(t *testing.T) {
+	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"on-comment": {On: config.TriggerOnPRComment, CommentContains: "@apiary"},
+		"on-reject":  {On: config.TriggerOnPRReviewChangesRequest},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m := r.RouteEvent(collabEvent("pr_comment", "hey @Apiary fix lint"), nil); len(m) != 1 || m[0].Route.ID != "on-comment" {
+		t.Errorf("matching comment must route to on-comment, got %v", m)
+	}
+	if m := r.RouteEvent(collabEvent("pr_comment", "no mention"), nil); len(m) != 0 {
+		t.Errorf("comment without the marker must not match, got %v", m)
+	}
+	if m := r.RouteEvent(collabEvent("pr_review_changes_requested", "please fix"), nil); len(m) != 1 || m[0].Route.ID != "on-reject" {
+		t.Errorf("changes_requested must route to on-reject, got %v", m)
+	}
+}
+
+func TestRouteEvent_DefaultAuthorGateIsCollaboratorsOnly(t *testing.T) {
+	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"wf": {On: config.TriggerOnPRComment},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev := collabEvent("pr_comment", "go")
+	ev.AuthorAssociation = "NONE"
+	if m := r.RouteEvent(ev, nil); len(m) != 0 {
+		t.Errorf("a stranger (association NONE) must not trigger by default, got %v", m)
+	}
+	ev.AuthorAssociation = "OWNER"
+	if m := r.RouteEvent(ev, nil); len(m) != 1 {
+		t.Errorf("an OWNER must trigger by default, got %v", m)
+	}
+}
+
+func TestRouteEvent_AuthorsListOverridesAssociation(t *testing.T) {
+	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"wf": {On: config.TriggerOnPRComment, Authors: []string{"Bob"}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev := collabEvent("pr_comment", "go")
+	if m := r.RouteEvent(ev, nil); len(m) != 0 {
+		t.Errorf("author not in authors list must not trigger even as COLLABORATOR, got %v", m)
+	}
+	ev.Author, ev.AuthorAssociation = "bob", "NONE"
+	if m := r.RouteEvent(ev, nil); len(m) != 1 {
+		t.Errorf("listed author must trigger regardless of association, got %v", m)
+	}
+}
+
+func TestRouteEvent_ItemCriteriaRequireRelatedTask(t *testing.T) {
+	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"wf": {On: config.TriggerOnPRComment, Match: config.RouteMatch{Source: "github", Labels: []string{"apiary"}}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev := collabEvent("pr_comment", "go")
+
+	if m := r.RouteEvent(ev, nil); len(m) != 0 {
+		t.Errorf("label criteria with no related task must not match, got %v", m)
+	}
+	task := &model.InternalTask{ID: "T1", Metadata: model.TaskMetadata{Source: "github", Labels: []string{"apiary"}}}
+	if m := r.RouteEvent(ev, task); len(m) != 1 {
+		t.Errorf("label criteria must match against the related task, got %v", m)
+	}
+	task.Metadata.Labels = nil
+	if m := r.RouteEvent(ev, task); len(m) != 0 {
+		t.Errorf("related task without the label must not match, got %v", m)
+	}
+}
+
+func TestRouteEvent_ItemRoutesAndEventRoutesAreDisjoint(t *testing.T) {
+	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"items":  {Match: config.RouteMatch{Source: "github"}},
+		"events": {On: config.TriggerOnPRComment, Match: config.RouteMatch{Source: "github"}},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Item routing never selects an event route.
+	task := model.InternalTask{ID: "T1", Metadata: model.TaskMetadata{Source: "github"}}
+	for _, m := range r.RouteAll(task) {
+		if m.Route.ID == "events" {
+			t.Error("RouteAll must not match an event route")
+		}
+	}
+	// Event routing never selects an item route.
+	for _, m := range r.RouteEvent(collabEvent("pr_comment", "go"), &task) {
+		if m.Route.ID == "items" {
+			t.Error("RouteEvent must not match an item route")
+		}
+	}
+	if !r.HasEventRoutes() {
+		t.Error("HasEventRoutes must be true when an event trigger exists")
+	}
+}

--- a/src/internal/router/event_test.go
+++ b/src/internal/router/event_test.go
@@ -26,9 +26,9 @@ func collabEvent(kind, body string) model.SourceEvent {
 	}
 }
 
-func TestRouteEvent_KindAndCommentContains(t *testing.T) {
+func TestRouteEvent_KindAndCommentMatches(t *testing.T) {
 	r, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
-		"on-comment": {On: config.TriggerOnPRComment, CommentContains: "@apiary"},
+		"on-comment": {On: config.TriggerOnPRComment, CommentMatches: `(?i)@apiary\s+(fix|update)`},
 		"on-reject":  {On: config.TriggerOnPRReviewChangesRequest},
 	}))
 	if err != nil {
@@ -41,8 +41,21 @@ func TestRouteEvent_KindAndCommentContains(t *testing.T) {
 	if m := r.RouteEvent(collabEvent("pr_comment", "no mention"), nil); len(m) != 0 {
 		t.Errorf("comment without the marker must not match, got %v", m)
 	}
+	// The regex is a full Go regexp: mention without a captured verb must miss.
+	if m := r.RouteEvent(collabEvent("pr_comment", "@apiary hello"), nil); len(m) != 0 {
+		t.Errorf("comment not matching the pattern must not match, got %v", m)
+	}
 	if m := r.RouteEvent(collabEvent("pr_review_changes_requested", "please fix"), nil); len(m) != 1 || m[0].Route.ID != "on-reject" {
 		t.Errorf("changes_requested must route to on-reject, got %v", m)
+	}
+}
+
+func TestRouterNew_RejectsInvalidCommentMatches(t *testing.T) {
+	_, err := New(eventRouterConfig(map[string]*config.TriggerConfig{
+		"bad": {On: config.TriggerOnPRComment, CommentMatches: "@apiary["},
+	}))
+	if err == nil {
+		t.Fatal("router.New must reject an invalid comment_matches pattern")
 	}
 }
 

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -34,7 +34,9 @@ type RouteTrace struct {
 type Router struct {
 	routes  []config.RouteConfig // sorted by priority ascending
 	workers map[string]config.WorkerConfig
-	regexes map[string]*regexp.Regexp // route ID → compiled regex
+	regexes map[string]*regexp.Regexp // route ID → compiled title_regex
+	// commentRegexes holds each event route's compiled comment_matches pattern.
+	commentRegexes map[string]*regexp.Regexp
 }
 
 // New builds a Router from the given config.
@@ -62,7 +64,7 @@ func New(cfg *config.Config) (*Router, error) {
 			Exclusive:          wf.Trigger.Exclusive,
 			Once:               wf.Trigger.Once,
 			On:                 wf.Trigger.EventKind(),
-			CommentContains:    wf.Trigger.CommentContains,
+			CommentMatches:     wf.Trigger.CommentMatches,
 			Authors:            wf.Trigger.Authors,
 			AuthorsAssociation: wf.Trigger.AuthorsAssociation,
 			MaxDispatches:      wf.Trigger.MaxDispatches,
@@ -73,6 +75,7 @@ func New(cfg *config.Config) (*Router, error) {
 	})
 
 	regexes := make(map[string]*regexp.Regexp)
+	commentRegexes := make(map[string]*regexp.Regexp)
 	for _, r := range routes {
 		if r.Match.TitleRegex != "" {
 			re, err := regexp.Compile(r.Match.TitleRegex)
@@ -81,9 +84,16 @@ func New(cfg *config.Config) (*Router, error) {
 			}
 			regexes[r.ID] = re
 		}
+		if r.CommentMatches != "" {
+			re, err := regexp.Compile(r.CommentMatches)
+			if err != nil {
+				return nil, fmt.Errorf("route %s: invalid comment_matches %q: %w", r.ID, r.CommentMatches, err)
+			}
+			commentRegexes[r.ID] = re
+		}
 	}
 
-	return &Router{routes: routes, workers: workers, regexes: regexes}, nil
+	return &Router{routes: routes, workers: workers, regexes: regexes, commentRegexes: commentRegexes}, nil
 }
 
 // firstAgentStep returns a representative agent id for a workflow's trigger

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -55,12 +55,17 @@ func New(cfg *config.Config) (*Router, error) {
 			continue
 		}
 		routes = append(routes, config.RouteConfig{
-			ID:        wf.ID,
-			Priority:  wf.Trigger.Priority,
-			Match:     wf.Trigger.Match,
-			Agent:     firstAgentStep(wf),
-			Exclusive: wf.Trigger.Exclusive,
-			Once:      wf.Trigger.Once,
+			ID:                 wf.ID,
+			Priority:           wf.Trigger.Priority,
+			Match:              wf.Trigger.Match,
+			Agent:              firstAgentStep(wf),
+			Exclusive:          wf.Trigger.Exclusive,
+			Once:               wf.Trigger.Once,
+			On:                 wf.Trigger.EventKind(),
+			CommentContains:    wf.Trigger.CommentContains,
+			Authors:            wf.Trigger.Authors,
+			AuthorsAssociation: wf.Trigger.AuthorsAssociation,
+			MaxDispatches:      wf.Trigger.MaxDispatches,
 		})
 	}
 	sort.Slice(routes, func(i, j int) bool {
@@ -106,6 +111,9 @@ func firstAgentStep(wf config.WorkflowConfig) string {
 func (r *Router) Route(item model.SourceItem) (Match, bool) {
 	t := targetFromItem(item)
 	for _, route := range r.routes {
+		if route.IsEventRoute() {
+			continue
+		}
 		if ok, _ := r.evaluateTarget(route, t); ok {
 			if m, ok := r.resolveMatch(route); ok {
 				return m, true
@@ -128,6 +136,9 @@ func (r *Router) RouteAll(task model.InternalTask) []Match {
 	t := targetFromTask(task)
 	var matches []Match
 	for _, route := range r.routes {
+		if route.IsEventRoute() {
+			continue
+		}
 		ok, _ := r.evaluateTarget(route, t)
 		if !ok {
 			continue
@@ -150,6 +161,9 @@ func (r *Router) ExplainTask(task model.InternalTask) []RouteTrace {
 	t := targetFromTask(task)
 	traces := make([]RouteTrace, 0, len(r.routes))
 	for _, route := range r.routes {
+		if route.IsEventRoute() {
+			continue
+		}
 		matched, reason := r.evaluateTarget(route, t)
 		selected := false
 		if matched {
@@ -326,6 +340,9 @@ func (r *Router) Explain(cell model.SourceItem) (Match, bool, []RouteTrace) {
 	found := false
 
 	for _, route := range r.routes {
+		if route.IsEventRoute() {
+			continue
+		}
 		t := RouteTrace{
 			RouteID:  route.ID,
 			Priority: route.Priority,

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
@@ -28,6 +29,7 @@ var (
 	_ source.CIStatusPoller  = (*Adapter)(nil)
 	_ source.SubIssueCreator = (*Adapter)(nil)
 	_ source.BlockerLister   = (*Adapter)(nil)
+	_ source.PREventPoller   = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -39,6 +41,11 @@ type Adapter struct {
 
 	filterStates []string
 	filterLabels []string
+
+	// self is the login of the adapter's own token identity, resolved lazily by
+	// selfLogin for PR event author exclusion.
+	selfOnce sync.Once
+	self     string
 }
 
 func (a *Adapter) ID() string { return a.id }

--- a/src/internal/source/github/client.go
+++ b/src/internal/source/github/client.go
@@ -170,6 +170,35 @@ func (c *client) getAllIssues(ctx context.Context, path string, params url.Value
 	return all, nil
 }
 
+// decodePages fetches every page of a list endpoint (per_page=100) and decodes
+// the concatenation. It stops when a page comes back short — the standard
+// heuristic that avoids threading Link headers through the client.
+func decodePages[T any](ctx context.Context, c *client, path string, params url.Values) ([]T, error) {
+	const perPage = 100
+	var all []T
+	for page := 1; ; page++ {
+		p := url.Values{}
+		for k, v := range params {
+			p[k] = v
+		}
+		p.Set("per_page", strconv.Itoa(perPage))
+		p.Set("page", strconv.Itoa(page))
+
+		body, err := c.get(ctx, path+"?"+p.Encode())
+		if err != nil {
+			return nil, err
+		}
+		var items []T
+		if err := json.Unmarshal(body, &items); err != nil {
+			return nil, fmt.Errorf("github: decoding %s page %d: %w", path, page, err)
+		}
+		all = append(all, items...)
+		if len(items) < perPage {
+			return all, nil
+		}
+	}
+}
+
 var linkNextRe = regexp.MustCompile(`<[^>]+>;\s*rel="([^"]+)"`)
 
 func hasNextPage(link string) bool {

--- a/src/internal/source/github/events.go
+++ b/src/internal/source/github/events.go
@@ -1,0 +1,263 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// prPathRe extracts a PR number from a comment html_url: an issue comment on a
+// pull request deep-links to .../pull/<n>#issuecomment-<id>, while a comment on
+// a plain issue deep-links to .../issues/<n>#... — the path segment is how the
+// two are told apart without an extra API call.
+var prPathRe = regexp.MustCompile(`/pull/(\d+)(?:[#/]|$)`)
+
+// closingRefRe matches a closing-keyword issue reference in a PR body
+// ("Closes #42", "fixes owner/repo#42"), the strongest signal of the PR's
+// originating work item.
+var closingRefRe = regexp.MustCompile(`(?i)(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)[\s:]+(?:[\w.-]+/[\w.-]+)?#(\d+)`)
+
+// issueRefRe matches any plain issue reference ("#42") as the fallback signal.
+var issueRefRe = regexp.MustCompile(`#(\d+)`)
+
+// PollPREvents returns the pull-request events (conversation comments, inline
+// review comments, and review submissions) created since the watermark, oldest
+// first per category. Implements source.PREventPoller.
+//
+// Loop prevention: events authored by the adapter's own token identity (the
+// account the daemon comments as) and by Bot-typed users are dropped here, so an
+// agent's own PR comments can never re-trigger a workflow.
+//
+// RelatedItemID is resolved best-effort by scanning the PR body for an issue
+// reference (closing keywords first), reusing one PR fetch per distinct PR and
+// poll. A PR with no discoverable parent issue yields events with an empty
+// RelatedItemID — the dispatcher then binds a standalone task for the PR.
+func (a *Adapter) PollPREvents(ctx context.Context, since time.Time) ([]model.SourceEvent, error) {
+	self := a.selfLogin(ctx)
+	sinceParam := since.UTC().Format(time.RFC3339)
+	var events []model.SourceEvent
+
+	// One PR fetch per distinct number per poll: PRURL + related-issue lookup.
+	prCache := map[int]*pullRequest{}
+	prFor := func(n int) *pullRequest {
+		if pr, ok := prCache[n]; ok {
+			return pr
+		}
+		body, err := a.client.get(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, n))
+		if err != nil {
+			aplog.Debug("github: events: fetch PR #%d: %v", n, err)
+			prCache[n] = nil
+			return nil
+		}
+		var pr pullRequest
+		if err := json.Unmarshal(body, &pr); err != nil {
+			prCache[n] = nil
+			return nil
+		}
+		prCache[n] = &pr
+		return &pr
+	}
+	describe := func(n int) (prURL, relatedItemID string) {
+		prURL = fmt.Sprintf("%s/%s/%s/pull/%d", a.webBaseURL, a.owner, a.repo, n)
+		if pr := prFor(n); pr != nil {
+			if pr.HTMLURL != "" {
+				prURL = pr.HTMLURL
+			}
+			relatedItemID = findRelatedIssue(pr.Body, n)
+		}
+		return prURL, relatedItemID
+	}
+
+	// 1. PR conversation comments — the /issues/comments endpoint returns
+	// comments on issues AND pull requests; the html_url path picks out the PRs.
+	comments, err := decodePages[issueComment](ctx, a.client,
+		fmt.Sprintf("/repos/%s/%s/issues/comments", a.owner, a.repo),
+		url.Values{"sort": {"updated"}, "direction": {"asc"}, "since": {sinceParam}})
+	if err != nil {
+		return nil, fmt.Errorf("github: polling issue comments: %w", err)
+	}
+	for _, cm := range comments {
+		n := prNumberFromURL(cm.HTMLURL)
+		if n == 0 || a.skipAuthor(cm.User, self) {
+			continue
+		}
+		// `since` filters on updated_at, so an edited old comment reappears here;
+		// gating on created_at keeps edits from firing as new events.
+		created, _ := time.Parse(time.RFC3339, cm.CreatedAt)
+		if !created.After(since) {
+			continue
+		}
+		prURL, itemID := describe(n)
+		events = append(events, model.SourceEvent{
+			ID:                fmt.Sprintf("comment-%d", cm.ID),
+			SourceID:          a.ID(),
+			Kind:              model.EventPRComment,
+			PRNumber:          n,
+			PRURL:             prURL,
+			Author:            cm.User.Login,
+			AuthorAssociation: cm.AuthorAssociation,
+			Body:              cm.Body,
+			SubmittedAt:       created,
+			RelatedItemID:     itemID,
+		})
+	}
+
+	// 2. Inline review comments (comments on a diff line).
+	rcomments, err := decodePages[reviewComment](ctx, a.client,
+		fmt.Sprintf("/repos/%s/%s/pulls/comments", a.owner, a.repo),
+		url.Values{"sort": {"updated"}, "direction": {"asc"}, "since": {sinceParam}})
+	if err != nil {
+		return nil, fmt.Errorf("github: polling review comments: %w", err)
+	}
+	for _, rc := range rcomments {
+		n := prNumberFromAPIURL(rc.PullRequestURL)
+		if n == 0 || a.skipAuthor(rc.User, self) {
+			continue
+		}
+		created, _ := time.Parse(time.RFC3339, rc.CreatedAt)
+		if !created.After(since) {
+			continue
+		}
+		prURL, itemID := describe(n)
+		events = append(events, model.SourceEvent{
+			ID:                fmt.Sprintf("review-comment-%d", rc.ID),
+			SourceID:          a.ID(),
+			Kind:              model.EventPRComment,
+			PRNumber:          n,
+			PRURL:             prURL,
+			Author:            rc.User.Login,
+			AuthorAssociation: rc.AuthorAssociation,
+			Body:              rc.Body,
+			SubmittedAt:       created,
+			RelatedItemID:     itemID,
+		})
+	}
+
+	// 3. Review submissions on recently-updated PRs. Reviews have no since-able
+	// list endpoint, so scope the walk to PRs updated inside the window (the
+	// updated_desc listing stops at the first stale PR).
+	prs, err := decodePages[pullRequest](ctx, a.client,
+		fmt.Sprintf("/repos/%s/%s/pulls", a.owner, a.repo),
+		url.Values{"state": {"all"}, "sort": {"updated"}, "direction": {"desc"}})
+	if err != nil {
+		return nil, fmt.Errorf("github: polling pull requests: %w", err)
+	}
+	for _, pr := range prs {
+		updated, _ := time.Parse(time.RFC3339, pr.UpdatedAt)
+		if !updated.After(since) {
+			break // updated_desc order: everything after this is older
+		}
+		pr := pr
+		prCache[pr.Number] = &pr
+		reviews, err := decodePages[review](ctx, a.client,
+			fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", a.owner, a.repo, pr.Number), nil)
+		if err != nil {
+			aplog.Debug("github: events: list reviews of PR #%d: %v", pr.Number, err)
+			continue
+		}
+		for _, rv := range reviews {
+			var kind string
+			switch rv.State {
+			case "APPROVED":
+				kind = model.EventPRReviewApproved
+			case "CHANGES_REQUESTED":
+				kind = model.EventPRReviewChangesRequest
+			default:
+				continue
+			}
+			submitted, _ := time.Parse(time.RFC3339, rv.SubmittedAt)
+			if !submitted.After(since) || a.skipAuthor(rv.User, self) {
+				continue
+			}
+			prURL, itemID := describe(pr.Number)
+			events = append(events, model.SourceEvent{
+				ID:                fmt.Sprintf("review-%d", rv.ID),
+				SourceID:          a.ID(),
+				Kind:              kind,
+				PRNumber:          pr.Number,
+				PRURL:             prURL,
+				Author:            rv.User.Login,
+				AuthorAssociation: rv.AuthorAssociation,
+				Body:              rv.Body,
+				SubmittedAt:       submitted,
+				RelatedItemID:     itemID,
+			})
+		}
+	}
+
+	return events, nil
+}
+
+// selfLogin returns the login of the adapter's own token identity, fetched once
+// per process (GET /user) and cached. Empty on failure (e.g. an installation
+// token with no /user) — bot-type filtering still applies.
+func (a *Adapter) selfLogin(ctx context.Context) string {
+	a.selfOnce.Do(func() {
+		body, err := a.client.get(ctx, "/user")
+		if err != nil {
+			aplog.Debug("github: events: resolve own login: %v", err)
+			return
+		}
+		var u user
+		if err := json.Unmarshal(body, &u); err != nil {
+			return
+		}
+		a.self = u.Login
+		aplog.Debug("github: events: own login is %q (excluded from PR events)", u.Login)
+	})
+	return a.self
+}
+
+// skipAuthor reports whether an event author must be dropped: the daemon's own
+// token identity, or any bot account.
+func (a *Adapter) skipAuthor(u user, self string) bool {
+	if u.Type == "Bot" || strings.HasSuffix(strings.ToLower(u.Login), "[bot]") {
+		return true
+	}
+	return self != "" && strings.EqualFold(u.Login, self)
+}
+
+// prNumberFromURL extracts the PR number from a browser html_url containing a
+// /pull/<n> segment, or 0 when the URL points at a plain issue.
+func prNumberFromURL(htmlURL string) int {
+	m := prPathRe.FindStringSubmatch(htmlURL)
+	if len(m) != 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// prNumberFromAPIURL extracts the PR number from an API pull_request_url
+// (.../pulls/<n>), or 0 when absent.
+func prNumberFromAPIURL(apiURL string) int {
+	i := strings.LastIndex(apiURL, "/")
+	if i < 0 {
+		return 0
+	}
+	n, _ := strconv.Atoi(apiURL[i+1:])
+	return n
+}
+
+// findRelatedIssue scans a PR body for the issue it originates from: the first
+// closing-keyword reference ("Closes #42") wins, else the first plain "#N" that
+// is not the PR itself. Returns "" when no reference is found.
+func findRelatedIssue(body string, prNumber int) string {
+	if m := closingRefRe.FindStringSubmatch(body); len(m) == 2 {
+		return m[1]
+	}
+	for _, m := range issueRefRe.FindAllStringSubmatch(body, -1) {
+		if n, _ := strconv.Atoi(m[1]); n != 0 && n != prNumber {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/src/internal/source/github/events_test.go
+++ b/src/internal/source/github/events_test.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// newEventTestAdapter builds an adapter against a fake GitHub API. The handler
+// map is keyed by path (query stripped); unmapped paths return an empty JSON
+// array so pagination loops terminate.
+func newEventTestAdapter(t *testing.T, handlers map[string]any) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if payload, ok := handlers[r.URL.Path]; ok {
+			_ = json.NewEncoder(w).Encode(payload)
+			return
+		}
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	a := &Adapter{}
+	a.SetID("github")
+	if err := a.Connect(context.Background(), map[string]any{"repo": "o/r", "base_url": srv.URL}); err != nil {
+		t.Fatal(err)
+	}
+	return a
+}
+
+func TestPollPREvents_CommentsReviewsAndExclusions(t *testing.T) {
+	since := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	newer := since.Add(time.Hour).Format(time.RFC3339)
+	older := since.Add(-time.Hour).Format(time.RFC3339)
+
+	handlers := map[string]any{
+		"/user": map[string]any{"login": "apiary-daemon"},
+		"/repos/o/r/issues/comments": []map[string]any{
+			// PR conversation comment by a collaborator — the event we want.
+			{"id": 1, "body": "@apiary fix lint", "created_at": newer,
+				"html_url":           "https://github.com/o/r/pull/7#issuecomment-1",
+				"author_association": "COLLABORATOR", "user": map[string]any{"login": "alice", "type": "User"}},
+			// Comment on a plain issue — not a PR event.
+			{"id": 2, "body": "n/a", "created_at": newer,
+				"html_url":           "https://github.com/o/r/issues/9#issuecomment-2",
+				"author_association": "OWNER", "user": map[string]any{"login": "alice", "type": "User"}},
+			// The daemon's own comment — excluded (loop prevention).
+			{"id": 3, "body": "✓ Apiary run complete", "created_at": newer,
+				"html_url":           "https://github.com/o/r/pull/7#issuecomment-3",
+				"author_association": "CONTRIBUTOR", "user": map[string]any{"login": "Apiary-Daemon", "type": "User"}},
+			// A bot comment — excluded.
+			{"id": 4, "body": "coverage report", "created_at": newer,
+				"html_url":           "https://github.com/o/r/pull/7#issuecomment-4",
+				"author_association": "NONE", "user": map[string]any{"login": "codecov[bot]", "type": "Bot"}},
+			// An edited old comment: updated now (so returned by since=...) but
+			// created before the watermark — must not re-fire.
+			{"id": 5, "body": "old edited", "created_at": older,
+				"html_url":           "https://github.com/o/r/pull/7#issuecomment-5",
+				"author_association": "MEMBER", "user": map[string]any{"login": "bob", "type": "User"}},
+		},
+		"/repos/o/r/pulls/comments": []map[string]any{
+			{"id": 10, "body": "inline nit", "created_at": newer,
+				"html_url":           "https://github.com/o/r/pull/7#discussion_r10",
+				"pull_request_url":   "https://api.github.com/repos/o/r/pulls/7",
+				"author_association": "MEMBER", "user": map[string]any{"login": "bob", "type": "User"}},
+		},
+		"/repos/o/r/pulls": []map[string]any{
+			{"number": 7, "state": "open", "updated_at": newer, "body": "Fixes #42",
+				"html_url": "https://github.com/o/r/pull/7"},
+			{"number": 3, "state": "open", "updated_at": older, "body": "", "html_url": ""},
+		},
+		"/repos/o/r/pulls/7": map[string]any{
+			"number": 7, "state": "open", "body": "Fixes #42", "html_url": "https://github.com/o/r/pull/7"},
+		"/repos/o/r/pulls/7/reviews": []map[string]any{
+			{"id": 100, "state": "CHANGES_REQUESTED", "body": "needs tests", "submitted_at": newer,
+				"author_association": "OWNER", "user": map[string]any{"login": "carol", "type": "User"}},
+			{"id": 101, "state": "COMMENTED", "body": "fyi", "submitted_at": newer,
+				"author_association": "OWNER", "user": map[string]any{"login": "carol", "type": "User"}},
+			{"id": 102, "state": "APPROVED", "body": "", "submitted_at": older,
+				"author_association": "OWNER", "user": map[string]any{"login": "carol", "type": "User"}},
+		},
+	}
+
+	a := newEventTestAdapter(t, handlers)
+	events, err := a.PollPREvents(context.Background(), since)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byID := map[string]model.SourceEvent{}
+	for _, ev := range events {
+		byID[ev.ID] = ev
+	}
+	if len(events) != 3 {
+		ids := make([]string, 0, len(events))
+		for _, ev := range events {
+			ids = append(ids, ev.ID)
+		}
+		t.Fatalf("expected 3 events (comment-1, review-comment-10, review-100), got %d: %s", len(events), strings.Join(ids, ", "))
+	}
+
+	cm := byID["comment-1"]
+	if cm.Kind != model.EventPRComment || cm.PRNumber != 7 || cm.Author != "alice" || cm.AuthorAssociation != "COLLABORATOR" {
+		t.Errorf("comment-1 = %+v", cm)
+	}
+	if cm.RelatedItemID != "42" {
+		t.Errorf("comment-1 related item = %q, want 42 (from \"Fixes #42\")", cm.RelatedItemID)
+	}
+	if cm.PRURL != "https://github.com/o/r/pull/7" {
+		t.Errorf("comment-1 pr url = %q", cm.PRURL)
+	}
+
+	if rc := byID["review-comment-10"]; rc.Kind != model.EventPRComment || rc.PRNumber != 7 || rc.Author != "bob" {
+		t.Errorf("review-comment-10 = %+v", rc)
+	}
+	if rv := byID["review-100"]; rv.Kind != model.EventPRReviewChangesRequest || rv.Author != "carol" || rv.Body != "needs tests" {
+		t.Errorf("review-100 = %+v", rv)
+	}
+}
+
+func TestFindRelatedIssue(t *testing.T) {
+	cases := []struct {
+		body string
+		pr   int
+		want string
+	}{
+		{"Closes #42", 7, "42"},
+		{"fixes o/r#12 and mentions #99", 7, "12"},
+		{"Resolved: #8", 7, "8"},
+		{"see #7 and #21", 7, "21"}, // self-reference skipped, fallback ref wins
+		{"no refs here", 7, ""},
+	}
+	for _, c := range cases {
+		if got := findRelatedIssue(c.body, c.pr); got != c.want {
+			t.Errorf("findRelatedIssue(%q) = %q, want %q", c.body, got, c.want)
+		}
+	}
+}

--- a/src/internal/source/github/types.go
+++ b/src/internal/source/github/types.go
@@ -18,6 +18,9 @@ type issue struct {
 
 type user struct {
 	Login string `json:"login"`
+	// Type distinguishes human accounts ("User") from "Bot" (and
+	// "Organization"). PR event polling drops Bot-authored events.
+	Type string `json:"type"`
 }
 
 type label struct {
@@ -75,11 +78,47 @@ type pullRequest struct {
 	Number         int    `json:"number"`
 	State          string `json:"state"`
 	HTMLURL        string `json:"html_url"`
+	Body           string `json:"body"`
+	UpdatedAt      string `json:"updated_at"`
 	Mergeable      *bool  `json:"mergeable"`
 	MergeableState string `json:"mergeable_state"`
 	Head           struct {
 		SHA string `json:"sha"`
 	} `json:"head"`
+}
+
+// issueComment is a repo-level issue comment (GET /repos/{o}/{r}/issues/comments),
+// carrying the author and URL fields PR event polling needs on top of the basic
+// comment shape. Comments on pull requests appear here too — their html_url path
+// contains /pull/ instead of /issues/.
+type issueComment struct {
+	ID                int64  `json:"id"`
+	Body              string `json:"body"`
+	CreatedAt         string `json:"created_at"`
+	HTMLURL           string `json:"html_url"`
+	AuthorAssociation string `json:"author_association"`
+	User              user   `json:"user"`
+}
+
+// reviewComment is an inline PR review comment (GET /repos/{o}/{r}/pulls/comments).
+type reviewComment struct {
+	ID                int64  `json:"id"`
+	Body              string `json:"body"`
+	CreatedAt         string `json:"created_at"`
+	HTMLURL           string `json:"html_url"`
+	PullRequestURL    string `json:"pull_request_url"`
+	AuthorAssociation string `json:"author_association"`
+	User              user   `json:"user"`
+}
+
+// review is one PR review (GET /repos/{o}/{r}/pulls/{n}/reviews).
+type review struct {
+	ID                int64  `json:"id"`
+	Body              string `json:"body"`
+	State             string `json:"state"` // APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED | PENDING
+	SubmittedAt       string `json:"submitted_at"`
+	AuthorAssociation string `json:"author_association"`
+	User              user   `json:"user"`
 }
 
 // commitStatus is the combined legacy status of a commit. TotalCount is 0 when no

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -125,6 +125,20 @@ type BlockerLister interface {
 	ListBlockers(ctx context.Context, cellID, linkType string) ([]BlockerRef, error)
 }
 
+// PREventPoller is an optional interface a source may implement to enumerate
+// pull-request events (comments and review submissions) since a watermark. The
+// dispatcher polls it alongside Poll and routes the events through workflow
+// triggers with an `on:` event kind (pr_comment, pr_review_approved,
+// pr_review_changes_requested). Sources that do not implement it cannot host
+// event triggers (rejected at config validation).
+//
+// Adapters must exclude events authored by their own token identity (and
+// bot-typed users), so an agent commenting through the daemon's account can
+// never re-trigger a workflow — the first line of loop prevention.
+type PREventPoller interface {
+	PollPREvents(ctx context.Context, since time.Time) ([]model.SourceEvent, error)
+}
+
 // SubIssueCreator is an optional interface a source may implement to create a
 // child work item linked to a parent (a sub-issue). The workflow engine uses it
 // to materialize a spawned InternalTask as a source sub-issue under the spawning

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -43,6 +43,10 @@ type dagRun struct {
 	cell     model.SourceItem      // execution view derived from task + primary binding
 	depth    int                   // nesting depth (0 = top-level; >0 = sub-workflow child)
 	seed     []MemoryStep          // inherited memory (sub-workflow snapshot from the parent)
+	// event is the PR event payload for an event-triggered instance, exposed to
+	// condition expressions as event.*. Nil for item-triggered (and rehydrated)
+	// instances.
+	event map[string]string
 
 	byID  map[string]config.StepConfig
 	order []string // step ids in declaration order (deterministic scheduling)
@@ -157,7 +161,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			// (routed through resultCh so on_fail applies) — silently treating it
 			// as false would skip the branch with no error signal (#180).
 			if step.Condition != "" {
-				evalCtx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
+				evalCtx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates, Event: r.event}
 				condOK, condErr := e.evalExpr(step.Condition, evalCtx)
 				if condErr != nil {
 					aplog.Error("workflow %s: step %q condition eval error %q: %v (failing step)", r.wf.ID, id, step.Condition, condErr)
@@ -360,7 +364,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 					}
 				}
 			}
-			evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates}
+			evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates, Event: r.event}
 			rejected, fwErr := e.evalExpr(step.FailWhen, evalCtx)
 			switch {
 			case fwErr != nil:
@@ -685,7 +689,7 @@ func (r *dagRun) markCondSkipped(id string) {
 // returns an error before any state is mutated — the caller fails the split
 // step rather than silently routing as if the branch didn't match (#180).
 func (e *Engine) runSplitStep(r *dagRun, step config.StepConfig) error {
-	ctx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates}
+	ctx := EvalContext{Cell: r.cell, Memory: r.memoryValues(), Steps: r.stepStates, Event: r.event}
 
 	chosen := map[string]bool{}
 	for _, b := range step.Branches {

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -349,6 +349,16 @@ func (e *Engine) NewInstanceID() string { return e.newID("wf") }
 // recorded and reflected in the final instance state and the success flag, not
 // returned.
 func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task model.InternalTask) (instanceID string, success bool, err error) {
+	return e.RunInstanceForEvent(ctx, wf, task, nil)
+}
+
+// RunInstanceForEvent is RunInstance with a PR event payload attached: the
+// event map (kind, body, author, author_association, pr_number, pr_url) is
+// exposed to the instance's condition expressions as ${{ event.* }}. A nil
+// event is the plain item-triggered path. The event scope lives in memory only:
+// an instance that parks and is rehydrated after a daemon restart resolves
+// event.* as missing.
+func (e *Engine) RunInstanceForEvent(ctx context.Context, wf config.WorkflowConfig, task model.InternalTask, event map[string]string) (instanceID string, success bool, err error) {
 	bindings := e.bindingsFor(ctx, task.ID)
 	cell := sourceItemView(task, bindings)
 
@@ -375,6 +385,7 @@ func (e *Engine) RunInstance(ctx context.Context, wf config.WorkflowConfig, task
 	}
 
 	r := e.initDAG(instID, wf, task, bindings, nil, 0)
+	r.event = event
 	outcome := e.driveDAG(ctx, r)
 	return instID, e.settle(ctx, r, outcome), nil
 }

--- a/src/internal/workflow/expr.go
+++ b/src/internal/workflow/expr.go
@@ -14,6 +14,10 @@ type EvalContext struct {
 	Cell   model.SourceItem
 	Memory map[string]string    // workflow-memory Step Data keys → rendered values
 	Steps  map[string]StepState // step id → terminal state info
+	// Event carries the PR event payload for an event-triggered instance
+	// (kind, body, author, author_association, pr_number, pr_url). Nil for
+	// item-triggered instances — event.* accessors then resolve as missing ("").
+	Event map[string]string
 }
 
 // StepState exposes a completed step's outcome to expressions.
@@ -446,6 +450,20 @@ func resolveAccessor(path []string, ctx EvalContext) (resolvedValue, error) {
 		default:
 			return resolvedValue{}, fmt.Errorf("unknown cell field %q", path[1])
 		}
+	case "event":
+		if len(path) != 2 {
+			return resolvedValue{}, fmt.Errorf("invalid event accessor %q", strings.Join(path, "."))
+		}
+		switch path[1] {
+		case "kind", "body", "author", "author_association", "pr_number", "pr_url":
+			v, ok := ctx.Event[path[1]]
+			if !ok {
+				return resolvedValue{kind: kMissing}, nil
+			}
+			return resolvedValue{kind: kString, s: v}, nil
+		default:
+			return resolvedValue{}, fmt.Errorf("unknown event field %q", path[1])
+		}
 	case "memory":
 		if len(path) != 2 {
 			return resolvedValue{}, fmt.Errorf("invalid memory accessor %q", strings.Join(path, "."))
@@ -474,6 +492,6 @@ func resolveAccessor(path []string, ctx EvalContext) (resolvedValue, error) {
 			return resolvedValue{}, fmt.Errorf("unknown step field %q", path[2])
 		}
 	default:
-		return resolvedValue{}, fmt.Errorf("unknown accessor root %q (want cell, memory, or steps)", path[0])
+		return resolvedValue{}, fmt.Errorf("unknown accessor root %q (want cell, memory, steps, or event)", path[0])
 	}
 }

--- a/src/internal/workflow/expr_event_test.go
+++ b/src/internal/workflow/expr_event_test.go
@@ -1,0 +1,64 @@
+package workflow
+
+import "testing"
+
+func TestExprEventScope(t *testing.T) {
+	ctx := EvalContext{Event: map[string]string{
+		"kind":               "pr_comment",
+		"body":               "@apiary fix the lint errors",
+		"author":             "alice",
+		"author_association": "MEMBER",
+		"pr_number":          "42",
+		"pr_url":             "https://github.com/o/r/pull/42",
+	}}
+
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`event.kind == "pr_comment"`, true},
+		{`event.kind == "pr_review_approved"`, false},
+		{`event.body contains "@apiary"`, true},
+		{`event.author == "alice" and event.author_association == "MEMBER"`, true},
+		{`event.pr_number == "42"`, true},
+	}
+	for _, c := range cases {
+		expr, err := ParseExpr(c.expr)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.expr, err)
+		}
+		got, err := expr.Eval(ctx)
+		if err != nil {
+			t.Fatalf("eval %q: %v", c.expr, err)
+		}
+		if got != c.want {
+			t.Errorf("%q = %v, want %v", c.expr, got, c.want)
+		}
+	}
+}
+
+// A nil event scope (item-triggered instance) resolves event fields as missing
+// ("") rather than erroring, so shared workflows stay usable on both axes.
+func TestExprEventScope_MissingOnItemInstances(t *testing.T) {
+	expr, err := ParseExpr(`event.kind == ""`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := expr.Eval(EvalContext{})
+	if err != nil {
+		t.Fatalf("eval with nil event: %v", err)
+	}
+	if !got {
+		t.Error("event.kind must resolve as missing (\"\") on item-triggered instances")
+	}
+}
+
+func TestExprEventScope_UnknownFieldErrors(t *testing.T) {
+	expr, err := ParseExpr(`event.nope == "x"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := expr.Eval(EvalContext{Event: map[string]string{}}); err == nil {
+		t.Error("unknown event field must error, not silently evaluate")
+	}
+}


### PR DESCRIPTION
Closes #356.

Implements the `trigger.on` event axis so workflows can be dispatched by pull-request activity, staying entirely in the poll model.

## What's new

### Config (`trigger.on`)
```yaml
workflows:
  - id: react-to-pr-comment
    trigger:
      on: pr_comment                 # item (default) | pr_comment | pr_review_approved | pr_review_changes_requested
      comment_matches: "(?i)@apiary" # pr_comment only, Go regexp (validated at load)
      max_dispatches: 5              # per-PR runaway-loop budget (0 = unlimited)
      # authors: [...]               # explicit login allow-list
      # authors_association: [...]   # default: [OWNER, MEMBER, COLLABORATOR]
```

- **Actor gating is on by default** — collaborators-only (`OWNER/MEMBER/COLLABORATOR`) unless `authors`/`authors_association` is declared, so drive-by comments from strangers can never spawn agents.
- `match.source` applies to the event; item-shaped criteria (`labels`, `states`, …) apply to the originating issue's task and only match when it exists.
- `once` is rejected on event triggers (each event already dispatches exactly once).

### Source capability (`source.PREventPoller` + `model.SourceEvent`)
GitHub implementation polls, per cycle:
- `GET /issues/comments?sort=updated&since=…` (PR conversation comments, picked out by `html_url`)
- `GET /pulls/comments?sort=updated&since=…` (inline review comments)
- `GET /pulls/{n}/reviews` for PRs updated inside the window (APPROVED / CHANGES_REQUESTED only)

Loop prevention at the adapter: events by the daemon's own token identity (`GET /user`, cached) and by bot accounts are dropped. Edited comments don't re-fire (gated on `created_at`). `RelatedItemID` resolves from the PR body's closing reference (`Closes #42`; first plain `#N` as fallback), one PR fetch per distinct PR per poll.

### Routing & exactly-once dedup
- Event routes and item routes are disjoint: `RouteAll`/`Route`/`Explain*` skip event routes; new `Router.RouteEvent` handles the event axis with the same priority/`exclusive` semantics.
- Two new SQLite tables: `pr_event_watermarks` (per-source watermark, **baselined to now on first enable** so history never storms) and `pr_event_dispatches` (INSERT-OR-IGNORE claim keyed `(source, event, workflow)`) — an event dispatches a workflow **exactly once across daemon restarts**; a 2-minute poll overlap makes the watermark race-safe.
- `max_dispatches` counts claims per `(workflow, PR)` as the ping-pong backstop.
- Instances bind to the originating issue's `InternalTask` via its `SourceBinding` when one exists (lineage/dashboard/transcripts unchanged); otherwise a stable standalone per-PR task (`pr-<n>`) is bound.

### Event payload
- Env: `APIARY_EVENT_KIND`, `APIARY_EVENT_AUTHOR`, `APIARY_EVENT_BODY`, `APIARY_PR_NUMBER`, `APIARY_PR_URL` on every step (workflow-env overlay; step env still wins).
- Expressions: new `event.*` accessor root (`kind`, `body`, `author`, `author_association`, `pr_number`, `pr_url`) usable in `if:`/`reject_when`/`fail_when`/splits. Resolves as missing ("") on item-triggered and restart-rehydrated instances.

### Validation & schema
- `on:` whitelist; `comment_matches` only with `pr_comment` and compiled at load (invalid regexp fails validate); event-only fields rejected on item triggers; `authors_association` enum; trigger source must implement `PREventPoller` via the new injected `config.SourceSupportsPREvents` hook (wired in `cli/adapters.go`, same pattern as `SourceSupportsDependencyWait`).
- `schema/apiary.json`: new trigger fields; also fixed the stale `sources[].type` enum (added `jira`), as flagged in the issue.

### Docs
`docs/workflows.md` (trigger section + accessors), `docs/github-source.md` (polling details + token perms), `.apiary/example-workflow.yaml` example.

## Notes / limitations
- Event dispatch bypasses the durable dispatch queue (in-process only) — the queue snapshot doesn't carry event payloads; can follow up if needed.
- `${{ event.* }}` lives in memory for the instance's first run; after a park + daemon restart it resolves as missing (documented). Env vars survive normal parking since they're re-composed from the snapshot-independent overlay only on fresh runs.
- Webhooks intentionally out of scope (poll model, per the issue's Alternatives).

## Testing
- `go build ./... && go vet ./... && go test ./...` — all green, gofmt clean.
- New tests: trigger validation (`config`), event routing + author gating (`router`), `event.*` expressions (`workflow`), watermark + exactly-once claims (`db`), `PollPREvents` against an httptest GitHub API incl. bot/self/edit exclusions (`github`), and dispatcher end-to-end: duplicate delivery → one instance, env payload reaches the agent, related-task binding, `max_dispatches` budget (`daemon`).
- `apiary validate` accepts the new example trigger via the real capability hook.

## Acceptance criteria
- [x] `trigger.on: pr_comment` + `comment_matches` dispatches exactly once per matching comment, surviving restarts
- [x] `pr_review_approved` / `pr_review_changes_requested` dispatch on review submission
- [x] Bot's own comments never trigger; author gating enforced by default
- [x] Event payload via env vars and `${{ event.* }}`
- [x] `apiary validate` rejects `on:` on incapable sources; schema updated
- [x] Docs + example config updated
