### PR TITLE
test(source): close coverage gaps on prometheus adapter (#357)

### DIFF
--- a/src/internal/cli/source_caps_wiring_test.go
+++ b/src/internal/cli/source_caps_wiring_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+
+	// Register the real source adapters, as cmd/apiary does, so the capability
+	// probe in init() inspects actual adapter instances.
+	_ "github.com/orlandoburli/apiary/internal/source/github"
+	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
+)
+
+// TestSourceCapsWiring_RealAdapters verifies the #357 capability probe against
+// the real registry: the prometheus alert adapter must present as fully
+// read-only, while github supports every write capability. If a write method
+// is ever added to the prometheus Adapter (or removed from github), this
+// catches the lint silently changing behavior.
+func TestSourceCapsWiring_RealAdapters(t *testing.T) {
+	if config.SourceCapabilities == nil {
+		t.Fatal("config.SourceCapabilities not wired by cli init()")
+	}
+
+	if caps := config.SourceCapabilities("prometheus"); caps != (config.SourceCaps{}) {
+		t.Errorf("prometheus caps = %+v, want all-false (read-only alert source)", caps)
+	}
+
+	want := config.SourceCaps{SetState: true, AddLabels: true, RemoveLabels: true, Approvals: true, CIWait: true, SubIssues: true}
+	if caps := config.SourceCapabilities("github"); caps != want {
+		t.Errorf("github caps = %+v, want %+v", caps, want)
+	}
+
+	if caps := config.SourceCapabilities("no-such-adapter"); caps != (config.SourceCaps{}) {
+		t.Errorf("unknown adapter caps = %+v, want all-false", caps)
+	}
+}
+
+// TestSourceCapsWiring_ValidateRejectsAlertWrites is the end-to-end acceptance
+// check for issue #357: `apiary validate` (cli wiring + real adapters) must
+// reject set_state, approval steps, and wait_for ci against a workflow pinned
+// to a prometheus source.
+func TestSourceCapsWiring_ValidateRejectsAlertWrites(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "prod-alerts", Type: "prometheus"}},
+		Agents:  []config.AgentConfig{{ID: "sre", Model: "m"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "investigate",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "prod-alerts"}},
+			Steps: []config.StepConfig{
+				{ID: "gate", Type: config.StepTypeApproval, Message: "ok?", ResumeOn: &config.ApprovalTrigger{CommentContains: "approved"}},
+				{ID: "ci", Type: config.StepTypeWaitFor, WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+			},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		}},
+	}
+
+	errs := cfg.Validate()
+	for _, want := range []string{"on_complete.set_state", "(approval)", "(wait_for ci)"} {
+		found := false
+		for _, e := range errs {
+			if strings.Contains(e.Error(), want) && strings.Contains(e.Error(), "prod-alerts") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a capability error for %s against prod-alerts, got: %v", want, errs)
+		}
+	}
+}
+
+// TestSourceCapsWiring_GithubWorkflowPasses is the mirror case: the same
+// features pinned to a github source produce no capability errors.
+func TestSourceCapsWiring_GithubWorkflowPasses(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "gh", Type: "github"}},
+		Agents:  []config.AgentConfig{{ID: "eng", Model: "m"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "fix",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "gh"}},
+			Steps: []config.StepConfig{
+				{ID: "work", Agent: "eng"},
+				{ID: "ci", Type: config.StepTypeWaitFor, WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+			},
+			OnComplete: &config.OnComplete{SetState: "done"},
+		}},
+	}
+
+	for _, e := range cfg.Validate() {
+		if strings.Contains(e.Error(), "capability") {
+			t.Errorf("unexpected capability error for github-pinned workflow: %v", e)
+		}
+	}
+}

--- a/src/internal/source/prometheus/adapter_test.go
+++ b/src/internal/source/prometheus/adapter_test.go
@@ -258,6 +258,121 @@ func TestToMatcher(t *testing.T) {
 	}
 }
 
+func TestConnectRejectsInvalidConfig(t *testing.T) {
+	cases := map[string]map[string]any{
+		"non-numeric max_new_per_poll": {"max_new_per_poll": "ten"},
+		"negative max_new_per_poll":    {"max_new_per_poll": -1},
+		"unparseable min_age":          {"min_age": "soon"},
+		"negative min_age":             {"min_age": "-1m"},
+		"non-string min_age":           {"min_age": 5},
+	}
+	for name, extra := range cases {
+		cfg := map[string]any{"alertmanager_url": "http://alertmanager.internal"}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		a := &Adapter{}
+		if err := a.Connect(context.Background(), cfg); err == nil {
+			t.Errorf("%s: expected Connect error for %v", name, extra)
+		}
+	}
+}
+
+func TestPollSkipsAlertsWithoutFingerprint(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	broken := mkAlert("", "NoFingerprint", "critical", started)
+	alerts := []map[string]any{broken, mkAlert("ok", "Fine", "critical", started)}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 || items[0].Metadata["fingerprint"] != "ok" {
+		t.Fatalf("expected only the fingerprinted alert, got %+v", items)
+	}
+}
+
+func TestPollStormCapZeroMeansUnlimited(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	var alerts []map[string]any
+	for i := 0; i < 25; i++ {
+		alerts = append(alerts, mkAlert(fmt.Sprintf("f%d", i), fmt.Sprintf("Alert%d", i), "critical", started))
+	}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, map[string]any{"max_new_per_poll": 0})
+
+	items, _ := a.Poll(context.Background(), time.Time{})
+	if len(items) != 25 {
+		t.Fatalf("max_new_per_poll=0 should disable the cap: got %d of 25", len(items))
+	}
+}
+
+func TestPollPrunesResolvedAlertsFromSeen(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	alerts := []map[string]any{mkAlert("f1", "HighErrorRate", "critical", started)}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(a.seen) != 1 {
+		t.Fatalf("expected 1 tracked fire cycle, got %d", len(a.seen))
+	}
+
+	// The alert resolves (disappears from Alertmanager): its fire cycle must be
+	// pruned so the seen map cannot grow without bound.
+	alerts = []map[string]any{}
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll after resolve: %v", err)
+	}
+	if len(a.seen) != 0 {
+		t.Errorf("resolved alert still tracked in seen (%d entries) — memory leak", len(a.seen))
+	}
+}
+
+func TestTitleAndDescriptionFallbacks(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	// No alertname label, no summary/description annotations.
+	alerts := []map[string]any{{
+		"fingerprint": "cafebabe",
+		"labels":      map[string]string{"severity": "warning"},
+		"annotations": map[string]string{},
+		"startsAt":    started.UTC().Format(time.RFC3339),
+		"status":      map[string]any{"state": "active"},
+	}}
+	srv := newTestServer(t, &alerts, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Title != "alert cafebabe" {
+		t.Errorf("Title = %q, want fingerprint fallback", items[0].Title)
+	}
+	if !strings.Contains(items[0].Description, "`severity`: `warning`") {
+		t.Errorf("Description missing labels section:\n%s", items[0].Description)
+	}
+}
+
+func TestPollPropagatesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err == nil {
+		t.Fatal("expected Poll to surface the API error")
+	}
+}
+
 func itemStub() model.SourceItem {
 	return model.SourceItem{ID: "f1:2026-08-05T00:00:00Z", SourceID: "prod-alerts"}
 }

--- a/src/internal/source/prometheus/client_test.go
+++ b/src/internal/source/prometheus/client_test.go
@@ -1,0 +1,175 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// newClientServer builds a test server whose handler sees every request and a
+// client pointed at it.
+func newClientServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *client) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, newClient(srv.URL, "", "", "")
+}
+
+func TestClientSendsBearerToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(srv.URL, "sekret", "", "")
+	if _, err := c.alerts(context.Background(), nil); err != nil {
+		t.Fatalf("alerts: %v", err)
+	}
+	if got != "Bearer sekret" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer sekret")
+	}
+}
+
+func TestClientSendsBasicAuth(t *testing.T) {
+	var user, pass string
+	var ok bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok = r.BasicAuth()
+		w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(srv.URL, "", "alice", "hunter2")
+	if _, err := c.alerts(context.Background(), nil); err != nil {
+		t.Fatalf("alerts: %v", err)
+	}
+	if !ok || user != "alice" || pass != "hunter2" {
+		t.Errorf("basic auth = (%q, %q, ok=%v), want (alice, hunter2, true)", user, pass, ok)
+	}
+}
+
+func TestClientBearerTakesPrecedenceOverBasic(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(srv.URL, "tok", "alice", "hunter2")
+	if _, err := c.alerts(context.Background(), nil); err != nil {
+		t.Fatalf("alerts: %v", err)
+	}
+	if got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want bearer to win over basic auth", got)
+	}
+}
+
+func TestClientRetriesOn5xxThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			w.Header().Set("Retry-After", "0") // keep the test fast
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(`[{"fingerprint":"f1","labels":{"alertname":"A"}}]`))
+	})
+
+	alerts, err := c.alerts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("alerts after retries: %v", err)
+	}
+	if len(alerts) != 1 || alerts[0].Fingerprint != "f1" {
+		t.Errorf("alerts = %+v, want the one recovered alert", alerts)
+	}
+	if n := calls.Load(); n != 3 {
+		t.Errorf("server saw %d requests, want 3 (2 failures + 1 success)", n)
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Write([]byte(`[]`))
+	})
+
+	if _, err := c.alerts(context.Background(), nil); err != nil {
+		t.Fatalf("alerts after 429: %v", err)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Errorf("server saw %d requests, want 2", n)
+	}
+}
+
+func TestClientRetryExhausted(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	_, err := c.alerts(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "exceeded 3 retries") {
+		t.Errorf("error = %v, want mention of exhausted retries", err)
+	}
+	if n := calls.Load(); n != int32(maxRetries) {
+		t.Errorf("server saw %d requests, want %d", n, maxRetries)
+	}
+}
+
+func TestClientDoesNotRetryOn4xx(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad matcher", http.StatusBadRequest)
+	})
+
+	_, err := c.alerts(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if !strings.Contains(err.Error(), "status 400") {
+		t.Errorf("error = %v, want status 400", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("server saw %d requests, want exactly 1 (4xx must not retry)", n)
+	}
+}
+
+func TestClientRejectsMalformedJSON(t *testing.T) {
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"not":"an array"`))
+	})
+
+	_, err := c.alerts(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "decoding alerts response") {
+		t.Errorf("error = %v, want decode failure", err)
+	}
+}
+
+func TestClientContextCancelStopsRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		cancel() // cancel while the first attempt is in flight
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := c.alerts(ctx, nil); err == nil {
+		t.Fatal("expected error when context is cancelled during retries")
+	}
+}


### PR DESCRIPTION
Test-only follow-up to #358 hardening the #357 acceptance criteria.

## Gaps closed

**`prometheus/client_test.go` (new — the HTTP client had zero direct tests)**
- bearer / basic auth headers, and bearer winning when both are set
- retry on 5xx and 429 honouring `Retry-After`, success after retries
- retry exhaustion after `maxRetries` attempts (server request count asserted)
- 4xx fails immediately with **no** retry
- malformed JSON surfaces a decode error
- context cancellation aborts the backoff loop

**`prometheus/adapter_test.go` (edge cases)**
- `Connect` rejects invalid `max_new_per_poll` / `min_age` values
- alerts without a fingerprint are skipped
- `max_new_per_poll: 0` disables the storm cap
- resolved alerts are pruned from the `seen` map (unbounded-growth guard)
- title/description fallbacks when `alertname`/annotations are absent
- API errors propagate out of `Poll`

**`cli/source_caps_wiring_test.go` (new — end-to-end acceptance check)**
The existing `config` lint tests use a fake capability registry; nothing verified the real wiring. These tests probe `config.SourceCapabilities` against the **real** adapters: `prometheus` must present all-false (read-only) and `github` all-true, and a full `Validate()` rejects `set_state` / approval steps / `wait_for: ci` pinned to a prometheus source while passing for github. If a write method is ever accidentally added to the prometheus `Adapter`, this fails.

All new tests run in ~0s (Retry-After: 0 keeps backoff paths fast). `go vet ./...` and the full `go test ./...` suite pass locally (no Go CI in this repo).