### PR TITLE
feat(prometheus): dispatch_by group — one task per Alertmanager group

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -146,6 +146,9 @@ sources:
       max_new_per_poll: 10
       # Flap dampener: alerts must have been firing at least this long.
       min_age: 1m
+      # One task per firing alert (default), or one per Alertmanager group —
+      # so an incident that fans out into a dozen alerts is one investigation.
+      # dispatch_by: group
       # Opt-in: silence a dispatched alert in Alertmanager while an agent
       # investigates it, so it stops paging the on-call. Off by default.
       # ack_via_silence: true

--- a/docs/prometheus-source.md
+++ b/docs/prometheus-source.md
@@ -47,6 +47,7 @@ workflows:
 | `basic_auth_user` / `basic_auth_password` | no | HTTP Basic auth (ignored when `bearer_token` is set) |
 | `max_new_per_poll` | no | Alert-storm cap: at most this many *not-yet-seen* alerts become tasks per poll; the overflow is logged and surfaces on later polls. `0` disables the cap. Default `10` |
 | `min_age` | no | Flap dampener: an alert must have been firing at least this long before it is ingested (complements the alerting rule's own `for:`). Default `1m` |
+| `dispatch_by` | no | `alert` (default) dispatches one task per firing alert; `group` dispatches one task per Alertmanager group, so one incident that fans out into many alerts becomes a single investigation |
 | `ack_via_silence` | no | When `true`, acknowledging a dispatched alert creates an Alertmanager silence for it, so it stops paging while an agent investigates. Default `false` (acknowledge is a no-op) |
 | `silence_duration` | no | How long an `ack_via_silence` silence lasts. Default `2h` |
 
@@ -83,7 +84,8 @@ workflows:
 - **Storm cap.** One bad deploy can fire 50 alerts in a single poll; each
   would become a task and an agent run. `max_new_per_poll` bounds how many
   new alerts are admitted per poll (oldest first); the rest are deferred to
-  subsequent polls and a warning names the deferred count.
+  subsequent polls and a warning names the deferred count. See also
+  `dispatch_by: group`, which collapses one incident into one task.
 - **Flap dampening.** `min_age` skips alerts younger than the threshold, so
   firing→resolved→firing blips never dispatch. Combined with the
   fingerprint+startsAt identity this also means a *resolved-and-refired*
@@ -134,6 +136,82 @@ config:
 - **Requires write access.** The configured token needs permission to POST
   silences. If Alertmanager rejects the request the error is logged and the
   run continues — a silence failure never fails the investigation.
+
+## Dispatching per group instead of per alert
+
+One bad deploy fires `HighErrorRate` on twelve pods. By default that is twelve
+tasks and twelve agent runs investigating the same incident. Alertmanager
+already groups those alerts — its `group_by` is exactly "what the on-call
+should be paged about once" — and `dispatch_by: group` follows that grouping:
+
+```yaml
+sources:
+  - id: prod-alerts
+    type: prometheus
+    config:
+      alertmanager_url: https://alertmanager.internal:9093
+      dispatch_by: group        # default is "alert"
+```
+
+The source then polls `GET /api/v2/alerts/groups` and emits one task per
+non-empty group, with every member alert rendered into the task body.
+
+### Group → task mapping
+
+| Task field | Group value |
+|---|---|
+| ID | `<group key>:<epoch>` — see below |
+| Number | 7-char hash of the group key |
+| Title | group's `alertname` + member count (`HighErrorRate (12 alerts)`) |
+| Description | group key, receiver, group labels, then each member alert in full |
+| Labels | the group-by labels, **plus** any label every member shares with the same value |
+| Type | `alert_group` |
+| Priority | the worst `severity` among the members |
+| URL | the first member's `generatorURL` |
+| Metadata | group key, epoch, receiver, group labels, member count, member fingerprints |
+
+The label rule is what makes trigger matching work: `severity` is usually not
+a `group_by` label, but if every member is `critical` then
+`labels: [severity:critical]` matches the group. If members disagree, the
+label is not group-wide and is left off.
+
+### Group identity and the fire cycle
+
+A single alert has a natural per-cycle identity (`fingerprint:startsAt`). A
+group does not: its membership churns constantly while an incident unfolds, so
+there is no timestamp on it that stays put.
+
+Apiary pins one. When a group first becomes non-empty, its **epoch** is set to
+the earliest `startsAt` among its members and then held for the whole cycle:
+
+```
+14:02  alert A fires    -> group non-empty, epoch := 14:02, dispatch
+14:09  alert B joins    -> same id, no re-dispatch
+14:20  alert A resolves -> same id, no re-dispatch   <- churn absorbed
+14:44  group empties    -> cycle ends, pin dropped
+15:10  alert C fires    -> epoch := 15:10, new dispatch
+```
+
+Deriving the epoch from the current members on every poll instead would make
+the id jump the moment the oldest alert resolved — re-dispatching an incident
+that was still being investigated. Pinning avoids that.
+
+The pin is in-memory. After a daemon restart the epoch is re-seeded from the
+current members' earliest `startsAt`, which reproduces the previous value
+whenever the oldest member is still firing — the usual case for an ongoing
+incident, so the investigation is not duplicated. It differs only if that
+oldest member resolved during the restart, which produces one new task for the
+ongoing group.
+
+### Interaction with the other options
+
+- **`max_new_per_poll`** counts *groups*, not member alerts.
+- **`min_age`** is measured against the group's epoch, so a just-formed group
+  is deferred. Maturing does not change its id.
+- **`ack_via_silence`** silences on the group-wide labels, so acknowledging
+  suppresses the whole group rather than one member.
+- **`interrupt_on_resolve`** treats a group as resolved when it is empty or
+  gone; the same two-confirmation debounce and fail-closed rules apply.
 
 ## Interrupting a run when the alert resolves
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -155,7 +155,7 @@
           },
           "config": {
             "type": "object",
-            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age, ack_via_silence, silence_duration. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. plugin: plugin (the id of an installed, enabled plugin with the source capability)",
+            "description": "Adapter-specific configuration. github: repo, api_key, base_url. jira: base_url, email, api_token, project. plane: workspace, project, api_key, base_url. prometheus: alertmanager_url, bearer_token, basic_auth_user, basic_auth_password, max_new_per_poll, min_age, dispatch_by, ack_via_silence, silence_duration. dynatrace: base_url, api_token, max_new_per_poll, min_age, lookback. plugin: plugin (the id of an installed, enabled plugin with the source capability)",
             "additionalProperties": true
           },
           "poll_interval": {

--- a/src/internal/source/prometheus/adapter.go
+++ b/src/internal/source/prometheus/adapter.go
@@ -71,6 +71,15 @@ type Adapter struct {
 	ackViaSilence   bool
 	silenceDuration time.Duration
 
+	// byGroup dispatches one task per Alertmanager group instead of one per
+	// alert, so a single incident that fans out into a dozen alerts becomes a
+	// single investigation.
+	byGroup bool
+
+	// groupEpoch pins each live group's cycle-start (see groupItemID). Entries
+	// are dropped when the group empties, which ends the cycle.
+	groupEpoch map[string]time.Time
+
 	// filters are Alertmanager matcher strings sent as filter= params,
 	// built from SourceFilters.Labels.
 	filters []string
@@ -148,6 +157,21 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 		a.minAge = d
 	}
 
+	if v, ok := cfg["dispatch_by"]; ok {
+		s, isString := v.(string)
+		if !isString {
+			return fmt.Errorf("prometheus: config.dispatch_by must be \"alert\" or \"group\", got %v", v)
+		}
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "alert", "":
+			a.byGroup = false
+		case "group":
+			a.byGroup = true
+		default:
+			return fmt.Errorf("prometheus: config.dispatch_by must be \"alert\" or \"group\", got %q", s)
+		}
+	}
+
 	a.ackViaSilence, _ = cfg["ack_via_silence"].(bool)
 
 	a.silenceDuration = defaultSilenceDuration
@@ -164,6 +188,7 @@ func (a *Adapter) Connect(_ context.Context, cfg map[string]any) error {
 	a.labels = map[string]map[string]string{}
 	a.silenced = map[string]silenceRecord{}
 	a.resolveStreak = map[string]int{}
+	a.groupEpoch = map[string]time.Time{}
 
 	aplog.Info("prometheus: configured  alertmanager=%s  max_new_per_poll=%d  min_age=%s  ack_via_silence=%v  silence_duration=%s",
 		baseURL, a.maxNewPerPoll, a.minAge, a.ackViaSilence, a.silenceDuration)
@@ -211,6 +236,10 @@ func toMatcher(l string) string {
 // the dispatcher's active-instance / once dedup keeps shadowing it; item IDs
 // (fingerprint:startsAt) make re-dispatch impossible while a fire cycle lasts.
 func (a *Adapter) Poll(ctx context.Context, _ time.Time) ([]model.SourceItem, error) {
+	if a.byGroup {
+		return a.pollGroups(ctx)
+	}
+
 	alerts, err := a.client.alerts(ctx, a.filters)
 	if err != nil {
 		return nil, fmt.Errorf("prometheus: polling alerts: %w", err)
@@ -441,6 +470,19 @@ func (a *Adapter) ResolvedItems(ctx context.Context, itemIDs []string) ([]string
 		return nil, nil
 	}
 
+	// In group mode the in-flight ids are group ids, so the live set must be
+	// built from groups too — comparing them against per-alert ids would find
+	// no match for anything and report every running investigation resolved.
+	if a.byGroup {
+		groups, err := a.client.allAlertGroups(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("prometheus: checking resolved alert groups: %w", err)
+		}
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		return a.confirmResolved(itemIDs, a.groupLiveIDs(groups)), nil
+	}
+
 	alerts, err := a.client.allAlerts(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("prometheus: checking resolved alerts: %w", err)
@@ -461,6 +503,13 @@ func (a *Adapter) ResolvedItems(ctx context.Context, itemIDs []string) ([]string
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	return a.confirmResolved(itemIDs, live), nil
+}
+
+// confirmResolved applies the debounce: an item absent from the live set is
+// only reported once it has been absent on resolveConfirmations consecutive
+// checks. Callers must hold a.mu.
+func (a *Adapter) confirmResolved(itemIDs []string, live map[string]struct{}) []string {
 	// Only the ids we were asked about are tracked, so the streak map cannot
 	// outgrow the set of in-flight investigations.
 	asked := make(map[string]struct{}, len(itemIDs))
@@ -484,7 +533,7 @@ func (a *Adapter) ResolvedItems(ctx context.Context, itemIDs []string) ([]string
 			delete(a.resolveStreak, id)
 		}
 	}
-	return resolved, nil
+	return resolved
 }
 
 // silenceMatchers builds the exact-equality matchers for one alert and reports

--- a/src/internal/source/prometheus/client.go
+++ b/src/internal/source/prometheus/client.go
@@ -90,6 +90,50 @@ func (c *client) createSilence(ctx context.Context, s silence) (string, error) {
 	return resp.SilenceID, nil
 }
 
+// alertGroups fetches the currently visible alerts already grouped by
+// Alertmanager's routing tree from GET /api/v2/alerts/groups. Same visibility
+// rules as alerts(): only active, unsilenced, uninhibited members.
+func (c *client) alertGroups(ctx context.Context, filters []string) ([]alertGroup, error) {
+	params := url.Values{
+		"active":    {"true"},
+		"silenced":  {"false"},
+		"inhibited": {"false"},
+	}
+	for _, f := range filters {
+		params.Add("filter", f)
+	}
+
+	data, err := c.get(ctx, "/api/v2/alerts/groups", params)
+	if err != nil {
+		return nil, err
+	}
+	var groups []alertGroup
+	if err := json.Unmarshal(data, &groups); err != nil {
+		return nil, fmt.Errorf("prometheus: decoding alert groups response: %w", err)
+	}
+	return groups, nil
+}
+
+// allAlertGroups is alertGroups with suppressed members included, for the
+// resolution check — a silenced group is still firing.
+func (c *client) allAlertGroups(ctx context.Context) ([]alertGroup, error) {
+	params := url.Values{
+		"active":    {"true"},
+		"silenced":  {"true"},
+		"inhibited": {"true"},
+	}
+
+	data, err := c.get(ctx, "/api/v2/alerts/groups", params)
+	if err != nil {
+		return nil, err
+	}
+	var groups []alertGroup
+	if err := json.Unmarshal(data, &groups); err != nil {
+		return nil, fmt.Errorf("prometheus: decoding alert groups response: %w", err)
+	}
+	return groups, nil
+}
+
 // allAlerts fetches every alert Alertmanager currently holds, including the
 // silenced and inhibited ones the normal poll deliberately excludes. Resolution
 // checks need this wider view: a silenced alert (notably one Apiary silenced

--- a/src/internal/source/prometheus/group.go
+++ b/src/internal/source/prometheus/group.go
@@ -1,0 +1,333 @@
+package prometheus
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// severityRank orders the severity label so a group can report the worst
+// severity among its members as its priority. Unknown values rank lowest.
+var severityRank = map[string]int{
+	"critical": 4,
+	"error":    3,
+	"warning":  2,
+	"info":     1,
+}
+
+// groupKey is the stable identity of an Alertmanager group: the receiver it
+// routes to plus its group-by label set. The v2 API does not return
+// Alertmanager's internal group key, so it is reconstructed from the two
+// things that define the group.
+func groupKey(g alertGroup) string {
+	parts := make([]string, 0, len(g.Labels))
+	for _, k := range sortedKeys(g.Labels) {
+		parts = append(parts, k+"="+g.Labels[k])
+	}
+	return g.Receiver.Name + "/{" + strings.Join(parts, ",") + "}"
+}
+
+// groupItemID is the per-fire-cycle identity of a group: its key plus the
+// epoch pinned when the group became non-empty.
+//
+// A group has no startsAt of its own, and its membership churns constantly
+// while an incident unfolds — so deriving the epoch from the current members on
+// every poll would make the identity jump the moment the oldest alert resolves,
+// re-dispatching an incident that is still being investigated. Pinning the
+// epoch for the whole cycle absorbs that churn: the id changes only when the
+// group empties and later fires again, which is exactly one fire cycle.
+func groupItemID(key string, epoch time.Time) string {
+	return key + ":" + epoch.UTC().Format(time.RFC3339)
+}
+
+// groupNumber is a short, stable human-facing reference for a group, mirroring
+// the 7-char fingerprint prefix used for single alerts.
+func groupNumber(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])[:7]
+}
+
+// epochFor returns the pinned cycle-start for a group, pinning it on first
+// sight. Callers must hold a.mu.
+//
+// On a cold start (daemon restarted mid-incident) there is nothing pinned, so
+// the epoch is seeded from the members' earliest startsAt — which reproduces
+// the value the previous process pinned whenever the oldest member is still
+// firing, so an ongoing investigation is not duplicated. It differs only in the
+// narrow case where that oldest member resolved during the restart.
+func (a *Adapter) epochFor(key string, members []alert) time.Time {
+	if epoch, ok := a.groupEpoch[key]; ok {
+		return epoch
+	}
+	epoch := earliestStart(members)
+	a.groupEpoch[key] = epoch
+	aplog.Debug("prometheus: group %s cycle started at %s (%d alert(s))", key, epoch.UTC().Format(time.RFC3339), len(members))
+	return epoch
+}
+
+func earliestStart(members []alert) time.Time {
+	var earliest time.Time
+	for _, al := range members {
+		if earliest.IsZero() || al.StartsAt.Before(earliest) {
+			earliest = al.StartsAt
+		}
+	}
+	return earliest
+}
+
+// pollGroups is the group-dispatch variant of Poll: one SourceItem per
+// non-empty Alertmanager group instead of one per alert.
+func (a *Adapter) pollGroups(ctx context.Context) ([]model.SourceItem, error) {
+	groups, err := a.client.alertGroups(ctx, a.filters)
+	if err != nil {
+		return nil, fmt.Errorf("prometheus: polling alert groups: %w", err)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	now := time.Now()
+	type candidate struct {
+		group alertGroup
+		key   string
+		epoch time.Time
+	}
+
+	var eligible []candidate
+	live := map[string]struct{}{}
+	for _, g := range groups {
+		members := firingMembers(g)
+		if len(members) == 0 {
+			continue // an empty group is not a fire cycle
+		}
+		key := groupKey(g)
+		live[key] = struct{}{}
+		epoch := a.epochFor(key, members)
+
+		// Flap dampener, applied to the cycle rather than to each alert: a
+		// group that has only just formed is left for a later poll. The epoch
+		// stays pinned meanwhile, so maturing does not change the identity.
+		if age := now.Sub(epoch); age < a.minAge {
+			aplog.Debug("prometheus: group %s age %s < min_age %s — deferred", key, age.Round(time.Second), a.minAge)
+			continue
+		}
+		g.alerts = members
+		eligible = append(eligible, candidate{group: g, key: key, epoch: epoch})
+	}
+
+	// Oldest cycle first so a storm drains deterministically.
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].epoch.Before(eligible[j].epoch) })
+
+	current := make(map[string]struct{}, len(eligible))
+	var items []model.SourceItem
+	newCount, dropped := 0, 0
+	for _, c := range eligible {
+		id := groupItemID(c.key, c.epoch)
+		current[id] = struct{}{}
+		if _, ok := a.seen[id]; !ok {
+			if a.maxNewPerPoll > 0 && newCount >= a.maxNewPerPoll {
+				dropped++
+				delete(current, id) // not surfaced: stays unseen for the next poll
+				continue
+			}
+			newCount++
+			a.seen[id] = struct{}{}
+		}
+		item := a.toGroupItem(c.group, c.key, c.epoch)
+		a.labels[id] = groupSilenceLabels(c.group)
+		items = append(items, item)
+	}
+	if dropped > 0 {
+		aplog.Warn("prometheus: storm cap — %d new group(s) deferred to next poll (max_new_per_poll=%d)", dropped, a.maxNewPerPoll)
+	}
+
+	for id := range a.seen {
+		if _, ok := current[id]; !ok {
+			delete(a.seen, id)
+			delete(a.labels, id)
+		}
+	}
+
+	// A group that emptied ends its cycle: drop the pin so the next time it
+	// fires it is a new item. Groups merely held back by the storm cap or
+	// min_age are still live and keep theirs.
+	for key := range a.groupEpoch {
+		if _, ok := live[key]; !ok {
+			delete(a.groupEpoch, key)
+		}
+	}
+
+	return items, nil
+}
+
+// firingMembers drops members that have already resolved but still linger in
+// the group until Alertmanager's resolve_timeout.
+func firingMembers(g alertGroup) []alert {
+	now := time.Now()
+	members := make([]alert, 0, len(g.Alerts))
+	for _, al := range g.Alerts {
+		if al.Fingerprint == "" {
+			continue
+		}
+		if !al.EndsAt.IsZero() && al.EndsAt.Before(now) {
+			continue
+		}
+		members = append(members, al)
+	}
+	return members
+}
+
+// groupSilenceLabels are the labels true of the whole group: its group-by
+// labels, plus any label every member carries with the same value. Silencing on
+// them suppresses exactly this group's alerts, and they are what trigger
+// matching sees — so `labels: [severity:critical]` matches a group whose
+// members are all critical, even when severity is not a group-by label.
+func groupSilenceLabels(g alertGroup) map[string]string {
+	labels := map[string]string{}
+	for k, v := range g.Labels {
+		labels[k] = v
+	}
+	if len(g.alerts) == 0 {
+		return labels
+	}
+
+	for k, v := range g.alerts[0].Labels {
+		if _, ok := labels[k]; ok {
+			continue
+		}
+		shared := true
+		for _, al := range g.alerts[1:] {
+			if al.Labels[k] != v {
+				shared = false
+				break
+			}
+		}
+		if shared {
+			labels[k] = v
+		}
+	}
+	return labels
+}
+
+func (a *Adapter) toGroupItem(g alertGroup, key string, epoch time.Time) model.SourceItem {
+	labels := groupSilenceLabels(g)
+
+	name := g.Labels["alertname"]
+	if name == "" {
+		name = labels["alertname"]
+	}
+	if name == "" {
+		name = "alert group"
+	}
+	title := fmt.Sprintf("%s (%d alerts)", name, len(g.alerts))
+	if len(g.alerts) == 1 {
+		title = fmt.Sprintf("%s (1 alert)", name)
+	}
+
+	itemLabels := make([]string, 0, len(labels))
+	for k, v := range labels {
+		itemLabels = append(itemLabels, k+":"+v)
+	}
+	sort.Strings(itemLabels)
+
+	fingerprints := make([]string, 0, len(g.alerts))
+	for _, al := range g.alerts {
+		fingerprints = append(fingerprints, al.Fingerprint)
+	}
+
+	return model.SourceItem{
+		ID:          groupItemID(key, epoch),
+		SourceID:    a.ID(),
+		Number:      groupNumber(key),
+		Title:       title,
+		Description: describeGroup(g, key, epoch),
+		Labels:      itemLabels,
+		Type:        "alert_group",
+		Priority:    worstSeverity(g.alerts),
+		State:       "firing",
+		URL:         firstGeneratorURL(g.alerts),
+		Metadata: map[string]any{
+			"groupKey":     key,
+			"epoch":        epoch.UTC().Format(time.RFC3339),
+			"receiver":     g.Receiver.Name,
+			"groupLabels":  g.Labels,
+			"labels":       labels,
+			"alertCount":   len(g.alerts),
+			"fingerprints": fingerprints,
+		},
+	}
+}
+
+func worstSeverity(members []alert) string {
+	worst, rank := "", 0
+	for _, al := range members {
+		s := al.Labels["severity"]
+		if r := severityRank[strings.ToLower(s)]; r > rank {
+			worst, rank = s, r
+		}
+	}
+	return worst
+}
+
+func firstGeneratorURL(members []alert) string {
+	for _, al := range members {
+		if al.GeneratorURL != "" {
+			return al.GeneratorURL
+		}
+	}
+	return ""
+}
+
+// describeGroup renders the group as the task body: what the group is, then
+// each member alert, so the agent sees the whole incident in one place.
+func describeGroup(g alertGroup, key string, epoch time.Time) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Alertmanager group with %d firing alert(s).\n\n", len(g.alerts))
+	fmt.Fprintf(&b, "- Group key: `%s`\n", key)
+	fmt.Fprintf(&b, "- Receiver: `%s`\n", g.Receiver.Name)
+	fmt.Fprintf(&b, "- Firing since %s\n", epoch.UTC().Format(time.RFC3339))
+
+	if len(g.Labels) > 0 {
+		b.WriteString("\n**Group labels**\n\n")
+		for _, k := range sortedKeys(g.Labels) {
+			fmt.Fprintf(&b, "- `%s`: %s\n", k, g.Labels[k])
+		}
+	}
+
+	for i, al := range g.alerts {
+		fmt.Fprintf(&b, "\n---\n\n### %d. %s\n\n", i+1, alertName(al))
+		b.WriteString(describe(al))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func alertName(al alert) string {
+	if n := al.Labels["alertname"]; n != "" {
+		return n
+	}
+	return "alert " + al.Fingerprint
+}
+
+// groupLiveIDs computes the item IDs of every currently live group, for the
+// resolution check. Callers must hold a.mu.
+func (a *Adapter) groupLiveIDs(groups []alertGroup) map[string]struct{} {
+	live := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		members := firingMembers(g)
+		if len(members) == 0 {
+			continue
+		}
+		key := groupKey(g)
+		live[groupItemID(key, a.epochFor(key, members))] = struct{}{}
+	}
+	return live
+}

--- a/src/internal/source/prometheus/group_test.go
+++ b/src/internal/source/prometheus/group_test.go
@@ -1,0 +1,414 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// groupServer serves GET /api/v2/alerts/groups and records silences, so group
+// tests can drive polling, resolution, and ack_via_silence against one server.
+type groupServer struct {
+	*httptest.Server
+
+	mu     sync.Mutex
+	groups []map[string]any
+	posted []silence
+}
+
+func newGroupServer(t *testing.T) *groupServer {
+	t.Helper()
+	s := &groupServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/alerts/groups":
+			s.mu.Lock()
+			groups := s.groups
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			if groups == nil {
+				groups = []map[string]any{}
+			}
+			_ = json.NewEncoder(w).Encode(groups)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v2/silences":
+			var body silence
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.mu.Lock()
+			s.posted = append(s.posted, body)
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"silenceID": "sil-1"})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func (s *groupServer) set(groups []map[string]any) {
+	s.mu.Lock()
+	s.groups = groups
+	s.mu.Unlock()
+}
+
+func (s *groupServer) silences() []silence {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]silence(nil), s.posted...)
+}
+
+// mkGroup builds an AlertGroup payload with the given group labels and members.
+func mkGroup(groupLabels map[string]string, members ...map[string]any) map[string]any {
+	return map[string]any{
+		"labels":   groupLabels,
+		"receiver": map[string]any{"name": "oncall"},
+		"alerts":   members,
+	}
+}
+
+// mkMember is mkAlert with control over the per-alert labels.
+func mkMember(fingerprint string, startsAt time.Time, labels map[string]string) map[string]any {
+	al := mkAlert(fingerprint, labels["alertname"], labels["severity"], startsAt)
+	al["labels"] = labels
+	return al
+}
+
+func groupAdapter(t *testing.T, url string, extra map[string]any) *Adapter {
+	t.Helper()
+	cfg := map[string]any{"dispatch_by": "group", "min_age": "0s"}
+	for k, v := range extra {
+		cfg[k] = v
+	}
+	return connect(t, url, cfg)
+}
+
+func pollItems(t *testing.T, a *Adapter) []model.SourceItem {
+	t.Helper()
+	items, err := a.Poll(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Poll: %v", err)
+	}
+	return items
+}
+
+// One group of three alerts becomes one task, not three.
+func TestGroupPollDispatchesOneItemPerGroup(t *testing.T) {
+	start := time.Now().Add(-10 * time.Minute)
+	srv := newGroupServer(t)
+	srv.set([]map[string]any{
+		mkGroup(map[string]string{"alertname": "HighErrorRate", "team": "platform"},
+			mkMember("aaa1", start, map[string]string{"alertname": "HighErrorRate", "team": "platform", "severity": "critical", "instance": "web-1"}),
+			mkMember("bbb2", start.Add(time.Minute), map[string]string{"alertname": "HighErrorRate", "team": "platform", "severity": "critical", "instance": "web-2"}),
+			mkMember("ccc3", start.Add(2*time.Minute), map[string]string{"alertname": "HighErrorRate", "team": "platform", "severity": "warning", "instance": "web-3"}),
+		),
+	})
+	a := groupAdapter(t, srv.URL, nil)
+
+	items := pollItems(t, a)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 group item, got %d", len(items))
+	}
+	it := items[0]
+
+	if it.Type != "alert_group" {
+		t.Errorf("Type = %q, want alert_group", it.Type)
+	}
+	if !strings.Contains(it.Title, "HighErrorRate") || !strings.Contains(it.Title, "3 alerts") {
+		t.Errorf("Title = %q, want the alert name and member count", it.Title)
+	}
+	// severity differs across members, so it is not a group-wide label.
+	for _, l := range it.Labels {
+		if strings.HasPrefix(l, "severity:") {
+			t.Errorf("severity must not be a group label when members disagree: %v", it.Labels)
+		}
+	}
+	if it.Priority != "critical" {
+		t.Errorf("Priority = %q, want the worst member severity (critical)", it.Priority)
+	}
+	if got := it.Metadata["alertCount"]; got != 3 {
+		t.Errorf("metadata alertCount = %v, want 3", got)
+	}
+	for _, want := range []string{"web-1", "web-2", "web-3"} {
+		if !strings.Contains(it.Description, want) {
+			t.Errorf("description missing member %q", want)
+		}
+	}
+}
+
+// A label every member shares is true of the group, so trigger matching sees it.
+func TestGroupLabelsIncludeSharedMemberLabels(t *testing.T) {
+	start := time.Now().Add(-10 * time.Minute)
+	srv := newGroupServer(t)
+	srv.set([]map[string]any{
+		mkGroup(map[string]string{"alertname": "HighErrorRate"},
+			mkMember("aaa1", start, map[string]string{"alertname": "HighErrorRate", "severity": "critical", "instance": "web-1"}),
+			mkMember("bbb2", start, map[string]string{"alertname": "HighErrorRate", "severity": "critical", "instance": "web-2"}),
+		),
+	})
+	a := groupAdapter(t, srv.URL, nil)
+
+	items := pollItems(t, a)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	var hasSeverity, hasInstance bool
+	for _, l := range items[0].Labels {
+		if l == "severity:critical" {
+			hasSeverity = true
+		}
+		if strings.HasPrefix(l, "instance:") {
+			hasInstance = true
+		}
+	}
+	if !hasSeverity {
+		t.Errorf("labels = %v, want severity:critical (shared by every member)", items[0].Labels)
+	}
+	if hasInstance {
+		t.Errorf("labels = %v, must not include instance (members disagree)", items[0].Labels)
+	}
+}
+
+// The epoch is pinned: churn inside a live group must not change its identity.
+func TestGroupIdentityIsStableAcrossMembershipChurn(t *testing.T) {
+	start := time.Now().Add(-20 * time.Minute)
+	oldest := mkMember("aaa1", start, map[string]string{"alertname": "HighErrorRate", "instance": "web-1"})
+	joiner := mkMember("bbb2", time.Now().Add(-5*time.Minute), map[string]string{"alertname": "HighErrorRate", "instance": "web-2"})
+
+	srv := newGroupServer(t)
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, oldest)})
+	a := groupAdapter(t, srv.URL, nil)
+
+	first := pollItems(t, a)
+	if len(first) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(first))
+	}
+	id := first[0].ID
+
+	// A new alert joins the group.
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, oldest, joiner)})
+	if got := pollItems(t, a); len(got) != 1 || got[0].ID != id {
+		t.Fatalf("id changed when an alert joined: %v, want %s", got, id)
+	}
+
+	// The OLDEST alert resolves — the case that would move a live-min epoch.
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, joiner)})
+	got := pollItems(t, a)
+	if len(got) != 1 || got[0].ID != id {
+		t.Fatalf("id changed when the oldest member resolved: %v, want %s — the epoch must stay pinned", got, id)
+	}
+}
+
+// A group that empties ends its cycle; firing again is a new item.
+func TestGroupRefireIsANewItem(t *testing.T) {
+	srv := newGroupServer(t)
+	first := mkMember("aaa1", time.Now().Add(-20*time.Minute), map[string]string{"alertname": "HighErrorRate"})
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, first)})
+	a := groupAdapter(t, srv.URL, nil)
+
+	firstItems := pollItems(t, a)
+	if len(firstItems) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(firstItems))
+	}
+
+	// The group empties: cycle over.
+	srv.set(nil)
+	if got := pollItems(t, a); len(got) != 0 {
+		t.Fatalf("expected no items for an empty group, got %v", got)
+	}
+
+	// It fires again with a later start.
+	second := mkMember("ddd4", time.Now().Add(-time.Minute), map[string]string{"alertname": "HighErrorRate"})
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, second)})
+	got := pollItems(t, a)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 item after re-fire, got %d", len(got))
+	}
+	if got[0].ID == firstItems[0].ID {
+		t.Fatalf("re-fire reused the previous cycle's id %s — it must dispatch as new work", got[0].ID)
+	}
+}
+
+// Members that already resolved but linger must not keep a cycle alive.
+func TestGroupIgnoresResolvedMembers(t *testing.T) {
+	srv := newGroupServer(t)
+	dead := mkMember("aaa1", time.Now().Add(-20*time.Minute), map[string]string{"alertname": "HighErrorRate"})
+	dead["endsAt"] = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, dead)})
+	a := groupAdapter(t, srv.URL, nil)
+
+	if got := pollItems(t, a); len(got) != 0 {
+		t.Fatalf("a group whose only member resolved must not dispatch, got %v", got)
+	}
+}
+
+// min_age dampens the group cycle, and maturing must not change the id.
+func TestGroupMinAgeDefersWithoutChangingIdentity(t *testing.T) {
+	srv := newGroupServer(t)
+	young := mkMember("aaa1", time.Now().Add(-time.Second), map[string]string{"alertname": "HighErrorRate"})
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, young)})
+	a := connect(t, srv.URL, map[string]any{"dispatch_by": "group", "min_age": "1h"})
+
+	if got := pollItems(t, a); len(got) != 0 {
+		t.Fatalf("a too-young group must be deferred, got %v", got)
+	}
+	// The epoch was pinned while deferred; it must survive to the dispatch.
+	a.mu.Lock()
+	pinned := len(a.groupEpoch)
+	a.mu.Unlock()
+	if pinned != 1 {
+		t.Fatalf("expected the deferred group's epoch to stay pinned, got %d entries", pinned)
+	}
+}
+
+// The storm cap counts groups, not member alerts.
+func TestGroupStormCapCountsGroups(t *testing.T) {
+	start := time.Now().Add(-10 * time.Minute)
+	srv := newGroupServer(t)
+	var groups []map[string]any
+	for _, name := range []string{"A", "B", "C"} {
+		groups = append(groups, mkGroup(map[string]string{"alertname": name},
+			mkMember("fp"+name, start, map[string]string{"alertname": name})))
+	}
+	srv.set(groups)
+	a := connect(t, srv.URL, map[string]any{"dispatch_by": "group", "min_age": "0s", "max_new_per_poll": 2})
+
+	if got := pollItems(t, a); len(got) != 2 {
+		t.Fatalf("expected the storm cap to admit 2 groups, got %d", len(got))
+	}
+	if got := pollItems(t, a); len(got) != 3 {
+		t.Fatalf("expected the deferred group on the next poll (3 total), got %d", len(got))
+	}
+}
+
+// Resolution must be evaluated against group ids, not per-alert ids — otherwise
+// every running investigation would look resolved.
+func TestGroupResolvedItemsUsesGroupIdentity(t *testing.T) {
+	start := time.Now().Add(-10 * time.Minute)
+	srv := newGroupServer(t)
+	member := mkMember("aaa1", start, map[string]string{"alertname": "HighErrorRate"})
+	srv.set([]map[string]any{mkGroup(map[string]string{"alertname": "HighErrorRate"}, member)})
+	a := groupAdapter(t, srv.URL, nil)
+
+	items := pollItems(t, a)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	id := items[0].ID
+
+	// Still firing: two checks, still nothing resolved.
+	for i := 0; i < 2; i++ {
+		got, err := a.ResolvedItems(context.Background(), []string{id})
+		if err != nil {
+			t.Fatalf("ResolvedItems: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("live group reported resolved: %v", got)
+		}
+	}
+
+	// The group empties.
+	srv.set(nil)
+	if _, err := a.ResolvedItems(context.Background(), []string{id}); err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	got, err := a.ResolvedItems(context.Background(), []string{id})
+	if err != nil {
+		t.Fatalf("ResolvedItems: %v", err)
+	}
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("ResolvedItems = %v, want [%s]", got, id)
+	}
+}
+
+// ack_via_silence on a group silences the whole group, on labels true of every
+// member.
+func TestGroupAcknowledgeSilencesWholeGroup(t *testing.T) {
+	start := time.Now().Add(-10 * time.Minute)
+	srv := newGroupServer(t)
+	srv.set([]map[string]any{
+		mkGroup(map[string]string{"alertname": "HighErrorRate", "team": "platform"},
+			mkMember("aaa1", start, map[string]string{"alertname": "HighErrorRate", "team": "platform", "instance": "web-1"}),
+			mkMember("bbb2", start, map[string]string{"alertname": "HighErrorRate", "team": "platform", "instance": "web-2"}),
+		),
+	})
+	a := groupAdapter(t, srv.URL, map[string]any{"ack_via_silence": true})
+
+	items := pollItems(t, a)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if err := a.Acknowledge(context.Background(), items[0], model.AckActionInProgress); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+
+	got := srv.silences()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 silence, got %d", len(got))
+	}
+	m := matcherMap(t, got[0])
+	if m["alertname"] != "HighErrorRate" || m["team"] != "platform" {
+		t.Errorf("matchers = %v, want the group labels", m)
+	}
+	if _, ok := m["instance"]; ok {
+		t.Errorf("matchers = %v, must not pin instance — that would silence only one member", m)
+	}
+}
+
+// Group mode is opt-in; the default stays one task per alert.
+func TestDispatchByDefaultsToAlert(t *testing.T) {
+	a := connect(t, "http://localhost:9093", nil)
+	if a.byGroup {
+		t.Fatal("dispatch_by defaulted to group; the per-alert default must be preserved")
+	}
+	a = connect(t, "http://localhost:9093", map[string]any{"dispatch_by": "alert"})
+	if a.byGroup {
+		t.Fatal("dispatch_by: alert enabled group mode")
+	}
+}
+
+func TestConnectRejectsUnknownDispatchBy(t *testing.T) {
+	for _, v := range []any{"groups", "per-alert", 7} {
+		a := &Adapter{}
+		err := a.Connect(context.Background(), map[string]any{
+			"alertmanager_url": "http://localhost:9093",
+			"dispatch_by":      v,
+		})
+		if err == nil {
+			t.Errorf("dispatch_by=%v: expected an error", v)
+		}
+	}
+}
+
+// Two groups routing to different receivers are distinct even with equal labels.
+func TestGroupKeyIncludesReceiver(t *testing.T) {
+	g1 := alertGroup{Labels: map[string]string{"alertname": "X"}, Receiver: groupReceiver{Name: "oncall"}}
+	g2 := alertGroup{Labels: map[string]string{"alertname": "X"}, Receiver: groupReceiver{Name: "pager"}}
+	if groupKey(g1) == groupKey(g2) {
+		t.Fatalf("group keys collide across receivers: %s", groupKey(g1))
+	}
+}
+
+// The key must not depend on Go's map iteration order.
+func TestGroupKeyIsDeterministic(t *testing.T) {
+	labels := map[string]string{"alertname": "X", "team": "platform", "env": "prod", "region": "eu"}
+	want := groupKey(alertGroup{Labels: labels, Receiver: groupReceiver{Name: "oncall"}})
+	for i := 0; i < 50; i++ {
+		clone := map[string]string{}
+		for k, v := range labels {
+			clone[k] = v
+		}
+		if got := groupKey(alertGroup{Labels: clone, Receiver: groupReceiver{Name: "oncall"}}); got != want {
+			t.Fatalf("group key varies across iterations: %q vs %q", got, want)
+		}
+	}
+}

--- a/src/internal/source/prometheus/types.go
+++ b/src/internal/source/prometheus/types.go
@@ -21,6 +21,23 @@ type alertStatus struct {
 	InhibitedBy []string `json:"inhibitedBy"`
 }
 
+// alertGroup is one entry of GET /api/v2/alerts/groups (openapi AlertGroup):
+// the alerts Alertmanager has grouped together by the routing tree's group_by
+// labels, which is the unit an on-call actually gets paged about.
+type alertGroup struct {
+	Labels   map[string]string `json:"labels"`
+	Receiver groupReceiver     `json:"receiver"`
+	Alerts   []alert           `json:"alerts"`
+
+	// alerts holds the members left after resolved ones are filtered out. It
+	// is set by the adapter, never decoded from the API.
+	alerts []alert
+}
+
+type groupReceiver struct {
+	Name string `json:"name"`
+}
+
 // silence is the POST /api/v2/silences request body (openapi PostableSilence).
 // Every matcher must hold for an alert to be suppressed.
 type silence struct {


### PR DESCRIPTION
## Summary

Last of the remaining items on #362, after `ack_via_silence` (#397) and `interrupt_on_resolve` (#398).

One bad deploy fires `HighErrorRate` on twelve pods, and today that is twelve tasks and twelve agent runs investigating one incident. Alertmanager's `group_by` already encodes "what the on-call should be paged about once"; `dispatch_by: group` follows that grouping and emits one task per non-empty group, with every member alert rendered into the task body.

Opt-in — `dispatch_by` defaults to `alert`, so existing configs are unchanged.

## The design decision this item was deferred for

The issue parked group dispatch because "groups have no stable fire-cycle epoch". A single alert has a natural per-cycle identity (`fingerprint:startsAt`), but a group's membership churns continuously during an incident and nothing on it stays put.

The resolution here is a **pinned epoch**: when a group first becomes non-empty its epoch is set to the members' earliest `startsAt`, then held for the whole cycle and dropped when the group empties.

```
14:02  alert A fires    -> group non-empty, epoch := 14:02, dispatch
14:09  alert B joins    -> same id, no re-dispatch
14:20  alert A resolves -> same id, no re-dispatch   <- churn absorbed
14:44  group empties    -> cycle ends, pin dropped
15:10  alert C fires    -> epoch := 15:10, new dispatch
```

Recomputing the epoch from the current members each poll — the obvious alternative, and fully restart-proof — moves the id the instant the oldest alert resolves, re-dispatching an incident that is still being investigated. That tradeoff is why pinning won.

**Restart caveat, stated plainly:** the pin is in-memory. After a daemon restart the epoch is re-seeded from the current members' earliest `startsAt`, which reproduces the pre-restart value whenever the oldest member is still firing — the usual case for an ongoing incident. It differs only when that oldest member resolved during the restart window, which produces one new task for the ongoing group. Documented in `docs/prometheus-source.md`.

## Interactions

Each of these is a place group mode could have quietly broken something:

- **`ResolvedItems`** now builds its live set from *groups* in group mode. Without this, in-flight group ids would be compared against per-alert ids, match nothing, and report **every running investigation as resolved** — `interrupt_on_resolve` would have interrupted all of them. Test covers it.
- **`ack_via_silence`** silences on the group-wide labels, so acknowledging suppresses the whole group rather than a single member.
- **`max_new_per_poll`** counts groups, not member alerts.
- **`min_age`** measures the group's cycle; a deferred group keeps its pin, so maturing never changes its id.

## Routing labels

Group labels are the `group_by` labels **plus any label every member carries with the same value**. `severity` is rarely a `group_by` label, so without this rule `labels: [severity:critical]` would never match a group. When members disagree the label is not group-wide and is omitted.

## Test plan

- `go build ./... && go vet ./...` clean; `gofmt` clean.
- `go test ./... -count=1` green; `-race` green on `source/prometheus`, `daemon`, `config`, `cli`.
- New `group_test.go`: one item per group with member details; shared-label promotion (and non-promotion when members disagree); identity stable when an alert joins **and when the oldest member resolves**; re-fire after the group empties is a new id; lingering resolved members do not keep a cycle alive; `min_age` defers while keeping the pin; storm cap counts groups; `ResolvedItems` uses group identity; `ack_via_silence` silences group-wide, not per-member; `dispatch_by` defaults to alert; invalid `dispatch_by` rejected (including non-string, a bug the test caught); group key includes the receiver and is iteration-order independent.
- `apiary validate` on `.apiary/example-apiary-full.yaml` reports the same 9 pre-existing errors as `main`.
- Not exercised against a live Alertmanager.

With this, every item on #362 is resolved: Dynatrace (#363), plugin-source bridge (#366), `ack_via_silence` (#397), `interrupt_on_resolve` (#398), group-key dispatch (here), and the generic webhook source dropped by design (polling-only).

Closes #362