### PR TITLE
fix(daemon): fail closed when `apiary restart` gets an unknown cell id (#377)

### DIFF
--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -20,6 +21,11 @@ func newRestartCmd() *cobra.Command {
 		Short: "Force-restart a stale task",
 		Long: `Kill the running dispatch for the given cell, reset its state, and
 re-queue it so the next poll picks it up again.
+
+<cell-id> is the source item id — the GitHub issue number, the Jira issue id, the
+key shown in the dashboard's task rows — NOT the internal task id. An id the
+daemon cannot resolve to a known cell fails with "unknown cell" and nothing is
+touched.
 
 Also strips the cell's control labels — the lock (e.g. "in-progress") and the
 stage marker (e.g. "agent:engineer") — so the task re-enters the flow from the
@@ -48,6 +54,12 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
+				// Surface the daemon's message (e.g. "unknown cell 019fd93…") —
+				// a bare status code hid which id actually got restarted (#377).
+				body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+				if msg := strings.TrimSpace(string(body)); msg != "" {
+					return fmt.Errorf("restart failed: %s", msg)
+				}
 				return fmt.Errorf("restart failed: HTTP %d", resp.StatusCode)
 			}
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -889,10 +889,24 @@ func (d *Dispatcher) Status() StatusResponse {
 	return resp
 }
 
+// ErrUnknownCell is returned by ForceRestart when the id names no cell this
+// daemon knows about. Restart is destructive — it cancels in-flight work — so an
+// id that resolves to nothing must fail closed instead of running the restart
+// side effects with an id from some other id space (#377).
+var ErrUnknownCell = errors.New("unknown cell")
+
 // ForceRestart cancels a running dispatch for the given cell, removes it from
 // tracking maps, marks the execution as interrupted in the DB, and resets the
 // source state so the cell can be picked up on the next poll.
+//
+// The id must be a cell id (the source item id: a GitHub issue number, a Jira
+// issue id, …) — not an internal task id. Anything else returns ErrUnknownCell
+// and nothing is touched.
 func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
+	if err := d.assertKnownCell(ctx, cellID); err != nil {
+		return err
+	}
+
 	// Cancel the running dispatch, if any
 	if val, ok := d.runCancel.LoadAndDelete(cellID); ok {
 		cancel := val.(context.CancelFunc)
@@ -982,6 +996,13 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 			aplog.Debug("force-restart %s: cannot fetch labels from %s: %v", cellID, sc.ID, err)
 			continue
 		}
+		// Never write to an item the adapter substituted for the one asked for:
+		// stripping labels off an unrelated cell is exactly the mis-targeting
+		// #377 reported. An empty id means the adapter does not report one.
+		if cell.ID != "" && cell.ID != cellID {
+			aplog.Error("force-restart %s: %s returned item %s — refusing to touch it", cellID, sc.ID, cell.ID)
+			continue
+		}
 		if labels := d.controlLabels(cell); len(labels) > 0 {
 			if err := remover.RemoveLabels(ctx, cell, labels); err != nil {
 				aplog.Error("force-restart %s: removing control labels %v: %v", cellID, labels, err)
@@ -993,6 +1014,60 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 
 	aplog.Info("force-restarted cell %s", cellID)
 	return nil
+}
+
+// assertKnownCell fails closed (ErrUnknownCell) unless cellID names a cell this
+// daemon actually knows: an in-flight run, a source binding, a workflow instance,
+// or a legacy execution row. Restart is destructive, and every step of it — the DB
+// updates, the source SetState, the label stripping — used to run unconditionally
+// on whatever raw id arrived, so an id from another id space (an internal task id,
+// or an item id that only exists in a different source) was applied blindly while
+// the CLI reported success. See #377.
+//
+// When the id is an internal task id, the error names the cell to use instead;
+// accepting the task id as an alias is deliberately left out of scope.
+func (d *Dispatcher) assertKnownCell(ctx context.Context, cellID string) error {
+	if cellID == "" {
+		return fmt.Errorf("%w: (empty id)", ErrUnknownCell)
+	}
+	// In-flight work is authoritative even before anything is persisted.
+	if _, ok := d.inFlight.Load(cellID); ok {
+		return nil
+	}
+	if _, ok := d.runCancel.Load(cellID); ok {
+		return nil
+	}
+	if d.db == nil {
+		// No store to validate against (unit harnesses); tracking maps are all
+		// there is, and the daemon always has a DB.
+		return nil
+	}
+
+	if b, err := d.db.SourceBindings().GetBindingBySourceItemID(ctx, cellID); err != nil {
+		return fmt.Errorf("restart %s: looking up binding: %w", cellID, err)
+	} else if b != nil {
+		return nil
+	}
+	if insts, err := d.db.ListWorkflowInstancesByCell(ctx, cellID); err != nil {
+		return fmt.Errorf("restart %s: listing workflow instances: %w", cellID, err)
+	} else if len(insts) > 0 {
+		return nil
+	}
+	if exec, err := d.db.GetLastExecution(ctx, cellID); err != nil {
+		return fmt.Errorf("restart %s: looking up executions: %w", cellID, err)
+	} else if exec != nil {
+		return nil
+	}
+
+	// Nothing matched. If the caller passed an internal task id, point at the
+	// cell id that would have worked instead of a bare "unknown".
+	if t, err := d.db.InternalTasks().GetTask(ctx, cellID); err == nil && t != nil {
+		if cell := d.cellIDForTask(ctx, t.ID); cell != "" && cell != cellID {
+			return fmt.Errorf("%w: %s is an internal task id, not a cell id — its cell is %s (try: apiary restart %s)",
+				ErrUnknownCell, cellID, cell, cell)
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrUnknownCell, cellID)
 }
 
 // controlLabels returns the labels on the cell that act as routing guards: any
@@ -1069,7 +1144,11 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			return
 		}
 		if err := d.ForceRestart(ctx, cellID); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrUnknownCell) {
+				status = http.StatusNotFound
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/src/internal/daemon/restart_unknown_id_test.go
+++ b/src/internal/daemon/restart_unknown_id_test.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// countingSource records every side effect ForceRestart performs on a source so a
+// test can assert that an unresolvable id touches nothing at all.
+type countingSource struct {
+	cell        model.SourceItem
+	polls       []string
+	statesSet   []string
+	removeCalls int
+}
+
+func (f *countingSource) ID() string                                    { return "jira" }
+func (f *countingSource) Connect(context.Context, map[string]any) error { return nil }
+func (f *countingSource) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (f *countingSource) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (f *countingSource) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (f *countingSource) PollTask(_ context.Context, id string) (model.SourceItem, error) {
+	f.polls = append(f.polls, id)
+	return f.cell, nil
+}
+func (f *countingSource) RemoveLabels(context.Context, model.SourceItem, []string) error {
+	f.removeCalls++
+	return nil
+}
+func (f *countingSource) SetState(_ context.Context, _ model.SourceItem, state string) error {
+	f.statesSet = append(f.statesSet, state)
+	return nil
+}
+
+func restartUnknownDispatcher(dbc *db.Client, fake *countingSource) *Dispatcher {
+	return &Dispatcher{
+		db: dbc,
+		cfg: &config.Config{
+			Sources: []config.SourceConfig{{ID: "jira"}},
+			Workflows: []config.WorkflowConfig{
+				{ID: "eng", Trigger: &config.TriggerConfig{Match: config.RouteMatch{
+					ExcludeLabels: []string{"in-progress"},
+				}}, Steps: []config.StepConfig{{ID: "run", Agent: "engineer"}}},
+			},
+		},
+		sources: map[string]source.Adapter{"jira": fake},
+	}
+}
+
+// TestForceRestart_UnknownIDIsRejected covers issue #377: `apiary restart <id>`
+// with an id that is not a cell (there, an internal_tasks id) reported success and
+// went on to run every restart side effect with that raw id — killing an unrelated
+// healthy run. An unresolvable id must fail loudly and touch nothing.
+func TestForceRestart_UnknownIDIsRejected(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	// Two Jira cells, mirroring the report: the id the user typed belongs to
+	// neither cell's id space.
+	_, instA := seedBoundTask(ctx, t, dbc, "jira", "295651")
+	_, instB := seedBoundTask(ctx, t, dbc, "jira", "297869")
+
+	fake := &countingSource{cell: model.SourceItem{ID: "297869", Labels: []string{"in-progress"}}}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	err := d.ForceRestart(ctx, "019fd9312ac74556ae907abbbd17e3be")
+	if err == nil {
+		t.Fatalf("ForceRestart with an unknown id must fail, got nil")
+	}
+	if !errors.Is(err, ErrUnknownCell) {
+		t.Fatalf("error = %v, want it to wrap ErrUnknownCell", err)
+	}
+
+	// Nothing was restarted: both healthy instances stay running.
+	for _, id := range []string{instA, instB} {
+		inst, err := dbc.GetWorkflowInstance(ctx, id)
+		if err != nil || inst == nil {
+			t.Fatalf("get instance %s: inst=%v err=%v", id, inst, err)
+		}
+		if inst.State != db.InstanceStateRunning {
+			t.Errorf("instance %s state = %q, want it left %q", id, inst.State, db.InstanceStateRunning)
+		}
+	}
+
+	// And no source was touched with the bogus id.
+	if len(fake.polls) != 0 || len(fake.statesSet) != 0 || fake.removeCalls != 0 {
+		t.Errorf("unknown id must not reach the source: polls=%v states=%v removeLabels=%d",
+			fake.polls, fake.statesSet, fake.removeCalls)
+	}
+}
+
+// TestForceRestart_InternalTaskIDPointsAtItsCell keeps the failure actionable: the
+// exact mistake from #377 (passing an internal task id) names the cell to use.
+func TestForceRestart_InternalTaskIDPointsAtItsCell(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	taskID, _ := seedBoundTask(ctx, t, dbc, "jira", "295651")
+
+	fake := &countingSource{}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	err := d.ForceRestart(ctx, taskID)
+	if err == nil || !errors.Is(err, ErrUnknownCell) {
+		t.Fatalf("ForceRestart(task id) = %v, want an ErrUnknownCell failure", err)
+	}
+	if !strings.Contains(err.Error(), "295651") {
+		t.Errorf("error %q should name the bound cell 295651", err)
+	}
+}
+
+// TestForceRestart_KnownCellStillRestarts guards the fix against over-reach: a real
+// cell id must still cancel, interrupt its instance, and strip control labels.
+func TestForceRestart_KnownCellStillRestarts(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	_, instID := seedBoundTask(ctx, t, dbc, "jira", "295651")
+
+	fake := &countingSource{cell: model.SourceItem{ID: "295651", Labels: []string{"in-progress", "bug"}}}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	if err := d.ForceRestart(ctx, "295651"); err != nil {
+		t.Fatalf("ForceRestart(known cell): %v", err)
+	}
+
+	inst, err := dbc.GetWorkflowInstance(ctx, instID)
+	if err != nil || inst == nil {
+		t.Fatalf("get instance: inst=%v err=%v", inst, err)
+	}
+	if inst.State != db.InstanceStateInterrupted {
+		t.Errorf("instance state = %q, want %q", inst.State, db.InstanceStateInterrupted)
+	}
+	if len(fake.statesSet) != 1 || fake.statesSet[0] != "todo" {
+		t.Errorf("statesSet = %v, want [todo]", fake.statesSet)
+	}
+	if fake.removeCalls != 1 {
+		t.Errorf("removeCalls = %d, want 1 (the in-progress control label)", fake.removeCalls)
+	}
+}


### PR DESCRIPTION
Fixes #377.

## The bug

`apiary restart <id>` never validated the id. The whole path is a pass-through:
`newRestartCmd` (`src/internal/cli/restart.go`) POSTs `/restart/<id>` over the Unix
socket, the handler (`src/internal/daemon/dispatcher.go`, `StartServer`) does
`strings.TrimPrefix(r.URL.Path, "/restart/")` and hands the raw string to
`Dispatcher.ForceRestart` — no lookup, no existence check, anywhere.

Inside `ForceRestart` every DB lookup is exact-match (`workflow_instances.cell_id`,
`task_executions.task_id`, `tasks.id` — all `TEXT`, no LIKE, no prefix match), so an
id from another id space silently matches nothing. But the function still returned
`nil`, so the CLI printed `✓ Restarted cell <id>`, and the *destructive* tail of the
function ran regardless with that raw id:

- `SetState(ctx, model.SourceItem{ID: cellID}, "todo")` is broadcast to **every**
  configured source — the id is never checked against the source it belongs to;
- the label-stripping loop calls `poller.PollTask(ctx, cellID)` and then
  `remover.RemoveLabels(ctx, cell, …)` on **the item the adapter returned**, never
  verifying it is the item that was asked for.

That second one is directly observable. Running the new test against the unfixed
code logs:

```
INFO force-restart 019fd9312ac74556ae907abbbd17e3be: removed control labels [in-progress]
INFO force-restarted cell 019fd9312ac74556ae907abbbd17e3be
```

— control labels stripped off cell `297869` while the log (and the CLI) name the id
the user typed. Same class of mis-targeting as the report: nothing in the path ever
asks "is this a cell I know?", and the success message always echoes the typed id,
so a wrong target is invisible.

Note on the reported log line: `force-restart 297869: interrupted workflow instance …`
formats `cellID`, and no query in the path can turn the task id into another cell's id
(all exact-match on TEXT columns), so that specific interrupt implies the daemon was
handed `297869`. I could not reproduce a code path that performs that substitution.
The fix removes the class of bug either way: an unresolvable id now touches nothing.

## The fix

- `assertKnownCell` runs first in `ForceRestart` and fails closed with a new
  `ErrUnknownCell` unless the id resolves to something real: an in-flight run
  (`inFlight`/`runCancel`), a `source_bindings` row, a `workflow_instances` row, or a
  legacy `task_executions` row. Nothing is cancelled, interrupted or written before it
  passes.
- Passing an internal task id — the exact mistake in the issue — fails with the cell
  id to use: `unknown cell: <task-id> is an internal task id, not a cell id — its cell
  is 295651 (try: apiary restart 295651)`. Resolving a task id to its bound cell
  *automatically* is deliberately left out of scope; it would be a reasonable follow-up
  (explicit `source_bindings` resolution), but restart should fail closed by default.
- The label-stripping loop now refuses to write to an item whose id differs from the
  requested one (second layer, covers adapters that substitute an item).
- IPC returns **404** for `ErrUnknownCell` (500 stays for real failures), and the CLI
  surfaces the daemon's message instead of `restart failed: HTTP 404`.
- CLI help text was misleading by omission — it said `<cell-id>` but never said an
  internal task id is not one. It now states the id is the source item id, not the
  internal task id, and that an unresolvable id fails and touches nothing.

## Tests

New `src/internal/daemon/restart_unknown_id_test.go`:

- `TestForceRestart_UnknownIDIsRejected` — two seeded Jira cells (295651 / 297869,
  mirroring the report); restarting an unknown hex id must error with `ErrUnknownCell`,
  leave **both** instances `running`, and never reach the source adapter.
- `TestForceRestart_InternalTaskIDPointsAtItsCell` — a real internal task id fails and
  the message names its bound cell.
- `TestForceRestart_KnownCellStillRestarts` — a valid cell id still interrupts its
  instance, sets the source state to `todo`, and strips control labels.

**Verified the tests fail without the fix.** With only the `ErrUnknownCell` sentinel
added and the validation reverted:

```
--- FAIL: TestForceRestart_UnknownIDIsRejected
    restart_unknown_id_test.go:82: ForceRestart with an unknown id must fail, got nil
--- FAIL: TestForceRestart_InternalTaskIDPointsAtItsCell
    restart_unknown_id_test.go:119: ForceRestart(task id) = <nil>, want an ErrUnknownCell failure
```

(and the mis-targeted `removed control labels [in-progress]` line quoted above.)
With the fix, all pass. From `src/`: `go build ./...`, `go vet ./...`, `go test ./...`
all clean.

## Blast radius (gitnexus, upstream on `ForceRestart`)

Risk HIGH by fan-out, 3 impacted symbols: direct caller `Dispatcher.StartServer`
(the `/restart/` IPC handler) at d=1, then `newRunCmd` / `init` in the CLI at d=2/d=3.
Only two production entry points reach it: `apiary restart` and the dashboard's
Shift+R, which already sends the cell id (`drillKeyFor` / `inst.CellID`) and so is
unaffected. `detect_changes` reports low risk, scope limited to the restart path.
