### PR TITLE
fix(daemon): make a dropped dispatch visible instead of silently succeeding (#380, #375)

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -96,6 +96,12 @@ type Dispatcher struct {
 	// concurrent poll from dispatching a fresh step-1 instance for the same pair
 	// before the resume descendant exists in the DB (issue #376).
 	autoResuming sync.Map
+	// dropNotified remembers, per task id, the reason signature of the last
+	// "every match was dropped" report, so the INFO line is emitted when a task
+	// first goes fully-dropped (and again whenever the reason changes) instead of
+	// once per poll interval for as long as a workflow runs. Cleared as soon as
+	// the task dispatches something again.
+	dropNotified sync.Map
 
 	stats  map[string]*sourceStat
 	statMu sync.RWMutex
@@ -114,8 +120,12 @@ type Dispatcher struct {
 	eventExporters []*plugin.Client
 
 	// Durable dispatch queue and optional embedded local protocol-1 worker.
-	dispatchQueue  queuepkg.Store
-	localWorker    *workerpkg.Runtime
+	dispatchQueue queuepkg.Store
+	// warnedUnsatisfiable holds the ids of queued jobs already reported as
+	// unleasable, so the periodic watchdog warns once per job instead of once per
+	// tick. An id is forgotten as soon as the job becomes satisfiable again.
+	warnedUnsatisfiable sync.Map
+	localWorker         *workerpkg.Runtime
 	queueWorker    queuepkg.Worker
 	queueProjectID string
 	queueWorkerID  string
@@ -606,6 +616,18 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 		go func() {
 			defer wg.Done()
 			d.cursorCostLoop(ctx)
+		}()
+	}
+
+	// Keep re-checking that every queued dispatch job can still be leased by some
+	// worker. The startup check alone misses the case that actually bites: a job
+	// enqueued later whose required pool/labels/capabilities nothing advertises,
+	// which then sits queued forever in silence (#375).
+	if d.dispatchQueue != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.queueWatchdogLoop(ctx)
 		}()
 	}
 
@@ -1504,17 +1526,33 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		// has a non-terminal instance for this task, so a re-poll does not dispatch
 		// a duplicate while it runs or waits at an approval step. Replaces the
 		// label-based lock (state_lock / "in-progress"), which is source-specific.
+		routed := len(matches)
+		var dropped []droppedMatch
 		if persisted && d.db != nil {
-			matches = d.dropAutoResumingMatches(task.ID, matches)
-			matches = d.dropActiveMatches(ctx, task.ID, matches)
-			matches = d.dropOnceMatches(ctx, task.ID, matches)
-			matches = d.dropCappedMatches(ctx, task, matches)
+			var batch []droppedMatch
+			matches, batch = d.dropAutoResumingMatches(task.ID, matches)
+			dropped = append(dropped, batch...)
+			matches, batch = d.dropActiveMatches(ctx, task.ID, matches)
+			dropped = append(dropped, batch...)
+			matches, batch = d.dropOnceMatches(ctx, task.ID, matches)
+			dropped = append(dropped, batch...)
+			matches, batch = d.dropCappedMatches(ctx, task, matches)
+			dropped = append(dropped, batch...)
 		}
 		if len(matches) == 0 {
-			aplog.Debug("cell %s (%q): no matching route, skipping", cell.LogLabel(), cell.Title)
+			if routed == 0 || len(dropped) == 0 {
+				aplog.Debug("cell %s (%q): no matching route, skipping", cell.LogLabel(), cell.Title)
+			} else {
+				// Every route that matched was removed by a pre-dispatch guard:
+				// nothing will run for this cell, and until #380 that was entirely
+				// silent. Report it (once per distinct reason set) so a wedged task
+				// is distinguishable from an idle one.
+				d.reportFullyDropped(ctx, cell, task, dropped)
+			}
 			d.inFlight.Delete(cell.ID)
 			continue
 		}
+		d.dropNotified.Delete(task.ID)
 		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
 	}
 
@@ -1693,29 +1731,102 @@ func (d *Dispatcher) recordRouteEvents(ctx context.Context, task model.InternalT
 	}
 }
 
+// droppedMatch records one workflow a pre-dispatch guard removed, and why. The
+// guards used to drop silently (a DEBUG line at most), so a task whose every
+// match was dropped looked exactly like an idle one: the poll reported the cell
+// and nothing else was ever said about it (issue #380). Collecting the reason
+// lets poll report the wedge at INFO and persist it as an execution event.
+type droppedMatch struct {
+	WorkflowID string
+	// Reason is a short, stable token — "active instance", "once", "capped",
+	// "auto-resuming", "guard error" — safe to log and to store in an event.
+	Reason string
+	// Detail is optional human context appended to the log line.
+	Detail string
+}
+
+// String renders "workflow (reason: detail)" for a log line.
+func (d droppedMatch) String() string {
+	if d.Detail == "" {
+		return fmt.Sprintf("%s (%s)", d.WorkflowID, d.Reason)
+	}
+	return fmt.Sprintf("%s (%s: %s)", d.WorkflowID, d.Reason, d.Detail)
+}
+
 // dropActiveMatches removes matches whose workflow already has a non-terminal
 // instance for this task (running or approval_waiting). It is the source-agnostic
 // in-flight guard: the in-memory inFlight marker is released when a workflow parks
 // at an approval step, so without this a later poll would dispatch a duplicate
 // while the instance is still waiting. Keyed on (task, workflow) so a completed
 // earlier workflow (e.g. triage) does not block the one a hand-off routes to.
+// Terminal states — including 'interrupted' — never block: an instance stranded
+// by a restart stays eligible for re-dispatch or manual resume (issue #380).
 // Fail-closed: on a query error the match is dropped (skip this poll, retry next)
 // rather than risk a duplicate dispatch.
-func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, matches []router.Match) []router.Match {
+//
+// Returns the surviving matches and, for each removed one, why it was removed.
+func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, matches []router.Match) ([]router.Match, []droppedMatch) {
 	out := make([]router.Match, 0, len(matches))
+	var dropped []droppedMatch
 	for _, m := range matches {
 		active, err := d.db.HasActiveInstanceForRoute(ctx, taskID, m.Route.ID)
 		if err != nil {
 			aplog.Error("in-flight check task %s workflow %s: %v — skipping this poll", taskID, m.Route.ID, err)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "guard error", Detail: err.Error()})
 			continue
 		}
 		if active {
 			aplog.Debug("task %s: workflow %s already active (running/approval_waiting), skipping re-dispatch", taskID, m.Route.ID)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "active instance"})
 			continue
 		}
 		out = append(out, m)
 	}
-	return out
+	return out, dropped
+}
+
+// dropSignature is the stable identity of a "fully dropped" outcome: the set of
+// (workflow, reason) pairs, order-independent. Two consecutive polls that drop
+// the same workflows for the same reasons share a signature and are reported once.
+func dropSignature(dropped []droppedMatch) string {
+	parts := make([]string, 0, len(dropped))
+	for _, drop := range dropped {
+		parts = append(parts, drop.WorkflowID+"="+drop.Reason)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// reportFullyDropped announces that a polled cell matched at least one route but
+// had every match removed by a pre-dispatch guard, so no workflow will run and no
+// instance will exist. Before #380 this outcome produced no log line at any level
+// and (in queue mode) a dispatch job that reported `succeeded` with nothing to
+// show for it, which made a permanently wedged task indistinguishable from an
+// idle one.
+//
+// One INFO line names the cell, the task, every dropped workflow and its reason;
+// a `dispatch.dropped` execution event per workflow makes the same fact queryable
+// per task. Repeats are suppressed while the reason set is unchanged: an
+// "active instance" drop is the normal state of a task whose workflow is still
+// running, and re-logging it every poll interval would bury the signal.
+func (d *Dispatcher) reportFullyDropped(ctx context.Context, cell model.SourceItem, task model.InternalTask, dropped []droppedMatch) {
+	signature := dropSignature(dropped)
+	if previous, seen := d.dropNotified.Load(task.ID); seen && previous == signature {
+		return
+	}
+	d.dropNotified.Store(task.ID, signature)
+
+	reasons := make([]string, 0, len(dropped))
+	for _, drop := range dropped {
+		reasons = append(reasons, drop.String())
+	}
+	aplog.Info("cell %s (%q): task %s matched %d workflow(s) but every one was dropped before dispatch — %s; nothing will run for this task until the reason clears",
+		cell.LogLabel(), cell.Title, task.ID, len(dropped), strings.Join(reasons, ", "))
+
+	for _, drop := range dropped {
+		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: task.ID, WorkflowID: drop.WorkflowID,
+			Metadata: map[string]any{"reason": drop.Reason, "detail": drop.Detail, "source_item_id": cell.ID}})
+	}
 }
 
 // dropOnceMatches removes matches whose trigger declared `once: true` and that
@@ -1726,8 +1837,9 @@ func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, match
 // #119). Only routes that opt in via `once` are checked; all others pass through.
 // Fail-closed: on a query error the (once) match is dropped — skip this poll and
 // retry next, rather than risk a duplicate fan-out.
-func (d *Dispatcher) dropOnceMatches(ctx context.Context, taskID string, matches []router.Match) []router.Match {
+func (d *Dispatcher) dropOnceMatches(ctx context.Context, taskID string, matches []router.Match) ([]router.Match, []droppedMatch) {
 	out := make([]router.Match, 0, len(matches))
+	var dropped []droppedMatch
 	for _, m := range matches {
 		if !m.Route.Once {
 			out = append(out, m)
@@ -1736,15 +1848,17 @@ func (d *Dispatcher) dropOnceMatches(ctx context.Context, taskID string, matches
 		done, err := d.db.HasCompletedInstanceForRoute(ctx, taskID, m.Route.ID)
 		if err != nil {
 			aplog.Error("once check task %s workflow %s: %v — skipping this poll", taskID, m.Route.ID, err)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "guard error", Detail: err.Error()})
 			continue
 		}
 		if done {
 			aplog.Debug("task %s: workflow %s already completed and is once-only, skipping re-dispatch", taskID, m.Route.ID)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "once", Detail: "already completed"})
 			continue
 		}
 		out = append(out, m)
 	}
-	return out
+	return out, dropped
 }
 
 // dropCappedMatches removes matches whose (task, workflow) has reached the
@@ -1755,12 +1869,13 @@ func (d *Dispatcher) dropOnceMatches(ctx context.Context, taskID string, matches
 // applied best-effort (so an issue parks to needs-attention and leaves the poll
 // set when the workflow defines one). Fail-open: on a count error the match is
 // kept (the cap is a safety net, not a correctness guard).
-func (d *Dispatcher) dropCappedMatches(ctx context.Context, task model.InternalTask, matches []router.Match) []router.Match {
+func (d *Dispatcher) dropCappedMatches(ctx context.Context, task model.InternalTask, matches []router.Match) ([]router.Match, []droppedMatch) {
 	limit := d.cfg.Settings.MaxAttempts
 	if limit <= 0 {
-		return matches
+		return matches, nil
 	}
 	out := make([]router.Match, 0, len(matches))
+	var dropped []droppedMatch
 	for _, m := range matches {
 		n, err := d.db.CountConsecutiveFailedInstances(ctx, task.ID, m.Route.ID)
 		if err != nil {
@@ -1771,11 +1886,12 @@ func (d *Dispatcher) dropCappedMatches(ctx context.Context, task model.InternalT
 		if n >= limit {
 			aplog.Warn("task %s: workflow %s hit failure cap (%d/%d consecutive failures), not re-dispatching", task.ID, m.Route.ID, n, limit)
 			d.parkCappedTask(ctx, task, m.Route.ID)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "capped", Detail: fmt.Sprintf("%d/%d consecutive failures", n, limit)})
 			continue
 		}
 		out = append(out, m)
 	}
-	return out
+	return out, dropped
 }
 
 // parkCappedTask applies a capped workflow's on_fail hook to the task's source

--- a/src/internal/daemon/dropped_dispatch_test.go
+++ b/src/internal/daemon/dropped_dispatch_test.go
@@ -1,0 +1,296 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+)
+
+// captureLogs redirects the global log sink for the duration of a test and
+// returns an accessor for everything logged. The sink is process-global, so
+// tests that use it must not run in parallel.
+func captureLogs(t *testing.T) func() []string {
+	t.Helper()
+	var mu sync.Mutex
+	var lines []string
+	aplog.SetSink(func(level, msg string) {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, level+" "+msg)
+	})
+	t.Cleanup(func() { aplog.SetSink(nil) })
+	return func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), lines...)
+	}
+}
+
+func openDropTestDB(t *testing.T, name string) *db.Client {
+	t.Helper()
+	dbc, err := db.New(context.Background(), filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	return dbc
+}
+
+// TestReportFullyDroppedIsVisible is the core regression for #380: when every
+// matched workflow is removed by a pre-dispatch guard, nothing runs and no
+// instance is created — that outcome must produce an INFO line naming the task,
+// the workflow and the drop reason, plus a queryable `dispatch.dropped` event.
+// It used to be reported only as a DEBUG "no matching route" line that did not
+// even distinguish "nothing matched" from "everything was dropped", so a wedged
+// task was indistinguishable from an idle one.
+func TestReportFullyDroppedIsVisible(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "dropped.db")
+	logs := captureLogs(t)
+
+	// jira-implement already completed; its trigger is once: true, so the guard
+	// removes it and the task has nothing left to dispatch.
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-implement", CellID: "295651", TaskID: "T1", State: db.InstanceStateDone})
+
+	d := &Dispatcher{db: dbc}
+	matches := []router.Match{{Route: config.RouteConfig{ID: "jira-implement", Once: true}}}
+
+	kept, dropped := d.dropOnceMatches(ctx, "T1", matches)
+	if len(kept) != 0 {
+		t.Fatalf("expected the once-route to be dropped, kept %d", len(kept))
+	}
+	if len(dropped) != 1 || dropped[0].WorkflowID != "jira-implement" || dropped[0].Reason != "once" {
+		t.Fatalf("guard must report which workflow it dropped and why; got %+v", dropped)
+	}
+
+	cell := model.SourceItem{ID: "295651", SourceID: "rl-jira", Title: "PSP-199"}
+	task := model.InternalTask{ID: "T1"}
+	d.reportFullyDropped(ctx, cell, task, dropped)
+
+	var info string
+	for _, line := range logs() {
+		if strings.HasPrefix(line, "INFO ") && strings.Contains(line, "dropped before dispatch") {
+			info = line
+		}
+	}
+	if info == "" {
+		t.Fatalf("a fully-dropped dispatch must log at INFO; got %v", logs())
+	}
+	for _, want := range []string{"T1", "jira-implement", "once", "295651"} {
+		if !strings.Contains(info, want) {
+			t.Errorf("INFO line must name %q; got %q", want, info)
+		}
+	}
+
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "T1", Type: "dispatch.dropped"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 dispatch.dropped event, got %d", len(events))
+	}
+	if events[0].WorkflowID != "jira-implement" || events[0].Metadata["reason"] != "once" {
+		t.Errorf("event must carry workflow and reason; got %+v", events[0])
+	}
+}
+
+// TestReportFullyDroppedSuppressesUnchangedRepeats keeps the new INFO line
+// useful. A task whose single workflow is running is "fully dropped" on every
+// poll; re-logging that every poll interval would bury the signal it exists to
+// provide. The line is emitted when the reason set first appears and again only
+// when it changes.
+func TestReportFullyDroppedSuppressesUnchangedRepeats(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "dropped-repeat.db")
+	logs := captureLogs(t)
+
+	d := &Dispatcher{db: dbc}
+	cell := model.SourceItem{ID: "295651", SourceID: "rl-jira", Title: "PSP-199"}
+	task := model.InternalTask{ID: "T1"}
+
+	active := []droppedMatch{{WorkflowID: "jira-implement", Reason: "active instance"}}
+	d.reportFullyDropped(ctx, cell, task, active)
+	d.reportFullyDropped(ctx, cell, task, active)
+	d.reportFullyDropped(ctx, cell, task, active)
+
+	count := func() int {
+		n := 0
+		for _, line := range logs() {
+			if strings.Contains(line, "dropped before dispatch") {
+				n++
+			}
+		}
+		return n
+	}
+	if got := count(); got != 1 {
+		t.Fatalf("an unchanged reason set must be reported once, got %d lines", got)
+	}
+
+	// A different reason is new information and must be reported.
+	d.reportFullyDropped(ctx, cell, task, []droppedMatch{{WorkflowID: "jira-implement", Reason: "capped"}})
+	if got := count(); got != 2 {
+		t.Fatalf("a changed reason must be reported again, got %d lines", got)
+	}
+
+	// After a successful dispatch clears the marker, the same reason is news again.
+	d.dropNotified.Delete("T1")
+	d.reportFullyDropped(ctx, cell, task, active)
+	if got := count(); got != 3 {
+		t.Fatalf("a re-wedge after a dispatch must be reported, got %d lines", got)
+	}
+}
+
+// TestExecuteQueuedJobSkipIsVisible covers the queue half of #380. A job the
+// dispatcher declines to execute (a redelivery of an already-completed workflow,
+// or a `once: true` route) still finishes as succeeded — but it must say so at
+// INFO, record a dispatch.dropped event, and carry a Note that lands on the
+// attempt row, so "succeeded and did nothing" is distinguishable from
+// "succeeded and ran a workflow" without inventing a new queue job state.
+func TestExecuteQueuedJobSkipIsVisible(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "queue-skip.db")
+	logs := captureLogs(t)
+
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-implement", CellID: "295651", TaskID: "T1", State: db.InstanceStateDone})
+
+	d := &Dispatcher{db: dbc}
+	payload, err := json.Marshal(dispatchJobPayload{
+		Version: dispatchPayloadVersion,
+		Cell:    model.SourceItem{ID: "295651", SourceID: "rl-jira"},
+		Task:    model.InternalTask{ID: "T1"},
+		Match:   router.Match{Route: config.RouteConfig{ID: "jira-implement", Once: true}},
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	result := d.ExecuteQueuedJob(ctx, queue.Job{ID: "job-1", TaskID: "T1", WorkflowID: "jira-implement", AttemptCount: 1, PayloadVersion: dispatchPayloadVersion, Payload: payload}, "worker-1")
+	if !result.Success {
+		t.Fatalf("a skipped job must still finish cleanly; got %+v", result)
+	}
+	if !strings.HasPrefix(result.Note, "skipped:") {
+		t.Errorf("a skipped job must carry an explanatory Note; got %q", result.Note)
+	}
+
+	var found bool
+	for _, line := range logs() {
+		if strings.HasPrefix(line, "INFO ") && strings.Contains(line, "without creating an instance") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a skipped queue job must log at INFO; got %v", logs())
+	}
+
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "T1", Type: "dispatch.dropped"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 dispatch.dropped event for the skipped job, got %d", len(events))
+	}
+}
+
+// TestWarnUnsatisfiableQueueJobsWarnsOncePerJob covers the #375 residue: a job
+// enqueued after startup that no registered worker can lease sits queued forever
+// while `apiary status` shows a healthy idle worker. The check now runs on a
+// timer instead of only at boot, so it must warn once per job (not once per
+// tick) and forget a job that becomes leasable again.
+func TestWarnUnsatisfiableQueueJobsWarnsOncePerJob(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "unsatisfiable.db")
+	logs := captureLogs(t)
+
+	store := dbc.Queue()
+	if err := store.RegisterWorker(ctx, &queue.Worker{ID: "worker-1", ProtocolVersion: queue.WorkerProtocolVersion, Pool: "default", Capabilities: []string{"apiary.workflow"}, Capacity: 1, Ready: true}); err != nil {
+		t.Fatalf("register worker: %v", err)
+	}
+	job := &queue.Job{IdempotencyKey: "T1:0:jira-implement", TaskID: "T1", WorkflowID: "jira-implement", Pool: "default", RequiredCapabilities: []string{"apiary.workflow", "runner:cursor-cli"}, PayloadVersion: 1, Payload: []byte(`{}`)}
+	if _, err := store.Enqueue(ctx, job); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	d := &Dispatcher{db: dbc, dispatchQueue: store}
+	d.warnUnsatisfiableQueueJobs(ctx)
+	d.warnUnsatisfiableQueueJobs(ctx)
+	d.warnUnsatisfiableQueueJobs(ctx)
+
+	warnings := 0
+	for _, line := range logs() {
+		if strings.HasPrefix(line, "WARN ") && strings.Contains(line, "not satisfiable by any registered worker") {
+			warnings++
+		}
+	}
+	if warnings != 1 {
+		t.Fatalf("an unleasable job must be warned about once per job, got %d warnings", warnings)
+	}
+
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "T1", Type: "dispatch.dropped"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 || events[0].Metadata["reason"] != "unsatisfiable by any worker" {
+		t.Fatalf("expected one unsatisfiable dispatch.dropped event, got %+v", events)
+	}
+}
+
+// TestDropActiveMatchesTreatsInterruptedAsTerminal is a CONTROL for #380's
+// second claim ("dropActiveMatches may treat interrupted as non-terminal, so a
+// single restart wedges a task forever"). It passes both before and after this
+// change: only running / approval_waiting / waiting shadow a workflow, and an
+// instance stranded 'interrupted' by a restart stays eligible for re-dispatch.
+func TestDropActiveMatchesTreatsInterruptedAsTerminal(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "interrupted.db")
+
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-implement", CellID: "297869", TaskID: "T2", State: db.InstanceStateInterrupted})
+
+	d := &Dispatcher{db: dbc}
+	kept, dropped := d.dropActiveMatches(ctx, "T2", []router.Match{{Route: config.RouteConfig{ID: "jira-implement"}}})
+	if len(kept) != 1 {
+		t.Fatalf("an interrupted instance is terminal and must not shadow a re-dispatch; kept %d, dropped %+v", len(kept), dropped)
+	}
+}
+
+// TestReconcileOrphanTaskCountersHealsPhantomOutstanding is a CONTROL for
+// #380's phantom `outstanding_workflows` claim. It passes both before and after
+// this change: the startup sweep recounts the counter from live instances for
+// every non-terminal task state, so a counter left inflated by a dispatch that
+// never produced an instance is reset to zero on the next daemon start.
+func TestReconcileOrphanTaskCountersHealsPhantomOutstanding(t *testing.T) {
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "counters.db")
+	tasks := dbc.InternalTasks()
+
+	task := &model.InternalTask{ID: "T3", Title: "PSP-199", State: model.TaskStateRunning}
+	if err := tasks.CreateTask(ctx, task); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.IncrementOutstanding(ctx, "T3", 1); err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	// Both instances are terminal: the counter is a phantom.
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-assigned-to-me", CellID: "295651", TaskID: "T3", State: db.InstanceStateDone})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "jira-implement", CellID: "295651", TaskID: "T3", State: db.InstanceStateDone})
+
+	if _, _, err := dbc.ReconcileOrphanTaskCounters(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	healed, err := tasks.GetTask(ctx, "T3")
+	if err != nil || healed == nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if healed.OutstandingWorkflows != 0 {
+		t.Errorf("outstanding counter must self-heal to 0 when no instance is live; got %d", healed.OutstandingWorkflows)
+	}
+}

--- a/src/internal/daemon/forcerestart_workflow_test.go
+++ b/src/internal/daemon/forcerestart_workflow_test.go
@@ -24,7 +24,7 @@ func TestForceRestart_InterruptsWorkflowInstance(t *testing.T) {
 	// Sanity: the running instance shadows its workflow before the restart.
 	match := router.Match{Route: config.RouteConfig{ID: "wf"}}
 	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
-	if kept := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 0 {
+	if kept, _ := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 0 {
 		t.Fatalf("precondition: running instance should shadow the workflow, got %d kept", len(kept))
 	}
 
@@ -42,7 +42,7 @@ func TestForceRestart_InterruptsWorkflowInstance(t *testing.T) {
 	}
 
 	// dropActiveMatches no longer shadows the workflow, so the next poll re-dispatches.
-	if kept := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 1 {
+	if kept, _ := d.dropActiveMatches(ctx, taskID, []router.Match{match}); len(kept) != 1 {
 		t.Fatalf("after restart the workflow should re-dispatch, got %d kept", len(kept))
 	}
 }

--- a/src/internal/daemon/inflight_guard_test.go
+++ b/src/internal/daemon/inflight_guard_test.go
@@ -34,7 +34,7 @@ func TestDropActiveMatches(t *testing.T) {
 		{Route: config.RouteConfig{ID: "triage"}},         // done → kept
 		{Route: config.RouteConfig{ID: "po-spec"}},        // never ran → kept
 	}
-	got := d.dropActiveMatches(ctx, "T1", matches)
+	got, _ := d.dropActiveMatches(ctx, "T1", matches)
 
 	kept := map[string]bool{}
 	for _, m := range got {

--- a/src/internal/daemon/once_guard_test.go
+++ b/src/internal/daemon/once_guard_test.go
@@ -37,7 +37,7 @@ func TestDropOnceMatches(t *testing.T) {
 		{Route: config.RouteConfig{ID: "implementation", Once: false}}, // not once → kept even though done
 		{Route: config.RouteConfig{ID: "po-spec", Once: true}},         // once but never ran → kept
 	}
-	got := d.dropOnceMatches(ctx, "T1", matches)
+	got, _ := d.dropOnceMatches(ctx, "T1", matches)
 
 	kept := map[string]bool{}
 	for _, m := range got {

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -116,6 +116,8 @@ func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, t
 			if isTerminalJobState(job.State) {
 				aplog.Warn("task %s: workflow %s not enqueued — dispatch key %q already belongs to a %s job; re-dispatch waits for a new dispatch generation",
 					task.ID, match.Route.ID, job.IdempotencyKey, job.State)
+				d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: task.ID, WorkflowID: match.Route.ID,
+					Metadata: map[string]any{"reason": "idempotency key held by a terminal job", "detail": string(job.State), "job_id": job.ID}})
 			} else {
 				aplog.Debug("task %s: workflow %s already enqueued (job %s, %s) — skipping duplicate", task.ID, match.Route.ID, job.ID, job.State)
 			}
@@ -174,9 +176,19 @@ func (d *Dispatcher) ExecuteQueuedJob(ctx context.Context, job queue.Job, worker
 			return queue.FinishResult{Error: fmt.Sprintf("check completed workflow: %v", err), Retry: true}
 		}
 		if completed {
-			aplog.Debug("queue job %s: workflow %s already completed for task %s — skipping redelivery",
-				job.ID, payload.Match.Route.ID, payload.Task.ID)
-			return queue.FinishResult{Success: true}
+			reason := "redelivery of an already-completed workflow"
+			if payload.Match.Route.Once {
+				reason = "trigger declared once: true and the workflow already completed"
+			}
+			// INFO, not DEBUG: this is the job finishing without creating an
+			// instance or a step run. Reported at DEBUG it was invisible on a
+			// --verbose daemon, and the job's `succeeded` state said nothing
+			// about the fact that no work happened (issue #380).
+			aplog.Info("queue job %s: not running workflow %s for task %s — %s; job finishes without creating an instance",
+				job.ID, payload.Match.Route.ID, payload.Task.ID, reason)
+			d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: payload.Task.ID, WorkflowID: payload.Match.Route.ID,
+				Metadata: map[string]any{"reason": "once", "detail": reason, "job_id": job.ID, "attempt": job.AttemptCount}})
+			return queue.FinishResult{Success: true, Note: "skipped: " + reason}
 		}
 	}
 	d.active.Add(1)
@@ -247,10 +259,37 @@ func (d *Dispatcher) settleRemoteQueueJob(ctx context.Context, job queue.Job) er
 	return d.db.InternalTasks().UpdateTaskState(ctx, job.TaskID, taskState)
 }
 
+// queueWatchdogInterval is how often the daemon re-checks whether every queued
+// dispatch job can still be leased by some registered worker.
+const queueWatchdogInterval = time.Minute
+
+// queueWatchdogLoop re-runs the unsatisfiable-job check on a timer, not only at
+// startup. A job enqueued *after* startup that no worker can lease — a workflow
+// whose agent requires a label or runner capability the embedded worker does not
+// advertise — otherwise sits queued forever with nothing said about it: the poll
+// keeps reporting the cell, `apiary status` shows a healthy idle worker, and the
+// task never runs. That is the "enqueued but never leased" shape of #375, and it
+// deserves to be loud whenever it happens, not just if it was true at boot.
+func (d *Dispatcher) queueWatchdogLoop(ctx context.Context) {
+	ticker := time.NewTicker(queueWatchdogInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.warnUnsatisfiableQueueJobs(ctx)
+		}
+	}
+}
+
 // warnUnsatisfiableQueueJobs logs a warning for queued jobs whose pool, labels,
 // or required capabilities no registered worker (including the embedded one)
 // can satisfy. Without it this failure mode is completely silent: jobs sit
 // queued forever while `apiary status` shows a ready worker with free capacity.
+// Each job is warned about once (tracked in warnedUnsatisfiable) so running the
+// check on a timer does not turn one stuck job into a log flood; a job that
+// later becomes leasable is forgotten so a recurrence is reported again.
 func (d *Dispatcher) warnUnsatisfiableQueueJobs(ctx context.Context) {
 	if d.dispatchQueue == nil {
 		return
@@ -273,14 +312,22 @@ func (d *Dispatcher) warnUnsatisfiableQueueJobs(ctx context.Context) {
 	if d.localWorker != nil {
 		workers = append(workers, d.queueWorker)
 	}
-	unsatisfiable := 0
+	unsatisfiable, fresh := 0, 0
 	for _, job := range jobs {
 		if !jobSatisfiableByAnyWorker(job, workers) {
 			unsatisfiable++
+			if _, warned := d.warnedUnsatisfiable.LoadOrStore(job.ID, struct{}{}); warned {
+				continue
+			}
+			fresh++
 			aplog.Warn("queued job %s (task %s, workflow %s) is not satisfiable by any registered worker: pool=%q required_labels=%v required_capabilities=%v", job.ID, job.TaskID, job.WorkflowID, job.Pool, job.RequiredLabels, job.RequiredCapabilities)
+			d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: job.TaskID, WorkflowID: job.WorkflowID,
+				Metadata: map[string]any{"reason": "unsatisfiable by any worker", "detail": fmt.Sprintf("pool=%q labels=%v capabilities=%v", job.Pool, job.RequiredLabels, job.RequiredCapabilities), "job_id": job.ID}})
+			continue
 		}
+		d.warnedUnsatisfiable.Delete(job.ID)
 	}
-	if unsatisfiable > 0 {
+	if fresh > 0 {
 		aplog.Warn("%d queued job(s) cannot be leased by any registered worker — they will stay queued until a worker advertising the required pool/labels/capabilities registers", unsatisfiable)
 	}
 }

--- a/src/internal/daemon/redispatch_cap_test.go
+++ b/src/internal/daemon/redispatch_cap_test.go
@@ -38,14 +38,14 @@ func TestDropCappedMatches(t *testing.T) {
 		{Route: config.RouteConfig{ID: "hatch"}},
 	}
 
-	out := d.dropCappedMatches(ctx, task, matches)
+	out, _ := d.dropCappedMatches(ctx, task, matches)
 	if len(out) != 1 || out[0].Route.ID != "hatch" {
 		t.Fatalf("expected only 'hatch' kept, got %+v", out)
 	}
 
 	// max_attempts <= 0 disables the cap entirely.
 	d.cfg.Settings.MaxAttempts = 0
-	if got := d.dropCappedMatches(ctx, task, matches); len(got) != 2 {
+	if got, _ := d.dropCappedMatches(ctx, task, matches); len(got) != 2 {
 		t.Errorf("disabled cap should keep all, got %d", len(got))
 	}
 }

--- a/src/internal/daemon/resume_auto.go
+++ b/src/internal/daemon/resume_auto.go
@@ -122,14 +122,16 @@ func (d *Dispatcher) taskSettled(ctx context.Context, taskID string) bool {
 // it, the first poll after a restart could dispatch a fresh step-1 instance in
 // parallel with the resume. Once the descendant row exists it is 'running' and
 // dropActiveMatches keeps guarding it.
-func (d *Dispatcher) dropAutoResumingMatches(taskID string, matches []router.Match) []router.Match {
+func (d *Dispatcher) dropAutoResumingMatches(taskID string, matches []router.Match) ([]router.Match, []droppedMatch) {
 	out := make([]router.Match, 0, len(matches))
+	var dropped []droppedMatch
 	for _, m := range matches {
 		if _, resuming := d.autoResuming.Load(autoResumeKey(taskID, m.Route.ID)); resuming {
 			aplog.Debug("task %s: workflow %s is being auto-resumed, skipping re-dispatch", taskID, m.Route.ID)
+			dropped = append(dropped, droppedMatch{WorkflowID: m.Route.ID, Reason: "auto-resuming"})
 			continue
 		}
 		out = append(out, m)
 	}
-	return out
+	return out, dropped
 }

--- a/src/internal/daemon/resume_auto_test.go
+++ b/src/internal/daemon/resume_auto_test.go
@@ -234,11 +234,11 @@ func TestDropAutoResumingMatches(t *testing.T) {
 		{Route: config.RouteConfig{ID: "impl"}},
 		{Route: config.RouteConfig{ID: "triage"}},
 	}
-	got := d.dropAutoResumingMatches("T1", matches)
+	got, _ := d.dropAutoResumingMatches("T1", matches)
 	if len(got) != 1 || got[0].Route.ID != "triage" {
 		t.Errorf("kept %+v, want only triage (impl is auto-resuming)", got)
 	}
-	if got := d.dropAutoResumingMatches("T2", matches); len(got) != 2 {
+	if got, _ := d.dropAutoResumingMatches("T2", matches); len(got) != 2 {
 		t.Errorf("another task must be unaffected, kept %d of 2", len(got))
 	}
 }

--- a/src/internal/db/queue_store.go
+++ b/src/internal/db/queue_store.go
@@ -72,6 +72,14 @@ func (s *QueueStore) Enqueue(ctx context.Context, job *queue.Job) (bool, error) 
 	return true, nil
 }
 
+// RegisterWorker inserts or refreshes a worker registration. active_jobs is
+// reset to zero on re-registration: a worker process registers once at startup
+// and by definition owns no leases at that moment, so a count left behind by a
+// previously-killed process is stale. Leaving it stale is silently harmful —
+// Claim refuses every job while active_jobs >= capacity, and the default
+// embedded-worker capacity is 1, so one orphaned lease means the restarted
+// daemon leases nothing at all until the old lease times out (issue #375).
+// The orphaned attempts themselves are still settled by ReclaimExpired.
 func (s *QueueStore) RegisterWorker(ctx context.Context, worker *queue.Worker) error {
 	if worker == nil || strings.TrimSpace(worker.ID) == "" {
 		return fmt.Errorf("worker id is required")
@@ -91,7 +99,8 @@ func (s *QueueStore) RegisterWorker(ctx context.Context, worker *queue.Worker) e
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET protocol_version=excluded.protocol_version, pool=excluded.pool,
 		  labels=excluded.labels, capabilities=excluded.capabilities, capacity=excluded.capacity,
-		  ready=excluded.ready, draining=excluded.draining, last_heartbeat=excluded.last_heartbeat, updated_at=excluded.updated_at
+		  ready=excluded.ready, draining=excluded.draining, active_jobs=0,
+		  last_heartbeat=excluded.last_heartbeat, updated_at=excluded.updated_at
 	`, worker.ID, worker.ProtocolVersion, nullStr(worker.Pool), string(labels), string(capabilities), worker.Capacity,
 		boolToInt(worker.Ready), boolToInt(worker.Draining), now, now, now)
 	if err != nil {
@@ -313,7 +322,14 @@ func (s *QueueStore) finish(ctx context.Context, jobID, attemptID, token string,
 			available = result.RetryAt.UTC()
 		}
 	}
-	if _, err = tx.ExecContext(ctx, `UPDATE dispatch_attempts SET state=?, finished_at=?, error_message=? WHERE id=? AND claim_token=? AND state='active'`, attemptState, now, nullStr(result.Error), attemptID, token); err != nil {
+	// error_message doubles as the attempt's explanation column: a failure records
+	// the error, a no-op success records its Note ("skipped: …"), so a job that
+	// succeeded without doing anything is distinguishable in the DB (issue #380).
+	explanation := result.Error
+	if explanation == "" {
+		explanation = result.Note
+	}
+	if _, err = tx.ExecContext(ctx, `UPDATE dispatch_attempts SET state=?, finished_at=?, error_message=? WHERE id=? AND claim_token=? AND state='active'`, attemptState, now, nullStr(explanation), attemptID, token); err != nil {
 		return err
 	}
 	terminal := any(nil)

--- a/src/internal/db/queue_store_test.go
+++ b/src/internal/db/queue_store_test.go
@@ -34,6 +34,65 @@ func registerQueueWorker(t *testing.T, store *QueueStore, id string, capacity in
 	}
 }
 
+// TestRegisterWorkerResetsStaleActiveJobs pins the restart invariant behind
+// #375's "enqueued but never leased" residue. active_jobs is a durable counter
+// incremented at claim and decremented at finish; a process killed mid-job never
+// decrements it. Claim refuses every job while active_jobs >= capacity and the
+// embedded worker's default capacity is 1, so a registration that carried the
+// stale count forward meant the restarted daemon leased nothing at all — jobs
+// piled up queued with no error anywhere. A worker registering owns no leases by
+// definition, so re-registration must zero the counter.
+func TestRegisterWorkerResetsStaleActiveJobs(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	store := client.Queue()
+	registerQueueWorker(t, store, "worker-1", 1, nil, nil)
+
+	if _, err := store.Enqueue(ctx, testJob("task:1:implement")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-1", LeaseDuration: time.Hour, WorkerTimeout: time.Hour}); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	// The daemon is killed here: the lease is still live and active_jobs is 1.
+	registerQueueWorker(t, store, "worker-1", 1, nil, nil)
+
+	if _, err := store.Enqueue(ctx, testJob("task:1:review")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-1", LeaseDuration: time.Hour, WorkerTimeout: time.Hour}); err != nil {
+		t.Fatalf("a freshly registered worker owns no leases and must be able to claim; got %v", err)
+	}
+}
+
+// TestFinishRecordsSkipNoteOnAttempt pins #380's "distinguishable outcome"
+// requirement without adding a queue job state: a job that succeeded while doing
+// no work carries its explanation on the attempt row, so `succeeded` rows can be
+// told apart in the DB.
+func TestFinishRecordsSkipNoteOnAttempt(t *testing.T) {
+	ctx := context.Background()
+	client, _ := queueTestClient(t)
+	store := client.Queue()
+	registerQueueWorker(t, store, "worker-1", 2, nil, nil)
+	if _, err := store.Enqueue(ctx, testJob("task:1:implement")); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(ctx, queue.ClaimRequest{WorkerID: "worker-1", LeaseDuration: time.Hour, WorkerTimeout: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Finish(ctx, claim.Job.ID, claim.Attempt.ID, claim.Attempt.ClaimToken, queue.FinishResult{Success: true, Note: "skipped: redelivery of an already-completed workflow"}); err != nil {
+		t.Fatal(err)
+	}
+	var message string
+	if err := client.db.QueryRowContext(ctx, `SELECT COALESCE(error_message,'') FROM dispatch_attempts WHERE id=?`, claim.Attempt.ID).Scan(&message); err != nil {
+		t.Fatal(err)
+	}
+	if message != "skipped: redelivery of an already-completed workflow" {
+		t.Errorf("attempt must record the skip note; got %q", message)
+	}
+}
+
 func TestQueuePersistsAndEnqueueIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	client, path := queueTestClient(t)

--- a/src/internal/queue/queue.go
+++ b/src/internal/queue/queue.go
@@ -131,6 +131,12 @@ type HeartbeatResult struct {
 type FinishResult struct {
 	Success bool
 	Error   string
+	// Note explains a successful finish that did no work — the control plane
+	// decided not to execute the job (a redelivery of an already-completed
+	// workflow, a `once: true` route). It is recorded on the attempt row so a
+	// no-op job is distinguishable from one that really ran, without inventing a
+	// queue-level state for a dispatch-level decision (issue #380).
+	Note string
 	// Retry is reserved for infrastructure failures where execution is safe to
 	// repeat. Ordinary workflow failures are terminal at the queue layer.
 	Retry   bool


### PR DESCRIPTION
Closes #380. Contributes to #375 (see "What #375 still does not explain" — it must stay open).

## What still reproduced on current `main`

Before writing anything I re-verified both issues against `main` after #386 / #383 / #381 landed.

**Already fixed, not touched here:**

- **#375's runs 3+ / #380's "jobs succeed with no instance"** — `ExecuteQueuedJob` applying `HasCompletedInstanceForRoute` to *every* job. PR #386 scoped it to redeliveries and genuine `once: true` routes. This was the mechanism behind the reporter's seven `succeeded` jobs; it also explains the self-reinforcing loop they hit, because `settleRemoteQueueJob` writes a `queue-<jobid>` placeholder instance in state `done` for a job that finished without one, and that placeholder then satisfies the completed-instance check forever.
- **#380 ask 2a — "`dropActiveMatches` may treat `interrupted` as non-terminal".** Does not reproduce. `HasActiveInstanceForRoute` counts only `running` / `approval_waiting` / `waiting`; an instance stranded `interrupted` by a restart is already eligible for re-dispatch. Covered by a control test, not a change.
- **#380 ask 2b — "the phantom `outstanding_workflows` survives the startup sweep".** Does not reproduce as a dispatch blocker. `outstanding_workflows` is never read by any pre-dispatch guard (it only drives task-lifecycle settlement and the dashboard), and `ReconcileOrphanTaskCounters` already recounts it from live instances for every non-terminal task state (`registered` / `running` / `approval_waiting`). The counter the reporter saw was inflated by the pre-#386 silent skip — `enqueueFanOut` incremented, the job succeeded without an instance, nothing decremented — which #386 removes at the source. Covered by a control test, not a change.

**Still reproduced, fixed here:** everything under #380 ask 1, plus one genuine leasing bug found while chasing #375.

## Changes

### #380 — a dropped dispatch must be visible

`dropAutoResumingMatches`, `dropActiveMatches`, `dropOnceMatches` and `dropCappedMatches` now return *why* each match was removed, alongside the survivors. When every matched route is dropped, `poll` emits one INFO line naming the cell, the task, each workflow and its reason (`active instance`, `once`, `capped`, `auto-resuming`, `guard error`) and records a `dispatch.dropped` execution event per workflow, so the fact is queryable per task and not only greppable.

Two deliberate calls:

- **Repeat suppression.** A task whose single workflow is running is "fully dropped" on *every* poll. Logging that at INFO every 120s would bury the signal the line exists to provide, so the report is keyed on the reason set and re-emitted only when it changes (or after the task dispatches again). One line when a task goes wedged, one more when the reason shifts.
- **"no route matched" (DEBUG, normal) is no longer conflated with "routes matched but all were dropped" (INFO, notable).** The old single DEBUG line said `no matching route` for both.

On the queue side, a job the dispatcher declines to run now logs at INFO, records the same event, and carries a new `queue.FinishResult.Note` that lands on the `dispatch_attempts.error_message` column — so a `succeeded` job that did nothing is distinguishable from one that ran a workflow, in the DB, not just in the log.

**On the requested `skipped`/`no_match` job state:** not proportionate, and I'd rather say why than add it quietly. `queue.JobState` is the protocol-1 wire enum: a new value means a schema change, a protocol bump, `isTerminalJobState` / `settleRemoteQueueJob` / status-count / dashboard updates, and remote workers seeing a state they don't know. More to the point it puts a *dispatch-level* decision ("the control plane chose not to run this") into the *queue* vocabulary, which is deliberately generic about what a job is. The attempt-row Note plus the `dispatch.dropped` event give the same forensic answer — which job, which task, which workflow, which reason — with none of that. If the state still turns out to be wanted, it's an easy follow-up on top of this.

### #375 — "enqueued but never leased"

Two findings, both real:

1. **`QueueStore.RegisterWorker` carried a stale `active_jobs` forward.** The counter is incremented at claim and decremented at finish/reclaim; a process killed mid-job never decrements it, and the `ON CONFLICT DO UPDATE` refreshed everything *except* that column. `Claim` returns `ErrNoJob` while `active_jobs >= capacity`, and the embedded worker's default capacity is **1** — so after a hard restart the daemon leased *nothing at all* until the orphaned lease timed out, with no error anywhere. A worker registering owns no leases by definition, so re-registration now zeroes it. (The orphaned attempts are still settled by `ReclaimExpired`, which is what makes this safe.)
2. **The unsatisfiable-queued-job check ran only at startup.** A job enqueued *later* whose required pool/labels/capabilities nothing advertises sat queued forever in silence: polls kept reporting the cell, `apiary status` kept showing a healthy idle worker. It now runs on a one-minute timer, warning once per job (not once per tick) with a `dispatch.dropped` event, and forgetting a job that becomes leasable again.

### What #375 still does not explain

**#375 should stay open.** Its runs 1 and 2 — `jira-implement` had never completed for those tasks, so neither the once-guard nor the idempotency key applies — are still not explained from the code. The two fixes above are the strongest candidates I could substantiate (both are silent, both stall leasing, both are cleared by a restart, which matches the reported shape exactly), but neither is *proven* to be what happened: the reporter never captured `dispatch_jobs` for those runs, so there is no evidence distinguishing "never enqueued" from "enqueued and never leased". I would rather leave the issue open than close it on a plausible story. The good news is that the visibility work here means a recurrence produces a log line and an event either way — an unleasable job now says so within a minute, and a fully-dropped poll says so on the first poll.

## Tests

Every fix-dependent test was proven to fail against the unfixed code by reverting the behavioural change, running, and restoring.

| Test | Reverted | Observed failure |
|---|---|---|
| `TestReportFullyDroppedIsVisible` | INFO → DEBUG, event recording disabled | `a fully-dropped dispatch must log at INFO; got []` |
| `TestReportFullyDroppedSuppressesUnchangedRepeats` | signature dedupe disabled | `an unchanged reason set must be reported once, got 3 lines` |
| `TestExecuteQueuedJobSkipIsVisible` | INFO→DEBUG, Note + event removed | all three assertions failed (no Note, no INFO, 0 events) |
| `TestWarnUnsatisfiableQueueJobsWarnsOncePerJob` | per-job dedupe removed | `must be warned about once per job, got 3 warnings` |
| `TestRegisterWorkerResetsStaleActiveJobs` | `active_jobs=0` removed from the upsert | `must be able to claim; got no compatible queued job` |
| `TestFinishRecordsSkipNoteOnAttempt` | Note fallback removed | `attempt must record the skip note; got ""` |

**Controls — pass both with and without the fix, by construction** (they exercise `HasActiveInstanceForRoute` and `ReconcileOrphanTaskCounters`, neither of which this PR modifies):

- `TestDropActiveMatchesTreatsInterruptedAsTerminal` — documents that #380 ask 2a does not reproduce.
- `TestReconcileOrphanTaskCountersHealsPhantomOutstanding` — documents that #380 ask 2b does not reproduce.

Full suite green from `src/`: `go build ./...`, `go vet ./...`, `go test ./...` — all 28 packages `ok`, no skips. (No Go CI in this repo; verified locally.)

`src/internal/workflow/dag_test.go` was not touched (#387 race being fixed in parallel).

## Blast radius (gitnexus, upstream)

- `dropActiveMatches` — **HIGH**, 3 impacted: `poll` (d=1) → `pollLoop` (d=2) → `Start` (d=3); modules Daemon (direct), Jira + Workflow (indirect). Same shape for the three sibling guards. The signature change is contained: `poll` is the only production caller, plus five test call sites updated in place. Semantics are unchanged — every guard keeps or drops exactly what it did before.
- `QueueStore.RegisterWorker` — LOW, 0 direct callers in the graph (invoked through the `queue.Store` interface by `worker.Runtime.Run` and the queuehttp server).
- `ExecuteQueuedJob` — LOW, 0 direct callers in the graph (invoked via `worker.ExecutorFunc` and the remote-worker entry point).
- `queue.FinishResult` gains a field; it is serialized whole across the queuehttp boundary, so older peers simply omit it. No wire break.

`detect_changes` (all scopes): 6 changed files, **0 changed indexed symbols, 0 affected processes, risk low**.
