### PR TITLE
refactor(source): remove dead WebhookHandler from Adapter interface

### DIFF
--- a/src/internal/daemon/apply_hook_test.go
+++ b/src/internal/daemon/apply_hook_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -32,7 +31,7 @@ func (f *fakeHookSource) Acknowledge(context.Context, model.SourceItem, model.Ac
 func (f *fakeHookSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (f *fakeHookSource) WebhookHandler() http.Handler { return nil }
+
 func (f *fakeHookSource) AddLabels(_ context.Context, _ model.SourceItem, labels []string) error {
 	f.ops = append(f.ops, "add")
 	f.added = append(f.added, labels...)
@@ -63,8 +62,6 @@ func (f *fakeBareSource) Acknowledge(context.Context, model.SourceItem, model.Ac
 func (f *fakeBareSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (f *fakeBareSource) WebhookHandler() http.Handler { return nil }
-
 func TestApplyHook_RemovesLabelsAfterAdditions(t *testing.T) {
 	fake := &fakeHookSource{}
 	d := &Dispatcher{sources: map[string]source.Adapter{"fake": fake}}

--- a/src/internal/daemon/engine_binding_test.go
+++ b/src/internal/daemon/engine_binding_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -58,7 +57,6 @@ func (a *recordingAdapter) SetState(_ context.Context, item model.SourceItem, st
 	a.mu.Unlock()
 	return nil
 }
-func (a *recordingAdapter) WebhookHandler() http.Handler { return nil }
 
 var (
 	_ source.Adapter     = (*recordingAdapter)(nil)

--- a/src/internal/daemon/fanout_test.go
+++ b/src/internal/daemon/fanout_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -30,7 +29,6 @@ func (a *fanoutAdapter) Acknowledge(context.Context, model.SourceItem, model.Ack
 func (a *fanoutAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (a *fanoutAdapter) WebhookHandler() http.Handler { return nil }
 
 // countingRunner records how many times it ran; all steps succeed.
 type countingRunner struct{ n atomic.Int32 }

--- a/src/internal/daemon/parked_approval_concurrency_test.go
+++ b/src/internal/daemon/parked_approval_concurrency_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -40,8 +39,6 @@ func (a *approvalAdapter) Acknowledge(context.Context, model.SourceItem, model.A
 func (a *approvalAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (a *approvalAdapter) WebhookHandler() http.Handler { return nil }
-
 func (a *approvalAdapter) PollTask(_ context.Context, cellID string) (model.SourceItem, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/src/internal/daemon/parked_wait_concurrency_test.go
+++ b/src/internal/daemon/parked_wait_concurrency_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -37,8 +36,6 @@ func (a *ciAdapter) Acknowledge(context.Context, model.SourceItem, model.AckActi
 func (a *ciAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (a *ciAdapter) WebhookHandler() http.Handler { return nil }
-
 func (a *ciAdapter) PollCIStatus(_ context.Context, cellID string) (source.CIStatus, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/src/internal/daemon/rehydrate_approval_test.go
+++ b/src/internal/daemon/rehydrate_approval_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ func (approvingPoller) Acknowledge(context.Context, model.SourceItem, model.AckA
 func (approvingPoller) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (approvingPoller) WebhookHandler() http.Handler { return nil }
+
 func (approvingPoller) PollTask(_ context.Context, cellID string) (model.SourceItem, error) {
 	return model.SourceItem{ID: cellID, SourceID: "src",
 		Comments: []model.Comment{{Body: "approve please"}}}, nil

--- a/src/internal/daemon/restart_labels_test.go
+++ b/src/internal/daemon/restart_labels_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -69,7 +68,7 @@ func (f *fakeRestartSource) Acknowledge(context.Context, model.SourceItem, model
 func (f *fakeRestartSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (f *fakeRestartSource) WebhookHandler() http.Handler { return nil }
+
 func (f *fakeRestartSource) PollTask(context.Context, string) (model.SourceItem, error) {
 	return f.cell, nil
 }

--- a/src/internal/daemon/task_pulls_test.go
+++ b/src/internal/daemon/task_pulls_test.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"errors"
-	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -31,7 +30,7 @@ func (a *prListerAdapter) Acknowledge(context.Context, model.SourceItem, model.A
 func (a *prListerAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (a *prListerAdapter) WebhookHandler() http.Handler { return nil }
+
 func (a *prListerAdapter) ListPullRequests(context.Context, string) ([]source.PullRequestRef, error) {
 	return a.prs, a.err
 }
@@ -132,4 +131,3 @@ func (plainAdapterNoLister) Acknowledge(context.Context, model.SourceItem, model
 func (plainAdapterNoLister) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
 	return nil
 }
-func (plainAdapterNoLister) WebhookHandler() http.Handler { return nil }

--- a/src/internal/source/dynatrace/adapter.go
+++ b/src/internal/source/dynatrace/adapter.go
@@ -17,7 +17,6 @@ package dynatrace
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"sort"
 	"strings"
@@ -374,8 +373,6 @@ func (a *Adapter) WriteResult(_ context.Context, cell model.SourceItem, result m
 	aplog.Debug("dynatrace: write result for %s (success=%v) — no-op for problems", cell.LogLabel(), result.Success)
 	return nil
 }
-
-func (a *Adapter) WebhookHandler() http.Handler { return nil }
 
 func toInt(v any) (int, error) {
 	switch n := v.(type) {

--- a/src/internal/source/dynatrace/adapter_test.go
+++ b/src/internal/source/dynatrace/adapter_test.go
@@ -248,9 +248,6 @@ func TestWriteOpsAreNoOps(t *testing.T) {
 	if err := a.WriteResult(context.Background(), itemStub(), resultStub()); err != nil {
 		t.Errorf("WriteResult: %v", err)
 	}
-	if a.WebhookHandler() != nil {
-		t.Error("WebhookHandler should be nil for the poll-only adapter")
-	}
 }
 
 func TestToCriterion(t *testing.T) {

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"sync"
@@ -217,8 +216,6 @@ func (a *Adapter) CreateSubIssue(ctx context.Context, parent, child model.Source
 
 	return a.toSourceItem(created), nil
 }
-
-func (a *Adapter) WebhookHandler() http.Handler { return nil }
 
 // PollTask fetches the current state of a single issue plus its comments, for
 // the workflow engine to evaluate approval-step conditions. Implements

--- a/src/internal/source/jira/adapter.go
+++ b/src/internal/source/jira/adapter.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -277,8 +276,6 @@ func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result
 	}
 	return nil
 }
-
-func (a *Adapter) WebhookHandler() http.Handler { return nil }
 
 // PollTask fetches the current state of a single issue plus its comments, for
 // the workflow engine to evaluate approval-step conditions. Implements

--- a/src/internal/source/plane/adapter.go
+++ b/src/internal/source/plane/adapter.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -284,8 +283,6 @@ func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result
 	}
 	return nil
 }
-
-func (a *Adapter) WebhookHandler() http.Handler { return nil }
 
 // SetState implements source.StateSetter.
 func (a *Adapter) SetState(ctx context.Context, cell model.SourceItem, stateName string) error {

--- a/src/internal/source/prometheus/adapter.go
+++ b/src/internal/source/prometheus/adapter.go
@@ -14,7 +14,6 @@ package prometheus
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"sort"
 	"strings"
@@ -327,8 +326,6 @@ func (a *Adapter) WriteResult(_ context.Context, cell model.SourceItem, result m
 	aplog.Debug("prometheus: write result for %s (success=%v) — no-op for alerts", cell.LogLabel(), result.Success)
 	return nil
 }
-
-func (a *Adapter) WebhookHandler() http.Handler { return nil }
 
 func toInt(v any) (int, error) {
 	switch n := v.(type) {

--- a/src/internal/source/prometheus/adapter_test.go
+++ b/src/internal/source/prometheus/adapter_test.go
@@ -237,9 +237,6 @@ func TestWriteOpsAreNoOps(t *testing.T) {
 	if err := a.WriteResult(context.Background(), itemStub(), resultStub()); err != nil {
 		t.Errorf("WriteResult: %v", err)
 	}
-	if a.WebhookHandler() != nil {
-		t.Error("WebhookHandler should be nil for the poll-only adapter")
-	}
 }
 
 func TestToMatcher(t *testing.T) {

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -31,10 +30,6 @@ type Adapter interface {
 
 	// WriteResult posts the run output back to the source task.
 	WriteResult(ctx context.Context, cell model.SourceItem, result model.RunResult) error
-
-	// WebhookHandler returns an http.Handler for push-mode sources.
-	// Returns nil for poll-only adapters.
-	WebhookHandler() http.Handler
 }
 
 // StateSetter is an optional interface that sources may implement to allow


### PR DESCRIPTION
## Summary

Apiary is polling-only by design — inbound webhook listeners were rejected (decision recorded in #362 discussion; PR #364 closed unmerged). The `WebhookHandler() http.Handler` method on `source.Adapter` was reserved for push mode, never wired to anything, and every adapter stubbed it with `return nil`. This removes the dead API:

- `source.Adapter` interface: method + `net/http` import dropped
- Adapters github, jira, plane, prometheus, dynatrace: nil stubs + unused `net/http` imports removed
- Daemon test fakes (8 files) and prometheus/dynatrace adapter tests: stubs and nil-assertions removed

16 files changed, 4 insertions(+), 47 deletions(-) — pure deletion, no behavior change.

## Verification

- gitnexus impact: `WebhookHandler` has zero callers (LOW risk, dead API confirmed)
- `gofmt -l` clean, `go vet ./...` clean
- `go test ./internal/...` all green

Refs #362