### PR TITLE
fix(daemon): close the remaining silent poll→dispatch paths (#375)

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -102,6 +102,10 @@ type Dispatcher struct {
 	// once per poll interval for as long as a workflow runs. Cleared as soon as
 	// the task dispatches something again.
 	dropNotified sync.Map
+	// staleInFlightWarned holds the cell ids already reported as holding a leaked
+	// in-flight marker, so the warning is emitted once per cell rather than once
+	// per poll interval for as long as the daemon runs.
+	staleInFlightWarned sync.Map
 
 	stats  map[string]*sourceStat
 	statMu sync.RWMutex
@@ -125,6 +129,9 @@ type Dispatcher struct {
 	// unleasable, so the periodic watchdog warns once per job instead of once per
 	// tick. An id is forgotten as soon as the job becomes satisfiable again.
 	warnedUnsatisfiable sync.Map
+	// warnedStalled holds the ids of queued jobs already reported as satisfiable
+	// but unleased, so the stall warning is emitted once per job.
+	warnedStalled sync.Map
 	localWorker         *workerpkg.Runtime
 	queueWorker    queuepkg.Worker
 	queueProjectID string
@@ -826,7 +833,7 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 
 		for _, cell := range cells {
 			cell := cell
-			if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
+			if _, loaded := d.inFlight.LoadOrStore(cell.ID, time.Now()); loaded {
 				continue
 			}
 			task, persisted := d.bindItem(ctx, cell)
@@ -1476,22 +1483,36 @@ func (d *Dispatcher) pollLoop(ctx context.Context, sc config.SourceConfig, adapt
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	// The incremental watermark only advances after a poll that actually reached
+	// the source. A failed poll that advanced it anyway made every item updated
+	// inside that window invisible forever: the next poll asks for changes since a
+	// moment it never observed, so a label hand-off performed during the outage is
+	// never seen again and the task stalls until a restart's full rescan (#375).
 	var lastPoll time.Time
-	d.poll(ctx, sc, adapter, lastPoll)
-	lastPoll = time.Now()
+	if err := d.poll(ctx, sc, adapter, lastPoll); err == nil {
+		lastPoll = time.Now()
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.poll(ctx, sc, adapter, lastPoll)
-			lastPoll = time.Now()
+			started := time.Now()
+			if err := d.poll(ctx, sc, adapter, lastPoll); err == nil {
+				lastPoll = started
+			} else {
+				aplog.Warn("source %s: keeping incremental watermark at %s after a failed poll so updates in that window are not skipped", sc.ID, lastPoll.Format(time.RFC3339))
+			}
 		}
 	}
 }
 
-func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter source.Adapter, since time.Time) {
+// poll runs one source cycle: re-check parked work, fetch items changed since
+// the watermark, route each one, and dispatch what survives the pre-dispatch
+// guards. It returns the source's fetch error (nil on success) so the caller can
+// decide whether the incremental watermark may advance.
+func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter source.Adapter, since time.Time) error {
 	// Re-evaluate any workflows parked at approval steps against their live tasks
 	// on each poll cycle (resume/abort/timeout) before fetching new work.
 	d.checkApprovals(ctx)
@@ -1504,7 +1525,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	cells, err := adapter.Poll(ctx, since)
 	if err != nil {
 		aplog.Error("source %s: poll error: %v", sc.ID, err)
-		return
+		return err
 	}
 	aplog.Info("source %s: found %d cell(s)", sc.ID, len(cells))
 	d.recordPoll(sc.ID, len(cells))
@@ -1515,7 +1536,14 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 
 	for _, cell := range cells {
 		cell := cell
-		if _, loaded := d.inFlight.LoadOrStore(cell.ID, struct{}{}); loaded {
+		if since, loaded := d.inFlight.LoadOrStore(cell.ID, time.Now()); loaded {
+			// The originally-suspected cause of #375 was an in-flight marker that
+			// was never released, which permanently poisoned the cell — invisibly,
+			// because this is the only line that mentions it and it is DEBUG. The
+			// marker is legitimately held only for as long as a dispatch takes to
+			// start, so a cell still marked after inFlightStaleAfter is a defect,
+			// not a busy cell: say so once, loudly, with the age.
+			d.reportStaleInFlight(ctx, cell, since)
 			aplog.Debug("cell %s: already in-flight, skipping", cell.LogLabel())
 			continue
 		}
@@ -1559,6 +1587,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	// PR events (trigger.on: pr_*) ride the same poll cadence, after item
 	// dispatch. Capability-gated inside; a no-event config is a no-op.
 	d.pollPREvents(ctx, sc, adapter)
+	return nil
 }
 
 // fanOut dispatches every workflow matched for a polled cell. One InternalTask
@@ -1783,6 +1812,31 @@ func (d *Dispatcher) dropActiveMatches(ctx context.Context, taskID string, match
 		out = append(out, m)
 	}
 	return out, dropped
+}
+
+// inFlightStaleAfter is how long a polled cell may stay marked in-flight before
+// the marker is treated as leaked rather than busy. The marker guards only the
+// window between routing a cell and handing its dispatches off (synchronously on
+// the queue path; until the last dispatch goroutine starts otherwise), so any
+// cell still marked after this long is a bug, not a long agent run.
+const inFlightStaleAfter = 15 * time.Minute
+
+// reportStaleInFlight warns once per cell when its in-flight marker has been held
+// implausibly long. #375 was first diagnosed as exactly this leak, and the only
+// evidence would have been a DEBUG line that says nothing about how long the
+// marker has been held — so a recurrence was undiagnosable from an INFO log.
+func (d *Dispatcher) reportStaleInFlight(ctx context.Context, cell model.SourceItem, stored any) {
+	since, ok := stored.(time.Time)
+	if !ok || time.Since(since) < inFlightStaleAfter {
+		return
+	}
+	if _, warned := d.staleInFlightWarned.LoadOrStore(cell.ID, struct{}{}); warned {
+		return
+	}
+	aplog.Warn("cell %s: in-flight marker held since %s (%s) — every poll has skipped this cell since then and no workflow can be dispatched for it until the daemon restarts; please report this on issue #375 with the log around that timestamp",
+		cell.LogLabel(), since.Format(time.RFC3339), time.Since(since).Truncate(time.Second))
+	d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", WorkflowID: "",
+		Metadata: map[string]any{"reason": "stale in-flight marker", "detail": time.Since(since).Truncate(time.Second).String(), "source_item_id": cell.ID}})
 }
 
 // dropSignature is the stable identity of a "fully dropped" outcome: the set of

--- a/src/internal/daemon/poll_visibility_test.go
+++ b/src/internal/daemon/poll_visibility_test.go
@@ -1,0 +1,179 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+// flakyAdapter records the watermark of every Poll call and fails the calls whose
+// index is listed in failOn, so a test can observe what the poll loop does with
+// the incremental watermark across a failure.
+type flakyAdapter struct {
+	mu     sync.Mutex
+	since  []time.Time
+	failOn map[int]bool
+	items  []model.SourceItem
+}
+
+func (a *flakyAdapter) ID() string                                    { return "src" }
+func (a *flakyAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *flakyAdapter) Poll(_ context.Context, since time.Time) ([]model.SourceItem, error) {
+	a.mu.Lock()
+	index := len(a.since)
+	a.since = append(a.since, since)
+	a.mu.Unlock()
+	if a.failOn[index] {
+		return nil, errors.New("source unavailable")
+	}
+	return a.items, nil
+}
+func (a *flakyAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *flakyAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *flakyAdapter) watermarks() []time.Time {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]time.Time, len(a.since))
+	copy(out, a.since)
+	return out
+}
+
+func eventsWithReason(t *testing.T, dbc *db.Client, reason string) []db.ExecutionEvent {
+	t.Helper()
+	all, err := dbc.ListExecutionEvents(context.Background(), db.ExecutionEventFilter{Type: "dispatch.dropped", Limit: 500})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	var out []db.ExecutionEvent
+	for _, event := range all {
+		if got, _ := event.Metadata["reason"].(string); got == reason {
+			out = append(out, event)
+		}
+	}
+	return out
+}
+
+// Issue #375: a poll that never reached the source must not advance the
+// incremental watermark. Advancing it makes every item updated during the
+// outage window permanently invisible — the exact "watermark advanced past the
+// update" shape in the report, where the hand-off label was never seen again
+// and only a restart's full rescan recovered it.
+func TestPollLoop_FailedPollDoesNotAdvanceWatermark(t *testing.T) {
+	adapter := &flakyAdapter{failOn: map[int]bool{1: true}}
+	d, _ := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src"}}})
+	d.sources["src"] = adapter
+	sc := d.cfg.Sources[0]
+	sc.PollInterval = "40ms"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); d.pollLoop(ctx, sc, adapter) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for len(adapter.watermarks()) < 4 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	marks := adapter.watermarks()
+	if len(marks) < 4 {
+		t.Fatalf("only %d poll(s) ran, need at least 4", len(marks))
+	}
+	// marks[1] is the failed poll. The poll after it must ask for changes since
+	// no later than the failed poll's own watermark, or the window it never saw
+	// is skipped for good.
+	if marks[2].After(marks[1]) {
+		t.Fatalf("watermark advanced across a failed poll: failed poll asked since %s, next poll asked since %s", marks[1], marks[2])
+	}
+}
+
+// Issue #375's original (disproved) diagnosis was a leaked in-flight marker. If
+// it ever does leak, the only evidence was a DEBUG line with no age, so the
+// failure was undiagnosable from a normal log. A marker held implausibly long
+// must now be reported.
+func TestPoll_ReportsStaleInFlightMarker(t *testing.T) {
+	ctx := context.Background()
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), adapter)
+
+	d.inFlight.Store("c1", time.Now().Add(-2*inFlightStaleAfter))
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+
+	events := eventsWithReason(t, dbc, "stale in-flight marker")
+	if len(events) != 1 {
+		t.Fatalf("stale in-flight marker produced %d event(s), want 1 — the leak is invisible", len(events))
+	}
+
+	// Reported once, not once per poll.
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	if events := eventsWithReason(t, dbc, "stale in-flight marker"); len(events) != 1 {
+		t.Fatalf("re-poll re-reported the same stale marker: %d event(s)", len(events))
+	}
+}
+
+// Issue #375, "enqueued but never leased": a job every worker *could* run on
+// pool/labels/capabilities, that nothing has leased, is invisible — the
+// capability watchdog passes it and `apiary status` shows a healthy worker. The
+// watchdog must explain the stall with the worker counters behind it.
+func TestQueueWatchdog_ReportsSatisfiableButUnleasedJob(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "queue.db")
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, dbPath, adapter)
+
+	// Register the embedded worker without running it, then saturate it the way
+	// an orphaned lease does against the default capacity of 1.
+	if err := dbc.Queue().RegisterWorker(ctx, &d.queueWorker); err != nil {
+		t.Fatalf("register worker: %v", err)
+	}
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	job := queueJobFor(t, dbc, "triage")
+	if job.State != queue.JobQueued {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	setStaleActiveJobs(t, dbPath, d.queueWorkerID, 1)
+	backdateJob(t, dbPath, job.ID, time.Now().Add(-2*queueStallThreshold))
+
+	d.warnUnsatisfiableQueueJobs(ctx)
+	events := eventsWithReason(t, dbc, "queued but never leased")
+	if len(events) != 1 {
+		t.Fatalf("a satisfiable job queued past the stall threshold produced %d event(s), want 1", len(events))
+	}
+	if detail, _ := events[0].Metadata["detail"].(string); detail == "" {
+		t.Fatal("stall event carries no explanation of which worker is blocking it")
+	}
+
+	// Warned once per job, not once per watchdog tick.
+	d.warnUnsatisfiableQueueJobs(ctx)
+	if events := eventsWithReason(t, dbc, "queued but never leased"); len(events) != 1 {
+		t.Fatalf("watchdog re-reported the same stalled job: %d event(s)", len(events))
+	}
+}
+
+// backdateJob rewrites a queue job's created_at so a test can reach the
+// watchdog's stall threshold without waiting.
+func backdateJob(t *testing.T, dbPath, jobID string, created time.Time) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err := raw.Exec(`UPDATE dispatch_jobs SET created_at=? WHERE id=?`, created.UTC(), jobID); err != nil {
+		t.Fatalf("backdate job: %v", err)
+	}
+}

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -308,8 +308,10 @@ func (d *Dispatcher) warnUnsatisfiableQueueJobs(ctx context.Context) {
 		return
 	}
 	// The embedded worker registers asynchronously in Start; include its spec
-	// so its own jobs are never reported as unsatisfiable during startup.
-	if d.localWorker != nil {
+	// so its own jobs are never reported as unsatisfiable during startup. Once it
+	// has a registration row that row is authoritative — appending the spec too
+	// would double-count it and make the stall diagnosis contradict itself.
+	if d.localWorker != nil && !hasWorkerID(workers, d.queueWorker.ID) {
 		workers = append(workers, d.queueWorker)
 	}
 	unsatisfiable, fresh := 0, 0
@@ -326,10 +328,67 @@ func (d *Dispatcher) warnUnsatisfiableQueueJobs(ctx context.Context) {
 			continue
 		}
 		d.warnedUnsatisfiable.Delete(job.ID)
+		d.warnStalledQueueJob(ctx, job, workers)
 	}
 	if fresh > 0 {
 		aplog.Warn("%d queued job(s) cannot be leased by any registered worker — they will stay queued until a worker advertising the required pool/labels/capabilities registers", unsatisfiable)
 	}
+}
+
+// queueStallThreshold is how long a job that *is* satisfiable may sit queued
+// before the watchdog explains why nothing has leased it.
+const queueStallThreshold = 5 * time.Minute
+
+// warnStalledQueueJob reports a job that no worker refuses on pool/labels/
+// capabilities yet nobody has leased. That is the second, previously invisible
+// half of "enqueued but never leased" (#375): the capability check passes, so
+// the job looks perfectly healthy, while every compatible worker is saturated
+// (active_jobs >= capacity, e.g. an orphaned lease against the default capacity
+// of 1), unready/draining, or has stopped heartbeating. `apiary status` shows a
+// worker and the poll keeps reporting the cell, so without this line there is
+// nothing in the logs to distinguish a stalled queue from an idle one.
+//
+// Warned once per job, with the exact worker counters an operator would
+// otherwise have to read out of the database by hand.
+func (d *Dispatcher) warnStalledQueueJob(ctx context.Context, job queue.Job, workers []queue.Worker) {
+	if time.Since(job.CreatedAt) < queueStallThreshold {
+		return
+	}
+	if _, warned := d.warnedStalled.LoadOrStore(job.ID, struct{}{}); warned {
+		return
+	}
+	timeout := d.cfg.Settings.Queue.WorkerTimeoutValue()
+	var reasons []string
+	for _, w := range workers {
+		if !jobSatisfiableByAnyWorker(job, []queue.Worker{w}) {
+			continue
+		}
+		switch {
+		case w.Draining || !w.Ready:
+			reasons = append(reasons, fmt.Sprintf("%s draining/not ready", w.ID))
+		case !w.LastHeartbeat.IsZero() && time.Since(w.LastHeartbeat) > timeout:
+			reasons = append(reasons, fmt.Sprintf("%s heartbeat stale by %s", w.ID, time.Since(w.LastHeartbeat).Truncate(time.Second)))
+		case w.ActiveJobs >= w.Capacity:
+			reasons = append(reasons, fmt.Sprintf("%s at capacity (active_jobs=%d capacity=%d)", w.ID, w.ActiveJobs, w.Capacity))
+		default:
+			reasons = append(reasons, fmt.Sprintf("%s idle (active_jobs=%d capacity=%d) — a concurrency limit is the remaining explanation", w.ID, w.ActiveJobs, w.Capacity))
+		}
+	}
+	detail := strings.Join(reasons, "; ")
+	aplog.Warn("queued job %s (task %s, workflow %s) has been queued for %s and no worker has leased it: %s",
+		job.ID, job.TaskID, job.WorkflowID, time.Since(job.CreatedAt).Truncate(time.Second), detail)
+	d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: job.TaskID, WorkflowID: job.WorkflowID,
+		Metadata: map[string]any{"reason": "queued but never leased", "detail": detail, "job_id": job.ID,
+			"queued_for": time.Since(job.CreatedAt).Truncate(time.Second).String()}})
+}
+
+func hasWorkerID(workers []queue.Worker, id string) bool {
+	for _, w := range workers {
+		if w.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func jobSatisfiableByAnyWorker(job queue.Job, workers []queue.Worker) bool {

--- a/src/internal/daemon/queue_worker_handoff_test.go
+++ b/src/internal/daemon/queue_worker_handoff_test.go
@@ -1,0 +1,345 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// lockedAdapter is a poll-only source whose item labels can be swapped between
+// polls (the label hand-off an agent performs) without racing the poll loop.
+type lockedAdapter struct {
+	mu    sync.Mutex
+	items []model.SourceItem
+}
+
+func (a *lockedAdapter) ID() string                                    { return "src" }
+func (a *lockedAdapter) Connect(context.Context, map[string]any) error { return nil }
+func (a *lockedAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]model.SourceItem, len(a.items))
+	copy(out, a.items)
+	return out, nil
+}
+func (a *lockedAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *lockedAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *lockedAdapter) setLabels(labels ...string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.items[0].Labels = labels
+}
+
+// newWorkerDispatcher builds a dispatcher in queue mode with the *real* embedded
+// queue worker (default capacity 1) attached to the given database, over the two
+// label-chained workflows of the README hand-off pattern: `triage` (label
+// ai-ready) hands off to `impl` (label ai-implement). Reusing the same dbPath
+// across two calls models a daemon restart over a live database.
+func newWorkerDispatcher(t *testing.T, dbPath string, adapter *lockedAdapter) (*Dispatcher, *db.Client) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}, {ID: "b", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{
+			{ID: "triage", Trigger: &config.TriggerConfig{Match: config.RouteMatch{Labels: []string{"ai-ready"}}},
+				Steps: []config.StepConfig{{ID: "run", Agent: "a"}}},
+			{ID: "impl", Trigger: &config.TriggerConfig{Match: config.RouteMatch{Labels: []string{"ai-implement"}}},
+				Steps: []config.StepConfig{{ID: "run", Agent: "b"}}},
+		},
+	}
+	cfg.Settings.Queue.ProjectID = "proj"
+	// Fast timers so the test exercises the same code paths without waiting on
+	// production-scale intervals.
+	cfg.Settings.Queue.PollInterval = "20ms"
+	cfg.Settings.Queue.LeaseDuration = "2s"
+	cfg.Settings.Queue.HeartbeatInterval = "200ms"
+	cfg.Settings.Queue.WorkerTimeout = "5s"
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": &countingRunner{}, "agent-b": &countingRunner{}},
+		agentRunner: map[string]string{"a": "claude-cli", "b": "claude-cli"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+		configFile:  filepath.Join(filepath.Dir(dbPath), "apiary.yaml"),
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	if err := d.configureDispatchQueue(); err != nil {
+		t.Fatalf("configure dispatch queue: %v", err)
+	}
+	if d.localWorker == nil {
+		t.Fatal("expected an embedded queue worker")
+	}
+	return d, dbc
+}
+
+// runWorker starts the embedded worker and returns a stop function.
+func runWorker(t *testing.T, d *Dispatcher) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := d.localWorker.Run(ctx); err != nil {
+			t.Errorf("embedded worker: %v", err)
+		}
+	}()
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Error("embedded worker did not stop")
+		}
+	}
+}
+
+// waitForInstance polls the DB until a real (non-placeholder) instance of
+// workflowID for the item's task reaches `done`, or the deadline passes.
+func waitForInstance(t *testing.T, dbc *db.Client, itemID, workflowID string, timeout time.Duration) bool {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		binding, _ := dbc.SourceBindings().GetBindingBySourceItem(ctx, "src", itemID)
+		if binding != nil {
+			instances, _ := dbc.ListWorkflowInstancesByTask(ctx, binding.TaskID)
+			for _, instance := range instances {
+				if instance.WorkflowID == workflowID && instance.State == db.InstanceStateDone && !strings.HasPrefix(instance.ID, "queue-") {
+					return true
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// setStaleActiveJobs writes an orphaned lease count onto a worker registration,
+// modelling a hard-killed worker process whose leases were never released.
+func setStaleActiveJobs(t *testing.T, dbPath, workerID string, count int) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer func() { _ = raw.Close() }()
+	if _, err := raw.Exec(`UPDATE worker_registrations SET active_jobs=? WHERE id=?`, count, workerID); err != nil {
+		t.Fatalf("set stale active_jobs: %v", err)
+	}
+}
+
+func queueDiagnostics(t *testing.T, dbc *db.Client) string {
+	t.Helper()
+	ctx := context.Background()
+	out := ""
+	jobs, _ := dbc.Queue().ListJobs(ctx, "", 100)
+	for _, job := range jobs {
+		out += "\n  job " + job.ID + " workflow=" + job.WorkflowID + " state=" + string(job.State)
+	}
+	workers, _ := dbc.Queue().ListWorkers(ctx)
+	for _, w := range workers {
+		out += "\n  worker " + w.ID + " active_jobs=" + strconv.Itoa(w.ActiveJobs) + " capacity=" + strconv.Itoa(w.Capacity) + " ready=" + strconv.FormatBool(w.Ready) + " draining=" + strconv.FormatBool(w.Draining)
+	}
+	return out
+}
+
+// Issue #375, first hand-off, end to end through the real embedded worker: the
+// triage workflow runs, the agent swaps the labels, and the very next
+// incremental poll must enqueue AND the worker must lease and run `impl` — with
+// no daemon restart. Capacity is the production default of 1, so the hand-off
+// job can only be leased if the earlier job released its slot.
+func TestQueueWorker_FirstHandoffDispatchesWithoutRestart(t *testing.T) {
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), adapter)
+	stop := runWorker(t, d)
+	defer stop()
+
+	ctx := context.Background()
+	sc := d.cfg.Sources[0]
+	d.poll(ctx, sc, adapter, time.Time{})
+	if !waitForInstance(t, dbc, "c1", "triage", 15*time.Second) {
+		t.Fatalf("triage never completed:%s", queueDiagnostics(t, dbc))
+	}
+
+	// The triage agent hands off by swapping the labels on the source item.
+	adapter.setLabels("ai-implement")
+	// The incremental poll that observes the update.
+	d.poll(ctx, sc, adapter, time.Now())
+	if !waitForInstance(t, dbc, "c1", "impl", 15*time.Second) {
+		t.Fatalf("hand-off workflow never ran after the incremental poll that saw the label change:%s", queueDiagnostics(t, dbc))
+	}
+}
+
+// Same hand-off, but the daemon is restarted (new Dispatcher + new embedded
+// worker over the same database) between the triage run and the label swap, and
+// the pre-restart worker is killed *without* draining — leaving a stale
+// active_jobs count and a leased row behind. The hand-off must still dispatch on
+// the first poll of the new process.
+func TestQueueWorker_HandoffAfterRestartWithStaleWorkerRow(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "queue.db")
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+
+	d1, dbc1 := newWorkerDispatcher(t, dbPath, adapter)
+	stop1 := runWorker(t, d1)
+	d1.poll(ctx, d1.cfg.Sources[0], adapter, time.Time{})
+	if !waitForInstance(t, dbc1, "c1", "triage", 15*time.Second) {
+		t.Fatalf("triage never completed:%s", queueDiagnostics(t, dbc1))
+	}
+	stop1()
+
+	_ = dbc1.Close()
+	// Simulate a hard kill: the worker row keeps a stale lease count that already
+	// saturates the default capacity of 1.
+	setStaleActiveJobs(t, dbPath, d1.queueWorkerID, 1)
+
+	adapter.setLabels("ai-implement")
+	d2, dbc2 := newWorkerDispatcher(t, dbPath, adapter)
+	stop2 := runWorker(t, d2)
+	defer stop2()
+	d2.poll(ctx, d2.cfg.Sources[0], adapter, time.Now())
+	if !waitForInstance(t, dbc2, "c1", "impl", 15*time.Second) {
+		t.Fatalf("hand-off never ran after restart with a stale worker row:%s", queueDiagnostics(t, dbc2))
+	}
+}
+
+// A `queue-<jobid>` placeholder instance in state `done` — written by
+// settleRemoteQueueJob for a job whose worker keeps its own instance state —
+// must not block a later hand-off to a *different* workflow, and must not block
+// a re-dispatch of the same workflow on a first delivery.
+func TestQueueWorker_PlaceholderInstanceDoesNotBlockHandoff(t *testing.T) {
+	ctx := context.Background()
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), adapter)
+	stop := runWorker(t, d)
+	defer stop()
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	if !waitForInstance(t, dbc, "c1", "triage", 15*time.Second) {
+		t.Fatalf("triage never completed:%s", queueDiagnostics(t, dbc))
+	}
+	binding, _ := dbc.SourceBindings().GetBindingBySourceItem(ctx, "src", "c1")
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "queue-fake", WorkflowID: "impl", TaskID: binding.TaskID, SourceID: "src", State: db.InstanceStateDone}); err != nil {
+		t.Fatalf("create placeholder: %v", err)
+	}
+
+	adapter.setLabels("ai-implement")
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Now())
+	if !waitForInstance(t, dbc, "c1", "impl", 15*time.Second) {
+		t.Fatalf("hand-off never ran with a done placeholder instance present:%s", queueDiagnostics(t, dbc))
+	}
+	jobs, _ := dbc.Queue().ListJobs(ctx, queue.JobSucceeded, 100)
+	if len(jobs) == 0 {
+		t.Fatal("expected at least one succeeded job")
+	}
+}
+
+// gatedRunner blocks every run until released, so a test can hold the embedded
+// worker's single capacity slot while other work is enqueued.
+type gatedRunner struct {
+	gate chan struct{}
+	runs chan struct{}
+}
+
+func newGatedRunner() *gatedRunner {
+	return &gatedRunner{gate: make(chan struct{}), runs: make(chan struct{}, 16)}
+}
+func (r *gatedRunner) ID() string                     { return "gated" }
+func (r *gatedRunner) Configure(map[string]any) error { return nil }
+func (r *gatedRunner) Run(ctx context.Context, _ model.RunRequest) (model.RunResult, error) {
+	select {
+	case r.runs <- struct{}{}:
+	default:
+	}
+	select {
+	case <-r.gate:
+	case <-ctx.Done():
+		return model.RunResult{}, ctx.Err()
+	}
+	return model.RunResult{Success: true}, nil
+}
+func (r *gatedRunner) release() { close(r.gate) }
+
+// Issue #375: the hand-off job is enqueued while the embedded worker's single
+// capacity slot is still held by the earlier workflow. The queued job must be
+// leased as soon as the slot frees — not left queued until a restart. This is
+// the shape a slow agent produces on the production default (worker_capacity 1).
+func TestQueueWorker_HandoffEnqueuedWhileWorkerBusyRunsWhenSlotFrees(t *testing.T) {
+	ctx := context.Background()
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), adapter)
+	// A lease long enough that the held job is not reclaimed while it blocks.
+	d.cfg.Settings.Queue.LeaseDuration = "60s"
+	if err := d.configureDispatchQueue(); err != nil {
+		t.Fatalf("reconfigure queue: %v", err)
+	}
+	gated := newGatedRunner()
+	d.runners["agent-a"] = gated
+	stop := runWorker(t, d)
+	defer stop()
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	select {
+	case <-gated.runs:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("triage never started:%s", queueDiagnostics(t, dbc))
+	}
+
+	// The hand-off arrives while the worker is saturated: the incremental poll
+	// observes it and must enqueue now so it runs as soon as the slot frees.
+	adapter.setLabels("ai-ready", "ai-implement")
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Now())
+	queued, err := dbc.Queue().ListJobs(ctx, queue.JobQueued, 10)
+	if err != nil {
+		t.Fatalf("list queued: %v", err)
+	}
+	if len(queued) == 0 {
+		t.Fatalf("hand-off was not enqueued while the worker was busy:%s", queueDiagnostics(t, dbc))
+	}
+	gated.release()
+
+	if !waitForInstance(t, dbc, "c1", "impl", 20*time.Second) {
+		t.Fatalf("hand-off job never ran after the worker's slot freed:%s", queueDiagnostics(t, dbc))
+	}
+}

--- a/src/internal/db/queue_store.go
+++ b/src/internal/db/queue_store.go
@@ -414,7 +414,7 @@ func (s *QueueStore) reclaimExpired(ctx context.Context, cutoff time.Time) (int,
 	if err := rows.Close(); err != nil {
 		return 0, err
 	}
-	now := time.Now().UTC()
+	now, reclaimed := time.Now().UTC(), 0
 	for _, item := range jobs {
 		if _, err := tx.ExecContext(ctx, `UPDATE dispatch_attempts SET state='expired', finished_at=?, error_message='lease expired' WHERE id=? AND state='active'`, now, item.attemptID); err != nil {
 			return 0, err
@@ -426,17 +426,28 @@ func (s *QueueStore) reclaimExpired(ctx context.Context, cutoff time.Time) (int,
 		} else if item.attempts >= item.max {
 			state, terminal = queue.JobFailed, now
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE dispatch_jobs SET state=?, available_at=?, lease_attempt_id=NULL, lease_token=NULL, lease_worker_id=NULL, lease_expires_at=NULL, terminal_at=?, updated_at=? WHERE id=? AND state='leased' AND lease_attempt_id=?`, state, now, terminal, now, item.jobID, item.attemptID); err != nil {
+		result, err := tx.ExecContext(ctx, `UPDATE dispatch_jobs SET state=?, available_at=?, lease_attempt_id=NULL, lease_token=NULL, lease_worker_id=NULL, lease_expires_at=NULL, terminal_at=?, updated_at=? WHERE id=? AND state='leased' AND lease_attempt_id=?`, state, now, terminal, now, item.jobID, item.attemptID)
+		if err != nil {
 			return 0, err
+		}
+		// Only release the worker's slot for a lease this pass actually broke. The
+		// rows were read before this transaction took its write lock, so a Finish
+		// on another connection can land in between and settle the job itself —
+		// and Finish already decremented. Decrementing again would undercount the
+		// worker's active leases and let it claim past its capacity, which on the
+		// default capacity of 1 means two agent runs at once.
+		if affected, _ := result.RowsAffected(); affected == 0 {
+			continue
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE worker_registrations SET active_jobs=CASE WHEN active_jobs>0 THEN active_jobs-1 ELSE 0 END, updated_at=? WHERE id=?`, now, item.workerID); err != nil {
 			return 0, err
 		}
+		reclaimed++
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
-	return len(jobs), nil
+	return reclaimed, nil
 }
 
 func (s *QueueStore) GetJob(ctx context.Context, id string) (*queue.Job, error) {

--- a/src/internal/worker/worker.go
+++ b/src/internal/worker/worker.go
@@ -96,9 +96,13 @@ func (r *Runtime) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			_ = r.store.SetWorkerDrain(context.Background(), r.config.Worker.ID, true)
 			active.Wait()
-			_ = r.store.HeartbeatWorker(context.Background(), r.config.Worker.ID, false)
+			// Stop the heartbeat loop *before* marking the worker unready: it
+			// writes ready=true on every tick, so a tick landing after the final
+			// heartbeat would resurrect a drained worker as ready — leaving a row
+			// that Claim accepts but no process is listening on.
 			stopHeartbeat()
 			heartbeatWG.Wait()
+			_ = r.store.HeartbeatWorker(context.Background(), r.config.Worker.ID, false)
 			return nil
 		case <-poll.C:
 			if _, err := r.store.ReclaimExpired(ctx, time.Now().UTC()); err != nil {


### PR DESCRIPTION
Refs #375. **#375 must stay open** — this PR does not explain the reporter's runs 1 and 2.

## What this is

A prove-or-disprove pass over every path from "an incremental poll observed the cell" to "no workflow instance exists", after #386 (queue re-dispatch) and #389 (dropped-dispatch visibility). The goal was to reproduce the first hand-off failing silently. It did not reproduce; what the enumeration turned up instead is three real defects and two diagnostics.

## Exhaustive path list (post-#389)

Every point in `Dispatcher.poll` where a polled cell yields no instance:

| # | Path | file:line | Visible? |
|---|------|-----------|----------|
| 1 | Cell already in-flight | `dispatcher.go:1532` | DEBUG only → **now WARN + event once the marker is implausibly old** |
| 2 | Bind failure | `dispatcher.go:1697` | ERROR; falls back to a transient task and still dispatches |
| 3 | `RouteAll` returned nothing | `dispatcher.go:1571` | DEBUG (normal) |
| 3b | Trigger matched but route unresolvable | `router.go:198` | **Unreachable** — `firstAgentStep` (`router.go:103`) falls back to the workflow id, so a workflow route always resolves |
| 4 | Every match dropped by a guard | `dispatcher.go:1579` → `reportFullyDropped` | INFO + `dispatch.dropped` per workflow (#389) |
| 4b | An *exclusive* match is dropped | `router.go:161` | The drop is reported, but the lower-priority routes it suppressed are not evaluated at all — behaviour left unchanged deliberately |
| 5a-d | enqueue: increment/generation/marshal/enqueue errors | `queue_dispatch.go:88-108` | ERROR |
| 5e | Idempotency key held by a **terminal** job | `queue_dispatch.go:117` | WARN + event (#389) |
| 5f | Key held by a **pending** job | `queue_dispatch.go:122` | DEBUG — correct de-duplication |
| 5g-i | Queued, never leased: pool/label/capability mismatch | `queue_dispatch.go:323` | WARN + event, on a timer (#389) |
| 5g-ii | Queued, never leased: **worker saturated / unready / heartbeat stale / concurrency limit** | — | **Was completely silent → now WARN + event after 5 min, naming each worker's counters** |
| 5g-iii | Worker unhealthy | `worker.go:116` | ERROR per claim tick |
| 5g-iv | Worker draining | `worker.go:112` | silent in the worker loop, now covered from the daemon side by 5g-ii |
| 6 | Job leased, dispatcher declines (redelivery / `once`) | `queue_dispatch.go:187` | INFO + event + attempt note (#389) |
| 7 | **Poll error advances the watermark** | `dispatcher.go:1479` | the error was logged, the *lost updates* were not — **fixed** |

## Reproduction attempts (all pass on unmodified main — no bug found)

`internal/daemon/queue_worker_handoff_test.go` drives the **real embedded worker** (`worker.Runtime`, default capacity 1) over a real SQLite queue, for the triage→impl label hand-off:

- next incremental poll after the hand-off dispatches, no restart;
- hand-off across a daemon restart with a stale `active_jobs=1` row left by a hard kill;
- hand-off enqueued while the single capacity slot is held by a blocked agent, must run when it frees;
- a `queue-<jobid>` placeholder instance in state `done` present for the target workflow.

None reproduces a silent no-dispatch.

## Real defects fixed

1. **The incremental watermark advanced across a failed poll** (`pollLoop`). Anything updated in that window is invisible for good — precisely the "watermark advanced past the update" step in the report. It now only advances after a poll that reached the source, and it advances to when the poll *started*, so an update landing mid-poll is still seen next tick. Re-observation is already the designed behaviour for a still-matching trigger, so this adds no duplicate-dispatch surface.
2. **`ReclaimExpired` double-released a capacity slot** (`queue_store.go`). The expired rows are read before the transaction takes its write lock, so a concurrent `Finish` can settle the job in between — and `Finish` already decremented. The decrement is now conditional on the lease this pass actually broke. Undercounting `active_jobs` lets a capacity-1 worker run two agents at once.
3. **Graceful drain could resurrect a drained worker as ready** (`worker.go`): the ready=false write happened before the heartbeat loop was stopped, and the loop writes ready=true every tick.

## Diagnostics added

- Stale in-flight marker: WARN once with the age + a `dispatch.dropped` event. The disproved original diagnosis of #375 would have produced no evidence at all above DEBUG.
- Queue stall watchdog: a job that *is* satisfiable but unleased for 5 minutes is reported once with each compatible worker's `active_jobs`/`capacity`/`ready`/heartbeat age.

## Fails-without-fix evidence

Each regression test was checked by reverting only its fix:

- `TestPollLoop_FailedPollDoesNotAdvanceWatermark` → *"watermark advanced across a failed poll"*
- `TestPoll_ReportsStaleInFlightMarker` → *"stale in-flight marker produced 0 event(s), want 1"*
- `TestQueueWatchdog_ReportsSatisfiableButUnleasedJob` → *"produced 0 event(s), want 1"*

## Verification

`go test ./...` and `go test -race ./...` pass repo-wide (`internal/daemon` also at `-count=3` under `-race`). Scope is `internal/daemon` / `internal/db` / `internal/worker` only — `internal/workflow` and `internal/config` untouched (#390).
