### PR TITLE
fix(db): stop losing queue writes to SQLITE_BUSY under concurrency (#369)

### DIFF
--- a/src/internal/db/busy.go
+++ b/src/internal/db/busy.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// Retry schedule for lock contention. busy_timeout already makes writers wait
+// up to 5s for a held lock, so reaching this path means the wait itself timed
+// out (or the transaction hit a snapshot conflict). A short, bounded retry
+// covers the burst; anything longer is a real problem the caller should see.
+var busyRetryDelays = []time.Duration{
+	5 * time.Millisecond,
+	20 * time.Millisecond,
+	80 * time.Millisecond,
+	200 * time.Millisecond,
+}
+
+// isBusy reports whether err is SQLite's "database is locked"/"table is locked"
+// family, including the SQLITE_BUSY_SNAPSHOT extended code raised when a
+// deferred transaction cannot upgrade its read snapshot to a write.
+func isBusy(err error) bool {
+	var se *sqlite.Error
+	if !errors.As(err, &se) {
+		return false
+	}
+	switch se.Code() {
+	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED,
+		sqlite3.SQLITE_BUSY_SNAPSHOT, sqlite3.SQLITE_BUSY_RECOVERY, sqlite3.SQLITE_BUSY_TIMEOUT:
+		return true
+	}
+	return false
+}
+
+// retryOnBusy runs op, retrying while SQLite reports the database as locked.
+//
+// op must be a whole transaction, not a fragment of one: a busy failure leaves
+// nothing committed (SQLite commits atomically), so re-running from the top is
+// safe and re-reads the state each time. Guard-clause transactions stay correct
+// under retry — if a competing writer won the race, the retry's own SELECT sees
+// the new state and returns the same ErrStaleClaim it would have returned
+// without contention.
+//
+// This is the second line of defence. The first is _txlock=immediate (see the
+// DSN in New), which stops read-then-write transactions from failing on a stale
+// snapshot in the first place.
+func retryOnBusy(ctx context.Context, op func() error) error {
+	err := op()
+	for attempt := 0; isBusy(err) && attempt < len(busyRetryDelays); attempt++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(busyRetryDelays[attempt]):
+		}
+		err = op()
+	}
+	return err
+}

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -41,6 +41,18 @@ func New(ctx context.Context, dbPath string) (*Client, error) {
 	//   cache_size=-20000 — ~20MB page cache; task_logs rows are ~10KB of agent
 	//                   stream text, so a bigger cache cuts cold-read disk hits.
 	//   temp_store=MEMORY — sorts/temp b-trees stay in RAM.
+	//   _txlock=immediate — take the write lock at BEGIN instead of on the first
+	//                   write. Every transaction in this package reads and then
+	//                   writes; under the default deferred mode such a
+	//                   transaction starts on a read snapshot, and if another
+	//                   connection commits before it upgrades, SQLite fails it
+	//                   with SQLITE_BUSY_SNAPSHOT *immediately* — busy_timeout
+	//                   does not apply, because waiting cannot refresh a stale
+	//                   snapshot. That lost queue-job finish writes under
+	//                   concurrency (#369). Taking the lock up front means the
+	//                   contention is resolved at BEGIN, where busy_timeout does
+	//                   apply. Read-only queries run outside transactions and are
+	//                   unaffected.
 	//   _time_format=sqlite — write time.Time as "2006-01-02 15:04:05.999999999
 	//                   -07:00". modernc's default is time.Time.String(), which
 	//                   appends " MST m=±…" (monotonic clock) — a form SQLite's
@@ -54,6 +66,7 @@ func New(ctx context.Context, dbPath string) (*Client, error) {
 			"&_pragma=synchronous(NORMAL)" +
 			"&_pragma=cache_size(-20000)" +
 			"&_pragma=temp_store(MEMORY)" +
+			"&_txlock=immediate" +
 			"&_time_format=sqlite"
 	}
 	db, err := sql.Open("sqlite", dsn)

--- a/src/internal/db/queue_concurrency_test.go
+++ b/src/internal/db/queue_concurrency_test.go
@@ -1,0 +1,249 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+// Regression for #369. Multiple workers finishing jobs at the same time used to
+// lose the finish write: every transaction here reads and then writes, and under
+// the default deferred transaction mode SQLite fails such a transaction with
+// SQLITE_BUSY_SNAPSHOT the moment another connection commits first — immediately,
+// without consulting busy_timeout. A lost finish leaves the job leased, so it is
+// re-run when the lease expires and the agent's work (and its side effects) are
+// duplicated.
+//
+// The test hammers claim/heartbeat/finish from parallel goroutines and asserts
+// every job reached a terminal state exactly once, with no lock errors.
+func TestQueueConcurrentFinishUnderContention(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+
+	const (
+		workers     = 8
+		jobsPerWork = 6
+		totalJobs   = workers * jobsPerWork
+	)
+
+	registerQueueWorker(t, store, "worker", totalJobs, nil, nil)
+
+	for i := 0; i < totalJobs; i++ {
+		job := testJob(fmt.Sprintf("task:concurrent:%d", i))
+		if _, err := store.Enqueue(ctx, job); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	var (
+		mu       sync.Mutex
+		failures []error
+		finished int
+	)
+	record := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		failures = append(failures, err)
+	}
+
+	// Every goroutine races the others through the full claim → heartbeat →
+	// finish cycle, which is where the interleaved read-then-write transactions
+	// collide.
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for i := 0; i < jobsPerWork; i++ {
+				claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", LeaseDuration: time.Minute})
+				if err != nil {
+					record(fmt.Errorf("claim: %w", err))
+					return
+				}
+				if claim == nil {
+					return // queue drained
+				}
+				if _, err := store.Heartbeat(ctx, claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, time.Minute); err != nil {
+					record(fmt.Errorf("heartbeat %s: %w", claim.Job.ID, err))
+					return
+				}
+				if err := store.Finish(ctx, claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+					record(fmt.Errorf("finish %s: %w", claim.Job.ID, err))
+					return
+				}
+				mu.Lock()
+				finished++
+				mu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for _, err := range failures {
+		if isBusy(err) {
+			t.Errorf("lock contention surfaced to the caller: %v", err)
+		} else {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	// Every finish must have stuck: a job still leased is one that would be
+	// re-run, which is the duplicate-work symptom from the issue.
+	succeeded, err := store.ListJobs(ctx, queue.JobSucceeded, totalJobs+1)
+	if err != nil {
+		t.Fatalf("list succeeded: %v", err)
+	}
+	if len(succeeded) != finished {
+		t.Errorf("succeeded=%d but %d finishes reported success — finish writes were lost", len(succeeded), finished)
+	}
+	leased, err := store.ListJobs(ctx, queue.JobLeased, totalJobs+1)
+	if err != nil {
+		t.Fatalf("list leased: %v", err)
+	}
+	if len(leased) != 0 {
+		t.Errorf("%d job(s) left leased after all workers finished; they would be re-run on lease expiry", len(leased))
+	}
+}
+
+// A busy failure must not leave a half-applied transaction behind: retryOnBusy
+// re-runs the whole operation, and a guard-clause transaction whose race was
+// lost must still report ErrStaleClaim rather than double-finishing.
+func TestQueueDoubleFinishIsStaleNotDuplicated(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	defer client.Close()
+	store := client.Queue()
+
+	registerQueueWorker(t, store, "worker", 1, nil, nil)
+	if _, err := store.Enqueue(ctx, testJob("task:double-finish")); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker", LeaseDuration: time.Minute})
+	if err != nil || claim == nil {
+		t.Fatalf("claim: %v (claim=%v)", err, claim)
+	}
+
+	if err := store.Finish(ctx, claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true}); err != nil {
+		t.Fatalf("first finish: %v", err)
+	}
+	err = store.Finish(ctx, claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true})
+	if !errors.Is(err, queue.ErrStaleClaim) {
+		t.Errorf("second finish = %v, want ErrStaleClaim", err)
+	}
+}
+
+// sqliteBusyErr returns a real SQLITE_BUSY from the driver rather than a
+// hand-made value: modernc's Error has no exported constructor, and a fabricated
+// error would not prove isBusy recognises what SQLite actually returns. A second
+// connection with no busy timeout writes while the first holds the write lock.
+func sqliteBusyErr(t *testing.T) error {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "busy.db")
+
+	holder, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(0)&_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	if _, err := holder.ExecContext(context.Background(), `CREATE TABLE t (id INTEGER PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold the write lock open for the duration of the contending write.
+	tx, err := holder.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(context.Background(), `INSERT INTO t (id) VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+
+	contender, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(0)&_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer contender.Close()
+	_, err = contender.ExecContext(context.Background(), `INSERT INTO t (id) VALUES (2)`)
+	if err == nil {
+		t.Fatal("expected the contending write to fail while the write lock is held")
+	}
+	return err
+}
+
+func TestIsBusyClassification(t *testing.T) {
+	if !isBusy(sqliteBusyErr(t)) {
+		t.Error("a real SQLITE_BUSY from the driver must be classified as busy")
+	}
+	if isBusy(nil) {
+		t.Error("nil is not a busy error")
+	}
+	if isBusy(errors.New("database is locked")) {
+		t.Error("a plain error with a matching message must not be classified as busy")
+	}
+	if isBusy(queue.ErrStaleClaim) {
+		t.Error("ErrStaleClaim is not a busy error")
+	}
+}
+
+// retryOnBusy must give up on a cancelled context instead of sleeping out the
+// whole schedule.
+func TestRetryOnBusyHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := retryOnBusy(ctx, func() error {
+		calls++
+		return sqliteBusyErr(t)
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Errorf("op ran %d times, want 1 before the cancelled context stopped it", calls)
+	}
+}
+
+// retryOnBusy must stop after the schedule is exhausted and return the error.
+func TestRetryOnBusyGivesUpAndReturnsTheError(t *testing.T) {
+	calls := 0
+	err := retryOnBusy(context.Background(), func() error {
+		calls++
+		return sqliteBusyErr(t)
+	})
+	if !isBusy(err) {
+		t.Errorf("err = %v, want a busy error", err)
+	}
+	if want := len(busyRetryDelays) + 1; calls != want {
+		t.Errorf("op ran %d times, want %d (initial attempt plus the retry schedule)", calls, want)
+	}
+}
+
+// A non-busy error must not be retried.
+func TestRetryOnBusyDoesNotRetryOtherErrors(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("constraint violation")
+	err := retryOnBusy(context.Background(), func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("err = %v, want the original error", err)
+	}
+	if calls != 1 {
+		t.Errorf("op ran %d times, want 1", calls)
+	}
+}

--- a/src/internal/db/queue_store.go
+++ b/src/internal/db/queue_store.go
@@ -122,6 +122,16 @@ func (s *QueueStore) SetWorkerDrain(ctx context.Context, workerID string, draini
 }
 
 func (s *QueueStore) Claim(ctx context.Context, request queue.ClaimRequest) (*queue.Claim, error) {
+	var claim *queue.Claim
+	err := retryOnBusy(ctx, func() error {
+		var err error
+		claim, err = s.claim(ctx, request)
+		return err
+	})
+	return claim, err
+}
+
+func (s *QueueStore) claim(ctx context.Context, request queue.ClaimRequest) (*queue.Claim, error) {
 	if request.LeaseDuration <= 0 {
 		request.LeaseDuration = 30 * time.Second
 	}
@@ -227,6 +237,16 @@ func (s *QueueStore) Claim(ctx context.Context, request queue.ClaimRequest) (*qu
 }
 
 func (s *QueueStore) Heartbeat(ctx context.Context, jobID, attemptID, token string, extension time.Duration) (*queue.HeartbeatResult, error) {
+	var res *queue.HeartbeatResult
+	err := retryOnBusy(ctx, func() error {
+		var err error
+		res, err = s.heartbeat(ctx, jobID, attemptID, token, extension)
+		return err
+	})
+	return res, err
+}
+
+func (s *QueueStore) heartbeat(ctx context.Context, jobID, attemptID, token string, extension time.Duration) (*queue.HeartbeatResult, error) {
 	if extension <= 0 {
 		extension = 30 * time.Second
 	}
@@ -257,7 +277,15 @@ func (s *QueueStore) Heartbeat(ctx context.Context, jobID, attemptID, token stri
 	return &queue.HeartbeatResult{LeaseExpiresAt: expires, CancelRequested: canceled != 0}, nil
 }
 
+// Finish is the most damaging write in the queue to lose: without it the job
+// stays leased until its lease expires and is then re-run, duplicating the
+// agent's work and any side effects it already performed. It retries on lock
+// contention rather than surfacing the error to the worker.
 func (s *QueueStore) Finish(ctx context.Context, jobID, attemptID, token string, result queue.FinishResult) error {
+	return retryOnBusy(ctx, func() error { return s.finish(ctx, jobID, attemptID, token, result) })
+}
+
+func (s *QueueStore) finish(ctx context.Context, jobID, attemptID, token string, result queue.FinishResult) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -335,6 +363,16 @@ func (s *QueueStore) ReleaseAffinity(ctx context.Context, jobID string) error {
 }
 
 func (s *QueueStore) ReclaimExpired(ctx context.Context, cutoff time.Time) (int, error) {
+	var n int
+	err := retryOnBusy(ctx, func() error {
+		var err error
+		n, err = s.reclaimExpired(ctx, cutoff)
+		return err
+	})
+	return n, err
+}
+
+func (s *QueueStore) reclaimExpired(ctx context.Context, cutoff time.Time) (int, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Closes #369.

## The issue's diagnosis was half right

Suggested fixes 1 and 2 — `journal_mode=WAL` and `busy_timeout=5000` — have been in `src/internal/db/client.go` since v0.10.0, with a test asserting `journal_mode = wal`. The "no `-wal` sidecar observed" evidence was misleading: SQLite checkpoints and removes it on clean close, so inspecting with the daemon stopped shows nothing.

So the report was real but the explanation wasn't, which is why the pragmas didn't help.

## Actual root cause

Every transaction in the `db` package **reads and then writes**. `Finish` is typical: `SELECT … WHERE state='leased' AND lease_token=?`, then three `UPDATE`s.

Under SQLite's default **deferred** transaction mode, that transaction begins on a read snapshot at the `SELECT`. If another connection commits before it upgrades to a write, SQLite fails it with `SQLITE_BUSY_SNAPSHOT` (extended code 517) **immediately** — the busy handler is never invoked, because waiting cannot refresh a stale snapshot. No value of `busy_timeout` prevents this.

That matches the reported symptom exactly: an instant failure, not a 5-second wait.

## Fix

**1. `_txlock=immediate` in the DSN.** Read-then-write transactions take the write lock at `BEGIN`, where `busy_timeout` *does* apply, so contention becomes a bounded wait instead of an instant error. I checked all 8 `BeginTx` call sites in the package — every one is read-then-write, and read-only queries run outside transactions, so nothing loses read concurrency.

**2. `retryOnBusy` (`src/internal/db/busy.go`).** Second line of defence for genuine lock waits that exhaust `busy_timeout` under the load in the report (concurrency 50 + dashboard + TUI). Wraps the queue's `Claim`/`Heartbeat`/`Finish`/`ReclaimExpired`. Retrying is safe because the unit is a whole transaction: a busy failure commits nothing, so the retry re-reads state, and a genuinely lost race still returns `ErrStaleClaim` rather than double-finishing (test covers this).

**Deliberately skipped: the issue's item 3, `SetMaxOpenConns(1)`.** The `Client` has a single pool shared by readers and writers, so capping it at one connection would serialize the dashboard's cold log reads behind daemon writes — a real regression to fix a problem items 1 and 2 already solve. Happy to revisit with a split read/write handle if contention persists.

## Verification

- Full `go test ./...`, `go vet`, `go build` pass; `go test -race ./internal/db/` passes; queue tests pass at `-count=10`.
- **The new concurrency test fails against the pre-fix code**, reproducing the reported error:
  ```
  lock contention surfaced to the caller: claim: database is locked (517)
  lock contention surfaced to the caller: claim: database is locked (5) (SQLITE_BUSY)
  ```
- Layer isolation, since it matters for review: **`_txlock=immediate` alone makes the test pass** (5 consecutive runs). The retry layer is insurance for production load the test cannot easily reproduce, not what makes the test green. If you'd rather ship the one-line DSN change alone, the retry commit is separable.
- `isBusy` is tested against a **real** driver error — a second connection writing while the first holds the write lock — not a fabricated one, since modernc's `Error` has no exported constructor and a hand-made value would prove nothing about what SQLite actually returns.
- Confirmed at runtime that the DSN change doesn't disturb the existing pragmas: `journal_mode=wal busy_timeout=5000`.

No config surface changed, so no docs update.

## Rollout

New binary plus a daemon restart. Existing databases need nothing — this is connection-level behaviour, not schema.