### PR TITLE
fix(config): emit singular output segment in for_each items path (#384)

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -570,15 +570,31 @@ func memoryWrites(m *MemoryConfig, field string) bool {
 
 // parseForEachExpr parses a for_each expression like `${{ design.tasks }}`
 // and returns the dot-path (for Items), the step id, and the field name.
-// For expressions that are already dot-paths, returns the path as-is.
+//
+// The emitted path must use the singular `output` segment: that is the items
+// contract both consumers enforce — workflow.resolveItemsFromContrib at runtime
+// and foreachItemsResolveToArray during graph validation. The plural `outputs`
+// belongs to the v2 *expression* surface (`${{ steps.x.outputs.y }}`, rewritten
+// to `memory.y`), which is a different thing; emitting it here produced an items
+// path no consumer accepts, so every v2-authored for_each failed with
+// "invalid items path".
+//
+// A caller who writes the full path themselves may spell it either way — the
+// plural is what the v2 docs show for expressions — so both are normalised, and
+// the step/field are reported either way so the caller can wire memory.write.
 func parseForEachExpr(expr string) (dotPath, stepID, field string) {
 	s := lowerExpr(expr)
-	// s is now e.g. "design.tasks" or "steps.design.outputs.tasks"
+	// s is now e.g. "design.tasks", "steps.design.output.tasks", or
+	// "steps.design.outputs.tasks".
 	parts := strings.SplitN(s, ".", 2)
 	if len(parts) == 2 && !strings.HasPrefix(s, "steps.") && !strings.HasPrefix(s, "memory.") {
-		return "steps." + parts[0] + ".outputs." + parts[1], parts[0], parts[1]
+		return "steps." + parts[0] + ".output." + parts[1], parts[0], parts[1]
 	}
-	// Already a full path.
+	if full := strings.SplitN(s, ".", 4); len(full) == 4 && full[0] == "steps" &&
+		(full[2] == "output" || full[2] == "outputs") {
+		return "steps." + full[1] + ".output." + full[3], full[1], full[3]
+	}
+	// Some other full path (e.g. memory.*) — pass through untouched.
 	return s, "", ""
 }
 

--- a/src/internal/config/lower_v2_foreach_test.go
+++ b/src/internal/config/lower_v2_foreach_test.go
@@ -1,0 +1,102 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// findStep returns the lowered step with the given id.
+func findStep(t *testing.T, wf config.WorkflowConfig, id string) config.StepConfig {
+	t.Helper()
+	for _, s := range wf.Steps {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("step %q not found in lowered workflow (steps=%d)", id, len(wf.Steps))
+	return config.StepConfig{}
+}
+
+// The items path must use the singular "output" segment — that is what
+// workflow.resolveItemsFromContrib and foreachItemsResolveToArray both require.
+// The lowering used to emit the plural "outputs", so no v2 for_each could run.
+func TestLowerV2_ForEachEmitsSingularOutputItemsPath(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{"short form", "${{ plan.issues }}"},
+		{"explicit singular", "${{ steps.plan.output.issues }}"},
+		{"explicit plural (v2 expression spelling)", "${{ steps.plan.outputs.issues }}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := config.WorkflowConfig{
+				ID: "w",
+				Steps: []config.StepConfig{
+					{
+						ID: "plan", Agent: "architect",
+						OutputSchema: &config.OutputSchema{Type: "object",
+							Properties: map[string]config.SchemaField{
+								"issues": {Type: "array", Items: &config.SchemaField{Type: "object"}},
+							}},
+					},
+					{
+						ID: "fan", ForEachExpr: tc.expr, As: "issue",
+						SubSteps: []config.StepConfig{{ID: "fix", Agent: "backend-dev"}},
+					},
+				},
+			}
+
+			lowered, err := config.LowerV2Workflow(wf)
+			if err != nil {
+				t.Fatalf("lower: %v", err)
+			}
+
+			fan := findStep(t, lowered, "fan")
+			if want := "steps.plan.output.issues"; fan.Items != want {
+				t.Errorf("items path = %q, want %q", fan.Items, want)
+			}
+
+			// The referenced field must be auto-added to the producing step's
+			// memory.write, or the array never reaches the contribution snapshot
+			// the runtime reads items from.
+			plan := findStep(t, lowered, "plan")
+			if plan.Memory == nil {
+				t.Fatalf("plan step has no memory config; expected %q auto-added to memory.write", "issues")
+			}
+			found := false
+			for _, w := range plan.Memory.Write {
+				if w == "issues" {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("memory.write = %v, want it to contain %q", plan.Memory.Write, "issues")
+			}
+		})
+	}
+}
+
+// A non-steps path (e.g. memory.*) must pass through untouched.
+func TestLowerV2_ForEachMemoryPathUntouched(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "w",
+		Steps: []config.StepConfig{
+			{ID: "plan", Agent: "architect"},
+			{
+				ID: "fan", ForEachExpr: "${{ memory.issues }}", As: "issue",
+				SubSteps: []config.StepConfig{{ID: "fix", Agent: "backend-dev"}},
+			},
+		},
+	}
+	lowered, err := config.LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("lower: %v", err)
+	}
+	if got := findStep(t, lowered, "fan").Items; got != "memory.issues" {
+		t.Errorf("items path = %q, want it passed through unchanged", got)
+	}
+}

--- a/src/internal/workflow/foreach_v2_lowered_test.go
+++ b/src/internal/workflow/foreach_v2_lowered_test.go
@@ -1,0 +1,80 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// v2ForeachWorkflow builds a workflow in **v2 authoring form** — `for_each:` as
+// an expression with a nested body — and lowers it the way Config.Validate does
+// before the engine ever sees it.
+func v2ForeachWorkflow(t *testing.T, forEachExpr string) config.WorkflowConfig {
+	t.Helper()
+	wf := config.WorkflowConfig{
+		ID: "w",
+		Steps: []config.StepConfig{
+			{
+				ID: "plan", Agent: "architect",
+				OutputSchema: &config.OutputSchema{Type: "object",
+					Properties: map[string]config.SchemaField{
+						"issues": {Type: "array", Items: &config.SchemaField{Type: "object"}},
+					}},
+			},
+			{
+				ID:          "fix-each",
+				ForEachExpr: forEachExpr,
+				As:          "issue",
+				SubSteps: []config.StepConfig{
+					{ID: "fix", Agent: "backend-dev", Prompt: "Fix {{ issue.file }}"},
+				},
+			},
+		},
+	}
+	lowered, err := config.LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatalf("lower v2 workflow: %v", err)
+	}
+	return lowered
+}
+
+// Regression: the v2 lowering emitted the items path with a plural "outputs"
+// segment, but both consumers require the singular "output" — so every
+// v2-authored for_each failed at runtime with `invalid items path`. This is the
+// end-to-end form: author in v2, lower, run, and require the body to execute
+// once per item.
+func TestForeach_V2LoweredRunsOnePerItem(t *testing.T) {
+	for _, expr := range []string{
+		"${{ plan.issues }}",               // short form
+		"${{ steps.plan.output.issues }}",  // explicit, singular
+		"${{ steps.plan.outputs.issues }}", // explicit, plural (v2 docs spelling)
+	} {
+		t.Run(expr, func(t *testing.T) {
+			cfg := baseCfg()
+			store := newFakeStore()
+			exec := newSeqExecutor()
+			exec.scripts["plan"] = []StepResult{planWithIssues(3)}
+			eng := testEngine(cfg, store, exec, &fakeSide{})
+
+			wf := v2ForeachWorkflow(t, expr)
+
+			_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+			if !success {
+				t.Fatalf("instance failed; the for_each step could not resolve its items (seen=%v)", exec.seen)
+			}
+
+			subRuns := 0
+			for _, r := range exec.seen {
+				if strings.HasPrefix(r, "fix-each[") {
+					subRuns++
+				}
+			}
+			if subRuns != 3 {
+				t.Fatalf("expected 3 sub-runs (one per item), got %d (seen=%v)", subRuns, exec.seen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #384. Found while fixing #379 (PR #381).

## Mechanism (confirmed, not assumed)

`parseForEachExpr` in `src/internal/config/lower_v2.go` lowered `for_each: ${{ plan.issues }}` to `steps.plan.outputs.issues` — **plural**. Both consumers require the **singular** `output`:

- `resolveItemsFromContrib` (`src/internal/workflow/foreach.go:198`) — `parts[2] != "output"` → `invalid items path`
- `foreachItemsResolveToArray` (`src/internal/config/workflow_graph.go:138`) — same check at graph-validation time

So no v2-authored `for_each` has ever run. The step fails permanently and its body never executes.

The plural spelling is not imaginary — it is the v2 **expression** surface (`${{ steps.x.outputs.y }}`, rewritten to `memory.y`). The items path is a separate contract, singular, and is what v1 `items:` has always used (see the archived specs under `openspec/changes/archive/2026-06-06-workflow-mode/`).

## Why the fix goes in the lowering, not the runtime

The items path is an internal string — users write `for_each: ${{ plan.issues }}`, never the path itself. Teaching the runtime to accept both spellings would create two names for one contract with no user-facing benefit, in two places that must then stay in sync. The lowering is the single producer, so it is the right place to normalise.

## Second defect fixed in the same function

The "already a full path" branch passed a caller-written path through untouched **and** returned empty `stepID`/`field`, so `ensureMemoryWrite` was never called — the array never reached the contribution snapshot the runtime reads from. So `for_each: ${{ steps.plan.outputs.issues }}` (the spelling the v2 design docs show) failed twice over. Both spellings are now normalised to singular and both report step/field.

## Test-fails-without-fix evidence

`TestForeach_V2LoweredRunsOnePerItem` is the strong form the issue asks for: author in v2, lower with `LowerV2Workflow`, run through the real engine, require the body to execute once per item. Against the unfixed lowering:

```
ERROR  workflow w: foreach "fix-each": invalid items path "steps.plan.outputs.issues" (want steps.<id>.output.<field>)
INFO   workflow w: step "fix-each" failed permanently
--- FAIL: TestForeach_V2LoweredRunsOnePerItem/${{_plan.issues_}}
        instance failed; the for_each step could not resolve its items (seen=[plan])
--- FAIL: TestForeach_V2LoweredRunsOnePerItem/${{_steps.plan.outputs.issues_}}
        instance failed; the for_each step could not resolve its items (seen=[plan])
```

— the exact error from the report. Stated honestly: the third sub-case (`${{ steps.plan.output.issues }}`, already singular) **passes both ways**. It is a control, not evidence; it pins down that the trigger is the lowering and not the runtime.

`TestLowerV2_ForEachEmitsSingularOutputItemsPath` covers the lowering directly, including that `issues` is auto-added to the producing step's `memory.write` for all three spellings, and `TestLowerV2_ForEachMemoryPathUntouched` checks a `memory.*` path still passes through.

## Existing tests

**None encoded the plural spelling** — I grepped `internal/config` and `internal/workflow` tests. That is precisely why this survived: the config tests build `Items:` by hand in the already-correct singular form, so the lowering path was never exercised end to end. No existing test needed changing.

## Verification

From `src/`: `go build ./...`, `go vet ./internal/config/ ./internal/workflow/`, and `go test ./...` all pass — no failures across the suite.

## Note for the merger

This touches `src/internal/config/lower_v2.go`, which PR #381 also modifies (different function — `lowerParallelStep`/`lowerForeachStep` there vs `parseForEachExpr` here). Whichever merges second may need a trivial rebase.