### PR TITLE
feat(sources): interrupt_on_resolve — stop a run whose alert resolved

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -153,6 +153,11 @@ sources:
       # run dies the silence must still expire on its own. Default 2h.
       # silence_duration: 2h
     poll_interval: 30s
+    # Opt-in: stop a still-running investigation when its alert stops firing.
+    # Default is to let the run finish — its findings usually outlive the
+    # alert. Suppressed alerts do not count as resolved, and an unreachable
+    # Alertmanager never stops anything.
+    # interrupt_on_resolve: true
     filters:
       # Alertmanager matchers, ANDed server-side. key=value, key:value, or a
       # raw matcher like env=~"prod|staging".

--- a/docs/prometheus-source.md
+++ b/docs/prometheus-source.md
@@ -94,8 +94,9 @@ workflows:
   optional write capabilities. `apiary validate` rejects workflows that pin
   this source and use `on_complete.set_state` / `add_labels`, approval
   steps, `wait_for` CI steps, or `materialize: sub_issue`.
-- **Resolved while running.** A running investigation is not interrupted
-  when its alert resolves; the workflow finishes normally.
+- **Resolved while running.** By default a running investigation is not
+  interrupted when its alert resolves; the workflow finishes normally. Set
+  `interrupt_on_resolve` on the source to opt into stopping it instead.
 
 ## Acknowledge via silence
 
@@ -133,6 +134,56 @@ config:
 - **Requires write access.** The configured token needs permission to POST
   silences. If Alertmanager rejects the request the error is logged and the
   run continues — a silence failure never fails the investigation.
+
+## Interrupting a run when the alert resolves
+
+Sometimes the alert clears on its own — a node came back, a deploy rolled
+back — and the investigation still running against it is now pointless work
+holding an agent slot. `interrupt_on_resolve` stops those runs.
+
+It is a **source-level** field, a sibling of `poll_interval`, not part of
+`config`:
+
+```yaml
+sources:
+  - id: prod-alerts
+    type: prometheus
+    interrupt_on_resolve: true
+    config:
+      alertmanager_url: https://alertmanager.internal:9093
+```
+
+Off by default, and deliberately so: an investigation's findings usually
+outlive the alert that prompted them, and a flapping alert would otherwise
+kill a run that was nearly done.
+
+When enabled, every poll cycle checks the alerts behind all in-flight
+instances of that source and stops the ones whose alert is gone. The check
+is conservative by design:
+
+- **Suppressed is not resolved.** The check queries Alertmanager for *every*
+  alert, including silenced and inhibited ones. This matters most with
+  `ack_via_silence`: the silence Apiary creates on dispatch would otherwise
+  make the alert look resolved and interrupt the very investigation that
+  created it.
+- **Two confirmations.** An alert must look gone on two consecutive checks
+  before anything is stopped, so one transient empty response — an
+  Alertmanager that just restarted and has not been re-fed by Prometheus yet
+  — cannot interrupt every running investigation at once. The cost is one
+  poll interval of latency.
+- **Fails closed.** If Alertmanager cannot be reached the error is logged and
+  nothing is stopped. "Could not tell" is never treated as "resolved".
+- **Parked runs count too.** Instances waiting at an approval or a `wait_for`
+  step are stopped as well — they are as pointless to keep alive as a
+  running one.
+
+A stopped instance is marked `interrupted`, exactly like `apiary stop`. It is
+not a failure, and it can be replayed later with `apiary resume` if the alert
+turns out to matter after all.
+
+Only sources whose adapter can distinguish a resolved item from an invisible
+one accept the flag; `apiary validate` rejects it on any other source type
+rather than letting it sit there doing nothing.
 
 ## Where results go
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -163,6 +163,10 @@
             "description": "Polling interval (e.g., '30s', '2m'). Defaults to 60s",
             "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
           },
+          "interrupt_on_resolve": {
+            "type": "boolean",
+            "description": "Stop still-running workflow instances when their source item is no longer active (e.g. an alert stopped firing). Off by default; only monitoring sources that can report a resolved item support it"
+          },
           "filters": {
             "type": "object",
             "description": "Task filtering rules",

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -47,6 +47,7 @@ func init() {
 		_, caps.Approvals = a.(source.TaskPoller)
 		_, caps.CIWait = a.(source.CIStatusPoller)
 		_, caps.SubIssues = a.(source.SubIssueCreator)
+		_, caps.Resolvable = a.(source.ItemResolver)
 		return caps
 	}
 }

--- a/src/internal/cli/source_caps_wiring_test.go
+++ b/src/internal/cli/source_caps_wiring_test.go
@@ -13,6 +13,15 @@ import (
 	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
 )
 
+// writeCaps strips the read-only capabilities, leaving only the write ones the
+// read-only-source lint is about. Resolvable (source.ItemResolver, backing
+// interrupt_on_resolve) is a read capability: a monitoring source having it
+// does not make it writable.
+func writeCaps(c config.SourceCaps) config.SourceCaps {
+	c.Resolvable = false
+	return c
+}
+
 // TestSourceCapsWiring_RealAdapters verifies the #357 capability probe against
 // the real registry: the prometheus alert adapter must present as fully
 // read-only, while github supports every write capability. If a write method
@@ -23,8 +32,14 @@ func TestSourceCapsWiring_RealAdapters(t *testing.T) {
 		t.Fatal("config.SourceCapabilities not wired by cli init()")
 	}
 
-	if caps := config.SourceCapabilities("prometheus"); caps != (config.SourceCaps{}) {
-		t.Errorf("prometheus caps = %+v, want all-false (read-only alert source)", caps)
+	promCaps := config.SourceCapabilities("prometheus")
+	if writeCaps(promCaps) != (config.SourceCaps{}) {
+		t.Errorf("prometheus write caps = %+v, want all-false (read-only alert source)", writeCaps(promCaps))
+	}
+	// Alerts resolve, and the adapter can say so — this is what
+	// interrupt_on_resolve is validated against.
+	if !promCaps.Resolvable {
+		t.Error("prometheus caps.Resolvable = false, want true (adapter implements source.ItemResolver)")
 	}
 
 	if caps := config.SourceCapabilities("dynatrace"); caps != (config.SourceCaps{}) {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -47,6 +47,13 @@ type SourceConfig struct {
 	Config       map[string]any `yaml:"config"`
 	PollInterval string         `yaml:"poll_interval"`
 	Filters      SourceFilters  `yaml:"filters"`
+
+	// InterruptOnResolve stops a still-running workflow instance when the
+	// source item that triggered it is no longer active (an alert that stopped
+	// firing). Off by default: the standing behaviour is to let an
+	// investigation finish, because its findings usually outlive the alert.
+	// Requires an adapter implementing source.ItemResolver.
+	InterruptOnResolve bool `yaml:"interrupt_on_resolve"`
 }
 
 func (s SourceConfig) ParsedPollInterval() (time.Duration, error) {

--- a/src/internal/config/interrupt_on_resolve_test.go
+++ b/src/internal/config/interrupt_on_resolve_test.go
@@ -1,0 +1,64 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// withResolveCaps points config.SourceCapabilities at a registry where only
+// "alerts" can report a resolved item.
+func withResolveCaps(t *testing.T) {
+	t.Helper()
+	prev := config.SourceCapabilities
+	config.SourceCapabilities = func(sourceType string) config.SourceCaps {
+		if sourceType == "alerts" {
+			return config.SourceCaps{Resolvable: true}
+		}
+		return config.SourceCaps{SetState: true, AddLabels: true, Approvals: true}
+	}
+	t.Cleanup(func() { config.SourceCapabilities = prev })
+}
+
+func resolveConfig(sources []config.SourceConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Sources: sources,
+		Workflows: []config.WorkflowConfig{{
+			ID:    "investigate",
+			Steps: []config.StepConfig{{ID: "s1", Agent: "sre"}},
+		}},
+	}
+}
+
+// A monitoring source that can report resolution accepts the flag.
+func TestInterruptOnResolve_AcceptedOnCapableSource(t *testing.T) {
+	withResolveCaps(t)
+
+	cfg := resolveConfig([]config.SourceConfig{
+		{ID: "prod-alerts", Type: "alerts", InterruptOnResolve: true},
+	})
+	errsNotContain(t, cfg.Validate(), "interrupt_on_resolve")
+}
+
+// A ticket source cannot tell a resolved item from a closed one; the flag would
+// silently do nothing, so it is rejected rather than ignored.
+func TestInterruptOnResolve_RejectedOnIncapableSource(t *testing.T) {
+	withResolveCaps(t)
+
+	cfg := resolveConfig([]config.SourceConfig{
+		{ID: "tickets", Type: "ticket", InterruptOnResolve: true},
+	})
+	errsContain(t, cfg.Validate(), "interrupt_on_resolve is not supported by source type \"ticket\"")
+}
+
+// Leaving the flag off is always valid, whatever the source type.
+func TestInterruptOnResolve_OffIsAlwaysValid(t *testing.T) {
+	withResolveCaps(t)
+
+	cfg := resolveConfig([]config.SourceConfig{
+		{ID: "tickets", Type: "ticket"},
+		{ID: "prod-alerts", Type: "alerts"},
+	})
+	errsNotContain(t, cfg.Validate(), "interrupt_on_resolve")
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -34,6 +34,7 @@ type SourceCaps struct {
 	Approvals    bool // source.TaskPoller — approval steps
 	CIWait       bool // source.CIStatusPoller — wait_for kind "ci"
 	SubIssues    bool // source.SubIssueCreator — materialize: sub_issue
+	Resolvable   bool // source.ItemResolver — interrupt_on_resolve
 }
 
 // SourceCapabilities reports the SourceCaps of a source type's adapter. The
@@ -182,6 +183,15 @@ func (c *Config) Validate() []error {
 				errs = append(errs, fmt.Errorf("sources[%d] %q: config.plugin is required for type \"plugin\" (the id of an enabled plugins[] instance with the \"source\" capability)", i, s.ID))
 			} else if !enabledPlugins[pluginID] {
 				errs = append(errs, fmt.Errorf("sources[%d] %q: config.plugin %q is not an enabled plugins[] instance", i, s.ID, pluginID))
+			}
+		}
+
+		// interrupt_on_resolve needs an adapter that can tell a resolved item
+		// from a merely invisible one. Silently ignoring the flag on a source
+		// that cannot would look like a policy that is on but never fires.
+		if s.InterruptOnResolve && SourceCapabilities != nil && s.Type != "" {
+			if !SourceCapabilities(s.Type).Resolvable {
+				errs = append(errs, fmt.Errorf("sources[%d] %q: interrupt_on_resolve is not supported by source type %q — only monitoring sources that can report a resolved item support it", i, s.ID, s.Type))
 			}
 		}
 	}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -132,8 +132,8 @@ type Dispatcher struct {
 	warnedUnsatisfiable sync.Map
 	// warnedStalled holds the ids of queued jobs already reported as satisfiable
 	// but unleased, so the stall warning is emitted once per job.
-	warnedStalled sync.Map
-	localWorker         *workerpkg.Runtime
+	warnedStalled  sync.Map
+	localWorker    *workerpkg.Runtime
 	queueWorker    queuepkg.Worker
 	queueProjectID string
 	queueWorkerID  string
@@ -1774,6 +1774,9 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 	// Re-check any workflows parked at wait_for steps (e.g. waiting for CI) so they
 	// advance, fail, or keep waiting based on live status.
 	d.checkWaits(ctx)
+
+	// Stop investigations whose alert resolved while they ran (opt-in).
+	d.checkResolved(ctx, sc, adapter)
 
 	aplog.Debug("polling source %s (since %s)", sc.ID, since.Format(time.RFC3339))
 	cells, err := adapter.Poll(ctx, since)

--- a/src/internal/daemon/resolved.go
+++ b/src/internal/daemon/resolved.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// liveInstanceStates are the states a workflow instance can be in while its
+// source item still matters: actively running, or parked waiting for something
+// that will never come once the item is gone.
+var liveInstanceStates = []string{
+	db.InstanceStateRunning,
+	db.InstanceStateWaiting,
+	db.InstanceStateApprovalWaiting,
+}
+
+// checkResolved stops workflow instances whose source item is no longer active
+// — an alert that stopped firing while the investigation was still running.
+//
+// Opt-in per source (interrupt_on_resolve) and only for adapters that can tell
+// a resolved item from a merely invisible one (source.ItemResolver). The
+// default across every source stays "let the run finish": an investigation's
+// findings usually outlive the alert that prompted them, and interrupting on
+// resolution throws away work that was nearly done.
+//
+// Fails closed at every step. If the source cannot answer, nothing is stopped.
+func (d *Dispatcher) checkResolved(ctx context.Context, sc config.SourceConfig, adapter source.Adapter) {
+	if !sc.InterruptOnResolve || d.db == nil {
+		return
+	}
+	resolver, ok := adapter.(source.ItemResolver)
+	if !ok {
+		// Validation rejects this combination; a daemon running an older config
+		// should still say why the policy is doing nothing rather than be silent.
+		aplog.Warn("source %s: interrupt_on_resolve is set but the adapter cannot report resolved items — ignoring", sc.ID)
+		return
+	}
+
+	// Map item id → instances, since one item can drive several workflows.
+	instancesByItem := map[string][]db.WorkflowInstance{}
+	for _, state := range liveInstanceStates {
+		instances, err := d.db.ListWorkflowInstancesByState(ctx, state)
+		if err != nil {
+			aplog.Error("source %s: interrupt_on_resolve: listing %s instances: %v", sc.ID, state, err)
+			return
+		}
+		for _, inst := range instances {
+			if inst.SourceID != sc.ID || inst.CellID == "" {
+				continue
+			}
+			instancesByItem[inst.CellID] = append(instancesByItem[inst.CellID], inst)
+		}
+	}
+	if len(instancesByItem) == 0 {
+		return
+	}
+
+	itemIDs := make([]string, 0, len(instancesByItem))
+	for id := range instancesByItem {
+		itemIDs = append(itemIDs, id)
+	}
+
+	resolved, err := resolver.ResolvedItems(ctx, itemIDs)
+	if err != nil {
+		// "Could not tell" is not "resolved". Leave everything running.
+		aplog.Error("source %s: interrupt_on_resolve: %v — leaving %d in-flight instance(s) running", sc.ID, err, len(instancesByItem))
+		return
+	}
+
+	for _, itemID := range resolved {
+		for _, inst := range instancesByItem[itemID] {
+			aplog.Info("source %s: item %s resolved — stopping workflow %q instance %s (was %s)",
+				sc.ID, itemID, inst.WorkflowID, inst.ID, inst.State)
+			if err := d.StopInstance(ctx, inst.ID); err != nil {
+				aplog.Error("source %s: stopping instance %s after resolve: %v", sc.ID, inst.ID, err)
+			}
+		}
+	}
+}

--- a/src/internal/daemon/resolved_test.go
+++ b/src/internal/daemon/resolved_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// fakeResolver is a source.Adapter that also implements source.ItemResolver,
+// recording what it was asked and returning a canned answer.
+type fakeResolver struct {
+	resolved []string
+	err      error
+	asked    [][]string
+}
+
+func (f *fakeResolver) ID() string                                    { return "prod-alerts" }
+func (f *fakeResolver) Connect(context.Context, map[string]any) error { return nil }
+func (f *fakeResolver) Poll(context.Context, time.Time) ([]model.SourceItem, error) {
+	return nil, nil
+}
+func (f *fakeResolver) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (f *fakeResolver) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (f *fakeResolver) ResolvedItems(_ context.Context, ids []string) ([]string, error) {
+	f.asked = append(f.asked, append([]string(nil), ids...))
+	return f.resolved, f.err
+}
+
+func instanceState(ctx context.Context, t *testing.T, dbc *db.Client, id string) string {
+	t.Helper()
+	inst, err := dbc.GetWorkflowInstance(ctx, id)
+	if err != nil || inst == nil {
+		t.Fatalf("get instance %s: inst=%v err=%v", id, inst, err)
+	}
+	return inst.State
+}
+
+func srcCfg(interrupt bool) config.SourceConfig {
+	return config.SourceConfig{ID: "prod-alerts", Type: "prometheus", InterruptOnResolve: interrupt}
+}
+
+// The default is unchanged: a resolved alert never interrupts a running run.
+func TestCheckResolved_OffByDefault(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", "fp:2026-01-01T00:00:00Z")
+
+	adapter := &fakeResolver{resolved: []string{"fp:2026-01-01T00:00:00Z"}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(false), adapter)
+
+	if len(adapter.asked) != 0 {
+		t.Errorf("resolution was queried despite interrupt_on_resolve being off")
+	}
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateRunning {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateRunning)
+	}
+}
+
+// With the opt-in on, a resolved alert stops its running instance.
+func TestCheckResolved_StopsInstance(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	itemID := "fp:2026-01-01T00:00:00Z"
+	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
+
+	adapter := &fakeResolver{resolved: []string{itemID}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if len(adapter.asked) != 1 || len(adapter.asked[0]) != 1 || adapter.asked[0][0] != itemID {
+		t.Fatalf("adapter asked %v, want [[%s]]", adapter.asked, itemID)
+	}
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateInterrupted {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateInterrupted)
+	}
+}
+
+// An alert still firing leaves its instance alone.
+func TestCheckResolved_LeavesUnresolvedRunning(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", "fp:2026-01-01T00:00:00Z")
+
+	adapter := &fakeResolver{} // nothing resolved
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateRunning {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateRunning)
+	}
+}
+
+// A source that cannot answer must not take anything down.
+func TestCheckResolved_FailsClosedOnError(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	itemID := "fp:2026-01-01T00:00:00Z"
+	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
+
+	adapter := &fakeResolver{resolved: []string{itemID}, err: errors.New("alertmanager unreachable")}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateRunning {
+		t.Fatalf("instance state = %q, want %q — an error must never read as resolved", got, db.InstanceStateRunning)
+	}
+}
+
+// Instances belonging to another source must not be touched, and must not even
+// be offered to this source's resolver.
+func TestCheckResolved_IgnoresOtherSources(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	_, otherInst := seedBoundTask(ctx, t, dbc, "github", "1956")
+
+	adapter := &fakeResolver{resolved: []string{"1956"}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if len(adapter.asked) != 0 {
+		t.Errorf("asked about another source's items: %v", adapter.asked)
+	}
+	if got := instanceState(ctx, t, dbc, otherInst); got != db.InstanceStateRunning {
+		t.Fatalf("other source's instance state = %q, want %q", got, db.InstanceStateRunning)
+	}
+}
+
+// A parked instance is as pointless to keep alive as a running one.
+func TestCheckResolved_StopsParkedInstance(t *testing.T) {
+	for _, state := range []string{db.InstanceStateWaiting, db.InstanceStateApprovalWaiting} {
+		t.Run(state, func(t *testing.T) {
+			ctx := context.Background()
+			dbc := openTestDB(ctx, t)
+			itemID := "fp:2026-01-01T00:00:00Z"
+			_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
+			if err := dbc.UpdateWorkflowInstanceState(ctx, instID, state); err != nil {
+				t.Fatalf("park instance: %v", err)
+			}
+
+			adapter := &fakeResolver{resolved: []string{itemID}}
+			d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+			d.checkResolved(ctx, srcCfg(true), adapter)
+
+			if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateInterrupted {
+				t.Fatalf("instance state = %q, want %q", got, db.InstanceStateInterrupted)
+			}
+		})
+	}
+}
+
+// A finished instance is terminal and must stay that way.
+func TestCheckResolved_LeavesTerminalInstances(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	itemID := "fp:2026-01-01T00:00:00Z"
+	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
+	if err := dbc.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateDone); err != nil {
+		t.Fatalf("finish instance: %v", err)
+	}
+
+	adapter := &fakeResolver{resolved: []string{itemID}}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if len(adapter.asked) != 0 {
+		t.Errorf("asked about a terminal instance's item: %v", adapter.asked)
+	}
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateDone {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateDone)
+	}
+}
+
+// Nothing in flight → no API call.
+func TestCheckResolved_NoInFlightWork(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	adapter := &fakeResolver{}
+	d := &Dispatcher{db: dbc, cfg: &config.Config{}}
+	d.checkResolved(ctx, srcCfg(true), adapter)
+
+	if len(adapter.asked) != 0 {
+		t.Errorf("queried the source with no in-flight instances: %v", adapter.asked)
+	}
+}

--- a/src/internal/source/prometheus/adapter.go
+++ b/src/internal/source/prometheus/adapter.go
@@ -50,6 +50,11 @@ const (
 	// if the agent dies or the daemon is killed the silence must expire on its
 	// own, or a still-firing alert would stay invisible forever.
 	defaultSilenceDuration = 2 * time.Hour
+
+	// resolveConfirmations is how many consecutive checks must agree that an
+	// alert is gone before ResolvedItems reports it. Two is the smallest value
+	// that survives a single transient empty listing.
+	resolveConfirmations = 2
 )
 
 // Adapter implements source.Adapter for Prometheus Alertmanager.
@@ -84,6 +89,15 @@ type Adapter struct {
 	// handed is reconstructed from a source binding and carries no Metadata,
 	// so the raw label map is not otherwise reachable. Pruned with seen.
 	labels map[string]map[string]string
+
+	// resolveStreak counts consecutive resolution checks in which an item
+	// looked resolved. Reporting on the first check would make a single
+	// unlucky moment — an Alertmanager that just restarted and has not been
+	// re-fed by Prometheus yet — read as "everything resolved" and interrupt
+	// every running investigation at once. Requiring two consecutive checks
+	// costs one poll interval of latency and removes that whole class of
+	// false positive. Reset the moment the item is seen live again.
+	resolveStreak map[string]int
 
 	// silenced records the silence created for an item ID and when it expires,
 	// so a second Acknowledge for the same fire cycle (re-dispatch, retried
@@ -149,6 +163,7 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 	a.seen = map[string]struct{}{}
 	a.labels = map[string]map[string]string{}
 	a.silenced = map[string]silenceRecord{}
+	a.resolveStreak = map[string]int{}
 
 	aplog.Info("prometheus: configured  alertmanager=%s  max_new_per_poll=%d  min_age=%s  ack_via_silence=%v  silence_duration=%s",
 		baseURL, a.maxNewPerPoll, a.minAge, a.ackViaSilence, a.silenceDuration)
@@ -403,6 +418,73 @@ func (a *Adapter) Acknowledge(ctx context.Context, cell model.SourceItem, action
 	aplog.Info("prometheus: silenced %s until %s (silence=%s, %d matcher(s))",
 		cell.LogLabel(), endsAt.UTC().Format(time.RFC3339), id, len(matchers))
 	return nil
+}
+
+// ResolvedItems reports which of the given item IDs correspond to alerts that
+// are no longer firing. It backs the source's interrupt_on_resolve policy, so a
+// false positive kills a live investigation — the implementation is
+// deliberately conservative in three ways:
+//
+//   - it queries Alertmanager for *every* alert, including silenced and
+//     inhibited ones, so a suppressed alert is never mistaken for a resolved
+//     one (an ack_via_silence silence would otherwise resolve its own alert);
+//   - an API error is returned, never interpreted as "everything resolved";
+//   - an item must look resolved on two consecutive checks before it is
+//     reported, so one bad moment (an Alertmanager that just restarted with an
+//     empty alert set) cannot interrupt every running investigation at once.
+//
+// An alert counts as gone when it is absent from the listing entirely, or is
+// present with endsAt in the past — how a resolved alert lingers until
+// Alertmanager's resolve_timeout drops it.
+func (a *Adapter) ResolvedItems(ctx context.Context, itemIDs []string) ([]string, error) {
+	if len(itemIDs) == 0 {
+		return nil, nil
+	}
+
+	alerts, err := a.client.allAlerts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("prometheus: checking resolved alerts: %w", err)
+	}
+
+	now := time.Now()
+	live := make(map[string]struct{}, len(alerts))
+	for _, al := range alerts {
+		if al.Fingerprint == "" {
+			continue
+		}
+		if !al.EndsAt.IsZero() && al.EndsAt.Before(now) {
+			continue // resolved, still within resolve_timeout
+		}
+		live[itemID(al)] = struct{}{}
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Only the ids we were asked about are tracked, so the streak map cannot
+	// outgrow the set of in-flight investigations.
+	asked := make(map[string]struct{}, len(itemIDs))
+	var resolved []string
+	for _, id := range itemIDs {
+		asked[id] = struct{}{}
+		if _, ok := live[id]; ok {
+			delete(a.resolveStreak, id)
+			continue
+		}
+		a.resolveStreak[id]++
+		if a.resolveStreak[id] < resolveConfirmations {
+			aplog.Debug("prometheus: %s looks resolved (%d/%d confirmations) — waiting for the next check",
+				id, a.resolveStreak[id], resolveConfirmations)
+			continue
+		}
+		resolved = append(resolved, id)
+	}
+	for id := range a.resolveStreak {
+		if _, ok := asked[id]; !ok {
+			delete(a.resolveStreak, id)
+		}
+	}
+	return resolved, nil
 }
 
 // silenceMatchers builds the exact-equality matchers for one alert and reports

--- a/src/internal/source/prometheus/client.go
+++ b/src/internal/source/prometheus/client.go
@@ -90,6 +90,30 @@ func (c *client) createSilence(ctx context.Context, s silence) (string, error) {
 	return resp.SilenceID, nil
 }
 
+// allAlerts fetches every alert Alertmanager currently holds, including the
+// silenced and inhibited ones the normal poll deliberately excludes. Resolution
+// checks need this wider view: a silenced alert (notably one Apiary silenced
+// itself via ack_via_silence) is still firing, and treating it as resolved
+// would interrupt the very investigation that silenced it.
+func (c *client) allAlerts(ctx context.Context) ([]alert, error) {
+	params := url.Values{
+		"active":      {"true"},
+		"silenced":    {"true"},
+		"inhibited":   {"true"},
+		"unprocessed": {"true"},
+	}
+
+	data, err := c.get(ctx, "/api/v2/alerts", params)
+	if err != nil {
+		return nil, err
+	}
+	var alerts []alert
+	if err := json.Unmarshal(data, &alerts); err != nil {
+		return nil, fmt.Errorf("prometheus: decoding alerts response: %w", err)
+	}
+	return alerts, nil
+}
+
 // get executes a GET, retrying on 429/5xx with exponential backoff
 // (honouring Retry-After when present).
 func (c *client) get(ctx context.Context, path string, params url.Values) ([]byte, error) {

--- a/src/internal/source/prometheus/resolved_test.go
+++ b/src/internal/source/prometheus/resolved_test.go
@@ -1,0 +1,268 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// resolveServer serves an alert listing and records the query it was asked
+// with, so tests can assert the resolution check widens its view to include
+// suppressed alerts.
+type resolveServer struct {
+	*httptest.Server
+
+	mu        sync.Mutex
+	alerts    []map[string]any
+	lastQuery map[string][]string
+	failWith  int
+	calls     int
+}
+
+func newResolveServer(t *testing.T) *resolveServer {
+	t.Helper()
+	s := &resolveServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/alerts" {
+			http.NotFound(w, r)
+			return
+		}
+		s.mu.Lock()
+		s.calls++
+		s.lastQuery = r.URL.Query()
+		fail, alerts := s.failWith, s.alerts
+		s.mu.Unlock()
+
+		if fail != 0 {
+			http.Error(w, "boom", fail)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(alerts)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *resolveServer) setAlerts(a []map[string]any) {
+	s.mu.Lock()
+	s.alerts = a
+	s.mu.Unlock()
+}
+
+func (s *resolveServer) setFailure(status int) {
+	s.mu.Lock()
+	s.failWith = status
+	s.mu.Unlock()
+}
+
+func (s *resolveServer) query() map[string][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastQuery
+}
+
+// resolveTwice runs the two consecutive checks the debounce requires and
+// returns what the second one reported.
+func resolveTwice(t *testing.T, a *Adapter, ids []string) []string {
+	t.Helper()
+	if _, err := a.ResolvedItems(context.Background(), ids); err != nil {
+		t.Fatalf("ResolvedItems (first): %v", err)
+	}
+	got, err := a.ResolvedItems(context.Background(), ids)
+	if err != nil {
+		t.Fatalf("ResolvedItems (second): %v", err)
+	}
+	return got
+}
+
+// The resolution check must ask for silenced and inhibited alerts too —
+// otherwise a suppressed alert reads as resolved.
+func TestResolvedItemsQueriesSuppressedAlerts(t *testing.T) {
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.ResolvedItems(context.Background(), []string{"abc:2026-01-01T00:00:00Z"}); err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	q := srv.query()
+	for _, key := range []string{"silenced", "inhibited"} {
+		var got string
+		if vs := q[key]; len(vs) > 0 {
+			got = vs[0]
+		}
+		if got != "true" {
+			t.Errorf("query %s = %q, want \"true\" — a suppressed alert is not a resolved alert", key, got)
+		}
+	}
+}
+
+// An alert Apiary silenced itself (ack_via_silence) is still firing.
+func TestResolvedItemsIgnoresSilencedAlert(t *testing.T) {
+	started := time.Now().Add(-10 * time.Minute)
+	al := mkAlert("abcdef1234567890", "HighErrorRate", "critical", started)
+	al["status"] = map[string]any{"state": "suppressed", "silencedBy": []string{"sil-1"}}
+
+	srv := newResolveServer(t)
+	srv.setAlerts([]map[string]any{al})
+	a := connect(t, srv.URL, nil)
+
+	id := "abcdef1234567890:" + started.UTC().Format(time.RFC3339)
+	if got := resolveTwice(t, a, []string{id}); len(got) != 0 {
+		t.Fatalf("silenced alert reported resolved: %v", got)
+	}
+}
+
+// An alert that vanished from Alertmanager is resolved — after confirmation.
+func TestResolvedItemsReportsMissingAlert(t *testing.T) {
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	id := "abcdef1234567890:2026-01-01T00:00:00Z"
+	got := resolveTwice(t, a, []string{id})
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("ResolvedItems = %v, want [%s]", got, id)
+	}
+}
+
+// One check is never enough: a single empty listing must not interrupt work.
+func TestResolvedItemsNeedsTwoConfirmations(t *testing.T) {
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	id := "abcdef1234567890:2026-01-01T00:00:00Z"
+	got, err := a.ResolvedItems(context.Background(), []string{id})
+	if err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("reported resolved on the first check: %v", got)
+	}
+}
+
+// An alert that blips out of the listing and comes back must reset the streak,
+// not accumulate toward an interrupt.
+func TestResolvedItemsResetsStreakWhenAlertReturns(t *testing.T) {
+	started := time.Now().Add(-10 * time.Minute)
+	id := "abcdef1234567890:" + started.UTC().Format(time.RFC3339)
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	// Check 1: missing.
+	if _, err := a.ResolvedItems(context.Background(), []string{id}); err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	// Check 2: back again — this must clear the streak.
+	srv.setAlerts([]map[string]any{mkAlert("abcdef1234567890", "HighErrorRate", "critical", started)})
+	if got, err := a.ResolvedItems(context.Background(), []string{id}); err != nil || len(got) != 0 {
+		t.Fatalf("ResolvedItems = %v, err = %v; want none", got, err)
+	}
+	// Check 3: missing again — one confirmation, not two.
+	srv.setAlerts(nil)
+	got, err := a.ResolvedItems(context.Background(), []string{id})
+	if err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("streak was not reset by the alert reappearing: %v", got)
+	}
+}
+
+// A resolved alert lingers with endsAt in the past until resolve_timeout.
+func TestResolvedItemsHonoursEndsAtInThePast(t *testing.T) {
+	started := time.Now().Add(-30 * time.Minute)
+	al := mkAlert("abcdef1234567890", "HighErrorRate", "critical", started)
+	al["endsAt"] = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+
+	srv := newResolveServer(t)
+	srv.setAlerts([]map[string]any{al})
+	a := connect(t, srv.URL, nil)
+
+	id := "abcdef1234567890:" + started.UTC().Format(time.RFC3339)
+	got := resolveTwice(t, a, []string{id})
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("ResolvedItems = %v, want [%s] — endsAt in the past means resolved", got, id)
+	}
+}
+
+// A still-firing alert carries endsAt in the future; it is not resolved.
+func TestResolvedItemsKeepsAlertWithFutureEndsAt(t *testing.T) {
+	started := time.Now().Add(-10 * time.Minute)
+	al := mkAlert("abcdef1234567890", "HighErrorRate", "critical", started)
+	al["endsAt"] = time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+
+	srv := newResolveServer(t)
+	srv.setAlerts([]map[string]any{al})
+	a := connect(t, srv.URL, nil)
+
+	id := "abcdef1234567890:" + started.UTC().Format(time.RFC3339)
+	if got := resolveTwice(t, a, []string{id}); len(got) != 0 {
+		t.Fatalf("firing alert reported resolved: %v", got)
+	}
+}
+
+// An unreachable Alertmanager means "could not tell", never "resolved".
+func TestResolvedItemsFailsClosedOnError(t *testing.T) {
+	srv := newResolveServer(t)
+	srv.setFailure(http.StatusInternalServerError)
+	a := connect(t, srv.URL, nil)
+
+	got, err := a.ResolvedItems(context.Background(), []string{"abc:2026-01-01T00:00:00Z"})
+	if err == nil {
+		t.Fatal("expected an error when Alertmanager is unreachable")
+	}
+	if len(got) != 0 {
+		t.Fatalf("reported %v resolved despite the error", got)
+	}
+}
+
+// No in-flight items means no API call at all.
+func TestResolvedItemsSkipsEmptyInput(t *testing.T) {
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	got, err := a.ResolvedItems(context.Background(), nil)
+	if err != nil || got != nil {
+		t.Fatalf("ResolvedItems(nil) = %v, %v; want nil, nil", got, err)
+	}
+	srv.mu.Lock()
+	calls := srv.calls
+	srv.mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("made %d API call(s) for an empty item set", calls)
+	}
+}
+
+// The streak map must not accumulate ids that are no longer in flight.
+func TestResolvedItemsForgetsUntrackedItems(t *testing.T) {
+	srv := newResolveServer(t)
+	a := connect(t, srv.URL, nil)
+
+	if _, err := a.ResolvedItems(context.Background(), []string{"gone:1", "gone:2"}); err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	if _, err := a.ResolvedItems(context.Background(), []string{"gone:1"}); err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+
+	a.mu.Lock()
+	_, stillTracked := a.resolveStreak["gone:2"]
+	a.mu.Unlock()
+	if stillTracked {
+		t.Error("resolveStreak still tracks an item that is no longer in flight")
+	}
+}
+
+// The adapter must satisfy the capability the dispatcher probes for.
+func TestAdapterImplementsItemResolver(t *testing.T) {
+	var a any = &Adapter{}
+	if _, ok := a.(interface {
+		ResolvedItems(context.Context, []string) ([]string, error)
+	}); !ok {
+		t.Fatal("*Adapter does not implement source.ItemResolver")
+	}
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -120,6 +120,22 @@ type BlockerLister interface {
 	ListBlockers(ctx context.Context, cellID, linkType string) ([]BlockerRef, error)
 }
 
+// ItemResolver is an optional interface a monitoring source may implement to
+// report which of its previously dispatched items are no longer active — an
+// alert that stopped firing, a problem that closed. The dispatcher uses it for
+// sources configured with interrupt_on_resolve, to stop investigations whose
+// signal went away while they were still running.
+//
+// Implementations must distinguish "resolved" from "not currently visible":
+// suppressed items (silenced, inhibited, filtered) are still live and must not
+// be reported. Reporting one interrupts real work.
+//
+// A non-nil error means "could not tell" and is never treated as resolution —
+// the dispatcher fails closed and leaves every instance running.
+type ItemResolver interface {
+	ResolvedItems(ctx context.Context, itemIDs []string) ([]string, error)
+}
+
 // PREventPoller is an optional interface a source may implement to enumerate
 // pull-request events (comments and review submissions) since a watermark. The
 // dispatcher polls it alongside Poll and routes the events through workflow


### PR DESCRIPTION
## Summary

Second of the three remaining items on #362, after `ack_via_silence` (#397).

An alert that clears on its own — node came back, deploy rolled back — leaves its investigation running against a signal that no longer exists, holding an agent slot. `interrupt_on_resolve: true` on a source stops those instances.

Off by default, deliberately: an investigation's findings usually outlive the alert that prompted them, and a flapping alert would otherwise kill a run that was nearly done. This preserves the behaviour `docs/prometheus-source.md` already documented.

- **New source capability.** `source.ItemResolver` reports which previously dispatched items are no longer active. Probed into `SourceCaps.Resolvable`, so `apiary validate` **rejects** `interrupt_on_resolve` on a source type that cannot answer, rather than leaving a flag that silently never fires.
- **Source-level field**, a sibling of `poll_interval` — the policy is daemon behaviour applied to a source, not adapter config, and it is generic across monitoring sources.
- **Reuses `StopInstance`**, so a stopped run is marked `interrupted` (not failed) and stays replayable with `apiary resume`.

### The interaction that drove the design

`ack_via_silence` (just merged) makes Apiary silence an alert on dispatch — and **silenced alerts are excluded from the normal poll**. A naive "not in the poll ⇒ resolved" check would therefore interrupt the very investigation that created the silence, every time both features were on.

So the prometheus implementation queries Alertmanager for *every* alert, `silenced=true&inhibited=true` included, and treats an alert as gone only when it is absent entirely or carries `endsAt` in the past. There is a regression test asserting the query widens, and one asserting a silenced alert is not reported.

Two further conservative choices, since a false positive kills live work:

- **Two confirmations.** An item must look resolved on two consecutive checks. Without it, an Alertmanager that just restarted and has not been re-fed by Prometheus returns an empty listing, and every running investigation dies at once. Costs one poll interval of latency.
- **Fails closed.** An API error is returned and never interpreted as resolution; the dispatcher logs it and leaves everything running.

Parked instances (`waiting`, `approval_waiting`) are stopped too — as pointless to keep alive as a running one. Terminal instances and other sources' instances are never touched.

### Note on an updated test

`TestSourceCapsWiring_RealAdapters` asserted prometheus caps were *all* false. `Resolvable` is a **read** capability, so it now asserts the write caps are all false (the read-only lint's actual subject) and that `Resolvable` is true. The read-only guarantee is unchanged.

Dynatrace has the same OPEN/RESOLVED shape and is the natural next adapter to implement `ItemResolver`; left out here to keep this reviewable, and its caps assertion is unchanged.

## Test plan

- `go build ./... && go vet ./...` clean; `gofmt` clean.
- `go test ./... -count=1` green; `-race` green on `daemon`, `source/...`, `config`, `cli`.
- `internal/source/prometheus/resolved_test.go`: query includes silenced/inhibited; silenced alert not resolved; missing alert resolved after confirmation; one check never enough; streak resets when the alert reappears; `endsAt` past vs future; fails closed on error; no API call for an empty set; streak map forgets untracked ids.
- `internal/daemon/resolved_test.go`: off by default (not even queried); stops a running instance; leaves an unresolved one; fails closed on error; ignores other sources; stops `waiting`/`approval_waiting`; leaves terminal instances; no query with nothing in flight.
- `internal/config/interrupt_on_resolve_test.go`: accepted on a capable source, rejected on an incapable one, always valid when off.
- `apiary validate` on `.apiary/example-apiary-full.yaml` reports the same 9 pre-existing errors as `main`.
- Not exercised against a live Alertmanager.

Refs #362