### PR TITLE
fix(daemon): auto-resume restart orphans for resume:auto workflows (#376)

### DIFF
--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -201,6 +201,20 @@ Daemon restarts (crash, upgrade, reboot) don't lose in-flight work:
   instances instead of leaving tasks stuck behind a ghost. Interrupted
   instances of resumable workflows can be continued with
   [`apiary resume`](cli.md#apiary-resume).
+- **Auto-resume (`resume: auto`).** A workflow that declares `resume: auto`
+  (which requires every step to be `idempotent: true`) does not wait for a
+  human: right after orphan reconciliation, the daemon continues each
+  interrupted instance itself — passed steps are replayed from cache and only
+  the step that was in flight re-runs. The continuation is a normal resume
+  descendant (`resumed_from` points at the orphan), and while it is starting,
+  a poll of the same task cannot dispatch a competing fresh run of that
+  workflow. Each orphan is continued at most once: an instance that already
+  has a descendant (from an earlier auto-resume or a manual `apiary resume`)
+  is left alone. Workflows on the default `resume: allowed` — and on
+  `resume: forbidden` — keep the older behavior: the interrupted instance
+  stays put and the next poll dispatches a fresh run from step 1, so a
+  long pipeline that must not restart from scratch should opt into
+  `resume: auto`.
 - **Force restart.** From the [dashboard](dashboard.md) (`R` on a task) or
   `apiary restart <task>`, a stale task's running dispatch is
   cancelled, its non-terminal instances are interrupted, and it is reset for

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -666,7 +666,11 @@ apiary resume <instance-id> --definition original
 ```
 
 The workflow's `resume` policy controls eligibility: `allowed` (default),
-`forbidden`, or `auto`. A manual resume creates a new workflow instance whose
+`forbidden`, or `auto`. With `auto` (which requires every step to be
+`idempotent: true`) the daemon also resumes by itself: instances orphaned by a
+restart are continued at startup instead of being re-dispatched from step 1 —
+see [Surviving restarts](resilience.md#surviving-restarts).
+A manual resume creates a new workflow instance whose
 `resumed_from` field points to the source attempt. Completed step rows selected
 for reuse are copied into that descendant and marked cached; the original
 attempt remains immutable. Their outputs and memory are restored without

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -91,6 +91,11 @@ type Dispatcher struct {
 	// approval instance while its cheap re-evaluation (and any follow-on resume/abort
 	// advance) is in flight, so overlapping poll cycles don't double-advance it.
 	approvalAdvancing sync.Map
+	// autoResuming holds the (task, workflow) pairs whose interrupted instance is
+	// being replayed by the startup auto-resume pass (resume: auto). It blocks a
+	// concurrent poll from dispatching a fresh step-1 instance for the same pair
+	// before the resume descendant exists in the DB (issue #376).
+	autoResuming sync.Map
 
 	stats  map[string]*sourceStat
 	statMu sync.RWMutex
@@ -562,6 +567,13 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// in-memory parked set is empty after a restart, so without this a poll-waiting
 	// instance would never be re-checked and its task would be stranded.
 	d.rehydrateParkedWaits(ctx)
+
+	// Continue instances the reconcile above just marked interrupted when their
+	// workflow declared `resume: auto`: replay the passed steps from cache and
+	// re-run only what was in flight, instead of letting the first poll dispatch
+	// a fresh run from step 1 and discard the completed work (issue #376). Must
+	// run before the poll loops start so the dispatch guard is already claimed.
+	d.resumeAutoInterrupted(ctx)
 
 	// Prune old service_logs/task_logs rows once at startup and then daily,
 	// mirroring the file-side retention (settings.log_max_age_days). Without
@@ -1414,6 +1426,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		// a duplicate while it runs or waits at an approval step. Replaces the
 		// label-based lock (state_lock / "in-progress"), which is source-specific.
 		if persisted && d.db != nil {
+			matches = d.dropAutoResumingMatches(task.ID, matches)
 			matches = d.dropActiveMatches(ctx, task.ID, matches)
 			matches = d.dropOnceMatches(ctx, task.ID, matches)
 			matches = d.dropCappedMatches(ctx, task, matches)

--- a/src/internal/daemon/resume_auto.go
+++ b/src/internal/daemon/resume_auto.go
@@ -1,0 +1,135 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// autoResumeKey keys the in-memory guard that stops a poll from dispatching a
+// fresh instance of a workflow whose interrupted instance is being auto-resumed.
+func autoResumeKey(taskID, workflowID string) string {
+	return taskID + "\x00" + workflowID
+}
+
+// resumeAutoInterrupted replays instances left interrupted by a previous daemon
+// process when their workflow opted into `resume: auto`.
+//
+// ReconcileOrphanWorkflowInstances flips every 'running' row to 'interrupted' at
+// startup, which frees the task to be re-dispatched — but re-dispatch creates a
+// brand-new instance starting at step 1, throwing away every step the killed run
+// had already passed (issue #376: a completed implementation and a passed review
+// were re-run after a restart, with duplicate-PR risk). `resume: auto` already
+// declares the workflow safe to replay (config validation requires every step to
+// be idempotent), so a restart should continue those runs rather than restart
+// them: the resume descendant carries the passed steps over from cache and only
+// re-runs the step that was in flight.
+//
+// Only `resume: auto` workflows are touched. Other policies keep today's
+// behavior (re-dispatch from step 1, or a manual `apiary resume`); blocking them
+// instead would strand every interrupted task until a human intervened.
+//
+// Called once at startup, after the reconcile passes (so orphans are already
+// interrupted and task counters already recounted — StartResume increments the
+// counter itself) and before the poll loops start.
+func (d *Dispatcher) resumeAutoInterrupted(ctx context.Context) {
+	if d.db == nil {
+		return
+	}
+	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateInterrupted)
+	if err != nil {
+		aplog.Warn("auto-resume interrupted instances: list: %v", err)
+		return
+	}
+
+	// Oldest first, so keeping the last candidate per (task, workflow) leaves the
+	// newest interrupted instance — the one carrying the most completed work.
+	// Several interrupted rows can share a key when earlier restarts left orphans
+	// that were never resumed.
+	latest := map[string]db.WorkflowInstance{}
+	var order []string
+	for i := range instances {
+		inst := instances[i]
+		wf, ok := d.workflowByID(inst.WorkflowID)
+		if !ok || wf.ResumePolicy() != config.ResumeAuto {
+			continue
+		}
+		key := autoResumeKey(inst.TaskID, inst.WorkflowID)
+		if _, seen := latest[key]; !seen {
+			order = append(order, key)
+		}
+		latest[key] = inst
+	}
+
+	resumed := 0
+	for _, key := range order {
+		inst := latest[key]
+		// A descendant already continued this instance (an earlier auto-resume, or
+		// a manual `apiary resume`); replaying it again would duplicate the run.
+		superseded, err := d.db.HasResumeDescendant(ctx, inst.ID)
+		if err != nil {
+			aplog.Warn("auto-resume %s: descendant check: %v", inst.ID, err)
+			continue
+		}
+		if superseded {
+			continue
+		}
+		if d.taskSettled(ctx, inst.TaskID) {
+			continue
+		}
+		// Claim the (task, workflow) pair before launching, so a poll that fires
+		// while the resume descendant is still being created does not dispatch a
+		// fresh instance alongside it. Released when the resume goroutine returns;
+		// by then the descendant row exists and dropActiveMatches takes over.
+		if _, loaded := d.autoResuming.LoadOrStore(key, struct{}{}); loaded {
+			continue
+		}
+		newID, err := d.startResume(ctx, inst.ID, ResumeOptions{}, func() { d.autoResuming.Delete(key) })
+		if err != nil {
+			d.autoResuming.Delete(key)
+			aplog.Warn("auto-resume %s (workflow %s): %v — leaving interrupted", inst.ID, inst.WorkflowID, err)
+			continue
+		}
+		aplog.Info("auto-resuming interrupted instance %s (workflow %s, resume: auto) as %s", inst.ID, inst.WorkflowID, newID)
+		resumed++
+	}
+	if resumed > 0 {
+		aplog.Info("auto-resumed %d interrupted workflow instance(s) from a previous run", resumed)
+	}
+}
+
+// taskSettled reports whether an instance's task has already reached a terminal
+// state, in which case there is nothing left to resume. An unknown/absent task
+// (legacy instances predating task ids) is not settled.
+func (d *Dispatcher) taskSettled(ctx context.Context, taskID string) bool {
+	if taskID == "" || d.db == nil {
+		return false
+	}
+	task, err := d.db.InternalTasks().GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return false
+	}
+	return task.State == model.TaskStateDone || task.State == model.TaskStateFailed
+}
+
+// dropAutoResumingMatches removes matches whose (task, workflow) is currently
+// being auto-resumed at startup. It closes the window between claiming an
+// interrupted instance and its resume descendant appearing in the DB: without
+// it, the first poll after a restart could dispatch a fresh step-1 instance in
+// parallel with the resume. Once the descendant row exists it is 'running' and
+// dropActiveMatches keeps guarding it.
+func (d *Dispatcher) dropAutoResumingMatches(taskID string, matches []router.Match) []router.Match {
+	out := make([]router.Match, 0, len(matches))
+	for _, m := range matches {
+		if _, resuming := d.autoResuming.Load(autoResumeKey(taskID, m.Route.ID)); resuming {
+			aplog.Debug("task %s: workflow %s is being auto-resumed, skipping re-dispatch", taskID, m.Route.ID)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}

--- a/src/internal/daemon/resume_auto_test.go
+++ b/src/internal/daemon/resume_auto_test.go
@@ -1,0 +1,366 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// stepRecordingRunner records the step id of every run it is asked to perform,
+// so a test can assert exactly which steps the engine (re-)executed.
+type stepRecordingRunner struct {
+	mu    sync.Mutex
+	steps []string
+}
+
+func (r *stepRecordingRunner) ID() string                     { return "recording" }
+func (r *stepRecordingRunner) Configure(map[string]any) error { return nil }
+func (r *stepRecordingRunner) Run(_ context.Context, req model.RunRequest) (model.RunResult, error) {
+	r.mu.Lock()
+	r.steps = append(r.steps, req.StepID)
+	r.mu.Unlock()
+	return model.RunResult{Success: true}, nil
+}
+
+func (r *stepRecordingRunner) ran() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.steps...)
+}
+
+// autoResumeWorkflow is the three-step pipeline of issue #376: plan and
+// implement already passed, the last step was in flight when the daemon died.
+func autoResumeWorkflow(policy string) config.WorkflowConfig {
+	return config.WorkflowConfig{
+		ID:      "impl",
+		Resume:  policy,
+		Trigger: &config.TriggerConfig{Priority: 10, Match: config.RouteMatch{Source: "src"}},
+		Steps: []config.StepConfig{
+			{ID: "plan", Agent: "a", Idempotent: true},
+			{ID: "implement", Agent: "a", Idempotent: true},
+			{ID: "qa", Agent: "a", Idempotent: true},
+		},
+	}
+}
+
+// autoResumeFixture builds a dispatcher over a real DB holding one task whose
+// `impl` instance was left interrupted by a daemon restart, with plan/implement
+// passed and qa interrupted.
+func autoResumeFixture(t *testing.T, policy string) (*Dispatcher, *db.Client, *stepRecordingRunner, string) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "resume-auto.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	task := &model.InternalTask{Title: "Ship it", State: model.TaskStateRunning}
+	if err := dbc.InternalTasks().CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	inst := &db.WorkflowInstance{
+		ID: "i-orphan", WorkflowID: "impl", CellID: "ISSUE-9", SourceID: "src",
+		TaskID: task.ID, State: db.InstanceStateInterrupted,
+	}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	for _, sr := range []db.StepRun{
+		{ID: "sr1", WorkflowInstanceID: inst.ID, StepID: "plan", AgentID: "a", State: db.StepStatePassed},
+		{ID: "sr2", WorkflowInstanceID: inst.ID, StepID: "implement", AgentID: "a", State: db.StepStatePassed},
+		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateInterrupted},
+	} {
+		sr := sr
+		if err := dbc.CreateStepRun(ctx, &sr); err != nil {
+			t.Fatalf("create step run: %v", err)
+		}
+	}
+
+	cfg := &config.Config{
+		Version:   "1",
+		Sources:   []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:    []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Settings:  config.Settings{},
+		Workflows: []config.WorkflowConfig{autoResumeWorkflow(policy)},
+	}
+	rt, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	runner := &stepRecordingRunner{}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      rt,
+		runners:     map[string]runnerpkg.Runner{"agent-a": runner},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	return d, dbc, runner, task.ID
+}
+
+// waitForDescendant polls for an instance whose resumed_from is sourceID.
+func waitForDescendant(t *testing.T, dbc *db.Client, taskID, sourceID string) *db.WorkflowInstance {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		instances, err := dbc.ListWorkflowInstancesByTask(ctx, taskID)
+		if err != nil {
+			t.Fatalf("list instances: %v", err)
+		}
+		for i := range instances {
+			if instances[i].ResumedFrom == sourceID {
+				return &instances[i]
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil
+}
+
+// TestResumeAutoInterrupted_ContinuesInsteadOfRestarting is the regression test
+// for issue #376: after a restart, an interrupted instance of a `resume: auto`
+// workflow must be continued from its cached steps — only the step that was in
+// flight re-runs — instead of the rescan starting a fresh run at step 1.
+func TestResumeAutoInterrupted_ContinuesInsteadOfRestarting(t *testing.T) {
+	d, dbc, runner, taskID := autoResumeFixture(t, config.ResumeAuto)
+
+	d.resumeAutoInterrupted(context.Background())
+
+	desc := waitForDescendant(t, dbc, taskID, "i-orphan")
+	if desc == nil {
+		t.Fatal("no resume descendant created for the interrupted resume:auto instance")
+	}
+
+	// Give the descendant a moment to settle, then assert only 'qa' re-ran.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, err := dbc.GetWorkflowInstance(context.Background(), desc.ID); err == nil && got != nil && got.State == db.InstanceStateDone {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	ran := runner.ran()
+	if len(ran) != 1 || ran[0] != "qa" {
+		t.Errorf("resumed run executed %v, want only [qa] (plan/implement must come from cache)", ran)
+	}
+}
+
+// TestResumeAutoInterrupted_SkipsNonAutoPolicies keeps today's behavior for
+// workflows that did not opt in: they are left interrupted (manual `apiary
+// resume` / re-dispatch), never replayed automatically.
+func TestResumeAutoInterrupted_SkipsNonAutoPolicies(t *testing.T) {
+	for _, policy := range []string{"", config.ResumeAllowed, config.ResumeForbidden} {
+		d, dbc, runner, taskID := autoResumeFixture(t, policy)
+		d.resumeAutoInterrupted(context.Background())
+		time.Sleep(200 * time.Millisecond)
+		if desc := waitForDescendantOnce(t, dbc, taskID, "i-orphan"); desc != nil {
+			t.Errorf("resume policy %q: unexpected auto-resume descendant %s", policy, desc.ID)
+		}
+		if ran := runner.ran(); len(ran) != 0 {
+			t.Errorf("resume policy %q: unexpected step runs %v", policy, ran)
+		}
+	}
+}
+
+func waitForDescendantOnce(t *testing.T, dbc *db.Client, taskID, sourceID string) *db.WorkflowInstance {
+	t.Helper()
+	instances, err := dbc.ListWorkflowInstancesByTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	for i := range instances {
+		if instances[i].ResumedFrom == sourceID {
+			return &instances[i]
+		}
+	}
+	return nil
+}
+
+// TestResumeAutoInterrupted_SkipsSupersededInstance ensures repeated restarts do
+// not fork several descendants from the same interrupted ancestor.
+func TestResumeAutoInterrupted_SkipsSupersededInstance(t *testing.T) {
+	ctx := context.Background()
+	d, dbc, runner, taskID := autoResumeFixture(t, config.ResumeAuto)
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "i-descendant", WorkflowID: "impl", CellID: "ISSUE-9", SourceID: "src",
+		TaskID: taskID, State: db.InstanceStateDone, ResumedFrom: "i-orphan",
+	}); err != nil {
+		t.Fatalf("create descendant: %v", err)
+	}
+
+	d.resumeAutoInterrupted(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	instances, err := dbc.ListWorkflowInstancesByTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	n := 0
+	for i := range instances {
+		if instances[i].ResumedFrom == "i-orphan" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("descendants of i-orphan = %d, want 1 (already superseded)", n)
+	}
+	if ran := runner.ran(); len(ran) != 0 {
+		t.Errorf("unexpected step runs %v", ran)
+	}
+}
+
+// TestDropAutoResumingMatches covers the dispatch guard: while a (task,
+// workflow) pair is being auto-resumed, a poll must not dispatch a fresh
+// instance for it — but other workflows and other tasks still flow.
+func TestDropAutoResumingMatches(t *testing.T) {
+	d := &Dispatcher{}
+	d.autoResuming.Store(autoResumeKey("T1", "impl"), struct{}{})
+
+	matches := []router.Match{
+		{Route: config.RouteConfig{ID: "impl"}},
+		{Route: config.RouteConfig{ID: "triage"}},
+	}
+	got := d.dropAutoResumingMatches("T1", matches)
+	if len(got) != 1 || got[0].Route.ID != "triage" {
+		t.Errorf("kept %+v, want only triage (impl is auto-resuming)", got)
+	}
+	if got := d.dropAutoResumingMatches("T2", matches); len(got) != 2 {
+		t.Errorf("another task must be unaffected, kept %d of 2", len(got))
+	}
+}
+
+// blockingRunner records step ids and holds each run open until release is
+// closed, so a test can observe a resume that is still in flight.
+type blockingRunner struct {
+	release chan struct{}
+	mu      sync.Mutex
+	steps   []string
+}
+
+func (r *blockingRunner) ID() string                     { return "blocking" }
+func (r *blockingRunner) Configure(map[string]any) error { return nil }
+func (r *blockingRunner) Run(ctx context.Context, req model.RunRequest) (model.RunResult, error) {
+	r.mu.Lock()
+	r.steps = append(r.steps, req.StepID)
+	r.mu.Unlock()
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+	}
+	return model.RunResult{Success: true}, nil
+}
+
+func (r *blockingRunner) ran() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.steps...)
+}
+
+// TestPollDoesNotRestartWhileAutoResuming is the end-to-end regression for issue
+// #376 at the poll level: the daemon restarts, the orphaned instance of a
+// `resume: auto` workflow is auto-resumed, and the very next poll of the same
+// still-matching source item must NOT dispatch a fresh instance from step 1.
+func TestPollDoesNotRestartWhileAutoResuming(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "resume-poll.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	item := model.SourceItem{ID: "ISSUE-9", SourceID: "src", Number: "#9", Title: "Ship it", State: "todo"}
+	adapter := &recordingAdapter{items: []model.SourceItem{item}}
+
+	cfg := &config.Config{
+		Version:   "1",
+		Sources:   []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:    []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{autoResumeWorkflow(config.ResumeAuto)},
+	}
+	rt, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	runner := &blockingRunner{release: make(chan struct{})}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      rt,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": runner},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	// Bind the item exactly as a poll would, so the interrupted instance hangs off
+	// the same InternalTask the next poll will route on.
+	task, err := d.binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	inst := &db.WorkflowInstance{
+		ID: "i-orphan", WorkflowID: "impl", CellID: item.ID, SourceID: "src",
+		TaskID: task.ID, State: db.InstanceStateInterrupted,
+	}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	for _, sr := range []db.StepRun{
+		{ID: "sr1", WorkflowInstanceID: inst.ID, StepID: "plan", AgentID: "a", State: db.StepStatePassed},
+		{ID: "sr2", WorkflowInstanceID: inst.ID, StepID: "implement", AgentID: "a", State: db.StepStatePassed},
+		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateInterrupted},
+	} {
+		sr := sr
+		if err := dbc.CreateStepRun(ctx, &sr); err != nil {
+			t.Fatalf("create step run: %v", err)
+		}
+	}
+
+	// Startup: continue the orphan, then poll while the resumed run is in flight.
+	d.resumeAutoInterrupted(ctx)
+	d.poll(ctx, cfg.Sources[0], adapter, time.Time{})
+	time.Sleep(300 * time.Millisecond)
+
+	ran := runner.ran()
+	for _, step := range ran {
+		if step != "qa" {
+			t.Errorf("poll re-ran %q: completed work was discarded and the pipeline restarted (ran=%v)", step, ran)
+		}
+	}
+
+	instances, err := dbc.ListWorkflowInstancesByTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	fresh := 0
+	for i := range instances {
+		if instances[i].ID != "i-orphan" && instances[i].ResumedFrom == "" {
+			fresh++
+		}
+	}
+	if fresh != 0 {
+		t.Errorf("%d fresh step-1 instance(s) dispatched alongside the resume; want 0", fresh)
+	}
+
+	// Let the in-flight runs finish before the DB is closed by t.Cleanup.
+	close(runner.release)
+	time.Sleep(300 * time.Millisecond)
+}

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -145,6 +145,13 @@ func (d *Dispatcher) ResumePreview(ctx context.Context, id string, opts ResumeOp
 // (daemon-lifetime) context. It returns promptly; the engine replays cached
 // steps and continues the run in the background. ctx must outlive the request.
 func (d *Dispatcher) StartResume(ctx context.Context, id string, opts ResumeOptions) (string, error) {
+	return d.startResume(ctx, id, opts, nil)
+}
+
+// startResume is StartResume with an optional onDone callback, invoked from the
+// resume goroutine once the replay has finished (successfully or not). Startup
+// auto-resume uses it to release its (task, workflow) dispatch guard.
+func (d *Dispatcher) startResume(ctx context.Context, id string, opts ResumeOptions, onDone func()) (string, error) {
 	if d.db == nil {
 		return "", ErrInstanceNotFound
 	}
@@ -190,6 +197,9 @@ func (d *Dispatcher) StartResume(ctx context.Context, id string, opts ResumeOpti
 	newID := d.workflowEngine().NewInstanceID()
 
 	go func() {
+		if onDone != nil {
+			defer onDone()
+		}
 		_, success, rerr := d.workflowEngine().ResumeInstance(ctx, inst, wf, task, steps, opts.FromStep, newID)
 		if rerr != nil {
 			if task.ID != "" {

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -230,6 +230,22 @@ func (c *Client) HasCompletedInstanceForRoute(ctx context.Context, taskID, workf
 	return n > 0, err
 }
 
+// HasResumeDescendant reports whether some instance was already created as a
+// resume of the given instance (its resumed_from points at it). Startup
+// auto-resume (resume: auto) uses it so an interrupted instance is replayed at
+// most once: a later restart must not fork a second descendant from an ancestor
+// that has already been continued.
+func (c *Client) HasResumeDescendant(ctx context.Context, instanceID string) (bool, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM workflow_instances WHERE resumed_from = ?
+	`, instanceID).Scan(&n)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return n > 0, err
+}
+
 // ListWorkflowInstancesByState returns all instances in the given state, oldest first.
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -171,6 +171,22 @@ func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
 	}
 }
 
+func TestHasResumeDescendant(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "a", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "b", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "a2", WorkflowID: "w", CellID: "c", State: InstanceStateRunning, ResumedFrom: "a"})
+
+	if got, err := c.HasResumeDescendant(ctx, "a"); err != nil || !got {
+		t.Errorf("HasResumeDescendant(a) = %v, %v; want true", got, err)
+	}
+	if got, err := c.HasResumeDescendant(ctx, "b"); err != nil || got {
+		t.Errorf("HasResumeDescendant(b) = %v, %v; want false", got, err)
+	}
+}
+
 func TestHasActiveInstanceForRoute(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)


### PR DESCRIPTION
Fixes #376.

## Root cause

`ReconcileOrphanWorkflowInstances` flips every instance left `running` by a
killed daemon to `interrupted` at startup. That is what frees the task for
re-dispatch — and re-dispatch is exactly the problem: `dropActiveMatches`
only treats `running`/`approval_waiting`/`waiting` as blocking, so the first
poll after the restart routes the task again and starts a **fresh instance at
step 1**. All the completed work of the killed run (in the reported case a
$36 implementation plus a passed review) is thrown away, even though the
workflow declared `resume: auto`.

`resume: auto` was only ever a *policy flag* — nothing in the daemon acted on
it. Resume existed (`ResumeInstance` + `restoreCachedSteps`), but only via the
manual `apiary resume` path.

## Fix strategy — resume for `auto`, no blocking for the rest

The issue offered two options; I implemented auto-resume and deliberately did
**not** implement the "interrupted blocks fresh dispatch" variant for the
other policies:

- **`resume: auto` → continue the orphan.** New startup pass
  `resumeAutoInterrupted` (in `src/internal/daemon/resume_auto.go`) runs right
  after the reconcile/rehydrate passes and before the poll loops. For each
  interrupted instance whose workflow is `resume: auto`, it calls the existing
  resume machinery: the descendant replays passed steps from cache and re-runs
  only the step that was in flight. The idempotency contract is respected —
  config validation already requires every step of a `resume: auto` workflow
  to be `idempotent: true`, and no other policy is auto-replayed.
- **Other policies → unchanged.** Blocking a fresh dispatch behind an
  interrupted instance for `resume: allowed` (the default) would strand every
  interrupted task after every restart until a human ran `apiary resume` —
  a much worse failure mode than a wasteful re-run, and a silent one. Those
  workflows keep today's behavior; the docs now point at `resume: auto` as
  the opt-in for pipelines that must not restart from scratch.

Safety details:

- **Race guard.** `d.autoResuming` (a `sync.Map` keyed on `(task, workflow)`)
  is claimed *before* the resume launches and released when the resume
  goroutine returns; `dropAutoResumingMatches` drops those matches in `poll`.
  This closes the window between claiming an orphan and its descendant row
  appearing — after which `dropActiveMatches` guards it as usual.
- **At most once.** New `db.HasResumeDescendant` skips an orphan that already
  has a descendant (earlier auto-resume, or a manual `apiary resume`), so
  repeated restarts never fork parallel continuations. When several
  interrupted rows share a `(task, workflow)`, only the newest is continued.
- **Settled tasks** (`done`/`failed`) are skipped.
- **Counters.** The pass runs after `ReconcileOrphanTaskCounters`, and
  `StartResume` increments `outstanding_workflows` itself, so the accounting
  stays correct.
- **Fail-soft.** If a resume cannot start (workflow removed, snapshot error),
  the guard is released and the instance is left interrupted — i.e. today's
  behavior, no eternal block.

`StartResume` gained an internal `startResume(..., onDone)` variant; the
public signature and the `apiary resume` path are unchanged.

## Test evidence (fails without the fix)

New tests in `src/internal/daemon/resume_auto_test.go` +
`TestHasResumeDescendant` in `src/internal/db/workflow_store_test.go`.

Verification: I stubbed `resumeAutoInterrupted` to return immediately
(simulating pre-fix behavior — the guard is then never claimed, so `poll`
behaves exactly as before) and re-ran:

```
--- FAIL: TestResumeAutoInterrupted_ContinuesInsteadOfRestarting (5.04s)
    resume_auto_test.go:145: no resume descendant created for the interrupted resume:auto instance
--- FAIL: TestPollDoesNotRestartWhileAutoResuming (0.63s)
    resume_auto_test.go:345: poll re-ran "plan": completed work was discarded and the pipeline restarted (ran=[plan])
```

The second failure reproduces the exact symptom from the issue: the poll
re-runs the pipeline from step 1. With the stub removed both pass, and the
resumed run executes only the interrupted step (`ran=[qa]`).

## Test results

From `src/`:

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go test -race ./internal/daemon/ ./internal/db/` — pass, no races
  (`internal/workflow` has a pre-existing `-race` failure in
  `TestDAG_ParallelFailWhen_ChildRejectionTriggersLoopback`, reproduced on
  `main` without these changes)

## Blast radius (gitnexus)

`dropActiveMatches` (the call site I extend in `poll`) is HIGH-risk upstream —
`poll` → `pollLoop` → `Start`, touching the Daemon/Jira/Workflow modules — so
the new filter is additive and side-effect-free (a pure in-memory map lookup),
and the auto-resume pass is a new leaf called once from `Start`.
`StartResume` upstream impact: LOW (0 callers besides the IPC handler; its
signature is unchanged). `detect_changes`: risk low, 6 files.

## Docs

`docs/resilience.md` no longer implies orphans are only manually resumable —
it documents auto-resume under "Surviving restarts", including the explicit
note that non-`auto` policies still re-dispatch from step 1.
`docs/workflows.md` cross-links it from the resume-policy paragraph.
