### PR TITLE
fix(workflow): run parallel/for_each groups after a condition-skipped step (#379)

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -228,8 +228,14 @@ func (lc *lowerCtx) lowerParallelStep(s StepConfig, prevID, inheritedCondition s
 		Type: StepTypeParallel,
 		Join: s.Join,
 	}
+	// Implicit sequencing uses SeqDependsOn, exactly like lowerLeafStep: a
+	// condition-skipped predecessor must not block its successor. With a hard
+	// DependsOn here, a parallel group authored after a pair of mutually
+	// exclusive `if:` steps could never become runnable (an explicit dep must be
+	// stPassed, and cond_skipped never is) — the group was silently stranded and
+	// the instance still reported success (#379).
 	if prevID != "" {
-		out.DependsOn = []string{prevID}
+		out.SeqDependsOn = []string{prevID}
 	}
 	ownCond, err := lc.rewriteExpr(s.If, s.ID)
 	if err != nil {
@@ -287,8 +293,11 @@ func (lc *lowerCtx) lowerForeachStep(s StepConfig, prevID, inheritedCondition st
 		Concurrency: s.Concurrency,
 		FailFast:    s.FailFast,
 	}
+	// Implicit sequencing via SeqDependsOn — same rationale as lowerParallelStep
+	// and lowerLeafStep: a condition-skipped predecessor must not strand the
+	// for_each node (#379).
 	if prevID != "" {
-		out.DependsOn = []string{prevID}
+		out.SeqDependsOn = []string{prevID}
 	}
 	ownCond, err := lc.rewriteExpr(s.If, s.ID)
 	if err != nil {

--- a/src/internal/config/lower_v2_seq_deps_test.go
+++ b/src/internal/config/lower_v2_seq_deps_test.go
@@ -1,0 +1,60 @@
+package config
+
+import "testing"
+
+// TestLowerV2_GroupNodesUseSeqDependsOn is the lowering-side regression test for
+// #379. Implicit sequencing between authored steps must always be expressed as
+// SeqDependsOn, for every node kind — leaf, parallel and for_each alike.
+//
+// The DAG engine treats the two edge kinds differently on purpose (dag.go
+// depsPassed): an explicit DependsOn requires the dependency to have *passed*,
+// while a SeqDependsOn is also satisfied by a condition-skipped dependency. The
+// lowering pass wired parallel and for_each nodes with a hard DependsOn, so a
+// group authored right after a conditional step could never become runnable when
+// that condition was false — it stayed pending forever, the scheduler went
+// quiescent, and (with no step in a failed state) the instance reported success
+// while its steps had silently never run.
+func TestLowerV2_GroupNodesUseSeqDependsOn(t *testing.T) {
+	wf := WorkflowConfig{ID: "seq-deps", Steps: []StepConfig{
+		{ID: "plan", Agent: "ag",
+			Output: &OutputSchema{Type: "object",
+				Properties: map[string]SchemaField{
+					"complexity": {Type: "string"},
+					"tasks":      {Type: "array"},
+				}}},
+		{ID: "implement", Agent: "ag", If: `${{ plan.complexity == "high" }}`},
+		{ID: "validate", Join: "all", ParallelSteps: []StepConfig{
+			{ID: "review", Agent: "ag"},
+			{ID: "qa", Agent: "ag"},
+		}},
+		{ID: "fan", ForEachExpr: "${{ plan.tasks }}", As: "task",
+			SubSteps: []StepConfig{{ID: "work", Agent: "ag"}}},
+	}}
+
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("LowerV2Workflow: %v", err)
+	}
+	byID := map[string]StepConfig{}
+	for _, s := range out.Steps {
+		byID[s.ID] = s
+	}
+
+	for _, tc := range []struct{ step, want string }{
+		{"implement", "plan"},
+		{"validate", "implement"},
+		{"fan", "validate"},
+	} {
+		s, ok := byID[tc.step]
+		if !ok {
+			t.Fatalf("step %q missing from lowered output", tc.step)
+		}
+		if len(s.DependsOn) != 0 {
+			t.Errorf("step %q depends_on = %v, want none — a hard edge strands the step when %q is condition-skipped (#379)",
+				tc.step, s.DependsOn, tc.want)
+		}
+		if len(s.SeqDependsOn) != 1 || s.SeqDependsOn[0] != tc.want {
+			t.Errorf("step %q seq_depends_on = %v, want [%s]", tc.step, s.SeqDependsOn, tc.want)
+		}
+	}
+}

--- a/src/internal/config/lower_v2_test.go
+++ b/src/internal/config/lower_v2_test.go
@@ -245,8 +245,13 @@ func TestLowerV2_ParallelStepKept(t *testing.T) {
 	if len(checks.SubSteps) != 2 {
 		t.Errorf("checks should have 2 children, got %d", len(checks.SubSteps))
 	}
-	if checks.DependsOn[0] != "setup" {
-		t.Errorf("checks depends_on = %v, want [setup]", checks.DependsOn)
+	// Implicit sequencing is a SeqDependsOn edge, never a hard DependsOn — a
+	// hard edge strands the group when its predecessor is condition-skipped (#379).
+	if len(checks.DependsOn) != 0 {
+		t.Errorf("checks depends_on = %v, want none (implicit sequencing uses seq_depends_on)", checks.DependsOn)
+	}
+	if len(checks.SeqDependsOn) != 1 || checks.SeqDependsOn[0] != "setup" {
+		t.Errorf("checks seq_depends_on = %v, want [setup]", checks.SeqDependsOn)
 	}
 }
 
@@ -294,8 +299,8 @@ func TestLowerV2_ParallelDoubleLowerIdempotent(t *testing.T) {
 	if len(checks.SubSteps) != 2 {
 		t.Errorf("checks children after double-lower = %d, want 2", len(checks.SubSteps))
 	}
-	if len(checks.DependsOn) != 1 || checks.DependsOn[0] != "setup" {
-		t.Errorf("checks depends_on after double-lower = %v, want [setup]", checks.DependsOn)
+	if len(checks.SeqDependsOn) != 1 || checks.SeqDependsOn[0] != "setup" {
+		t.Errorf("checks seq_depends_on after double-lower = %v, want [setup]", checks.SeqDependsOn)
 	}
 
 	// Strongest assertion: the second pass must reproduce the first pass exactly.

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -460,7 +460,34 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			return outcomeFailed
 		}
 	}
+
+	// Stranded steps: the scheduler went quiescent while a declared step is still
+	// pending. Such a step neither ran, nor had its own condition evaluate false,
+	// nor was cascade-skipped by a failed/skipped dependency — it simply became
+	// unreachable (typically an explicit depends_on on a condition-skipped step).
+	// Reporting success here silently drops declared work, which is how a pair of
+	// quality gates disappeared from a pipeline with no signal at all (#379).
+	// Fail loudly instead: a declared step that never ran is not a success.
+	if stranded := r.strandedSteps(); len(stranded) > 0 {
+		aplog.Error("workflow %s: instance %s finished with steps that never ran and were never skipped: %s — failing the instance rather than reporting success (check depends_on against condition-skipped steps)",
+			r.wf.ID, r.instID, strings.Join(stranded, ", "))
+		return outcomeFailed
+	}
 	return outcomeDone
+}
+
+// strandedSteps returns the ids of steps still pending once the scheduler has
+// gone quiescent, in declaration order. A pending step at quiescence can never
+// run: nothing is in flight to unblock it and no further control flow is
+// possible. See driveDAG for why this is a failure and not a success.
+func (r *dagRun) strandedSteps() []string {
+	var ids []string
+	for _, id := range r.order {
+		if r.state[id] == stPending {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 // enterApproval parks the run at an approval step: it posts the step message to
@@ -598,8 +625,17 @@ func (r *dagRun) skipUnreachable() bool {
 			continue
 		}
 		// Explicit dep ended skipped/failed → this step can never run.
+		// A condition-skipped explicit dep cascades too: depsPassed requires an
+		// explicit dependency to have *passed*, so the dependent is unreachable.
+		// Recording it as skipped (instead of leaving it pending forever) is what
+		// the cascade always intended, and it is announced in the log — a step
+		// that quietly disappears from a pipeline is exactly what #379 cost.
 		for _, dep := range r.byID[id].DependsOn {
-			if r.state[dep] == stSkipped || r.state[dep] == stFailed {
+			if st := r.state[dep]; st == stSkipped || st == stFailed || st == stCondSkipped {
+				if st == stCondSkipped {
+					aplog.Warn("workflow %s: step %q skipped — its explicit depends_on %q was condition-skipped (use an if: on this step, or rely on implicit sequencing, if it should still run)",
+						r.wf.ID, id, dep)
+				}
 				r.markSkipped(id)
 				progress = true
 				break

--- a/src/internal/workflow/dag_parallel_after_conditional_test.go
+++ b/src/internal/workflow/dag_parallel_after_conditional_test.go
@@ -1,0 +1,199 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// condPairThenParallelWF builds the shape reported in #379: a plan step, a pair
+// of mutually-exclusive conditional steps (only one of which ever runs), then a
+// `parallel:` quality gate, then a trailing sequential step. Authored in v2 form
+// and lowered exactly like a real config, so the test exercises the lowering
+// pass and the DAG scheduler together.
+func condPairThenParallelWF(t *testing.T) config.WorkflowConfig {
+	t.Helper()
+	wf := config.WorkflowConfig{ID: "cond-par", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect",
+			Output: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{"complexity": {Type: "string"}}},
+			Memory: &config.MemoryConfig{Write: []string{"complexity"}}},
+		{ID: "implement", Agent: "backend-dev", If: `${{ memory.complexity != "high" }}`},
+		{ID: "implement-hard", Agent: "backend-dev", If: `${{ memory.complexity == "high" }}`},
+		{ID: "validate", Join: "all", ParallelSteps: []config.StepConfig{
+			{ID: "review", Agent: "architect"},
+			{ID: "qa-validate", Agent: "architect"},
+		}},
+		{ID: "ask-review", Agent: "architect"},
+	}}
+	lowered, err := config.LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("LowerV2Workflow: %v", err)
+	}
+	return lowered
+}
+
+// TestDAG_ParallelAfterConditionalPair_Runs is the regression test for #379: a
+// `parallel:` group placed after a pair of mutually-exclusive conditional steps
+// must run exactly once no matter which branch the condition took.
+//
+// Before the fix the lowering pass wired the parallel node with an explicit
+// DependsOn on its predecessor. An explicit dep must be fully *passed*
+// (dag.go depsPassed), and a condition-skipped step never reaches stPassed, so
+// whenever the immediately-preceding conditional step was skipped the parallel
+// node stayed pending forever: no worker ran it, skipUnreachable did not touch
+// it (cond_skipped is not a cascade trigger), the scheduler went quiescent and,
+// with no step in stFailed, the instance reported SUCCESS.
+func TestDAG_ParallelAfterConditionalPair_Runs(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		complexity string
+		ranStep    string
+		skipped    string
+	}{
+		{"low complexity skips implement-hard", "low", "implement", "implement-hard"},
+		{"high complexity skips implement", "high", "implement-hard", "implement"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := newSeqExecutor()
+			exec.scripts["plan"] = []StepResult{
+				{Success: true, StructuredOutput: map[string]any{"complexity": tc.complexity}},
+			}
+			eng := testEngine(baseCfg(), newFakeStore(), exec, &fakeSide{})
+
+			_, success, err := eng.RunInstance(context.Background(), condPairThenParallelWF(t), model.InternalTask{ID: "c1"})
+			if err != nil {
+				t.Fatalf("RunInstance: %v", err)
+			}
+			if !success {
+				t.Fatal("expected the instance to succeed")
+			}
+			if exec.ran(tc.ranStep) != 1 {
+				t.Errorf("%s ran %d times, want 1", tc.ranStep, exec.ran(tc.ranStep))
+			}
+			if exec.ran(tc.skipped) != 0 {
+				t.Errorf("%s ran %d times, want 0 (condition false)", tc.skipped, exec.ran(tc.skipped))
+			}
+			// The heart of #379: the quality gates must not be silently dropped.
+			if exec.ran("review") != 1 {
+				t.Errorf("parallel child review ran %d times, want 1 (#379: group never executed)", exec.ran("review"))
+			}
+			if exec.ran("qa-validate") != 1 {
+				t.Errorf("parallel child qa-validate ran %d times, want 1 (#379: group never executed)", exec.ran("qa-validate"))
+			}
+			// And everything after the group must run too.
+			if exec.ran("ask-review") != 1 {
+				t.Errorf("ask-review ran %d times, want 1 (successor of the stranded group)", exec.ran("ask-review"))
+			}
+		})
+	}
+}
+
+// TestDAG_ForeachAfterConditionalStep_Runs is the for_each twin of #379: the
+// lowering pass wired foreach nodes with the same hard DependsOn edge, so a
+// for_each placed after a condition-skipped step was stranded identically.
+// The workflow is expressed in IR form (Type: foreach + Items) because the v2
+// `for_each:` lowering emits a `steps.<id>.outputs.<field>` items path that the
+// runtime rejects — a separate defect, not in scope here.
+func TestDAG_ForeachAfterConditionalStep_Runs(t *testing.T) {
+	wf := config.WorkflowConfig{ID: "cond-fe", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect",
+			OutputSchema: &config.OutputSchema{Type: "object",
+				Properties: map[string]config.SchemaField{
+					"complexity": {Type: "string"},
+					"tasks":      {Type: "array"},
+				}},
+			Memory: &config.MemoryConfig{Write: []string{"complexity", "tasks"}}},
+		{ID: "implement-hard", Agent: "backend-dev", SeqDependsOn: []string{"plan"},
+			Condition: `memory.complexity == "high"`},
+		{ID: "fan", Type: config.StepTypeForeach, SeqDependsOn: []string{"implement-hard"},
+			Items: "steps.plan.output.tasks", As: "task",
+			Step: &config.StepConfig{ID: "work", Agent: "backend-dev"}},
+	}}
+
+	exec := newSeqExecutor()
+	exec.scripts["plan"] = []StepResult{{Success: true, StructuredOutput: map[string]any{
+		"complexity": "low",
+		"tasks":      []any{"t1", "t2"},
+	}}}
+	eng := testEngine(baseCfg(), newFakeStore(), exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("expected the instance to succeed")
+	}
+	// Item steps are dispatched as "<foreach id>[<index>]".
+	if exec.ran("fan[0]") != 1 || exec.ran("fan[1]") != 1 {
+		t.Errorf("foreach body runs = fan[0]:%d fan[1]:%d, want 1 each", exec.ran("fan[0]"), exec.ran("fan[1]"))
+	}
+}
+
+// TestDAG_CondSkippedExplicitDep_CascadesToSkipped covers the recording half of
+// #379: a step whose explicit depends_on was condition-skipped can never run
+// (depsPassed demands a passed dependency), so it must be recorded as skipped
+// rather than left pending. Before the fix it sat pending forever — invisible in
+// the run, and indistinguishable from a step nobody had gotten to yet.
+func TestDAG_CondSkippedExplicitDep_CascadesToSkipped(t *testing.T) {
+	wf := config.WorkflowConfig{ID: "cond-explicit", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect"},
+		{ID: "maybe", Agent: "backend-dev", DependsOn: []string{"plan"}, Condition: `cell.title == "never"`},
+		{ID: "after", Agent: "backend-dev", DependsOn: []string{"maybe"}},
+	}}
+
+	exec := newSeqExecutor()
+	eng := testEngine(baseCfg(), newFakeStore(), exec, &fakeSide{})
+	r := eng.initDAG("wf-x", wf, model.InternalTask{ID: "c1"}, nil, nil, 0)
+	outcome := eng.driveDAG(context.Background(), r)
+
+	if outcome != outcomeDone {
+		t.Fatalf("outcome = %v, want outcomeDone (an intentional condition skip is not a failure)", outcome)
+	}
+	if r.state["maybe"] != stCondSkipped {
+		t.Errorf("maybe state = %q, want %q", r.state["maybe"], stCondSkipped)
+	}
+	if r.state["after"] != stSkipped {
+		t.Errorf("after state = %q, want %q (must be recorded as skipped, not left pending)", r.state["after"], stSkipped)
+	}
+	if exec.ran("after") != 0 {
+		t.Errorf("after ran %d times, want 0", exec.ran("after"))
+	}
+}
+
+// TestDAG_StrandedStepFailsInstance covers the second half of #379: an instance
+// that goes quiescent with a declared step still pending — neither run, nor
+// condition-skipped, nor cascade-skipped — must NOT report success. That is the
+// state #379 produced (the parallel group sat pending forever) and the engine
+// happily called it done.
+//
+// The graph is driven directly with a dependency pre-seeded into a state that no
+// cascade rule covers, which is the generic shape of the bug: this guard fires
+// for any future wiring defect that makes a step unreachable, without relying on
+// the specific lowering mistake that caused #379.
+func TestDAG_StrandedStepFailsInstance(t *testing.T) {
+	wf := config.WorkflowConfig{ID: "stranded", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect"},
+		{ID: "after", Agent: "backend-dev", DependsOn: []string{"plan"}},
+	}}
+
+	exec := newSeqExecutor()
+	eng := testEngine(baseCfg(), newFakeStore(), exec, &fakeSide{})
+	r := eng.initDAG("wf-x", wf, model.InternalTask{ID: "c1"}, nil, nil, 0)
+	// plan is neither runnable nor terminal: "after" can never become runnable.
+	r.state["plan"] = stWaiting
+
+	if outcome := eng.driveDAG(context.Background(), r); outcome != outcomeFailed {
+		t.Fatalf("outcome = %v, want outcomeFailed: step %q never ran and was never skipped, reporting success hides dropped work (#379)",
+			outcome, "after")
+	}
+	if got := r.strandedSteps(); len(got) != 1 || got[0] != "after" {
+		t.Errorf("strandedSteps() = %v, want [after]", got)
+	}
+	if exec.ran("after") != 0 {
+		t.Errorf("after ran %d times, want 0", exec.ran("after"))
+	}
+}


### PR DESCRIPTION
Fixes #379.

## Root cause

Two distinct edge kinds exist in the DAG IR and the engine treats them differently *on purpose* (`internal/workflow/dag.go`, `depsPassed`):

- `depends_on` — the dependency must be **`stPassed`**.
- `seq_depends_on` (implicit sequencing emitted by the v2 lowering pass) — also satisfied when the dependency is **`cond_skipped`**, so an `if:` that evaluates false does not block the next step.

`lowerLeafStep` correctly emitted `SeqDependsOn`. `lowerParallelStep` and `lowerForeachStep` emitted a hard `DependsOn` (`internal/config/lower_v2.go`).

So for the workflow in the issue, `validate` was lowered as `depends_on: [implement-hard]`. With `complexity: low`, `implement-hard` was condition-skipped and never reached `stPassed`, so:

1. `depsPassed("validate")` was false forever → the group was never dispatched.
2. `skipUnreachable` only cascaded on `stSkipped` / `stFailed`, never on `stCondSkipped` → the group was never marked skipped either. It just sat in `stPending`.
3. `ask-review` (`seq_depends_on: [validate]`) was blocked behind it.
4. The scheduler went quiescent, the final loop in `driveDAG` found **no step in `stFailed`**, and returned `outcomeDone` → `settle` marked the instance `done`, fired `on_complete`, and labelled the ticket finished.

That also explains why the reporter's sequential version worked: a plain step in that position is lowered with `seq_depends_on`, which tolerates the condition skip.

The bug is order-dependent in a way worth noting: it only fires when the *immediately preceding* step is the one that gets skipped. The test matrix here covers both branches, and the `complexity: high` case passes even without the fix.

## Changes

**`src/internal/config/lower_v2.go`** — `lowerParallelStep` and `lowerForeachStep` now emit `SeqDependsOn` for implicit sequencing, matching `lowerLeafStep`. This is the fix for the group never executing. `validateStepGraph` already merges both edge kinds, so cycle detection and `on_fail.goto` ancestry are unaffected.

**`src/internal/workflow/dag.go`** — the silent-success half, two parts:

1. `skipUnreachable` now cascades a **condition-skipped explicit dep** into a recorded skip, and logs a `WARN` naming the step and the dep. This state was previously unreachable-but-pending forever; recording it as skipped is what the cascade always intended (see `TestDAG_ConditionSkipsStep`, which asserted the step doesn't run but never checked its state), and the warning means an intentional cascade is at least visible in the log.
2. `driveDAG` now returns `outcomeFailed`, with an `ERROR` naming the steps, when the scheduler goes quiescent with any step still `stPending`. A declared step that never ran, was never condition-skipped, and was never cascade-skipped is not a success. This is the generic guard for the whole bug class — it would have caught #379 at the engine level regardless of which lowering mistake produced it.

## Tests

New: `src/internal/workflow/dag_parallel_after_conditional_test.go`, `src/internal/config/lower_v2_seq_deps_test.go`.

**Confirmed failing against unfixed code** (fix stashed, tests kept):

- `TestLowerV2_GroupNodesUseSeqDependsOn` — FAIL without the lowering fix.
- `TestDAG_ParallelAfterConditionalPair_Runs/low_complexity_skips_implement-hard` — FAIL without the lowering fix: `review ran 0 times, want 1`, `qa-validate ran 0 times, want 1`, `ask-review ran 0 times, want 1`. (The `high` sub-case passes both ways — it is the control, and documents that the trigger is specifically a skipped *immediate* predecessor.)
- `TestDAG_StrandedStepFailsInstance` and `TestDAG_CondSkippedExplicitDep_CascadesToSkipped` — FAIL without the `dag.go` changes (the first via `outcomeDone`, i.e. exactly the reported silent success).

`TestDAG_ForeachAfterConditionalStep_Runs` exercises the engine path for a `for_each` after a condition-skipped step; it is written in IR form (see below) and passes both ways — it is coverage, not a reproduction. The lowering half of the foreach fix is covered by `TestLowerV2_GroupNodesUseSeqDependsOn`, which does fail without the fix.

**Full suite**: `go build ./... && go vet ./... && go test ./...` from `src/` — all 25 packages pass, 0 failures. `src/sdk` (separate module) builds and passes too.

## ⚠️ Existing tests modified

`src/internal/config/lower_v2_test.go`, two assertions in `TestLowerV2_ParallelStepKept` and `TestLowerV2_ParallelDoubleLowerIdempotent`, both changed from asserting `checks.DependsOn == [setup]` to `checks.SeqDependsOn == [setup]` (plus an explicit assertion that `DependsOn` is now empty).

These tests encoded the buggy wiring. They were written to check that the parallel node keeps its predecessor edge at all — the edge *kind* was incidental to their purpose (idempotence and non-dissolution of the group), and both still verify that. Nothing else in either test changed.

No test's expectation of *runtime behaviour* was weakened.

## Separate defect noticed, not fixed here

`parseForEachExpr` (`lower_v2.go`) lowers `for_each: ${{ plan.tasks }}` to the items path `steps.plan.outputs.tasks`, but both `foreachItemsResolveToArray` (validation) and `resolveItemsFromContrib` (runtime) require `steps.<id>.output.<field>` — singular. A v2-authored `for_each` therefore fails at runtime with `invalid items path`. That is why `TestDAG_ForeachAfterConditionalStep_Runs` is written in IR form. Out of scope for #379; worth its own issue.

## Blast radius

`gitnexus impact --upstream`: `lowerParallelStep` → **LOW**, 4 impacted symbols, all inside `internal/config` (`lowerSteps` → `LowerV2Workflow` → `LowerV2WorkflowInConfig`), 1 module. `driveDAG` → **LOW**; its callers are the five entry points inside `internal/workflow` (`RunInstance`, `RunInstanceForEvent`, resume, approval, wait-park, sub-workflow), all of which route the outcome through `settle`.

## Rollout

Config change: none — existing YAML is unaffected, the lowering output changes shape only. Deploying needs a new binary; live instances already parked are unaffected (rehydration replays the lowered snapshot).
