### PR TITLE
feat(source): generic webhook source — push events into workflows via daemon HTTP listener (#362)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -170,6 +170,33 @@ sources:
       # match entity tags; raw criteria like displayId("P-123") pass through.
       labels: ["severity=availability", "managementZone=Prod"]
 
+  - id: alert-hooks
+    type: webhook
+    # Push-mode source: senders POST JSON to the daemon's webhook listener at
+    # /webhook/alert-hooks (requires settings.webhook.listen). Deliveries
+    # dispatch immediately; poll_interval is only the fallback cadence.
+    # Read-only source like prometheus/dynatrace: publish findings to a
+    # ticket source.
+    config:
+      # Shared secret for the selected auth mode (required unless auth: none).
+      secret: ${WEBHOOK_SECRET}
+      # bearer (default): Authorization: Bearer <secret> on every delivery.
+      # hmac: X-Apiary-Timestamp + X-Apiary-Signature (sha256=<hex HMAC over
+      #   "<timestamp>.<body>">), with replay protection inside `tolerance`.
+      # none: accept everything — only behind a trusted network boundary.
+      auth: bearer
+      # generic (default): one JSON object (or array / {"events": [...]}) with
+      #   optional id/title/description/labels/priority/state/url fields.
+      # alertmanager: the webhook_configs payload — firing alerts map exactly
+      #   like the prometheus poll source (fingerprint:startsAt identity).
+      format: alertmanager
+      # max_pending: 100        # pending-queue bound; overflow gets 429
+      # max_body_bytes: 1048576 # per-delivery body cap; larger gets 413
+      # tolerance: 5m           # hmac timestamp window
+    filters:
+      # Delivery-time filters: every label must be present on the event.
+      labels: ["severity=critical"]
+
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:
   # === Claude-based agents (original design) ===
@@ -498,6 +525,12 @@ workflows:
 settings:
   concurrency: 2
   log_level: info
+  # Inbound webhook listener for push-mode sources (type: webhook). Each
+  # push-capable source mounts at POST /webhook/{source-id}; GET /healthz
+  # answers 200. Plain HTTP — put a TLS-terminating reverse proxy in front
+  # on untrusted networks. Empty/absent disables the listener.
+  webhook:
+    listen: 127.0.0.1:8090
   state_lock: true
   # Stop re-dispatching a (task, workflow) after this many consecutive failed
   # instances (rate-limited runs fail over and don't count). <=0 disables.

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -71,6 +71,23 @@ workflow dispatches.
 - **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
 - **Setup:** See [Dynatrace Source configuration](dynatrace-source.md)
 
+### Webhook (generic push)
+
+**Status:** ✅ Stable | **Auth:** Shared-secret bearer or HMAC signature
+
+Push-mode source: anything that can POST JSON delivers events straight to the
+daemon's webhook listener — Alertmanager `webhook_configs`, Loki ruler,
+Elastic Watcher, CI scripts. Deliveries dispatch immediately (no poll-interval
+latency) and the Alertmanager format keeps the same dedup identity as the
+Prometheus poll source.
+
+- **Requirements:** `settings.webhook.listen` set on the daemon; TLS-terminating
+  reverse proxy recommended on untrusted networks
+- **Guardrails:** Bounded pending queue (429 on overflow), body-size cap, and
+  HMAC replay protection built in
+- **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
+- **Setup:** See [Webhook Source configuration](webhook-source.md)
+
 ### Linear
 
 **Status:** 🔄 Planned | **Auth:** API token

--- a/docs/webhook-source.md
+++ b/docs/webhook-source.md
@@ -1,0 +1,172 @@
+# Webhook Source
+
+The `webhook` source adapter is **push-mode**: anything that can POST JSON —
+Alertmanager `webhook_configs`, Loki ruler, Elastic Watcher, a CI script, a
+`curl` in a cron job — delivers events to the daemon, and each accepted event
+becomes an Apiary task routed through normal workflow trigger matching
+(labels, states, `title_regex`). It is the push counterpart of the
+[Prometheus](prometheus-source.md) and [Dynatrace](dynatrace-source.md) poll
+sources.
+
+Two pieces work together:
+
+- **`settings.webhook.listen`** starts one daemon-wide HTTP listener. Every
+  push-capable source is mounted at `POST /webhook/{source-id}`; `GET
+  /healthz` answers 200 for probes.
+- **`sources[].type: webhook`** declares a receiving source and owns its own
+  authentication, payload format, and storm limits.
+
+## Configuration
+
+```yaml
+settings:
+  webhook:
+    listen: 127.0.0.1:8090        # daemon-wide inbound listener
+
+sources:
+  - id: alert-hooks
+    type: webhook
+    poll_interval: 60s            # fallback cadence; deliveries dispatch immediately
+    config:
+      secret: ${WEBHOOK_SECRET}
+      auth: bearer                # bearer (default) | hmac | none
+      format: alertmanager        # generic (default) | alertmanager
+    filters:
+      labels: ["severity=critical"]
+
+workflows:
+  - id: investigate-alert
+    trigger:
+      match: { source: alert-hooks }
+      once: true
+    steps:
+      - id: investigate
+        agent: sre-investigator
+```
+
+A `webhook` source without `settings.webhook.listen` is rejected at
+validation — it could never receive anything.
+
+### `config` fields
+
+| Field | Required | Description |
+|---|---|---|
+| `secret` | yes, unless `auth: none` | Shared secret used by the selected auth mode |
+| `auth` | no | `bearer` (default): senders put the secret in `Authorization: Bearer …`. `hmac`: senders sign each delivery (below). `none`: accept everything — explicit opt-out, only behind a trusted network boundary |
+| `format` | no | `generic` (default) or `alertmanager` (the Alertmanager `webhook_configs` payload) |
+| `max_pending` | no | Bounds the in-memory queue of not-yet-dispatched events; overflow deliveries get `429` so the sender's retry re-delivers later. Default `100` |
+| `max_body_bytes` | no | Per-delivery body cap; larger bodies get `413`. Default `1048576` (1 MiB) |
+| `tolerance` | no | HMAC-mode timestamp window (e.g. `"5m"`). Default `5m` |
+
+### `filters`
+
+Applied at delivery time, before enqueueing:
+
+| Field | Description |
+|---|---|
+| `labels` | Every entry (`key=value` or `key:value`) must be present on the event |
+| `states` | When set, the event's state must be one of these (e.g. `["firing"]`) |
+
+## Authentication
+
+The listener serves plain HTTP. On anything but a loopback/private network,
+put it behind a TLS-terminating reverse proxy — both auth modes assume the
+transport hides headers and bodies from onlookers.
+
+### `auth: bearer` (default)
+
+Every delivery must carry `Authorization: Bearer <secret>`. This is what
+Alertmanager's `webhook_configs` can produce natively:
+
+```yaml
+# alertmanager.yml
+receivers:
+  - name: apiary
+    webhook_configs:
+      - url: https://hooks.example.com/webhook/alert-hooks
+        http_config:
+          authorization:
+            credentials: <the source's secret>
+```
+
+### `auth: hmac`
+
+For senders that can compute a signature (scripts, watchers, your own
+services). Each delivery carries:
+
+```
+X-Apiary-Timestamp: <unix seconds>
+X-Apiary-Signature: sha256=<hex of HMAC-SHA256(secret, "<timestamp>.<raw body>")>
+```
+
+Replay protection is built in: the timestamp is bound into the signature and
+must be within `tolerance` of the daemon's clock, and a signature already
+seen inside the window is rejected. Example sender:
+
+```bash
+ts=$(date +%s)
+body='{"title":"deploy failed","labels":{"service":"api"}}'
+sig=$(printf '%s.%s' "$ts" "$body" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" -r | cut -d' ' -f1)
+curl -X POST "https://hooks.example.com/webhook/alert-hooks" \
+  -H "X-Apiary-Timestamp: $ts" \
+  -H "X-Apiary-Signature: sha256=$sig" \
+  -d "$body"
+```
+
+## Payload formats
+
+### `format: generic`
+
+One JSON object per event; batches as a top-level array or an
+`{"events": [...]}` envelope. All fields optional:
+
+| Field | Maps to |
+|---|---|
+| `id` | Task identity — a sender that retries the same `id` never dispatches twice while the first run lives. Defaults to a hash of the body |
+| `title` (or `summary`) | Task title. Default `webhook event <id>` |
+| `description` | Task description body (the full payload is always appended as JSON) |
+| `labels` | Routable labels; object `{"k":"v"}` or array `["k:v", "k=v"]` |
+| `priority` (or `severity`) | Task priority |
+| `state` | Task state; default `open` |
+| `url` | Deep link back to the sender |
+
+### `format: alertmanager`
+
+The Alertmanager webhook payload (version 4). Each **firing** alert in the
+delivery becomes one task with exactly the same mapping and identity scheme
+as the [prometheus poll source](prometheus-source.md)
+(`fingerprint:startsAt`, alert labels as `key:value` task labels, summary and
+annotations rendered into the description) — so switching a fleet from poll
+to push keeps dedup semantics. `resolved` notifications are ignored.
+
+## Behavior
+
+- **Immediate dispatch** — a delivery wakes the source's poll loop, so
+  routing happens right away; `poll_interval` is only the fallback cadence.
+- **Exactly-once per event ID** — re-deliveries of an event still queued are
+  dropped; re-deliveries after dispatch are shadowed by the persisted
+  task/instance dedup, like any polled item.
+- **Storm guard** — the pending queue is bounded (`max_pending`); overflow
+  gets `429 queue full, retry later` and is never silently dropped.
+- **Read-only source** — like the other monitoring sources, webhook events
+  accept no write-backs: `Acknowledge`/`WriteResult` are no-ops, and
+  validation rejects workflows that need `set_state`, label writes,
+  approvals, or `wait_for: ci` against this source.
+
+### Response codes
+
+| Code | Meaning |
+|---|---|
+| `202` | Accepted; body reports `{"accepted":N,"dropped":M}` |
+| `400` | Unparseable payload |
+| `401` | Auth failed (bad token, bad/stale/replayed signature) |
+| `405` | Not a POST |
+| `413` | Body over `max_body_bytes` |
+| `429` | Queue full — retry later |
+
+## Where results go
+
+Same answer as the other read-only monitoring sources: nowhere on the
+sender's side. Give the workflow a step that publishes findings — a comment
+or issue via `APIARY_PUBLISH`, or a spawned follow-up task via
+`APIARY_SPAWN` — on a ticket source (GitHub, Jira, Plane).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Plane: plane-source.md
       - Prometheus: prometheus-source.md
       - Dynatrace: dynatrace-source.md
+      - Webhook: webhook-source.md
   - Reference:
       - CLI: cli.md
       - Dashboard: dashboard.md

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -151,11 +151,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "jira", "plane", "prometheus", "dynatrace"]
+            "enum": ["github", "jira", "plane", "prometheus", "dynatrace", "webhook"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. webhook: secret, auth (bearer|hmac|none), format (generic|alertmanager), max_pending, max_body_bytes, tolerance — requires settings.webhook.listen",
             "additionalProperties": true
           },
           "poll_interval": {
@@ -671,6 +671,14 @@
               "items": { "type": "string" },
               "minItems": 1
             }
+          }
+        },
+        "webhook": {
+          "type": "object",
+          "description": "Inbound webhook listener for push-mode sources. Each push-capable source is mounted at POST /webhook/{source-id}",
+          "additionalProperties": false,
+          "properties": {
+            "listen": { "type": "string", "description": "TCP address for inbound webhooks, for example 127.0.0.1:8090. Empty disables the listener. Serve behind a TLS-terminating reverse proxy on untrusted networks" }
           }
         },
         "queue": {

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
 	_ "github.com/orlandoburli/apiary/internal/source/plane"
 	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
+	_ "github.com/orlandoburli/apiary/internal/source/webhook"
 
 	_ "github.com/orlandoburli/apiary/internal/runner/providers"
 )

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -24,6 +24,16 @@ func init() {
 		_, ok = a.(source.BlockerLister)
 		return ok
 	}
+	// Push capability: a fresh instance's WebhookHandler is non-nil for push
+	// sources even before Connect, so validation can require
+	// settings.webhook.listen at lint time.
+	config.SourcePushCapable = func(sourceType string) bool {
+		a, ok := source.New(sourceType)
+		if !ok {
+			return false
+		}
+		return a.WebhookHandler() != nil
+	}
 	config.SourceSupportsPREvents = func(sourceType string) bool {
 		a, ok := source.New(sourceType)
 		if !ok {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -350,12 +350,25 @@ type Settings struct {
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
 	Queue         QueueSettings      `yaml:"queue"`
+	Webhook       WebhookSettings    `yaml:"webhook"`
 	// DefaultFallbacks is a fallback chain applied to every agent that does not
 	// define its own fallbacks[]. Entries must reference defined runner IDs.
 	DefaultFallbacks []FallbackConfig `yaml:"default_fallbacks,omitempty"`
 	// CreditExhaustedCooldown is how long a runner type is paused after a
 	// credit-exhausted failure. Default "24h".
 	CreditExhaustedCooldown string `yaml:"credit_exhausted_cooldown,omitempty"`
+}
+
+// WebhookSettings controls the daemon's inbound webhook listener. When Listen
+// is set, every push-capable source (adapter with a non-nil WebhookHandler,
+// e.g. type "webhook") is mounted at POST /webhook/{source-id}. The listener
+// serves plain HTTP — put it behind a TLS-terminating reverse proxy when
+// senders deliver over untrusted networks; per-source authentication
+// (shared-secret bearer or HMAC) lives in the source config.
+type WebhookSettings struct {
+	// Listen is the TCP address for inbound webhooks (e.g. "127.0.0.1:8090"
+	// or ":8090"). Empty disables the listener.
+	Listen string `yaml:"listen,omitempty"`
 }
 
 // QueueSettings controls durable dispatch and the embedded protocol-1 worker.

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -50,6 +50,14 @@ var SourceCapabilities func(sourceType string) SourceCaps
 // skipped.
 var SourceSupportsDependencyWait func(sourceType string) bool
 
+// SourcePushCapable reports whether a source type's adapter accepts pushed
+// deliveries (returns a non-nil WebhookHandler), which requires the daemon's
+// webhook listener (settings.webhook.listen). The cli package injects it
+// (config cannot import the source package without inverting the dependency
+// direction). When nil — configs built in code, isolated tests — the check is
+// skipped.
+var SourcePushCapable func(sourceType string) bool
+
 // SourceSupportsPREvents reports whether a source type's adapter can poll
 // pull-request events (implements source.PREventPoller), which a workflow
 // trigger with an `on:` event kind requires. The cli package injects it (config
@@ -164,6 +172,12 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("sources[%d]: duplicate id %q", i, s.ID))
 		}
 		sourceIDs[s.ID] = true
+
+		// A push source without the daemon listener can never receive a
+		// delivery — dead config, rejected loudly.
+		if SourcePushCapable != nil && SourcePushCapable(s.Type) && strings.TrimSpace(c.Settings.Webhook.Listen) == "" {
+			errs = append(errs, fmt.Errorf("sources[%d] %q: type %q receives pushed events and requires settings.webhook.listen (e.g. \"127.0.0.1:8090\")", i, s.ID, s.Type))
+		}
 	}
 
 	agentIDs := map[string]bool{}

--- a/src/internal/config/webhook_validate_test.go
+++ b/src/internal/config/webhook_validate_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// pushConfig is a minimal valid config with one webhook-type source.
+func pushConfig(listen string) *Config {
+	return &Config{
+		Version: "1",
+		Sources: []SourceConfig{{ID: "hooks", Type: "webhook", Config: map[string]any{"secret": "s"}}},
+		Settings: Settings{
+			Webhook: WebhookSettings{Listen: listen},
+		},
+	}
+}
+
+func TestPushSourceRequiresWebhookListen(t *testing.T) {
+	prev := SourcePushCapable
+	defer func() { SourcePushCapable = prev }()
+	SourcePushCapable = func(sourceType string) bool { return sourceType == "webhook" }
+
+	errs := pushConfig("").Validate()
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "settings.webhook.listen") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("webhook source without settings.webhook.listen should error, got: %v", errs)
+	}
+
+	for _, err := range pushConfig("127.0.0.1:8090").Validate() {
+		if strings.Contains(err.Error(), "settings.webhook.listen") {
+			t.Errorf("listen set — unexpected error: %v", err)
+		}
+	}
+
+	// Hook not injected (isolated tests): check skipped.
+	SourcePushCapable = nil
+	for _, err := range pushConfig("").Validate() {
+		if strings.Contains(err.Error(), "settings.webhook.listen") {
+			t.Errorf("nil hook — check must be skipped, got: %v", err)
+		}
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -49,8 +49,15 @@ type Dispatcher struct {
 	configFile string
 	startedAt  time.Time
 
-	router      *router.Router
-	sources     map[string]source.Adapter
+	router  *router.Router
+	sources map[string]source.Adapter
+	// sourceWake holds a 1-buffered wake channel per push-capable source
+	// (adapter implementing SetWake): a webhook delivery signals it and the
+	// source's poll loop runs immediately instead of waiting out its interval.
+	sourceWake map[string]chan struct{}
+	// webhookAddr is the bound webhook listener address (string), set by
+	// startWebhookServer; empty until the listener is up.
+	webhookAddr atomic.Value
 	runners     map[string]runnerimpl.Runner
 	agentRunner map[string]string
 	// agentFallbacks holds each agent's rate-limit failover chain (primary
@@ -209,6 +216,7 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		startedAt:       time.Now(),
 		router:          r,
 		sources:         make(map[string]source.Adapter),
+		sourceWake:      make(map[string]chan struct{}),
 		runners:         make(map[string]runnerimpl.Runner),
 		agentRunner:     make(map[string]string),
 		agentFallbacks:  make(map[string][]runnerCandidate),
@@ -291,6 +299,21 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 		}); ok {
 			js.SetJQL(sc.Filters.JQL)
 		}
+		// Push-capable adapters get a wake channel: a webhook delivery nudges
+		// the source's poll loop for immediate dispatch instead of waiting out
+		// the poll interval. Wired here, before StartServer mounts the webhook
+		// listener, so no delivery can race an unset callback.
+		if ws, ok := adapter.(interface{ SetWake(func()) }); ok {
+			ch := make(chan struct{}, 1)
+			d.sourceWake[sc.ID] = ch
+			ws.SetWake(func() {
+				select {
+				case ch <- struct{}{}:
+				default: // a wake is already pending
+				}
+			})
+		}
+
 		d.sources[sc.ID] = adapter
 		d.stats[sc.ID] = &sourceStat{}
 	}
@@ -584,7 +607,7 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			d.pollLoop(ctx, sc, adapter)
+			d.pollLoop(ctx, sc, adapter, d.sourceWake[sc.ID])
 		}()
 	}
 }
@@ -1326,12 +1349,20 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		_ = srv.Close()
 		return err
 	}
+	if err := d.startWebhookServer(ctx, wg); err != nil {
+		_ = srv.Close()
+		return err
+	}
 
 	return nil
 }
 
-// pollLoop polls a single source on its configured interval.
-func (d *Dispatcher) pollLoop(ctx context.Context, sc config.SourceConfig, adapter source.Adapter) {
+// pollLoop polls a single source on its configured interval. wake, when
+// non-nil, triggers an immediate extra poll — push sources (webhook) signal it
+// on delivery so dispatch latency is not bound to the poll interval. A nil
+// wake channel blocks forever in the select, so poll-only sources are
+// unaffected.
+func (d *Dispatcher) pollLoop(ctx context.Context, sc config.SourceConfig, adapter source.Adapter, wake <-chan struct{}) {
 	interval, err := sc.ParsedPollInterval()
 	if err != nil {
 		aplog.Error("source %s: invalid poll_interval: %v — using 60s", sc.ID, err)
@@ -1350,6 +1381,9 @@ func (d *Dispatcher) pollLoop(ctx context.Context, sc config.SourceConfig, adapt
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			d.poll(ctx, sc, adapter, lastPoll)
+			lastPoll = time.Now()
+		case <-wake:
 			d.poll(ctx, sc, adapter, lastPoll)
 			lastPoll = time.Now()
 		}

--- a/src/internal/daemon/webhook_server.go
+++ b/src/internal/daemon/webhook_server.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+// startWebhookServer starts the inbound webhook listener
+// (settings.webhook.listen) and mounts every push-capable source — an adapter
+// whose WebhookHandler() is non-nil — at POST /webhook/{source-id}. The
+// adapter owns authentication (bearer/HMAC) and payload parsing; the daemon
+// only routes by path. No-op when settings.webhook.listen is empty (config
+// validation already rejects webhook-type sources without it) or when no
+// configured source can receive pushes.
+func (d *Dispatcher) startWebhookServer(ctx context.Context, wg *sync.WaitGroup) error {
+	address := strings.TrimSpace(d.cfg.Settings.Webhook.Listen)
+	if address == "" {
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mounted := 0
+	for id, adapter := range d.sources {
+		handler := adapter.WebhookHandler()
+		if handler == nil {
+			continue
+		}
+		path := "/webhook/" + id
+		mux.Handle(path, handler)
+		mounted++
+		aplog.Info("webhook: source %s mounted at POST %s", id, path)
+	}
+	if mounted == 0 {
+		aplog.Warn("settings.webhook.listen is set but no configured source accepts pushes — webhook listener not started")
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return fmt.Errorf("listen for webhooks on %s: %w", address, err)
+	}
+	d.webhookAddr.Store(listener.Addr().String())
+	server := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			aplog.Error("webhook server: %v", err)
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	aplog.Info("webhook listener on %s (%d source(s) mounted)", listener.Addr(), mounted)
+	return nil
+}

--- a/src/internal/daemon/webhook_server_test.go
+++ b/src/internal/daemon/webhook_server_test.go
@@ -1,0 +1,122 @@
+package daemon
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// pushAdapter is a minimal push-capable source: it records deliveries and
+// exposes a trivial WebhookHandler.
+type pushAdapter struct {
+	mu       sync.Mutex
+	received []string
+}
+
+func (a *pushAdapter) ID() string                                    { return "push" }
+func (a *pushAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *pushAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (a *pushAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *pushAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *pushAdapter) WebhookHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		a.mu.Lock()
+		a.received = append(a.received, string(body))
+		a.mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	})
+}
+
+func TestStartWebhookServerRoutesBySource(t *testing.T) {
+	push := &pushAdapter{}
+	poll := &fanoutAdapter{}
+	d := &Dispatcher{
+		cfg: &config.Config{Settings: config.Settings{
+			Webhook: config.WebhookSettings{Listen: "127.0.0.1:0"},
+		}},
+		sources: map[string]source.Adapter{"push-src": push, "poll-src": poll},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	// Cancel first, then wait: the server goroutines only exit on ctx.Done().
+	defer wg.Wait()
+	defer cancel()
+	if err := d.startWebhookServer(ctx, &wg); err != nil {
+		t.Fatalf("startWebhookServer: %v", err)
+	}
+
+	base := "http://" + d.webhookAddr.Load().(string)
+
+	resp, err := http.Post(base+"/webhook/push-src", "application/json", strings.NewReader(`{"id":"e1"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("push-src: got %d, want 202", resp.StatusCode)
+	}
+	push.mu.Lock()
+	got := len(push.received)
+	push.mu.Unlock()
+	if got != 1 {
+		t.Errorf("adapter received %d deliveries, want 1", got)
+	}
+
+	// Poll-only sources are not mounted; unknown paths 404.
+	for _, path := range []string{"/webhook/poll-src", "/webhook/nope"} {
+		resp, err := http.Post(base+path, "application/json", strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatalf("post %s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("%s: got %d, want 404", path, resp.StatusCode)
+		}
+	}
+
+	resp, err = http.Get(base + "/healthz")
+	if err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthz: got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestStartWebhookServerNoops(t *testing.T) {
+	// Empty listen: no-op.
+	d := &Dispatcher{cfg: &config.Config{}, sources: map[string]source.Adapter{"push": &pushAdapter{}}}
+	var wg sync.WaitGroup
+	if err := d.startWebhookServer(context.Background(), &wg); err != nil {
+		t.Errorf("empty listen: %v", err)
+	}
+
+	// Listen set but no push-capable source: warns and does not listen.
+	d = &Dispatcher{
+		cfg: &config.Config{Settings: config.Settings{
+			Webhook: config.WebhookSettings{Listen: "127.0.0.1:0"},
+		}},
+		sources: map[string]source.Adapter{"poll": &fanoutAdapter{}},
+	}
+	if err := d.startWebhookServer(context.Background(), &wg); err != nil {
+		t.Errorf("no push sources: %v", err)
+	}
+	wg.Wait()
+}

--- a/src/internal/source/webhook/adapter.go
+++ b/src/internal/source/webhook/adapter.go
@@ -1,0 +1,327 @@
+// Package webhook provides a push-mode source adapter: anything that can POST
+// JSON (Alertmanager webhook_configs, Loki ruler, Elastic Watcher, custom
+// scripts) delivers events to the daemon's webhook listener, and each accepted
+// event becomes an Apiary SourceItem routed through the normal workflow
+// trigger matching (labels, states, title_regex).
+//
+// The adapter itself owns request authentication (shared-secret bearer or
+// HMAC signatures with replay protection), payload parsing (generic JSON or
+// the Alertmanager webhook format), and a bounded in-memory queue that the
+// dispatcher drains via Poll. The daemon mounts WebhookHandler() at
+// POST /webhook/{source-id} on the listener configured by
+// settings.webhook.listen (see daemon.startWebhookServer).
+//
+// Like the prometheus poll source, webhook events are read-only work items:
+// none of the optional write capabilities are implemented, Acknowledge and
+// WriteResult are no-ops, and config validation rejects workflows that need
+// write capabilities against this source (config.SourceCapabilities).
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func init() {
+	source.Register("webhook", func() source.Adapter { return &Adapter{} })
+}
+
+const (
+	// defaultMaxPending bounds the in-memory event queue between polls — the
+	// push-side storm guardrail, sibling of the prometheus adapter's
+	// max_new_per_poll. Overflow deliveries are rejected with 429 so the
+	// sender's own retry policy re-delivers once the queue drains.
+	defaultMaxPending = 100
+
+	// defaultMaxBodyBytes caps a single delivery's body.
+	defaultMaxBodyBytes = 1 << 20 // 1 MiB
+
+	// defaultTolerance is the HMAC timestamp window: signed deliveries older
+	// (or further in the future) than this are rejected, and signatures seen
+	// within the window are cached to block replays.
+	defaultTolerance = 5 * time.Minute
+)
+
+// Adapter implements source.Adapter for pushed JSON events.
+type Adapter struct {
+	id string
+
+	authMode     string // "bearer", "hmac", or "none"
+	secret       string
+	format       string // "generic" or "alertmanager"
+	maxPending   int
+	maxBodyBytes int64
+	tolerance    time.Duration
+
+	filterStates []string // lowercased; empty = accept any state
+	filterLabels []string // normalized "key:value", lowercased; all must match
+
+	mu     sync.Mutex
+	queue  []model.SourceItem
+	queued map[string]struct{}  // item IDs currently in the queue (drop re-deliveries)
+	wake   func()               // set by the dispatcher; nudges an immediate poll
+	seen   map[string]time.Time // hmac replay cache: signature → expiry
+
+	now func() time.Time // test hook; time.Now when nil
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+// SetID sets the source ID for this adapter.
+func (a *Adapter) SetID(id string) { a.id = id }
+
+// SetWake registers a callback invoked whenever a delivery enqueues at least
+// one event, so the dispatcher can poll immediately instead of waiting out the
+// source's poll interval.
+func (a *Adapter) SetWake(f func()) {
+	a.mu.Lock()
+	a.wake = f
+	a.mu.Unlock()
+}
+
+// Connect validates config. No outbound connection is made — the adapter only
+// receives.
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	a.secret, _ = cfg["secret"].(string)
+
+	a.authMode = "bearer"
+	if v, ok := cfg["auth"]; ok {
+		s, _ := v.(string)
+		switch s {
+		case "bearer", "hmac", "none":
+			a.authMode = s
+		default:
+			return fmt.Errorf("webhook: config.auth must be \"bearer\", \"hmac\", or \"none\", got %v", v)
+		}
+	}
+	if a.authMode == "none" {
+		aplog.Warn("webhook %s: auth \"none\" — every POST to this source's path is accepted; only use behind a trusted network boundary", a.id)
+	} else if a.secret == "" {
+		return fmt.Errorf("webhook: config.secret is required (or set auth: \"none\" explicitly to accept unauthenticated deliveries)")
+	}
+
+	a.format = "generic"
+	if v, ok := cfg["format"]; ok {
+		s, _ := v.(string)
+		switch s {
+		case "generic", "alertmanager":
+			a.format = s
+		default:
+			return fmt.Errorf("webhook: config.format must be \"generic\" or \"alertmanager\", got %v", v)
+		}
+	}
+
+	a.maxPending = defaultMaxPending
+	if v, ok := cfg["max_pending"]; ok {
+		n, err := toInt(v)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("webhook: config.max_pending must be a positive integer, got %v", v)
+		}
+		a.maxPending = n
+	}
+
+	a.maxBodyBytes = defaultMaxBodyBytes
+	if v, ok := cfg["max_body_bytes"]; ok {
+		n, err := toInt(v)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("webhook: config.max_body_bytes must be a positive integer, got %v", v)
+		}
+		a.maxBodyBytes = int64(n)
+	}
+
+	a.tolerance = defaultTolerance
+	if v, ok := cfg["tolerance"]; ok {
+		s, _ := v.(string)
+		d, err := time.ParseDuration(s)
+		if err != nil || d <= 0 {
+			return fmt.Errorf("webhook: config.tolerance must be a positive duration (e.g. \"5m\"), got %v", v)
+		}
+		a.tolerance = d
+	}
+
+	a.queued = map[string]struct{}{}
+	a.seen = map[string]time.Time{}
+
+	aplog.Info("webhook %s: configured  auth=%s  format=%s  max_pending=%d  max_body_bytes=%d",
+		a.id, a.authMode, a.format, a.maxPending, a.maxBodyBytes)
+	return nil
+}
+
+// SetFilters stores trigger-side filters applied on delivery: an event is
+// enqueued only when its state matches filters.states (if set) and it carries
+// every filters.labels entry ("key:value" or "key=value").
+func (a *Adapter) SetFilters(states, labels []string) {
+	for _, s := range states {
+		a.filterStates = append(a.filterStates, strings.ToLower(strings.TrimSpace(s)))
+	}
+	for _, l := range labels {
+		a.filterLabels = append(a.filterLabels, normalizeLabel(l))
+	}
+}
+
+func normalizeLabel(l string) string {
+	l = strings.ToLower(strings.TrimSpace(l))
+	if k, v, ok := strings.Cut(l, "="); ok {
+		return strings.TrimSpace(k) + ":" + strings.TrimSpace(v)
+	}
+	return l
+}
+
+// matchesFilters reports whether an item passes the configured source filters.
+func (a *Adapter) matchesFilters(item model.SourceItem) bool {
+	if len(a.filterStates) > 0 {
+		ok := false
+		state := strings.ToLower(item.State)
+		for _, s := range a.filterStates {
+			if s == state {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	if len(a.filterLabels) == 0 {
+		return true
+	}
+	have := make(map[string]struct{}, len(item.Labels))
+	for _, l := range item.Labels {
+		have[strings.ToLower(l)] = struct{}{}
+	}
+	for _, want := range a.filterLabels {
+		if _, ok := have[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// enqueue adds items to the pending queue, skipping IDs already queued
+// (sender re-deliveries between polls) and rejecting overflow past
+// max_pending. Returns accepted and dropped-for-overflow counts.
+func (a *Adapter) enqueue(items []model.SourceItem) (accepted, dropped int) {
+	a.mu.Lock()
+	var wake func()
+	for _, item := range items {
+		if _, ok := a.queued[item.ID]; ok {
+			continue // duplicate delivery of an event still awaiting a poll
+		}
+		if len(a.queue) >= a.maxPending {
+			dropped++
+			continue
+		}
+		a.queued[item.ID] = struct{}{}
+		a.queue = append(a.queue, item)
+		accepted++
+	}
+	if accepted > 0 {
+		wake = a.wake
+	}
+	a.mu.Unlock()
+	if wake != nil {
+		wake()
+	}
+	return accepted, dropped
+}
+
+// Poll drains the pending queue. The since parameter is ignored: delivery
+// order and dedup are handled at enqueue time, and re-dispatch of an already
+// dispatched event ID is prevented downstream by the persisted task/instance
+// dedup, exactly as for polled sources.
+func (a *Adapter) Poll(_ context.Context, _ time.Time) ([]model.SourceItem, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	items := a.queue
+	a.queue = nil
+	a.queued = map[string]struct{}{}
+	return items, nil
+}
+
+// Acknowledge is a no-op: a pushed event has no source-side state to set.
+func (a *Adapter) Acknowledge(_ context.Context, cell model.SourceItem, action model.AckAction) error {
+	aplog.Debug("webhook %s: acknowledge %s (%s) — no-op for pushed events", a.id, cell.LogLabel(), action)
+	return nil
+}
+
+// WriteResult is a no-op: the sender is fire-and-forget. The intended pattern
+// is a workflow step that publishes findings to a ticket source
+// (APIARY_PUBLISH / APIARY_SPAWN) instead.
+func (a *Adapter) WriteResult(_ context.Context, cell model.SourceItem, result model.RunResult) error {
+	aplog.Debug("webhook %s: write result for %s (success=%v) — no-op for pushed events", a.id, cell.LogLabel(), result.Success)
+	return nil
+}
+
+// WebhookHandler serves POST deliveries: authenticates, parses per the
+// configured format, applies source filters, and enqueues. Non-nil even
+// before Connect so config validation can probe push capability on a fresh
+// instance.
+func (a *Adapter) WebhookHandler() http.Handler {
+	return http.HandlerFunc(a.serveHTTP)
+}
+
+func (a *Adapter) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := readBody(w, r, a.maxBodyBytes)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	if err := a.authenticate(r, body); err != nil {
+		aplog.Warn("webhook %s: rejected delivery from %s: %v", a.id, r.RemoteAddr, err)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	items, err := a.parse(body)
+	if err != nil {
+		aplog.Warn("webhook %s: unparseable delivery from %s: %v", a.id, r.RemoteAddr, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	filtered := items[:0]
+	for _, item := range items {
+		if a.matchesFilters(item) {
+			filtered = append(filtered, item)
+		}
+	}
+
+	accepted, dropped := a.enqueue(filtered)
+	if dropped > 0 {
+		aplog.Warn("webhook %s: queue full — %d event(s) rejected (max_pending=%d); sender should retry", a.id, dropped, a.maxPending)
+	}
+	if accepted == 0 && dropped > 0 {
+		http.Error(w, "queue full, retry later", http.StatusTooManyRequests)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	fmt.Fprintf(w, `{"accepted":%d,"dropped":%d}`, accepted, dropped)
+}
+
+func toInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	}
+	return 0, fmt.Errorf("not an integer: %v", v)
+}

--- a/src/internal/source/webhook/adapter_test.go
+++ b/src/internal/source/webhook/adapter_test.go
@@ -1,0 +1,275 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func newAdapter(t *testing.T, cfg map[string]any) *Adapter {
+	t.Helper()
+	a := &Adapter{}
+	a.SetID("hooks")
+	if err := a.Connect(context.Background(), cfg); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	return a
+}
+
+func deliver(t *testing.T, a *Adapter, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	a.WebhookHandler().ServeHTTP(rec, req)
+	return rec
+}
+
+func bearerReq(body, token string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/webhook/hooks", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+func TestRegistered(t *testing.T) {
+	a, ok := source.New("webhook")
+	if !ok {
+		t.Fatal("webhook adapter not registered")
+	}
+	if a.WebhookHandler() == nil {
+		t.Error("WebhookHandler must be non-nil on a fresh instance (push-capability probe)")
+	}
+}
+
+func TestConnectValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  map[string]any
+	}{
+		{"missing secret", map[string]any{}},
+		{"missing secret hmac", map[string]any{"auth": "hmac"}},
+		{"bad auth", map[string]any{"secret": "s", "auth": "basic"}},
+		{"bad format", map[string]any{"secret": "s", "format": "xml"}},
+		{"bad max_pending", map[string]any{"secret": "s", "max_pending": 0}},
+		{"bad max_body_bytes", map[string]any{"secret": "s", "max_body_bytes": -1}},
+		{"bad tolerance", map[string]any{"secret": "s", "tolerance": "soon"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{}
+			if err := a.Connect(context.Background(), tc.cfg); err == nil {
+				t.Errorf("Connect(%v) should fail", tc.cfg)
+			}
+		})
+	}
+
+	// auth: none needs no secret.
+	a := &Adapter{}
+	if err := a.Connect(context.Background(), map[string]any{"auth": "none"}); err != nil {
+		t.Errorf("auth none without secret should connect: %v", err)
+	}
+}
+
+func TestBearerAuth(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+
+	if rec := deliver(t, a, bearerReq(`{"title":"x"}`, "tok")); rec.Code != http.StatusAccepted {
+		t.Errorf("valid token: got %d, want 202 (%s)", rec.Code, rec.Body)
+	}
+	if rec := deliver(t, a, bearerReq(`{"title":"x"}`, "wrong")); rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong token: got %d, want 401", rec.Code)
+	}
+	noAuth := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	if rec := deliver(t, a, noAuth); rec.Code != http.StatusUnauthorized {
+		t.Errorf("missing header: got %d, want 401", rec.Code)
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if rec := deliver(t, a, req); rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET: got %d, want 405", rec.Code)
+	}
+}
+
+func TestBodyTooLarge(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok", "max_body_bytes": 10})
+	if rec := deliver(t, a, bearerReq(`{"title":"way past ten bytes"}`, "tok")); rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("oversized body: got %d, want 413", rec.Code)
+	}
+}
+
+func TestBadJSON(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+	if rec := deliver(t, a, bearerReq(`{nope`, "tok")); rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid JSON: got %d, want 400", rec.Code)
+	}
+}
+
+func signed(body, secret string, ts time.Time) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	tsStr := strconv.FormatInt(ts.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(tsStr + "." + body))
+	req.Header.Set(headerTimestamp, tsStr)
+	req.Header.Set(headerSignature, signaturePrefix+hex.EncodeToString(mac.Sum(nil)))
+	return req
+}
+
+func TestHMACAuth(t *testing.T) {
+	now := time.Now()
+	a := newAdapter(t, map[string]any{"secret": "s3cr3t", "auth": "hmac"})
+	a.now = func() time.Time { return now }
+
+	body := `{"id":"e1","title":"x"}`
+	if rec := deliver(t, a, signed(body, "s3cr3t", now)); rec.Code != http.StatusAccepted {
+		t.Errorf("valid signature: got %d, want 202 (%s)", rec.Code, rec.Body)
+	}
+
+	// Replay of the identical signed request is rejected.
+	if rec := deliver(t, a, signed(body, "s3cr3t", now)); rec.Code != http.StatusUnauthorized {
+		t.Errorf("replayed signature: got %d, want 401", rec.Code)
+	}
+
+	if rec := deliver(t, a, signed(body, "wrong-secret", now)); rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong secret: got %d, want 401", rec.Code)
+	}
+
+	// Timestamp outside the tolerance window.
+	if rec := deliver(t, a, signed(body, "s3cr3t", now.Add(-10*time.Minute))); rec.Code != http.StatusUnauthorized {
+		t.Errorf("stale timestamp: got %d, want 401", rec.Code)
+	}
+
+	// Tampered body under a valid signature.
+	req := signed(body, "s3cr3t", now.Add(time.Second))
+	req.Body = http.NoBody
+	if rec := deliver(t, a, req); rec.Code != http.StatusUnauthorized {
+		t.Errorf("tampered body: got %d, want 401", rec.Code)
+	}
+
+	// Missing headers.
+	bare := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	if rec := deliver(t, a, bare); rec.Code != http.StatusUnauthorized {
+		t.Errorf("missing signature headers: got %d, want 401", rec.Code)
+	}
+}
+
+func TestEnqueuePollDrain(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+
+	deliver(t, a, bearerReq(`{"id":"e1","title":"first"}`, "tok"))
+	deliver(t, a, bearerReq(`{"id":"e2","title":"second"}`, "tok"))
+	// Duplicate delivery of a queued event is dropped silently.
+	if rec := deliver(t, a, bearerReq(`{"id":"e1","title":"first"}`, "tok")); rec.Code != http.StatusAccepted {
+		t.Errorf("duplicate delivery: got %d, want 202", rec.Code)
+	}
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if items[0].ID != "e1" || items[1].ID != "e2" {
+		t.Errorf("order/ids wrong: %q, %q", items[0].ID, items[1].ID)
+	}
+	if items[0].SourceID != "hooks" {
+		t.Errorf("SourceID = %q, want hooks", items[0].SourceID)
+	}
+
+	// Drained: next poll is empty, and the same event may be re-delivered
+	// (downstream task/instance dedup owns re-dispatch prevention).
+	if items, _ := a.Poll(context.Background(), time.Time{}); len(items) != 0 {
+		t.Errorf("second poll returned %d items, want 0", len(items))
+	}
+	if rec := deliver(t, a, bearerReq(`{"id":"e1","title":"first"}`, "tok")); rec.Code != http.StatusAccepted {
+		t.Errorf("re-delivery after drain: got %d, want 202", rec.Code)
+	}
+}
+
+func TestQueueOverflow(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok", "max_pending": 2})
+
+	for i := 0; i < 2; i++ {
+		deliver(t, a, bearerReq(fmt.Sprintf(`{"id":"e%d"}`, i), "tok"))
+	}
+	if rec := deliver(t, a, bearerReq(`{"id":"overflow"}`, "tok")); rec.Code != http.StatusTooManyRequests {
+		t.Errorf("overflow: got %d, want 429", rec.Code)
+	}
+
+	// Draining frees capacity.
+	_, _ = a.Poll(context.Background(), time.Time{})
+	if rec := deliver(t, a, bearerReq(`{"id":"overflow"}`, "tok")); rec.Code != http.StatusAccepted {
+		t.Errorf("after drain: got %d, want 202", rec.Code)
+	}
+}
+
+func TestWake(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+	woke := 0
+	a.SetWake(func() { woke++ })
+
+	deliver(t, a, bearerReq(`{"id":"e1"}`, "tok"))
+	if woke != 1 {
+		t.Errorf("wake called %d times, want 1", woke)
+	}
+	// A delivery that enqueues nothing (duplicate) does not wake.
+	deliver(t, a, bearerReq(`{"id":"e1"}`, "tok"))
+	if woke != 1 {
+		t.Errorf("wake after duplicate: %d, want 1", woke)
+	}
+}
+
+func TestFilters(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+	a.SetFilters([]string{"open"}, []string{"team=sre"})
+
+	deliver(t, a, bearerReq(`{"id":"match","labels":{"team":"sre"}}`, "tok"))
+	deliver(t, a, bearerReq(`{"id":"wrong-label","labels":{"team":"web"}}`, "tok"))
+	deliver(t, a, bearerReq(`{"id":"wrong-state","state":"resolved","labels":{"team":"sre"}}`, "tok"))
+
+	items, _ := a.Poll(context.Background(), time.Time{})
+	if len(items) != 1 || items[0].ID != "match" {
+		t.Fatalf("filters kept %d items (want just \"match\"): %+v", len(items), items)
+	}
+}
+
+func TestNoOpsAndCaps(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok"})
+	if err := a.Acknowledge(context.Background(), model.SourceItem{ID: "e1"}, "dispatched"); err != nil {
+		t.Errorf("Acknowledge: %v", err)
+	}
+	if err := a.WriteResult(context.Background(), model.SourceItem{ID: "e1"}, model.RunResult{Success: true}); err != nil {
+		t.Errorf("WriteResult: %v", err)
+	}
+
+	// Read-only: none of the optional write capabilities may be implemented,
+	// or config validation would wrongly allow write features on this source.
+	var s source.Adapter = a
+	if _, ok := s.(source.StateSetter); ok {
+		t.Error("webhook must not implement StateSetter")
+	}
+	if _, ok := s.(source.LabelAdder); ok {
+		t.Error("webhook must not implement LabelAdder")
+	}
+	if _, ok := s.(source.TaskPoller); ok {
+		t.Error("webhook must not implement TaskPoller")
+	}
+	if _, ok := s.(source.CIStatusPoller); ok {
+		t.Error("webhook must not implement CIStatusPoller")
+	}
+	if _, ok := s.(source.SubIssueCreator); ok {
+		t.Error("webhook must not implement SubIssueCreator")
+	}
+}

--- a/src/internal/source/webhook/auth.go
+++ b/src/internal/source/webhook/auth.go
@@ -1,0 +1,114 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Signature headers for auth: "hmac". The sender computes
+// HMAC-SHA256(secret, "<timestamp>.<raw body>") and sends:
+//
+//	X-Apiary-Timestamp: <unix seconds>
+//	X-Apiary-Signature: sha256=<hex digest>
+//
+// The timestamp is bound into the signature so a captured delivery cannot be
+// replayed outside the tolerance window, and signatures seen inside the
+// window are cached and rejected on reuse.
+const (
+	headerTimestamp = "X-Apiary-Timestamp"
+	headerSignature = "X-Apiary-Signature"
+	signaturePrefix = "sha256="
+)
+
+// readBody reads at most maxBytes of the request body.
+func readBody(w http.ResponseWriter, r *http.Request, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxBodyBytes
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("body exceeds %d bytes", maxBytes)
+	}
+	return body, nil
+}
+
+// authenticate verifies a delivery per the configured auth mode.
+func (a *Adapter) authenticate(r *http.Request, body []byte) error {
+	switch a.authMode {
+	case "none":
+		return nil
+	case "bearer":
+		return a.checkBearer(r)
+	case "hmac":
+		return a.checkHMAC(r, body)
+	}
+	return fmt.Errorf("unknown auth mode %q", a.authMode)
+}
+
+func (a *Adapter) checkBearer(r *http.Request) error {
+	auth := r.Header.Get("Authorization")
+	token, ok := strings.CutPrefix(auth, "Bearer ")
+	if !ok {
+		return fmt.Errorf("missing Authorization: Bearer header")
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(a.secret)) != 1 {
+		return fmt.Errorf("bearer token mismatch")
+	}
+	return nil
+}
+
+func (a *Adapter) checkHMAC(r *http.Request, body []byte) error {
+	sig, ok := strings.CutPrefix(r.Header.Get(headerSignature), signaturePrefix)
+	if !ok {
+		return fmt.Errorf("missing %s: %s<hex> header", headerSignature, signaturePrefix)
+	}
+	given, err := hex.DecodeString(sig)
+	if err != nil {
+		return fmt.Errorf("%s is not hex", headerSignature)
+	}
+
+	tsHeader := r.Header.Get(headerTimestamp)
+	tsSec, err := strconv.ParseInt(tsHeader, 10, 64)
+	if err != nil {
+		return fmt.Errorf("missing or invalid %s header (unix seconds)", headerTimestamp)
+	}
+	now := time.Now()
+	if a.now != nil {
+		now = a.now()
+	}
+	ts := time.Unix(tsSec, 0)
+	if diff := now.Sub(ts); diff > a.tolerance || diff < -a.tolerance {
+		return fmt.Errorf("timestamp outside the ±%s tolerance window", a.tolerance)
+	}
+
+	mac := hmac.New(sha256.New, []byte(a.secret))
+	mac.Write([]byte(tsHeader))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	if !hmac.Equal(given, mac.Sum(nil)) {
+		return fmt.Errorf("signature mismatch")
+	}
+
+	// Replay guard: a valid signature is single-use within the tolerance
+	// window (after the window the timestamp check alone rejects it).
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for s, exp := range a.seen {
+		if now.After(exp) {
+			delete(a.seen, s)
+		}
+	}
+	if _, replayed := a.seen[sig]; replayed {
+		return fmt.Errorf("replayed signature")
+	}
+	a.seen[sig] = now.Add(a.tolerance)
+	return nil
+}

--- a/src/internal/source/webhook/payload.go
+++ b/src/internal/source/webhook/payload.go
@@ -1,0 +1,338 @@
+package webhook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// parse maps a delivery body to SourceItems per the configured format.
+func (a *Adapter) parse(body []byte) ([]model.SourceItem, error) {
+	switch a.format {
+	case "alertmanager":
+		return a.parseAlertmanager(body)
+	default:
+		return a.parseGeneric(body)
+	}
+}
+
+// genericEvent is the payload shape for format: "generic". Every field is
+// optional; unknown fields are preserved in Metadata via the raw payload.
+type genericEvent struct {
+	ID          string          `json:"id"`
+	Title       string          `json:"title"`
+	Summary     string          `json:"summary"`
+	Description string          `json:"description"`
+	Labels      json.RawMessage `json:"labels"` // {"k":"v"} object or ["k:v"] array
+	Priority    string          `json:"priority"`
+	Severity    string          `json:"severity"`
+	State       string          `json:"state"`
+	URL         string          `json:"url"`
+}
+
+// parseGeneric maps one JSON object (or an {"events": [...]} / top-level
+// array batch) to SourceItems. Identity: the event's own id when given,
+// otherwise a hash of its JSON — so a sender that retries the same body never
+// dispatches twice, while distinct payloads always get distinct IDs.
+func (a *Adapter) parseGeneric(body []byte) ([]model.SourceItem, error) {
+	trimmed := strings.TrimSpace(string(body))
+	var raws []json.RawMessage
+	switch {
+	case strings.HasPrefix(trimmed, "["):
+		if err := json.Unmarshal(body, &raws); err != nil {
+			return nil, fmt.Errorf("invalid JSON array: %w", err)
+		}
+	default:
+		var batch struct {
+			Events []json.RawMessage `json:"events"`
+		}
+		if err := json.Unmarshal(body, &batch); err != nil {
+			return nil, fmt.Errorf("invalid JSON: %w", err)
+		}
+		if batch.Events != nil {
+			raws = batch.Events
+		} else {
+			raws = []json.RawMessage{json.RawMessage(body)}
+		}
+	}
+
+	items := make([]model.SourceItem, 0, len(raws))
+	for _, raw := range raws {
+		var ev genericEvent
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			return nil, fmt.Errorf("invalid event object: %w", err)
+		}
+		items = append(items, a.genericItem(ev, raw))
+	}
+	return items, nil
+}
+
+func (a *Adapter) genericItem(ev genericEvent, raw json.RawMessage) model.SourceItem {
+	id := ev.ID
+	if id == "" {
+		sum := sha256.Sum256(raw)
+		id = hex.EncodeToString(sum[:])[:16]
+	}
+
+	title := ev.Title
+	if title == "" {
+		title = ev.Summary
+	}
+	if title == "" {
+		title = "webhook event " + id
+	}
+
+	labels := parseLabels(ev.Labels)
+
+	priority := ev.Priority
+	if priority == "" {
+		priority = ev.Severity
+	}
+
+	state := ev.State
+	if state == "" {
+		state = "open"
+	}
+
+	number := id
+	if len(number) > 7 {
+		number = number[:7]
+	}
+
+	var meta map[string]any
+	_ = json.Unmarshal(raw, &meta)
+
+	now := time.Now()
+	return model.SourceItem{
+		ID:          id,
+		SourceID:    a.ID(),
+		Number:      number,
+		Title:       title,
+		Description: describeGeneric(ev, labels, raw),
+		Labels:      labels,
+		Type:        "webhook",
+		Priority:    priority,
+		State:       state,
+		URL:         ev.URL,
+		Metadata:    map[string]any{"payload": meta},
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+}
+
+// parseLabels accepts either an object ({"k":"v"}) or an array (["k:v",
+// "k=v", "bare"]) and normalizes to the router's "key:value" form.
+func parseLabels(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var asMap map[string]string
+	if err := json.Unmarshal(raw, &asMap); err == nil {
+		labels := make([]string, 0, len(asMap))
+		for k, v := range asMap {
+			labels = append(labels, k+":"+v)
+		}
+		sort.Strings(labels)
+		return labels
+	}
+	var asList []string
+	if err := json.Unmarshal(raw, &asList); err == nil {
+		labels := make([]string, 0, len(asList))
+		for _, l := range asList {
+			if k, v, ok := strings.Cut(l, "="); ok {
+				l = strings.TrimSpace(k) + ":" + strings.TrimSpace(v)
+			}
+			labels = append(labels, l)
+		}
+		sort.Strings(labels)
+		return labels
+	}
+	aplog.Debug("webhook: labels field is neither an object nor a string array — ignored")
+	return nil
+}
+
+func describeGeneric(ev genericEvent, labels []string, raw json.RawMessage) string {
+	var b strings.Builder
+	if ev.Summary != "" && ev.Summary != ev.Title {
+		b.WriteString(ev.Summary)
+		b.WriteString("\n\n")
+	}
+	if ev.Description != "" {
+		b.WriteString(ev.Description)
+		b.WriteString("\n\n")
+	}
+	if len(labels) > 0 {
+		b.WriteString("**Labels**\n\n")
+		for _, l := range labels {
+			fmt.Fprintf(&b, "- `%s`\n", l)
+		}
+		b.WriteString("\n")
+	}
+	if ev.URL != "" {
+		fmt.Fprintf(&b, "Source: %s\n\n", ev.URL)
+	}
+	b.WriteString("**Payload**\n\n```json\n")
+	b.Write(compactJSON(raw))
+	b.WriteString("\n```")
+	return b.String()
+}
+
+func compactJSON(raw json.RawMessage) []byte {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	pretty, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return raw
+	}
+	return pretty
+}
+
+// amPayload is the Alertmanager webhook payload (version "4"), as sent by
+// webhook_configs. Unlike the GET /api/v2/alerts shape the poll adapter
+// consumes, alerts arrive grouped and carry a per-alert status string.
+type amPayload struct {
+	Version string    `json:"version"`
+	Status  string    `json:"status"` // group status: firing | resolved
+	Alerts  []amAlert `json:"alerts"`
+}
+
+type amAlert struct {
+	Status       string            `json:"status"` // firing | resolved
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	StartsAt     time.Time         `json:"startsAt"`
+	EndsAt       time.Time         `json:"endsAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Fingerprint  string            `json:"fingerprint"`
+}
+
+// parseAlertmanager maps each firing alert in the delivery to a SourceItem
+// with the same identity scheme as the prometheus poll adapter
+// (fingerprint:startsAt — stable per fire cycle), so switching a source
+// between poll and push keeps dedup semantics. Resolved alerts are skipped:
+// the resolved-while-running policy is a separate opt-in (#362).
+func (a *Adapter) parseAlertmanager(body []byte) ([]model.SourceItem, error) {
+	var p amPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return nil, fmt.Errorf("invalid Alertmanager payload: %w", err)
+	}
+	if p.Alerts == nil {
+		return nil, fmt.Errorf("invalid Alertmanager payload: missing alerts array")
+	}
+
+	var items []model.SourceItem
+	for _, al := range p.Alerts {
+		if !strings.EqualFold(al.Status, "firing") {
+			aplog.Debug("webhook %s: skipping %s alert %s", a.id, al.Status, al.Fingerprint)
+			continue
+		}
+		if al.Fingerprint == "" {
+			aplog.Debug("webhook %s: skipping alert without fingerprint (labels=%v)", a.id, al.Labels)
+			continue
+		}
+		items = append(items, a.alertItem(al))
+	}
+	return items, nil
+}
+
+func (a *Adapter) alertItem(al amAlert) model.SourceItem {
+	name := al.Labels["alertname"]
+	if name == "" {
+		name = "alert " + al.Fingerprint
+	}
+	title := name
+	if s := al.Annotations["summary"]; s != "" {
+		title = fmt.Sprintf("%s: %s", name, s)
+	}
+
+	labels := make([]string, 0, len(al.Labels))
+	for k, v := range al.Labels {
+		labels = append(labels, k+":"+v)
+	}
+	sort.Strings(labels)
+
+	number := al.Fingerprint
+	if len(number) > 7 {
+		number = number[:7]
+	}
+
+	return model.SourceItem{
+		ID:          al.Fingerprint + ":" + al.StartsAt.UTC().Format(time.RFC3339),
+		SourceID:    a.ID(),
+		Number:      number,
+		Title:       title,
+		Description: describeAlert(al),
+		Labels:      labels,
+		Type:        "alert",
+		Priority:    al.Labels["severity"],
+		State:       "firing",
+		URL:         al.GeneratorURL,
+		Metadata: map[string]any{
+			"fingerprint":  al.Fingerprint,
+			"labels":       al.Labels,
+			"annotations":  al.Annotations,
+			"startsAt":     al.StartsAt.UTC().Format(time.RFC3339),
+			"endsAt":       al.EndsAt.UTC().Format(time.RFC3339),
+			"generatorURL": al.GeneratorURL,
+			"status":       al.Status,
+		},
+		CreatedAt: al.StartsAt,
+		UpdatedAt: al.StartsAt,
+	}
+}
+
+// describeAlert renders the alert as the task description, mirroring the
+// prometheus poll adapter so the investigating agent gets labels,
+// annotations, and the generator link regardless of transport.
+func describeAlert(al amAlert) string {
+	var b strings.Builder
+	if s := al.Annotations["summary"]; s != "" {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+	if d := al.Annotations["description"]; d != "" {
+		b.WriteString(d)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("**Labels**\n\n")
+	for _, k := range sortedKeys(al.Labels) {
+		fmt.Fprintf(&b, "- `%s`: `%s`\n", k, al.Labels[k])
+	}
+
+	wrote := false
+	for _, k := range sortedKeys(al.Annotations) {
+		if k == "summary" || k == "description" {
+			continue
+		}
+		if !wrote {
+			b.WriteString("\n**Annotations**\n\n")
+			wrote = true
+		}
+		fmt.Fprintf(&b, "- `%s`: %s\n", k, al.Annotations[k])
+	}
+
+	fmt.Fprintf(&b, "\nFiring since %s.", al.StartsAt.UTC().Format(time.RFC3339))
+	if al.GeneratorURL != "" {
+		fmt.Fprintf(&b, "\nSource expression: %s", al.GeneratorURL)
+	}
+	return b.String()
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/src/internal/source/webhook/payload_test.go
+++ b/src/internal/source/webhook/payload_test.go
@@ -1,0 +1,160 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func genericAdapter(t *testing.T) *Adapter {
+	t.Helper()
+	return newAdapter(t, map[string]any{"secret": "tok"})
+}
+
+func TestGenericSingleObject(t *testing.T) {
+	a := genericAdapter(t)
+	items, err := a.parse([]byte(`{
+		"id": "deploy-42",
+		"title": "Deploy failed",
+		"description": "the rollout stalled",
+		"labels": {"severity": "critical", "service": "api"},
+		"severity": "critical",
+		"state": "failing",
+		"url": "https://ci.example.com/42"
+	}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	it := items[0]
+	if it.ID != "deploy-42" || it.Title != "Deploy failed" || it.State != "failing" || it.Priority != "critical" || it.URL != "https://ci.example.com/42" {
+		t.Errorf("mapped item wrong: %+v", it)
+	}
+	if len(it.Labels) != 2 || it.Labels[0] != "service:api" || it.Labels[1] != "severity:critical" {
+		t.Errorf("labels = %v, want sorted k:v pairs", it.Labels)
+	}
+	if !strings.Contains(it.Description, "the rollout stalled") || !strings.Contains(it.Description, "```json") {
+		t.Errorf("description missing content or payload block:\n%s", it.Description)
+	}
+	if it.Type != "webhook" {
+		t.Errorf("type = %q, want webhook", it.Type)
+	}
+}
+
+func TestGenericFallbacks(t *testing.T) {
+	a := genericAdapter(t)
+	body := `{"summary":"disk almost full","labels":["team=sre","critical"]}`
+	items, err := a.parse([]byte(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	it := items[0]
+	if it.Title != "disk almost full" {
+		t.Errorf("title fallback to summary failed: %q", it.Title)
+	}
+	if it.ID == "" || len(it.ID) != 16 {
+		t.Errorf("hash id = %q, want 16 hex chars", it.ID)
+	}
+	if it.State != "open" {
+		t.Errorf("state default = %q, want open", it.State)
+	}
+	if len(it.Labels) != 2 || it.Labels[0] != "critical" || it.Labels[1] != "team:sre" {
+		t.Errorf("array labels = %v", it.Labels)
+	}
+
+	// Identical body → identical hash id; different body → different id.
+	again, _ := a.parse([]byte(body))
+	if again[0].ID != it.ID {
+		t.Error("hash id is not stable for the same body")
+	}
+	other, _ := a.parse([]byte(`{"summary":"something else"}`))
+	if other[0].ID == it.ID {
+		t.Error("distinct bodies must hash to distinct ids")
+	}
+}
+
+func TestGenericBatches(t *testing.T) {
+	a := genericAdapter(t)
+
+	arr, err := a.parse([]byte(`[{"id":"a"},{"id":"b"}]`))
+	if err != nil || len(arr) != 2 {
+		t.Fatalf("array batch: %v (%d items)", err, len(arr))
+	}
+	env, err := a.parse([]byte(`{"events":[{"id":"a"},{"id":"b"},{"id":"c"}]}`))
+	if err != nil || len(env) != 3 {
+		t.Fatalf("events envelope: %v (%d items)", err, len(env))
+	}
+}
+
+func TestAlertmanagerFormat(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok", "format": "alertmanager"})
+
+	payload := `{
+		"version": "4",
+		"status": "firing",
+		"alerts": [
+			{
+				"status": "firing",
+				"labels": {"alertname": "HighErrorRate", "severity": "critical", "service": "api"},
+				"annotations": {"summary": "5xx over 5%", "description": "error budget burning"},
+				"startsAt": "2026-08-05T10:00:00Z",
+				"endsAt": "0001-01-01T00:00:00Z",
+				"generatorURL": "http://prom/graph?g0.expr=...",
+				"fingerprint": "abcdef1234567890"
+			},
+			{
+				"status": "resolved",
+				"labels": {"alertname": "OldAlert"},
+				"startsAt": "2026-08-05T08:00:00Z",
+				"fingerprint": "ffff000011112222"
+			},
+			{
+				"status": "firing",
+				"labels": {"alertname": "NoFingerprint"},
+				"startsAt": "2026-08-05T09:00:00Z"
+			}
+		]
+	}`
+	items, err := a.parse([]byte(payload))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1 (resolved + fingerprint-less skipped)", len(items))
+	}
+	it := items[0]
+	if it.ID != "abcdef1234567890:2026-08-05T10:00:00Z" {
+		t.Errorf("id = %q, want fingerprint:startsAt", it.ID)
+	}
+	if it.Title != "HighErrorRate: 5xx over 5%" {
+		t.Errorf("title = %q", it.Title)
+	}
+	if it.State != "firing" || it.Type != "alert" || it.Priority != "critical" {
+		t.Errorf("state/type/priority wrong: %+v", it)
+	}
+	if it.Number != "abcdef1" {
+		t.Errorf("number = %q, want abcdef1", it.Number)
+	}
+	want := []string{"alertname:HighErrorRate", "service:api", "severity:critical"}
+	if len(it.Labels) != 3 || it.Labels[0] != want[0] || it.Labels[1] != want[1] || it.Labels[2] != want[2] {
+		t.Errorf("labels = %v, want %v", it.Labels, want)
+	}
+	if !it.CreatedAt.Equal(time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)) {
+		t.Errorf("createdAt = %v", it.CreatedAt)
+	}
+	if !strings.Contains(it.Description, "error budget burning") || !strings.Contains(it.Description, "`severity`: `critical`") {
+		t.Errorf("description missing annotation/labels:\n%s", it.Description)
+	}
+}
+
+func TestAlertmanagerInvalid(t *testing.T) {
+	a := newAdapter(t, map[string]any{"secret": "tok", "format": "alertmanager"})
+	if _, err := a.parse([]byte(`{"version":"4"}`)); err == nil {
+		t.Error("payload without alerts array should fail")
+	}
+	if _, err := a.parse([]byte(`not json`)); err == nil {
+		t.Error("non-JSON should fail")
+	}
+}


### PR DESCRIPTION
Implements the **Generic webhook source** item of #362: wires `source.Adapter.WebhookHandler()` daemon-wide so anything that can POST JSON (Alertmanager `webhook_configs`, Loki ruler, Elastic Watcher, CI scripts) pushes events straight into workflow trigger matching.

## Design (proposed here for review)

**Listener config** — one daemon-wide listener, `settings.webhook.listen: "127.0.0.1:8090"`. Started from `Dispatcher.StartServer` beside the queue protocol server; plain HTTP by design (TLS terminates at a reverse proxy on untrusted networks). `GET /healthz` for probes.

**Per-source path routing** — every source whose adapter returns a non-nil `WebhookHandler()` is mounted at `POST /webhook/{source-id}`. The daemon only routes by path; auth, parsing, and limits live in the adapter, so future push adapters (Dynatrace webhook, GitHub webhooks) reuse the same listener.

**Auth** (per-source `config`):
- `auth: bearer` (default) — `Authorization: Bearer <secret>`, constant-time compare. What Alertmanager's `http_config.authorization` can produce natively.
- `auth: hmac` — Stripe-style: `X-Apiary-Timestamp` + `X-Apiary-Signature: sha256=<hex HMAC-SHA256(secret, "<ts>.<body>")>`.
- `auth: none` — explicit opt-out, startup warning.

**Replay protection** (hmac mode) — the timestamp is bound into the signature and must be within `tolerance` (default 5m) of the daemon clock; valid signatures are cached and single-use inside the window. Outside the window the timestamp check alone rejects.

**Delivery → dispatch** — the handler parses (`format: generic` | `alertmanager`), applies `filters`, and enqueues into a bounded in-memory queue (`max_pending`, default 100 — 429 on overflow so the sender's retry re-delivers). The dispatcher drains it via the normal `Poll` path, so binding, routing, in-flight/once/active dedup, fan-out, and the durable queue all apply unchanged. A delivery signals a per-source wake channel so `pollLoop` runs immediately — `poll_interval` is only the fallback cadence.

**Identity / exactly-once** — generic events use their `id` field (or a body hash); Alertmanager alerts use `fingerprint:startsAt` exactly like the prometheus poll adapter, so a fleet can switch poll→push without changing dedup semantics. Re-deliveries still queued are dropped; re-deliveries after dispatch are shadowed by the persisted task/instance dedup.

**Validation** — new `config.SourcePushCapable` hook (probed in `cli/adapters.go` like the other capability hooks): a webhook-type source without `settings.webhook.listen` is a lint error. The adapter is read-only (no write capabilities), so the existing capability lint rejects `set_state`/labels/approvals/`wait_for: ci` against it.

## Changes
- `src/internal/source/webhook/` — adapter, auth (bearer/HMAC/replay), payload mapping (generic + Alertmanager), tests
- `src/internal/daemon/webhook_server.go` — listener + per-source mounting; `dispatcher.go` — wake channels, `pollLoop` wake case (additive; poll-only sources get a nil channel)
- `src/internal/config/` — `settings.webhook`, `SourcePushCapable` hook + lint, test
- Docs: `docs/webhook-source.md`, supported-integrations, mkdocs nav, `schema/apiary.json`, `.apiary/example-apiary-full.yaml`

## Testing
- `go test ./internal/...` green locally (no Go CI in this repo)
- Adapter tests: auth modes incl. replay/stale-timestamp/tampered-body, both formats, queue overflow/dedup/drain, filters, wake, read-only capability probes
- Daemon test: real TCP listener, routing to the right source, 404 for poll-only/unknown, healthz

Left for #362: webhook push for the dynatrace adapter, plugin-source bridge, `ack_via_silence`, group-key dispatch, resolved-while-running policy.
