### PR TITLE
fix(router): make an exclusive claim that is later dropped visible (#380)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -81,6 +81,25 @@ that:
   runs are not blocked; they stay eligible for retry up to
   `settings.max_attempts`.
 
+An exclusive claim is **not** re-evaluated if the exclusive workflow is
+afterwards held back before dispatch — because it already has a live instance,
+because it is a spent `once` route, or because it hit the consecutive-failure
+cap. The task simply runs nothing that cycle: falling through to the triggers
+the exclusive one suppressed would start exactly the work it exists to prevent,
+alongside a run that may still be active. The daemon reports the situation at
+`INFO` and names the suppressed workflows, e.g.:
+
+```text
+cell ISSUE-9 ("Ship it"): task 019f… matched 1 workflow(s) but every one was
+dropped before dispatch — decompose (once: already completed); exclusive
+workflow decompose had already suppressed 1 lower-priority match(es) (review),
+which are not reconsidered; nothing will run for this task until the reason clears
+```
+
+If you want the lower-priority workflow to take over in that state, make the
+handover explicit — narrow the exclusive trigger's `match` so it stops matching
+once its work is done (e.g. on a label the workflow itself sets).
+
 ### PR event triggers (`on:`)
 
 By default a trigger matches **work items** (issues/tickets polled from a

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -138,6 +138,11 @@ type TriggerConfig struct {
 	// Exclusive, when true, stops trigger evaluation after this trigger matches:
 	// no lower-priority trigger is considered. Use it for a terminal classifier or
 	// catch-all that must own a task alone rather than fan out alongside others.
+	//
+	// The claim holds even when a pre-dispatch guard later drops this workflow
+	// (live instance, spent `once`, failure cap): the suppressed triggers are not
+	// reconsidered, since running them then would duplicate the work this trigger
+	// exists to own. The daemon names them in its fully-dropped INFO report.
 	Exclusive bool `yaml:"exclusive"`
 	// Once, when true, makes the workflow run at most once per task: once it has a
 	// completed (done) instance for the task, later polls do not re-dispatch it even

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1549,7 +1549,19 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 		}
 		task, persisted := d.bindItem(ctx, cell)
 		d.recordRouteEvents(ctx, task)
-		matches := d.router.RouteAll(task)
+		matches, suppressedMatches := d.router.RouteAllWithSuppressed(task)
+		// An exclusive trigger stops routing at itself, so the routes below it were
+		// never considered. If a guard now removes that winner the task is left with
+		// nothing, and the suppressed routes are not reconsidered — deliberately, as
+		// falling through would duplicate the run the guard is protecting. Carry them
+		// so the fully-dropped report can name what the exclusive claim cost.
+		suppressed := suppressedRoutes{}
+		if len(suppressedMatches) > 0 && len(matches) > 0 {
+			suppressed.ExclusiveWorkflowID = matches[len(matches)-1].Route.ID
+			for _, m := range suppressedMatches {
+				suppressed.WorkflowIDs = append(suppressed.WorkflowIDs, m.Route.ID)
+			}
+		}
 		// Source-agnostic in-flight guard: drop any matched workflow that already
 		// has a non-terminal instance for this task, so a re-poll does not dispatch
 		// a duplicate while it runs or waits at an approval step. Replaces the
@@ -1575,7 +1587,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 				// nothing will run for this cell, and until #380 that was entirely
 				// silent. Report it (once per distinct reason set) so a wedged task
 				// is distinguishable from an idle one.
-				d.reportFullyDropped(ctx, cell, task, dropped)
+				d.reportFullyDropped(ctx, cell, task, dropped, suppressed)
 			}
 			d.inFlight.Delete(cell.ID)
 			continue
@@ -1839,13 +1851,30 @@ func (d *Dispatcher) reportStaleInFlight(ctx context.Context, cell model.SourceI
 		Metadata: map[string]any{"reason": "stale in-flight marker", "detail": time.Since(since).Truncate(time.Second).String(), "source_item_id": cell.ID}})
 }
 
+// suppressedRoutes names the lower-priority workflows an exclusive trigger stopped
+// the router from considering, and the exclusive workflow that did it. It is empty
+// unless an exclusive route matched. The dispatcher never dispatches these: see
+// router.RouteAllWithSuppressed for why re-routing to them would duplicate work.
+// It carries them only so a fully-dropped report can say what the exclusive claim
+// suppressed — otherwise a task whose exclusive winner is dropped by a guard looks
+// like a task with no viable workflow at all.
+type suppressedRoutes struct {
+	ExclusiveWorkflowID string
+	WorkflowIDs         []string
+}
+
 // dropSignature is the stable identity of a "fully dropped" outcome: the set of
-// (workflow, reason) pairs, order-independent. Two consecutive polls that drop
-// the same workflows for the same reasons share a signature and are reported once.
-func dropSignature(dropped []droppedMatch) string {
-	parts := make([]string, 0, len(dropped))
+// (workflow, reason) pairs plus any suppressed routes, order-independent. Two
+// consecutive polls that drop the same workflows for the same reasons share a
+// signature and are reported once; a config change that adds or removes a
+// suppressed fallback changes it, so the new picture is reported.
+func dropSignature(dropped []droppedMatch, suppressed suppressedRoutes) string {
+	parts := make([]string, 0, len(dropped)+len(suppressed.WorkflowIDs))
 	for _, drop := range dropped {
 		parts = append(parts, drop.WorkflowID+"="+drop.Reason)
+	}
+	for _, id := range suppressed.WorkflowIDs {
+		parts = append(parts, id+"=suppressed")
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ",")
@@ -1863,8 +1892,14 @@ func dropSignature(dropped []droppedMatch) string {
 // per task. Repeats are suppressed while the reason set is unchanged: an
 // "active instance" drop is the normal state of a task whose workflow is still
 // running, and re-logging it every poll interval would bury the signal.
-func (d *Dispatcher) reportFullyDropped(ctx context.Context, cell model.SourceItem, task model.InternalTask, dropped []droppedMatch) {
-	signature := dropSignature(dropped)
+//
+// When the dropped set includes an exclusive winner, the line also names the
+// lower-priority workflows that winner stopped the router from considering. Those
+// are NOT re-routed to (that would duplicate the run the guard is protecting), so
+// without naming them the operator sees "nothing will run" with no hint that a
+// viable fallback exists one priority down.
+func (d *Dispatcher) reportFullyDropped(ctx context.Context, cell model.SourceItem, task model.InternalTask, dropped []droppedMatch, suppressed suppressedRoutes) {
+	signature := dropSignature(dropped, suppressed)
 	if previous, seen := d.dropNotified.Load(task.ID); seen && previous == signature {
 		return
 	}
@@ -1874,12 +1909,21 @@ func (d *Dispatcher) reportFullyDropped(ctx context.Context, cell model.SourceIt
 	for _, drop := range dropped {
 		reasons = append(reasons, drop.String())
 	}
-	aplog.Info("cell %s (%q): task %s matched %d workflow(s) but every one was dropped before dispatch — %s; nothing will run for this task until the reason clears",
-		cell.LogLabel(), cell.Title, task.ID, len(dropped), strings.Join(reasons, ", "))
+	suppressedNote := ""
+	if len(suppressed.WorkflowIDs) > 0 {
+		suppressedNote = fmt.Sprintf("; exclusive workflow %s had already suppressed %d lower-priority match(es) (%s), which are not reconsidered",
+			suppressed.ExclusiveWorkflowID, len(suppressed.WorkflowIDs), strings.Join(suppressed.WorkflowIDs, ", "))
+	}
+	aplog.Info("cell %s (%q): task %s matched %d workflow(s) but every one was dropped before dispatch — %s%s; nothing will run for this task until the reason clears",
+		cell.LogLabel(), cell.Title, task.ID, len(dropped), strings.Join(reasons, ", "), suppressedNote)
 
 	for _, drop := range dropped {
+		metadata := map[string]any{"reason": drop.Reason, "detail": drop.Detail, "source_item_id": cell.ID}
+		if drop.WorkflowID == suppressed.ExclusiveWorkflowID && len(suppressed.WorkflowIDs) > 0 {
+			metadata["suppressed"] = strings.Join(suppressed.WorkflowIDs, ",")
+		}
 		d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: task.ID, WorkflowID: drop.WorkflowID,
-			Metadata: map[string]any{"reason": drop.Reason, "detail": drop.Detail, "source_item_id": cell.ID}})
+			Metadata: metadata})
 	}
 }
 

--- a/src/internal/daemon/dropped_dispatch_test.go
+++ b/src/internal/daemon/dropped_dispatch_test.go
@@ -75,7 +75,7 @@ func TestReportFullyDroppedIsVisible(t *testing.T) {
 
 	cell := model.SourceItem{ID: "295651", SourceID: "rl-jira", Title: "PSP-199"}
 	task := model.InternalTask{ID: "T1"}
-	d.reportFullyDropped(ctx, cell, task, dropped)
+	d.reportFullyDropped(ctx, cell, task, dropped, suppressedRoutes{})
 
 	var info string
 	for _, line := range logs() {
@@ -119,9 +119,9 @@ func TestReportFullyDroppedSuppressesUnchangedRepeats(t *testing.T) {
 	task := model.InternalTask{ID: "T1"}
 
 	active := []droppedMatch{{WorkflowID: "jira-implement", Reason: "active instance"}}
-	d.reportFullyDropped(ctx, cell, task, active)
-	d.reportFullyDropped(ctx, cell, task, active)
-	d.reportFullyDropped(ctx, cell, task, active)
+	d.reportFullyDropped(ctx, cell, task, active, suppressedRoutes{})
+	d.reportFullyDropped(ctx, cell, task, active, suppressedRoutes{})
+	d.reportFullyDropped(ctx, cell, task, active, suppressedRoutes{})
 
 	count := func() int {
 		n := 0
@@ -137,14 +137,14 @@ func TestReportFullyDroppedSuppressesUnchangedRepeats(t *testing.T) {
 	}
 
 	// A different reason is new information and must be reported.
-	d.reportFullyDropped(ctx, cell, task, []droppedMatch{{WorkflowID: "jira-implement", Reason: "capped"}})
+	d.reportFullyDropped(ctx, cell, task, []droppedMatch{{WorkflowID: "jira-implement", Reason: "capped"}}, suppressedRoutes{})
 	if got := count(); got != 2 {
 		t.Fatalf("a changed reason must be reported again, got %d lines", got)
 	}
 
 	// After a successful dispatch clears the marker, the same reason is news again.
 	d.dropNotified.Delete("T1")
-	d.reportFullyDropped(ctx, cell, task, active)
+	d.reportFullyDropped(ctx, cell, task, active, suppressedRoutes{})
 	if got := count(); got != 3 {
 		t.Fatalf("a re-wedge after a dispatch must be reported, got %d lines", got)
 	}

--- a/src/internal/daemon/exclusive_suppression_test.go
+++ b/src/internal/daemon/exclusive_suppression_test.go
@@ -1,0 +1,177 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// exclusiveSuppressionFixture builds a dispatcher over two workflows that both
+// match the same item: `decompose` is exclusive AND `once: true`, so it claims the
+// task alone; `review` sits one priority below it and never gets evaluated while
+// the exclusive one matches.
+//
+// The task already has a completed `decompose` instance, which is exactly the
+// state where the gap shows: RouteAll returns [decompose], dropOnceMatches removes
+// it, and the poll ends with zero matches even though `review` matched.
+func exclusiveSuppressionFixture(t *testing.T) (*Dispatcher, *db.Client, *recordingAdapter, config.SourceConfig, string) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "exclusive.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	item := model.SourceItem{ID: "ISSUE-9", SourceID: "src", Number: "#9", Title: "Ship it", State: "todo"}
+	adapter := &recordingAdapter{items: []model.SourceItem{item}}
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{
+			{ID: "decompose",
+				Trigger: &config.TriggerConfig{Priority: 10, Exclusive: true, Once: true, Match: config.RouteMatch{Source: "src"}},
+				Steps:   []config.StepConfig{{ID: "split", Agent: "a"}}},
+			{ID: "review",
+				Trigger: &config.TriggerConfig{Priority: 20, Match: config.RouteMatch{Source: "src"}},
+				Steps:   []config.StepConfig{{ID: "look", Agent: "a"}}},
+		},
+	}
+	rt, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      rt,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": &stepRecordingRunner{}},
+		agentRunner: map[string]string{"a": "claude"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+
+	// Bind the item exactly as a poll would, then record the spent `once` run so
+	// the guard has something to drop on the next poll.
+	task, err := d.binder.Bind(ctx, item)
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "i-done", WorkflowID: "decompose", CellID: item.ID, SourceID: "src",
+		TaskID: task.ID, State: db.InstanceStateDone,
+	}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	return d, dbc, adapter, cfg.Sources[0], task.ID
+}
+
+// An exclusive trigger that a pre-dispatch guard later removes leaves the task
+// with nothing to run, and the routes it suppressed are deliberately NOT
+// reconsidered — re-routing to them would start work the exclusive trigger exists
+// to prevent. The INFO report must therefore name them, so the operator can see
+// that a lower-priority workflow matched and was suppressed rather than reading
+// "nothing will run" as "nothing matched".
+func TestPoll_ExclusiveWinnerDroppedNamesSuppressedRoutes(t *testing.T) {
+	logs := captureLogs(t)
+	d, dbc, adapter, sc, taskID := exclusiveSuppressionFixture(t)
+	ctx := context.Background()
+
+	if err := d.poll(ctx, sc, adapter, time.Time{}); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	var info string
+	for _, line := range logs() {
+		if strings.HasPrefix(line, "INFO ") && strings.Contains(line, "dropped before dispatch") {
+			info = line
+		}
+	}
+	if info == "" {
+		t.Fatalf("a fully-dropped dispatch must log at INFO; got %v", logs())
+	}
+	for _, want := range []string{"decompose", "once", "review", "suppressed"} {
+		if !strings.Contains(info, want) {
+			t.Errorf("INFO line must mention %q so the suppression is visible; got %q", want, info)
+		}
+	}
+
+	// The diagnostic must not become a behaviour change: nothing may be dispatched
+	// for the suppressed route.
+	instances, err := dbc.ListWorkflowInstancesByTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	for i := range instances {
+		if instances[i].WorkflowID != "decompose" {
+			t.Fatalf("suppressed route %q was dispatched; the exclusive claim must still hold", instances[i].WorkflowID)
+		}
+	}
+
+	// The same fact is queryable per task: the exclusive workflow's drop event
+	// carries the routes it suppressed.
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: taskID, Type: "dispatch.dropped"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 dispatch.dropped event, got %d", len(events))
+	}
+	if got, _ := events[0].Metadata["suppressed"].(string); got != "review" {
+		t.Errorf("dispatch.dropped metadata must name the suppressed routes, got %q", got)
+	}
+}
+
+// Without an exclusive winner the report is unchanged: no suppression note, no
+// suppression metadata. Guards against the diagnostic leaking into ordinary drops.
+func TestReportFullyDropped_NoSuppressionNoteWithoutExclusive(t *testing.T) {
+	logs := captureLogs(t)
+	ctx := context.Background()
+	dbc := openDropTestDB(t, "no-suppression.db")
+	d := &Dispatcher{db: dbc}
+
+	d.reportFullyDropped(ctx, model.SourceItem{ID: "ISSUE-9", SourceID: "src"}, model.InternalTask{ID: "T1"},
+		[]droppedMatch{{WorkflowID: "impl", Reason: "active instance"}}, suppressedRoutes{})
+
+	for _, line := range logs() {
+		if strings.Contains(line, "dropped before dispatch") && strings.Contains(line, "suppressed") {
+			t.Fatalf("no exclusive route matched, so nothing was suppressed; got %q", line)
+		}
+	}
+	events, err := dbc.ListExecutionEvents(ctx, db.ExecutionEventFilter{TaskID: "T1", Type: "dispatch.dropped"})
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 dispatch.dropped event, got %d", len(events))
+	}
+	if _, ok := events[0].Metadata["suppressed"]; ok {
+		t.Errorf("suppressed metadata must be absent when nothing was suppressed: %+v", events[0].Metadata)
+	}
+}
+
+// The repeat-suppression signature must account for the suppressed set: a config
+// change that adds a fallback below the exclusive route changes the picture the
+// operator needs, so it has to be reported rather than swallowed as a repeat.
+func TestDropSignature_ChangesWithSuppressedRoutes(t *testing.T) {
+	dropped := []droppedMatch{{WorkflowID: "decompose", Reason: "once"}}
+	bare := dropSignature(dropped, suppressedRoutes{})
+	with := dropSignature(dropped, suppressedRoutes{ExclusiveWorkflowID: "decompose", WorkflowIDs: []string{"review"}})
+	if bare == with {
+		t.Fatalf("signature must distinguish a suppressed fallback from none, both %q", bare)
+	}
+}

--- a/src/internal/router/routeall_test.go
+++ b/src/internal/router/routeall_test.go
@@ -1,6 +1,7 @@
 package router_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/config"
@@ -142,5 +143,84 @@ func TestRouteAll_PartialMatchFiltersByConditions(t *testing.T) {
 	}
 	if got := ids(r.RouteAll(task(withLabels("ai-ready")))); len(got) != 2 {
 		t.Fatalf("expected both routes with the label, got %v", got)
+	}
+}
+
+// RouteAllWithSuppressed reports the routes an exclusive winner stopped the
+// router from considering — and only the ones that would themselves have run.
+// This is what lets the dispatcher explain a task whose exclusive match is later
+// removed by a pre-dispatch guard: without it, "no workflow will run" hides the
+// fact that a lower-priority workflow matched and was suppressed.
+func TestRouteAllWithSuppressed_NamesRoutesBelowTheExclusiveWinner(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		exclusiveRoute("classify", 10, "investigator", config.RouteMatch{Source: "src-a"}),
+		agentRoute("review", 20, "reviewer", config.RouteMatch{Source: "src-a"}),
+		// Would not have matched anyway: it must not be reported as suppressed.
+		agentRoute("labelled", 30, "b", config.RouteMatch{Source: "src-a", Labels: []string{"ai-ready"}}),
+		agentRoute("docs", 40, "scribe", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches, suppressed := r.RouteAllWithSuppressed(task())
+	if got := ids(matches); len(got) != 1 || got[0] != "classify" {
+		t.Fatalf("expected only the exclusive winner to be dispatchable, got %v", got)
+	}
+	if got := ids(suppressed); len(got) != 2 || got[0] != "review" || got[1] != "docs" {
+		t.Fatalf("expected [review docs] suppressed (in priority order, excluding non-matching), got %v", got)
+	}
+
+	// The suppressed set is diagnostic only: RouteAll must keep returning exactly
+	// the dispatchable matches, or the exclusive claim would fan out after all.
+	if got := ids(r.RouteAll(task())); len(got) != 1 || got[0] != "classify" {
+		t.Fatalf("RouteAll must not dispatch suppressed routes, got %v", got)
+	}
+}
+
+// Without an exclusive match nothing is suppressed, whether or not routes match.
+func TestRouteAllWithSuppressed_NoExclusiveNoSuppression(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		agentRoute("review", 10, "reviewer", config.RouteMatch{Source: "src-a"}),
+		agentRoute("docs", 20, "scribe", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matches, suppressed := r.RouteAllWithSuppressed(task())
+	if len(matches) != 2 {
+		t.Fatalf("expected both routes to fan out, got %v", ids(matches))
+	}
+	if suppressed != nil {
+		t.Fatalf("expected no suppression without an exclusive route, got %v", ids(suppressed))
+	}
+}
+
+// ExplainTask keeps reporting the routes below an exclusive winner instead of
+// stopping at it, so the per-route execution events (route.rejected) exist for
+// them and name the route that claimed the task.
+func TestExplainTask_ReportsSuppressedRoutesBelowExclusive(t *testing.T) {
+	r, err := router.New(cfg([]config.RouteConfig{
+		exclusiveRoute("classify", 10, "investigator", config.RouteMatch{Source: "src-a"}),
+		agentRoute("review", 20, "reviewer", config.RouteMatch{Source: "src-a"}),
+	}, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	traces := r.ExplainTask(task())
+	if len(traces) != 2 {
+		t.Fatalf("expected a trace for every route, got %d: %+v", len(traces), traces)
+	}
+	if !traces[0].Selected || traces[0].RouteID != "classify" {
+		t.Fatalf("expected classify to win, got %+v", traces[0])
+	}
+	below := traces[1]
+	if below.RouteID != "review" || below.Selected {
+		t.Fatalf("a route below an exclusive winner must be traced but not selected, got %+v", below)
+	}
+	if !strings.Contains(below.Reason, "classify") || !strings.Contains(below.Reason, "suppressed") {
+		t.Fatalf("the reason must name the exclusive route that suppressed it, got %q", below.Reason)
 	}
 }

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -143,8 +143,28 @@ func (r *Router) Route(item model.SourceItem) (Match, bool) {
 // attributes (labels, state, source, type, priority) are kept live by the
 // SourceBinder on each poll, so RouteAll observes the same data Route would.
 func (r *Router) RouteAll(task model.InternalTask) []Match {
+	matches, _ := r.RouteAllWithSuppressed(task)
+	return matches
+}
+
+// RouteAllWithSuppressed returns RouteAll's fan-out together with the lower-priority
+// routes an exclusive winner claimed the task away from — restricted to those that
+// would themselves have matched and resolved, i.e. exactly the workflows that would
+// have run had the exclusive trigger not been there. It is nil whenever no exclusive
+// route matched, and evaluating it costs nothing extra in that case (RouteAll already
+// scans every route when it does not break early).
+//
+// The suppressed set is DIAGNOSTIC ONLY and must never be dispatched. A pre-dispatch
+// guard may later remove the exclusive winner — it already has a live instance, it is
+// a spent `once` route, it hit the consecutive-failure cap — which leaves the task
+// with zero matches even though these routes matched. Falling through to them there
+// would run work the exclusive trigger exists to prevent: alongside the instance that
+// is still active, or on every poll forever once the winner is permanently spent.
+// The dispatcher names them in its fully-dropped report instead, so the operator can
+// see the suppression and decide.
+func (r *Router) RouteAllWithSuppressed(task model.InternalTask) (matches, suppressed []Match) {
 	t := targetFromTask(task)
-	var matches []Match
+	claimed := false
 	for _, route := range r.routes {
 		if route.IsEventRoute() {
 			continue
@@ -157,19 +177,26 @@ func (r *Router) RouteAll(task model.InternalTask) []Match {
 		if !ok {
 			continue
 		}
+		if claimed {
+			suppressed = append(suppressed, m)
+			continue
+		}
 		matches = append(matches, m)
 		if route.Exclusive {
-			break
+			claimed = true
 		}
 	}
-	return matches
+	return matches, suppressed
 }
 
 // ExplainTask returns the same fan-out decision as RouteAll together with a
-// stable reason for every route evaluated before an exclusive match.
+// stable reason for every route. Routes below an exclusive winner are reported
+// too — not selected, but with a reason naming the route that claimed the task,
+// so a trigger that silently lost to an exclusive one is still visible.
 func (r *Router) ExplainTask(task model.InternalTask) []RouteTrace {
 	t := targetFromTask(task)
 	traces := make([]RouteTrace, 0, len(r.routes))
+	claimedBy := ""
 	for _, route := range r.routes {
 		if route.IsEventRoute() {
 			continue
@@ -182,10 +209,16 @@ func (r *Router) ExplainTask(task model.InternalTask) []RouteTrace {
 				reason = "matched conditions but route has no resolvable agent or worker"
 			}
 		}
+		if claimedBy != "" {
+			if selected {
+				reason = fmt.Sprintf("suppressed: exclusive route %q claimed this task", claimedBy)
+			}
+			selected = false
+		}
 		traces = append(traces, RouteTrace{RouteID: route.ID, Priority: route.Priority, Agent: route.Agent,
 			Worker: route.Worker, Matched: matched, Selected: selected, Reason: reason})
 		if selected && route.Exclusive {
-			break
+			claimedBy = route.ID
 		}
 	}
 	return traces


### PR DESCRIPTION
## Problem

`Router.RouteAll` stops evaluating routes after the first match whose trigger declares `exclusive: true`. `Dispatcher.poll` then runs the pre-dispatch guards (`dropAutoResumingMatches` / `dropActiveMatches` / `dropOnceMatches` / `dropCappedMatches`) over that result.

If a guard removes the exclusive winner, the triggers it suppressed were never evaluated at all — the task ends with zero matches even though a lower-priority workflow legitimately matched. Since #389 the drop itself is reported at INFO, but not the fact that other routes were suppressed by a winner that then went away, so the operator reads "nothing will run" as "nothing matched".

## Decision: diagnostic, not re-routing

Falling through to the suppressed routes is wrong for every guard:

| guard | falling through would… |
|---|---|
| `dropActiveMatches` / `dropAutoResumingMatches` | run a second workflow **alongside** the exclusive instance that is still live |
| `dropOnceMatches` | re-dispatch the fallback on **every poll forever** — the winner is permanently spent, so nothing ever reclaims the task |
| `dropCappedMatches` | silently promote a fallback as failure policy, which is not what `exclusive` means |
| guard error | fail **open** where the guard deliberately fails closed |

So the claim is kept and the suppression is reported.

## Changes

- `router.RouteAllWithSuppressed(task) (matches, suppressed []Match)` — the dispatchable fan-out plus the routes the exclusive winner stopped evaluation before, restricted to those that would themselves have matched and resolved. `RouteAll` delegates to it, so the dispatchable set is byte-identical; the extra scan only happens after an exclusive match (`RouteAll` already scanned every route otherwise).
- `ExplainTask` no longer stops at the exclusive winner — routes below it are traced (`Selected: false`) with a reason naming the route that claimed the task, so `route.rejected` execution events exist for them instead of nothing.
- `reportFullyDropped` names the suppressed workflows in its INFO line and puts them in the exclusive workflow's `dispatch.dropped` event metadata (`suppressed`). `dropSignature` accounts for them, so adding a fallback below an exclusive trigger is reported rather than swallowed as a repeat.
- `docs/workflows.md` documents the interaction and the explicit-handover alternative (narrow the exclusive trigger's `match` so it stops matching once its work is done).

New INFO line:

```text
cell ISSUE-9 ("Ship it"): task 019f… matched 1 workflow(s) but every one was dropped
before dispatch — decompose (once: already completed); exclusive workflow decompose
had already suppressed 1 lower-priority match(es) (review), which are not
reconsidered; nothing will run for this task until the reason clears
```

## Tests

- `TestPoll_ExclusiveWinnerDroppedNamesSuppressedRoutes` — end-to-end at the poll level (exclusive + `once` winner already completed, `review` one priority below): asserts the INFO line names the suppressed route, that **no instance is created for it** (the diagnostic must not become a behaviour change), and that the event metadata carries it. Verified it fails without the change.
- `TestRouteAllWithSuppressed_NamesRoutesBelowTheExclusiveWinner` — only routes that would themselves have matched are reported; `RouteAll` still dispatches only the winner.
- `TestRouteAllWithSuppressed_NoExclusiveNoSuppression`, `TestReportFullyDropped_NoSuppressionNoteWithoutExclusive`, `TestDropSignature_ChangesWithSuppressedRoutes`, `TestExplainTask_ReportsSuppressedRoutesBelowExclusive`.

`go test -race ./...` passes clean.