### PR TITLE
feat(ui): compact token counts and US-dollar cost formatting

### DIFF
--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/daemon"
+	"github.com/orlandoburli/apiary/internal/format"
 )
 
 var (
@@ -96,7 +97,7 @@ func compareInstances(beforeID, afterID string, asJSON bool) error {
 		if row.OutputChanged {
 			output = "changed"
 		}
-		usage := fmt.Sprintf("%+d / %+.5f", row.TokenDelta, row.CostDeltaUSD)
+		usage := fmt.Sprintf("%s / %s", format.TokensDelta(row.TokenDelta), format.USDDelta(row.CostDeltaUSD))
 		timing := fmt.Sprintf("%+dms", row.DurationDeltaMS)
 		fmt.Printf("%-18s %-13s %-13s %-10s %-10s %-12s %-10s\n", truncate(row.StepID, 18), before, after, input, output, usage, timing)
 		if row.BeforeModel != row.AfterModel || row.BeforeRunner != row.AfterRunner {
@@ -192,12 +193,12 @@ func showInstance(id string, asJSON bool) error {
 				stateColor(s.State).Render(state),
 			)
 			if s.TotalTokens > 0 {
-				usage := fmt.Sprintf("%d in / %d out / %d total", s.InputTokens, s.OutputTokens, s.TotalTokens)
+				usage := fmt.Sprintf("%s in / %s out / %s total", format.Tokens(s.InputTokens), format.Tokens(s.OutputTokens), format.Tokens(s.TotalTokens))
 				if s.CacheCreationTokens > 0 || s.CacheReadTokens > 0 {
-					usage += fmt.Sprintf("  ·  cache %d write / %d read", s.CacheCreationTokens, s.CacheReadTokens)
+					usage += fmt.Sprintf("  ·  cache %s write / %s read", format.Tokens(s.CacheCreationTokens), format.Tokens(s.CacheReadTokens))
 				}
 				if s.CostUSD > 0 {
-					usage += fmt.Sprintf("  ·  $%.5f", s.CostUSD)
+					usage += "  ·  " + format.USD(s.CostUSD)
 				}
 				fmt.Printf("       %s\n", instMuted.Render(usage))
 			}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/format"
 	"github.com/orlandoburli/apiary/internal/model"
 )
 
@@ -3035,11 +3036,11 @@ func (a *App) renderOverviewTab(height int) string {
 
 	costStr := "—"
 	if o.TodayCostUSD > 0 {
-		costStr = fmt.Sprintf("$%.4f", o.TodayCostUSD)
+		costStr = format.USD(o.TodayCostUSD)
 	}
 	tokensStr := "—"
 	if o.TodayTokens > 0 {
-		tokensStr = fmt.Sprintf("%d in / %d out / %d total", o.TodayInputTokens, o.TodayOutputTokens, o.TodayTokens)
+		tokensStr = fmt.Sprintf("%s in / %s out / %s total", format.Tokens(o.TodayInputTokens), format.Tokens(o.TodayOutputTokens), format.Tokens(o.TodayTokens))
 	}
 	fmt.Fprintf(&b,
 		"\nTasks (24h):\n"+
@@ -3450,12 +3451,12 @@ func (a *App) taskDetailLines(t *TasksTab) []string {
 	}
 	row(endedLabel, completed)
 	row("Duration", dur)
-	row("Tokens", fmt.Sprintf("%d in / %d out / %d total", inTok, outTok, totalTok))
+	row("Tokens", fmt.Sprintf("%s in / %s out / %s total", format.Tokens(inTok), format.Tokens(outTok), format.Tokens(totalTok)))
 	if cacheCreate > 0 || cacheRead > 0 {
 		row("Cache", fmt.Sprintf("%d write / %d read", cacheCreate, cacheRead))
 	}
 	row("Turns / Calls", fmt.Sprintf("%d / %d", d.NumTurns, d.NumToolCalls))
-	row("Cost", fmt.Sprintf("$%.4f", cost))
+	row("Cost", format.USD(cost))
 	if d.URL != "" {
 		row("URL", StyleInfo.Render(d.URL))
 	}
@@ -3721,7 +3722,7 @@ func wfInstanceSummary(inst *WorkflowInstanceItem) string {
 		parts = append(parts, fmtTokensShort(inst.CacheCreationTokens+inst.CacheReadTokens)+" cache")
 	}
 	if inst.CostUSD > 0 {
-		parts = append(parts, fmt.Sprintf("$%.4f", inst.CostUSD))
+		parts = append(parts, format.USD(inst.CostUSD))
 	}
 	return StyleMuted.Render(strings.Join(parts, "  ·  "))
 }
@@ -4286,7 +4287,7 @@ func (a *App) renderAgentList(ag *AgentsTab, height int) string {
 		success := padLeft(successRateStyled(agent.SuccessRate), successW)
 		cost := "—"
 		if agent.TotalCostUSD > 0 {
-			cost = fmt.Sprintf("$%.2f", agent.TotalCostUSD)
+			cost = format.USD(agent.TotalCostUSD)
 		}
 		cost = padLeft(cost, costW)
 		if selected {
@@ -4397,10 +4398,10 @@ func (a *App) renderAgentDetail(ag *AgentsTab, height int) string {
 	if d.TotalTokens > 0 || d.TotalCostUSD > 0 {
 		b.WriteString("\n")
 		if d.TotalTokens > 0 {
-			row("Total tokens", fmt.Sprintf("%d", d.TotalTokens))
+			row("Total tokens", format.Tokens(d.TotalTokens))
 		}
 		if d.TotalCostUSD > 0 {
-			row("Total cost", fmt.Sprintf("$%.4f", d.TotalCostUSD))
+			row("Total cost", format.USD(d.TotalCostUSD))
 		}
 	}
 	return a.box("AGENT DETAILS — "+d.ID, b.String(), height)
@@ -5037,16 +5038,11 @@ func valueOr(s, fallback string) string {
 
 // fmtTokensShort renders a token count compactly (842, 1.2k, 3.4M); "—" for zero.
 func fmtTokensShort(n int) string {
-	switch {
-	case n <= 0:
+	if n <= 0 {
+		// Table cells read better with an em dash than a zero.
 		return "—"
-	case n < 1000:
-		return fmt.Sprintf("%d", n)
-	case n < 1_000_000:
-		return fmt.Sprintf("%.1fk", float64(n)/1000)
-	default:
-		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
 	}
+	return format.Tokens(n)
 }
 
 // tsTimeFmt is the fixed-width timestamp shown in step/instance table cells:
@@ -5322,11 +5318,11 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 		right.WriteString("\n")
 
 		if s.TotalTokens > 0 {
-			row2("Tokens", fmt.Sprintf("%d in / %d out / %d total", s.InputTokens, s.OutputTokens, s.TotalTokens))
+			row2("Tokens", fmt.Sprintf("%s in / %s out / %s total", format.Tokens(s.InputTokens), format.Tokens(s.OutputTokens), format.Tokens(s.TotalTokens)))
 			if s.CacheCreationTokens > 0 || s.CacheReadTokens > 0 {
-				row2("Cache", fmt.Sprintf("%d write / %d read", s.CacheCreationTokens, s.CacheReadTokens))
+				row2("Cache", fmt.Sprintf("%s write / %s read", format.Tokens(s.CacheCreationTokens), format.Tokens(s.CacheReadTokens)))
 			}
-			row2("Cost", fmt.Sprintf("$%.5f", s.CostUSD))
+			row2("Cost", format.USD(s.CostUSD))
 			row2("Turns", fmt.Sprintf("%d turns / %d calls", s.NumTurns, s.NumToolCalls))
 			right.WriteString("\n")
 		}

--- a/src/internal/dashboard/charts.go
+++ b/src/internal/dashboard/charts.go
@@ -3,6 +3,8 @@ package dashboard
 import (
 	"fmt"
 	"strings"
+
+	"github.com/orlandoburli/apiary/internal/format"
 )
 
 type barItem struct {
@@ -88,35 +90,8 @@ func barChart(items []barItem, opts barOpts) string {
 }
 
 // formatVal renders a USD value for chart columns.
-func formatVal(v float64) string {
-	switch {
-	case v >= 1:
-		return fmt.Sprintf("$%.2f", v)
-	case v > 0:
-		return fmt.Sprintf("$%.4f", v)
-	default:
-		return "$0.00"
-	}
-}
+func formatVal(v float64) string { return format.USD(v) }
 
-// formatTokens renders a token count as an integer with thousands separators,
-// e.g. 98180082 -> "98,180,082".
-func formatTokens(v float64) string {
-	n := int64(v)
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	digits := fmt.Sprintf("%d", n)
-	var parts []string
-	for len(digits) > 3 {
-		parts = append([]string{digits[len(digits)-3:]}, parts...)
-		digits = digits[:len(digits)-3]
-	}
-	parts = append([]string{digits}, parts...)
-	out := strings.Join(parts, ",")
-	if neg {
-		out = "-" + out
-	}
-	return out
-}
+// formatTokens renders a token count for chart columns, compactly (1.5k, 65M)
+// so the value column stays narrow enough to leave room for the bar.
+func formatTokens(v float64) string { return format.Tokens(int(v)) }

--- a/src/internal/dashboard/render_test.go
+++ b/src/internal/dashboard/render_test.go
@@ -526,7 +526,7 @@ func TestTaskDetailShowsUsageWhenPresent(t *testing.T) {
 		CostUSD:      0.0425,
 	}
 	out := stripANSI(a.renderTaskDetail(a.model.tasksTab, 20))
-	if !strings.Contains(out, "1500 in / 420 out / 1920 total") {
+	if !strings.Contains(out, "1.5k in / 420 out / 1.9k total") {
 		t.Errorf("should show token breakdown; got:\n%s", out)
 	}
 	if !strings.Contains(out, "8 / 23") {
@@ -554,7 +554,7 @@ func TestTaskDetailShowsUsageWhenZero(t *testing.T) {
 	if !strings.Contains(out, "0 / 0") {
 		t.Errorf("should show turns/calls even when zero; got:\n%s", out)
 	}
-	if !strings.Contains(out, "$0.0000") {
+	if !strings.Contains(out, "$0.00") {
 		t.Errorf("should show cost even when zero; got:\n%s", out)
 	}
 }

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -226,8 +226,8 @@ func TestRenderWorkflowSteps_StepSpanAndTokens(t *testing.T) {
 	out := stripANSI(renderWorkflowSteps(inst))
 	for _, want := range []string{
 		"STARTED", "ENDED", "DURATION", "TOKENS", "STATE", // column header
-		"06-08 13:42:01", "06-08 13:50:16", "42.1k", // step row cells
-		"06-08 13:42:01 → 06-08 13:52:11", "50.3k tokens", // instance rollup
+		"06-08 13:42:01", "06-08 13:50:16", "42k", // step row cells (compact: no decimal above 10 units)
+		"06-08 13:42:01 → 06-08 13:52:11", "50k tokens", // instance rollup
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("rendered steps missing %q:\n%s", want, out)

--- a/src/internal/format/number.go
+++ b/src/internal/format/number.go
@@ -1,0 +1,136 @@
+// Package format renders numbers for display. These helpers are presentation
+// only — stored and transported values stay exact; nothing here should be parsed
+// back or used in arithmetic.
+package format
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// unit thresholds for compact token counts, largest first.
+var tokenUnits = []struct {
+	limit float64
+	sufix string
+}{
+	{1e12, "T"},
+	{1e9, "B"},
+	{1e6, "M"},
+	{1e3, "k"},
+}
+
+// Tokens renders a token count compactly: 842, 1.5k, 65M, 1.2B.
+//
+// One decimal is kept below 10 units (1.5k) and dropped above it (65M), which
+// is where the extra digit stops carrying information in a table cell. A value
+// that rounds up to the next unit is promoted, so 999,999 renders as "1M" rather
+// than "1000k".
+func Tokens(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	sign := ""
+	v := float64(n)
+	if v < 0 {
+		sign, v = "-", -v
+	}
+	for i, u := range tokenUnits {
+		if v < u.limit {
+			continue
+		}
+		scaled := v / u.limit
+		// Rounding can push the value into the next unit up (999,999 → 1000.0k).
+		if rounded := roundTo(scaled, 1); rounded >= 1000 && i > 0 {
+			u = tokenUnits[i-1]
+			scaled = v / u.limit
+		}
+		return sign + trimFloat(scaled) + u.sufix
+	}
+	return sign + strconv.FormatInt(int64(v), 10)
+}
+
+// TokensDelta renders a signed token difference: +1.5k, -840, 0.
+func TokensDelta(n int) string {
+	if n > 0 {
+		return "+" + Tokens(n)
+	}
+	// Tokens already carries the minus sign for negatives.
+	return Tokens(n)
+}
+
+// USD renders a monetary amount in US dollars: $1,234.56, $0.0425, -$3.20.
+//
+// Amounts below a dollar keep four decimals, because per-step agent costs are
+// routinely fractions of a cent and rounding them to $0.00 would erase the only
+// figure on the row. Anything smaller than the smallest representable amount
+// renders as "<$0.0001" rather than a misleading zero.
+func USD(v float64) string {
+	if v == 0 || math.IsNaN(v) {
+		return "$0.00"
+	}
+	sign := ""
+	if v < 0 {
+		sign, v = "-", -v
+	}
+	if v < 1 {
+		if v < 0.00005 {
+			return sign + "<$0.0001"
+		}
+		return sign + "$" + strconv.FormatFloat(v, 'f', 4, 64)
+	}
+	whole, frac := math.Modf(v)
+	cents := int(math.Round(frac * 100))
+	if cents == 100 { // 1.999 → 2.00, not 1.100
+		whole, cents = whole+1, 0
+	}
+	return sign + "$" + group(int64(whole)) + fmt.Sprintf(".%02d", cents)
+}
+
+// USDDelta renders a signed monetary difference: +$0.0425, -$3.20, $0.00.
+func USDDelta(v float64) string {
+	if v > 0 {
+		return "+" + USD(v)
+	}
+	// USD already carries the minus sign for negatives.
+	return USD(v)
+}
+
+// Count renders an exact integer with thousands separators: 98,180,082. Use it
+// where the precise figure matters; prefer Tokens for table cells.
+func Count(n int) string {
+	if n < 0 {
+		return "-" + group(int64(-n))
+	}
+	return group(int64(n))
+}
+
+// group inserts thousands separators into a non-negative integer.
+func group(n int64) string {
+	digits := strconv.FormatInt(n, 10)
+	if len(digits) <= 3 {
+		return digits
+	}
+	var parts []string
+	for len(digits) > 3 {
+		parts = append([]string{digits[len(digits)-3:]}, parts...)
+		digits = digits[:len(digits)-3]
+	}
+	return strings.Join(append([]string{digits}, parts...), ",")
+}
+
+// trimFloat renders a scaled value with one decimal below 10 and none above,
+// dropping a trailing ".0" so 1000 reads as "1k" rather than "1.0k".
+func trimFloat(v float64) string {
+	if v >= 10 {
+		return strconv.FormatInt(int64(math.Round(v)), 10)
+	}
+	s := strconv.FormatFloat(roundTo(v, 1), 'f', 1, 64)
+	return strings.TrimSuffix(s, ".0")
+}
+
+func roundTo(v float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return math.Round(v*shift) / shift
+}

--- a/src/internal/format/number_test.go
+++ b/src/internal/format/number_test.go
@@ -1,0 +1,112 @@
+package format
+
+import "testing"
+
+func TestTokens(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{842, "842"},
+		{999, "999"},
+		{1000, "1k"},
+		{1500, "1.5k"},
+		{1949, "1.9k"},
+		{9950, "10k"}, // rounds past the one-decimal band
+		{12_500, "13k"},
+		{999_499, "999k"},
+		{999_999, "1M"}, // promoted rather than "1000k"
+		{1_000_000, "1M"},
+		{1_250_000, "1.3M"},
+		{65_000_000, "65M"},
+		{1_200_000_000, "1.2B"},
+		{2_500_000_000_000, "2.5T"},
+		{-1500, "-1.5k"},
+		{-842, "-842"},
+	}
+	for _, tc := range tests {
+		if got := Tokens(tc.in); got != tc.want {
+			t.Errorf("Tokens(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTokensDelta(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{1500, "+1.5k"},
+		{-1500, "-1.5k"},
+		{42, "+42"},
+	}
+	for _, tc := range tests {
+		if got := TokensDelta(tc.in); got != tc.want {
+			t.Errorf("TokensDelta(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUSD(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want string
+	}{
+		{0, "$0.00"},
+		{0.0425, "$0.0425"},
+		{0.00004, "<$0.0001"}, // would round to $0.0000
+		{0.9999, "$0.9999"},
+		{1, "$1.00"},
+		{1.5, "$1.50"},
+		{3.204, "$3.20"},
+		{1234.56, "$1,234.56"},
+		{98180.082, "$98,180.08"},
+		{1_234_567.89, "$1,234,567.89"},
+		{1.999, "$2.00"}, // carry into the whole part
+		{-3.2, "-$3.20"},
+		{-0.0425, "-$0.0425"},
+	}
+	for _, tc := range tests {
+		if got := USD(tc.in); got != tc.want {
+			t.Errorf("USD(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUSDDelta(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want string
+	}{
+		{0, "$0.00"},
+		{0.0425, "+$0.0425"},
+		{-0.0425, "-$0.0425"},
+		{2, "+$2.00"},
+	}
+	for _, tc := range tests {
+		if got := USDDelta(tc.in); got != tc.want {
+			t.Errorf("USDDelta(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{1000, "1,000"},
+		{98_180_082, "98,180,082"},
+		{-1_500, "-1,500"},
+	}
+	for _, tc := range tests {
+		if got := Count(tc.in); got != tc.want {
+			t.Errorf("Count(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Token counts were rendered raw (`98180082`) and costs as bare fixed-precision floats, inconsistently across views — `%.2f`, `%.4f` and `%.5f` all appeared for the same kind of value.

## New package

`internal/format` — presentation only. Stored and transported values are untouched; nothing here is parsed back or used in arithmetic.

| Helper | Output |
|---|---|
| `Tokens(n)` | `842`, `1.5k`, `42k`, `65M`, `1.2B` |
| `TokensDelta(n)` | `+1.5k`, `-840` |
| `USD(v)` | `$1,234.56`, `$0.0425`, `-$3.20`, `<$0.0001` |
| `USDDelta(v)` | `+$0.0425`, `-$3.20` |
| `Count(n)` | `98,180,082` — exact, with separators |

## Sites converted

**Dashboard** — overview cost + token rollup, daily cost and daily token bar charts, task detail, agent list and agent detail, workflow instance rollup, workflow monitor step detail (tokens, cache, cost). `fmtTokensShort` and the chart formatters now delegate to the package rather than each rolling their own.

**CLI** — `apiary instances show` (tokens, cache, cost) and `apiary instances compare` (token and cost deltas, previously `%+d / %+.5f`).

Before / after in the task detail view:

```
Tokens:        65412000 in / 1204500 out / 66616500 total
Cost:          $1284.5567
->
Tokens:        65M in / 1.2M out / 67M total
Cost:          $1,284.56
```

## Two judgment calls worth reviewing

**Precision below a dollar.** Per-step agent costs are routinely fractions of a cent, so `USD` keeps four decimals under $1 instead of rounding to `$0.00` and erasing the only figure on the row. Amounts too small even for that render as `<$0.0001`, not a misleading zero.

**One decimal below 10 units, none above.** `1.5k` but `42k` and `65M`. This slightly reduces what the workflow token column used to show (`42.1k` → `42k`) — a 0.2% difference, immaterial at a glance, and it matches the `1M` / `65M` style requested. Consequence worth naming: with every view compact, **exact token counts are no longer visible anywhere in the UI** (they remain exact in the database). `Count` exists and is tested if you'd rather have detail panels show `66,616,500` while tables stay compact — a one-line change per site.

## Not converted

Runner stream annotations and agent transcripts (`cost=$%.4f` in `runner/execution/cli.go` and `transcript.go`) and daemon log lines (`cursor_cost.go`) keep raw values — those are diagnostic records where precision beats readability. Say the word if you want the transcript ones included, since those are user-facing.

## Verification

- Full `go test ./...`, `go vet`, `go build` pass.
- 5 table-driven tests over the new package covering unit boundaries and the rounding traps: `999999` promotes to `1M` rather than `1000k`, `9950` → `10k`, `1.999` carries to `$2.00` rather than `$1.100`, negatives on both helpers, and the `<$0.0001` floor.
- Three existing dashboard render tests updated for the new output — those assertions are the before/after evidence.
- Rendered the detail view with large (`65M` / `$1,284.56`) and tiny (`842` / `<$0.0001`) values to confirm both ends read correctly in a real panel.