### PR TITLE
fix(queue): let a re-dispatched workflow actually run instead of silently succeeding (#375)

### DIFF
--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -107,11 +107,33 @@ func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, t
 			continue
 		}
 		if !created {
+			// The idempotency key already exists. While the existing job is still
+			// pending this is the intended de-duplication of an overlapping poll;
+			// once it is terminal the dispatch is being dropped, and the only
+			// thing that frees the key is a new dispatch generation. That used to
+			// be completely silent — the poll reported the cell and nothing else
+			// ever happened. Say so.
+			if isTerminalJobState(job.State) {
+				aplog.Warn("task %s: workflow %s not enqueued — dispatch key %q already belongs to a %s job; re-dispatch waits for a new dispatch generation",
+					task.ID, match.Route.ID, job.IdempotencyKey, job.State)
+			} else {
+				aplog.Debug("task %s: workflow %s already enqueued (job %s, %s) — skipping duplicate", task.ID, match.Route.ID, job.ID, job.State)
+			}
 			d.rollbackQueuedOutstanding(ctx, task.ID, nil)
 			continue
 		}
 		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "queue.enqueued", TaskID: task.ID, WorkflowID: match.Route.ID, Metadata: map[string]any{"job_id": job.ID, "generation": generation, "pool": pool, "required_labels": labels, "required_capabilities": capabilities}})
 	}
+}
+
+// isTerminalJobState reports whether a queue job has finished for good — its
+// idempotency key can never be reused by a later dispatch of the same round.
+func isTerminalJobState(state queue.JobState) bool {
+	switch state {
+	case queue.JobSucceeded, queue.JobFailed, queue.JobCanceled:
+		return true
+	}
+	return false
 }
 
 func (d *Dispatcher) rollbackQueuedOutstanding(ctx context.Context, taskID string, err error) {
@@ -135,12 +157,25 @@ func (d *Dispatcher) ExecuteQueuedJob(ctx context.Context, job queue.Job, worker
 	if payload.Version != dispatchPayloadVersion {
 		return queue.FinishResult{Error: fmt.Sprintf("unsupported dispatch payload version %d", payload.Version)}
 	}
-	if d.db != nil && payload.Task.ID != "" {
+	// Redelivery guard. A job whose lease expired (or whose worker died) mid-run is
+	// re-claimed with a bumped attempt count, and re-running an agent that already
+	// finished duplicates its side effects — so a *redelivery* is skipped when the
+	// workflow has since completed. A first delivery (attempt 1) must NOT be skipped
+	// unless the trigger opted into `once: true`: the non-queue path re-dispatches a
+	// still-matching trigger on every poll, and the routing layer (dropActiveMatches
+	// / dropOnceMatches / dropCappedMatches) is what decides whether a re-dispatch is
+	// legitimate. Applying the completed-instance check to every job made that
+	// decision unappealable in queue mode: the job reported success without ever
+	// creating an instance, so a workflow could never run a second time for a task
+	// and the stall was invisible in the logs.
+	if d.db != nil && payload.Task.ID != "" && (job.AttemptCount > 1 || payload.Match.Route.Once) {
 		completed, err := d.db.HasCompletedInstanceForRoute(ctx, payload.Task.ID, payload.Match.Route.ID)
 		if err != nil {
 			return queue.FinishResult{Error: fmt.Sprintf("check completed workflow: %v", err), Retry: true}
 		}
 		if completed {
+			aplog.Debug("queue job %s: workflow %s already completed for task %s — skipping redelivery",
+				job.ID, payload.Match.Route.ID, payload.Task.ID)
 			return queue.FinishResult{Success: true}
 		}
 	}

--- a/src/internal/daemon/queue_redispatch_test.go
+++ b/src/internal/daemon/queue_redispatch_test.go
@@ -1,0 +1,246 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// mutableAdapter is a poll-only source whose items can be mutated between polls,
+// so a test can reproduce a label hand-off performed by an agent.
+type mutableAdapter struct{ items []model.SourceItem }
+
+func (a *mutableAdapter) ID() string                                    { return "src" }
+func (a *mutableAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *mutableAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return a.items, nil
+}
+func (a *mutableAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *mutableAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+
+// newQueueDispatcher builds a dispatcher wired for queue-mode dispatch (durable
+// jobs instead of inline goroutines) over the two label-chained workflows the
+// README's hand-off pattern uses: `triage` (label ai-ready) hands off to `impl`
+// (label ai-implement).
+func newQueueDispatcher(t *testing.T, once bool) (*Dispatcher, *mutableAdapter, *db.Client) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "queue.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}, {ID: "b", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{
+			{ID: "triage", Trigger: &config.TriggerConfig{Once: once, Match: config.RouteMatch{Labels: []string{"ai-ready"}}},
+				Steps: []config.StepConfig{{ID: "run", Agent: "a"}}},
+			{ID: "impl", Trigger: &config.TriggerConfig{Match: config.RouteMatch{Labels: []string{"ai-implement"}}},
+				Steps: []config.StepConfig{{ID: "run", Agent: "b"}}},
+		},
+	}
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	adapter := &mutableAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d := &Dispatcher{
+		cfg:            cfg,
+		db:             dbc,
+		router:         r,
+		sources:        map[string]source.Adapter{"src": adapter},
+		runners:        map[string]runnerpkg.Runner{"agent-a": &countingRunner{}, "agent-b": &countingRunner{}},
+		agentRunner:    map[string]string{"a": "claude-cli", "b": "claude-cli"},
+		agentSem:       map[string]chan struct{}{},
+		stats:          map[string]*sourceStat{"src": {}},
+		dispatchQueue:  dbc.Queue(),
+		queueProjectID: "proj",
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, adapter, dbc
+}
+
+func queueJobFor(t *testing.T, dbc *db.Client, workflowID string) queue.Job {
+	t.Helper()
+	jobs, err := dbc.Queue().ListJobs(context.Background(), "", 100)
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	for _, job := range jobs {
+		if job.WorkflowID == workflowID {
+			return job
+		}
+	}
+	t.Fatalf("no queued job for workflow %q (jobs=%d)", workflowID, len(jobs))
+	return queue.Job{}
+}
+
+func instancesFor(t *testing.T, dbc *db.Client, taskID, workflowID string) []db.WorkflowInstance {
+	t.Helper()
+	all, err := dbc.ListWorkflowInstancesByTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	var out []db.WorkflowInstance
+	for _, instance := range all {
+		if instance.WorkflowID == workflowID {
+			out = append(out, instance)
+		}
+	}
+	return out
+}
+
+// Issue #375: a label hand-off must dispatch on the next incremental poll, with
+// no daemon restart. This walks the whole queue-mode cycle — poll, enqueue,
+// execute, hand off, poll again — and guards the in-memory in-flight marker:
+// the queue path releases it as soon as the job is enqueued, so a later poll
+// must never skip the cell as "already in-flight".
+func TestQueuePoll_LabelHandoffDispatchesOnNextPoll(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := newQueueDispatcher(t, false)
+	sc := d.cfg.Sources[0]
+
+	d.poll(ctx, sc, adapter, time.Time{})
+	triage := queueJobFor(t, dbc, "triage")
+
+	if _, held := d.inFlight.Load("c1"); held {
+		t.Fatal("in-flight marker still held after the queue path enqueued the cell's dispatch")
+	}
+
+	// A second poll while the job is still queued must not double-enqueue.
+	d.poll(ctx, sc, adapter, time.Now())
+	if jobs, _ := dbc.Queue().ListJobs(ctx, "", 100); len(jobs) != 1 {
+		t.Fatalf("re-poll while queued created %d job(s), want 1", len(jobs))
+	}
+
+	// The worker executes the triage job: its instance completes and the task settles.
+	if res := d.ExecuteQueuedJob(ctx, triage, "w1"); !res.Success {
+		t.Fatalf("triage job failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+	if task.State != model.TaskStateDone {
+		t.Fatalf("task state = %q after triage, want done", task.State)
+	}
+
+	// The triage agent handed off by swapping the labels on the source item.
+	adapter.items[0].Labels = []string{"ai-implement"}
+	d.poll(ctx, sc, adapter, time.Now())
+
+	impl := queueJobFor(t, dbc, "impl")
+	if res := d.ExecuteQueuedJob(ctx, impl, "w1"); !res.Success {
+		t.Fatalf("impl job failed: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "impl")); got != 1 {
+		t.Fatalf("hand-off produced %d instance(s) of the impl workflow, want 1", got)
+	}
+}
+
+// Issue #375: in queue mode a workflow that already completed for a task could
+// never run again. ExecuteQueuedJob short-circuited on *any* completed instance
+// for the route, so a legitimately re-dispatched job reported success without
+// creating an instance — invisibly, since nothing was logged and no run started.
+// A re-dispatch is the routing layer's decision (dropActiveMatches /
+// dropOnceMatches / dropCappedMatches); a first delivery must honour it.
+func TestExecuteQueuedJob_RunsRedispatchAfterEarlierCompletion(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := newQueueDispatcher(t, false)
+	sc := d.cfg.Sources[0]
+
+	d.poll(ctx, sc, adapter, time.Time{})
+	first := queueJobFor(t, dbc, "triage")
+	if res := d.ExecuteQueuedJob(ctx, first, "w1"); !res.Success {
+		t.Fatalf("first triage job failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 1 {
+		t.Fatalf("first run produced %d instance(s), want 1", got)
+	}
+
+	// The item still carries ai-ready, so a later poll re-dispatches triage —
+	// exactly what the non-queue path does for a trigger that keeps matching.
+	d.poll(ctx, sc, adapter, time.Now())
+	jobs, _ := dbc.Queue().ListJobs(ctx, "", 100)
+	if len(jobs) != 2 {
+		t.Fatalf("re-poll enqueued %d job(s) in total, want 2 (the re-dispatch was dropped)", len(jobs))
+	}
+	var redispatch queue.Job
+	for _, job := range jobs {
+		if job.WorkflowID == "triage" && job.ID != first.ID {
+			redispatch = job
+		}
+	}
+	if redispatch.ID == "" {
+		t.Fatal("re-poll did not enqueue a second triage job")
+	}
+	redispatch.AttemptCount = 1 // first delivery of the new job
+
+	if res := d.ExecuteQueuedJob(ctx, redispatch, "w1"); !res.Success {
+		t.Fatalf("re-dispatched job failed: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 2 {
+		t.Fatalf("re-dispatched job produced %d instance(s) of triage, want 2 — the job reported success without running", got)
+	}
+}
+
+// The redelivery guard must stay: a job re-claimed after its lease expired
+// (attempt > 1) must not re-run a workflow that has since completed, or the
+// agent's side effects are duplicated.
+func TestExecuteQueuedJob_SkipsRedeliveryOfCompletedWorkflow(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := newQueueDispatcher(t, false)
+	sc := d.cfg.Sources[0]
+
+	d.poll(ctx, sc, adapter, time.Time{})
+	job := queueJobFor(t, dbc, "triage")
+	if res := d.ExecuteQueuedJob(ctx, job, "w1"); !res.Success {
+		t.Fatalf("first delivery failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	job.AttemptCount = 2 // lease expired, the job was re-claimed
+	if res := d.ExecuteQueuedJob(ctx, job, "w1"); !res.Success {
+		t.Fatalf("redelivery should settle as success: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 1 {
+		t.Fatalf("redelivery produced %d instance(s), want 1 (no duplicate run)", got)
+	}
+}
+
+// A `once: true` trigger keeps its run-at-most-once guarantee on the queue path
+// even for a first delivery.
+func TestExecuteQueuedJob_SkipsOnceRouteAfterCompletion(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := newQueueDispatcher(t, true)
+	sc := d.cfg.Sources[0]
+
+	d.poll(ctx, sc, adapter, time.Time{})
+	job := queueJobFor(t, dbc, "triage")
+	if res := d.ExecuteQueuedJob(ctx, job, "w1"); !res.Success {
+		t.Fatalf("first delivery failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	job.AttemptCount = 1
+	if res := d.ExecuteQueuedJob(ctx, job, "w1"); !res.Success {
+		t.Fatalf("once-route replay should settle as success: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 1 {
+		t.Fatalf("once route ran %d time(s), want 1", got)
+	}
+}


### PR DESCRIPTION
Refs #375.

## The reported diagnosis is wrong

#375 blames a leaked in-memory `inFlight` marker on the queue path. It is not leaked.
`Dispatcher.fanOut` releases it synchronously right after `enqueueFanOut` returns —
in `main` **and** in the v0.13.0 tag the reporter is running:

```go
if persisted && d.dispatchQueue != nil && wg == nil {
    d.enqueueFanOut(ctx, cell, task, matches)
    d.inFlight.Delete(cell.ID)   // present in v0.13.0 too
    return
}
```

`TestQueuePoll_LabelHandoffDispatchesOnNextPoll` (added here) walks the whole
queue-mode cycle — poll → enqueue → execute → agent swaps the labels → poll again —
and asserts both that the marker is gone after the enqueue and that the hand-off
workflow is enqueued and executed on the next incremental poll. It passes on
unmodified `main`. The "already in-flight, skipping" line in the issue was inferred,
not observed.

## What is actually broken on the queue path

`ExecuteQueuedJob` short-circuited on **any** completed instance for the job's route:

```go
completed, err := d.db.HasCompletedInstanceForRoute(ctx, payload.Task.ID, payload.Match.Route.ID)
if completed { return queue.FinishResult{Success: true} }
```

`HasCompletedInstanceForRoute` is documented as the `once: true` guard
(`dropOnceMatches` checks `m.Route.Once`; this call site checked nothing). Applied to
every job it means **in queue mode a workflow can never run a second time for a
task** — the job settles as succeeded, no instance is created, no run starts, and
nothing is logged. That is the same symptom shape the issue describes: the poll finds
the cell and nothing happens, silently. The non-queue path has no such guard — a
still-matching trigger re-dispatches on every poll.

Scoped to the two cases it is for:

- **redelivery** (`job.AttemptCount > 1`): the lease expired or the worker died
  mid-run, so re-running would duplicate the agent's side effects — still skipped;
- **`once: true` routes**: run-at-most-once still honoured on a first delivery.

A first delivery of a fresh job now defers to the routing layer
(`dropActiveMatches` / `dropOnceMatches` / `dropCappedMatches`), which is what
decides whether a re-dispatch is legitimate.

Second change, observability only: `enqueueFanOut` silently dropped a dispatch when
the idempotency key `task:generation:workflow` already belonged to a **terminal**
job (the key is `UNIQUE` for all time, and the generation only advances when the task
is terminal at increment time). It now warns with the key and the existing job state;
the ordinary overlapping-poll de-duplication logs at debug. No behaviour change.

## Test-fails-without-fix evidence

With `internal/daemon/queue_dispatch.go` stashed (tests unchanged):

```
--- FAIL: TestExecuteQueuedJob_RunsRedispatchAfterEarlierCompletion (0.02s)
    queue_redispatch_test.go:197: re-dispatched job produced 1 instance(s) of triage,
        want 2 — the job reported success without running
FAIL	github.com/orlandoburli/apiary/internal/daemon
```

With the fix restored, all four new tests pass. `go build ./... && go vet ./... &&
go test ./...` from `src/` are green.

## Honest scope note

This fixes a real, provable silent-stall on the queue dispatch path, but I could not
reproduce the reporter's exact runs 1 and 2, where `jira-implement` had **never**
completed for those tasks — neither this guard nor the idempotency key applies to a
first-ever hand-off, and the hand-off dispatches correctly in the end-to-end test.
Their run 3 (labels reset on an issue `jira-implement` had already completed for,
nothing dispatched afterwards) is exactly what this fixes. If runs 1/2 recur after
this lands, the two new log lines plus `apiary status` queue counters should show
whether the job was enqueued and simply never leased — the remaining unexplained
possibility is a job sitting `queued` (embedded worker capacity defaults to 1).

## Blast radius

`ExecuteQueuedJob` — callers: `executeQueuedJob` (embedded worker) and the queue
protocol server (remote workers). `impact` reports LOW risk (no downstream symbols).
`enqueueFanOut` is called only from `fanOut`. No signature changes.