### PR TITLE
fix(restart): dispatch immediately and accept the item reference

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -152,13 +152,43 @@ apiary dispatch --cell <source-id>/<task-id> --worker <worker-id>
 
 ### `apiary restart`
 
-Force-restart a stale task: cancel its running dispatch, interrupt its
-non-terminal instances, and reset it for re-dispatch on the next cycle. Same
+Force-restart a stale task: cancel its running dispatch, cancel its queued jobs,
+interrupt its non-terminal instances, strip its control labels — then re-route the
+item and dispatch it **immediately**, without waiting for the next poll. Same
 action as `R` in the dashboard.
 
 ```sh
-apiary restart <task-id>
+apiary restart CDT-123     # Jira key
+apiary restart '#1953'     # GitHub issue number (quote it — # starts a comment)
+apiary restart 1953        # the cell id also works
 ```
+
+The argument is the item's **human reference** (a Jira key, a GitHub issue number)
+or its **cell id** (the raw source item id). The reference is usually what you
+want: on Jira the cell id is the opaque numeric issue id, which appears in no
+interface — the key is the only thing you can see.
+
+Matching ignores case and a leading `#`. An exact cell id always wins over a
+number. A reference that matches items in **two different sources** is rejected
+rather than guessed at, and names both candidates so you can restart the cell id
+directly. An argument that resolves to nothing fails and touches nothing; if it is
+an internal task id, the error names the item to use instead.
+
+Restart overrides the `once` and failure-cap (`settings.max_attempts`) guards,
+since a task wedged behind either is what restart exists for; any override is
+printed. It does not override the in-flight guard, so a live workflow is never run
+twice. The command reports what it dispatched:
+
+```
+✓ Restarted CDT-123 (10042) (control labels cleared)
+  ! overrode guard: implement (failure cap)
+  → dispatched 1 workflow(s): implement
+```
+
+The item is echoed as `reference (cell id)` when the two differ, so it is always
+clear which item was acted on. `dispatched 0` means the cleanup ran but no
+workflow matches the item in its current state — usually a label the triggers
+don't match.
 
 ### `apiary delete`
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -160,9 +160,25 @@ the step selection or scroll position.
 
 Pressing **`R`** (Shift+R) on a selected task shows a centered confirmation
 modal with a rounded border. Press `y` / `Y` to confirm or any other key to
-cancel. This sends a restart request to the daemon via Unix socket —
-the task's running dispatch is cancelled and its state is reset to `todo` for
-re-dispatch on the next cycle.
+cancel. This sends a restart request to the daemon via Unix socket: the task's
+running dispatch and queued jobs are cancelled, its non-terminal instances are
+interrupted, its control labels are stripped, and the item is re-routed and
+dispatched **immediately** — it does not wait for the next poll.
+
+The result appears as a one-line banner above the footer, and the list refreshes
+straight away so the new run is visible:
+
+- `✓ Restarted CDT-123 (10042) — dispatched 1 workflow(s): implement`
+- `✗ Restarted CDT-123 (10042) — but no workflow matches it right now, so nothing was dispatched`
+
+The banner names the item the way you know it — the Jira key, the GitHub issue
+number — with the raw cell id in parentheses when the two differ.
+- `✗ Restart failed: …` — the daemon's own message, e.g. an id that is an internal
+  task id rather than a cell id.
+
+Restart deliberately overrides the `once` and failure-cap guards (the banner names
+what it overrode); it never overrides the in-flight guard, so a workflow that is
+genuinely running is not started a second time.
 
 Pressing **`C`** on a selected task works the same way — confirm with `y` / `Y`
 to delete the task's logs and execution records, or any other key to cancel.

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -216,9 +216,12 @@ Daemon restarts (crash, upgrade, reboot) don't lose in-flight work:
   long pipeline that must not restart from scratch should opt into
   `resume: auto`.
 - **Force restart.** From the [dashboard](dashboard.md) (`R` on a task) or
-  `apiary restart <task>`, a stale task's running dispatch is
-  cancelled, its non-terminal instances are interrupted, and it is reset for
-  re-dispatch on the next cycle.
+  `apiary restart <task>`, a stale task's running dispatch and queued jobs are
+  cancelled, its non-terminal instances are interrupted, its control labels are
+  stripped, and it is re-routed and dispatched immediately. Restart overrides the
+  `once` and failure-cap guards — a task parked behind either is exactly what it
+  is for — but never the in-flight guard, so a live workflow is not run twice.
+  Both surfaces report what was dispatched, including "nothing matched".
 
 ## Timeouts
 

--- a/src/internal/cli/restart.go
+++ b/src/internal/cli/restart.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 
@@ -20,7 +22,7 @@ func newRestartCmd() *cobra.Command {
 		Use:   "restart <cell-id>",
 		Short: "Force-restart a stale task",
 		Long: `Kill the running dispatch for the given cell, reset its state, and
-re-queue it so the next poll picks it up again.
+dispatch it again immediately.
 
 <cell-id> is the source item id — the GitHub issue number, the Jira issue id, the
 key shown in the dashboard's task rows — NOT the internal task id. An id the
@@ -30,12 +32,16 @@ touched.
 Also strips the cell's control labels — the lock (e.g. "in-progress") and the
 stage marker (e.g. "agent:engineer") — so the task re-enters the flow from the
 start instead of being shadowed by a stale label. The labels removed are derived
-from the routes' exclude_label_prefix / exclude_labels.`,
+from the routes' exclude_label_prefix / exclude_labels.
+
+Restart overrides the ` + "`once`" + ` and failure-cap guards, since a task wedged behind
+either is exactly what restart exists to unwedge; overrides are reported. It does
+not override the in-flight guard, so a live workflow is never run twice.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cellID := strings.TrimSpace(args[0])
-			if cellID == "" {
-				return fmt.Errorf("cell id is required")
+			ref := strings.TrimSpace(args[0])
+			if ref == "" {
+				return fmt.Errorf("a cell id or item reference is required")
 			}
 
 			socketPath := daemon.SocketPath(config.DataDir(configFile))
@@ -46,7 +52,9 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 			}
 			client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
 
-			url := fmt.Sprintf("http://apiary/restart/%s", cellID)
+			// PathEscape, not raw: a GitHub reference is "#1953" and a bare '#'
+			// would be parsed as a URL fragment, so the daemon would see an empty id.
+			url := "http://apiary/restart/" + neturl.PathEscape(ref)
 			resp, err := client.Post(url, "application/json", nil)
 			if err != nil {
 				return fmt.Errorf("cannot reach daemon: %w", err)
@@ -63,7 +71,24 @@ from the routes' exclude_label_prefix / exclude_labels.`,
 				return fmt.Errorf("restart failed: HTTP %d", resp.StatusCode)
 			}
 
-			fmt.Printf("✓ Restarted cell %s (control labels cleared; re-enters the flow on the next poll)\n", cellID)
+			var res daemon.RestartResult
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			if err := json.Unmarshal(body, &res); err != nil {
+				// An older daemon answers 200 with an empty body. The restart did
+				// happen; only the detail is missing.
+				fmt.Printf("✓ Restarted %s (control labels cleared)\n", ref)
+				return nil
+			}
+
+			fmt.Printf("✓ Restarted %s (control labels cleared)\n", res.Label())
+			for _, o := range res.Overridden {
+				fmt.Printf("  ! overrode guard: %s\n", o)
+			}
+			if res.Dispatched == 0 {
+				fmt.Printf("  → no workflow matches the item right now; nothing dispatched\n")
+				return nil
+			}
+			fmt.Printf("  → dispatched %d workflow(s): %s\n", res.Dispatched, strings.Join(res.Workflows, ", "))
 			return nil
 		},
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -936,16 +937,118 @@ func (d *Dispatcher) Status() StatusResponse {
 // side effects with an id from some other id space (#377).
 var ErrUnknownCell = errors.New("unknown cell")
 
-// ForceRestart cancels a running dispatch for the given cell, removes it from
-// tracking maps, marks the execution as interrupted in the DB, and resets the
-// source state so the cell can be picked up on the next poll.
+// RestartResult reports what a force-restart actually did. Restart used to return
+// nothing but an error, so "the cleanup ran" and "a new run started" were
+// indistinguishable to every caller — which is why the dashboard's R looked like a
+// no-op even when it worked. Dispatched/Workflows say whether new work exists now;
+// Overridden names the pre-dispatch guards an explicit restart deliberately
+// ignored, so a bypass is never silent.
+type RestartResult struct {
+	CellID     string   `json:"cell_id"`
+	Ref        string   `json:"ref,omitempty"` // human reference (CDT-123, #1953) if the item has one
+	Dispatched int      `json:"dispatched"`
+	Workflows  []string `json:"workflows,omitempty"`
+	Overridden []string `json:"overridden,omitempty"`
+}
+
+// Label returns the reference to show a human: the item's own number when it has
+// one, else the raw cell id. Reporting a bare cell id is close to useless on
+// sources whose id is not what people see — a Jira restart would echo "10042" for
+// what the user knows as CDT-123.
+func (r RestartResult) Label() string {
+	if r.Ref != "" && r.Ref != r.CellID {
+		return fmt.Sprintf("%s (%s)", r.Ref, r.CellID)
+	}
+	return r.CellID
+}
+
+// ErrAmbiguousRef is returned when a human item reference matches items in more
+// than one source. Restart is destructive, so a reference that could mean two
+// different items must be disambiguated by the caller rather than guessed at.
+var ErrAmbiguousRef = errors.New("ambiguous item reference")
+
+// resolveCellRef maps whatever the caller passed to a cell id. A cell id is
+// returned unchanged; anything else is looked up as a human item reference (Jira
+// key, GitHub issue number, Dynatrace display id) against the source bindings.
 //
-// The id must be a cell id (the source item id: a GitHub issue number, a Jira
-// issue id, …) — not an internal task id. Anything else returns ErrUnknownCell
-// and nothing is touched.
-func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
+// This exists because for several sources the cell id is not a thing any human
+// ever sees: the Jira adapter binds on the opaque numeric issue id, so `apiary
+// restart CDT-123` — the only form a user could reasonably type — failed as an
+// unknown cell while the id that did work appeared nowhere in the UI.
+func (d *Dispatcher) resolveCellRef(ctx context.Context, ref string) (cellID, number string, err error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || d.db == nil {
+		return ref, "", nil
+	}
+
+	// An exact cell id always wins: it is unambiguous, and a source whose ids and
+	// numbers overlap (GitHub, where both derive from the issue number) must not
+	// take the slower path.
+	if b, err := d.db.SourceBindings().GetBindingBySourceItemID(ctx, ref); err == nil && b != nil {
+		return b.SourceItemID, b.SourceItemNumber, nil
+	}
+
+	bindings, err := d.db.SourceBindings().ListBindingsBySourceItemNumber(ctx, ref)
+	if err != nil {
+		return ref, "", fmt.Errorf("restart %s: looking up item reference: %w", ref, err)
+	}
+	if len(bindings) == 0 {
+		return ref, "", nil // not a known reference; assertKnownCell decides
+	}
+
+	// Several bindings are fine when they are the same item (one item can be bound
+	// more than once over its life); distinct items are not.
+	distinct := map[string]model.SourceBinding{}
+	for _, b := range bindings {
+		distinct[b.SourceID+":"+b.SourceItemID] = b
+	}
+	if len(distinct) > 1 {
+		var opts []string
+		for _, b := range distinct {
+			opts = append(opts, fmt.Sprintf("%s:%s", b.SourceID, b.SourceItemID))
+		}
+		sort.Strings(opts)
+		return ref, "", fmt.Errorf("%w: %q matches %d items (%s) — restart the cell id directly",
+			ErrAmbiguousRef, ref, len(distinct), strings.Join(opts, ", "))
+	}
+
+	b := bindings[0]
+	aplog.Info("restart: resolved item reference %q to cell %s (source %s)", ref, b.SourceItemID, b.SourceID)
+	return b.SourceItemID, b.SourceItemNumber, nil
+}
+
+// ForceRestart cancels a running dispatch for the given cell, removes it from
+// tracking maps, marks the execution as interrupted in the DB, resets the source
+// state, strips the cell's control labels — and then re-routes and dispatches the
+// cell immediately rather than leaving it for the next poll.
+//
+// The immediate dispatch is the point: waiting for the poll tick meant a restart
+// produced no observable effect for up to a full poll_interval, and on the queue
+// path it usually produced none at all (the dispatch generation never moved, so
+// every re-enqueue collided with the restarted round's own idempotency keys).
+// Restart now bumps the generation and dispatches inline; the poll remains a
+// fallback for anything this path cannot resolve (e.g. a source with no
+// TaskPoller).
+//
+// An explicit restart also overrides the `once` and failure-cap guards: those
+// describe what automatic re-polling may do on its own, and a task wedged behind
+// either is exactly the task a human reaches for restart to unwedge. The
+// in-flight guard is NOT overridden — restart never runs a workflow twice
+// concurrently.
+//
+// The argument may be a cell id (the source item id) or the item's human
+// reference (a Jira key like CDT-123, a GitHub issue number like #1953) — the
+// latter is resolved through the source bindings. It may NOT be an internal task
+// id; that, and anything else that resolves to nothing, returns ErrUnknownCell
+// and touches nothing.
+func (d *Dispatcher) ForceRestart(ctx context.Context, ref string) (RestartResult, error) {
+	cellID, number, err := d.resolveCellRef(ctx, ref)
+	if err != nil {
+		return RestartResult{CellID: ref}, err
+	}
+	res := RestartResult{CellID: cellID, Ref: number}
 	if err := d.assertKnownCell(ctx, cellID); err != nil {
-		return err
+		return res, err
 	}
 
 	// Cancel the running dispatch, if any
@@ -1017,14 +1120,16 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 
 	// Strip control labels so the cell re-enters routing from the start instead
 	// of being shadowed by a stale lock (e.g. "in-progress") or a stage marker
-	// (e.g. "agent:engineer"). Needs the source's current labels (TaskPoller) and
-	// label removal (LabelRemover); sources missing either are skipped.
+	// (e.g. "agent:engineer"). Needs the source's current labels (TaskPoller);
+	// removal additionally needs LabelRemover. The fetched item is also what the
+	// inline re-dispatch below routes on, so a source that can only be read still
+	// yields a restart — it just cannot clear labels.
+	var (
+		restartCell    model.SourceItem
+		restartAdapter source.Adapter
+	)
 	for _, sc := range d.cfg.Sources {
 		adapter, ok := d.sources[sc.ID]
-		if !ok {
-			continue
-		}
-		remover, ok := adapter.(source.LabelRemover)
 		if !ok {
 			continue
 		}
@@ -1044,17 +1149,146 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, cellID string) error {
 			aplog.Error("force-restart %s: %s returned item %s — refusing to touch it", cellID, sc.ID, cell.ID)
 			continue
 		}
-		if labels := d.controlLabels(cell); len(labels) > 0 {
+		labels := d.controlLabels(cell)
+		if remover, ok := adapter.(source.LabelRemover); ok && len(labels) > 0 {
 			if err := remover.RemoveLabels(ctx, cell, labels); err != nil {
 				aplog.Error("force-restart %s: removing control labels %v: %v", cellID, labels, err)
 			} else {
 				aplog.Info("force-restart %s: removed control labels %v", cellID, labels)
 			}
 		}
+		if restartAdapter == nil {
+			// Route on the post-strip label set. Re-reading it from the source
+			// would race the removal we just issued (forges apply label writes
+			// asynchronously), and a stale read puts the lock label straight back
+			// into routing — the cell would be dropped by the very exclusion the
+			// strip exists to clear.
+			cell.ID = cellID
+			cell.Labels = withoutLabels(cell.Labels, labels)
+			restartCell, restartAdapter = cell, adapter
+		}
 	}
 
 	aplog.Info("force-restarted cell %s", cellID)
-	return nil
+
+	// Dispatch now instead of deferring to the next poll tick.
+	if restartAdapter != nil {
+		res.Dispatched, res.Workflows, res.Overridden = d.redispatchCell(ctx, restartCell, restartAdapter)
+	} else {
+		aplog.Warn("force-restart %s: no source could fetch the item — falling back to the next poll for re-dispatch", cellID)
+	}
+	return res, nil
+}
+
+// withoutLabels returns labels minus remove, compared case-insensitively to match
+// controlLabels' own comparison.
+func withoutLabels(labels, remove []string) []string {
+	if len(remove) == 0 {
+		return labels
+	}
+	drop := make(map[string]bool, len(remove))
+	for _, l := range remove {
+		drop[strings.ToLower(l)] = true
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if !drop[strings.ToLower(l)] {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// redispatchCell re-routes a just-restarted cell and dispatches every workflow
+// that matches, returning the count, the workflow ids, and the guards it
+// overrode. It is the poll loop's per-cell body minus the guards an explicit
+// restart is meant to defeat: `once` and the consecutive-failure cap are skipped
+// (and reported), while the in-flight guard still applies so a restart can never
+// double-run a live workflow.
+//
+// The dispatch generation is bumped before fan-out: the queue keys jobs on
+// taskID:generation:routeID, so without a bump every re-enqueue would be
+// swallowed as a duplicate of the round that was just interrupted.
+func (d *Dispatcher) redispatchCell(ctx context.Context, cell model.SourceItem, adapter source.Adapter) (int, []string, []string) {
+	if d.router == nil {
+		// Reachable from the IPC path in harnesses that wire a dispatcher without
+		// a router; the poll loop always has one. Cleanup already ran, so the
+		// restart itself stands — there is just nothing to route with.
+		return 0, nil, nil
+	}
+	if _, loaded := d.inFlight.LoadOrStore(cell.ID, time.Now()); loaded {
+		aplog.Warn("force-restart %s: cell went in-flight again before re-dispatch — leaving it to the poll", cell.LogLabel())
+		return 0, nil, nil
+	}
+
+	task, persisted := d.bindItem(ctx, cell)
+	d.recordRouteEvents(ctx, task)
+	matches := d.router.RouteAll(task)
+
+	var overridden []string
+	if persisted && d.db != nil {
+		var dropped []droppedMatch
+		matches, dropped = d.dropAutoResumingMatches(task.ID, matches)
+		var batch []droppedMatch
+		matches, batch = d.dropActiveMatches(ctx, task.ID, matches)
+		dropped = append(dropped, batch...)
+
+		// Report what a normal poll would additionally have dropped, then keep
+		// those matches anyway. Restart is the documented escape hatch for both.
+		if _, once := d.dropOnceMatches(ctx, task.ID, matches); len(once) > 0 {
+			for _, m := range once {
+				aplog.Info("force-restart %s: overriding `once` guard for workflow %s (%s)", cell.LogLabel(), m.WorkflowID, m.Detail)
+				overridden = append(overridden, m.WorkflowID+" (once)")
+			}
+		}
+		if _, capped := d.dropCappedMatches(ctx, task, matches); len(capped) > 0 {
+			for _, m := range capped {
+				aplog.Info("force-restart %s: overriding failure cap for workflow %s (%s)", cell.LogLabel(), m.WorkflowID, m.Detail)
+				overridden = append(overridden, m.WorkflowID+" (failure cap)")
+			}
+		}
+		for _, m := range dropped {
+			aplog.Info("force-restart %s: workflow %s not re-dispatched (%s)", cell.LogLabel(), m.WorkflowID, m.Reason)
+		}
+	}
+
+	if len(matches) == 0 {
+		aplog.Warn("force-restart %s: nothing to dispatch — no workflow matches the cell in its current state", cell.LogLabel())
+		d.inFlight.Delete(cell.ID)
+		return 0, nil, overridden
+	}
+
+	// Cancel the interrupted round's queue jobs. Cancelling the run context only
+	// reaches an inline dispatch; a queued or leased job survives it and would be
+	// claimed later, running the round restart just tore down alongside the fresh
+	// one. Queued jobs go terminal immediately, leased ones are flagged so their
+	// worker stops at the next heartbeat.
+	if persisted && d.dispatchQueue != nil {
+		for _, m := range matches {
+			if n, err := d.dispatchQueue.RequestCancelFor(ctx, task.ID, m.Route.ID); err != nil {
+				aplog.Error("force-restart %s: cancel queued jobs for workflow %s: %v", cell.LogLabel(), m.Route.ID, err)
+			} else if n > 0 {
+				aplog.Info("force-restart %s: cancelled %d queued/leased job(s) for workflow %s", cell.LogLabel(), n, m.Route.ID)
+			}
+		}
+	}
+
+	if persisted && d.db != nil {
+		if gen, err := d.db.InternalTasks().BumpGeneration(ctx, task.ID); err != nil {
+			aplog.Error("force-restart %s: bump dispatch generation: %v — re-dispatch may be deduplicated away", cell.LogLabel(), err)
+		} else {
+			aplog.Debug("force-restart %s: dispatch generation now %d", cell.LogLabel(), gen)
+		}
+	}
+
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m.Route.ID)
+	}
+	d.dropNotified.Delete(task.ID)
+	aplog.Info("force-restart %s: dispatching %d workflow(s): %v", cell.LogLabel(), len(ids), ids)
+	d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+	return len(ids), ids, overridden
 }
 
 // assertKnownCell fails closed (ErrUnknownCell) unless cellID names a cell this
@@ -1101,11 +1335,16 @@ func (d *Dispatcher) assertKnownCell(ctx context.Context, cellID string) error {
 	}
 
 	// Nothing matched. If the caller passed an internal task id, point at the
-	// cell id that would have worked instead of a bare "unknown".
+	// reference that would have worked instead of a bare "unknown" — the item's
+	// own number when it has one, since that is what the user can actually see.
 	if t, err := d.db.InternalTasks().GetTask(ctx, cellID); err == nil && t != nil {
 		if cell := d.cellIDForTask(ctx, t.ID); cell != "" && cell != cellID {
-			return fmt.Errorf("%w: %s is an internal task id, not a cell id — its cell is %s (try: apiary restart %s)",
-				ErrUnknownCell, cellID, cell, cell)
+			suggest := cell
+			if bs, err := d.db.ListBindingsByTask(ctx, t.ID); err == nil && len(bs) > 0 && bs[0].SourceItemNumber != "" {
+				suggest = bs[0].SourceItemNumber
+			}
+			return fmt.Errorf("%w: %s is an internal task id, not a cell id — its item is %s (try: apiary restart %s)",
+				ErrUnknownCell, cellID, cell, suggest)
 		}
 	}
 	return fmt.Errorf("%w: %s", ErrUnknownCell, cellID)
@@ -1179,20 +1418,35 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 	mux.HandleFunc("/approvals", d.handleApprovals)
 	mux.HandleFunc("/approvals/", d.handleApprovalResponse)
 	mux.HandleFunc("/restart/", func(w http.ResponseWriter, r *http.Request) {
-		cellID := strings.TrimPrefix(r.URL.Path, "/restart/")
+		// Human references reach this route too (CDT-123, #1953), and '#' must be
+		// percent-encoded by the caller or it would be read as a URL fragment and
+		// never arrive. Decode it back before resolving.
+		cellID := strings.TrimPrefix(r.URL.EscapedPath(), "/restart/")
+		if decoded, err := url.PathUnescape(cellID); err == nil {
+			cellID = decoded
+		}
 		if cellID == "" {
-			http.Error(w, "missing cell id", http.StatusBadRequest)
+			http.Error(w, "missing cell id or item reference", http.StatusBadRequest)
 			return
 		}
-		if err := d.ForceRestart(ctx, cellID); err != nil {
+		res, err := d.ForceRestart(ctx, cellID)
+		if err != nil {
 			status := http.StatusInternalServerError
-			if errors.Is(err, ErrUnknownCell) {
+			switch {
+			case errors.Is(err, ErrUnknownCell):
 				status = http.StatusNotFound
+			case errors.Is(err, ErrAmbiguousRef):
+				status = http.StatusConflict
 			}
 			http.Error(w, err.Error(), status)
 			return
 		}
+		// Report what was dispatched, not just that the call succeeded: callers
+		// need to distinguish "restarted and N workflows are running" from
+		// "restarted and nothing matched".
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(res)
 	})
 	mux.HandleFunc("/api/config/agent/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {

--- a/src/internal/daemon/forcerestart_workflow_test.go
+++ b/src/internal/daemon/forcerestart_workflow_test.go
@@ -28,7 +28,7 @@ func TestForceRestart_InterruptsWorkflowInstance(t *testing.T) {
 		t.Fatalf("precondition: running instance should shadow the workflow, got %d kept", len(kept))
 	}
 
-	if err := d.ForceRestart(ctx, "1956"); err != nil {
+	if _, err := d.ForceRestart(ctx, "1956"); err != nil {
 		t.Fatalf("ForceRestart: %v", err)
 	}
 

--- a/src/internal/daemon/restart_dispatch_test.go
+++ b/src/internal/daemon/restart_dispatch_test.go
@@ -1,0 +1,225 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+// pollableAdapter is a mutableAdapter that also satisfies source.TaskPoller, which
+// ForceRestart needs to fetch the item it re-routes.
+type pollableAdapter struct{ mutableAdapter }
+
+func (a *pollableAdapter) PollTask(_ context.Context, id string) (model.SourceItem, error) {
+	for _, item := range a.items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return model.SourceItem{}, nil
+}
+
+func jobsFor(t *testing.T, d *Dispatcher, workflowID string) []queue.Job {
+	t.Helper()
+	all, err := d.db.Queue().ListJobs(context.Background(), "", 100)
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	var out []queue.Job
+	for _, job := range all {
+		if job.WorkflowID == workflowID {
+			out = append(out, job)
+		}
+	}
+	return out
+}
+
+// TestForceRestart_DispatchesImmediately is the headline behaviour: restart must
+// produce a new run right away. It used to only reset state and leave the actual
+// re-dispatch to the next poll tick, so for up to a full poll_interval a restart
+// had no observable effect at all — the dashboard's R looked like a no-op.
+func TestForceRestart_DispatchesImmediately(t *testing.T) {
+	ctx := context.Background()
+	d, base, dbc := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	// One normal poll puts the cell in flight with a queued job.
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	if got := len(jobsFor(t, d, "triage")); got != 1 {
+		t.Fatalf("setup: %d triage job(s) after the first poll, want 1", got)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	res, err := d.ForceRestart(ctx, "c1")
+	if err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+
+	if res.Dispatched != 1 {
+		t.Fatalf("restart dispatched %d workflow(s), want 1 — restart must not wait for the next poll", res.Dispatched)
+	}
+	if len(res.Workflows) != 1 || res.Workflows[0] != "triage" {
+		t.Errorf("restart dispatched %v, want [triage]", res.Workflows)
+	}
+
+	// A fresh job exists, and the interrupted round's job is no longer claimable.
+	jobs := jobsFor(t, d, "triage")
+	if len(jobs) != 2 {
+		t.Fatalf("after restart there are %d triage job(s), want 2 (the interrupted one plus the new one)", len(jobs))
+	}
+	var live, canceled int
+	for _, job := range jobs {
+		if job.State == queue.JobCanceled {
+			canceled++
+			continue
+		}
+		live++
+	}
+	if canceled != 1 {
+		t.Errorf("restart left %d cancelled job(s), want 1 — the interrupted round's job stays claimable and would double-run", canceled)
+	}
+	if live != 1 {
+		t.Errorf("restart left %d live job(s), want exactly 1", live)
+	}
+
+	// The generation moved, which is what frees the idempotency key.
+	gen, err := dbc.InternalTasks().Generation(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	if gen == 0 {
+		t.Error("dispatch generation still 0 after restart — the re-enqueue would collide with the restarted round's key")
+	}
+}
+
+// TestForceRestart_BumpsGenerationForRunningTask covers the reason restart could
+// not dispatch on the queue path at all. Queue jobs are keyed
+// taskID:generation:routeID, and the generation only advances implicitly for a
+// task in done/failed. A force-restarted task is typically still *running* — the
+// exact case restart exists for — so its generation never moved and every
+// re-enqueue was swallowed as a duplicate of the round being restarted.
+func TestForceRestart_BumpsGenerationForRunningTask(t *testing.T) {
+	ctx := context.Background()
+	d, base, dbc := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	task := taskForCell(t, dbc, "src", "c1")
+	if task.State == model.TaskStateDone || task.State == model.TaskStateFailed {
+		t.Fatalf("setup: task is %q; this test needs the running case", task.State)
+	}
+	before, _ := dbc.InternalTasks().Generation(ctx, task.ID)
+
+	if _, err := d.ForceRestart(ctx, "c1"); err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+
+	after, _ := dbc.InternalTasks().Generation(ctx, task.ID)
+	if after <= before {
+		t.Fatalf("generation went %d → %d, want it to advance for a running task", before, after)
+	}
+
+	// Distinct keys are the observable consequence: same task, same route, two
+	// dispatchable jobs.
+	keys := map[string]bool{}
+	for _, job := range jobsFor(t, d, "triage") {
+		if keys[job.IdempotencyKey] {
+			t.Fatalf("duplicate idempotency key %q — the re-dispatch was deduplicated away", job.IdempotencyKey)
+		}
+		keys[job.IdempotencyKey] = true
+	}
+	if len(keys) != 2 {
+		t.Errorf("got %d distinct job key(s), want 2", len(keys))
+	}
+}
+
+// TestForceRestart_OverridesOnceGuard: `once: true` stops automatic re-polling
+// from re-running a completed workflow, but an explicit human restart is the
+// documented escape hatch — and a once-only workflow is one of the states people
+// actually reach for restart from. The override is reported, never silent.
+func TestForceRestart_OverridesOnceGuard(t *testing.T) {
+	ctx := context.Background()
+	d, base, dbc := newQueueDispatcher(t, true) // triage is once:true
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	first := queueJobFor(t, dbc, "triage")
+	if res := d.ExecuteQueuedJob(ctx, first, "w1"); !res.Success {
+		t.Fatalf("triage job failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	// A normal poll is now a no-op: the once guard drops the only match.
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Now())
+	if got := len(jobsFor(t, d, "triage")); got != 1 {
+		t.Fatalf("setup: poll enqueued %d triage job(s), want 1 — the once guard should have dropped it", got)
+	}
+
+	res, err := d.ForceRestart(ctx, "c1")
+	if err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+
+	if res.Dispatched != 1 {
+		t.Fatalf("restart dispatched %d workflow(s), want 1 — a once-only workflow must still be restartable", res.Dispatched)
+	}
+	if len(res.Overridden) != 1 {
+		t.Fatalf("restart reported overrides %v, want exactly one (the once guard)", res.Overridden)
+	}
+	if got := len(jobsFor(t, d, "triage")); got != 2 {
+		t.Errorf("after restart there are %d triage job(s), want 2", got)
+	}
+	if _, err := dbc.InternalTasks().Generation(ctx, task.ID); err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+}
+
+// TestForceRestart_ReportsNothingDispatched keeps the no-op case honest: when the
+// cell matches no workflow, restart must say so rather than report a bare success
+// the caller cannot distinguish from a real dispatch.
+func TestForceRestart_ReportsNothingDispatched(t *testing.T) {
+	ctx := context.Background()
+	d, base, _ := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+
+	// Drop the label every trigger matches on, so nothing routes any more.
+	adapter.items[0].Labels = nil
+
+	res, err := d.ForceRestart(ctx, "c1")
+	if err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+	if res.Dispatched != 0 || len(res.Workflows) != 0 {
+		t.Fatalf("restart reported %d dispatched (%v), want 0 — nothing matches the cell", res.Dispatched, res.Workflows)
+	}
+}
+
+// TestForceRestart_ReleasesInFlightWhenNothingDispatches guards the failure mode
+// that would be worse than the original bug: a restart that takes the in-flight
+// marker and never gives it back would make the cell permanently invisible to
+// every later poll (#375).
+func TestForceRestart_ReleasesInFlightWhenNothingDispatches(t *testing.T) {
+	ctx := context.Background()
+	d, base, _ := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	adapter.items[0].Labels = nil
+
+	if _, err := d.ForceRestart(ctx, "c1"); err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+	if _, held := d.inFlight.Load("c1"); held {
+		t.Fatal("in-flight marker still held after a restart that dispatched nothing — the cell would never be polled again")
+	}
+}

--- a/src/internal/daemon/restart_labels_test.go
+++ b/src/internal/daemon/restart_labels_test.go
@@ -91,7 +91,7 @@ func TestForceRestart_StripsControlLabels(t *testing.T) {
 		sources: map[string]source.Adapter{"fake": fake},
 	}
 
-	if err := d.ForceRestart(context.Background(), "42"); err != nil {
+	if _, err := d.ForceRestart(context.Background(), "42"); err != nil {
 		t.Fatalf("ForceRestart: %v", err)
 	}
 

--- a/src/internal/daemon/restart_ref_test.go
+++ b/src/internal/daemon/restart_ref_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// seedJiraTask seeds the shape that made restart unusable on Jira: the binding's
+// item id is the opaque numeric issue id, while the only reference a human ever
+// sees is the key.
+func seedJiraTask(ctx context.Context, t *testing.T, dbc *db.Client, itemID, key string) string {
+	t.Helper()
+	task := &model.InternalTask{Title: "Fix the thing", State: model.TaskStateRunning}
+	binding := &model.SourceBinding{SourceID: "jira", SourceItemID: itemID, SourceItemNumber: key}
+	if err := dbc.CreateTaskWithBinding(ctx, task, binding); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	inst := &db.WorkflowInstance{
+		ID: "wf_" + itemID, WorkflowID: "eng", TaskID: task.ID,
+		CellID: itemID, SourceID: "jira", State: db.InstanceStateRunning,
+	}
+	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	return task.ID
+}
+
+// TestForceRestart_AcceptsJiraKey is the case that motivated reference
+// resolution: the Jira adapter binds on the numeric issue id (10042), so the key
+// the user reads everywhere — CDT-123 — was rejected as an unknown cell, and the
+// id that did work appeared in no interface at all.
+func TestForceRestart_AcceptsJiraKey(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	seedJiraTask(ctx, t, dbc, "10042", "CDT-123")
+
+	fake := &countingSource{cell: model.SourceItem{ID: "10042", Labels: []string{"in-progress"}}}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	res, err := d.ForceRestart(ctx, "CDT-123")
+	if err != nil {
+		t.Fatalf("ForceRestart(%q): %v", "CDT-123", err)
+	}
+	if res.CellID != "10042" {
+		t.Errorf("resolved cell id = %q, want 10042", res.CellID)
+	}
+	if res.Ref != "CDT-123" {
+		t.Errorf("Ref = %q, want CDT-123", res.Ref)
+	}
+	// The label is what surfaces in the CLI and the dashboard banner.
+	if got := res.Label(); !strings.Contains(got, "CDT-123") {
+		t.Errorf("Label() = %q, want it to lead with the key the user typed", got)
+	}
+	// And it restarted the right item: the state reset reached the source.
+	if len(fake.statesSet) == 0 {
+		t.Error("restart did not reach the source — the key resolved to nothing")
+	}
+}
+
+// TestForceRestart_JiraKeyIsCaseInsensitive: people type cdt-123.
+func TestForceRestart_JiraKeyIsCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	seedJiraTask(ctx, t, dbc, "10042", "CDT-123")
+
+	d := restartUnknownDispatcher(dbc, &countingSource{cell: model.SourceItem{ID: "10042"}})
+
+	res, err := d.ForceRestart(ctx, "cdt-123")
+	if err != nil {
+		t.Fatalf("ForceRestart(lowercase key): %v", err)
+	}
+	if res.CellID != "10042" {
+		t.Errorf("resolved cell id = %q, want 10042", res.CellID)
+	}
+}
+
+// TestForceRestart_AcceptsGitHubHashRef covers the GitHub shape, where the number
+// carries a '#' the item id does not. It also pins the bare-id form, which must
+// keep working unchanged.
+func TestForceRestart_AcceptsGitHubHashRef(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	seedBoundTask(ctx, t, dbc, "jira", "1953") // seeds number "#1953"
+
+	for _, ref := range []string{"#1953", "1953"} {
+		d := restartUnknownDispatcher(dbc, &countingSource{cell: model.SourceItem{ID: "1953"}})
+		res, err := d.ForceRestart(ctx, ref)
+		if err != nil {
+			t.Fatalf("ForceRestart(%q): %v", ref, err)
+		}
+		if res.CellID != "1953" {
+			t.Errorf("ForceRestart(%q) resolved to %q, want 1953", ref, res.CellID)
+		}
+	}
+}
+
+// TestForceRestart_AmbiguousRefIsRejected keeps #377's fail-closed promise intact
+// for the new input: a reference that names two different items in two sources
+// must not be guessed at, because guessing wrong cancels an unrelated healthy run.
+func TestForceRestart_AmbiguousRefIsRejected(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	// Same human reference, two sources, two different items.
+	for _, s := range []struct{ source, itemID string }{{"jira", "10042"}, {"github", "77"}} {
+		task := &model.InternalTask{Title: "dup", State: model.TaskStateRunning}
+		binding := &model.SourceBinding{SourceID: s.source, SourceItemID: s.itemID, SourceItemNumber: "DUP-1"}
+		if err := dbc.CreateTaskWithBinding(ctx, task, binding); err != nil {
+			t.Fatalf("seed %s: %v", s.source, err)
+		}
+	}
+
+	fake := &countingSource{}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	_, err := d.ForceRestart(ctx, "DUP-1")
+	if err == nil {
+		t.Fatal("an ambiguous reference must fail, got nil")
+	}
+	if !errors.Is(err, ErrAmbiguousRef) {
+		t.Fatalf("error = %v, want it to wrap ErrAmbiguousRef", err)
+	}
+	if !strings.Contains(err.Error(), "jira:10042") || !strings.Contains(err.Error(), "github:77") {
+		t.Errorf("error %q should name both candidates so the user can pick", err)
+	}
+	if len(fake.polls) != 0 || len(fake.statesSet) != 0 || fake.removeCalls != 0 {
+		t.Errorf("ambiguous reference must touch nothing: polls=%v states=%v removes=%d",
+			fake.polls, fake.statesSet, fake.removeCalls)
+	}
+}
+
+// TestForceRestart_CellIDWinsOverNumber: when an id is simultaneously a valid cell
+// id for one item and the number of another, the exact cell id must win — it is
+// the unambiguous form, and resolution must never redirect it elsewhere.
+func TestForceRestart_CellIDWinsOverNumber(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	// Item A's cell id is "500". Item B's human number is also "500".
+	seedJiraTask(ctx, t, dbc, "500", "CDT-1")
+	seedJiraTask(ctx, t, dbc, "999", "500")
+
+	d := restartUnknownDispatcher(dbc, &countingSource{cell: model.SourceItem{ID: "500"}})
+
+	res, err := d.ForceRestart(ctx, "500")
+	if err != nil {
+		t.Fatalf("ForceRestart: %v", err)
+	}
+	if res.CellID != "500" {
+		t.Errorf("resolved to %q, want the exact cell id 500 — an exact id must not be re-resolved as someone else's number", res.CellID)
+	}
+}
+
+// TestForceRestart_UnknownRefStillFailsClosed: reference resolution must not
+// become a way to smuggle an unresolvable id past the #377 guard.
+func TestForceRestart_UnknownRefStillFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	seedJiraTask(ctx, t, dbc, "10042", "CDT-123")
+
+	fake := &countingSource{}
+	d := restartUnknownDispatcher(dbc, fake)
+
+	_, err := d.ForceRestart(ctx, "CDT-999")
+	if !errors.Is(err, ErrUnknownCell) {
+		t.Fatalf("ForceRestart(unknown key) = %v, want ErrUnknownCell", err)
+	}
+	if len(fake.polls) != 0 || len(fake.statesSet) != 0 {
+		t.Errorf("unknown reference must touch nothing: polls=%v states=%v", fake.polls, fake.statesSet)
+	}
+}
+
+// TestForceRestart_TaskIDErrorSuggestsHumanRef keeps the #377 hint useful: telling
+// someone to retry with an opaque Jira item id is not much better than "unknown",
+// so the suggestion names the key.
+func TestForceRestart_TaskIDErrorSuggestsHumanRef(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	taskID := seedJiraTask(ctx, t, dbc, "10042", "CDT-123")
+
+	d := restartUnknownDispatcher(dbc, &countingSource{})
+
+	_, err := d.ForceRestart(ctx, taskID)
+	if !errors.Is(err, ErrUnknownCell) {
+		t.Fatalf("ForceRestart(task id) = %v, want ErrUnknownCell", err)
+	}
+	if !strings.Contains(err.Error(), "CDT-123") {
+		t.Errorf("error %q should suggest the key CDT-123, not just the opaque item id", err)
+	}
+}

--- a/src/internal/daemon/restart_unknown_id_test.go
+++ b/src/internal/daemon/restart_unknown_id_test.go
@@ -77,7 +77,7 @@ func TestForceRestart_UnknownIDIsRejected(t *testing.T) {
 	fake := &countingSource{cell: model.SourceItem{ID: "297869", Labels: []string{"in-progress"}}}
 	d := restartUnknownDispatcher(dbc, fake)
 
-	err := d.ForceRestart(ctx, "019fd9312ac74556ae907abbbd17e3be")
+	_, err := d.ForceRestart(ctx, "019fd9312ac74556ae907abbbd17e3be")
 	if err == nil {
 		t.Fatalf("ForceRestart with an unknown id must fail, got nil")
 	}
@@ -114,7 +114,7 @@ func TestForceRestart_InternalTaskIDPointsAtItsCell(t *testing.T) {
 	fake := &countingSource{}
 	d := restartUnknownDispatcher(dbc, fake)
 
-	err := d.ForceRestart(ctx, taskID)
+	_, err := d.ForceRestart(ctx, taskID)
 	if err == nil || !errors.Is(err, ErrUnknownCell) {
 		t.Fatalf("ForceRestart(task id) = %v, want an ErrUnknownCell failure", err)
 	}
@@ -134,7 +134,7 @@ func TestForceRestart_KnownCellStillRestarts(t *testing.T) {
 	fake := &countingSource{cell: model.SourceItem{ID: "295651", Labels: []string{"in-progress", "bug"}}}
 	d := restartUnknownDispatcher(dbc, fake)
 
-	if err := d.ForceRestart(ctx, "295651"); err != nil {
+	if _, err := d.ForceRestart(ctx, "295651"); err != nil {
 		t.Fatalf("ForceRestart(known cell): %v", err)
 	}
 

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +23,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/format"
 	"github.com/orlandoburli/apiary/internal/model"
@@ -31,6 +34,11 @@ const refreshInterval = 2 * time.Second
 
 // queryTimeout bounds each database query so a locked DB never blocks the UI.
 const queryTimeout = 2 * time.Second
+
+// noticeTTL is how long an action-result banner stays on screen. Long enough to
+// read a dispatched-workflow list without hunting for it, short enough that it
+// does not linger over the view it covers.
+const noticeTTL = 8 * time.Second
 
 // taskLogTailLimit caps how many of a task's most recent log lines are loaded
 // when the logs view opens. task_logs rows are large (~10KB of agent stream), so
@@ -181,6 +189,14 @@ type mdWarmedMsg struct {
 	rendered map[string][]string
 }
 
+// noticeMsg carries a one-line result banner for an action the user triggered
+// (restart, clear, stop). Those actions run against the daemon over IPC and used
+// to report nothing at all, success or failure alike.
+type noticeMsg struct {
+	text  string
+	isErr bool
+}
+
 // ── lifecycle ───────────────────────────────────────────────────────────────
 
 // Init initializes the app: enter alt-screen, fetch the first tab, start timer.
@@ -223,6 +239,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.logMDCache[m] = lines
 			}
 		}
+
+	case noticeMsg:
+		// Show the banner and refresh straight away: a restart that dispatched
+		// work has already created the instance the user is looking for.
+		a.model.notice = msg.text
+		a.model.noticeIsErr = msg.isErr
+		a.model.noticeUntil = time.Now().Add(noticeTTL)
+		return a, a.fetchActiveTab()
 
 	case tickMsg:
 		// Re-query the active tab and schedule the next tick.
@@ -1570,7 +1594,14 @@ func (a *App) focusedTaskID() (string, bool) {
 	return "", false
 }
 
-// restartTaskCmd sends a force-restart request to the daemon via the IPC socket.
+// restartTaskCmd sends a force-restart request to the daemon via the IPC socket
+// and reports the outcome as a noticeMsg.
+//
+// Every failure here used to be discarded — transport errors returned nil and the
+// status code was never read — so a 404 ("that id is an internal task id, not a
+// cell id") and a successful restart were indistinguishable on screen: the modal
+// closed and nothing happened. The daemon's message is the whole diagnosis, so it
+// goes to the user verbatim.
 func (a *App) restartTaskCmd(taskID string) tea.Cmd {
 	return func() tea.Msg {
 		socketPath := a.socketPath
@@ -1580,13 +1611,40 @@ func (a *App) restartTaskCmd(taskID string) tea.Cmd {
 			},
 		}
 		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
-		url := fmt.Sprintf("http://apiary/restart/%s", taskID)
-		resp, err := client.Post(url, "application/json", nil)
+		// PathEscape: the reference may be a GitHub "#1953", and a raw '#' would be
+		// read as a URL fragment, leaving the daemon with an empty id.
+		resp, err := client.Post("http://apiary/restart/"+neturl.PathEscape(taskID), "application/json", nil)
 		if err != nil {
-			return nil
+			return noticeMsg{text: fmt.Sprintf("Restart failed: cannot reach daemon: %v", err), isErr: true}
 		}
-		resp.Body.Close()
-		return nil
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if resp.StatusCode != http.StatusOK {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			}
+			return noticeMsg{text: "Restart failed: " + msg, isErr: true}
+		}
+
+		var res daemon.RestartResult
+		if err := json.Unmarshal(body, &res); err != nil {
+			return noticeMsg{text: fmt.Sprintf("Restarted %s", taskID)}
+		}
+		// res.Label() prefers the item's own reference (CDT-123, #1953) over the
+		// cell id, which on sources like Jira is an opaque number the user has
+		// never seen.
+		switch {
+		case res.Dispatched == 0:
+			return noticeMsg{text: fmt.Sprintf("Restarted %s — but no workflow matches it right now, so nothing was dispatched", res.Label()), isErr: true}
+		default:
+			text := fmt.Sprintf("Restarted %s — dispatched %d workflow(s): %s", res.Label(), res.Dispatched, strings.Join(res.Workflows, ", "))
+			if len(res.Overridden) > 0 {
+				text += " (overrode " + strings.Join(res.Overridden, ", ") + ")"
+			}
+			return noticeMsg{text: text}
+		}
 	}
 }
 
@@ -1632,11 +1690,29 @@ func (a *App) clearLogsCmd(taskID string) tea.Cmd {
 		url := fmt.Sprintf("http://apiary/clearlogs/%s", taskID)
 		resp, err := client.Post(url, "application/json", nil)
 		if err != nil {
-			return nil
+			return noticeMsg{text: fmt.Sprintf("Clear logs failed: cannot reach daemon: %v", err), isErr: true}
 		}
-		resp.Body.Close()
-		return nil
+		defer resp.Body.Close()
+		if msg, ok := ipcFailure(resp, "Clear logs"); !ok {
+			return msg
+		}
+		return noticeMsg{text: fmt.Sprintf("Cleared logs for %s", taskID)}
 	}
+}
+
+// ipcFailure turns a non-2xx IPC response into a noticeMsg carrying the daemon's
+// own message. ok is true when the response was a success and the caller should
+// build its own notice.
+func ipcFailure(resp *http.Response, action string) (noticeMsg, bool) {
+	if resp.StatusCode < 400 {
+		return noticeMsg{}, true
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+	return noticeMsg{text: action + " failed: " + msg, isErr: true}, false
 }
 
 // stopInstanceCmd sends a POST /instances/stop/{id} request to stop a workflow
@@ -1652,10 +1728,13 @@ func (a *App) stopInstanceCmd(instanceID string) tea.Cmd {
 		url := fmt.Sprintf("http://apiary/instances/stop/%s", instanceID)
 		resp, err := client.Post(url, "application/json", nil)
 		if err != nil {
-			return nil
+			return noticeMsg{text: fmt.Sprintf("Stop failed: cannot reach daemon: %v", err), isErr: true}
 		}
-		resp.Body.Close()
-		return nil
+		defer resp.Body.Close()
+		if msg, ok := ipcFailure(resp, "Stop"); !ok {
+			return msg
+		}
+		return noticeMsg{text: fmt.Sprintf("Stopped workflow instance %s", instanceID)}
 	}
 }
 
@@ -2860,6 +2939,9 @@ func (a *App) View() string {
 	tabsHeight := lipgloss.Height(tabs)
 
 	footer := a.renderFooter()
+	if banner := a.renderNotice(); banner != "" {
+		footer = lipgloss.JoinVertical(lipgloss.Left, banner, footer)
+	}
 	footerHeight := lipgloss.Height(footer)
 
 	contentHeight := a.model.height - tabsHeight - footerHeight - 1
@@ -2890,6 +2972,26 @@ func (a *App) View() string {
 		view = a.renderConfirmModal(view)
 	}
 	return view
+}
+
+// renderNotice draws the action-result banner above the footer, or "" once it has
+// expired. It is the only feedback surface for IPC actions, so it renders errors
+// in full rather than truncating to a status word.
+func (a *App) renderNotice() string {
+	if a.model.notice == "" || time.Now().After(a.model.noticeUntil) {
+		return ""
+	}
+	style := StyleSuccess
+	prefix := "✓ "
+	if a.model.noticeIsErr {
+		style = StyleError
+		prefix = "✗ "
+	}
+	text := prefix + a.model.notice
+	if w := a.model.width - 2; w > 8 && lipgloss.Width(text) > w {
+		text = ansi.Truncate(text, w, "…")
+	}
+	return style.Render(" " + text)
 }
 
 func (a *App) renderConfirmModal(view string) string {

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -26,6 +26,10 @@ type Model struct {
 
 	confirmAction string // "restart" or "clear" or "stop" when awaiting confirmation
 	confirmTaskID string
+
+	notice      string    // one-line result banner for the last IPC action
+	noticeIsErr bool      // render the banner as an error
+	noticeUntil time.Time // banner expiry; zero means no banner
 }
 
 // OverviewTab shows dispatcher status and summary metrics.

--- a/src/internal/db/binding_store.go
+++ b/src/internal/db/binding_store.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -83,6 +84,43 @@ func (s *SourceBindingStore) GetBindingBySourceItemID(ctx context.Context, sourc
 		return nil, nil
 	}
 	return b, err
+}
+
+// ListBindingsBySourceItemNumber returns every binding whose human-facing item
+// reference matches, compared case-insensitively and ignoring a leading '#'.
+//
+// The reference is what people actually have: a Jira key (CDT-123) or a GitHub
+// issue number (#1953). For several sources it is nothing like the item id — Jira
+// binds on the opaque numeric issue id, so the only id a user could see in the UI
+// was useless as a restart argument. All matches are returned rather than the
+// first, because acting on a reference that resolves to two different items in
+// two sources is exactly the mis-targeting #377 was about; the caller decides.
+func (s *SourceBindingStore) ListBindingsBySourceItemNumber(ctx context.Context, number string) ([]model.SourceBinding, error) {
+	number = strings.TrimPrefix(strings.TrimSpace(number), "#")
+	if number == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, task_id, source_id, source_item_id, COALESCE(source_item_url,''),
+		       COALESCE(source_item_number,''), created_at
+		FROM source_bindings
+		WHERE TRIM(COALESCE(source_item_number,''), '#') = ? COLLATE NOCASE
+		ORDER BY created_at ASC
+	`, number)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.SourceBinding
+	for rows.Next() {
+		b, err := scanBinding(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *b)
+	}
+	return out, rows.Err()
 }
 
 // DeleteBindingsByTask removes all source bindings for a task. Used when a task is

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -229,6 +229,27 @@ func (s *InternalTaskStore) Generation(ctx context.Context, id string) (int, err
 	return generation, err
 }
 
+// BumpGeneration advances a task's dispatch generation by one and returns the new
+// value. IncrementOutstanding bumps the generation implicitly, but only for a task
+// sitting in done/failed — which a force-restarted task is not: it is typically
+// still running, so its generation never moved and the queue's
+// taskID:generation:routeID idempotency key stayed pinned to the terminal jobs of
+// the round being restarted. Every re-dispatch then collapsed into "key already
+// belongs to a terminal job" and no new run was ever created. An explicit restart
+// is a new round by definition, so it bumps the generation unconditionally.
+func (s *InternalTaskStore) BumpGeneration(ctx context.Context, id string) (int, error) {
+	var generation int
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE internal_tasks SET generation = COALESCE(generation,0) + 1, updated_at = ?
+		WHERE id = ?
+		RETURNING generation
+	`, time.Now(), id).Scan(&generation)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return generation, err
+}
+
 // DeleteTask removes a task row by ID. Workflow instances, bindings, and logs are
 // removed by their own stores; this only drops the internal_tasks row. Deleting a
 // non-existent id is a no-op (no error), so it is safe to call for orphaned cells.


### PR DESCRIPTION
## Summary

The dashboard's `R` looked like it did nothing. It turned out to be three separate defects stacked on top of each other.

- **Restart never dispatched.** `ForceRestart` only cleared shadowing state and left the re-dispatch to the next poll tick, so a restart had no observable effect for up to a full `poll_interval`.
- **On the queue path it could not dispatch at all.** Jobs are keyed `taskID:generation:routeID`, and the dispatch generation only advances implicitly for a task in `done`/`failed`. A force-restarted task is typically still `running` — the exact case restart exists for — so the generation never moved and every re-enqueue collided with the idempotency keys of the round being restarted (`dispatch.dropped`, "key already belongs to a terminal job"). Restart now bumps the generation explicitly.
- **Every failure was swallowed.** `restartTaskCmd` returned `nil` on transport error and never read the status code, so a 404 and a success were indistinguishable on screen. `clearLogsCmd` and `stopInstanceCmd` had the identical shape.

Restart now re-routes and dispatches inline via `redispatchCell`, and reports what it did through a `RestartResult` (dispatched count, workflow ids, overridden guards).

Two things surfaced while building it:

- **Queue jobs from the interrupted round stayed claimable.** Cancelling the run context only reaches an inline dispatch; a queued or leased job survived it and would later be claimed, running the round restart had just torn down alongside the fresh one. Restart now cancels them.
- **Routing had to use the post-strip label set held in memory.** Re-reading from the source races the label removal just issued, and a stale read puts the lock label straight back into routing — the cell would be dropped by the very exclusion the strip exists to clear.

### Guard overrides

`once` and the consecutive-failure cap are overridden and reported — a task wedged behind either is precisely what a human reaches for restart to unwedge. The in-flight guard is **not** overridden, so a live workflow is never run twice.

### Item references

For several sources the cell id is not something any human ever sees: the Jira adapter binds on the opaque numeric issue id, so `apiary restart CDT-123` failed as an unknown cell while the id that did work (`10042`) appeared in no interface at all.

Restart now accepts the item's human reference — a Jira key, a GitHub issue number — resolved through the source bindings, case-insensitively and ignoring a leading `#`. An exact cell id always wins over another item's number. A reference matching items in **two different sources** returns `ErrAmbiguousRef` (HTTP 409) naming both candidates rather than guessing, keeping #377's fail-closed promise: guessing wrong cancels an unrelated healthy run. `#` is percent-encoded on the wire, since `http://apiary/restart/#1953` would parse as a URL fragment and arrive empty.

Output names the item as `CDT-123 (10042)` when reference and cell id differ.

```
✓ Restarted CDT-123 (10042) (control labels cleared)
  ! overrode guard: implement (failure cap)
  → dispatched 1 workflow(s): implement
```

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `go test -race ./internal/daemon/ -run TestForceRestart` — passes.
- 13 new tests across `restart_dispatch_test.go` and `restart_ref_test.go`: immediate dispatch, generation bump for a running task, `once` override, nothing-matched reporting, in-flight release when nothing dispatches, Jira key, case-insensitive key, both GitHub forms, ambiguous reference rejected, cell id beats number, unknown reference still fails closed, improved task-id hint.
- Verified the new tests catch the real defect: reverting just the `BumpGeneration` call fails `TestForceRestart_DispatchesImmediately` (`1 triage job(s), want 2`) and `TestForceRestart_BumpsGenerationForRunningTask` (`generation went 0 → 0`).
- Existing `ForceRestart` tests (#377 fail-closed, label stripping, instance interruption) still pass unchanged apart from the new return signature.

## Notes

- Rollout needs a **new daemon binary**, not just a dashboard rebuild — the dispatch logic is daemon-side. Against an older daemon the dashboard degrades cleanly (empty body → plain "Restarted" notice).
- Not addressed here: the dashboard posts `TaskID`, which falls back to the internal task id when a task has no source binding, so `R` still 404s in that case. It is now a visible error rather than a silent no-op. Fix is a one-liner in `focusedTaskID` (send `DrillKey`), left out to keep this diff scoped.