### PR TITLE
test(workflow): make seqExecutor goroutine-safe so -race works (#387)

### DIFF
--- a/src/internal/workflow/dag_test.go
+++ b/src/internal/workflow/dag_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -11,7 +12,15 @@ import (
 
 // seqExecutor returns a different scripted result per call to the same step,
 // for testing retry loops. Falls back to the last scripted result, then to ok.
+//
+// mu guards calls/seen: parallel and for_each steps run their children on
+// separate goroutines, so ExecuteStep is called concurrently and the bookkeeping
+// races without it. Without the lock `go test -race` fails on this package —
+// which is the one package whose concurrency most needs the race detector.
+// scripts is written only during test setup, before the run starts, so reads of
+// it are safe under the same lock.
 type seqExecutor struct {
+	mu      sync.Mutex
 	scripts map[string][]StepResult
 	calls   map[string]int
 	seen    []string
@@ -22,6 +31,8 @@ func newSeqExecutor() *seqExecutor {
 }
 
 func (s *seqExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.seen = append(s.seen, req.Step.ID)
 	i := s.calls[req.Step.ID]
 	s.calls[req.Step.ID]++
@@ -36,7 +47,20 @@ func (s *seqExecutor) ExecuteStep(_ context.Context, req StepRequest) StepResult
 	}
 }
 
-func (s *seqExecutor) ran(stepID string) int { return s.calls[stepID] }
+func (s *seqExecutor) ran(stepID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[stepID]
+}
+
+// seenIDs returns a copy of the executed step ids. Assertions must go through
+// this rather than reading the field, so a test that inspects progress while
+// goroutines are still running does not race.
+func (s *seqExecutor) seenIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.seen...)
+}
 
 func countSeen(seen []StepRequest, id string) int {
 	n := 0

--- a/src/internal/workflow/foreach_test.go
+++ b/src/internal/workflow/foreach_test.go
@@ -74,13 +74,13 @@ func TestForeach_RunsOnePerItem(t *testing.T) {
 
 	// Three sub-runs, one per item, with rendered prompts.
 	subRuns := 0
-	for _, r := range exec.seen {
+	for _, r := range exec.seenIDs() {
 		if strings.HasPrefix(r, "fix-each[") {
 			subRuns++
 		}
 	}
 	if subRuns != 3 {
-		t.Fatalf("expected 3 sub-runs, got %d (seen=%v)", subRuns, exec.seen)
+		t.Fatalf("expected 3 sub-runs, got %d (seen=%v)", subRuns, exec.seenIDs())
 	}
 }
 
@@ -155,7 +155,7 @@ func TestForeach_FailFast(t *testing.T) {
 	}
 	// fail_fast: stop after the first failing item → only 1 sub-run.
 	subRuns := 0
-	for _, id := range exec.seen {
+	for _, id := range exec.seenIDs() {
 		if strings.HasPrefix(id, "fix-each[") {
 			subRuns++
 		}

--- a/src/internal/workflow/foreach_v2_lowered_test.go
+++ b/src/internal/workflow/foreach_v2_lowered_test.go
@@ -63,17 +63,17 @@ func TestForeach_V2LoweredRunsOnePerItem(t *testing.T) {
 
 			_, success, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
 			if !success {
-				t.Fatalf("instance failed; the for_each step could not resolve its items (seen=%v)", exec.seen)
+				t.Fatalf("instance failed; the for_each step could not resolve its items (seen=%v)", exec.seenIDs())
 			}
 
 			subRuns := 0
-			for _, r := range exec.seen {
+			for _, r := range exec.seenIDs() {
 				if strings.HasPrefix(r, "fix-each[") {
 					subRuns++
 				}
 			}
 			if subRuns != 3 {
-				t.Fatalf("expected 3 sub-runs (one per item), got %d (seen=%v)", subRuns, exec.seen)
+				t.Fatalf("expected 3 sub-runs (one per item), got %d (seen=%v)", subRuns, exec.seenIDs())
 			}
 		})
 	}


### PR DESCRIPTION
Closes #387.

## Problem

`go test -race ./internal/workflow/` failed on clean `main`:

```
WARNING: DATA RACE
  workflow.(*seqExecutor).ExecuteStep()
  workflow.(*Engine).runStep()
  workflow.(*Engine).runParallelStep.func1()
Previous write at 0x00c00037d5a0 by goroutine 21:
  workflow.(*seqExecutor).ExecuteStep()
--- FAIL: TestDAG_ParallelFailWhen_ChildRejectionTriggersLoopback
    testing.go:1712: race detected during execution of test
```

The race is in the **test fake**, not the engine. `runParallelStep` runs children on separate goroutines, so `ExecuteStep` is called concurrently, and `seqExecutor` had no mutex — `s.seen = append(...)` and `s.calls[id]++` both race.

No production code is racing. The cost is lost coverage: the race detector was unusable on the most concurrency-heavy package in the repo, which is exactly where a real race would hide.

## Fix

- `sync.Mutex` on `seqExecutor`, guarding `ExecuteStep` and `ran`.
- New `seenIDs()` returning a copy under the lock; the `seen` read sites in the for_each tests now go through it, so a test that inspects progress mid-run cannot race.
- The sibling fakes `fakeExecutor` and `concurrentExecutor` already had mutexes — only `seqExecutor` was missing one.

## Verification

- `go test -race ./internal/workflow/ -count=2` — passes (was a reliable failure before).
- **`go test -race ./...` passes across every package**, so the detector is now usable repo-wide, not just on the one test that happened to fail.
- `go build ./...`, `go vet ./...`, `go test ./...` all clean.

Test-only change; no production behaviour is affected.