### PR TITLE
feat(prometheus): ack_via_silence — silence an alert while an agent investigates

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -146,6 +146,12 @@ sources:
       max_new_per_poll: 10
       # Flap dampener: alerts must have been firing at least this long.
       min_age: 1m
+      # Opt-in: silence a dispatched alert in Alertmanager while an agent
+      # investigates it, so it stops paging the on-call. Off by default.
+      # ack_via_silence: true
+      # How long that silence lasts. It is a ceiling, not an estimate: if the
+      # run dies the silence must still expire on its own. Default 2h.
+      # silence_duration: 2h
     poll_interval: 30s
     filters:
       # Alertmanager matchers, ANDed server-side. key=value, key:value, or a

--- a/docs/prometheus-source.md
+++ b/docs/prometheus-source.md
@@ -23,6 +23,8 @@ sources:
       bearer_token: ${ALERTMANAGER_TOKEN}   # optional
       max_new_per_poll: 10                  # optional, storm cap
       min_age: 1m                           # optional, flap dampener
+      ack_via_silence: true                 # optional, silence while investigating
+      silence_duration: 2h                  # optional, how long that silence lasts
     filters:
       labels: ["severity=critical", "team=platform"]
 
@@ -45,6 +47,8 @@ workflows:
 | `basic_auth_user` / `basic_auth_password` | no | HTTP Basic auth (ignored when `bearer_token` is set) |
 | `max_new_per_poll` | no | Alert-storm cap: at most this many *not-yet-seen* alerts become tasks per poll; the overflow is logged and surfaces on later polls. `0` disables the cap. Default `10` |
 | `min_age` | no | Flap dampener: an alert must have been firing at least this long before it is ingested (complements the alerting rule's own `for:`). Default `1m` |
+| `ack_via_silence` | no | When `true`, acknowledging a dispatched alert creates an Alertmanager silence for it, so it stops paging while an agent investigates. Default `false` (acknowledge is a no-op) |
+| `silence_duration` | no | How long an `ack_via_silence` silence lasts. Default `2h` |
 
 ### `filters`
 
@@ -85,13 +89,50 @@ workflows:
   fingerprint+startsAt identity this also means a *resolved-and-refired*
   alert within the window is a fresh item only once it has stayed firing.
 - **Read-only.** Alerts have no assignable state, labels, or comments to
-  write back to: `Acknowledge` and result write-back are no-ops, and the
-  adapter implements none of the optional write capabilities.
-  `apiary validate` rejects workflows that pin this source and use
-  `on_complete.set_state` / `add_labels`, approval steps, `wait_for` CI
-  steps, or `materialize: sub_issue`.
+  write back to: result write-back is a no-op, `Acknowledge` is one too
+  unless `ack_via_silence` is set, and the adapter implements none of the
+  optional write capabilities. `apiary validate` rejects workflows that pin
+  this source and use `on_complete.set_state` / `add_labels`, approval
+  steps, `wait_for` CI steps, or `materialize: sub_issue`.
 - **Resolved while running.** A running investigation is not interrupted
   when its alert resolves; the workflow finishes normally.
+
+## Acknowledge via silence
+
+By default a dispatched alert keeps notifying: Apiary picking it up is
+invisible to Alertmanager, so the on-call is still paged for something an
+agent is already working on. Setting `ack_via_silence: true` closes that gap
+— when the workflow acknowledges the alert, the adapter creates a silence
+for it:
+
+```yaml
+config:
+  alertmanager_url: https://alertmanager.internal:9093
+  ack_via_silence: true
+  silence_duration: 2h
+```
+
+- **Pinned to one alert.** The silence carries an exact-equality matcher for
+  every label of the alert that was dispatched, so it suppresses that alert
+  and nothing else. It is never a regex or a partial match.
+- **Always time-boxed.** `silence_duration` is a ceiling, not an estimate of
+  how long the investigation takes. If the agent crashes or the daemon is
+  killed, the silence still expires on its own and a genuinely unresolved
+  alert comes back — Apiary never suppresses an alert indefinitely.
+- **Only on dispatch.** A skipped item is never silenced: it was not picked
+  up, so hiding it would be hiding an alert nobody is looking at.
+- **At most one per fire cycle.** Re-acknowledging the same alert (a retried
+  step, a re-dispatch) does not stack a second silence. A silence that
+  Alertmanager *rejected* is not recorded as done, so a later acknowledge
+  retries it.
+- **The alert leaves the poll.** Silenced alerts are excluded from
+  `GET /api/v2/alerts`, so a silenced alert stops being returned until the
+  silence lapses. It does not re-dispatch when it comes back: the task ID is
+  still `fingerprint:startsAt` for that same fire cycle, and the persisted
+  task identity dedups it.
+- **Requires write access.** The configured token needs permission to POST
+  silences. If Alertmanager rejects the request the error is logged and the
+  run continues — a silence failure never fails the investigation.
 
 ## Where results go
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -155,7 +155,7 @@
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. plugin: plugin (the id of an installed, enabled plugin with the source capability)",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age, ack_via_silence, silence_duration. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. plugin: plugin (the id of an installed, enabled plugin with the source capability)",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/internal/source/prometheus/adapter.go
+++ b/src/internal/source/prometheus/adapter.go
@@ -6,9 +6,13 @@
 //
 // Alerts are read-only work items: the adapter deliberately implements none of
 // the optional write capabilities (StateSetter, LabelAdder, TaskPoller,
-// CIStatusPoller, SubIssueCreator…). Acknowledge and WriteResult are no-ops;
-// config validation rejects workflows that need write capabilities against a
-// source that lacks them (config.SourceCapabilities).
+// CIStatusPoller, SubIssueCreator…). WriteResult is a no-op and Acknowledge is
+// one too by default; config validation rejects workflows that need write
+// capabilities against a source that lacks them (config.SourceCapabilities).
+//
+// The one opt-in write is ack_via_silence: with it enabled, acknowledging a
+// dispatched alert creates a time-boxed Alertmanager silence for that alert, so
+// it stops paging while an agent investigates.
 package prometheus
 
 import (
@@ -40,6 +44,12 @@ const (
 	// least this long before it is surfaced. Complements the alerting rule's
 	// own `for:` clause; 0 would dispatch on the very first evaluation.
 	defaultMinAge = time.Minute
+
+	// defaultSilenceDuration bounds an ack_via_silence silence. It is a
+	// deliberate ceiling, not an estimate of how long an investigation runs:
+	// if the agent dies or the daemon is killed the silence must expire on its
+	// own, or a still-firing alert would stay invisible forever.
+	defaultSilenceDuration = 2 * time.Hour
 )
 
 // Adapter implements source.Adapter for Prometheus Alertmanager.
@@ -49,6 +59,12 @@ type Adapter struct {
 
 	maxNewPerPoll int
 	minAge        time.Duration
+
+	// ackViaSilence turns Acknowledge from a no-op into "create an
+	// Alertmanager silence for this alert", so a dispatched alert stops
+	// re-notifying the on-call while an agent investigates it.
+	ackViaSilence   bool
+	silenceDuration time.Duration
 
 	// filters are Alertmanager matcher strings sent as filter= params,
 	// built from SourceFilters.Labels.
@@ -62,6 +78,24 @@ type Adapter struct {
 	// is still prevented downstream by the persisted task/instance dedup.
 	mu   sync.Mutex
 	seen map[string]struct{}
+
+	// labels caches the exact label set of every surfaced alert, keyed by item
+	// ID. Acknowledge needs it to build silence matchers: the SourceItem it is
+	// handed is reconstructed from a source binding and carries no Metadata,
+	// so the raw label map is not otherwise reachable. Pruned with seen.
+	labels map[string]map[string]string
+
+	// silenced records the silence created for an item ID and when it expires,
+	// so a second Acknowledge for the same fire cycle (re-dispatch, retried
+	// step) does not stack a second silence. Entries are dropped once expired,
+	// which also bounds the map.
+	silenced map[string]silenceRecord
+}
+
+// silenceRecord is one live silence the adapter created.
+type silenceRecord struct {
+	id     string
+	expiry time.Time
 }
 
 func (a *Adapter) ID() string { return a.id }
@@ -100,10 +134,24 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 		a.minAge = d
 	}
 
-	a.seen = map[string]struct{}{}
+	a.ackViaSilence, _ = cfg["ack_via_silence"].(bool)
 
-	aplog.Info("prometheus: configured  alertmanager=%s  max_new_per_poll=%d  min_age=%s",
-		baseURL, a.maxNewPerPoll, a.minAge)
+	a.silenceDuration = defaultSilenceDuration
+	if v, ok := cfg["silence_duration"]; ok {
+		s, _ := v.(string)
+		d, err := time.ParseDuration(s)
+		if err != nil || d <= 0 {
+			return fmt.Errorf("prometheus: config.silence_duration must be a positive duration (e.g. \"2h\"), got %v", v)
+		}
+		a.silenceDuration = d
+	}
+
+	a.seen = map[string]struct{}{}
+	a.labels = map[string]map[string]string{}
+	a.silenced = map[string]silenceRecord{}
+
+	aplog.Info("prometheus: configured  alertmanager=%s  max_new_per_poll=%d  min_age=%s  ack_via_silence=%v  silence_duration=%s",
+		baseURL, a.maxNewPerPoll, a.minAge, a.ackViaSilence, a.silenceDuration)
 	return nil
 }
 
@@ -192,6 +240,7 @@ func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, er
 			newCount++
 			a.seen[id] = struct{}{}
 		}
+		a.labels[id] = al.Labels
 		items = append(items, a.toSourceItem(al))
 	}
 	if dropped > 0 {
@@ -199,9 +248,13 @@ func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, er
 	}
 
 	// Prune fire cycles that ended so a re-fire (new startsAt) counts as new.
+	// An alert silenced by ack_via_silence also drops out here (silenced
+	// alerts are excluded from the poll); its persisted task identity, not
+	// this map, is what keeps it from re-dispatching when the silence lapses.
 	for id := range a.seen {
 		if _, ok := current[id]; !ok {
 			delete(a.seen, id)
+			delete(a.labels, id)
 		}
 	}
 
@@ -312,11 +365,89 @@ func sortedKeys(m map[string]string) []string {
 	return keys
 }
 
-// Acknowledge is a no-op: an alert has no assignable/in-progress state to set.
-// Silencing on dispatch (ack_via_silence) is a possible future opt-in.
-func (a *Adapter) Acknowledge(_ context.Context, cell model.SourceItem, action model.AckAction) error {
-	aplog.Debug("prometheus: acknowledge %s (%s) — no-op for alerts", cell.LogLabel(), action)
+// Acknowledge is a no-op by default: an alert has no assignable/in-progress
+// state to set. With ack_via_silence enabled it instead creates an Alertmanager
+// silence pinned to the dispatched alert's exact label set, so the alert stops
+// paging the on-call for as long as an agent is investigating it.
+//
+// Only the in_progress action silences. A skip means the item was never
+// dispatched, and suppressing an alert nobody is looking at would hide it.
+func (a *Adapter) Acknowledge(ctx context.Context, cell model.SourceItem, action model.AckAction) error {
+	if !a.ackViaSilence || action != model.AckActionInProgress {
+		aplog.Debug("prometheus: acknowledge %s (%s) — no-op for alerts", cell.LogLabel(), action)
+		return nil
+	}
+
+	now := time.Now()
+	matchers, ok := a.silenceMatchers(cell, now)
+	if !ok {
+		return nil // already silenced, or nothing safe to match on
+	}
+
+	endsAt := now.Add(a.silenceDuration)
+	id, err := a.client.createSilence(ctx, silence{
+		Matchers:  matchers,
+		StartsAt:  now,
+		EndsAt:    endsAt,
+		CreatedBy: "apiary",
+		Comment:   fmt.Sprintf("Apiary is investigating this alert (task %s). Expires automatically.", cell.ID),
+	})
+	if err != nil {
+		return fmt.Errorf("prometheus: silencing %s: %w", cell.LogLabel(), err)
+	}
+
+	a.mu.Lock()
+	a.silenced[cell.ID] = silenceRecord{id: id, expiry: endsAt}
+	a.mu.Unlock()
+
+	aplog.Info("prometheus: silenced %s until %s (silence=%s, %d matcher(s))",
+		cell.LogLabel(), endsAt.UTC().Format(time.RFC3339), id, len(matchers))
 	return nil
+}
+
+// silenceMatchers builds the exact-equality matchers for one alert and reports
+// whether a silence should be created at all (false when this fire cycle is
+// already silenced, or when no label set could be recovered).
+//
+// The label set comes from the poll-time cache, which holds the alert's raw
+// labels. When the daemon restarted between the poll and this call the cache is
+// cold, so it falls back to the item's "key:value" labels — lossless here
+// because a Prometheus label name can never contain a colon, so splitting on
+// the first one reproduces the original pair.
+func (a *Adapter) silenceMatchers(cell model.SourceItem, now time.Time) ([]matcher, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for id, rec := range a.silenced {
+		if !rec.expiry.After(now) {
+			delete(a.silenced, id)
+		}
+	}
+	if rec, ok := a.silenced[cell.ID]; ok {
+		aplog.Debug("prometheus: %s already silenced until %s (silence=%s) — skipping",
+			cell.LogLabel(), rec.expiry.UTC().Format(time.RFC3339), rec.id)
+		return nil, false
+	}
+
+	labels := a.labels[cell.ID]
+	if len(labels) == 0 {
+		labels = map[string]string{}
+		for _, l := range cell.Labels {
+			if k, v, found := strings.Cut(l, ":"); found {
+				labels[k] = v
+			}
+		}
+	}
+	if len(labels) == 0 {
+		aplog.Warn("prometheus: cannot silence %s — no label set available; leaving the alert unsilenced", cell.LogLabel())
+		return nil, false
+	}
+
+	matchers := make([]matcher, 0, len(labels))
+	for _, k := range sortedKeys(labels) {
+		matchers = append(matchers, matcher{Name: k, Value: labels[k], IsEqual: true})
+	}
+	return matchers, true
 }
 
 // WriteResult is a no-op: Alertmanager has no per-alert comment surface. The

--- a/src/internal/source/prometheus/client.go
+++ b/src/internal/source/prometheus/client.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -62,9 +63,42 @@ func (c *client) alerts(ctx context.Context, filters []string) ([]alert, error) 
 	return alerts, nil
 }
 
-// get executes the request, retrying on 429/5xx with exponential backoff
+// createSilence posts a silence to POST /api/v2/silences and returns the
+// silence ID Alertmanager assigned. Callers build the matchers from the exact
+// label set of the alert being silenced, so the silence suppresses that one
+// alert and nothing else.
+//
+// A retried POST can in principle create a second identical silence (if the
+// first attempt succeeded but its response was lost). Two silences with the
+// same matchers and window are harmless — they suppress the same alert for the
+// same period — and the adapter records the first returned ID so one
+// Acknowledge never silences twice.
+func (c *client) createSilence(ctx context.Context, s silence) (string, error) {
+	payload, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("prometheus: encoding silence: %w", err)
+	}
+
+	data, err := c.do(ctx, http.MethodPost, "/api/v2/silences", nil, payload)
+	if err != nil {
+		return "", err
+	}
+	var resp silenceResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("prometheus: decoding silence response: %w", err)
+	}
+	return resp.SilenceID, nil
+}
+
+// get executes a GET, retrying on 429/5xx with exponential backoff
 // (honouring Retry-After when present).
 func (c *client) get(ctx context.Context, path string, params url.Values) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, path, params, nil)
+}
+
+// do executes the request, retrying on 429/5xx with exponential backoff
+// (honouring Retry-After when present). A nil body sends no request payload.
+func (c *client) do(ctx context.Context, method, path string, params url.Values, body []byte) ([]byte, error) {
 	fullPath := path
 	if len(params) > 0 {
 		fullPath += "?" + params.Encode()
@@ -72,11 +106,18 @@ func (c *client) get(ctx context.Context, path string, params url.Values) ([]byt
 
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+fullPath, nil)
+		var payload io.Reader
+		if body != nil {
+			payload = bytes.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+fullPath, payload)
 		if err != nil {
 			return nil, err
 		}
 		req.Header.Set("Accept", "application/json")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
 		if c.bearerToken != "" {
 			req.Header.Set("Authorization", "Bearer "+c.bearerToken)
 		} else if c.basicUser != "" {
@@ -86,34 +127,34 @@ func (c *client) get(ctx context.Context, path string, params url.Values) ([]byt
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			lastErr = err
-			aplog.Debug("prometheus: GET %s failed (attempt %d/%d): %v", path, attempt+1, maxRetries, err)
+			aplog.Debug("prometheus: %s %s failed (attempt %d/%d): %v", method, path, attempt+1, maxRetries, err)
 			if !backoffWait(ctx, nil, attempt) {
 				return nil, ctx.Err()
 			}
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return nil, err
 		}
 
-		aplog.Debug("prometheus: GET %s → %d", path, resp.StatusCode)
+		aplog.Debug("prometheus: %s %s → %d", method, path, resp.StatusCode)
 
 		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			lastErr = fmt.Errorf("alertmanager API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+			lastErr = fmt.Errorf("alertmanager API %s %s: status %d: %s", method, path, resp.StatusCode, truncateBody(respBody))
 			if !backoffWait(ctx, resp, attempt) {
 				return nil, ctx.Err()
 			}
 			continue
 		}
 		if resp.StatusCode >= 400 {
-			return nil, fmt.Errorf("alertmanager API GET %s: status %d: %s", path, resp.StatusCode, truncateBody(body))
+			return nil, fmt.Errorf("alertmanager API %s %s: status %d: %s", method, path, resp.StatusCode, truncateBody(respBody))
 		}
-		return body, nil
+		return respBody, nil
 	}
-	return nil, fmt.Errorf("alertmanager API GET %s: exceeded %d retries: %w", path, maxRetries, lastErr)
+	return nil, fmt.Errorf("alertmanager API %s %s: exceeded %d retries: %w", method, path, maxRetries, lastErr)
 }
 
 // backoffWait sleeps for the retry delay (Retry-After header if present,

--- a/src/internal/source/prometheus/silence_test.go
+++ b/src/internal/source/prometheus/silence_test.go
@@ -1,0 +1,284 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// silenceServer serves alerts on GET /api/v2/alerts and records every silence
+// posted to POST /api/v2/silences.
+type silenceServer struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	posted   []silence
+	failWith int // when non-zero, silences are rejected with this status
+}
+
+func newSilenceServer(t *testing.T, alerts *[]map[string]any) *silenceServer {
+	t.Helper()
+	s := &silenceServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/alerts":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(*alerts)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v2/silences":
+			s.mu.Lock()
+			fail := s.failWith
+			s.mu.Unlock()
+			if fail != 0 {
+				http.Error(w, "nope", fail)
+				return
+			}
+			var body silence
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			s.mu.Lock()
+			s.posted = append(s.posted, body)
+			n := len(s.posted)
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"silenceID": "sil-" + string(rune('0'+n))})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *silenceServer) silences() []silence {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]silence(nil), s.posted...)
+}
+
+func (s *silenceServer) rejectWith(status int) {
+	s.mu.Lock()
+	s.failWith = status
+	s.mu.Unlock()
+}
+
+// pollOne polls the adapter and returns the single item it surfaced.
+func pollOne(t *testing.T, a *Adapter) model.SourceItem {
+	t.Helper()
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	return items[0]
+}
+
+func matcherMap(t *testing.T, s silence) map[string]string {
+	t.Helper()
+	m := map[string]string{}
+	for _, mt := range s.Matchers {
+		if mt.IsRegex {
+			t.Errorf("matcher %q must be exact equality, got a regex", mt.Name)
+		}
+		if !mt.IsEqual {
+			t.Errorf("matcher %q must be a positive match (isEqual)", mt.Name)
+		}
+		m[mt.Name] = mt.Value
+	}
+	return m
+}
+
+// The default is unchanged: acknowledging an alert writes nothing back.
+func TestAcknowledgeNoSilenceByDefault(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, nil)
+
+	item := pollOne(t, a)
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if got := srv.silences(); len(got) != 0 {
+		t.Fatalf("expected no silence without ack_via_silence, got %d", len(got))
+	}
+}
+
+// With the opt-in on, a dispatched alert is silenced on its exact label set.
+func TestAcknowledgeCreatesSilence(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true, "silence_duration": "30m"})
+
+	item := pollOne(t, a)
+	before := time.Now()
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+
+	got := srv.silences()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 silence, got %d", len(got))
+	}
+	s := got[0]
+
+	want := map[string]string{"alertname": "HighErrorRate", "severity": "critical", "team": "platform"}
+	m := matcherMap(t, s)
+	if len(m) != len(want) {
+		t.Fatalf("matchers = %v, want %v", m, want)
+	}
+	for k, v := range want {
+		if m[k] != v {
+			t.Errorf("matcher %s = %q, want %q", k, m[k], v)
+		}
+	}
+
+	if d := s.EndsAt.Sub(s.StartsAt); d < 29*time.Minute || d > 31*time.Minute {
+		t.Errorf("silence window = %s, want ~30m", d)
+	}
+	if s.EndsAt.Before(before) {
+		t.Errorf("silence already expired at creation: endsAt=%s", s.EndsAt)
+	}
+	if s.CreatedBy == "" || s.Comment == "" {
+		t.Errorf("silence must be attributable: createdBy=%q comment=%q", s.CreatedBy, s.Comment)
+	}
+}
+
+// A skipped item was never dispatched — silencing it would hide an alert
+// nobody is looking at.
+func TestAcknowledgeSkipDoesNotSilence(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	item := pollOne(t, a)
+	if err := a.Acknowledge(context.Background(), item, model.AckActionSkip); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+	if got := srv.silences(); len(got) != 0 {
+		t.Fatalf("expected no silence for a skip, got %d", len(got))
+	}
+}
+
+// Re-acknowledging the same fire cycle must not stack a second silence.
+func TestAcknowledgeIsIdempotentPerFireCycle(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	item := pollOne(t, a)
+	for i := 0; i < 3; i++ {
+		if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+			t.Fatalf("Acknowledge #%d: %v", i+1, err)
+		}
+	}
+	if got := srv.silences(); len(got) != 1 {
+		t.Fatalf("expected exactly 1 silence across 3 acks, got %d", len(got))
+	}
+}
+
+// After a restart the poll-time label cache is cold; the item's "key:value"
+// labels must still reproduce the exact matcher set.
+func TestAcknowledgeFallsBackToItemLabels(t *testing.T) {
+	alerts := []map[string]any{}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	// Never polled: this item came back from a persisted binding.
+	item := model.SourceItem{
+		ID:       "abcdef1234567890:2026-01-01T00:00:00Z",
+		SourceID: "prod-alerts",
+		Labels:   []string{"alertname:HighErrorRate", "instance:web-1:9100", "severity:critical"},
+	}
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+
+	got := srv.silences()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 silence, got %d", len(got))
+	}
+	m := matcherMap(t, got[0])
+	want := map[string]string{"alertname": "HighErrorRate", "instance": "web-1:9100", "severity": "critical"}
+	if len(m) != len(want) {
+		t.Fatalf("matchers = %v, want %v", m, want)
+	}
+	for k, v := range want {
+		if m[k] != v {
+			t.Errorf("matcher %s = %q, want %q — a colon in a label value must survive", k, m[k], v)
+		}
+	}
+}
+
+// With no labels at all a silence would match every alert. Refuse to create it.
+func TestAcknowledgeWithoutLabelsDoesNotSilence(t *testing.T) {
+	alerts := []map[string]any{}
+	srv := newSilenceServer(t, &alerts)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	item := model.SourceItem{ID: "unknown:2026-01-01T00:00:00Z", SourceID: "prod-alerts"}
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge must not fail the dispatch: %v", err)
+	}
+	if got := srv.silences(); len(got) != 0 {
+		t.Fatalf("expected no silence without labels, got %d", len(got))
+	}
+}
+
+// A rejected silence surfaces as an error so the failure is visible in the log
+// rather than silently leaving the alert paging.
+func TestAcknowledgeReportsSilenceFailure(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	srv.rejectWith(http.StatusForbidden)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	item := pollOne(t, a)
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err == nil {
+		t.Fatal("expected an error when Alertmanager rejects the silence")
+	}
+}
+
+// A failed silence must not be recorded as done — the next ack retries.
+func TestAcknowledgeRetriesAfterFailure(t *testing.T) {
+	alerts := []map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", time.Now().Add(-10*time.Minute))}
+	srv := newSilenceServer(t, &alerts)
+	srv.rejectWith(http.StatusForbidden)
+	a := connect(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	item := pollOne(t, a)
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err == nil {
+		t.Fatal("expected the first ack to fail")
+	}
+
+	srv.rejectWith(0)
+	if err := a.Acknowledge(context.Background(), item, model.AckActionInProgress); err != nil {
+		t.Fatalf("second Acknowledge: %v", err)
+	}
+	if got := srv.silences(); len(got) != 1 {
+		t.Fatalf("expected the retry to create the silence, got %d", len(got))
+	}
+}
+
+func TestConnectRejectsBadSilenceDuration(t *testing.T) {
+	for _, v := range []any{"nope", "0s", "-5m", 42} {
+		a := &Adapter{}
+		err := a.Connect(context.Background(), map[string]any{
+			"alertmanager_url": "http://localhost:9093",
+			"silence_duration": v,
+		})
+		if err == nil {
+			t.Errorf("silence_duration=%v: expected an error", v)
+		}
+	}
+}

--- a/src/internal/source/prometheus/types.go
+++ b/src/internal/source/prometheus/types.go
@@ -20,3 +20,28 @@ type alertStatus struct {
 	SilencedBy  []string `json:"silencedBy"`
 	InhibitedBy []string `json:"inhibitedBy"`
 }
+
+// silence is the POST /api/v2/silences request body (openapi PostableSilence).
+// Every matcher must hold for an alert to be suppressed.
+type silence struct {
+	Matchers  []matcher `json:"matchers"`
+	StartsAt  time.Time `json:"startsAt"`
+	EndsAt    time.Time `json:"endsAt"`
+	CreatedBy string    `json:"createdBy"`
+	Comment   string    `json:"comment"`
+}
+
+// matcher is one label condition of a silence. The adapter only ever emits
+// exact equality on the alert's own labels (IsRegex and IsEqual defaults),
+// which pins the silence to a single alert.
+type matcher struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	IsRegex bool   `json:"isRegex"`
+	IsEqual bool   `json:"isEqual"`
+}
+
+// silenceResponse is the POST /api/v2/silences response body.
+type silenceResponse struct {
+	SilenceID string `json:"silenceID"`
+}


### PR DESCRIPTION
## Summary

First of the three remaining items on #362 (Dynatrace shipped in #363, the plugin-source bridge in #366, and the generic webhook source was dropped by design).

Today, Apiary dispatching an alert is invisible to Alertmanager: the alert keeps firing and keeps paging the on-call while an agent is already investigating it. `ack_via_silence: true` makes the adapter's previously no-op `Acknowledge` create an Alertmanager silence instead.

- **Pinned to one alert.** Matchers are exact equality on every label of the dispatched alert — never a regex, never a partial match, so it cannot silence a broader family.
- **Always time-boxed.** `silence_duration` (default `2h`) is a deliberate ceiling, not an estimate of investigation length: if the agent dies or the daemon is killed, the silence still expires and a genuinely unresolved alert comes back.
- **Only on dispatch.** `AckActionSkip` never silences — the item was not picked up, so suppressing it would hide an alert nobody is looking at.
- **At most one per fire cycle.** Re-acknowledging (retried step, re-dispatch) does not stack silences. A silence Alertmanager *rejected* is not recorded as done, so a later ack retries it.
- **Non-fatal.** A silence failure returns an error that the caller logs; it never fails the investigation.

Off by default — existing configs are unchanged.

### Implementation note

`Acknowledge` is handed a `SourceItem` reconstructed from a source binding (`sourceItemFromBinding`), which carries **no `Metadata`** — so the alert's raw label map is not reachable there. Labels therefore come from a poll-time cache keyed by item ID, pruned alongside `seen`. When the daemon restarted between the poll and the ack the cache is cold, and it falls back to the item's `"key:value"` labels; that fallback is lossless because a Prometheus label *name* can never contain a colon, so splitting on the first one reproduces the original pair (covered by a test using `instance:web-1:9100`).

One consequence worth knowing: a silenced alert drops out of `GET /api/v2/alerts` (the poll excludes silenced alerts). It does not re-dispatch when the silence lapses — the ID is still `fingerprint:startsAt` for that fire cycle and the persisted task identity dedups it. Documented in `docs/prometheus-source.md`.

`client.get` was refactored into a shared `do` so POST reuses the existing 429/5xx + `Retry-After` backoff.

## Test plan

- `go build ./... && go vet ./...` clean.
- `go test ./... -count=1` green; `go test ./internal/source/prometheus/ -race` green.
- New `silence_test.go` covers: no silence by default; exact matcher set and window; skip does not silence; idempotent across 3 acks; cold-cache fallback preserving a colon in a label value; refusal to silence with no labels (a matcher-less silence would match everything); error surfaced on rejection; retry after a rejected silence; `silence_duration` validation.
- `apiary validate` on `.apiary/example-apiary-full.yaml` reports the same 9 pre-existing errors as `main` — unchanged by this PR.
- Not exercised against a live Alertmanager.

Refs #362