### PR TITLE
feat(plugin): source bridge — out-of-process plugins as poll sources (#362)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -187,7 +187,9 @@ sources:
 #   - id: dev.apiary.source-file
 #     timeout: 5s
 #     config:
-#       path: .apiary/incoming-items.json
+#       # Absolute path: plugin processes run with cwd = their install dir,
+#       # so relative paths would resolve inside .apiary/plugins/<id>/.
+#       path: /path/to/project/.apiary/incoming-items.json
 
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:

--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -170,6 +170,25 @@ sources:
       # match entity tags; raw criteria like displayId("P-123") pass through.
       labels: ["severity=availability", "managementZone=Prod"]
 
+  # Plugin-bridged source: polls an out-of-process `source`-capability plugin
+  # (declared under plugins: below) on the normal poll interval. Read-only
+  # like the monitoring sources; see docs/plugins.md#source-plugins.
+  # - id: custom-items
+  #   type: plugin
+  #   poll_interval: 30s
+  #   config:
+  #     plugin: dev.apiary.source-file   # id of the enabled plugin instance
+  #   filters:
+  #     labels: ["severity=critical"]    # forwarded to the plugin's poll
+
+# Out-of-process plugins (docs/plugins.md). A `source`-capability plugin can
+# back a `type: plugin` source (see the commented custom-items source above).
+# plugins:
+#   - id: dev.apiary.source-file
+#     timeout: 5s
+#     config:
+#       path: .apiary/incoming-items.json
+
 # ── Agents ─────────────────────────────────────────────────────────────────────
 agents:
   # === Claude-based agents (original design) ===

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [Rate Limits & Resilience](docs/resilience.md) for details.
 | [Tasks & Fan-out](docs/tasks-and-fanout.md) | `APIARY_PUBLISH`, `APIARY_SPAWN`, task-level hooks |
 | [Agent Memory](docs/memory.md) | `APIARY_MEMORIZE`, task/global memory tiers, recall, curation |
 | [Rate Limits & Resilience](docs/resilience.md) | Failover chains and unattended-dispatch safeguards |
+| [Plugins](docs/plugins.md) | Out-of-process extensions — architecture, custom sources, event exporters |
 | [CLI Reference](docs/cli.md) | Every command and flag |
 | [Dashboard](docs/dashboard.md) | The terminal UI, tab by tab |
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See [Rate Limits & Resilience](docs/resilience.md) for details.
 | [Agent Memory](docs/memory.md) | `APIARY_MEMORIZE`, task/global memory tiers, recall, curation |
 | [Rate Limits & Resilience](docs/resilience.md) | Failover chains and unattended-dispatch safeguards |
 | [Plugins](docs/plugins.md) | Out-of-process extensions — architecture, custom sources, event exporters |
+| [Plugin SDK](docs/plugin-sdk.md) | Writing plugins in Go, Python, Rust, Bash — or any language |
 | [CLI Reference](docs/cli.md) | Every command and flag |
 | [Dashboard](docs/dashboard.md) | The terminal UI, tab by tab |
 

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -1,0 +1,254 @@
+# Plugin SDK
+
+Plugins talk to Apiary over a deliberately small JSON protocol (see
+[Protocol version 1](plugins.md#protocol-version-1)), so a plugin can be
+written in **any language**. For Go there is an official SDK that handles the
+protocol envelope for you; for everything else this page specifies exactly
+what your code — or an SDK you build for your language — must do.
+
+## Go SDK
+
+Import path:
+
+```go
+import pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+```
+
+The SDK lives in the main Apiary module (`src/sdk/plugin`) and has no
+dependencies beyond the standard library.
+
+### Entry points
+
+| Symbol | Purpose |
+|---|---|
+| `Main(handler Handler)` | Call from `main()`: serves one request on stdin/stdout, writes protocol failures to stderr, exits non-zero on transport errors. This is all a plugin `main` needs |
+| `ServeOne(ctx, in, out, handler) error` | The engine behind `Main`, with injectable reader/writer — use it in tests |
+| `Handler` | `func(context.Context, Request) (any, *ResponseError)` — your plugin logic. Return `(result, nil)` for success or `(nil, &ResponseError{...})` for failure |
+
+The SDK decodes the single request (rejecting unknown envelope fields),
+refuses protocol mismatches with a well-formed `error` response, invokes your
+handler, echoes the request ID, and encodes the response — the whole
+[transport contract](plugins.md#protocol-version-1), so your handler only
+sees typed data.
+
+### Request and response types
+
+```go
+type Request struct {
+    Protocol   int             // always 1 once your handler runs
+    RequestID  string          // echoed for you — no need to touch it
+    Capability Capability      // "source", "event_exporter", …
+    Method     string          // e.g. "poll"
+    Config     map[string]any  // your instance's config: block from apiary.yaml
+    Payload    json.RawMessage // method input — unmarshal into the typed structs below
+}
+
+type ResponseError struct {
+    Code    string // machine-readable, e.g. "unsupported_method", "read_failed"
+    Message string // human-readable
+}
+```
+
+Capability constants: `CapabilitySource`, `CapabilityEventExporter` (live),
+plus `CapabilityRunner`, `CapabilityWorkflowAction`,
+`CapabilityApprovalProvider`, `CapabilitySecretProvider` (reserved).
+
+### Source plugin types
+
+For `capability: source` the SDK defines the full wire contract in
+`sdk/plugin/source.go` — use these instead of hand-rolling maps:
+
+| Symbol | Role |
+|---|---|
+| `SourceMethodPoll`, `SourceMethodAcknowledge`, `SourceMethodWriteResult` | Method name constants to switch on |
+| `SourcePollRequest` | Poll payload: `Since` (RFC3339, informational), `States`/`Labels` (the source's `filters:`, forwarded for backend-side filtering) |
+| `SourcePollResult` | Your poll answer: `Items []SourceItem` |
+| `SourceItem` | One work item. `ID` is **required and is the dedup key** — keep it stable per dispatch-worthy occurrence; items without it are dropped. `Labels` use `key:value` form and drive trigger matching. Timestamps are RFC3339 strings; empty means "now" |
+| `SourceAckRequest`, `SourceWriteResultRequest` | Payloads of the two write-back methods |
+| `SourceOKResult` | The conventional `{"ok": true}` answer when there is nothing to mark |
+
+### A complete source plugin in Go
+
+This is the bundled reference plugin (`src/examples/plugins/source-file`),
+trimmed to its essence:
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "os"
+
+    pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+func main() { pluginsdk.Main(serve) }
+
+func serve(_ context.Context, req pluginsdk.Request) (any, *pluginsdk.ResponseError) {
+    if req.Capability != pluginsdk.CapabilitySource {
+        return nil, &pluginsdk.ResponseError{Code: "unsupported_capability", Message: "expected capability source"}
+    }
+    switch req.Method {
+    case pluginsdk.SourceMethodPoll:
+        path, _ := req.Config["path"].(string)
+        raw, err := os.ReadFile(path)
+        if os.IsNotExist(err) {
+            return pluginsdk.SourcePollResult{Items: []pluginsdk.SourceItem{}}, nil
+        }
+        if err != nil {
+            return nil, &pluginsdk.ResponseError{Code: "read_failed", Message: err.Error()}
+        }
+        var items []pluginsdk.SourceItem
+        if err := json.Unmarshal(raw, &items); err != nil {
+            return nil, &pluginsdk.ResponseError{Code: "invalid_items", Message: err.Error()}
+        }
+        return pluginsdk.SourcePollResult{Items: items}, nil
+    case pluginsdk.SourceMethodAcknowledge, pluginsdk.SourceMethodWriteResult:
+        return pluginsdk.SourceOKResult{OK: true}, nil
+    default:
+        return nil, &pluginsdk.ResponseError{Code: "unsupported_method", Message: fmt.Sprintf("unknown method %q", req.Method)}
+    }
+}
+```
+
+Build it as a static binary, pair it with a manifest declaring
+`"capabilities": ["source"]`, and [install it](plugins.md#installing-a-plugin).
+
+### Testing without Apiary
+
+The protocol is pipeable, so a shell one-liner is a complete integration test:
+
+```bash
+echo '{"protocol":1,"request_id":"t1","capability":"source","method":"poll","config":{"path":"items.json"}}' \
+  | ./apiary-plugin-source-file
+```
+
+In Go tests, drive `ServeOne` with a `strings.Reader` and a `bytes.Buffer` —
+no subprocess needed.
+
+## Other languages
+
+There is no official SDK outside Go yet (tracked in
+[#367](https://github.com/orlandoburli/apiary/issues/367)) — but none is
+required. The protocol is small enough to implement
+directly; the [Python plugin in the protocol docs](plugins.md#a-complete-plugin-in-20-lines)
+is 20 lines with no dependencies.
+
+### Bash example
+
+The floor is genuinely low: a plugin can be a **shell script** — the manifest's
+`executable` only needs to be executable. With `jq` for the JSON handling, a
+complete `source` plugin that surfaces failed launchd/systemd-style services
+(here: a hard-coded item) is:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+req=$(cat)                                       # the single request, stdin → EOF
+request_id=$(jq -r '.request_id' <<<"$req")
+method=$(jq -r '.method' <<<"$req")
+
+respond() { jq -nc --arg id "$request_id" "{protocol: 1, request_id: \$id} + $1"; }
+
+case "$method" in
+  poll)
+    echo "checking services..." >&2               # diagnostics → stderr only
+    respond '{result: {items: [{
+      id: "sh-1",
+      title: "Hello from Bash",
+      labels: ["origin:bash"],
+      state: "open"
+    }]}}'
+    ;;
+  acknowledge|write_result)
+    respond '{result: {ok: true}}'
+    ;;
+  *)
+    respond "{error: {code: \"unsupported_method\", message: \"unknown method $method\"}}"
+    ;;
+esac
+```
+
+Real-world versions swap the hard-coded item for `curl`/`jq` against whatever
+API you monitor. Mind stdout purity: every `echo` that isn't the response must
+go to stderr (`>&2`).
+
+### Rust example
+
+A minimal `source` plugin in Rust (verified against the daemon; `serde_json`
+is the only dependency):
+
+```toml
+# Cargo.toml
+[package]
+name = "apiary-plugin-rust-source"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1"
+```
+
+```rust
+// src/main.rs
+use serde_json::{json, Value};
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).expect("read stdin");
+    let req: Value = serde_json::from_str(&input).expect("decode request");
+    let request_id = req["request_id"].as_str().unwrap_or_default();
+
+    let body = if req["protocol"] != json!(1) {
+        json!({"error": {"code": "unsupported_protocol", "message": "expected protocol 1"}})
+    } else if req["capability"] == json!("source") && req["method"] == json!("poll") {
+        eprintln!("polling upstream..."); // diagnostics → stderr only
+        json!({"result": {"items": [{
+            "id": "rs-1",
+            "title": "Hello from Rust",
+            "labels": ["origin:rust"],
+            "state": "open"
+        }]}})
+    } else if req["capability"] == json!("source")
+        && (req["method"] == json!("acknowledge") || req["method"] == json!("write_result"))
+    {
+        json!({"result": {"ok": true}})
+    } else {
+        json!({"error": {"code": "unsupported_method",
+                         "message": format!("unknown {}.{}", req["capability"], req["method"])}})
+    };
+
+    let mut response = json!({"protocol": 1, "request_id": request_id});
+    response.as_object_mut().unwrap().extend(body.as_object().unwrap().clone());
+    println!("{}", response); // exactly one JSON object on stdout
+}
+```
+
+Build with `cargo build --release`, copy `target/release/apiary-plugin-rust-source`
+next to a manifest, done.
+
+### Writing an SDK for your language
+
+If you maintain plugins in another language, wrap the boilerplate once. A
+minimal SDK must:
+
+1. **Read stdin to EOF** and decode exactly one request object; treat trailing
+   data as an error.
+2. **Verify `protocol == 1`**; on mismatch, respond with an
+   `unsupported_protocol` error rather than crashing.
+3. **Echo `request_id` verbatim** in the response.
+4. **Guard stdout purity**: emit exactly one JSON object, nothing before or
+   after; route all logging to stderr.
+5. **Enforce the result/error dichotomy**: exactly one of the two, `error`
+   always carrying non-empty `code` and `message`.
+6. **Exit 0 on a delivered response**, non-zero only on transport failures.
+7. Optionally, mirror the typed structs from `sdk/plugin/source.go` so plugin
+   authors get the same guidance the Go SDK gives (`id` required, RFC3339
+   timestamps, `key:value` labels).
+
+Keep it stateless — the process serves one request and exits, so an SDK needs
+no connection handling, retries, or lifecycle management.

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -132,7 +132,10 @@ no subprocess needed.
 
 There is no official SDK outside Go yet (tracked in
 [#367](https://github.com/orlandoburli/apiary/issues/367)) — but none is
-required. The protocol is small enough to implement
+required. Complete installable examples ship in `src/examples/plugins/`:
+`source-bash` (shell script, no build step) and `source-node`
+(TypeScript compiled to a shebang executable), both behaviorally identical to
+the Go `source-file` plugin. The protocol is small enough to implement
 directly; the [Python plugin in the protocol docs](plugins.md#a-complete-plugin-in-20-lines)
 is 20 lines with no dependencies.
 
@@ -174,7 +177,9 @@ esac
 
 Real-world versions swap the hard-coded item for `curl`/`jq` against whatever
 API you monitor. Mind stdout purity: every `echo` that isn't the response must
-go to stderr (`>&2`).
+go to stderr (`>&2`). A complete, installable Bash plugin (config handling,
+error responses, file-backed items) ships as
+`src/examples/plugins/source-bash`.
 
 ### Rust example
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -416,7 +416,15 @@ requires them.
 
 ## Reference plugins
 
-`src/examples/plugins/event-file` demonstrates an `event_exporter` that appends one
-redacted event JSON object per line. `src/examples/plugins/source-file`
-demonstrates a `source` plugin that polls work items from a JSON file. Each
-README contains build and installation commands.
+Each directory under `src/examples/plugins/` ships a manifest, a README with
+build/install commands, and a complete plugin:
+
+| Plugin | Language | Demonstrates |
+|---|---|---|
+| `event-file` | Go (SDK) | An `event_exporter` appending one redacted event JSON object per line |
+| `source-file` | Go (SDK) | A `source` plugin polling work items from a JSON file |
+| `source-bash` | Bash + jq | The same file-backed source as a shell script — no build step at all |
+| `source-node` | TypeScript (Node) | The same file-backed source compiled with `tsc` to a shebang executable |
+
+The three source plugins are behaviorally identical on purpose: diff them to
+see the same contract expressed in each ecosystem.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -226,12 +226,33 @@ delete the plugin's directory.
 
 ## Protocol version 1
 
-Apiary starts a fresh process for each invocation, writes one compact JSON object
-plus a newline to stdin, and expects one JSON response on stdout. Diagnostic
-output belongs on stderr. Stdout is limited to 4 MiB and captured stderr to 64
-KiB. The per-instance deadline cancels and terminates the child process.
+The transport is plain **stdin/stdout**. From the plugin's point of view, one
+invocation is:
 
-Request:
+1. Apiary starts your executable (fresh process, every time).
+2. Your **stdin** receives exactly one JSON object followed by a newline, then
+   stdin is closed. Read it to EOF and decode it — no framing, no length
+   prefix, no second request will ever arrive.
+3. Do the work.
+4. Write exactly **one** JSON object to **stdout** — the response — and exit
+   `0`. Nothing else may go to stdout: a log line, a progress dot, or a second
+   JSON object makes the whole invocation fail as a malformed response.
+5. Anything you want to say for humans (debug output, warnings) goes to
+   **stderr**. Apiary captures up to 64 KiB of it and attaches it to error
+   messages; it is ignored on success.
+
+In shell terms, Apiary is doing the equivalent of:
+
+```bash
+echo '<request JSON>' | ./your-plugin > response.json 2> diagnostics.log
+```
+
+Limits: stdout ≤ 4 MiB, captured stderr ≤ 64 KiB, wall-clock capped by the
+instance's `timeout` (default 10s) — the deadline kills the process and fails
+that invocation. Exiting non-zero also fails the invocation, even if a
+response was written.
+
+### The request you receive
 
 ```json
 {
@@ -244,12 +265,62 @@ Request:
 }
 ```
 
-Success and failure responses echo the request ID:
+| Field | What to do with it |
+|---|---|
+| `protocol` | Refuse anything other than `1` with an `error` response |
+| `request_id` | Echo it verbatim in your response — Apiary rejects a mismatch |
+| `capability` / `method` | Select the operation; unknown combinations deserve an `error` with code `unsupported_method` |
+| `config` | Your instance's `config:` block from `apiary.yaml`, passed on every call — plugins get no other configuration channel |
+| `payload` | The method's input (shape per capability, e.g. [source methods](#source-plugins)); may be absent |
+
+### The response you send
+
+Exactly one of `result` or `error`, always echoing `protocol` and
+`request_id`:
 
 ```json
-{"protocol":1,"request_id":"1784736000000000000","result":{"written":true}}
-{"protocol":1,"request_id":"1784736000000000000","error":{"code":"write_failed","message":"permission denied"}}
+{"protocol": 1, "request_id": "1784736000000000000", "result": {"written": true}}
 ```
+
+```json
+{"protocol": 1, "request_id": "1784736000000000000", "error": {"code": "write_failed", "message": "permission denied"}}
+```
+
+An `error` needs both a non-empty machine-readable `code` and a human
+`message`; a response carrying both `result` and `error`, or neither, is
+malformed.
+
+### A complete plugin in 20 lines
+
+The contract is small enough that this Python script is a valid plugin — it
+answers `source.poll` with one hard-coded item:
+
+```python
+#!/usr/bin/env python3
+import json, sys
+
+req = json.load(sys.stdin)                      # 1. read the single request
+
+def respond(result=None, error=None):           # 4. one response object, stdout
+    print(json.dumps({"protocol": 1, "request_id": req["request_id"],
+                      **({"result": result} if error is None else {"error": error})}))
+
+if req["protocol"] != 1:
+    respond(error={"code": "unsupported_protocol", "message": "expected protocol 1"})
+elif req["capability"] == "source" and req["method"] == "poll":
+    print("polling upstream...", file=sys.stderr)   # diagnostics → stderr only
+    respond({"items": [{"id": "py-1", "title": "Hello from Python",
+                        "labels": ["origin:python"], "state": "open"}]})
+elif req["capability"] == "source" and req["method"] in ("acknowledge", "write_result"):
+    respond({"ok": True})
+else:
+    respond(error={"code": "unsupported_method",
+                   "message": f"unknown {req['capability']}.{req['method']}"})
+```
+
+Make it executable, name it in a manifest with `"capabilities": ["source"]`,
+and it installs like any other plugin. Go authors get all of the envelope
+handling for free from the SDK — see below.
 
 Capability method vocabulary:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -110,7 +110,7 @@ Capability method vocabulary:
 
 | Capability | Protocol methods |
 |---|---|
-| `source` | `connect`, `poll`, `acknowledge`, `write_result`, plus optional source capabilities |
+| `source` | `poll`, `acknowledge`, `write_result` (see [Source plugins](#source-plugins)) |
 | `runner` | `configure`, `run` |
 | `workflow_action` | `run` |
 | `approval_provider` | `notify`, `remind`, `escalate` |
@@ -118,9 +118,52 @@ Capability method vocabulary:
 | `event_exporter` | `export` |
 
 Protocol envelopes are stable; capability payloads use the corresponding
-versioned Apiary internal contract. The first runtime integration is
-`event_exporter`. The remaining capability names reserve the same manifest and
-transport boundary for their proxies without requiring a new installation model.
+versioned Apiary internal contract. The runtime integrations are
+`event_exporter` and `source`. The remaining capability names reserve the same
+manifest and transport boundary for their proxies without requiring a new
+installation model.
+
+## Source plugins
+
+A `source`-capable plugin is a **poll-mode work source**: the daemon bridges a
+`type: plugin` entry in `sources:` to one enabled plugin instance and invokes
+it on the source's `poll_interval` — plugins never push into the daemon.
+
+```yaml
+plugins:
+  - id: com.example.nagios
+    timeout: 10s
+    config:
+      api_url: https://nagios.internal/api
+
+sources:
+  - id: nagios-alerts
+    type: plugin
+    poll_interval: 30s
+    config:
+      plugin: com.example.nagios   # the plugin instance to bridge
+    filters:
+      labels: ["severity=critical"]
+```
+
+Methods (wire types in `sdk/plugin/source.go`):
+
+| Method | Payload → result |
+|---|---|
+| `poll` | `{since, states, labels}` → `{items: [...]}` — the current work items; `states`/`labels` are the source's `filters`, forwarded for backend-side filtering |
+| `acknowledge` | `{item, action}` → `{ok: true}` — called after dispatch; return ok if there is nothing to mark |
+| `write_result` | `{item, success, output, error}` → `{ok: true}` — the run outcome; return ok if there is no result surface |
+
+Each item's `id` is the dedup key: keep it stable per dispatch-worthy
+occurrence and re-return ongoing items on every poll — the daemon's
+task/instance dedup prevents re-dispatch, exactly as for the in-tree
+monitoring sources. Items without an `id` are dropped. Timestamps are RFC3339
+strings; `labels` use `key:value` form and drive workflow trigger matching.
+
+Plugin-backed sources are **read-only**: they cannot host approval steps, CI
+waits, `set_state`, or label write-back — `apiary validate` rejects workflows
+that require those against a `type: plugin` source. Publish findings to a
+ticket source (`APIARY_PUBLISH` / `APIARY_SPAWN`) instead.
 
 Go plugin authors can import `github.com/orlandoburli/apiary/sdk/plugin` and call
 `plugin.Main(handler)`. The SDK decodes one request, rejects protocol mismatches,
@@ -153,8 +196,9 @@ the service account's filesystem and network access. Use OS-level sandboxing,
 containers, restricted service users, and egress controls where the trust level
 requires them.
 
-## Reference plugin
+## Reference plugins
 
 `src/examples/plugins/event-file` demonstrates an `event_exporter` that appends one
-redacted event JSON object per line. Its README contains build and installation
-commands.
+redacted event JSON object per line. `src/examples/plugins/source-file`
+demonstrates a `source` plugin that polls work items from a JSON file. Each
+README contains build and installation commands.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -384,7 +384,9 @@ ticket source (`APIARY_PUBLISH` / `APIARY_SPAWN`) instead.
 Go plugin authors can import `github.com/orlandoburli/apiary/sdk/plugin` and call
 `plugin.Main(handler)`. The SDK decodes one request, rejects protocol mismatches,
 echoes the request ID, and emits the structured response envelope. Plugins in
-other languages can implement the JSON examples above directly.
+other languages implement the JSON contract directly — the
+[Plugin SDK page](plugin-sdk.md) has the full Go reference plus verified
+Python, Rust, and Bash examples.
 
 ## Trust and secrets
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -85,33 +85,98 @@ Failure semantics follow the integration point: a failed `poll` is logged and
 retried on the next interval like any source poll error; a failed `export` is
 logged and dropped. A plugin can never take the dispatcher down.
 
-## Install and enable
+## Where plugins live
 
-An installed plugin is a directory containing `apiary-plugin.json` and the
-executable named by that manifest. The default search directory is
-`.apiary/plugins` beside `apiary.yaml`; `plugin_dirs` overrides it.
+An installed plugin is **one directory per plugin**, named by its id, holding
+exactly two things: the manifest and the executable it names.
+
+```
+<project>/
+├── apiary.yaml
+├── .env
+└── .apiary/
+    └── plugins/                          ← default search directory
+        ├── dev.apiary.source-file/       ← one directory per plugin id
+        │   ├── apiary-plugin.json        ← manifest
+        │   └── apiary-plugin-source-file ← executable (chmod +x)
+        └── com.example.nagios/
+            ├── apiary-plugin.json
+            └── nagios-source
+```
+
+The default search directory is `.apiary/plugins` **beside `apiary.yaml`**.
+`plugin_dirs` replaces it; list several to layer scopes:
 
 ```yaml
 plugin_dirs:
-  - .apiary/plugins
-  - ~/.local/share/apiary/plugins
-
-plugins:
-  - id: dev.apiary.event-file
-    enabled: true                 # omitted means true
-    timeout: 5s                   # default: 10s, per invocation
-    config:
-      path: .apiary/events.jsonl
+  - .apiary/plugins                  # project-local: plugins for this project only
+  - ~/.local/share/apiary/plugins   # user-global: shared across your projects
+  # - /opt/apiary/plugins           # system-wide: daemon-as-a-service installs
 ```
 
-Use `apiary plugins`, `apiary plugins inspect <id>`, and
-`apiary plugins validate` to inspect installations. `apiary validate` also
-discovers every enabled plugin and validates its configuration against the
-manifest's JSON Schema. Set `enabled: false` to keep an installed/configured
-plugin available without starting or schema-validating it.
+Relative entries resolve beside `apiary.yaml`. Discovery scans every listed
+directory; a plugin id appearing in more than one is an error — Apiary never
+picks a winner by path order. Keep the directories writable only by the
+Apiary operator or service account: plugins run with the daemon's OS
+permissions.
 
-Relative plugin directories resolve beside `apiary.yaml`. Discovery is
-deterministic and rejects duplicate IDs rather than choosing one by path order.
+## Installing a plugin
+
+Apiary has no plugin registry and never downloads plugins — installation is
+placing files, deliberately. Using the bundled `source-file` reference plugin
+as the example:
+
+**1. Obtain the executable.** Build it from source or download a release from
+the plugin's publisher, then verify the artifact out of band (checksum,
+signature):
+
+```bash
+go build -o apiary-plugin-source-file ./src/examples/plugins/source-file
+```
+
+**2. Create the plugin's directory** under a searched location, named by the
+plugin id, and copy in the manifest and executable:
+
+```bash
+mkdir -p .apiary/plugins/dev.apiary.source-file
+cp apiary-plugin.json apiary-plugin-source-file .apiary/plugins/dev.apiary.source-file/
+chmod +x .apiary/plugins/dev.apiary.source-file/apiary-plugin-source-file
+```
+
+**3. Check the installation** — discovery and manifest validation, no plugin
+code executed:
+
+```bash
+apiary plugins list                # dev.apiary.source-file  1.0.0  enabled  source
+apiary plugins inspect dev.apiary.source-file
+apiary plugins validate
+```
+
+**4. Enable it in `apiary.yaml`.** Installation makes a plugin *available*;
+only a `plugins:` entry makes it *run*:
+
+```yaml
+plugins:
+  - id: dev.apiary.source-file
+    enabled: true                 # omitted means true
+    timeout: 5s                   # default: 10s, per invocation
+    config:                       # validated against the manifest's config_schema
+      path: /path/to/project/.apiary/incoming-items.json
+```
+
+`apiary validate` now also validates this instance's `config` against the
+manifest's JSON Schema. Set `enabled: false` to keep an installed plugin
+configured but inert.
+
+**5. Restart the daemon.** Plugin clients are created at startup; a plugin
+installed or reconfigured while the daemon runs is picked up on the next
+start.
+
+To **upgrade**, verify the new artifact in a staging directory, stop Apiary,
+replace the whole plugin directory atomically, run `apiary plugins validate`,
+and restart (details under [Trust and secrets](#trust-and-secrets)). To
+**uninstall**, remove the `plugins:` entry (or set `enabled: false`) and
+delete the plugin's directory.
 
 ## Manifest version 1
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,6 +5,86 @@ loading Go binaries. A plugin crash, invalid response, or timeout terminates onl
 that invocation; it does not crash the dispatcher. Plugins are never executed
 during discovery or configuration validation.
 
+## Architecture
+
+A plugin is an **executable file** (any language) installed in a directory
+together with a manifest. The daemon never links against it and never keeps it
+running: every call spawns a fresh process, writes one JSON request to its
+stdin, reads one JSON response from its stdout, and the process exits.
+
+```mermaid
+flowchart LR
+    subgraph daemon [apiary daemon]
+        DISC[Discovery<br/>plugin_dirs → registry] --> VAL[Validation<br/>manifest + config schema]
+        VAL --> CLIENT[Plugin client<br/>one per enabled instance]
+        SRC["type: plugin source<br/>(poll interval)"] --> CLIENT
+        EVT[execution events] --> CLIENT
+    end
+    CLIENT -- "spawn per call<br/>JSON on stdin" --> PROC[plugin process]
+    PROC -- "one JSON response<br/>on stdout, then exit" --> CLIENT
+    PROC --> BACKEND[(backing system:<br/>API, file, queue…)]
+```
+
+The moving parts, in the order they run:
+
+1. **Discovery** scans `plugin_dirs` for directories containing
+   `apiary-plugin.json`, builds a registry, and rejects duplicate IDs. No
+   plugin code executes during discovery.
+2. **Validation** (`apiary validate`, `apiary plugins validate`, daemon
+   startup) checks the manifest — schema version, semver compatibility with
+   the host, protocol version, executable safety, checksum pin — and
+   validates each enabled instance's `config` against the manifest's JSON
+   Schema. Still no plugin code executes.
+3. **Client creation** happens at daemon startup for every enabled instance
+   whose manifest declares a capability the daemon integrates (see the
+   [capability table](#protocol-version-1)). The client re-verifies the
+   executable's checksum pin here and before every later invocation.
+4. **Invocation** is where plugin code finally runs — see the lifecycle below.
+
+### Invocation lifecycle
+
+Each call is single-shot and stateless:
+
+1. The client re-checks the pinned checksum (cheap `stat()` unless the file
+   changed) and spawns the executable with a deadline (the instance's
+   `timeout`, default 10s).
+2. One compact JSON request — protocol version, request ID, capability,
+   method, the instance's `config`, and the call payload — is written to the
+   child's stdin, followed by a newline.
+3. The plugin does its work (call an API, read a file …) and writes exactly
+   one JSON response to stdout, echoing the request ID. Diagnostics belong on
+   stderr.
+4. The client enforces the contract: protocol version match, request-ID echo,
+   a single response object, stdout ≤ 4 MiB, stderr capture ≤ 64 KiB. The
+   deadline kills the process; a crash, timeout, or malformed response fails
+   only that invocation.
+
+Because every call is a fresh process, **plugins hold no in-memory state
+between calls**. State lives in the backing system the plugin fronts (or a
+file it manages). This is what makes the isolation story simple — there is no
+long-running sidecar to supervise, leak, or restart.
+
+### Process environment
+
+| Aspect | Behavior |
+|---|---|
+| Working directory | The **plugin's install directory**, not the project root — relative paths in plugin `config` resolve there, so prefer absolute paths |
+| Environment | Minimal allowlist (`PATH`, `HOME`, `TMPDIR`, locale/timezone) plus only the variables named in the manifest's `security.secret_env` — daemon secrets never leak in by default |
+| Identity | `APIARY_PLUGIN_ID` and `APIARY_PLUGIN_PROTOCOL` are always set |
+| Configuration | Passed inside every request (`config` field) — never via environment or files |
+
+### How capabilities integrate
+
+| Capability | When the daemon invokes it |
+|---|---|
+| `source` | A `sources[]` entry with `type: plugin` bridges to the instance; the daemon calls `poll` on the source's `poll_interval` and forwards `acknowledge`/`write_result` after dispatch. Polling only — plugins never push into the daemon |
+| `event_exporter` | Once per persisted (redacted) execution event |
+| `runner`, `workflow_action`, `approval_provider`, `secret_provider` | Reserved: manifest and transport are stable, daemon integration not yet wired |
+
+Failure semantics follow the integration point: a failed `poll` is logged and
+retried on the next interval like any source poll error; a failed `export` is
+logged and dropped. A plugin can never take the dispatcher down.
+
 ## Install and enable
 
 An installed plugin is a directory containing `apiary-plugin.json` and the

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -71,6 +71,19 @@ workflow dispatches.
 - **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
 - **Setup:** See [Dynatrace Source configuration](dynatrace-source.md)
 
+### Custom sources via plugins
+
+**Status:** ✅ Stable | **Auth:** Plugin-defined
+
+Any system can become a poll source without a fork: ship an out-of-process
+`source`-capability plugin (protocol 1, any language) and bridge it with
+`type: plugin`. The daemon invokes the plugin on the source's poll interval;
+items flow through normal workflow trigger matching.
+
+- **Requirements:** Plugin installed in `plugin_dirs` and enabled under `plugins:`
+- **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
+- **Setup:** See [Source plugins](plugins.md#source-plugins) and the `source-file` reference plugin
+
 ### Linear
 
 **Status:** 🔄 Planned | **Auth:** API token

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,9 @@ nav:
       - Plane: plane-source.md
       - Prometheus: prometheus-source.md
       - Dynatrace: dynatrace-source.md
-  - Plugins: plugins.md
+  - Plugins:
+      - Overview & Architecture: plugins.md
+      - Plugin SDK: plugin-sdk.md
   - Reference:
       - CLI: cli.md
       - Dashboard: dashboard.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Plane: plane-source.md
       - Prometheus: prometheus-source.md
       - Dynatrace: dynatrace-source.md
+  - Plugins: plugins.md
   - Reference:
       - CLI: cli.md
       - Dashboard: dashboard.md

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -151,11 +151,11 @@
           "type": {
             "type": "string",
             "description": "Source adapter type",
-            "enum": ["github", "jira", "plane", "prometheus", "dynatrace"]
+            "enum": ["github", "jira", "plane", "prometheus", "dynatrace", "plugin"]
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. plugin: plugin (the id of an installed, enabled plugin with the source capability)",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/cmd/apiary/main.go
+++ b/src/cmd/apiary/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/orlandoburli/apiary/internal/source/github"
 	_ "github.com/orlandoburli/apiary/internal/source/jira"
 	_ "github.com/orlandoburli/apiary/internal/source/plane"
+	_ "github.com/orlandoburli/apiary/internal/source/pluginsource"
 	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
 
 	_ "github.com/orlandoburli/apiary/internal/runner/providers"

--- a/src/examples/plugins/source-bash/README.md
+++ b/src/examples/plugins/source-bash/README.md
@@ -1,0 +1,42 @@
+# Source-bash reference plugin
+
+The same behavior as the Go [`source-file`](../source-file/README.md) plugin —
+poll Apiary work items from a JSON file — implemented as a **Bash script**, to
+show that a plugin is just an executable speaking one JSON request/response on
+stdin/stdout. Requires `bash` and `jq` on the daemon host.
+
+There is nothing to build. Install by copying the script and manifest:
+
+```bash
+mkdir -p .apiary/plugins/dev.apiary.source-bash
+cp src/examples/plugins/source-bash/apiary-plugin.json \
+   src/examples/plugins/source-bash/apiary-plugin-source-bash \
+   .apiary/plugins/dev.apiary.source-bash/
+chmod +x .apiary/plugins/dev.apiary.source-bash/apiary-plugin-source-bash
+apiary plugins validate
+```
+
+Enable and bridge it in `apiary.yaml` (absolute `path` — plugin processes run
+with cwd set to their install directory):
+
+```yaml
+plugins:
+  - id: dev.apiary.source-bash
+    timeout: 5s
+    config:
+      path: /path/to/project/.apiary/incoming-items.json
+
+sources:
+  - id: bash-items
+    type: plugin
+    poll_interval: 30s
+    config:
+      plugin: dev.apiary.source-bash
+```
+
+Test it without Apiary — the protocol is pipeable:
+
+```bash
+echo '{"protocol":1,"request_id":"t1","capability":"source","method":"poll","config":{"path":"items.json"}}' \
+  | ./apiary-plugin-source-bash
+```

--- a/src/examples/plugins/source-bash/apiary-plugin-source-bash
+++ b/src/examples/plugins/source-bash/apiary-plugin-source-bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Reference protocol-1 source plugin in Bash: polls Apiary work items from the
+# JSON file named by config.path — the same behavior as the Go source-file
+# plugin, to show the contract is small enough for a shell script. Requires jq.
+set -euo pipefail
+
+req=$(cat)                                   # the single request, stdin → EOF
+request_id=$(jq -r '.request_id' <<<"$req")
+protocol=$(jq -r '.protocol' <<<"$req")
+capability=$(jq -r '.capability' <<<"$req")
+method=$(jq -r '.method' <<<"$req")
+
+respond() { jq -nc --arg id "$request_id" "{protocol: 1, request_id: \$id} + $1"; }
+
+if [[ "$protocol" != "1" ]]; then
+  respond '{error: {code: "unsupported_protocol", message: "expected protocol 1"}}'
+  exit 0
+fi
+if [[ "$capability" != "source" ]]; then
+  respond '{error: {code: "unsupported_capability", message: "expected capability source"}}'
+  exit 0
+fi
+
+case "$method" in
+  poll)
+    path=$(jq -r '.config.path // empty' <<<"$req")
+    if [[ -z "$path" ]]; then
+      respond '{error: {code: "invalid_config", message: "config.path is required"}}'
+    elif [[ ! -f "$path" ]]; then
+      # An absent file simply means no work yet.
+      respond '{result: {items: []}}'
+    elif items=$(jq -ec 'if type == "array" then . else error("not an array") end' "$path" 2>/dev/null); then
+      echo "poll: $(jq 'length' <<<"$items") item(s) from $path" >&2   # diagnostics → stderr
+      respond "{result: {items: $items}}"
+    else
+      respond "{error: {code: \"invalid_items\", message: \"$path must hold a JSON array of items\"}}"
+    fi
+    ;;
+  acknowledge|write_result)
+    # Nothing to mark in a plain file; report success so the host logs stay clean.
+    respond '{result: {ok: true}}'
+    ;;
+  *)
+    respond "{error: {code: \"unsupported_method\", message: \"unknown method $method\"}}"
+    ;;
+esac

--- a/src/examples/plugins/source-bash/apiary-plugin.json
+++ b/src/examples/plugins/source-bash/apiary-plugin.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "dev.apiary.source-bash",
+  "version": "1.0.0",
+  "apiary": ">= 0.13.0-0",
+  "protocol": 1,
+  "executable": "apiary-plugin-source-bash",
+  "capabilities": ["source"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "minLength": 1}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  },
+  "security": {
+    "network": false,
+    "read_paths": ["configured items file"]
+  }
+}

--- a/src/examples/plugins/source-file/README.md
+++ b/src/examples/plugins/source-file/README.md
@@ -22,7 +22,7 @@ plugins:
   - id: dev.apiary.source-file
     timeout: 5s
     config:
-      path: .apiary/incoming-items.json
+      path: /path/to/project/.apiary/incoming-items.json
 
 sources:
   - id: file-items
@@ -31,6 +31,12 @@ sources:
     config:
       plugin: dev.apiary.source-file
 ```
+
+!!! note
+    Use an absolute `path`. Plugin processes run with their working directory
+    set to the plugin's install directory (not the project root), so a
+    relative path would resolve inside `.apiary/plugins/dev.apiary.source-file/`
+    — and an absent file there reads as "no work yet".
 
 The items file holds a JSON array in the SDK wire shape
 (`sdk/plugin/source.go`); IDs are the dedup key, so keep them stable:

--- a/src/examples/plugins/source-file/README.md
+++ b/src/examples/plugins/source-file/README.md
@@ -1,0 +1,48 @@
+# Source-file reference plugin
+
+This minimal protocol-1 `source` plugin polls Apiary work items from a JSON
+file. Any external process can append items to the file and Apiary dispatches
+matching workflows on the next poll — the simplest possible custom source.
+
+Build and install it from the repository root:
+
+```bash
+go build -o src/examples/plugins/source-file/apiary-plugin-source-file ./src/examples/plugins/source-file
+mkdir -p .apiary/plugins/dev.apiary.source-file
+cp src/examples/plugins/source-file/apiary-plugin.json \
+  src/examples/plugins/source-file/apiary-plugin-source-file \
+  .apiary/plugins/dev.apiary.source-file/
+apiary plugins validate
+```
+
+Then enable it and bridge a source to it in `apiary.yaml`:
+
+```yaml
+plugins:
+  - id: dev.apiary.source-file
+    timeout: 5s
+    config:
+      path: .apiary/incoming-items.json
+
+sources:
+  - id: file-items
+    type: plugin
+    poll_interval: 30s
+    config:
+      plugin: dev.apiary.source-file
+```
+
+The items file holds a JSON array in the SDK wire shape
+(`sdk/plugin/source.go`); IDs are the dedup key, so keep them stable:
+
+```json
+[
+  {
+    "id": "task-001",
+    "title": "Investigate checkout latency",
+    "description": "p99 above 2s since the 14:00 deploy.",
+    "labels": ["team:payments", "severity:high"],
+    "state": "open"
+  }
+]
+```

--- a/src/examples/plugins/source-file/apiary-plugin.json
+++ b/src/examples/plugins/source-file/apiary-plugin.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "dev.apiary.source-file",
+  "version": "1.0.0",
+  "apiary": ">= 0.13.0-0",
+  "protocol": 1,
+  "executable": "apiary-plugin-source-file",
+  "capabilities": ["source"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "minLength": 1}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  },
+  "security": {
+    "network": false,
+    "read_paths": ["configured items file"]
+  }
+}

--- a/src/examples/plugins/source-file/main.go
+++ b/src/examples/plugins/source-file/main.go
@@ -1,0 +1,52 @@
+// Command apiary-plugin-source-file is the reference protocol-1 source
+// plugin: it polls work items from a JSON file, so any external process can
+// drop items there and have Apiary dispatch workflows for them. It shows the
+// full CapabilitySource contract — poll returns the file's items each cycle
+// (stable IDs make re-dispatch impossible downstream), acknowledge and
+// write_result are honest no-ops.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+func main() {
+	pluginsdk.Main(serve)
+}
+
+func serve(_ context.Context, req pluginsdk.Request) (any, *pluginsdk.ResponseError) {
+	if req.Capability != pluginsdk.CapabilitySource {
+		return nil, &pluginsdk.ResponseError{Code: "unsupported_capability", Message: "expected capability source"}
+	}
+	switch req.Method {
+	case pluginsdk.SourceMethodPoll:
+		return poll(req)
+	case pluginsdk.SourceMethodAcknowledge, pluginsdk.SourceMethodWriteResult:
+		// Nothing to mark in a plain file; report success so the host logs stay clean.
+		return pluginsdk.SourceOKResult{OK: true}, nil
+	default:
+		return nil, &pluginsdk.ResponseError{Code: "unsupported_method", Message: fmt.Sprintf("unknown method %q", req.Method)}
+	}
+}
+
+func poll(req pluginsdk.Request) (any, *pluginsdk.ResponseError) {
+	path, _ := req.Config["path"].(string)
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		// An absent file simply means no work yet.
+		return pluginsdk.SourcePollResult{Items: []pluginsdk.SourceItem{}}, nil
+	}
+	if err != nil {
+		return nil, &pluginsdk.ResponseError{Code: "read_failed", Message: err.Error()}
+	}
+	var items []pluginsdk.SourceItem
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, &pluginsdk.ResponseError{Code: "invalid_items", Message: fmt.Sprintf("%s must hold a JSON array of items: %v", path, err)}
+	}
+	return pluginsdk.SourcePollResult{Items: items}, nil
+}

--- a/src/examples/plugins/source-node/.gitignore
+++ b/src/examples/plugins/source-node/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+apiary-plugin-source-node
+package-lock.json

--- a/src/examples/plugins/source-node/README.md
+++ b/src/examples/plugins/source-node/README.md
@@ -1,0 +1,49 @@
+# Source-node reference plugin (TypeScript)
+
+The same behavior as the Go [`source-file`](../source-file/README.md) plugin —
+poll Apiary work items from a JSON file — implemented in **TypeScript** and run
+with Node, to show plugins can be written in any ecosystem. No runtime
+dependencies; TypeScript is a dev-time dependency only. Requires `node` on the
+daemon host.
+
+Build (compiles `main.ts` and prepends a `#!/usr/bin/env node` shebang so the
+output is directly executable):
+
+```bash
+cd src/examples/plugins/source-node
+npm install
+npm run build          # produces ./apiary-plugin-source-node
+```
+
+Install:
+
+```bash
+mkdir -p .apiary/plugins/dev.apiary.source-node
+cp apiary-plugin.json apiary-plugin-source-node .apiary/plugins/dev.apiary.source-node/
+apiary plugins validate
+```
+
+Enable and bridge it in `apiary.yaml` (absolute `path` — plugin processes run
+with cwd set to their install directory):
+
+```yaml
+plugins:
+  - id: dev.apiary.source-node
+    timeout: 5s
+    config:
+      path: /path/to/project/.apiary/incoming-items.json
+
+sources:
+  - id: node-items
+    type: plugin
+    poll_interval: 30s
+    config:
+      plugin: dev.apiary.source-node
+```
+
+Test it without Apiary — the protocol is pipeable:
+
+```bash
+echo '{"protocol":1,"request_id":"t1","capability":"source","method":"poll","config":{"path":"items.json"}}' \
+  | ./apiary-plugin-source-node
+```

--- a/src/examples/plugins/source-node/apiary-plugin.json
+++ b/src/examples/plugins/source-node/apiary-plugin.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "dev.apiary.source-node",
+  "version": "1.0.0",
+  "apiary": ">= 0.13.0-0",
+  "protocol": 1,
+  "executable": "apiary-plugin-source-node",
+  "capabilities": ["source"],
+  "config_schema": {
+    "type": "object",
+    "properties": {
+      "path": {"type": "string", "minLength": 1}
+    },
+    "required": ["path"],
+    "additionalProperties": false
+  },
+  "security": {
+    "network": false,
+    "read_paths": ["configured items file"]
+  }
+}

--- a/src/examples/plugins/source-node/main.ts
+++ b/src/examples/plugins/source-node/main.ts
@@ -1,0 +1,66 @@
+// Reference protocol-1 source plugin in TypeScript (Node): polls Apiary work
+// items from the JSON file named by config.path — the same behavior as the Go
+// source-file plugin. No runtime dependencies; compiled with tsc to a single
+// executable script (see package.json).
+import { readFileSync } from "node:fs";
+
+interface Request {
+  protocol: number;
+  request_id: string;
+  capability: string;
+  method: string;
+  config?: Record<string, unknown>;
+  payload?: unknown;
+}
+
+interface ResponseError {
+  code: string;
+  message: string;
+}
+
+function respond(requestId: string, body: { result?: unknown; error?: ResponseError }): void {
+  // Exactly one JSON object on stdout — all diagnostics belong on stderr.
+  process.stdout.write(JSON.stringify({ protocol: 1, request_id: requestId, ...body }) + "\n");
+}
+
+function poll(config: Record<string, unknown>): { result?: unknown; error?: ResponseError } {
+  const path = typeof config.path === "string" ? config.path : "";
+  if (path === "") {
+    return { error: { code: "invalid_config", message: "config.path is required" } };
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { result: { items: [] } }; // an absent file simply means no work yet
+    }
+    return { error: { code: "read_failed", message: String(err) } };
+  }
+  let items: unknown;
+  try {
+    items = JSON.parse(raw);
+  } catch (err) {
+    return { error: { code: "invalid_items", message: `${path} must hold a JSON array of items: ${err}` } };
+  }
+  if (!Array.isArray(items)) {
+    return { error: { code: "invalid_items", message: `${path} must hold a JSON array of items` } };
+  }
+  console.error(`poll: ${items.length} item(s) from ${path}`); // diagnostics → stderr
+  return { result: { items } };
+}
+
+const input = readFileSync(0, "utf8"); // the single request, stdin → EOF
+const req = JSON.parse(input) as Request;
+
+if (req.protocol !== 1) {
+  respond(req.request_id ?? "", { error: { code: "unsupported_protocol", message: "expected protocol 1" } });
+} else if (req.capability !== "source") {
+  respond(req.request_id, { error: { code: "unsupported_capability", message: "expected capability source" } });
+} else if (req.method === "poll") {
+  respond(req.request_id, poll(req.config ?? {}));
+} else if (req.method === "acknowledge" || req.method === "write_result") {
+  respond(req.request_id, { result: { ok: true } }); // nothing to mark in a plain file
+} else {
+  respond(req.request_id, { error: { code: "unsupported_method", message: `unknown method ${req.method}` } });
+}

--- a/src/examples/plugins/source-node/package.json
+++ b/src/examples/plugins/source-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "apiary-plugin-source-node",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Apiary reference source plugin in TypeScript (Node)",
+  "scripts": {
+    "build": "tsc && printf '#!/usr/bin/env node\\n' | cat - dist/main.js > apiary-plugin-source-node && chmod +x apiary-plugin-source-node"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "typescript": "^5"
+  }
+}

--- a/src/examples/plugins/source-node/tsconfig.json
+++ b/src/examples/plugins/source-node/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "types": ["node"]
+  },
+  "files": ["main.ts"]
+}

--- a/src/internal/config/plugin_source_validate_test.go
+++ b/src/internal/config/plugin_source_validate_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+func pluginSourceConfig(pluginRef string, instances []plugin.InstanceConfig) *Config {
+	cfg := map[string]any{}
+	if pluginRef != "" {
+		cfg["plugin"] = pluginRef
+	}
+	return &Config{
+		Version: "1",
+		Sources: []SourceConfig{{ID: "bridged", Type: "plugin", Config: cfg}},
+		Plugins: instances,
+	}
+}
+
+func hasErrContaining(errs []error, want string) bool {
+	for _, err := range errs {
+		if strings.Contains(err.Error(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPluginSourceReferenceValidation(t *testing.T) {
+	disabled := false
+	declared := []plugin.InstanceConfig{{ID: "com.example.mon"}}
+
+	cases := []struct {
+		name      string
+		cfg       *Config
+		wantErr   string
+		wantClean bool
+	}{
+		{"missing plugin key", pluginSourceConfig("", nil), "config.plugin is required", false},
+		{"undeclared plugin", pluginSourceConfig("com.example.nope", declared), "not an enabled plugins[] instance", false},
+		{"disabled plugin", pluginSourceConfig("com.example.off", []plugin.InstanceConfig{{ID: "com.example.off", Enabled: &disabled}}), "not an enabled plugins[] instance", false},
+		{"valid reference", pluginSourceConfig("com.example.mon", declared), "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.cfg.Validate()
+			if tc.wantClean {
+				if hasErrContaining(errs, "config.plugin") {
+					t.Errorf("unexpected plugin-source error: %v", errs)
+				}
+				return
+			}
+			if !hasErrContaining(errs, tc.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", errs, tc.wantErr)
+			}
+		})
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -152,6 +152,14 @@ func (c *Config) Validate() []error {
 		errs = append(errs, fmt.Errorf("default_runner %q: not defined in runners", c.DefaultRunner))
 	}
 
+	// Enabled plugin instance ids, for plugin-bridged source references.
+	enabledPlugins := map[string]bool{}
+	for _, p := range c.Plugins {
+		if p.IsEnabled() {
+			enabledPlugins[p.ID] = true
+		}
+	}
+
 	sourceIDs := map[string]bool{}
 	for i, s := range c.Sources {
 		if s.ID == "" {
@@ -164,6 +172,18 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("sources[%d]: duplicate id %q", i, s.ID))
 		}
 		sourceIDs[s.ID] = true
+
+		// A plugin-bridged source must name a declared, enabled plugin
+		// instance — the daemon resolves it at startup, but a broken
+		// reference should fail `apiary validate`, not the daemon.
+		if s.Type == "plugin" {
+			pluginID, _ := s.Config["plugin"].(string)
+			if strings.TrimSpace(pluginID) == "" {
+				errs = append(errs, fmt.Errorf("sources[%d] %q: config.plugin is required for type \"plugin\" (the id of an enabled plugins[] instance with the \"source\" capability)", i, s.ID))
+			} else if !enabledPlugins[pluginID] {
+				errs = append(errs, fmt.Errorf("sources[%d] %q: config.plugin %q is not an enabled plugins[] instance", i, s.ID, pluginID))
+			}
+		}
 	}
 
 	agentIDs := map[string]bool{}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/source/pluginsource"
 	"github.com/orlandoburli/apiary/internal/version"
 	workerpkg "github.com/orlandoburli/apiary/internal/worker"
 	"github.com/orlandoburli/apiary/internal/workflow"
@@ -229,6 +230,16 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 	if len(pluginErrs) > 0 {
 		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
 	}
+	// Source-capable plugin clients, keyed by plugin id, resolved by `type:
+	// plugin` sources (pluginsource bridge) below.
+	sourceClients, pluginErrs := plugin.EnabledClients(registry, cfg.Plugins, plugin.CapabilitySource)
+	if len(pluginErrs) > 0 {
+		return nil, fmt.Errorf("plugins: %w", errors.Join(pluginErrs...))
+	}
+	sourcePlugins := make(map[string]*plugin.Client, len(sourceClients))
+	for _, client := range sourceClients {
+		sourcePlugins[client.ID()] = client
+	}
 	if dbClient != nil {
 		dbClient.SetEventSensitiveFields(cfg.Settings.Events.SensitiveFields)
 	}
@@ -276,6 +287,17 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 			SetID(id string)
 		}); ok {
 			si.SetID(sc.ID)
+		}
+
+		// Plugin-bridged sources resolve their plugin client at Connect; hand
+		// them the enabled source-capable clients before connecting.
+		if pb, ok := adapter.(interface {
+			BindPluginLookup(func(pluginID string) (pluginsource.Invoker, bool))
+		}); ok {
+			pb.BindPluginLookup(func(pluginID string) (pluginsource.Invoker, bool) {
+				client, ok := sourcePlugins[pluginID]
+				return client, ok
+			})
 		}
 
 		if err := adapter.Connect(ctx, sc.Config); err != nil {

--- a/src/internal/source/pluginsource/adapter.go
+++ b/src/internal/source/pluginsource/adapter.go
@@ -1,0 +1,215 @@
+// Package pluginsource bridges an out-of-process source plugin
+// (CapabilitySource, protocol 1) to the source.Adapter interface, so third
+// parties can ship poll-mode sources without a fork. A source declares
+// `type: plugin` and names the plugin instance in config:
+//
+//	plugins:
+//	  - id: com.example.nagios
+//	sources:
+//	  - id: nagios-alerts
+//	    type: plugin
+//	    config:
+//	      plugin: com.example.nagios
+//	    poll_interval: 30s
+//
+// The daemon injects a lookup over the enabled CapabilitySource plugin
+// clients (BindPluginLookup) before Connect; each Poll/Acknowledge/
+// WriteResult then becomes one single-shot plugin invocation (see
+// sdk/plugin/source.go for the wire contract). Polling only: like every
+// Apiary source, the plugin is asked for items on the source's interval —
+// plugins never push into the daemon.
+//
+// Plugin sources are read-only work items, like the in-tree monitoring
+// sources: none of the optional write capabilities are implemented, so
+// config validation rejects workflows that need set_state, label writes,
+// approvals, or CI waits against them (config.SourceCapabilities).
+package pluginsource
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+func init() {
+	source.Register("plugin", func() source.Adapter { return &Adapter{} })
+}
+
+// Invoker is the slice of plugin.Client the bridge needs; narrowed so tests
+// stub it without subprocesses.
+type Invoker interface {
+	ID() string
+	Invoke(ctx context.Context, capability pluginsdk.Capability, method string, payload any, result any) error
+}
+
+// Adapter implements source.Adapter over a source-capable plugin client.
+type Adapter struct {
+	id     string
+	lookup func(pluginID string) (Invoker, bool)
+	client Invoker
+
+	filterStates []string
+	filterLabels []string
+}
+
+func (a *Adapter) ID() string { return a.id }
+
+// SetID sets the source ID for this adapter.
+func (a *Adapter) SetID(id string) { a.id = id }
+
+// BindPluginLookup injects the resolver over enabled source-capable plugin
+// clients. The daemon calls it before Connect; a nil or missing lookup makes
+// Connect fail rather than silently polling nothing.
+func (a *Adapter) BindPluginLookup(lookup func(pluginID string) (Invoker, bool)) {
+	a.lookup = lookup
+}
+
+// SetFilters stores the source's filters; they are forwarded on every poll so
+// the plugin can filter at its backend.
+func (a *Adapter) SetFilters(states, labels []string) {
+	a.filterStates = states
+	a.filterLabels = labels
+}
+
+// Connect resolves the configured plugin instance. No invocation is made:
+// plugins are single-shot processes with nothing persistent to connect to,
+// and the first poll surfaces runtime problems on the normal error path.
+func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
+	pluginID, _ := cfg["plugin"].(string)
+	if strings.TrimSpace(pluginID) == "" {
+		return fmt.Errorf("plugin source: config.plugin is required (the id of an installed, enabled plugin with the \"source\" capability)")
+	}
+	if a.lookup == nil {
+		return fmt.Errorf("plugin source: no plugin registry available (daemon wiring)")
+	}
+	client, ok := a.lookup(pluginID)
+	if !ok {
+		return fmt.Errorf("plugin source: plugin %q is not an enabled plugin with the \"source\" capability — declare it under plugins: and check `apiary validate`", pluginID)
+	}
+	a.client = client
+	aplog.Info("plugin source %s: bridged to plugin %s", a.id, client.ID())
+	return nil
+}
+
+// Poll asks the plugin for its current items via one source.poll invocation.
+func (a *Adapter) Poll(ctx context.Context, since time.Time) ([]model.SourceItem, error) {
+	req := pluginsdk.SourcePollRequest{States: a.filterStates, Labels: a.filterLabels}
+	if !since.IsZero() {
+		req.Since = since.UTC().Format(time.RFC3339)
+	}
+	var res pluginsdk.SourcePollResult
+	if err := a.client.Invoke(ctx, pluginsdk.CapabilitySource, pluginsdk.SourceMethodPoll, req, &res); err != nil {
+		return nil, fmt.Errorf("plugin source %s: %w", a.id, err)
+	}
+
+	items := make([]model.SourceItem, 0, len(res.Items))
+	for _, wi := range res.Items {
+		if strings.TrimSpace(wi.ID) == "" {
+			aplog.Warn("plugin source %s: plugin %s returned an item without id (title %q) — dropped", a.id, a.client.ID(), wi.Title)
+			continue
+		}
+		items = append(items, a.toSourceItem(wi))
+	}
+	return items, nil
+}
+
+func (a *Adapter) toSourceItem(wi pluginsdk.SourceItem) model.SourceItem {
+	number := wi.Number
+	if number == "" {
+		number = wi.ID
+	}
+	title := wi.Title
+	if title == "" {
+		title = "plugin item " + wi.ID
+	}
+	labels := append([]string(nil), wi.Labels...)
+	sort.Strings(labels)
+
+	now := time.Now()
+	created := parseTime(wi.CreatedAt, now)
+	updated := parseTime(wi.UpdatedAt, created)
+
+	return model.SourceItem{
+		ID:          wi.ID,
+		SourceID:    a.id,
+		Number:      number,
+		Title:       title,
+		Description: wi.Description,
+		Labels:      labels,
+		Type:        wi.Type,
+		Priority:    wi.Priority,
+		State:       wi.State,
+		URL:         wi.URL,
+		Metadata:    wi.Metadata,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+	}
+}
+
+func parseTime(value string, fallback time.Time) time.Time {
+	if value == "" {
+		return fallback
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return fallback
+	}
+	return t
+}
+
+// Acknowledge forwards the dispatch acknowledgement. Failures are returned to
+// the caller, which logs them without failing the run — matching how ack
+// errors behave for in-tree sources.
+func (a *Adapter) Acknowledge(ctx context.Context, cell model.SourceItem, action model.AckAction) error {
+	req := pluginsdk.SourceAckRequest{Item: toWireItem(cell), Action: string(action)}
+	var res pluginsdk.SourceOKResult
+	if err := a.client.Invoke(ctx, pluginsdk.CapabilitySource, pluginsdk.SourceMethodAcknowledge, req, &res); err != nil {
+		return fmt.Errorf("plugin source %s: %w", a.id, err)
+	}
+	return nil
+}
+
+// WriteResult forwards the run outcome.
+func (a *Adapter) WriteResult(ctx context.Context, cell model.SourceItem, result model.RunResult) error {
+	errMsg := ""
+	if result.Error != nil {
+		errMsg = result.Error.Error()
+	}
+	req := pluginsdk.SourceWriteResultRequest{
+		Item:    toWireItem(cell),
+		Success: result.Success,
+		Output:  result.Output,
+		Error:   errMsg,
+	}
+	var res pluginsdk.SourceOKResult
+	if err := a.client.Invoke(ctx, pluginsdk.CapabilitySource, pluginsdk.SourceMethodWriteResult, req, &res); err != nil {
+		return fmt.Errorf("plugin source %s: %w", a.id, err)
+	}
+	return nil
+}
+
+// toWireItem maps the model item back to the SDK wire shape for ack /
+// write_result payloads.
+func toWireItem(cell model.SourceItem) pluginsdk.SourceItem {
+	return pluginsdk.SourceItem{
+		ID:          cell.ID,
+		Number:      cell.Number,
+		Title:       cell.Title,
+		Description: cell.Description,
+		Labels:      cell.Labels,
+		Type:        cell.Type,
+		Priority:    cell.Priority,
+		State:       cell.State,
+		URL:         cell.URL,
+		Metadata:    cell.Metadata,
+		CreatedAt:   cell.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   cell.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}

--- a/src/internal/source/pluginsource/adapter_test.go
+++ b/src/internal/source/pluginsource/adapter_test.go
@@ -1,0 +1,225 @@
+package pluginsource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+	pluginsdk "github.com/orlandoburli/apiary/sdk/plugin"
+)
+
+// fakeInvoker records invocations and returns canned results per method.
+type fakeInvoker struct {
+	id      string
+	results map[string]any   // method → result value (JSON round-tripped)
+	errs    map[string]error // method → forced error
+	calls   []recordedCall
+}
+
+type recordedCall struct {
+	capability pluginsdk.Capability
+	method     string
+	payload    any
+}
+
+func (f *fakeInvoker) ID() string { return f.id }
+
+func (f *fakeInvoker) Invoke(_ context.Context, capability pluginsdk.Capability, method string, payload any, result any) error {
+	f.calls = append(f.calls, recordedCall{capability, method, payload})
+	if err := f.errs[method]; err != nil {
+		return err
+	}
+	value, ok := f.results[method]
+	if !ok || result == nil {
+		return nil
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, result)
+}
+
+func connected(t *testing.T, f *fakeInvoker) *Adapter {
+	t.Helper()
+	a := &Adapter{}
+	a.SetID("bridged")
+	a.BindPluginLookup(func(id string) (Invoker, bool) {
+		if id == f.id {
+			return f, true
+		}
+		return nil, false
+	})
+	if err := a.Connect(context.Background(), map[string]any{"plugin": f.id}); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	return a
+}
+
+func TestRegisteredReadOnly(t *testing.T) {
+	a, ok := source.New("plugin")
+	if !ok {
+		t.Fatal("plugin source adapter not registered")
+	}
+	// Read-only: the capability lint must see none of the write interfaces.
+	if _, ok := a.(source.StateSetter); ok {
+		t.Error("plugin source must not implement StateSetter")
+	}
+	if _, ok := a.(source.LabelAdder); ok {
+		t.Error("plugin source must not implement LabelAdder")
+	}
+	if _, ok := a.(source.TaskPoller); ok {
+		t.Error("plugin source must not implement TaskPoller")
+	}
+	if _, ok := a.(source.CIStatusPoller); ok {
+		t.Error("plugin source must not implement CIStatusPoller")
+	}
+	if _, ok := a.(source.SubIssueCreator); ok {
+		t.Error("plugin source must not implement SubIssueCreator")
+	}
+}
+
+func TestConnectValidation(t *testing.T) {
+	lookup := func(id string) (Invoker, bool) {
+		if id == "com.example.ok" {
+			return &fakeInvoker{id: id}, true
+		}
+		return nil, false
+	}
+
+	cases := []struct {
+		name    string
+		bind    bool
+		cfg     map[string]any
+		wantErr string
+	}{
+		{"missing plugin key", true, map[string]any{}, "config.plugin is required"},
+		{"unknown plugin", true, map[string]any{"plugin": "com.example.nope"}, "not an enabled plugin"},
+		{"no lookup injected", false, map[string]any{"plugin": "com.example.ok"}, "no plugin registry"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Adapter{}
+			if tc.bind {
+				a.BindPluginLookup(lookup)
+			}
+			err := a.Connect(context.Background(), tc.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Connect = %v, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	a := &Adapter{}
+	a.BindPluginLookup(lookup)
+	if err := a.Connect(context.Background(), map[string]any{"plugin": "com.example.ok"}); err != nil {
+		t.Errorf("valid config: %v", err)
+	}
+}
+
+func TestPollMapsItems(t *testing.T) {
+	f := &fakeInvoker{id: "com.example.mon", results: map[string]any{
+		pluginsdk.SourceMethodPoll: pluginsdk.SourcePollResult{Items: []pluginsdk.SourceItem{
+			{
+				ID:          "prob-1",
+				Number:      "P-1",
+				Title:       "Disk almost full",
+				Description: "90% on /var",
+				Labels:      []string{"severity:high", "host:db1"},
+				Type:        "alert",
+				Priority:    "high",
+				State:       "open",
+				URL:         "https://mon.example.com/prob-1",
+				Metadata:    map[string]any{"origin": "nagios"},
+				CreatedAt:   "2026-08-05T10:00:00Z",
+				UpdatedAt:   "2026-08-05T11:00:00Z",
+			},
+			{ID: "prob-2"},         // minimal item: defaults fill in
+			{Title: "no id, drop"}, // no ID → dropped
+		}},
+	}}
+	a := connected(t, f)
+	a.SetFilters([]string{"open"}, []string{"team:sre"})
+
+	since := time.Date(2026, 8, 5, 9, 0, 0, 0, time.UTC)
+	items, err := a.Poll(context.Background(), since)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2 (id-less dropped)", len(items))
+	}
+
+	full := items[0]
+	if full.ID != "prob-1" || full.SourceID != "bridged" || full.Number != "P-1" || full.Priority != "high" || full.Type != "alert" {
+		t.Errorf("mapped item wrong: %+v", full)
+	}
+	if !full.CreatedAt.Equal(time.Date(2026, 8, 5, 10, 0, 0, 0, time.UTC)) || !full.UpdatedAt.Equal(time.Date(2026, 8, 5, 11, 0, 0, 0, time.UTC)) {
+		t.Errorf("timestamps wrong: %v / %v", full.CreatedAt, full.UpdatedAt)
+	}
+
+	minimal := items[1]
+	if minimal.Number != "prob-2" || minimal.Title != "plugin item prob-2" {
+		t.Errorf("defaults wrong: %+v", minimal)
+	}
+	if minimal.CreatedAt.IsZero() || !minimal.UpdatedAt.Equal(minimal.CreatedAt) {
+		t.Errorf("time defaults wrong: %v / %v", minimal.CreatedAt, minimal.UpdatedAt)
+	}
+
+	// The poll payload carries since + filters for backend-side filtering.
+	call := f.calls[len(f.calls)-1]
+	if call.capability != pluginsdk.CapabilitySource || call.method != pluginsdk.SourceMethodPoll {
+		t.Fatalf("unexpected call: %+v", call)
+	}
+	req, ok := call.payload.(pluginsdk.SourcePollRequest)
+	if !ok {
+		t.Fatalf("payload type %T", call.payload)
+	}
+	if req.Since != "2026-08-05T09:00:00Z" || len(req.States) != 1 || len(req.Labels) != 1 {
+		t.Errorf("poll request wrong: %+v", req)
+	}
+}
+
+func TestPollError(t *testing.T) {
+	f := &fakeInvoker{id: "com.example.mon", errs: map[string]error{
+		pluginsdk.SourceMethodPoll: errors.New("boom"),
+	}}
+	a := connected(t, f)
+	if _, err := a.Poll(context.Background(), time.Time{}); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("Poll = %v, want wrapped boom", err)
+	}
+}
+
+func TestAcknowledgeAndWriteResultForward(t *testing.T) {
+	f := &fakeInvoker{id: "com.example.mon", results: map[string]any{
+		pluginsdk.SourceMethodAcknowledge: pluginsdk.SourceOKResult{OK: true},
+		pluginsdk.SourceMethodWriteResult: pluginsdk.SourceOKResult{OK: true},
+	}}
+	a := connected(t, f)
+
+	cell := model.SourceItem{ID: "prob-1", Title: "t", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := a.Acknowledge(context.Background(), cell, "dispatched"); err != nil {
+		t.Errorf("Acknowledge: %v", err)
+	}
+	ack := f.calls[len(f.calls)-1]
+	if ack.method != pluginsdk.SourceMethodAcknowledge {
+		t.Fatalf("ack method %q", ack.method)
+	}
+	if req := ack.payload.(pluginsdk.SourceAckRequest); req.Item.ID != "prob-1" || req.Action != "dispatched" {
+		t.Errorf("ack payload wrong: %+v", req)
+	}
+
+	if err := a.WriteResult(context.Background(), cell, model.RunResult{Success: false, Output: "log", Error: fmt.Errorf("step failed")}); err != nil {
+		t.Errorf("WriteResult: %v", err)
+	}
+	wr := f.calls[len(f.calls)-1].payload.(pluginsdk.SourceWriteResultRequest)
+	if wr.Success || wr.Output != "log" || wr.Error != "step failed" {
+		t.Errorf("write_result payload wrong: %+v", wr)
+	}
+}

--- a/src/internal/source/pluginsource/e2e_test.go
+++ b/src/internal/source/pluginsource/e2e_test.go
@@ -1,0 +1,77 @@
+package pluginsource
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+// TestBridgeThroughRealPluginProcess exercises the whole path — bridge →
+// plugin.Client → subprocess → JSON protocol — against a shell-script plugin
+// that answers source.poll with two items.
+func TestBridgeThroughRealPluginProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script plugin fake requires a POSIX shell")
+	}
+
+	root := t.TempDir()
+	script := `#!/bin/sh
+request=$(cat)
+request_id=$(printf '%s' "$request" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"protocol":1,"request_id":"%s","result":{"items":[{"id":"e2e-1","title":"From the real process","labels":["kind:e2e"],"state":"open"},{"id":"e2e-2"}]}}\n' "$request_id"
+`
+	if err := os.WriteFile(filepath.Join(root, "plugin"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]any{
+		"schema_version": 1,
+		"id":             "dev.apiary.e2e-source",
+		"version":        "1.0.0",
+		"apiary":         ">= 0.1.0-0",
+		"protocol":       1,
+		"executable":     "plugin",
+		"capabilities":   []string{"source"},
+	}
+	raw, _ := json.Marshal(manifest)
+	if err := os.WriteFile(filepath.Join(root, plugin.ManifestFilename), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	installed, err := plugin.Load(root, "dev")
+	if err != nil {
+		t.Fatalf("load plugin: %v", err)
+	}
+	client, err := plugin.NewClient(installed, plugin.InstanceConfig{ID: installed.Manifest.ID})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	a := &Adapter{}
+	a.SetID("e2e")
+	a.BindPluginLookup(func(id string) (Invoker, bool) {
+		if id == installed.Manifest.ID {
+			return client, true
+		}
+		return nil, false
+	})
+	if err := a.Connect(context.Background(), map[string]any{"plugin": installed.Manifest.ID}); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if len(items) != 2 || items[0].ID != "e2e-1" || items[0].SourceID != "e2e" || items[1].Title != "plugin item e2e-2" {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+	if len(items[0].Labels) != 1 || items[0].Labels[0] != "kind:e2e" {
+		t.Errorf("labels = %v", items[0].Labels)
+	}
+}

--- a/src/sdk/plugin/source.go
+++ b/src/sdk/plugin/source.go
@@ -1,0 +1,87 @@
+package plugin
+
+// Wire contract for CapabilitySource plugins. The host bridges a `type:
+// plugin` source in apiary.yaml to one plugin instance and invokes these
+// methods over the standard single-shot protocol; the plugin polls its
+// backing system and returns work items. Source plugins are read-only, like
+// the in-tree monitoring sources: items they surface cannot host approval
+// steps, CI waits, or label/state write-back.
+const (
+	// SourceMethodPoll returns the current work items (SourcePollResult).
+	// Invoked on the source's poll interval with a SourcePollRequest. Items
+	// must carry stable IDs: the host dispatches each distinct ID at most
+	// once per its dedup rules, and an item returned on every poll while it
+	// stays relevant is the expected shape (mirror of the in-tree
+	// monitoring adapters).
+	SourceMethodPoll = "poll"
+
+	// SourceMethodAcknowledge is invoked after an item has been dispatched
+	// (SourceAckRequest). Plugins with nothing to mark should return
+	// SourceOKResult{OK: true} rather than an error.
+	SourceMethodAcknowledge = "acknowledge"
+
+	// SourceMethodWriteResult is invoked with the run outcome for an item
+	// (SourceWriteResultRequest). Plugins with no result surface should
+	// return SourceOKResult{OK: true} rather than an error.
+	SourceMethodWriteResult = "write_result"
+)
+
+// SourceItem is one unit of work surfaced by a source plugin.
+type SourceItem struct {
+	// ID is the source-native identifier and the dedup key — it must be
+	// stable for the lifetime of the item and unique per dispatch-worthy
+	// occurrence. Items without an ID are dropped by the host.
+	ID string `json:"id"`
+	// Number is the human-facing reference (e.g. "INC-42"). Defaults to ID.
+	Number string `json:"number,omitempty"`
+	Title  string `json:"title,omitempty"`
+	// Description becomes the task body handed to the agent.
+	Description string `json:"description,omitempty"`
+	// Labels drive workflow trigger matching; use "key:value" form.
+	Labels   []string `json:"labels,omitempty"`
+	Type     string   `json:"type,omitempty"`
+	Priority string   `json:"priority,omitempty"`
+	State    string   `json:"state,omitempty"`
+	URL      string   `json:"url,omitempty"`
+	// Metadata is carried opaquely onto the task.
+	Metadata map[string]any `json:"metadata,omitempty"`
+	// CreatedAt / UpdatedAt are RFC3339 timestamps; empty means "now".
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// SourcePollRequest is the payload of SourceMethodPoll.
+type SourcePollRequest struct {
+	// Since is the previous poll time (RFC3339), empty on the first poll.
+	// Informational: plugins that re-return ongoing items may ignore it.
+	Since string `json:"since,omitempty"`
+	// States / Labels are the source's `filters` from apiary.yaml, forwarded
+	// so the plugin can filter at the backend where possible.
+	States []string `json:"states,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+// SourcePollResult is the result of SourceMethodPoll.
+type SourcePollResult struct {
+	Items []SourceItem `json:"items"`
+}
+
+// SourceAckRequest is the payload of SourceMethodAcknowledge.
+type SourceAckRequest struct {
+	Item SourceItem `json:"item"`
+	// Action is the host's ack action (e.g. "dispatched").
+	Action string `json:"action"`
+}
+
+// SourceWriteResultRequest is the payload of SourceMethodWriteResult.
+type SourceWriteResultRequest struct {
+	Item    SourceItem `json:"item"`
+	Success bool       `json:"success"`
+	Output  string     `json:"output,omitempty"`
+	Error   string     `json:"error,omitempty"`
+}
+
+// SourceOKResult is the conventional result for acknowledge/write_result.
+type SourceOKResult struct {
+	OK bool `json:"ok"`
+}


### PR DESCRIPTION
Implements the **plugin-source bridge** item of #362: `CapabilitySource` was reserved in the plugin protocol but the daemon only instantiated event-exporter plugins. Third parties can now ship monitoring/work sources out-of-process, in any language — no fork needed.

**Polling only, by design**: the daemon invokes the plugin on the source's `poll_interval`; plugins never push into the daemon (per the polling-only decision recorded on #362).

## How it works

```yaml
plugins:
  - id: com.example.nagios
    config: { api_url: https://nagios.internal/api }

sources:
  - id: nagios-alerts
    type: plugin
    poll_interval: 30s
    config:
      plugin: com.example.nagios
    filters:
      labels: ["severity=critical"]
```

- **Bridge adapter** (`internal/source/pluginsource`, registered as `type: plugin`): `Poll` → one single-shot `source.poll` invocation returning `{items}`; `Acknowledge`/`WriteResult` forward as `source.acknowledge` / `source.write_result`. Filters are forwarded in the poll payload for backend-side filtering.
- **Wire contract** (`sdk/plugin/source.go`): typed request/result structs + method constants — the surface third-party authors code against. Stable item `id`s are the dedup key, mirroring the in-tree monitoring sources (re-return ongoing items every poll; the daemon's task/instance dedup prevents re-dispatch).
- **Daemon wiring**: `New` builds `EnabledClients(CapabilitySource)` and injects a lookup into the bridge via `BindPluginLookup` before `Connect` — additive, no signature changes.
- **Read-only**: the bridge implements no write capabilities, so the existing capability lint rejects `set_state`/labels/approvals/CI waits against plugin sources.
- **Validation**: a `type: plugin` source must name a declared, enabled `plugins[]` instance — broken references fail `apiary validate`, not daemon start. (Capability/installed-ness is still checked at daemon start, where the registry exists.)
- **Reference plugin**: `src/examples/plugins/source-file` polls items from a JSON file (the simplest custom source; also the doc example).

## Testing
- `go vet` + full `go test ./internal/... ./sdk/...` green locally (no Go CI in this repo)
- Bridge unit tests via a fake invoker (connect validation, item mapping/defaults/id-less drop, payload contents, error wrapping, read-only interface probes)
- One end-to-end test through a **real subprocess**: shell-script plugin + manifest → `plugin.Load` → `plugin.NewClient` → bridge `Poll`
- Config validation cases for missing/undeclared/disabled plugin references

Remaining #362 items after this: `ack_via_silence`, group-key dispatch, resolved-while-running.
