### PR TITLE
fix(dashboard): keep step columns aligned when selected, add resizable monitor split

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -133,6 +133,29 @@ completed. A task that was retried shows its attempt count in the Details view.
 ![Task detail view](screenshots/tasks-detail.png)
 ![Task logs view](screenshots/tasks-logs.png)
 
+#### Workflow monitor
+
+Pressing `Enter` on a task whose work is driven by a workflow opens the live
+monitor: the step list on the left, and the selected step's detail — or its logs
+— on the right.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Move between steps |
+| `Enter` / `l` | Open the selected step's logs in the right panel |
+| `-` / `+` | **Resize the split** — narrow or widen the step list, 5% at a time |
+| `[` / `]` | Switch between workflow instances, when a task fanned out to several |
+| `t` | Open the step's [transcript](#watching-the-live-conversation-debug-mode) |
+| `r` | Refresh the monitor |
+| `X` / `R` | Stop the workflow / restart the whole task (both confirm first) |
+| `Esc` / `Backspace` / `h` / `←` | Back (closes the log panel first, then the monitor) |
+
+The split defaults to 40% and is clamped between 20% and 80% so neither panel
+becomes unreadable. Widening the step list past the default reveals the `DUR`
+column, which the default width clips. `-` / `+` work while the log panel is
+open, which is usually when you want the extra room; resizing never disturbs
+the step selection or scroll position.
+
 #### Force restart and clear logs
 
 Pressing **`R`** (Shift+R) on a selected task shows a centered confirmation

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1295,6 +1295,15 @@ func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
 			a.selectWorkflowInstance(t, t.WorkflowInstanceIdx+1)
 		}
 
+	case "-", "_":
+		// Narrow the step list, giving the detail/log panel more room. Works in
+		// both sub-views: the split is what you adjust while reading logs.
+		adjustWorkflowSplit(t, -wfMonitorSplitStepPct)
+
+	case "+", "=":
+		// Widen the step list.
+		adjustWorkflowSplit(t, wfMonitorSplitStepPct)
+
 	case "l", "enter":
 		// Open logs for the selected step.
 		if !t.WorkflowShowLogs && t.WorkflowStepIdx < len(inst.Steps) {
@@ -4906,13 +4915,13 @@ func (a *App) footerKeys() []fkey {
 				return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"end", "follow"}, {"t", label}, {"r", "reload"}, {"q", "quit"}}
 			case TaskViewWorkflow:
 				if t.WorkflowShowLogs {
-					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"q", "quit"}}
+					return []fkey{{"esc", "back"}, {"↑/↓", "scroll"}, {"-/+", "split"}, {"q", "quit"}}
 				}
 				keys := []fkey{{"↑/↓", "step"}, {"enter/l", "logs"}, {"t", "transcript"}}
 				if len(t.WorkflowInstances) > 1 {
 					keys = append(keys, fkey{"[ ]", "workflow"})
 				}
-				return append(keys, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
+				return append(keys, fkey{"-/+", "split"}, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
 			}
 		}
 		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
@@ -5145,14 +5154,46 @@ func truncate(s string, max int) string {
 // panel widths of the workflow monitor. Shared with logMsgWidth so the STEP
 // LOGS panel wraps log lines to the panel it renders in instead of the full
 // terminal width (which fitLine would then clip on the right).
+// Split bounds for the monitor's two panels, as a percentage of the usable
+// width. The minimums keep both panels wide enough to stay readable: the step
+// list has a ~47-column layout and the log panel wraps its text to whatever it
+// is given.
+const (
+	wfMonitorDefaultSplitPct = 40
+	wfMonitorMinSplitPct     = 20
+	wfMonitorMaxSplitPct     = 80
+	wfMonitorSplitStepPct    = 5
+)
+
 func (a *App) wfMonitorPanelWidths() (leftW, rightW int) {
 	totalW := a.model.width - 2
-	leftW = totalW * 2 / 5
+	pct := wfMonitorDefaultSplitPct
+	if t := a.model.tasksTab; t != nil && t.WorkflowSplitPct != 0 {
+		pct = t.WorkflowSplitPct
+	}
+	leftW = totalW * pct / 100
 	rightW = totalW - leftW - 1
 	if leftW < 20 {
 		leftW = 20
 	}
 	return leftW, rightW
+}
+
+// adjustWorkflowSplit widens (delta > 0) or narrows the step-list panel,
+// clamping to the readable range. Called from the monitor's -/+ keys.
+func adjustWorkflowSplit(t *TasksTab, delta int) {
+	pct := t.WorkflowSplitPct
+	if pct == 0 {
+		pct = wfMonitorDefaultSplitPct
+	}
+	pct += delta
+	if pct < wfMonitorMinSplitPct {
+		pct = wfMonitorMinSplitPct
+	}
+	if pct > wfMonitorMaxSplitPct {
+		pct = wfMonitorMaxSplitPct
+	}
+	t.WorkflowSplitPct = pct
 }
 
 // renderWorkflowMonitor renders the live workflow instance monitor.
@@ -5183,7 +5224,9 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 	}
 
 	// Header row
-	hdr := pad("", 2) + pad("STEP", 18) + " " + pad("AGENT", 14) + " " + pad("STATE", 10) + " " + "DUR"
+	// Column widths mirror the body rows below exactly (2 glyph + 17 step + 1 +
+	// 13 agent + 3 + 10 state + 1), so every header sits over its own column.
+	hdr := pad("", 2) + pad("STEP", 17) + " " + pad("AGENT", 13) + "   " + pad("STATE", 10) + " " + "DUR"
 	left.WriteString(StyleTableHeader.Render(fitLine(hdr, leftW)) + "\n")
 	bodyRows--
 
@@ -5209,10 +5252,16 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 		state := truncate(s.State, 10)
 		dur := truncate(s.Duration, 8)
 
-		row := glyph + " " + pad(stepName, 17) + " " + pad(agent, 13) + "   " + pad(state, 10) + " " + StyleMuted.Render(dur)
+		// Columns are padded identically in both states so the selected row
+		// stays aligned with its neighbours and the header; only the leading
+		// glyph and the styling change. The selected marker is the same visual
+		// width as the glyph it replaces, so nothing shifts sideways.
+		cols := pad(stepName, 17) + " " + pad(agent, 13) + "   " + pad(state, 10) + " "
+		var row string
 		if selected {
-			row = StyleSelectedRow.Render(fitLine("  "+stepName+" "+agent+"   "+state+" "+dur, leftW))
-			row = StyleFocusedArrow.Render("▶") + " " + StyleSelectedRow.Render(fitLine(stepName+" "+agent+"   "+state+" "+dur, leftW-2))
+			row = StyleFocusedArrow.Render("▶") + " " + StyleSelectedRow.Render(fitLine(cols+dur, leftW-2))
+		} else {
+			row = glyph + " " + cols + StyleMuted.Render(dur)
 		}
 		left.WriteString(fitLine(row, leftW) + "\n")
 	}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -102,6 +102,11 @@ type TasksTab struct {
 	WorkflowLogFollow   bool   // pin the step-log panel to the tail; cleared by scrolling up
 	WorkflowLogStepID   string // step whose logs fill the panel (scopes live-tail refreshes)
 	WorkflowShowLogs    bool   // true when the log panel is expanded
+	// WorkflowSplitPct is the step-list panel's share of the monitor width, as a
+	// percentage, adjustable with -/+ so a long log line can be given more room
+	// while watching a run. Zero means "unset" and falls back to
+	// wfMonitorDefaultSplitPct; see wfMonitorPanelWidths.
+	WorkflowSplitPct int
 
 	// Transcript sub-view (View == TaskViewTranscript): a markdown transcript
 	// file rendered in-app with glamour, live-tailed while the run continues.

--- a/src/internal/dashboard/workflow_monitor_layout_test.go
+++ b/src/internal/dashboard/workflow_monitor_layout_test.go
@@ -1,0 +1,200 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// monitorApp builds an App sitting on the workflow monitor with a few steps.
+func monitorApp(t *testing.T, stepIdx int) *App {
+	t.Helper()
+	a := newTestApp(120, 30)
+	a.model.tasksTab = &TasksTab{
+		View: TaskViewWorkflow,
+		WorkflowInstance: &WorkflowInstanceItem{
+			ID:       "wf_layout",
+			Workflow: "implementation",
+			State:    "running",
+			Steps: []WorkflowStepItem{
+				{StepID: "plan", Agent: "architect", State: "passed", Duration: "12s"},
+				{StepID: "implement", Agent: "backend-dev", State: "running", Duration: "3s"},
+				{StepID: "review", Agent: "reviewer", State: "pending", Duration: "—"},
+			},
+		},
+		WorkflowStepIdx: stepIdx,
+	}
+	a.model.tasksTab.WorkflowInstances = []*WorkflowInstanceItem{a.model.tasksTab.WorkflowInstance}
+	return a
+}
+
+// stepRows returns the left panel's step rows only. The panels are joined
+// horizontally and the right one repeats the step name, so a whole-line match
+// would also pick up detail-panel text (and silently compare the wrong lines).
+func stepRows(t *testing.T, a *App) []string {
+	t.Helper()
+	out := stripANSI(a.renderWorkflowMonitor(a.model.tasksTab, 20))
+	var rows []string
+	for _, line := range strings.Split(out, "\n") {
+		// │ left panel │ right panel │ — take the left cell only.
+		cells := strings.Split(line, "│")
+		if len(cells) < 3 {
+			continue
+		}
+		left := cells[1]
+		for _, name := range []string{"plan", "implement", "review"} {
+			// Anchor on the step-name column so the header row is excluded.
+			if strings.Contains(left, name) {
+				rows = append(rows, left)
+				break
+			}
+		}
+	}
+	return rows
+}
+
+// columnStarts records where each of the step row's columns begins, so rows can
+// be compared to each other regardless of which one is selected.
+func columnStarts(row string) []int {
+	var starts []int
+	inField := false
+	for i, r := range row {
+		switch {
+		case r != ' ' && !inField:
+			starts = append(starts, i)
+			inField = true
+		case r == ' ' && inField:
+			inField = false
+		}
+	}
+	return starts
+}
+
+// Regression: the selected row used to be built from unpadded fields, so
+// selecting a step collapsed its columns and the row jumped out of alignment
+// with its neighbours.
+func TestWorkflowMonitorSelectedRowKeepsColumnAlignment(t *testing.T) {
+	// The agent column is what visibly shifts, and it differs per row, so
+	// compare the same row selected vs unselected.
+	unselected := stepRows(t, monitorApp(t, 0))
+	selected := stepRows(t, monitorApp(t, 1))
+
+	if len(unselected) < 3 || len(selected) < 3 {
+		t.Fatalf("expected 3 step rows, got %d and %d", len(unselected), len(selected))
+	}
+
+	// Row 1 ("implement") is unselected in the first render and selected in the
+	// second; its columns must land in the same places either way.
+	wantStarts := columnStarts(unselected[1])
+	gotStarts := columnStarts(selected[1])
+	if len(wantStarts) != len(gotStarts) {
+		t.Fatalf("selected row has %d columns, unselected has %d:\n unselected: %q\n selected:   %q",
+			len(gotStarts), len(wantStarts), unselected[1], selected[1])
+	}
+	for i := range wantStarts {
+		if wantStarts[i] != gotStarts[i] {
+			t.Errorf("column %d starts at %d when selected, %d when not:\n unselected: %q\n selected:   %q",
+				i, gotStarts[i], wantStarts[i], unselected[1], selected[1])
+		}
+	}
+}
+
+// Every row must start its columns at the same offsets, whichever is selected.
+func TestWorkflowMonitorAllRowsShareColumnOffsets(t *testing.T) {
+	for sel := 0; sel < 3; sel++ {
+		rows := stepRows(t, monitorApp(t, sel))
+		if len(rows) < 3 {
+			t.Fatalf("selection %d: expected 3 step rows, got %d", sel, len(rows))
+		}
+		// Every column is padded to a fixed width, so all rows — selected or not
+		// — must place their columns at identical offsets.
+		want := columnStarts(rows[0])
+		for i, row := range rows[1:] {
+			got := columnStarts(row)
+			if len(got) != len(want) {
+				t.Errorf("selection %d: row %d has %d columns, row 0 has %d:\n %q\n %q",
+					sel, i+1, len(got), len(want), rows[0], row)
+				continue
+			}
+			for c := range want {
+				if got[c] != want[c] {
+					t.Errorf("selection %d: row %d column %d starts at %d, row 0 at %d:\n %q\n %q",
+						sel, i+1, c, got[c], want[c], rows[0], row)
+				}
+			}
+		}
+	}
+}
+
+func TestWorkflowMonitorSplitDefaultsAndResizes(t *testing.T) {
+	a := monitorApp(t, 0)
+	tab := a.model.tasksTab
+
+	baseLeft, baseRight := a.wfMonitorPanelWidths()
+
+	// Narrowing the step list must give the detail panel the room back.
+	adjustWorkflowSplit(tab, -wfMonitorSplitStepPct)
+	narrowLeft, narrowRight := a.wfMonitorPanelWidths()
+	if narrowLeft >= baseLeft {
+		t.Errorf("step list did not narrow: %d → %d", baseLeft, narrowLeft)
+	}
+	if narrowRight <= baseRight {
+		t.Errorf("detail panel did not widen: %d → %d", baseRight, narrowRight)
+	}
+
+	// And widening it takes the room back.
+	adjustWorkflowSplit(tab, wfMonitorSplitStepPct)
+	if gotLeft, _ := a.wfMonitorPanelWidths(); gotLeft != baseLeft {
+		t.Errorf("split did not return to the default width: got %d, want %d", gotLeft, baseLeft)
+	}
+}
+
+func TestWorkflowMonitorSplitClampsToReadableRange(t *testing.T) {
+	tab := &TasksTab{}
+	for i := 0; i < 40; i++ {
+		adjustWorkflowSplit(tab, -wfMonitorSplitStepPct)
+	}
+	if tab.WorkflowSplitPct != wfMonitorMinSplitPct {
+		t.Errorf("split floor = %d, want %d", tab.WorkflowSplitPct, wfMonitorMinSplitPct)
+	}
+	for i := 0; i < 40; i++ {
+		adjustWorkflowSplit(tab, wfMonitorSplitStepPct)
+	}
+	if tab.WorkflowSplitPct != wfMonitorMaxSplitPct {
+		t.Errorf("split ceiling = %d, want %d", tab.WorkflowSplitPct, wfMonitorMaxSplitPct)
+	}
+}
+
+// The split keys must work while the log panel is open — that is the view you
+// are in when you want more room for output.
+func TestWorkflowMonitorSplitKeysWorkInLogView(t *testing.T) {
+	a := monitorApp(t, 0)
+	a.model.tasksTab.WorkflowShowLogs = true
+
+	a.handleWorkflowMonitorKey("-")
+	if got := a.model.tasksTab.WorkflowSplitPct; got != wfMonitorDefaultSplitPct-wfMonitorSplitStepPct {
+		t.Errorf("'-' in log view: split = %d, want %d", got, wfMonitorDefaultSplitPct-wfMonitorSplitStepPct)
+	}
+	a.handleWorkflowMonitorKey("+")
+	if got := a.model.tasksTab.WorkflowSplitPct; got != wfMonitorDefaultSplitPct {
+		t.Errorf("'+' in log view: split = %d, want %d", got, wfMonitorDefaultSplitPct)
+	}
+}
+
+// Resizing must not disturb the step cursor or the log panel.
+func TestWorkflowMonitorSplitKeepsSelectionAndLogPanel(t *testing.T) {
+	a := monitorApp(t, 2)
+	a.model.tasksTab.WorkflowShowLogs = true
+	a.model.tasksTab.WorkflowLogStepID = "review"
+
+	a.handleWorkflowMonitorKey("-")
+
+	if got := a.model.tasksTab.WorkflowStepIdx; got != 2 {
+		t.Errorf("step cursor moved on resize: got %d, want 2", got)
+	}
+	if !a.model.tasksTab.WorkflowShowLogs {
+		t.Error("log panel closed on resize")
+	}
+	if got := a.model.tasksTab.WorkflowLogStepID; got != "review" {
+		t.Errorf("log panel re-scoped on resize: got %q, want \"review\"", got)
+	}
+}


### PR DESCRIPTION
Two changes to the Tasks tab's workflow monitor, both reported from live use.

## 1. Selected step lost its column alignment

The step list built the selected row from **unpadded** fields, while every other row padded each column to a fixed width:

```go
// selected — no padding, columns collapse
StyleSelectedRow.Render(fitLine(stepName+" "+agent+"   "+state+" "+dur, leftW-2))
// unselected
glyph + " " + pad(stepName, 17) + " " + pad(agent, 13) + "   " + pad(state, 10) + " " + dur
```

So moving the cursor made the highlighted row jump sideways:

```
▶ plan architect   passed 12s                      <- selected: collapsed
● implement         backend-dev     running        <- everything else
○ review            reviewer        pending
```

Both states now share one padded column string; only the leading glyph and the styling differ. The selection marker is the same visual width as the glyph it replaces, so nothing shifts.

While in there: the header's `AGENT` column sat one character right of the agent data (`pad("STEP", 18)` against a 17-wide data column). Header widths now mirror the body exactly. There was also a dead first assignment to `row`, immediately overwritten by the next line — removed.

## 2. Resizable split

`-` / `+` adjust the step list's share of the width by 5%, clamped to 20–80% (default 40%, unchanged). Rationale: the right panel is where step output goes, and 60% of an 80-column terminal is not much to read agent logs in.

- Works in **both** sub-views — including with the log panel open, which is when you actually want the room.
- Resizing leaves the step cursor, scroll position and log panel scoping untouched (covered by a test).
- Widening past the default reveals the `DUR` column, which the 40% default clips.
- The log wrap cache is keyed on width and already resets on change (`ensureLogCache`), so re-wrapping is correct after a resize.

State lives in `TasksTab.WorkflowSplitPct`; `0` means unset and falls back to the default, so no migration concern.

At 20% / 40% / 65%:

```
│  STEP              AGE│ implement
│✓ plan              arc│  State:       ● running

│  STEP              AGENT           STATE      │ implement
│✓ plan              architect       passed     │  State:       ● running

│  STEP              AGENT           STATE      DUR              │ implement
│✓ plan              architect       passed     12s              │  State:       ● running
```

## Verification

- Full `go test ./...`, `go vet`, `go build` pass.
- New `workflow_monitor_layout_test.go`: column-offset comparison of the same row selected vs unselected, all-rows-share-offsets across every selection, split default/resize/clamp, split keys in the log view, and selection preservation across a resize.
- **The alignment tests were confirmed to fail against the pre-fix code**, reproducing the exact reported symptom:
  ```
  selected row has 5 columns, unselected has 4:
   unselected: "● implement         backend-dev     running    "
   selected:   "▶ implement backend-dev   running 3s           "
  ```
  My first version of that test passed against the buggy code — it matched whole rendered lines, and the right-hand detail panel repeats the step name, so it was comparing the wrong lines. It now splits at the panel divider and compares the left cell only.
- `gitnexus detect_changes` scope is confined to the monitor's render/key paths.

Docs: new **Workflow monitor** subsection in `docs/dashboard.md` — the monitor's keys were previously undocumented, so this covers `[`/`]`, `t`, `X`/`R` and the new `-`/`+` alongside the split's bounds and behaviour.