### PR TITLE
feat(source): dynatrace adapter — trigger workflows from open problems (#362)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -144,6 +144,32 @@ sources:
       # raw matcher like env=~"prod|staging".
       labels: ["severity=critical", "team=platform"]
 
+  - id: prod-problems
+    type: dynatrace
+    config:
+      # Environment URL — SaaS ({env-id}.live.dynatrace.com) or Managed
+      # (https://host/e/{env-id}). /api/v2/problems is polled (Davis has
+      # already correlated root cause + impacted entities into one problem).
+      # Read-only source: problems have no state, labels, or comments to
+      # write back; publish findings to a ticket source.
+      base_url: https://abc12345.live.dynatrace.com
+      # Access token with the problems.read scope.
+      api_token: ${DYNATRACE_API_TOKEN}
+      # Problem-storm cap: at most this many not-yet-seen problems become
+      # tasks per poll (oldest first); overflow surfaces on later polls. 0 = off.
+      max_new_per_poll: 10
+      # Flap dampener: problems must have been open at least this long.
+      min_age: 1m
+      # How far back the from= window reaches (the API defaults to 2h, which
+      # would hide older still-open problems).
+      lookback: 720h
+    poll_interval: 30s
+    filters:
+      # problemSelector criteria, ANDed server-side. severity=/impact=/
+      # managementZone= map to selector functions; other key=value pairs
+      # match entity tags; raw criteria like displayId("P-123") pass through.
+      labels: ["severity=availability", "managementZone=Prod"]
+
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:
   # === Claude-based agents (original design) ===

--- a/docs/dynatrace-source.md
+++ b/docs/dynatrace-source.md
@@ -1,0 +1,103 @@
+# Dynatrace Source
+
+The `dynatrace` source adapter polls the **Dynatrace problems API**
+(`GET /api/v2/problems`) and maps each open problem to an Apiary task — so an
+AI-detected operational problem, not just a human-filed ticket, can trigger a
+workflow. The canonical pattern: Dynatrace opens a problem (`Response time
+degradation` on service X) → an investigation workflow dispatches → the agent
+pulls logs, diagnoses, and publishes findings as a GitHub issue or fix PR.
+
+Problems are polled (not individual events or metrics) because Davis has the
+correlation semantics already applied: one problem groups the root cause and
+every impacted entity, so a cascading failure is one task, not fifty.
+
+## Configuration
+
+```yaml
+sources:
+  - id: prod-problems
+    type: dynatrace
+    poll_interval: 30s
+    config:
+      base_url: https://abc12345.live.dynatrace.com
+      api_token: ${DYNATRACE_API_TOKEN}   # scope: problems.read
+      max_new_per_poll: 10                # optional, storm cap
+      min_age: 1m                         # optional, flap dampener
+      lookback: 720h                      # optional, from= window
+    filters:
+      labels: ["severity=availability", "managementZone=Prod"]
+
+workflows:
+  - id: investigate-problem
+    trigger:
+      match: { source: prod-problems }
+      once: true
+    steps:
+      - id: investigate
+        agent: sre-investigator
+```
+
+### `config` fields
+
+| Field | Required | Description |
+|---|---|---|
+| `base_url` | yes | Environment URL — SaaS (`https://{env-id}.live.dynatrace.com`) or Managed (`https://{host}/e/{env-id}`) |
+| `api_token` | yes | Access token with the `problems.read` scope, sent as `Authorization: Api-Token …` |
+| `max_new_per_poll` | no | Problem-storm cap: at most this many *not-yet-seen* problems become tasks per poll; the overflow is logged and surfaces on later polls. `0` disables the cap. Default `10` |
+| `min_age` | no | Flap dampener: a problem must have been open at least this long before it is ingested. Default `1m` |
+| `lookback` | no | How far back the poll's `from=` window reaches. The problems API defaults to the last 2 hours, which would hide older still-open problems, so the adapter always sends an explicit window. Default `720h` (30 days) |
+
+### `filters`
+
+| Field | Description |
+|---|---|
+| `labels` | Mapped to `problemSelector` criteria, ANDed and evaluated server-side. `severity=availability` / `impact=services` / `managementZone=Prod` map to the corresponding selector functions; any other `key=value` (or `key:value`) pair matches an entity tag (`entityTags("key:value")`); a raw criterion (`displayId("P-123")`) is passed through untouched; a bare word matches the problem title (`text(…)`) |
+| `states` | Not applicable — only open problems are polled; any value other than `open` is ignored with a warning |
+
+## Problem → task mapping
+
+| Task field | Problem value |
+|---|---|
+| ID | `problemId` — unique per problem occurrence; a later occurrence of the same failure gets a fresh ID |
+| Number | `displayId` (e.g. `P-2145`) |
+| Title | problem title |
+| Description | severity/impact, root cause entity, affected entities, management zones, tags, open-since timestamp |
+| Labels | `severity:<severityLevel>`, `impact:<impactLevel>`, `zone:<each management zone>`, plus every entity tag as `key:value` — so `trigger.match.labels: [severity:availability]` works verbatim |
+| Type | `problem` |
+| Priority | the severity level, lowercased (`availability`, `error`, `performance`, …) |
+| State | `open` |
+| URL | deep link to the problem details view |
+| Metadata | problemId, displayId, severityLevel, impactLevel, status, startTime, management zones, entity tags |
+
+## Behavior
+
+- **Exactly once per occurrence.** The task ID is the Dynatrace `problemId`,
+  which is unique per problem occurrence: while the problem stays open the ID
+  is constant and the dispatcher's dedup (active-instance drop, `once: true`,
+  persisted task identity) prevents re-dispatch — including across daemon
+  restarts. When the problem resolves and the failure later recurs, Dynatrace
+  opens a new problem with a fresh ID, producing a new task and a new
+  dispatch.
+- **Storm cap.** One bad deploy can open dozens of problems in a single poll;
+  each would become a task and an agent run. `max_new_per_poll` bounds how
+  many new problems are admitted per poll (oldest first); the rest are
+  deferred to subsequent polls and a warning names the deferred count.
+- **Flap dampening.** `min_age` skips problems younger than the threshold, so
+  open→resolved blips never dispatch.
+- **Read-only.** Problems have no assignable state or labels to write back
+  to: `Acknowledge` and result write-back are no-ops, and the adapter
+  implements none of the optional write capabilities. `apiary validate`
+  rejects workflows that pin this source and use `on_complete.set_state` /
+  `add_labels`, approval steps, `wait_for` CI steps, or
+  `materialize: sub_issue`. Posting problem comments (`problems.write`) is a
+  possible future opt-in.
+- **Resolved while running.** A running investigation is not interrupted when
+  its problem resolves; the workflow finishes normally.
+
+## Where results go
+
+Since the adapter cannot comment on a problem, the natural output of an
+investigation workflow is a *ticket* source: have the agent emit
+`APIARY_PUBLISH` (write findings back to a bound item) or `APIARY_SPAWN`
+(create follow-up work, optionally materialized as a GitHub sub-issue).
+Problem in from Dynatrace, findings out as a GitHub issue.

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -56,18 +56,26 @@ comments to write back — publish findings to a ticket source instead.
 - **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
 - **Setup:** See [Prometheus Source configuration](prometheus-source.md)
 
+### Dynatrace
+
+**Status:** ✅ Stable | **Auth:** API token (`problems.read` scope)
+
+Polls open problems from the Dynatrace problems API (`/api/v2/problems`) and
+maps them to tasks, following the same read-only monitoring-source shape as
+the Prometheus adapter: an AI-detected problem opens → an investigation
+workflow dispatches.
+
+- **Requirements:** Dynatrace SaaS or Managed environment with an access token
+  holding the `problems.read` scope
+- **Guardrails:** Problem-storm dispatch cap and flap dampening built in
+- **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
+- **Setup:** See [Dynatrace Source configuration](dynatrace-source.md)
+
 ### Linear
 
 **Status:** 🔄 Planned | **Auth:** API token
 
 Support for Linear is in development.
-
-### Dynatrace
-
-**Status:** 🔄 Planned | **Auth:** API token
-
-Problem-based monitoring source (`/api/v2/problems`), following the same
-read-only shape as the Prometheus adapter.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Jira: jira-source.md
       - Plane: plane-source.md
       - Prometheus: prometheus-source.md
+      - Dynatrace: dynatrace-source.md
   - Reference:
       - CLI: cli.md
       - Dashboard: dashboard.md

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -138,7 +138,7 @@
     },
     "sources": {
       "type": "array",
-      "description": "Task sources (github, jira, plane, prometheus)",
+      "description": "Task sources (github, jira, plane, prometheus, dynatrace)",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -151,11 +151,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "jira", "plane", "prometheus"]
+            "enum": ["github", "jira", "plane", "prometheus", "dynatrace"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/orlandoburli/apiary/internal/cli"
 
+	_ "github.com/orlandoburli/apiary/internal/source/dynatrace"
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
 	_ "github.com/orlandoburli/apiary/internal/source/plane"

--- a/src/internal/cli/source_caps_wiring_test.go
+++ b/src/internal/cli/source_caps_wiring_test.go
@@ -8,6 +8,7 @@ import (
 
 	// Register the real source adapters, as cmd/apiary does, so the capability
 	// probe in init() inspects actual adapter instances.
+	_ "github.com/orlandoburli/apiary/internal/source/dynatrace"
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
 )
@@ -24,6 +25,10 @@ func TestSourceCapsWiring_RealAdapters(t *testing.T) {
 
 	if caps := config.SourceCapabilities("prometheus"); caps != (config.SourceCaps{}) {
 		t.Errorf("prometheus caps = %+v, want all-false (read-only alert source)", caps)
+	}
+
+	if caps := config.SourceCapabilities("dynatrace"); caps != (config.SourceCaps{}) {
+		t.Errorf("dynatrace caps = %+v, want all-false (read-only problem source)", caps)
 	}
 
 	want := config.SourceCaps{SetState: true, AddLabels: true, RemoveLabels: true, Approvals: true, CIWait: true, SubIssues: true}

--- a/src/internal/source/dynatrace/adapter.go
+++ b/src/internal/source/dynatrace/adapter.go
@@ -1,0 +1,390 @@
+// Package dynatrace provides a read-only source adapter that polls the
+// Dynatrace problems API (GET /api/v2/problems) and maps each open problem to
+// an Apiary SourceItem, so workflow trigger matching (labels, states,
+// title_regex) works against operational signals exactly as it does against
+// tickets — the monitoring-source shape introduced by the prometheus adapter,
+// backed by a different client.
+//
+// Problems are read-only work items: the adapter deliberately implements none
+// of the optional write capabilities (StateSetter, LabelAdder, TaskPoller,
+// CIStatusPoller, SubIssueCreator…). Acknowledge and WriteResult are no-ops;
+// config validation rejects workflows that need write capabilities against a
+// source that lacks them (config.SourceCapabilities). Comment write-back via
+// POST /api/v2/problems/{id}/comments (problems.write scope) is a possible
+// future opt-in.
+package dynatrace
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func init() {
+	source.Register("dynatrace", func() source.Adapter { return &Adapter{} })
+}
+
+const (
+	// defaultMaxNewPerPoll caps how many not-yet-seen problems one poll may
+	// surface — the problem-storm guardrail. One bad deploy can open dozens of
+	// problems at once; without a cap each becomes a task + agent run in the
+	// same tick. Overflow problems are logged and surface on later polls.
+	defaultMaxNewPerPoll = 10
+
+	// defaultMinAge is the flap dampener: a problem must have been open at
+	// least this long before it is surfaced. 0 would dispatch the moment
+	// Dynatrace opens the problem.
+	defaultMinAge = time.Minute
+
+	// defaultLookback bounds the from= query parameter. The problems API
+	// defaults to the last 2 hours, which would silently hide older still-open
+	// problems, so the adapter always sends an explicit window.
+	defaultLookback = 30 * 24 * time.Hour
+)
+
+// Adapter implements source.Adapter for Dynatrace problems.
+type Adapter struct {
+	id     string
+	client *client
+
+	maxNewPerPoll int
+	minAge        time.Duration
+	lookback      time.Duration
+
+	// selector is the problemSelector criteria list built from
+	// SourceFilters.Labels; status("open") is always appended at poll time.
+	selector []string
+
+	// seen tracks problem IDs already surfaced, so the storm cap only counts
+	// genuinely new problems and an ongoing problem is re-returned every poll
+	// (the dispatcher's active/once dedup relies on that). Entries are pruned
+	// when the problem is no longer open. In-memory only: after a restart
+	// every open problem counts as new again, but re-dispatch is still
+	// prevented downstream by the persisted task/instance dedup.
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+// SetID sets the source ID for this adapter.
+func (a *Adapter) SetID(id string) { a.id = id }
+
+// Connect validates config and creates the HTTP client.
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	baseURL, _ := cfg["base_url"].(string)
+	if baseURL == "" {
+		return fmt.Errorf("dynatrace: config.base_url is required")
+	}
+	apiToken, _ := cfg["api_token"].(string)
+	if apiToken == "" {
+		return fmt.Errorf("dynatrace: config.api_token is required (scope: problems.read)")
+	}
+	a.client = newClient(baseURL, apiToken)
+
+	a.maxNewPerPoll = defaultMaxNewPerPoll
+	if v, ok := cfg["max_new_per_poll"]; ok {
+		n, err := toInt(v)
+		if err != nil || n < 0 {
+			return fmt.Errorf("dynatrace: config.max_new_per_poll must be a non-negative integer, got %v", v)
+		}
+		a.maxNewPerPoll = n
+	}
+
+	a.minAge = defaultMinAge
+	if v, ok := cfg["min_age"]; ok {
+		s, _ := v.(string)
+		d, err := time.ParseDuration(s)
+		if err != nil || d < 0 {
+			return fmt.Errorf("dynatrace: config.min_age must be a non-negative duration (e.g. \"2m\"), got %v", v)
+		}
+		a.minAge = d
+	}
+
+	a.lookback = defaultLookback
+	if v, ok := cfg["lookback"]; ok {
+		s, _ := v.(string)
+		d, err := time.ParseDuration(s)
+		if err != nil || d <= 0 {
+			return fmt.Errorf("dynatrace: config.lookback must be a positive duration (e.g. \"720h\"), got %v", v)
+		}
+		a.lookback = d
+	}
+
+	a.seen = map[string]struct{}{}
+
+	aplog.Info("dynatrace: configured  base_url=%s  max_new_per_poll=%d  min_age=%s  lookback=%s",
+		baseURL, a.maxNewPerPoll, a.minAge, a.lookback)
+	return nil
+}
+
+// SetFilters maps SourceFilters.Labels to problemSelector criteria.
+// Entries may be a raw criterion (`severityLevel("AVAILABILITY")`), a known
+// key=value pair (severityLevel, impactLevel, managementZone), a generic
+// key=value / key:value pair (matched as an entity tag), or a bare word
+// (matched against the problem title). States are not sent to Dynatrace (only
+// open problems are polled); a states filter other than "open" is warned
+// about here to avoid a filter that silently never matches.
+func (a *Adapter) SetFilters(states, labels []string) {
+	for _, l := range labels {
+		a.selector = append(a.selector, toCriterion(l))
+	}
+	for _, s := range states {
+		if !strings.EqualFold(s, "open") {
+			aplog.Warn("dynatrace: filters.states %q ignored — only open problems are polled", s)
+		}
+	}
+}
+
+// criterionRe recognises a raw problemSelector criterion with an explicit
+// function-call shape, which is passed through untouched.
+var criterionRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*\(.*\)$`)
+
+// toCriterion normalises a filters.labels entry to a problemSelector criterion.
+func toCriterion(l string) string {
+	l = strings.TrimSpace(l)
+	if criterionRe.MatchString(l) {
+		return l
+	}
+	k, v, cut := strings.Cut(l, "=")
+	if !cut {
+		k, v, cut = strings.Cut(l, ":")
+	}
+	if cut {
+		k, v = strings.TrimSpace(k), strings.TrimSpace(v)
+		switch strings.ToLower(k) {
+		case "severitylevel", "severity":
+			return fmt.Sprintf("severityLevel(%q)", strings.ToUpper(v))
+		case "impactlevel", "impact":
+			return fmt.Sprintf("impactLevel(%q)", strings.ToUpper(v))
+		case "managementzone", "management_zone", "zone":
+			return fmt.Sprintf("managementZones(%q)", v)
+		}
+		return fmt.Sprintf("entityTags(%q)", k+":"+v)
+	}
+	// A bare word is most useful as a title text match.
+	return fmt.Sprintf("text(%q)", l)
+}
+
+// Poll returns the currently open problems as SourceItems. The since parameter
+// is ignored on purpose: an ongoing problem must be returned on every poll so
+// the dispatcher's active-instance / once dedup keeps shadowing it; the
+// problem ID is unique per problem occurrence, so re-dispatch is impossible
+// while the problem stays open.
+func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, error) {
+	selector := strings.Join(append([]string{`status("open")`}, a.selector...), ",")
+	problems, err := a.client.problems(ctx, selector, time.Now().Add(-a.lookback))
+	if err != nil {
+		return nil, fmt.Errorf("dynatrace: polling problems: %w", err)
+	}
+
+	now := time.Now()
+	var eligible []problem
+	for _, p := range problems {
+		if p.ProblemID == "" {
+			aplog.Debug("dynatrace: skipping problem without problemId (title=%q)", p.Title)
+			continue
+		}
+		// Flap dampener: too-young problems are left for a later poll (not
+		// marked seen), so open→resolved blips shorter than min_age never
+		// become tasks.
+		if age := now.Sub(startTime(p)); age < a.minAge {
+			aplog.Debug("dynatrace: problem %s age %s < min_age %s — deferred", p.ProblemID, age.Round(time.Second), a.minAge)
+			continue
+		}
+		eligible = append(eligible, p)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Oldest first so a storm drains deterministically.
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].StartTime < eligible[j].StartTime })
+
+	current := make(map[string]struct{}, len(eligible))
+	var items []model.SourceItem
+	newCount := 0
+	dropped := 0
+	for _, p := range eligible {
+		current[p.ProblemID] = struct{}{}
+		if _, ok := a.seen[p.ProblemID]; !ok {
+			if a.maxNewPerPoll > 0 && newCount >= a.maxNewPerPoll {
+				dropped++
+				delete(current, p.ProblemID) // not surfaced: stays unseen for the next poll
+				continue
+			}
+			newCount++
+			a.seen[p.ProblemID] = struct{}{}
+		}
+		items = append(items, a.toSourceItem(p))
+	}
+	if dropped > 0 {
+		aplog.Warn("dynatrace: storm cap — %d new problem(s) deferred to next poll (max_new_per_poll=%d)", dropped, a.maxNewPerPoll)
+	}
+
+	// Prune problems that resolved so the seen map cannot grow without bound.
+	// A later occurrence of the same failure gets a fresh problemId and
+	// dispatches again as a new item.
+	for id := range a.seen {
+		if _, ok := current[id]; !ok {
+			delete(a.seen, id)
+		}
+	}
+
+	return items, nil
+}
+
+func startTime(p problem) time.Time { return time.UnixMilli(p.StartTime) }
+
+func (a *Adapter) toSourceItem(p problem) model.SourceItem {
+	title := p.Title
+	if title == "" {
+		title = "problem " + p.DisplayID
+	}
+
+	// Problem attributes become routable "key:value" item labels (the router
+	// lowercases both sides), e.g. trigger match `labels: [severity:availability]`.
+	labels := []string{
+		"severity:" + strings.ToLower(p.SeverityLevel),
+		"impact:" + strings.ToLower(p.ImpactLevel),
+	}
+	for _, z := range p.ManagementZones {
+		labels = append(labels, "zone:"+z.Name)
+	}
+	for _, t := range p.EntityTags {
+		labels = append(labels, tagLabel(t))
+	}
+	sort.Strings(labels)
+
+	return model.SourceItem{
+		ID:          p.ProblemID,
+		SourceID:    a.ID(),
+		Number:      p.DisplayID,
+		Title:       title,
+		Description: describe(p),
+		Labels:      labels,
+		Type:        "problem",
+		Priority:    strings.ToLower(p.SeverityLevel),
+		State:       "open",
+		URL:         a.problemURL(p),
+		Metadata: map[string]any{
+			"problemId":       p.ProblemID,
+			"displayId":       p.DisplayID,
+			"severityLevel":   p.SeverityLevel,
+			"impactLevel":     p.ImpactLevel,
+			"status":          p.Status,
+			"startTime":       startTime(p).UTC().Format(time.RFC3339),
+			"managementZones": zoneNames(p.ManagementZones),
+			"entityTags":      tagStrings(p.EntityTags),
+		},
+		CreatedAt: startTime(p),
+		UpdatedAt: startTime(p),
+	}
+}
+
+// problemURL is the browser deep link to the problem details view.
+func (a *Adapter) problemURL(p problem) string {
+	return fmt.Sprintf("%s/#problems/problemdetails;pid=%s", a.client.baseURL, p.ProblemID)
+}
+
+// tagLabel renders an entity tag as a routable "key:value" label; key-only
+// tags keep Dynatrace's own string representation.
+func tagLabel(t entityTag) string {
+	if t.Key != "" && t.Value != "" {
+		return t.Key + ":" + t.Value
+	}
+	if t.StringRepresentation != "" {
+		return t.StringRepresentation
+	}
+	return t.Key + t.Value
+}
+
+// describe renders the full problem payload as the task description, so the
+// investigating agent receives severity, entities, and the deep link without
+// needing Dynatrace access of its own.
+func describe(p problem) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Dynatrace problem **%s** — severity `%s`, impact `%s`.\n", p.DisplayID, p.SeverityLevel, p.ImpactLevel)
+
+	if p.RootCauseEntity != nil && p.RootCauseEntity.Name != "" {
+		fmt.Fprintf(&b, "\n**Root cause entity**: `%s` (%s)\n", p.RootCauseEntity.Name, p.RootCauseEntity.EntityID.Type)
+	}
+
+	if len(p.AffectedEntities) > 0 {
+		b.WriteString("\n**Affected entities**\n\n")
+		for _, e := range p.AffectedEntities {
+			fmt.Fprintf(&b, "- `%s` (%s)\n", e.Name, e.EntityID.Type)
+		}
+	}
+
+	if len(p.ManagementZones) > 0 {
+		b.WriteString("\n**Management zones**\n\n")
+		for _, z := range p.ManagementZones {
+			fmt.Fprintf(&b, "- `%s`\n", z.Name)
+		}
+	}
+
+	if len(p.EntityTags) > 0 {
+		b.WriteString("\n**Tags**\n\n")
+		for _, t := range p.EntityTags {
+			fmt.Fprintf(&b, "- `%s`\n", tagLabel(t))
+		}
+	}
+
+	fmt.Fprintf(&b, "\nOpen since %s.", startTime(p).UTC().Format(time.RFC3339))
+	return b.String()
+}
+
+func zoneNames(zones []namedRef) []string {
+	names := make([]string, 0, len(zones))
+	for _, z := range zones {
+		names = append(names, z.Name)
+	}
+	return names
+}
+
+func tagStrings(tags []entityTag) []string {
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, tagLabel(t))
+	}
+	return out
+}
+
+// Acknowledge is a no-op: a problem has no assignable/in-progress state to set.
+func (a *Adapter) Acknowledge(_ context.Context, cell model.SourceItem, action model.AckAction) error {
+	aplog.Debug("dynatrace: acknowledge %s (%s) — no-op for problems", cell.LogLabel(), action)
+	return nil
+}
+
+// WriteResult is a no-op: result write-back is not implemented for problems.
+// The intended pattern is a workflow step that publishes findings to a ticket
+// source (APIARY_PUBLISH / APIARY_SPAWN) instead. Posting a problem comment
+// (problems.write) is a possible future opt-in.
+func (a *Adapter) WriteResult(_ context.Context, cell model.SourceItem, result model.RunResult) error {
+	aplog.Debug("dynatrace: write result for %s (success=%v) — no-op for problems", cell.LogLabel(), result.Success)
+	return nil
+}
+
+func (a *Adapter) WebhookHandler() http.Handler { return nil }
+
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	}
+	return 0, fmt.Errorf("not an integer: %v", v)
+}

--- a/src/internal/source/dynatrace/adapter_test.go
+++ b/src/internal/source/dynatrace/adapter_test.go
@@ -1,0 +1,410 @@
+package dynatrace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// newTestServer serves the given problems on GET /api/v2/problems and records
+// the last request's query values.
+func newTestServer(t *testing.T, problems *[]map[string]any, lastQuery *map[string][]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/problems" {
+			http.NotFound(w, r)
+			return
+		}
+		if lastQuery != nil {
+			*lastQuery = r.URL.Query()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"totalCount": len(*problems),
+			"pageSize":   500,
+			"problems":   *problems,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func mkProblem(id, displayID, title string, start time.Time) map[string]any {
+	return map[string]any{
+		"problemId":     id,
+		"displayId":     displayID,
+		"title":         title,
+		"impactLevel":   "SERVICES",
+		"severityLevel": "AVAILABILITY",
+		"status":        "OPEN",
+		"startTime":     start.UnixMilli(),
+		"endTime":       -1,
+		"affectedEntities": []map[string]any{
+			{"entityId": map[string]string{"id": "SERVICE-1", "type": "SERVICE"}, "name": "checkout-service"},
+		},
+		"rootCauseEntity": map[string]any{
+			"entityId": map[string]string{"id": "HOST-1", "type": "HOST"}, "name": "prod-host-7",
+		},
+		"managementZones": []map[string]any{{"id": "z1", "name": "Prod"}},
+		"entityTags": []map[string]any{
+			{"context": "CONTEXTLESS", "key": "team", "value": "platform", "stringRepresentation": "team:platform"},
+		},
+	}
+}
+
+func connect(t *testing.T, url string, extra map[string]any) *Adapter {
+	t.Helper()
+	a := &Adapter{}
+	a.SetID("prod-problems")
+	cfg := map[string]any{"base_url": url, "api_token": "dt0c01.sekret"}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	if err := a.Connect(context.Background(), cfg); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	return a
+}
+
+func TestConnectRequiresURLAndToken(t *testing.T) {
+	a := &Adapter{}
+	if err := a.Connect(context.Background(), map[string]any{"api_token": "x"}); err == nil {
+		t.Fatal("expected error for missing base_url")
+	}
+	if err := a.Connect(context.Background(), map[string]any{"base_url": "https://abc.live.dynatrace.com"}); err == nil {
+		t.Fatal("expected error for missing api_token")
+	}
+}
+
+func TestPollMapsProblems(t *testing.T) {
+	started := time.Now().Add(-10 * time.Minute)
+	problems := []map[string]any{mkProblem("6120279862528180338_1620308532000V2", "P-2145", "Response time degradation", started)}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	it := items[0]
+
+	if it.ID != "6120279862528180338_1620308532000V2" {
+		t.Errorf("ID = %q, want the problemId", it.ID)
+	}
+	if it.SourceID != "prod-problems" {
+		t.Errorf("SourceID = %q", it.SourceID)
+	}
+	if it.Number != "P-2145" {
+		t.Errorf("Number = %q, want the displayId", it.Number)
+	}
+	if it.Title != "Response time degradation" {
+		t.Errorf("Title = %q", it.Title)
+	}
+	if it.State != "open" {
+		t.Errorf("State = %q, want open", it.State)
+	}
+	if it.Type != "problem" {
+		t.Errorf("Type = %q, want problem", it.Type)
+	}
+	if it.Priority != "availability" {
+		t.Errorf("Priority = %q, want availability", it.Priority)
+	}
+	wantLabels := []string{"impact:services", "severity:availability", "team:platform", "zone:Prod"}
+	if len(it.Labels) != len(wantLabels) {
+		t.Fatalf("Labels = %v, want %v", it.Labels, wantLabels)
+	}
+	for i, l := range wantLabels {
+		if it.Labels[i] != l {
+			t.Errorf("Labels[%d] = %q, want %q", i, it.Labels[i], l)
+		}
+	}
+	wantURL := srv.URL + "/#problems/problemdetails;pid=6120279862528180338_1620308532000V2"
+	if it.URL != wantURL {
+		t.Errorf("URL = %q, want %q", it.URL, wantURL)
+	}
+	if it.Metadata["displayId"] != "P-2145" {
+		t.Errorf("Metadata.displayId = %v", it.Metadata["displayId"])
+	}
+	for _, want := range []string{"P-2145", "AVAILABILITY", "checkout-service", "prod-host-7", "Prod", "team:platform", "Open since"} {
+		if !strings.Contains(it.Description, want) {
+			t.Errorf("Description missing %q:\n%s", want, it.Description)
+		}
+	}
+}
+
+func TestPollIDStableAcrossPolls(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	problems := []map[string]any{mkProblem("pid-1", "P-1", "Down", started)}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, nil)
+
+	first, _ := a.Poll(context.Background(), time.Time{})
+	second, _ := a.Poll(context.Background(), time.Time{})
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("expected the open problem on every poll: %d then %d", len(first), len(second))
+	}
+	if first[0].ID != second[0].ID {
+		t.Errorf("ID changed across polls: %q vs %q", first[0].ID, second[0].ID)
+	}
+
+	// A new occurrence after resolution (fresh problemId) is a NEW item.
+	problems[0] = mkProblem("pid-2", "P-2", "Down", started.Add(30*time.Minute))
+	third, _ := a.Poll(context.Background(), time.Time{})
+	if len(third) != 1 {
+		t.Fatalf("expected 1 item on re-occurrence, got %d", len(third))
+	}
+	if third[0].ID == first[0].ID {
+		t.Error("new problem occurrence kept the old ID — would never re-dispatch")
+	}
+}
+
+func TestPollMinAgeDampensFlaps(t *testing.T) {
+	problems := []map[string]any{
+		mkProblem("young", "P-1", "Flappy", time.Now().Add(-10*time.Second)),
+		mkProblem("old", "P-2", "Stable", time.Now().Add(-10*time.Minute)),
+	}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, map[string]any{"min_age": "1m"})
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 || items[0].Metadata["problemId"] != "old" {
+		t.Fatalf("expected only the old problem, got %+v", items)
+	}
+}
+
+func TestPollStormCap(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	var problems []map[string]any
+	for i := 0; i < 5; i++ {
+		problems = append(problems, mkProblem(fmt.Sprintf("pid-%d", i), fmt.Sprintf("P-%d", i), fmt.Sprintf("Problem %d", i),
+			started.Add(time.Duration(i)*time.Minute)))
+	}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, map[string]any{"max_new_per_poll": 2})
+
+	// Poll 1: only the 2 oldest new problems surface.
+	items, _ := a.Poll(context.Background(), time.Time{})
+	if len(items) != 2 {
+		t.Fatalf("poll 1: expected 2 items, got %d", len(items))
+	}
+	if items[0].Metadata["problemId"] != "pid-0" || items[1].Metadata["problemId"] != "pid-1" {
+		t.Errorf("poll 1: expected oldest first, got %v and %v", items[0].Metadata["problemId"], items[1].Metadata["problemId"])
+	}
+
+	// Poll 2: the 2 already-seen keep flowing plus 2 more new ones.
+	items, _ = a.Poll(context.Background(), time.Time{})
+	if len(items) != 4 {
+		t.Fatalf("poll 2: expected 4 items, got %d", len(items))
+	}
+
+	// Poll 3: all 5.
+	items, _ = a.Poll(context.Background(), time.Time{})
+	if len(items) != 5 {
+		t.Fatalf("poll 3: expected 5 items, got %d", len(items))
+	}
+}
+
+func TestPollSendsSelectorAndWindow(t *testing.T) {
+	problems := []map[string]any{}
+	var q map[string][]string
+	srv := newTestServer(t, &problems, &q)
+	a := connect(t, srv.URL, nil)
+	a.SetFilters([]string{"open"}, []string{"severity=availability", "team:platform", `managementZones("Prod")`, "zone=Web", "checkout"})
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+
+	want := `status("open"),severityLevel("AVAILABILITY"),entityTags("team:platform"),managementZones("Prod"),managementZones("Web"),text("checkout")`
+	if got := q["problemSelector"]; len(got) != 1 || got[0] != want {
+		t.Errorf("problemSelector = %v, want %q", q["problemSelector"], want)
+	}
+	if got := q["from"]; len(got) != 1 || got[0] == "" {
+		t.Errorf("from param = %v, want an explicit lookback window", q["from"])
+	}
+	if got := q["pageSize"]; len(got) != 1 || got[0] != "500" {
+		t.Errorf("pageSize param = %v, want [500]", q["pageSize"])
+	}
+}
+
+func TestWriteOpsAreNoOps(t *testing.T) {
+	a := &Adapter{}
+	if err := a.Acknowledge(context.Background(), itemStub(), "in_progress"); err != nil {
+		t.Errorf("Acknowledge: %v", err)
+	}
+	if err := a.WriteResult(context.Background(), itemStub(), resultStub()); err != nil {
+		t.Errorf("WriteResult: %v", err)
+	}
+	if a.WebhookHandler() != nil {
+		t.Error("WebhookHandler should be nil for the poll-only adapter")
+	}
+}
+
+func TestToCriterion(t *testing.T) {
+	cases := map[string]string{
+		"severity=availability":         `severityLevel("AVAILABILITY")`,
+		"severityLevel:ERROR":           `severityLevel("ERROR")`,
+		"impact=services":               `impactLevel("SERVICES")`,
+		"managementZone=Prod":           `managementZones("Prod")`,
+		" zone = Web ":                  `managementZones("Web")`,
+		"team=platform":                 `entityTags("team:platform")`,
+		"team:platform":                 `entityTags("team:platform")`,
+		`displayId("P-123")`:            `displayId("P-123")`,
+		`severityLevel("CUSTOM_ALERT")`: `severityLevel("CUSTOM_ALERT")`,
+		"checkout":                      `text("checkout")`,
+	}
+	for in, want := range cases {
+		if got := toCriterion(in); got != want {
+			t.Errorf("toCriterion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestConnectRejectsInvalidConfig(t *testing.T) {
+	cases := map[string]map[string]any{
+		"non-numeric max_new_per_poll": {"max_new_per_poll": "ten"},
+		"negative max_new_per_poll":    {"max_new_per_poll": -1},
+		"unparseable min_age":          {"min_age": "soon"},
+		"negative min_age":             {"min_age": "-1m"},
+		"non-string min_age":           {"min_age": 5},
+		"unparseable lookback":         {"lookback": "forever"},
+		"zero lookback":                {"lookback": "0h"},
+	}
+	for name, extra := range cases {
+		cfg := map[string]any{"base_url": "https://abc.live.dynatrace.com", "api_token": "x"}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		a := &Adapter{}
+		if err := a.Connect(context.Background(), cfg); err == nil {
+			t.Errorf("%s: expected Connect error for %v", name, extra)
+		}
+	}
+}
+
+func TestPollSkipsProblemsWithoutID(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	broken := mkProblem("", "P-0", "NoID", started)
+	problems := []map[string]any{broken, mkProblem("ok", "P-1", "Fine", started)}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 || items[0].Metadata["problemId"] != "ok" {
+		t.Fatalf("expected only the identified problem, got %+v", items)
+	}
+}
+
+func TestPollStormCapZeroMeansUnlimited(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	var problems []map[string]any
+	for i := 0; i < 25; i++ {
+		problems = append(problems, mkProblem(fmt.Sprintf("pid-%d", i), fmt.Sprintf("P-%d", i), fmt.Sprintf("Problem %d", i), started))
+	}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, map[string]any{"max_new_per_poll": 0})
+
+	items, _ := a.Poll(context.Background(), time.Time{})
+	if len(items) != 25 {
+		t.Fatalf("max_new_per_poll=0 should disable the cap: got %d of 25", len(items))
+	}
+}
+
+func TestPollPrunesResolvedProblemsFromSeen(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	problems := []map[string]any{mkProblem("pid-1", "P-1", "Down", started)}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(a.seen) != 1 {
+		t.Fatalf("expected 1 tracked problem, got %d", len(a.seen))
+	}
+
+	// The problem resolves (disappears from the open set): it must be pruned
+	// so the seen map cannot grow without bound.
+	problems = []map[string]any{}
+	if _, err := a.Poll(context.Background(), time.Time{}); err != nil {
+		t.Fatalf("Poll after resolve: %v", err)
+	}
+	if len(a.seen) != 0 {
+		t.Errorf("resolved problem still tracked in seen (%d entries) — memory leak", len(a.seen))
+	}
+}
+
+func TestTitleFallbackAndKeyOnlyTags(t *testing.T) {
+	started := time.Now().Add(-time.Hour)
+	problems := []map[string]any{{
+		"problemId":     "pid-1",
+		"displayId":     "P-77",
+		"title":         "",
+		"impactLevel":   "SERVICES",
+		"severityLevel": "ERROR",
+		"status":        "OPEN",
+		"startTime":     started.UnixMilli(),
+		"endTime":       -1,
+		"entityTags": []map[string]any{
+			{"context": "CONTEXTLESS", "key": "canary", "stringRepresentation": "canary"},
+		},
+	}}
+	srv := newTestServer(t, &problems, nil)
+	a := connect(t, srv.URL, nil)
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Title != "problem P-77" {
+		t.Errorf("Title = %q, want displayId fallback", items[0].Title)
+	}
+	found := false
+	for _, l := range items[0].Labels {
+		if l == "canary" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Labels = %v, want key-only tag rendered as %q", items[0].Labels, "canary")
+	}
+}
+
+func TestPollPropagatesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.Poll(context.Background(), time.Time{}); err == nil {
+		t.Fatal("expected Poll to surface the API error")
+	}
+}
+
+func itemStub() model.SourceItem {
+	return model.SourceItem{ID: "pid-1", SourceID: "prod-problems"}
+}
+
+func resultStub() model.RunResult {
+	return model.RunResult{Success: true}
+}

--- a/src/internal/source/dynatrace/client.go
+++ b/src/internal/source/dynatrace/client.go
@@ -1,0 +1,146 @@
+package dynatrace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+const (
+	maxRetries  = 3
+	baseBackoff = time.Second
+
+	// pageSize is the maximum the problems API allows per page.
+	pageSize = 500
+)
+
+type client struct {
+	baseURL    string
+	apiToken   string
+	httpClient *http.Client
+}
+
+func newClient(baseURL, apiToken string) *client {
+	return &client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiToken:   apiToken,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// problems fetches every problem matching the selector from
+// GET /api/v2/problems, following nextPageKey pagination. from bounds the
+// problem start time (the API defaults to now-2h, which would hide older
+// still-open problems).
+func (c *client) problems(ctx context.Context, selector string, from time.Time) ([]problem, error) {
+	params := url.Values{
+		"pageSize": {strconv.Itoa(pageSize)},
+		"from":     {from.UTC().Format(time.RFC3339)},
+	}
+	if selector != "" {
+		params.Set("problemSelector", selector)
+	}
+
+	var all []problem
+	for {
+		data, err := c.get(ctx, "/api/v2/problems", params)
+		if err != nil {
+			return nil, err
+		}
+		var page problemsPage
+		if err := json.Unmarshal(data, &page); err != nil {
+			return nil, fmt.Errorf("dynatrace: decoding problems response: %w", err)
+		}
+		all = append(all, page.Problems...)
+		if page.NextPageKey == "" {
+			return all, nil
+		}
+		// Subsequent pages take ONLY nextPageKey; other params are rejected.
+		params = url.Values{"nextPageKey": {page.NextPageKey}}
+	}
+}
+
+// get executes the request, retrying on 429/5xx with exponential backoff
+// (honouring Retry-After when present).
+func (c *client) get(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	fullPath := path
+	if len(params) > 0 {
+		fullPath += "?" + params.Encode()
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+fullPath, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Authorization", "Api-Token "+c.apiToken)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			aplog.Debug("dynatrace: GET %s failed (attempt %d/%d): %v", path, attempt+1, maxRetries, err)
+			if !backoffWait(ctx, nil, attempt) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		aplog.Debug("dynatrace: GET %s → %d", path, resp.StatusCode)
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("dynatrace API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+			if !backoffWait(ctx, resp, attempt) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("dynatrace API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("dynatrace API GET %s: exceeded %d retries: %w", path, maxRetries, lastErr)
+}
+
+// backoffWait sleeps for the retry delay (Retry-After header if present,
+// exponential backoff otherwise). Returns false when the context was cancelled.
+func backoffWait(ctx context.Context, resp *http.Response, attempt int) bool {
+	wait := baseBackoff * (1 << attempt)
+	if resp != nil {
+		if h := resp.Header.Get("Retry-After"); h != "" {
+			if secs, err := strconv.Atoi(h); err == nil {
+				wait = time.Duration(secs) * time.Second
+			}
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(wait):
+		return true
+	}
+}
+
+func truncateBody(b []byte) string {
+	const max = 512
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "…"
+}

--- a/src/internal/source/dynatrace/client_test.go
+++ b/src/internal/source/dynatrace/client_test.go
@@ -1,0 +1,184 @@
+package dynatrace
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newClientServer builds a test server whose handler sees every request and a
+// client pointed at it.
+func newClientServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *client) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, newClient(srv.URL, "dt0c01.sekret")
+}
+
+func emptyPage(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(map[string]any{"totalCount": 0, "pageSize": 500, "problems": []any{}})
+}
+
+func TestClientSendsAPIToken(t *testing.T) {
+	var got string
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		emptyPage(w)
+	})
+
+	if _, err := c.problems(context.Background(), "", time.Now()); err != nil {
+		t.Fatalf("problems: %v", err)
+	}
+	if got != "Api-Token dt0c01.sekret" {
+		t.Errorf("Authorization = %q, want %q", got, "Api-Token dt0c01.sekret")
+	}
+}
+
+func TestClientFollowsPagination(t *testing.T) {
+	var calls atomic.Int32
+	var secondQuery map[string][]string
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			json.NewEncoder(w).Encode(map[string]any{
+				"totalCount":  2,
+				"pageSize":    1,
+				"nextPageKey": "KEY2",
+				"problems":    []map[string]any{{"problemId": "pid-1"}},
+			})
+			return
+		}
+		secondQuery = r.URL.Query()
+		json.NewEncoder(w).Encode(map[string]any{
+			"totalCount": 2,
+			"pageSize":   1,
+			"problems":   []map[string]any{{"problemId": "pid-2"}},
+		})
+	})
+
+	problems, err := c.problems(context.Background(), `status("open")`, time.Now())
+	if err != nil {
+		t.Fatalf("problems: %v", err)
+	}
+	if len(problems) != 2 || problems[0].ProblemID != "pid-1" || problems[1].ProblemID != "pid-2" {
+		t.Errorf("problems = %+v, want both pages in order", problems)
+	}
+	if got := secondQuery["nextPageKey"]; len(got) != 1 || got[0] != "KEY2" {
+		t.Errorf("page 2 nextPageKey = %v, want [KEY2]", secondQuery["nextPageKey"])
+	}
+	// Follow-up pages must carry ONLY nextPageKey — the API rejects repeats of
+	// the original params.
+	for _, banned := range []string{"problemSelector", "from", "pageSize"} {
+		if _, ok := secondQuery[banned]; ok {
+			t.Errorf("page 2 still carries %s param: %v", banned, secondQuery[banned])
+		}
+	}
+}
+
+func TestClientRetriesOn5xxThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) < 3 {
+			w.Header().Set("Retry-After", "0") // keep the test fast
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{"problems": []map[string]any{{"problemId": "pid-1"}}})
+	})
+
+	problems, err := c.problems(context.Background(), "", time.Now())
+	if err != nil {
+		t.Fatalf("problems after retries: %v", err)
+	}
+	if len(problems) != 1 || problems[0].ProblemID != "pid-1" {
+		t.Errorf("problems = %+v, want the one recovered problem", problems)
+	}
+	if n := calls.Load(); n != 3 {
+		t.Errorf("server saw %d requests, want 3 (2 failures + 1 success)", n)
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		emptyPage(w)
+	})
+
+	if _, err := c.problems(context.Background(), "", time.Now()); err != nil {
+		t.Fatalf("problems after 429: %v", err)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Errorf("server saw %d requests, want 2", n)
+	}
+}
+
+func TestClientRetryExhausted(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	_, err := c.problems(context.Background(), "", time.Now())
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "exceeded 3 retries") {
+		t.Errorf("error = %v, want mention of exhausted retries", err)
+	}
+	if n := calls.Load(); n != int32(maxRetries) {
+		t.Errorf("server saw %d requests, want %d", n, maxRetries)
+	}
+}
+
+func TestClientDoesNotRetryOn4xx(t *testing.T) {
+	var calls atomic.Int32
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "invalid selector", http.StatusBadRequest)
+	})
+
+	_, err := c.problems(context.Background(), "", time.Now())
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if !strings.Contains(err.Error(), "status 400") {
+		t.Errorf("error = %v, want status 400", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("server saw %d requests, want exactly 1 (4xx must not retry)", n)
+	}
+}
+
+func TestClientRejectsMalformedJSON(t *testing.T) {
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"problems": [`))
+	})
+
+	_, err := c.problems(context.Background(), "", time.Now())
+	if err == nil || !strings.Contains(err.Error(), "decoding problems response") {
+		t.Errorf("error = %v, want decode failure", err)
+	}
+}
+
+func TestClientContextCancelStopsRetries(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	_, c := newClientServer(t, func(w http.ResponseWriter, r *http.Request) {
+		cancel() // cancel while the first attempt is in flight
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := c.problems(ctx, "", time.Now()); err == nil {
+		t.Fatal("expected error when context is cancelled during retries")
+	}
+}

--- a/src/internal/source/dynatrace/types.go
+++ b/src/internal/source/dynatrace/types.go
@@ -1,0 +1,48 @@
+package dynatrace
+
+// problem is one entry of Dynatrace's GET /api/v2/problems response. Only the
+// fields the adapter consumes are declared.
+type problem struct {
+	ProblemID        string      `json:"problemId"`
+	DisplayID        string      `json:"displayId"`
+	Title            string      `json:"title"`
+	ImpactLevel      string      `json:"impactLevel"`   // INFRASTRUCTURE, SERVICES, APPLICATION, ENVIRONMENT
+	SeverityLevel    string      `json:"severityLevel"` // AVAILABILITY, ERROR, PERFORMANCE, RESOURCE_CONTENTION, CUSTOM_ALERT, ...
+	Status           string      `json:"status"`        // OPEN, RESOLVED, CLOSED
+	StartTime        int64       `json:"startTime"`     // ms since epoch
+	EndTime          int64       `json:"endTime"`       // ms since epoch, -1 while OPEN
+	AffectedEntities []entityRef `json:"affectedEntities"`
+	ImpactedEntities []entityRef `json:"impactedEntities"`
+	RootCauseEntity  *entityRef  `json:"rootCauseEntity"`
+	ManagementZones  []namedRef  `json:"managementZones"`
+	ProblemFilters   []namedRef  `json:"problemFilters"`
+	EntityTags       []entityTag `json:"entityTags"`
+}
+
+type entityRef struct {
+	EntityID struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"entityId"`
+	Name string `json:"name"`
+}
+
+type namedRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type entityTag struct {
+	Context              string `json:"context"`
+	Key                  string `json:"key"`
+	Value                string `json:"value"`
+	StringRepresentation string `json:"stringRepresentation"`
+}
+
+// problemsPage is the paginated envelope of GET /api/v2/problems.
+type problemsPage struct {
+	TotalCount  int       `json:"totalCount"`
+	PageSize    int       `json:"pageSize"`
+	NextPageKey string    `json:"nextPageKey"`
+	Problems    []problem `json:"problems"`
+}


### PR DESCRIPTION
## Summary

First Phase 2 item of #362: the **Dynatrace source adapter**, following the read-only monitoring-source shape introduced by the prometheus adapter (#357/#358) with a different client.

- Polls `GET /api/v2/problems` and maps each open problem to a task: `problemId` as the stable per-occurrence item ID (a recurrence gets a fresh ID → new dispatch), `displayId` as the human number, severity/impact/zone/entity tags as routable `key:value` labels, full problem context (root cause, affected entities) rendered into the description.
- `filters.labels` → `problemSelector` criteria: `severity=`/`impact=`/`managementZone=` map to the corresponding selector functions, generic `key=value` pairs match entity tags, raw criteria like `displayId("P-123")` pass through, bare words match the title.
- Client: `Api-Token` auth, 429/5xx retry with `Retry-After`, `nextPageKey` pagination (follow-up pages carry only the key, as the API requires), and an explicit `from=` lookback window (default 30d) because the API's 2h default would silently hide older still-open problems.
- Same guardrails as prometheus: `max_new_per_poll` storm cap (oldest first, overflow deferred) and `min_age` flap dampener.
- Read-only: `Acknowledge`/`WriteResult` are no-ops and no optional write capability is implemented, so the #357 capability lint rejects `set_state`/`add_labels`/approvals/`wait_for` ci/`materialize` against this source. Comment write-back (`problems.write`) left as a future opt-in.
- Wiring: registered in `cmd/apiary`, covered by the real-registry caps wiring test, schema enum + docs page + supported-integrations + example config updated.

Part of #362 (Dynatrace item). Webhook push, plugin-source bridge, and the remaining items stay open on that issue.

## Test plan

- `go test ./internal/source/dynatrace/...` — 16 new tests: item mapping, ID stability across polls and re-occurrence, storm cap (incl. 0 = unlimited), min-age dampening, seen-map pruning, selector building, pagination, auth header, retry/backoff behavior, error propagation, config rejection.
- `go test ./internal/cli/` — capability wiring test now asserts dynatrace presents as all-false (read-only) against the real registry.
- Full `go test ./...`, `go vet`, `gofmt` clean.