### PR TITLE
fix(runner): pass a permission flag on claude-cli so headless agents can use tools (#370)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -16,6 +16,14 @@ runners:
   # Claude CLI runner (local development, no API keys needed). The preset runs
   # `claude --output-format stream-json --verbose` so Apiary can parse usage,
   # results, and rate-limit events; no config needed.
+  #
+  # The preset also passes --dangerously-skip-permissions: headless agents can't
+  # answer a permission prompt, so without it every tool call is denied and the
+  # agent finishes having silently done nothing. To narrow it, set
+  #   config:
+  #     permission_mode: default          # or acceptEdits / plan
+  #     allowed_tools: ["Read", "Grep"]   # pre-approved tool names
+  # See docs/runners.md#tool-permissions.
   - id: claude-cli
     type: cli
     provider: claude

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -87,6 +87,10 @@ Claude's structured event stream into
 - `rate_limit_event` detection, which drives
   [failover](resilience.md#runner-failures--failover).
 
+The preset also passes `--dangerously-skip-permissions`, because headless
+`claude -p` cannot display a permission prompt — see
+[Tool permissions](#tool-permissions) to narrow that.
+
 #### OpenCode (`provider: opencode`)
 
 Requires the `opencode` binary on `PATH`. The preset invokes
@@ -143,14 +147,55 @@ All `config` keys, with each provider's preset defaults:
 | Key | Description | claude | opencode | codex | cursor |
 |---|---|---|---|---|---|
 | `command` | Binary to invoke (override to use a wrapper or absolute path) | `claude` | `opencode` | `codex` | `agent` |
-| `args` | Extra argv appended after the preset's args | `--output-format stream-json --verbose` | `run` | `exec --sandbox workspace-write` | `-p --output-format stream-json --force` |
+| `args` | Extra argv appended after the preset's args | `--output-format stream-json --verbose` | `run` | `exec --sandbox workspace-write` | `-p --output-format stream-json` |
 | `model_flag` | Flag used to pass the step's model | `--model` | `--model` | `--model` | `--model` |
 | `prompt_flag` | Flag used to pass the prompt | `-p` | *(positional)* | *(positional)* | *(positional)* |
 | `prompt_positional` | Pass the prompt as the last positional argument | `false` | `true` | `true` | `true` |
 | `turns_flag` | Flag used to pass a max-turns limit | — | — | — | — |
+| `permission_mode` | Tool-permission posture (see below) | `bypass` | — | — | `bypass` |
+| `allowed_tools` | Tool names to pre-approve | — | — | — | — |
+| `permission_flag` | Provider flag for a named permission mode | `--permission-mode` | — | — | — |
+| `permission_bypass_args` | Argv that disables the permission prompt | `--dangerously-skip-permissions` | — | — | `--force` |
+| `allowed_tools_flag` | Provider flag for the allow-list | `--allowedTools` | — | — | — |
 
 Prompt delivery: via `prompt_flag` when set, as the last positional argument
 when `prompt_positional: true`, otherwise on **stdin**.
+
+### Tool permissions
+
+Apiary only ever runs agents non-interactively, so an agent cannot answer a
+permission prompt. A provider that gates tools behind one denies **every** call
+— Bash, Grep, and MCP alike — and the failure is quiet: the agent runs to
+completion, reports success, and has written nothing. Claude and Cursor both
+gate by default, so their presets ship with `permission_mode: bypass`.
+
+| `permission_mode` | Effect |
+|---|---|
+| `bypass` *(preset default for claude and cursor)* | Emits `permission_bypass_args` — the agent may use every tool without asking |
+| `default` | Emits no permission flags at all; the provider's own default applies |
+| anything else | Passed through to `permission_flag` as a provider-native mode name (claude: `acceptEdits`, `plan`, …) |
+
+A mode the provider cannot honour is rejected at config load, so the daemon
+fails loudly instead of starting agents that silently cannot act.
+
+To grant a narrow set of tools instead of a blanket bypass, combine
+`permission_mode: default` with `allowed_tools`:
+
+```yaml
+runners:
+  - id: claude-triage
+    type: cli
+    provider: claude
+    config:
+      permission_mode: default
+      allowed_tools: ["Read", "Grep", "mcp__atlassian__jira_add_comment"]
+```
+
+!!! warning "Bypass and untrusted input"
+    `bypass` lets the agent run any command in its working directory. For
+    runners that process issues or comments from untrusted authors, pair it
+    with [sandboxing](#sandboxing-agent-execution) so a successful prompt
+    injection is contained, or narrow the runner with `allowed_tools`.
 
 ## API runners
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -57,7 +57,7 @@
           },
           "config": {
             "type": "object",
-            "description": "Engine options. CLI engine keys: command, args, model_flag, prompt_flag, prompt_positional, turns_flag (provider presets cover them; override only when needed). API engine keys: api_key, base_url, endpoint",
+            "description": "Engine options. CLI engine keys: command, args, model_flag, prompt_flag, prompt_positional, turns_flag, permission_mode, allowed_tools, permission_flag, permission_bypass_args, allowed_tools_flag (provider presets cover them; override only when needed). permission_mode is 'bypass' (skip the provider's permission prompt — the claude/cursor preset default, required for headless tool use), 'default' (emit no permission flags), or a provider-native mode name such as acceptEdits or plan. API engine keys: api_key, base_url, endpoint",
             "additionalProperties": true,
             "properties": {
               "command": {

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -45,6 +45,71 @@ type CliRunner struct {
 	// trailing-"*" prefix) to forward to the agent beyond the built-in system and
 	// provider-credential allowlist. Unlisted host secrets are never inherited.
 	envPassthrough []string
+	// permissionArgs are the resolved tool-permission flags for this runner,
+	// built by Configure from permission_mode/allowed_tools and the provider's
+	// permission_flag/permission_bypass_args/allowed_tools_flag defaults.
+	// Headless agents cannot answer an interactive permission prompt, so a
+	// provider that gates tools behind one denies every call unless these are
+	// passed (see resolvePermissionArgs).
+	permissionArgs []string
+	// permissionFlag is the provider's flag for a named permission mode
+	// (claude: "--permission-mode"); empty means the provider has no such flag.
+	permissionFlag string
+	// permissionBypassArgs fully disable the provider's permission prompt
+	// (claude: "--dangerously-skip-permissions", cursor: "--force").
+	permissionBypassArgs []string
+	// allowedToolsFlag pre-approves a specific tool list (claude:
+	// "--allowedTools"); empty means the provider has no such flag.
+	allowedToolsFlag string
+	// permissionMode / allowedTools are the raw config values, kept so the
+	// resolved permissionArgs can be rebuilt when Configure runs again (provider
+	// defaults first, then the user's runner config).
+	permissionMode string
+	allowedTools   []string
+}
+
+// permissionModeBypass disables the provider's permission prompt entirely.
+// "bypassPermissions" is accepted as an alias because that is the name Claude
+// Code itself uses for the equivalent --permission-mode value.
+const permissionModeBypass = "bypass"
+
+// permissionModeDefault leaves the provider's own default in place: no
+// permission flags are emitted at all.
+const permissionModeDefault = "default"
+
+// resolvePermissionArgs maps the runner's permission_mode/allowed_tools config
+// onto the provider's permission flags.
+//
+// Non-interactive agents (the only kind apiary runs) cannot answer a permission
+// prompt, so any tool the provider gates behind one is denied outright — the run
+// still "succeeds", it just silently writes nothing. Providers therefore need an
+// explicit permission posture; see the mode semantics in the CLI runner docs.
+func resolvePermissionArgs(mode string, allowedTools []string, permissionFlag string, bypassArgs []string, allowedToolsFlag string) ([]string, error) {
+	var args []string
+	switch mode {
+	case permissionModeDefault:
+		// Provider default: emit nothing, even if the provider has flags.
+	case permissionModeBypass, "bypassPermissions":
+		if len(bypassArgs) == 0 {
+			return nil, fmt.Errorf("permission_mode %q is not supported by this provider (no permission_bypass_args configured)", mode)
+		}
+		args = append(args, bypassArgs...)
+	default:
+		// Any other value is passed through as a provider-native mode name
+		// (claude: acceptEdits, plan, …) so new upstream modes work without a
+		// code change here.
+		if permissionFlag == "" {
+			return nil, fmt.Errorf("permission_mode %q is not supported by this provider (no permission_flag configured); use %q or %q", mode, permissionModeBypass, permissionModeDefault)
+		}
+		args = append(args, permissionFlag, mode)
+	}
+	if len(allowedTools) > 0 {
+		if allowedToolsFlag == "" {
+			return nil, fmt.Errorf("allowed_tools is not supported by this provider (no allowed_tools_flag configured)")
+		}
+		args = append(args, allowedToolsFlag, strings.Join(allowedTools, ","))
+	}
+	return args, nil
 }
 
 func (r *CliRunner) ID() string { return "cli" }
@@ -77,6 +142,45 @@ func (r *CliRunner) Configure(config map[string]any) error {
 	if v, ok := config["mcp_format"].(string); ok && v != "" {
 		r.mcpFormat = v
 	}
+	if v, ok := config["permission_flag"].(string); ok {
+		r.permissionFlag = v
+	}
+	if v, ok := config["allowed_tools_flag"].(string); ok {
+		r.allowedToolsFlag = v
+	}
+	if raw, ok := config["permission_bypass_args"].([]any); ok {
+		r.permissionBypassArgs = nil
+		for _, a := range raw {
+			if s, ok := a.(string); ok {
+				r.permissionBypassArgs = append(r.permissionBypassArgs, s)
+			}
+		}
+	}
+	if v, ok := config["permission_mode"].(string); ok && strings.TrimSpace(v) != "" {
+		r.permissionMode = strings.TrimSpace(v)
+	}
+	if raw, ok := config["allowed_tools"].([]any); ok {
+		r.allowedTools = nil
+		for _, a := range raw {
+			if s, ok := a.(string); ok && strings.TrimSpace(s) != "" {
+				r.allowedTools = append(r.allowedTools, strings.TrimSpace(s))
+			}
+		}
+	}
+	// Rebuild on every Configure: providers register their defaults with one
+	// call and the user's runner config arrives in a second, so the mode and the
+	// provider flags it maps onto can be set by different calls. An unset mode
+	// means "provider default" — emit nothing — which keeps providers that never
+	// opt in behaving exactly as before.
+	mode := r.permissionMode
+	if mode == "" {
+		mode = permissionModeDefault
+	}
+	permArgs, err := resolvePermissionArgs(mode, r.allowedTools, r.permissionFlag, r.permissionBypassArgs, r.allowedToolsFlag)
+	if err != nil {
+		return fmt.Errorf("cli runner: %w", err)
+	}
+	r.permissionArgs = permArgs
 	if v, ok := config["mcps"].([]model.MCPServer); ok {
 		r.mcps = v
 	}
@@ -144,6 +248,9 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	// Inject MCP activation args (e.g. claude's "--mcp-config <path>") before the
 	// model/prompt flags; the provider config itself was written by setupMCP.
 	argv = append(argv, r.mcpRunArgs...)
+	// Tool-permission posture. Emitted after r.args so an explicit
+	// permission_mode wins over anything a user pinned in the raw args list.
+	argv = append(argv, r.permissionArgs...)
 	if r.modelFlag != "" && req.Model != "" {
 		argv = append(argv, r.modelFlag, req.Model)
 	}

--- a/src/internal/runner/execution/cli_permissions_test.go
+++ b/src/internal/runner/execution/cli_permissions_test.go
@@ -1,0 +1,63 @@
+package execution
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolvePermissionArgs(t *testing.T) {
+	const (
+		permFlag  = "--permission-mode"
+		toolsFlag = "--allowedTools"
+	)
+	bypass := []string{"--dangerously-skip-permissions"}
+
+	tests := []struct {
+		name         string
+		mode         string
+		allowedTools []string
+		permFlag     string
+		bypassArgs   []string
+		toolsFlag    string
+		want         []string
+		wantErr      string
+	}{
+		{name: "bypass", mode: "bypass", permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: []string{"--dangerously-skip-permissions"}},
+		{name: "bypassPermissions alias", mode: "bypassPermissions", permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: []string{"--dangerously-skip-permissions"}},
+		{name: "default emits nothing", mode: "default", permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: nil},
+		// Unknown modes pass through so new upstream modes need no code change.
+		{name: "named mode passthrough", mode: "acceptEdits", permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: []string{"--permission-mode", "acceptEdits"}},
+		{name: "allowed tools joined", mode: "default", allowedTools: []string{"Bash", "Read"}, permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: []string{"--allowedTools", "Bash,Read"}},
+		{name: "allowed tools alongside mode", mode: "plan", allowedTools: []string{"Read"}, permFlag: permFlag, bypassArgs: bypass, toolsFlag: toolsFlag,
+			want: []string{"--permission-mode", "plan", "--allowedTools", "Read"}},
+		{name: "bypass unsupported", mode: "bypass", wantErr: "no permission_bypass_args"},
+		{name: "named mode unsupported", mode: "acceptEdits", bypassArgs: bypass, wantErr: "no permission_flag"},
+		{name: "allowed tools unsupported", mode: "default", allowedTools: []string{"Bash"}, wantErr: "no allowed_tools_flag"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolvePermissionArgs(tc.mode, tc.allowedTools, tc.permFlag, tc.bypassArgs, tc.toolsFlag)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got args %v", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if strings.Join(got, " ") != strings.Join(tc.want, " ") {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/internal/runner/providers/providers.go
+++ b/src/internal/runner/providers/providers.go
@@ -28,10 +28,19 @@ func init() {
 	// are appended after these, and claude tolerates repeated flags (last wins).
 	// turns_flag is only emitted when the agent sets max_turns > 0 (see
 	// execution.CliRunner.Run), so runs stay uncapped by default.
+	// permission_mode defaults to "bypass" (→ --dangerously-skip-permissions):
+	// claude in headless `-p` mode cannot show a permission prompt, so without it
+	// every Bash/Grep/MCP call is denied and the agent completes having silently
+	// written nothing. This mirrors cursor-cli's --force. Narrow it per runner
+	// with permission_mode: default|acceptEdits|plan and allowed_tools.
 	runner.Register("claude-cli", cliFactory("claude", map[string]any{
-		"args":       []any{"--output-format", "stream-json", "--verbose"},
-		"mcp_format": "claude",
-		"turns_flag": "--max-turns",
+		"args":                   []any{"--output-format", "stream-json", "--verbose"},
+		"mcp_format":             "claude",
+		"turns_flag":             "--max-turns",
+		"permission_mode":        "bypass",
+		"permission_flag":        "--permission-mode",
+		"permission_bypass_args": []any{"--dangerously-skip-permissions"},
+		"allowed_tools_flag":     "--allowedTools",
 	}))
 
 	runner.Register("opencode-cli", cliFactory("opencode", map[string]any{
@@ -53,11 +62,16 @@ func init() {
 
 	// Cursor agent CLI — requires the `agent` binary from https://cursor.com/install.
 	// Runs headlessly with stream-json output; --force auto-approves file changes.
+	// --force moved from args to permission_bypass_args so it can be turned off
+	// with permission_mode: default, like every other CLI provider. The emitted
+	// argv is unchanged by default.
 	runner.Register("cursor-cli", cliFactory("agent", map[string]any{
-		"args":              []any{"-p", "--output-format", "stream-json", "--force"},
-		"prompt_flag":       "",
-		"prompt_positional": true,
-		"mcp_format":        "cursor",
+		"args":                   []any{"-p", "--output-format", "stream-json"},
+		"prompt_flag":            "",
+		"prompt_positional":      true,
+		"mcp_format":             "cursor",
+		"permission_mode":        "bypass",
+		"permission_bypass_args": []any{"--force"},
 	}))
 
 	// ── API providers ──────────────────────────────────────────────────────────

--- a/src/internal/runner/providers/providers_test.go
+++ b/src/internal/runner/providers/providers_test.go
@@ -90,3 +90,72 @@ func TestCodexCliPresetUsesExecWithWorkspaceWrite(t *testing.T) {
 		t.Errorf("codex-cli preset must start argv with `exec --sandbox workspace-write`: %q", out)
 	}
 }
+
+// Regression for #370: headless claude denies every tool call unless a
+// permission flag is passed, and the run still reports success — so the agent
+// finishes having written nothing. The default must bypass the prompt.
+func TestClaudeCliBypassesPermissionsByDefault(t *testing.T) {
+	out := echoRun(t, "claude-cli", nil)
+	if !strings.Contains(out, "--dangerously-skip-permissions") {
+		t.Errorf("claude-cli must bypass permissions by default: %q", out)
+	}
+}
+
+func TestClaudeCliPermissionModeNarrowsToNamedMode(t *testing.T) {
+	out := echoRun(t, "claude-cli", map[string]any{"permission_mode": "acceptEdits"})
+	if !strings.Contains(out, "--permission-mode acceptEdits") {
+		t.Errorf("named permission mode missing from argv: %q", out)
+	}
+	if strings.Contains(out, "--dangerously-skip-permissions") {
+		t.Errorf("named permission mode must replace the bypass flag: %q", out)
+	}
+}
+
+func TestClaudeCliPermissionModeDefaultEmitsNoFlags(t *testing.T) {
+	out := echoRun(t, "claude-cli", map[string]any{"permission_mode": "default"})
+	if strings.Contains(out, "--dangerously-skip-permissions") || strings.Contains(out, "--permission-mode") {
+		t.Errorf("permission_mode default must emit no permission flags: %q", out)
+	}
+}
+
+func TestClaudeCliAllowedToolsEmitsCommaList(t *testing.T) {
+	out := echoRun(t, "claude-cli", map[string]any{
+		"permission_mode": "default",
+		"allowed_tools":   []any{"Bash", "mcp__atlassian__jira_add_comment"},
+	})
+	if !strings.Contains(out, "--allowedTools Bash,mcp__atlassian__jira_add_comment") {
+		t.Errorf("allowed_tools missing from argv: %q", out)
+	}
+}
+
+// cursor's --force moved from args to permission_bypass_args; the emitted argv
+// must not change, and the flag must now be switchable off like claude's.
+func TestCursorCliStillForcesByDefault(t *testing.T) {
+	out := echoRun(t, "cursor-cli", nil)
+	if !strings.Contains(out, "--force") {
+		t.Errorf("cursor-cli must keep --force by default: %q", out)
+	}
+}
+
+func TestCursorCliPermissionModeDefaultDropsForce(t *testing.T) {
+	out := echoRun(t, "cursor-cli", map[string]any{"permission_mode": "default"})
+	if strings.Contains(out, "--force") {
+		t.Errorf("permission_mode default must drop --force: %q", out)
+	}
+}
+
+// A provider with no permission flags must reject a mode it cannot honour,
+// rather than silently ignoring it and leaving the agent tool-less.
+func TestUnsupportedPermissionModeFailsAtConfigure(t *testing.T) {
+	r, ok := runner.New("opencode-cli")
+	if !ok {
+		t.Fatal("opencode-cli not registered")
+	}
+	err := r.Configure(map[string]any{"command": "echo", "permission_mode": "bypass"})
+	if err == nil {
+		t.Fatal("expected configure to reject an unsupported permission_mode")
+	}
+	if !strings.Contains(err.Error(), "not supported by this provider") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #370.

## Problem

Claude in headless `-p` mode cannot display a permission prompt, so every tool call an agent made — Bash, Grep, MCP alike — came back with:

```
Claude requested permissions to use <tool>, but you haven't granted it yet.
```

The run still reported success, so agents finished having silently written nothing. `cursor-cli` already passed `--force` for exactly this reason; `claude-cli` had no equivalent, and a repo-wide search for `--dangerously-skip-permissions`, `permission_mode`, `--permission-mode` and `--allowedTools` turned up nothing anywhere, docs included.

## Change

Rather than hardcoding the bypass flag, the CLI engine gains a per-runner tool-permission posture:

```yaml
runners:
  - id: claude-triage
    type: cli
    provider: claude
    config:
      permission_mode: default          # or bypass / acceptEdits / plan
      allowed_tools: ["Read", "Grep", "mcp__atlassian__jira_add_comment"]
```

`resolvePermissionArgs` maps that onto provider flags (`permission_flag`, `permission_bypass_args`, `allowed_tools_flag`), so the semantics stay in the engine and the flag names stay in the provider preset.

| `permission_mode` | Effect |
|---|---|
| `bypass` (claude/cursor preset default) | emits `permission_bypass_args` |
| `default` | emits no permission flags |
| anything else | passed through to `permission_flag` as a provider-native mode name |

A mode the provider cannot honour is **rejected at config load**, so the daemon fails loudly instead of starting agents that silently cannot act — which is the actual failure mode this bug was.

## Note on the default

`claude-cli` defaults to `bypass`. This widens tool access on upgrade for anyone running claude-cli, so it is a deliberate call rather than a silent one: without it the runner is non-functional out of the box, and it matches what `cursor-cli` has always done. `permission_mode: default` opts out, `allowed_tools` narrows.

The bypass is **not** conditional on sandboxing. `bypass` plus untrusted issue authors is exactly what `runners[].sandbox` exists for, so the docs carry a warning pointing at it; making the default sandbox-aware is a reasonable follow-up.

## Beyond the issue's scope

`cursor-cli`'s `--force` moves from `args` to `permission_bypass_args` so it can be switched off the same way. Emitted argv is unchanged by default, and a test asserts that.

## Verification

- Full `go test ./...`, `go vet`, `go build` all pass.
- Provider-level argv tests through the existing `echoRun` harness: default bypasses; a named mode replaces the bypass flag; `default` emits nothing; `allowed_tools` joins comma-separated; cursor keeps `--force` by default and drops it on `permission_mode: default`; an unsupported mode fails `Configure`.
- Table test for the resolver in `cli_permissions_test.go`.
- `gitnexus impact` on `CliRunner.Configure`: LOW (single caller, `providers.init`). `detect_changes` scope matched the touched symbols exactly.
- `apiary validate` on the example config reports 9 errors — verified against a stashed tree that all 9 pre-exist this branch. Unrelated, but the example config does not currently validate.

Docs: new **Tool permissions** section in `docs/runners.md`, engine-config table rows, schema `config` description, and a comment in `.apiary/example-apiary-full.yaml`.