### PR TITLE
fix(workflow): fail closed when a reject_when gate cannot be evaluated (#390)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -165,6 +165,8 @@ steps:
         approach:   {type: string}
       required: [complexity, approach]
     on_missing_output: warn       # warn (default) | fail | ignore
+                                  # warn still fails a reject_when gate that
+                                  # reads this step's own memory.write keys
     memory:
       write: [complexity, approach]
 ```
@@ -176,7 +178,7 @@ steps:
 | `prompt` | Step instruction, appended to the task context (title, description, labels) and the agent's soul file |
 | `summary_prompt` | Asks the agent for a short summary, stored on the step and shown in the dashboard |
 | `output` | JSON Schema for structured output (alias: `output_schema`) — see below |
-| `on_missing_output` | What to do when `output` is declared but not satisfied: `warn` (default), `fail`, `ignore` |
+| `on_missing_output` | What to do when `output` is declared but not satisfied: `warn` (default), `fail`, `ignore`. Under `warn` the step still passes, but a `reject_when` gate reading one of this step's own `memory.write` keys fails closed — see [review loops](#reject_when--on_reject--review-loops). `ignore` opts out of both |
 | `memory` | Which output fields to persist, and whether to inject memory — see [Workflow memory](#workflow-memory) |
 | `publish` / `spawn` | Control agent-emitted write-backs and child tasks — see [Tasks & fan-out](tasks-and-fanout.md) |
 | `env` | Step-scope environment variables (highest precedence) |
@@ -258,6 +260,23 @@ loop back on rejection:
 When `reject_when` evaluates true the step is treated as failed and the
 engine restarts from `restart_from`, up to `max` times. The reviewer's
 `feedback` is in memory, so the implementer sees *why* it was rejected.
+
+**Gates fail closed.** A gate that cannot be evaluated is never a pass. If the
+gate reads a memory key the step itself declared in `memory.write` and the
+agent did not emit a value for it — typically because it skipped its
+`APIARY_OUTPUT:` line, or emitted it without that field — the step **fails**
+instead of quietly reading `""` and deciding "not rejected". In the example
+above, a reviewer that rejects the work in prose but forgets the output line
+fails the `review` step and takes the `on_reject` loop back to `implement`,
+rather than passing the work along as approved.
+
+This is scoped to keys the gating step owns: a gate reading a key written by
+some *earlier* step is unchanged, and so are `if:` conditions and split
+branches. Opt out for a single step with `on_missing_output: ignore`.
+
+The condition is recorded as a `step.gate_unevaluable` execution event (visible
+in the dashboard and the event stream) and the step run is persisted as
+`failed`, not only logged.
 
 #### `parallel:` — concurrent steps
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -957,7 +957,7 @@
         },
         "on_missing_output": {
           "type": "string",
-          "description": "Behavior when output_schema is declared but not satisfied",
+          "description": "Behavior when output_schema is declared but not satisfied: warn (default) logs and records a step.missing_output event but still passes the step; fail fails the step; ignore silences both. Independent of this setting (except under ignore), a reject_when/fail_when gate reading one of this step's own memory.write keys fails the step when the agent emitted no value for that key — an unevaluable gate never reads as a pass",
           "enum": ["warn", "fail", "ignore"],
           "default": "warn"
         },

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -615,6 +615,29 @@ func (c *Client) recordStepEvent(ctx context.Context, sr *StepRun, eventType str
 	_ = c.RecordExecutionEvent(ctx, event)
 }
 
+// UpdateStepRunState rewrites only the state (and output) of an existing step
+// run. The workflow scheduler calls it when a post-execution gate — fail_when
+// (reject_when) or on_missing_output — fails a step whose runner exited 0, so
+// the persisted row matches the decision the workflow actually took (#390). A
+// state change emits the usual step.* execution event.
+func (c *Client) UpdateStepRunState(ctx context.Context, id, state, output string) error {
+	var previous, stepID, instanceID string
+	if err := c.db.QueryRowContext(ctx,
+		`SELECT state, step_id, workflow_instance_id FROM step_runs WHERE id = ?`, id).
+		Scan(&previous, &stepID, &instanceID); err != nil {
+		return err
+	}
+	if _, err := c.db.ExecContext(ctx,
+		`UPDATE step_runs SET state = ?, output = ? WHERE id = ?`, state, nullStr(output), id); err != nil {
+		return err
+	}
+	if previous != state {
+		c.recordStepEvent(ctx, &StepRun{ID: id, WorkflowInstanceID: instanceID, StepID: stepID, State: state},
+			stepStateEventType(state))
+	}
+	return nil
+}
+
 // ListStepRuns returns all step runs for an instance, in insertion order.
 func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun, error) {
 	rows, err := c.db.QueryContext(ctx, `

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -369,6 +369,54 @@ func TestStepRun_CRUD(t *testing.T) {
 	}
 }
 
+// TestUpdateStepRunState covers the post-gate state correction used when a
+// fail_when / on_missing_output gate fails a step whose runner exited 0 (#390):
+// the row flips to failed, keeps its other fields, and emits a step.failed event.
+func TestUpdateStepRunState(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "wf_g", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
+	sr := &StepRun{ID: "sr_g", WorkflowInstanceID: "wf_g", StepID: "review", AgentID: "reviewer",
+		State: StepStatePassed, Output: "ok", Summary: "- reviewed", TotalTokens: 42}
+	if err := c.CreateStepRun(ctx, sr); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+
+	if err := c.UpdateStepRunState(ctx, "sr_g", StepStateFailed, "gate unevaluable"); err != nil {
+		t.Fatalf("update step run state: %v", err)
+	}
+
+	runs, err := c.ListStepRuns(ctx, "wf_g")
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 step run, got %d", len(runs))
+	}
+	if runs[0].State != StepStateFailed || runs[0].Output != "gate unevaluable" {
+		t.Errorf("state/output not updated: %+v", runs[0])
+	}
+	if runs[0].Summary != "- reviewed" || runs[0].TotalTokens != 42 {
+		t.Errorf("unrelated fields clobbered: %+v", runs[0])
+	}
+
+	events, err := c.ListExecutionEvents(ctx, ExecutionEventFilter{WorkflowInstanceID: "wf_g", Type: "step.failed"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("step.failed events = %d, want 1", len(events))
+	}
+	if events[0].StepID != "review" {
+		t.Errorf("event step_id = %q, want review", events[0].StepID)
+	}
+
+	if err := c.UpdateStepRunState(ctx, "missing", StepStateFailed, ""); err == nil {
+		t.Error("expected an error updating an unknown step run")
+	}
+}
+
 func TestStepRun_OrderedByInsertion(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -329,52 +329,29 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			r.waitDeadline = time.Time{}
 		}
 
-		// on_missing_output: fail — declared output schema required structured output.
-		if res.Success && step.OutputSchema != nil &&
-			step.OnMissingOutput == config.OnMissingOutputFail &&
-			len(res.StructuredOutput) == 0 {
-			res.Success = false
-			aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", r.wf.ID, step.ID)
-		}
-		// Default warn policy: the step still passes, but say so loudly — every
-		// condition keyed on the missing fields will now evaluate against "".
-		if res.Success && step.OutputSchema != nil &&
-			step.OnMissingOutput != config.OnMissingOutputIgnore &&
-			len(res.StructuredOutput) == 0 {
+		// Missing structured output for a step that declared an output schema.
+		if res.Success && step.OutputSchema != nil && len(res.StructuredOutput) == 0 &&
+			step.OnMissingOutput != config.OnMissingOutputIgnore {
 			aplog.Error("workflow %s: step %q declared output_schema but emitted no APIARY_OUTPUT — conditions reading its fields will see empty values", r.wf.ID, step.ID)
+			// Beyond the log line: record it on the instance so it is visible in
+			// the dashboard / event stream, not only in the daemon log (#390).
+			e.recordStepExecutionEvent(ctx, r, step.ID, "step.missing_output", map[string]any{
+				"policy":       missingOutputPolicy(step),
+				"memory_write": step.MemoryWriteFields(),
+			})
+			// on_missing_output: fail — declared output schema required structured output.
+			if step.OnMissingOutput == config.OnMissingOutputFail {
+				res.Success = false
+				res.Output = fmt.Sprintf("on_missing_output=fail: step %q declared an output schema but emitted no APIARY_OUTPUT", step.ID)
+				aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", r.wf.ID, step.ID)
+				e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+			}
 		}
 
-		// fail_when — evaluate on the scheduler goroutine after the agent runs.
-		// An expression that cannot be parsed or evaluated fails the step —
-		// silently treating it as "not rejected" would pass a result the gate
-		// was supposed to inspect (#180).
+		// fail_when (authored as reject_when) — evaluate on the scheduler
+		// goroutine after the agent runs.
 		if res.Success && step.FailWhen != "" {
-			transientMem := r.memoryValues()
-			for field, val := range res.StructuredOutput {
-				transientMem[field] = renderValue(val)
-			}
-			// A parallel step's own StructuredOutput is empty — its children's fresh
-			// contributions are only merged into r.contrib after this check, so
-			// overlay them here (declaration order, last-write-wins) or a gate like
-			// `memory.qa_verdict == "rejected"` would read the stale/empty value.
-			if step.StepType() == config.StepTypeParallel {
-				for _, c := range wr.parallelContribs {
-					for field, val := range c.Structured {
-						transientMem[field] = renderValue(val)
-					}
-				}
-			}
-			evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates, Event: r.event}
-			rejected, fwErr := e.evalExpr(step.FailWhen, evalCtx)
-			switch {
-			case fwErr != nil:
-				res.Success = false
-				res.Output = fmt.Sprintf("fail_when eval error %q: %v", step.FailWhen, fwErr)
-				aplog.Error("workflow %s: step %q fail_when eval error %q: %v (failing step)", r.wf.ID, step.ID, step.FailWhen, fwErr)
-			case rejected:
-				res.Success = false
-				aplog.Info("workflow %s: step %q rejected (fail_when matched)", r.wf.ID, step.ID)
-			}
+			res = e.applyFailWhen(ctx, r, step, res, wr.parallelContribs)
 		}
 
 		ss := StepState{State: passFail(res.Success), Output: res.Output}
@@ -857,6 +834,127 @@ func passFail(success bool) string {
 		return stPassed
 	}
 	return stFailed
+}
+
+// applyFailWhen evaluates a step's fail_when (reject_when) gate and returns the
+// possibly-failed result.
+//
+// Three ways the gate can fail the step:
+//
+//  1. The expression cannot be parsed or evaluated — silently treating it as
+//     "not rejected" would pass a result the gate was supposed to inspect (#180).
+//  2. The gate reads memory keys THIS step declared in `memory.write` but never
+//     emitted (typically: the agent omitted its APIARY_OUTPUT line). The gate is
+//     unevaluable, so it fails closed — a rejected review must never be recorded
+//     as passed just because the verdict went missing (#390).
+//  3. The gate matched: the agent rejected the work.
+func (e *Engine) applyFailWhen(ctx context.Context, r *dagRun, step config.StepConfig, res StepResult, parallelContribs []MemoryStep) StepResult {
+	transientMem := r.memoryValues()
+	for field, val := range res.StructuredOutput {
+		transientMem[field] = renderValue(val)
+	}
+	// A parallel step's own StructuredOutput is empty — its children's fresh
+	// contributions are only merged into r.contrib after this check, so
+	// overlay them here (declaration order, last-write-wins) or a gate like
+	// `memory.qa_verdict == "rejected"` would read the stale/empty value.
+	if step.StepType() == config.StepTypeParallel {
+		for _, c := range parallelContribs {
+			for field, val := range c.Structured {
+				transientMem[field] = renderValue(val)
+			}
+		}
+	}
+	evalCtx := EvalContext{Cell: r.cell, Memory: transientMem, Steps: r.stepStates, Event: r.event}
+
+	gate, parseErr := ParseExpr(stripExprDelimiters(step.FailWhen))
+	if parseErr != nil {
+		res.Success = false
+		res.Output = fmt.Sprintf("fail_when eval error %q: %v", step.FailWhen, parseErr)
+		aplog.Error("workflow %s: step %q fail_when eval error %q: %v (failing step)", r.wf.ID, step.ID, step.FailWhen, parseErr)
+		e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+		return res
+	}
+
+	// Fail closed on an unevaluable gate, unless the step opted out with
+	// on_missing_output: ignore.
+	if step.OnMissingOutput != config.OnMissingOutputIgnore {
+		if unset := unevaluableGateKeys(gate, step, res, parallelContribs); len(unset) > 0 {
+			res.Success = false
+			res.Output = fmt.Sprintf("gate %q cannot be evaluated: step declared memory.write key(s) %s but emitted no value for them "+
+				"(missing or incomplete APIARY_OUTPUT) — failing closed", step.FailWhen, strings.Join(unset, ", "))
+			aplog.Error("workflow %s: step %q gate %q is unevaluable — no value for memory key(s) %s that the step declares in memory.write; failing the step (fail closed, #390)",
+				r.wf.ID, step.ID, step.FailWhen, strings.Join(unset, ", "))
+			e.recordStepExecutionEvent(ctx, r, step.ID, "step.gate_unevaluable", map[string]any{
+				"gate":       step.FailWhen,
+				"unset_keys": unset,
+			})
+			e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+			return res
+		}
+	}
+
+	rejected, evalErr := gate.Eval(evalCtx)
+	switch {
+	case evalErr != nil:
+		res.Success = false
+		res.Output = fmt.Sprintf("fail_when eval error %q: %v", step.FailWhen, evalErr)
+		aplog.Error("workflow %s: step %q fail_when eval error %q: %v (failing step)", r.wf.ID, step.ID, step.FailWhen, evalErr)
+		e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+	case rejected:
+		res.Success = false
+		aplog.Info("workflow %s: step %q rejected (fail_when matched)", r.wf.ID, step.ID)
+		e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+	}
+	return res
+}
+
+// unevaluableGateKeys returns the sorted memory keys the gate reads that this
+// step promised to write (`memory.write`) but did not emit in its structured
+// output. A non-empty result means the gate is reading values the step was
+// responsible for producing and did not — the gate cannot decide anything.
+//
+// Only keys the step itself owns are considered: a gate reading a key written
+// by some earlier step is that step's responsibility, and keys that were never
+// declared anywhere are an authoring error caught by `apiary validate`.
+func unevaluableGateKeys(gate *Expr, step config.StepConfig, res StepResult, parallelContribs []MemoryStep) []string {
+	declared := map[string]struct{}{}
+	produced := map[string]struct{}{}
+	add := func(fields []string, structured map[string]any) {
+		for _, f := range fields {
+			declared[f] = struct{}{}
+		}
+		for k := range structured {
+			produced[k] = struct{}{}
+		}
+	}
+	if step.StepType() == config.StepTypeParallel {
+		// The parallel step emits nothing itself; its children own the keys.
+		for _, c := range parallelContribs {
+			add(c.WriteFields, c.Structured)
+		}
+	} else {
+		add(step.MemoryWriteFields(), res.StructuredOutput)
+	}
+
+	var unset []string
+	for _, key := range gate.MemoryRefs() {
+		if _, isDeclared := declared[key]; !isDeclared {
+			continue
+		}
+		if _, ok := produced[key]; !ok {
+			unset = append(unset, key)
+		}
+	}
+	return unset
+}
+
+// missingOutputPolicy returns the effective on_missing_output policy of a step
+// (the empty authored value means the `warn` default).
+func missingOutputPolicy(step config.StepConfig) string {
+	if step.OnMissingOutput == "" {
+		return config.OnMissingOutputWarn
+	}
+	return step.OnMissingOutput
 }
 
 // evalExpr parses and evaluates a condition expression. Strips optional ${{ }}

--- a/src/internal/workflow/dag_missing_output_gate_test.go
+++ b/src/internal/workflow/dag_missing_output_gate_test.go
@@ -1,0 +1,292 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// These tests pin the fail-closed contract from #390: a reject_when/fail_when
+// gate that reads memory keys its own step declared in memory.write but never
+// emitted cannot be evaluated, and an unevaluable gate must never read as a
+// pass. The reported incident: the reviewer agent said "rejected" in prose,
+// omitted its APIARY_OUTPUT line, `memory.verdict` stayed unset, the gate
+// compared "" against "rejected" → false, and the step was recorded as passed.
+
+// reviewStep builds the step shape from the issue: an output schema with a
+// verdict, memory.write of that verdict, and a gate reading it.
+func reviewStep(onMissing string) config.StepConfig {
+	return config.StepConfig{
+		ID: "review", Agent: "architect", DependsOn: []string{"implement"},
+		OutputSchema: &config.OutputSchema{
+			Type: "object",
+			Properties: map[string]config.SchemaField{
+				"verdict":  {Type: "string", Enum: []string{"approved", "rejected"}},
+				"feedback": {Type: "string"},
+			},
+			Required: []string{"verdict"},
+		},
+		Memory:          &config.MemoryConfig{Write: []string{"verdict", "feedback"}},
+		FailWhen:        `memory.verdict == "rejected"`,
+		OnMissingOutput: onMissing,
+	}
+}
+
+func reviewWF(onMissing string, extra ...config.StepConfig) config.WorkflowConfig {
+	steps := []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		reviewStep(onMissing),
+	}
+	return config.WorkflowConfig{ID: "review-gate-wf", Steps: append(steps, extra...)}
+}
+
+// TestDAG_GateUnevaluableFailsClosed is the core regression: the agent exits 0
+// with no structured output, so the gate's operand is unset. The step must fail
+// rather than pass, and downstream steps must not run.
+func TestDAG_GateUnevaluableFailsClosed(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, Output: "Verdict: rejected. Race on the shared map."},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := reviewWF("", config.StepConfig{ID: "qa", Agent: "backend-dev", DependsOn: []string{"review"}})
+
+	instID, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure: a gate whose operand is unset must not read as a pass")
+	}
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+	if contains(executedIDs(exec.seen), "qa") {
+		t.Errorf("downstream step must not run after an unevaluable gate, got %v", executedIDs(exec.seen))
+	}
+}
+
+// TestDAG_GateUnevaluableMarksStepRunFailed pins the visibility half: the
+// persisted step_runs row must read failed, not the `passed` the runner
+// produced (the row in the issue said `passed` with a NULL structured_output).
+func TestDAG_GateUnevaluableMarksStepRunFailed(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"review": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	if _, success, err := eng.RunInstance(context.Background(), reviewWF(""), model.InternalTask{ID: "c1"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	} else if success {
+		t.Fatal("expected instance failure")
+	}
+
+	states := store.stepRunStates("review")
+	if len(states) != 1 || states[0] != db.StepStateFailed {
+		t.Errorf("step_runs state for review = %v, want [failed]", states)
+	}
+}
+
+// TestDAG_GateUnevaluableRecordsEvent pins the operator-visible signal: an
+// execution event (dashboard / event stream), not just an ERROR log line.
+func TestDAG_GateUnevaluableRecordsEvent(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"review": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	if _, _, err := eng.RunInstance(context.Background(), reviewWF(""), model.InternalTask{ID: "c1"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	evs := store.eventsOfType("step.gate_unevaluable")
+	if len(evs) != 1 {
+		t.Fatalf("step.gate_unevaluable events = %d, want 1", len(evs))
+	}
+	if evs[0].StepID != "review" {
+		t.Errorf("event step_id = %q, want review", evs[0].StepID)
+	}
+	keys, _ := evs[0].Metadata["unset_keys"].([]string)
+	if len(keys) != 1 || keys[0] != "verdict" {
+		t.Errorf("event unset_keys = %v, want [verdict]", evs[0].Metadata["unset_keys"])
+	}
+}
+
+// TestDAG_MissingOutputRecordsEvent covers the warn default with no gate at
+// all: the step still passes (unchanged behaviour), but the missing output is
+// now recorded on the instance instead of living only in the daemon log.
+func TestDAG_MissingOutputRecordsEvent(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"classify": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{ID: "warn-wf", Steps: []config.StepConfig{{
+		ID: "classify", Agent: "architect",
+		OutputSchema: &config.OutputSchema{Type: "object",
+			Properties: map[string]config.SchemaField{"track": {Type: "string"}}},
+		Memory: &config.MemoryConfig{Write: []string{"track"}},
+	}}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("a missing output with no gate reading it still passes under the warn default")
+	}
+	evs := store.eventsOfType("step.missing_output")
+	if len(evs) != 1 {
+		t.Fatalf("step.missing_output events = %d, want 1", len(evs))
+	}
+	if got := evs[0].Metadata["policy"]; got != config.OnMissingOutputWarn {
+		t.Errorf("event policy = %v, want warn", got)
+	}
+}
+
+// TestDAG_GateUnevaluablePartialOutput covers the partial case: the agent
+// emitted structured output, but not the key the gate reads.
+func TestDAG_GateUnevaluablePartialOutput(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, StructuredOutput: map[string]any{"feedback": "looks risky"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(), reviewWF(""), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected failure: the gate's key is missing even though other keys were emitted")
+	}
+}
+
+// TestDAG_GateUnevaluableRoutesThroughOnFail verifies the fail-closed failure
+// takes the normal failure route, so the authored on_reject.restart_from
+// (lowered to on_fail.goto) loops back instead of dead-ending.
+func TestDAG_GateUnevaluableRoutesThroughOnFail(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"review": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	step := reviewStep("")
+	step.OnFail = &config.StepOutcome{Goto: "implement", MaxRetries: 2}
+	wf := config.WorkflowConfig{ID: "review-loop-wf", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"}, step,
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected instance failure after the retry budget is exhausted")
+	}
+	if got := countSeen(exec.seen, "implement"); got != 3 {
+		t.Errorf("implement ran %d times, want 3 (initial + 2 loop-backs)", got)
+	}
+}
+
+// TestDAG_GateUnevaluableIgnoreOptsOut verifies the explicit opt-out:
+// on_missing_output: ignore means "I know this output may be absent" and keeps
+// the old permissive behaviour.
+func TestDAG_GateUnevaluableIgnoreOptsOut(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"review": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(),
+		reviewWF(config.OnMissingOutputIgnore), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("on_missing_output: ignore must opt out of the fail-closed gate check")
+	}
+}
+
+// ── controls: these pass with and without the fix ───────────────────────────
+
+// TestDAG_GateEvaluableApprovedPasses is a control: the agent emitted the
+// verdict, the gate is evaluable and false, the step passes.
+func TestDAG_GateEvaluableApprovedPasses(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, StructuredOutput: map[string]any{"verdict": "approved", "feedback": "ok"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(), reviewWF(""), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("an evaluable gate that does not match must still pass")
+	}
+}
+
+// TestDAG_GateEvaluableRejectedFails is a control: the ordinary rejection path.
+func TestDAG_GateEvaluableRejectedFails(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: true, StructuredOutput: map[string]any{"verdict": "rejected"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(), reviewWF(""), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("a matching gate must fail the step")
+	}
+}
+
+// TestDAG_GateOnForeignMemoryKeyUnaffected is a control that documents the
+// deliberate scope: the check only covers keys the gating step itself declared
+// in memory.write. A gate reading a key owned by another step is unchanged.
+func TestDAG_GateOnForeignMemoryKeyUnaffected(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"review": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	step := reviewStep("")
+	step.FailWhen = `memory.qa_verdict == "rejected"` // written by no step in this workflow
+	step.Memory = &config.MemoryConfig{Write: []string{"verdict"}}
+	step.OutputSchema.Required = nil
+	wf := config.WorkflowConfig{ID: "foreign-key-wf", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"}, step,
+	}}
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("gates over keys this step does not own are out of scope for the fail-closed check")
+	}
+}
+
+// TestExpr_MemoryRefs pins the accessor extraction the gate check relies on.
+func TestExpr_MemoryRefs(t *testing.T) {
+	e, err := ParseExpr(`memory.verdict == "rejected" or (not memory.done == "yes" and cell.priority == "P1")`)
+	if err != nil {
+		t.Fatalf("ParseExpr: %v", err)
+	}
+	if got := strings.Join(e.MemoryRefs(), ","); got != "done,verdict" {
+		t.Errorf("MemoryRefs = %q, want \"done,verdict\"", got)
+	}
+}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -46,6 +46,14 @@ type ciPollRecorder interface {
 	RecordCIPollCheck(ctx context.Context, p *db.CIPollCheck) error
 }
 
+// stepRunStateUpdater is the optional capability the engine uses to correct a
+// step run's recorded state after the scheduler's post-execution gates ran.
+// *db.Client satisfies it; fake stores in tests that omit it simply keep the
+// state the runner wrote.
+type stepRunStateUpdater interface {
+	UpdateStepRunState(ctx context.Context, id, state, output string) error
+}
+
 type executionEventRecorder interface {
 	RecordExecutionEvent(context.Context, *db.ExecutionEvent) error
 }
@@ -168,7 +176,13 @@ type StepResult struct {
 	// InputPrompt is the composed prompt of the final (winning) attempt, persisted
 	// onto the step run for cost auditing and replay.
 	InputPrompt string
-	Err         error
+	// StepRunID is the id of the step_runs row this result was persisted to.
+	// The scheduler uses it to correct the recorded state when a post-execution
+	// gate (fail_when / on_missing_output) fails a step whose agent exited 0 —
+	// otherwise the row would read `passed` for a step the workflow failed (#390).
+	// Empty for step kinds that persist no step run (parallel, foreach, split).
+	StepRunID string
+	Err       error
 }
 
 // StepExecutor performs the actual runner invocation for a single agent step.
@@ -633,7 +647,37 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	e.memorizeStep(instID, task, step, res)
 	e.publishStep(ctx, task, bindings, res, sr)
 	_ = e.store.UpdateStepRun(ctx, sr)
+	res.StepRunID = sr.ID
 	return res
+}
+
+// markStepRunFailed flips a persisted step run to failed after the scheduler's
+// post-execution gates rejected a step whose agent itself exited 0. Without it
+// the step_runs row keeps the `passed` the runner produced while the workflow
+// treats the step as failed — the exact mismatch reported in #390. Best-effort:
+// a store that cannot update state (or a step kind with no row) changes nothing.
+func (e *Engine) markStepRunFailed(ctx context.Context, stepRunID, output string) {
+	if stepRunID == "" {
+		return
+	}
+	updater, ok := e.store.(stepRunStateUpdater)
+	if !ok {
+		return
+	}
+	if err := updater.UpdateStepRunState(ctx, stepRunID, db.StepStateFailed, output); err != nil {
+		aplog.Error("step run %s: mark failed: %v", stepRunID, err)
+	}
+}
+
+// recordStepExecutionEvent records a lifecycle event attributed to a specific
+// step (recordExecutionEvent attributes to the run's waiting step instead).
+func (e *Engine) recordStepExecutionEvent(ctx context.Context, r *dagRun, stepID, eventType string, metadata map[string]any) {
+	recorder, ok := e.store.(executionEventRecorder)
+	if !ok || r == nil {
+		return
+	}
+	_ = recorder.RecordExecutionEvent(ctx, &db.ExecutionEvent{Type: eventType, TaskID: r.task.ID, WorkflowID: r.wf.ID,
+		WorkflowInstanceID: r.instID, StepID: stepID, Metadata: metadata})
 }
 
 // secretPattern returns the name of the first common credential pattern found

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -38,6 +38,7 @@ type fakeStore struct {
 	stepOrder []string
 	bindings  map[string][]model.SourceBinding // task id → bindings (for bindingLister)
 	ciPolls   []db.CIPollCheck                 // recorded wait_for CI polls (for ciPollRecorder)
+	events    []db.ExecutionEvent              // recorded lifecycle events (for executionEventRecorder)
 	ancestors map[string][]model.InternalTask  // task id → lineage (for ancestorLister)
 }
 
@@ -115,6 +116,55 @@ func (f *fakeStore) UpdateStepRun(_ context.Context, sr *db.StepRun) error {
 	f.stepRuns[sr.ID] = &cp
 	f.mu.Unlock()
 	return nil
+}
+
+// UpdateStepRunState satisfies stepRunStateUpdater so the engine can correct a
+// step run's state after a post-execution gate, as *db.Client does.
+func (f *fakeStore) UpdateStepRunState(_ context.Context, id, state, output string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sr, ok := f.stepRuns[id]
+	if !ok {
+		return errTest
+	}
+	sr.State, sr.Output = state, output
+	return nil
+}
+
+// RecordExecutionEvent satisfies executionEventRecorder so tests can assert on
+// the lifecycle events the engine emits.
+func (f *fakeStore) RecordExecutionEvent(_ context.Context, ev *db.ExecutionEvent) error {
+	cp := *ev
+	f.mu.Lock()
+	f.events = append(f.events, cp)
+	f.mu.Unlock()
+	return nil
+}
+
+// eventsOfType returns the recorded events with the given type.
+func (f *fakeStore) eventsOfType(t string) []db.ExecutionEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []db.ExecutionEvent
+	for _, ev := range f.events {
+		if ev.Type == t {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// stepRunStates returns the persisted state of every step run for a step id.
+func (f *fakeStore) stepRunStates(stepID string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, id := range f.stepOrder {
+		if sr := f.stepRuns[id]; sr != nil && sr.StepID == stepID {
+			out = append(out, sr.State)
+		}
+	}
+	return out
 }
 
 // fakeExecutor returns scripted results keyed by step ID and records requests.

--- a/src/internal/workflow/expr.go
+++ b/src/internal/workflow/expr.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -67,6 +68,38 @@ func LintExpr(src string) error {
 
 // String returns the original source.
 func (e *Expr) String() string { return e.src }
+
+// MemoryRefs returns the sorted, de-duplicated set of `memory.<key>` keys the
+// expression reads. The scheduler uses it to detect a gate it cannot actually
+// evaluate — a `reject_when` reading a key its own step declared in
+// `memory.write` but never emitted (#390).
+func (e *Expr) MemoryRefs() []string {
+	seen := map[string]struct{}{}
+	collectMemoryRefs(e.root, seen)
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func collectMemoryRefs(n exprNode, seen map[string]struct{}) {
+	switch t := n.(type) {
+	case orNode:
+		collectMemoryRefs(t.l, seen)
+		collectMemoryRefs(t.r, seen)
+	case andNode:
+		collectMemoryRefs(t.l, seen)
+		collectMemoryRefs(t.r, seen)
+	case notNode:
+		collectMemoryRefs(t.x, seen)
+	case cmpNode:
+		if len(t.path) == 2 && t.path[0] == "memory" {
+			seen[t.path[1]] = struct{}{}
+		}
+	}
+}
 
 // ── lexer ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #390.

## The actual mechanism

Not what the title of the issue suggests. `on_missing_output: warn` is only half of it — the decisive part is in the expression engine:

- `resolveAccessor` maps an unset `memory.<key>` to `resolvedValue{kind: kMissing}`.
- `equals()` then falls through to string comparison, where `kMissing` renders as `""`.
- So `memory.verdict == "rejected"` with no verdict is a clean, error-free **false**.

That is why the fail-loud contract from #180/#182 did not catch it: those semantics fail the step on a *parse or eval error*, and there is no error here. The gate simply had nothing to look at and answered "not rejected". `passed` was recorded, `on_reject` never fired, and QA ran on rejected work.

## The fix — option 2, targeted (with a bit of option 3)

**A gate whose operands the step itself failed to produce fails the step.** Concretely: when a `fail_when` (authored `reject_when`) gate reads a `memory.<key>` that this step declared in its own `memory.write`, and the step emitted no value for that key, the gate is unevaluable and the step fails. This covers both the reported case (no `APIARY_OUTPUT` at all) and the partial case (output emitted, gate's field missing). The failure goes through the ordinary failure path, so `on_reject.restart_from` loops back to `implement` — the pipeline does the right thing instead of shipping.

Why not the others:

- **Option 1 (missing output fails the step whenever a gate reads its `memory.write` keys)** is nearly the same rule stated at output-granularity. Evaluating it per-key is strictly better: it also catches structured output that arrives without the gated field, which option 1 would let through.
- **Option 2 in its broad form (any unevaluable gate fails)** would fail gates over keys owned by *other* steps, including steps legitimately skipped by an `if:` condition. That is a large blast radius for a fix aimed at a specific, provable defect. The rule here is scoped to keys the gating step is contractually responsible for producing (`memory.write` already requires a matching `output_schema` field at validate time), so "declared but absent" is unambiguous.
- **Option 3 alone** is not enough — the reporter had the log line already. It is included as reinforcement, not as the fix.

`if:` conditions and split branches are unchanged.

## Default NOT flipped — read this if you maintain configs

`on_missing_output` stays `warn` by default. Flipping it to `fail` would fail every existing step that declares an `output:` schema for any reason (memory hand-off, comments, dashboards), not just gating ones — a broad behaviour change for every deployed config in exchange for a narrower guarantee than this fix gives.

What does change for existing configs: **a step with `reject_when` over its own `memory.write` keys now fails when the agent omits those keys.** That is the point of the fix, and it is the behaviour the issue asks for, but it is a behaviour change — such a step used to pass. Per-step opt-out: `on_missing_output: ignore`.

## Visibility

An operator has to be able to see this happened:

- New `step.gate_unevaluable` execution event (step id, gate source, unset keys) and `step.missing_output` event (effective policy, declared `memory.write`). Both land in the dashboard task detail and the events HTTP/IPC stream, not just the daemon log.
- **The `step_runs` row is now corrected.** Post-execution gates run on the scheduler goroutine *after* `runStep` already persisted the row — so a `fail_when` rejection used to leave `step_runs.state = passed` while the workflow treated the step as failed (exactly the `review | passed | NULL` row in the issue). New `db.Client.UpdateStepRunState` flips the row to `failed` and emits the usual `step.failed` event. This now applies to every post-execution gate failure: unevaluable gate, `fail_when` match, eval error, and `on_missing_output: fail`.

## Tests — proven to fail without the fix

Each was verified by disabling one piece of the fix, running, and restoring.

Experiment A — fail-closed check disabled (`internal/workflow/dag.go`):

| Test | Without fix |
|---|---|
| `TestDAG_GateUnevaluableFailsClosed` | FAIL |
| `TestDAG_GateUnevaluablePartialOutput` | FAIL |
| `TestDAG_GateUnevaluableRoutesThroughOnFail` | FAIL |
| `TestDAG_GateUnevaluableMarksStepRunFailed` | FAIL |
| `TestDAG_GateUnevaluableRecordsEvent` | FAIL |

Experiment B — `markStepRunFailed` made a no-op (fail-closed intact): `TestDAG_GateUnevaluableMarksStepRunFailed` FAIL, everything else PASS.

Experiment C — `recordStepExecutionEvent` made a no-op: `TestDAG_GateUnevaluableRecordsEvent` FAIL and `TestDAG_MissingOutputRecordsEvent` FAIL, everything else PASS.

Controls that pass both with and without the fix: `TestDAG_GateEvaluableApprovedPasses`, `TestDAG_GateEvaluableRejectedFails`, `TestDAG_GateUnevaluableIgnoreOptsOut`, `TestDAG_GateOnForeignMemoryKeyUnaffected` (documents the deliberate scope limit), `TestExpr_MemoryRefs`, plus the pre-existing `TestDAG_OnMissingOutputFail` / `TestDAG_OnMissingOutputWarnDoesNotFail`.

`TestUpdateStepRunState` (`internal/db`) covers the new store method; it is new API, so its "without the fix" state is a compile failure rather than a behavioural one.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` green. `go test -race ./...` green except `internal/worker/TestRuntimeGracefulDrainWaitsForActiveJob`, which is a **pre-existing timing flake** — confirmed by stashing this branch's changes and reproducing it on the clean tree (`-race -count=10`). Touched packages (`workflow`, `db`, `daemon`, `config`) are green under `-race`.

## Blast radius

`gitnexus impact` upstream: `Engine.runStep` HIGH (4 direct callers: `driveDAG`, `runParallelStep`, `executeForeachSequential`, `executeForeachConcurrent`) — but the change there is purely additive (`StepResult.StepRunID`). `Engine.driveDAG` and `Engine.evalExpr` LOW, no callers outside the package. `db.Client.UpdateStepRunState` and `Expr.MemoryRefs` are new symbols with no existing callers. `detect_changes`: risk low, no affected execution flows.

## Related

Third silent quality-gate failure this week, after #379 (parallel group skipped, instance still success) and #380/#375. Same guiding principle: a gate that cannot be evaluated must not read as a pass.
