### PR TITLE
fix(queue): stop the startup reconcile from failing a parked workflow (#375)

### DIFF
--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -218,13 +218,24 @@ func (d *Dispatcher) settleRemoteQueueJob(ctx context.Context, job queue.Job) er
 	} else if existing != nil {
 		return nil
 	}
-	// An embedded worker persists its real instance and settles the task itself.
+	// An embedded worker persists its real instance and settles the task itself,
+	// so a real instance of this job's workflow that is at least as new as the job
+	// means the local engine owns this run — whatever state it is in. Requiring a
+	// *terminal* state here was wrong for a run that parks: a workflow waiting at
+	// an approval or a wait_for step reports a non-success to the queue, so its job
+	// settles `failed` while the instance is very much alive. The reconcile then
+	// wrote a `queue-<jobid>` instance in state `failed` for a route that had not
+	// finished, decremented the outstanding counter the parked instance decrements
+	// again when it resolves, and marked the whole task failed. The phantom failure
+	// also counts toward the consecutive-failure cap, so a few restarts while
+	// parked are enough for dropCappedMatches to stop dispatching the route
+	// altogether (issue #375).
 	instances, err := d.db.ListWorkflowInstancesByTask(ctx, job.TaskID)
 	if err != nil {
 		return err
 	}
 	for _, instance := range instances {
-		if instance.WorkflowID == job.WorkflowID && !instance.CreatedAt.Before(job.CreatedAt) && (instance.State == db.InstanceStateDone || instance.State == db.InstanceStateFailed || instance.State == db.InstanceStateInterrupted) {
+		if instance.WorkflowID == job.WorkflowID && !instance.CreatedAt.Before(job.CreatedAt) {
 			return nil
 		}
 	}

--- a/src/internal/daemon/queue_settle_parked_test.go
+++ b/src/internal/daemon/queue_settle_parked_test.go
@@ -1,0 +1,201 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/router"
+	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// newParkingWorkerDispatcher builds a queue-mode dispatcher with the real
+// embedded worker over a workflow that parks at an approval gate after its first
+// agent step. The queue job for such a run reaches `succeeded` while its workflow
+// instance is still `approval_waiting`: the engine owns the instance and settles
+// the task when the approval resolves, long after the job is terminal.
+func newParkingWorkerDispatcher(t *testing.T, dbPath string, adapter *lockedAdapter) (*Dispatcher, *db.Client) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{ID: "src", Type: "fake"}},
+		Agents:  []config.AgentConfig{{ID: "a", Model: "test/model"}, {ID: "b", Model: "test/model"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "triage",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Labels: []string{"ai-ready"}}},
+			Steps: []config.StepConfig{
+				{ID: "plan", Agent: "a"},
+				{ID: "gate", Type: config.StepTypeApproval, DependsOn: []string{"plan"},
+					Message:  "Plan ready.",
+					ResumeOn: &config.ApprovalTrigger{CommentContains: "approve"},
+					Timeout:  "48h"},
+				{ID: "run", Agent: "b", DependsOn: []string{"gate"}},
+			},
+		}},
+	}
+	cfg.Settings.Queue.ProjectID = "proj"
+	cfg.Settings.Queue.PollInterval = "20ms"
+	cfg.Settings.Queue.LeaseDuration = "2s"
+	cfg.Settings.Queue.HeartbeatInterval = "200ms"
+	cfg.Settings.Queue.WorkerTimeout = "5s"
+
+	r, err := router.New(cfg)
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	d := &Dispatcher{
+		cfg:         cfg,
+		db:          dbc,
+		router:      r,
+		sources:     map[string]source.Adapter{"src": adapter},
+		runners:     map[string]runnerpkg.Runner{"agent-a": &countingRunner{}, "agent-b": &countingRunner{}},
+		agentRunner: map[string]string{"a": "claude-cli", "b": "claude-cli"},
+		agentSem:    map[string]chan struct{}{},
+		stats:       map[string]*sourceStat{"src": {}},
+		configFile:  filepath.Join(filepath.Dir(dbPath), "apiary.yaml"),
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	if err := d.configureDispatchQueue(); err != nil {
+		t.Fatalf("configure dispatch queue: %v", err)
+	}
+	if d.localWorker == nil {
+		t.Fatal("expected an embedded queue worker")
+	}
+	return d, dbc
+}
+
+// waitForInstanceState polls until the item's task has an instance of workflowID
+// in the given state (ignoring `queue-` placeholders), or the deadline passes.
+func waitForInstanceState(t *testing.T, dbc *db.Client, itemID, workflowID, state string, timeout time.Duration) bool {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		binding, _ := dbc.SourceBindings().GetBindingBySourceItem(ctx, "src", itemID)
+		if binding != nil {
+			instances, _ := dbc.ListWorkflowInstancesByTask(ctx, binding.TaskID)
+			for _, instance := range instances {
+				if instance.WorkflowID == workflowID && instance.State == state && !strings.HasPrefix(instance.ID, "queue-") {
+					return true
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForTerminalJob polls until at least one dispatch job has reached a
+// terminal state, or the deadline passes.
+func waitForTerminalJob(t *testing.T, dbc *db.Client, timeout time.Duration) bool {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, state := range []queue.JobState{queue.JobSucceeded, queue.JobFailed, queue.JobCanceled} {
+			if jobs, _ := dbc.Queue().ListJobs(ctx, state, 10); len(jobs) > 0 {
+				return true
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// Issue #375, the settle path. A queue job whose workflow parked at an approval
+// reaches `succeeded` while the real instance is still `approval_waiting`. The
+// startup reconcile must recognise that the local engine still owns that
+// instance and leave it alone. It used to skip only when it found a *terminal*
+// instance for the job's workflow, so a parked one fell through and the
+// reconcile wrote a `queue-<jobid>` instance in state `done` for the very route
+// that had not finished — and decremented the task's outstanding counter that
+// the parked instance will decrement again when the approval resolves.
+//
+// The phantom `done` instance is what makes this a #375 defect rather than a
+// bookkeeping wart: HasCompletedInstanceForRoute then reports the route as
+// completed, so a `once: true` route and any redelivery of it are silently
+// declined for a workflow that never actually finished.
+func TestReconcileTerminalQueueJobs_LeavesParkedInstanceAlone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "queue.db")
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+
+	d1, dbc1 := newParkingWorkerDispatcher(t, dbPath, adapter)
+	stop1 := runWorker(t, d1)
+	d1.poll(ctx, d1.cfg.Sources[0], adapter, time.Time{})
+	if !waitForInstanceState(t, dbc1, "c1", "triage", db.InstanceStateApprovalWaiting, 15*time.Second) {
+		t.Fatalf("workflow never parked at the approval gate:%s", queueDiagnostics(t, dbc1))
+	}
+	// The job that started the parked run goes terminal even though the run is
+	// not: parking is reported as a non-success, so the job settles `failed`.
+	if !waitForTerminalJob(t, dbc1, 10*time.Second) {
+		t.Fatalf("expected the parked run's job to have gone terminal:%s", queueDiagnostics(t, dbc1))
+	}
+	binding, _ := dbc1.SourceBindings().GetBindingBySourceItem(ctx, "src", "c1")
+	if binding == nil {
+		t.Fatal("no source binding for c1")
+	}
+	taskID := binding.TaskID
+	before, err := dbc1.InternalTasks().GetTask(ctx, taskID)
+	if err != nil || before == nil {
+		t.Fatalf("read task: %v", err)
+	}
+	stop1()
+
+	// The daemon restarts. Startup reconcile walks every terminal queue job.
+	d2, dbc2 := newParkingWorkerDispatcher(t, dbPath, adapter)
+	d2.reconcileTerminalQueueJobs(ctx)
+
+	instances, err := dbc2.ListWorkflowInstancesByTask(ctx, taskID)
+	if err != nil {
+		t.Fatalf("list instances: %v", err)
+	}
+	parked := 0
+	for _, instance := range instances {
+		if strings.HasPrefix(instance.ID, "queue-") {
+			t.Errorf("startup reconcile wrote placeholder instance %s (workflow %s, state %s) for a run still parked at an approval",
+				instance.ID, instance.WorkflowID, instance.State)
+		}
+		if instance.State == db.InstanceStateApprovalWaiting {
+			parked++
+		}
+	}
+	if parked != 1 {
+		t.Errorf("parked instance count = %d, want 1", parked)
+	}
+	completed, err := dbc2.HasCompletedInstanceForRoute(ctx, taskID, "triage")
+	if err != nil {
+		t.Fatalf("completed check: %v", err)
+	}
+	if completed {
+		t.Error("route reported as completed while its only instance is still parked at an approval")
+	}
+	after, err := dbc2.InternalTasks().GetTask(ctx, taskID)
+	if err != nil || after == nil {
+		t.Fatalf("read task after reconcile: %v", err)
+	}
+	if after.OutstandingWorkflows != before.OutstandingWorkflows {
+		t.Errorf("outstanding counter = %d after reconcile, want %d — the parked instance will decrement it again when the approval resolves",
+			after.OutstandingWorkflows, before.OutstandingWorkflows)
+	}
+	if after.State != before.State {
+		t.Errorf("task state = %q after reconcile, want %q", after.State, before.State)
+	}
+}

--- a/src/internal/daemon/queue_worker_handoff_test.go
+++ b/src/internal/daemon/queue_worker_handoff_test.go
@@ -183,6 +183,31 @@ func queueDiagnostics(t *testing.T, dbc *db.Client) string {
 	return out
 }
 
+// Issue #375, the reporter's actual label shape: the triage agent *adds* the
+// hand-off label and leaves its own trigger label in place, so the incremental
+// poll matches BOTH workflows. The fan-out enqueues two jobs onto a worker whose
+// capacity is the production default of 1, and the first of them is a re-dispatch
+// of a workflow that has already completed for this task — the exact combination
+// that used to short-circuit inside ExecuteQueuedJob. The hand-off must still run.
+func TestQueueWorker_HandoffWithBothLabelsRetained(t *testing.T) {
+	ctx := context.Background()
+	adapter := &lockedAdapter{items: []model.SourceItem{{ID: "c1", SourceID: "src", Title: "Do it", Labels: []string{"ai-ready"}}}}
+	d, dbc := newWorkerDispatcher(t, filepath.Join(t.TempDir(), "queue.db"), adapter)
+	stop := runWorker(t, d)
+	defer stop()
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	if !waitForInstance(t, dbc, "c1", "triage", 15*time.Second) {
+		t.Fatalf("triage never completed:%s", queueDiagnostics(t, dbc))
+	}
+
+	adapter.setLabels("ai-ready", "ai-implement")
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Now())
+	if !waitForInstance(t, dbc, "c1", "impl", 15*time.Second) {
+		t.Fatalf("hand-off never ran when the triage label stayed on the item:%s", queueDiagnostics(t, dbc))
+	}
+}
+
 // Issue #375, first hand-off, end to end through the real embedded worker: the
 // triage workflow runs, the agent swaps the labels, and the very next
 // incremental poll must enqueue AND the worker must lease and run `impl` — with


### PR DESCRIPTION
Fifth pass on #375. This one reconstructs the failure against the **v0.13.0 source the reporter actually ran**, instead of against `main` — which is what the previous four passes did, and why they concluded "cannot reproduce".

## What reproduces on v0.13.0

A scratch worktree at the `v0.13.0` tag, running the four end-to-end hand-off scenarios (real embedded worker, capacity 1 — the production default — over a real SQLite queue):

| scenario | v0.13.0 | main |
|---|---|---|
| hand-off on the next incremental poll | pass | pass |
| hand-off after a restart, previous worker row left at `active_jobs=1` | **silent stall** | pass |
| hand-off enqueued while the single capacity slot is held | pass | pass |
| `done` placeholder instance present for the hand-off route | **silent stall** | pass |

Both failures are the reporter's symptom exactly — a poll that reports the cell, and nothing after it, at any log level:

- **stale worker row**: `RegisterWorker` did not reset `active_jobs`, so `Claim` refused every job and the hand-off sat `queued` forever; on v0.13.0 a restart did *not* clear it either. Fixed by #389 / #393.
- **completed-instance short-circuit**: `ExecuteQueuedJob` applied `HasCompletedInstanceForRoute` to every job, so the job reported `succeeded` with no instance, no step run and no log. Fixed by #386.

So the merged fixes do close the reproducible v0.13.0 stalls. See the report on the issue for what that does and does not settle about runs 1 and 2 specifically.

## The live defect this PR fixes

Found while enumerating that same path on `main`, and it is a real one.

A workflow that parks at an approval (or a `wait_for`) reports a non-success to the queue, so **its job settles `failed` while the instance is alive**. `settleRemoteQueueJob` skipped only when it found a *terminal* instance for the job's workflow, so a parked one fell through and the startup reconcile:

1. wrote a `queue-<jobid>` instance in state `failed` for a route that had not finished,
2. decremented the outstanding counter that the parked instance decrements *again* when the approval resolves,
3. marked the whole task `failed`.

The phantom failure also counts toward `CountConsecutiveFailedInstances`, so a handful of restarts while parked are enough for `dropCappedMatches` to stop dispatching the route altogether — the same silent poll→no-dispatch stall as #375, reached from a different direction.

**Fix:** a real instance of the job's workflow that is at least as new as the job means the local engine owns this run, whatever state it is in. The reconcile leaves it alone.

## Tests

- `TestReconcileTerminalQueueJobs_LeavesParkedInstanceAlone` — drives the real embedded worker to a parked approval, then restarts over the same database. Without the fix it reports all three symptoms:
  ```
  startup reconcile wrote placeholder instance queue-job-37e1f… (workflow triage, state failed) for a run still parked at an approval
  outstanding counter = 0 after reconcile, want 1
  task state = "failed" after reconcile, want "registered"
  ```
- `TestQueueWorker_HandoffWithBothLabelsRetained` — the reporter's actual label shape: the agent *adds* the hand-off label without removing its own, so the poll matches both workflows and the fan-out enqueues two jobs, the first a re-dispatch of an already-completed workflow. Untested until now; passes on both v0.13.0 and `main`, kept as the regression guard.

`go test ./...` and `go test -race ./...` pass repo-wide.

## Deliberately not fixed here

A parked run's job settling `failed` is wrong reporting in its own right — `apiary status` shows a failed job for a healthy workflow waiting on an approval. Distinguishing parked from failed needs a signal `RunInstance` does not currently return, and guessing at it on the dispatch path risks duplicate agent runs. Worth its own change.

Refs #375.