### PR TITLE
feat(improve): evidence pack — mine execution history into metrics (#402)

### DIFF
--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Ativas
 
 - **step-wallclock-attribution** — Atribuição de wall-clock por step (thinking / writing / esperas de tool / tarefas em background) gravada em `task_executions` e `step_runs` ao lado das colunas de token, lista das chamadas mais lentas, payload do evento `system:task_started` no log, e comando `apiary profile <instance-id> [--json]`. GitHub issue #399.
+- **self-improvement-advisor** — `apiary improve`: standalone command that mines the execution history (step/instance/execution metrics, failure clusters, sampled transcripts), has an agent reason over it at a configurable effort level, and emits an evidence-backed report plus a validated unified diff over the whole config workspace (`apiary.yaml`, workflow files, soul files, skill definitions) — or applies it with `--apply`, leaving undo to git. Ledger tables record what was proposed and applied so `apiary improve effect` measures the before/after delta.
 
 ## Arquivadas
 

--- a/openspec/changes/self-improvement-advisor/proposal.md
+++ b/openspec/changes/self-improvement-advisor/proposal.md
@@ -1,0 +1,428 @@
+# Proposal: Self-Improvement Advisor (`apiary improve`)
+
+## Why
+
+Apiary already records everything needed to judge how well its own agents and workflows
+perform, and then throws that judgement away. Every step run persists timing, token and
+cache breakdown, turns, tool calls, cost, exit state and the full composed prompt
+(`step_runs`, `task_executions`); every failover records a `failure_kind`; every CI wait
+records each poll; every session writes a markdown transcript. Today that data only
+answers "what happened to this task" in the dashboard. Nobody asks the cross-cutting
+question:
+
+> Across the last 200 runs, which steps are wasting money, which agent instructions keep
+> producing rework, and what should I change in `apiary.yaml` and the soul files?
+
+That question is answered manually, if at all — reading transcripts one by one. The
+result is that configuration drifts: `max_turns` caps set once and never revisited, a
+review step that fails 40% of the time and always passes on retry, an agent whose soul
+file no longer matches the workflow around it, a fallback chain never exercised, steps
+that run sequentially but have no data dependency.
+
+The gap is that **Apiary has no feedback loop from its own execution history back into
+its own configuration.** This change adds one: a standalone command that mines the
+execution history, has an agent reason over it, and emits either a reviewable diff or an
+applied change to the config and soul files — plus the bookkeeping to tell, on the next
+run, whether the last set of changes actually helped.
+
+---
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Execution stats** | Per-task/per-instance views in the dashboard | Cross-run aggregation by workflow, step, agent, runner and model |
+| **Config tuning** | Manual, from memory | Evidence-backed recommendations tied to specific metrics |
+| **Soul files** | Hand-edited, never reviewed against outcomes | Reviewed against the transcripts of the runs they produced |
+| **Effort** | n/a | `--effort quick\|standard\|deep`, trading tokens/time for depth |
+| **Delivery** | n/a | Markdown report + unified diff (default) or direct apply behind `--apply` |
+| **Feedback** | None | Applied recommendations are recorded and re-scored on the next run (before/after) |
+| **Runtime** | n/a | Standalone one-shot command; does not require the daemon to be running |
+
+The advisor reads and may propose changes to the **whole agent-configuration workspace**:
+`apiary.yaml`, referenced workflow files, every soul file, every skill definition the
+agents declare, and the generated agent prompt files. Version control is the user's
+safety net — the command assumes the workspace is a git repository and does not try to
+reimplement undo.
+
+Explicitly **not** in scope: an autonomous loop that rewrites config unattended, changes
+to Go source, and changes to secrets — `.env`, tokens, and any secret-bearing config value.
+
+---
+
+## New Concepts
+
+| Concept | Description |
+|---|---|
+| **Evidence pack** | A deterministic, LLM-free bundle of aggregated metrics + selected transcript excerpts, built in Go from the SQLite database. The single input to the advisor agent. Reproducible and inspectable (`--dump-evidence`). |
+| **Finding** | An observation with a metric behind it: scope (workflow/step/agent), symptom, the numbers that support it, and severity. Findings exist without recommendations. |
+| **Recommendation** | A proposed change addressing one or more findings: target file, rationale, confidence, expected effect, and a patch. |
+| **Config workspace** | Every file that shapes agent behaviour, discovered from the config: `apiary.yaml`, referenced workflow files, soul files, skill definitions, generated agent prompt files. The advisor reads all of it and may propose edits anywhere in it, minus the exclusion list. |
+| **Effort level** | How much of the history is mined, how many transcripts are read, how many agent passes run, and whether a critic pass reviews each patch. |
+| **Improvement ledger** | `improvement_runs` / `improvement_findings` tables recording what was proposed, what was applied and when — so the next run can measure the delta on the same metrics. |
+
+---
+
+## Design
+
+### 1. Command shape
+
+```
+apiary improve [flags]
+```
+
+```
+scope of the analysis
+  --since 30d                    history window (default: 14d)
+  --workflow <id>                restrict analysis to one workflow (repeatable)
+  --agent <id>                   restrict analysis to one agent's runs (repeatable)
+  --focus cost|latency|reliability|quality|all   what to optimise for (default: all)
+
+who performs the analysis (see §5)
+  --advisor <agent-id>           agent that runs the analysis
+  --runner <id> --model <name>   ad-hoc runner/model pair, no config entry needed
+  --profile <name>               apply profiles.<name> overrides (global flag)
+
+depth and delivery
+  --effort quick|standard|deep   depth of analysis (default: standard)
+  --output report|diff|json      what to print (default: diff, report always included)
+  --apply                        write the changes to disk instead of printing a diff
+                                 (workspace is assumed to be under version control)
+  --out <dir>                    write report/diff/evidence to a directory
+  --dump-evidence                print the evidence pack and exit (no agent call, no
+                                 advisor needed)
+  --yes                          skip the confirmation prompt when applying
+```
+
+The command is standalone: it opens the database read-only, builds the evidence pack,
+invokes a runner directly through `runner.New(...)` (the same path the daemon uses, but
+without the dispatcher, queue or workflow engine), and writes its output locally. It works
+with the daemon stopped, and takes no dispatch slots when it is running.
+
+Sub-commands:
+
+```
+apiary improve history            list past improvement runs
+apiary improve show <run-id>      re-print a past run's report and diff
+apiary improve effect <run-id>    before/after comparison for an applied run
+```
+
+### 2. Evidence pack — deterministic, computed in Go
+
+No LLM is involved in producing the numbers. New package `internal/improve` with a
+`metrics.go` that issues read-only aggregate queries over the existing schema.
+
+**Per step** (`step_runs` ⋈ `workflow_instances` ⋈ `task_executions`):
+
+- run count, pass / fail / skipped / skipped_cached rates
+- duration p50 / p95 (`finished_at - started_at`)
+- mean and total `total_tokens`, `cost_usd`, `num_turns`, `num_tool_calls`
+- cache reuse: `cache_read_tokens / input_tokens` — a low ratio on a hot step means the
+  prompt prefix churns between runs
+- prompt weight: `length(input_prompt)` vs `output_tokens` — a large prompt producing a
+  tiny output is a prompt-design smell
+- failover rate and `failure_kind` distribution (`rate_limited` / `credit_exhausted` /
+  `aborted`), from `task_executions.attempt > 1`
+
+**Per workflow** (`workflow_instances`, `step_runs`):
+
+- instance count by terminal state, end-to-end p50/p95 duration, cost per completed instance
+- **rework loops**: the same `step_id` appearing more than once in one instance —
+  the direct signature of an `on_fail`/`goto` cycle
+- **step concurrency opportunity**: consecutive sequential steps where no later step's
+  `if`/expression references an earlier step's output — candidates for `parallel`
+- dead paths: steps and whole workflows with zero runs in the window
+- wait cost: `ci_poll_checks` per wait step (poll count, terminal status distribution,
+  timeouts) and approval latency from `approval_requests` / `approval_responses`
+
+**Per agent / runner / model** (`task_executions`, `agents`):
+
+- success rate, mean cost and duration, turn distribution
+- `max_turns` saturation: how often a run ends at exactly the configured cap
+- agents configured but never dispatched; fallback chains never exercised
+
+**Failure taxonomy**: `error_message` on failed executions normalised (numbers, paths,
+IDs stripped) and grouped, so "the same failure 30 times" reads as one cluster with a
+count instead of 30 lines.
+
+**Transcript sampling** (effort-dependent): for each hotspot, N transcripts are selected —
+the worst failures plus one successful control — truncated to a per-step character budget.
+This is the only free-text input, and it is what lets the advisor say something about
+*instructions* rather than only about *numbers*.
+
+The pack is a serialisable struct; `--dump-evidence` prints it as JSON. This makes the
+whole feature testable without an LLM and lets the metrics layer ship and be trusted before
+the agent layer is wired up.
+
+### 3. Config workspace — discovery and exclusions
+
+The second half of the input, alongside the metrics, is the configuration that produced
+them. It is discovered from the config rather than hard-coded, so it stays correct as a
+project grows:
+
+| Source | Discovered from |
+|---|---|
+| Main config | `--config` / `resolveConfigFile()` (`apiary.yaml`, `.apiary/apiary.yaml`) |
+| Workflow files | `workflows[].uses` / sub-workflow references, resolved transitively |
+| Soul files | `agents[].soul_file` (already validated to exist by `cfg.Validate()`) |
+| Skill definitions | `agents[].skills` resolved against the skill directories (`.claude/skills/<name>/SKILL.md` and the runner's skill paths) |
+| Agent prompt files | The generated per-agent markdown the dispatcher writes (`~/.config/opencode/agents/<id>.md`) — read as context, not edited, since it is generated from the soul file |
+| Plugin manifests | `plugin_dirs` / `plugins[]` — read-only context |
+
+**Exclusions**, enforced before anything reaches the prompt or a patch:
+
+- `.env`, any file matching `*.env` / `*secret*` / `*credential*`
+- config values under secret-bearing keys (`source_token`, `env` values, MCP env blocks) —
+  redacted through the existing redaction path, never echoed back in a patch
+- `.git/`, the SQLite database, log and transcript directories
+- anything outside the config workspace root
+
+A patch targeting an excluded path is dropped with a warning rather than rendered. Nothing
+else is restricted: souls, skills and workflow YAML are all fair game at every effort level.
+
+Because skill files and soul files are prose, they get the same treatment as any other
+input — the advisor is asked to correlate an instruction with the runs it produced, e.g.
+"this skill says *always run the full suite*, and the transcripts show 40 minutes spent
+there on steps that only touch docs".
+
+### 4. Effort levels
+
+| | `quick` | `standard` (default) | `deep` |
+|---|---|---|---|
+| History window default | 7d | 14d | 90d |
+| Transcripts read | 0 | ~2 per hotspot, top 5 hotspots | ~5 per hotspot, top 15 hotspots |
+| Workspace files read | config + souls/skills of flagged agents | config + souls/skills of every agent with runs in the window | entire config workspace |
+| Agent passes | 1 | 1 analysis + 1 patch | 1 per workflow + patch + critic pass per patch |
+| Patch validation | config lint | config lint + expr lint | config lint + expr lint + counter-argument from the critic |
+| Typical output | 3–5 findings | findings + diff across config, souls and skills | findings + diff + rejected-alternatives section |
+
+Effort scales *how much* is read and how hard each patch is scrutinised — never *which
+kinds* of file may be changed. Even `quick` can propose a soul-file edit if the metrics
+point there; it just reads less to get to that conclusion.
+
+Effort maps to concrete knobs on the run: `MaxTurns`, transcript budget, hotspot count,
+and the number of agent invocations. Cost is reported at the end of every run, from the
+same token accounting the daemon uses.
+
+### 5. Advisor identity — which runner and model executes the analysis
+
+The advisor is **a normal Apiary agent**, resolved through the same path the dispatcher
+uses, so nothing new is invented: `agent → agents[].runner (or default_runner) →
+runners[<id>] → rc.AdapterName() → runnerimpl.New(adapter) → Configure(rc.Config + MCPs +
+sandbox + env_passthrough)`, with the model taken from `agents[].model`.
+
+This matters because **`model` is required per agent and there is no config-level default
+model** — `daemon.New` hard-errors with `agent %q: model is required`. So the command
+cannot silently fall back to "the default model": there isn't one. Resolution is explicit,
+in this order:
+
+1. `--advisor <agent-id>` — one-off override.
+2. `--runner <id> --model <name>` — ad-hoc pair, no config entry needed. Both required
+   together; a lone `--model` is an error, since the runner determines the adapter.
+3. `settings.improve.agent` — the configured advisor.
+4. An agent whose id is `improver`, by convention.
+5. **Error**, with a message naming the four options above and a copy-pasteable config
+   snippet. No guessing.
+
+```yaml
+settings:
+  improve:
+    agent: improver          # which agent runs the analysis
+    effort_models:           # optional: effort picks the model
+      quick:    claude-haiku-4-5
+      standard: claude-sonnet-5
+      deep:     claude-opus-5
+```
+
+`effort_models` is the one addition worth making: analysing aggregates at `quick` and
+reasoning over transcripts and prose at `deep` are genuinely different jobs, and paying
+`deep` prices for a `quick` run is waste. When set, effort overrides `agents[].model` for
+that run; the runner is unchanged. An unset effort falls through to the agent's own model.
+
+Two existing mechanisms come along for free because the advisor is an ordinary agent:
+
+- **Profiles** — the global `--profile <name>` flag applies `profiles.<name>` overrides
+  (runner, model, fallbacks) to the advisor exactly as it does for daemon agents, so
+  `apiary improve --profile cheap` works with no new code.
+- **Fallbacks** — `agents[].fallbacks` and `settings.default_fallbacks` are honoured. The
+  command reuses `execution.FailureDetectorFor(adapter)` to classify a rate-limit or
+  credit-exhaustion rejection and advances the chain. Without this a `deep` run that
+  trips the 5-hour limit halfway through would throw away everything it had done.
+
+Flag naming note: `--agent` is a **scope filter** ("only analyse this agent's runs"), and
+`--advisor` selects **who does the analysing**. These are easy to conflate, so the two
+concerns get visibly different names rather than `--agent` / `--agent-id`.
+
+### 5b. Prompt and output contract
+
+The advisor ships with a default soul file, so it works before any config exists. Its
+prompt carries:
+
+1. The evidence pack (metrics as compact tables, not raw JSON dumps).
+2. The current `apiary.yaml` and any referenced workflow/soul files, with secrets redacted.
+3. The change surface and the hard constraints.
+4. The improvement ledger: what was recommended before, what was applied, what the metric
+   did afterwards — so it does not re-propose a change that was already tried and reverted.
+
+It returns structured output (`APIARY_OUTPUT`, the existing mechanism) shaped as:
+
+```json
+{
+  "findings": [
+    { "id": "f1", "scope": "workflow:review-pr/step:lint",
+      "symptom": "fails on first attempt 42% of runs, passes on retry 95% of the time",
+      "evidence": ["fail_rate=0.42 n=88", "retry_success=0.95"],
+      "severity": "high", "focus": "reliability" }
+  ],
+  "recommendations": [
+    { "id": "r1", "addresses": ["f1"], "file": "apiary.yaml",
+      "summary": "gate the lint step behind a build-artifacts check instead of retrying",
+      "rationale": "...", "confidence": "medium",
+      "expected_effect": "≈37 fewer wasted runs/2wk, ≈$4.10",
+      "patch": "<unified diff>" }
+  ]
+}
+```
+
+Patches are unified diffs against files in the change surface. Anything outside it, and
+anything touching a secret-bearing key, is dropped with a warning before rendering.
+
+### 6. Validation and apply
+
+A recommendation is only presented if its patch survives, in order:
+
+1. **Path check** — the target is inside the config workspace and not on the exclusion list.
+2. **Apply-in-memory** — the diff applies cleanly to the current file content.
+3. **Config validation** — if the target is config, the result parses and passes
+   `cfg.Validate()` (which also re-checks that every `soul_file` still resolves).
+4. **Expression lint** — `config.LintExpr` over all conditions in the candidate config
+   (the existing hook, so a proposed `if`/`reject_when` that would hard-fail at runtime is
+   caught here rather than in production).
+5. **Warnings** — `cfg.WorkflowWarnings()` on the candidate; new warnings are shown
+   alongside the diff.
+
+Prose targets — souls and skills — clear steps 1 and 2 only; there is nothing to lint in a
+markdown instruction file. That asymmetry is worth stating plainly: **a bad soul-file edit
+cannot be caught by validation, only by review or by its effect on the next runs.** The
+critic pass at `deep` and the effect measurement in §7 are the two mitigations.
+
+Failing patches are not silently dropped: they are listed in a "could not be validated"
+section with the reason, since a rejected patch is often still a useful signal.
+
+`--apply` writes the files, prints the summary of what changed, and stops. It does not
+back up, snapshot or offer to revert: the workspace is expected to be under version
+control, and `git diff` / `git checkout` are better at that job than anything this command
+would reimplement. It prints one line naming the modified files so the follow-up `git diff`
+is obvious, and warns (without refusing) when the workspace is not a git repository, since
+that is the one case where the assumption does not hold.
+
+Applying never restarts the daemon. The command prints the reminder that a running daemon
+must be restarted to pick up config changes.
+
+### 7. Improvement ledger and effect measurement
+
+Two tables, added through the existing idempotent migration list:
+
+```sql
+CREATE TABLE improvement_runs (
+  id TEXT PRIMARY KEY,              -- ulid
+  effort TEXT NOT NULL,
+  focus TEXT,
+  window_start TIMESTAMP, window_end TIMESTAMP,
+  scope TEXT,                       -- JSON: workflow/agent filters
+  evidence_digest TEXT,             -- hash of the evidence pack, for reproducibility
+  report_path TEXT, diff_path TEXT,
+  applied BOOLEAN DEFAULT 0, applied_at TIMESTAMP,
+  cost_usd REAL DEFAULT 0, total_tokens INTEGER DEFAULT 0,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE improvement_findings (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  scope TEXT NOT NULL,              -- "workflow:x/step:y" | "agent:z"
+  focus TEXT, severity TEXT, confidence TEXT,
+  symptom TEXT, rationale TEXT,
+  baseline_metrics TEXT,            -- JSON snapshot of the metrics that justified it
+  patch TEXT,
+  state TEXT NOT NULL,              -- proposed|applied|rejected|reverted
+  FOREIGN KEY(run_id) REFERENCES improvement_runs(id)
+);
+```
+
+Because `baseline_metrics` is captured at proposal time and the scope is a stable key,
+`apiary improve effect <run-id>` recomputes the same metrics over the window *since* the
+apply and prints the delta:
+
+```
+review-pr/lint    fail rate  0.42 → 0.06   (-86%)   n=88 → n=61
+review-pr/lint    cost/run   $0.31 → $0.19 (-39%)
+```
+
+This is what makes the feature a loop rather than a one-shot report: the next `improve`
+run reads the ledger and is told which of its own past suggestions worked.
+
+### 8. Scheduling (optional, later)
+
+Nothing in the design requires the daemon, so a periodic run is just the command on a
+timer. A `settings.improve.schedule` knob that has the daemon run it in report-only mode
+and post the report through the existing notification channels is a natural follow-up,
+deliberately left out of this change so the reviewable-diff path lands first.
+
+---
+
+## Implementation Phases
+
+**Phase 1 — Metrics engine.** `internal/improve`: evidence pack types, read-only aggregate
+queries, normalised failure clustering, transcript sampling, `--dump-evidence`. No LLM.
+Unit tests against a seeded database. Ships useful on its own (`apiary improve
+--dump-evidence` is already a real diagnostic).
+
+**Phase 2 — Advisor agent.** Prompt composition, standalone runner invocation, structured
+output parsing, markdown report, effort levels, cost accounting. `--output report`.
+
+**Phase 3 — Patches and validation.** Workspace discovery and exclusion enforcement, diff
+generation, the five-stage validation gate, `--output diff`.
+
+**Phase 4 — Apply.** `--apply`: write the files, report what changed, warn if the workspace
+is not version-controlled.
+
+**Phase 5 — Ledger and effect.** Migrations, `improve history|show|effect`, past-run
+context injected into the prompt.
+
+**Phase 6 — Docs and defaults.** Docs page under `docs/`, default `improver` soul file,
+schema regeneration (`schema/apiary.json`) if any config keys are added, example config
+updates.
+
+Phases 1–4 are the minimum shippable feature. Phase 5 is what makes it self-improving
+rather than merely advisory.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The advisor proposes plausible-sounding but wrong changes | Every finding must cite metrics; every patch passes config+expr validation; `deep` adds a critic pass; diff is the default, apply is opt-in |
+| Correlation read as causation (a step is slow because its task is hard) | Metrics are grouped by step *and* workflow so cross-workflow comparison of the same agent is available; the report states sample sizes and suppresses findings below a minimum `n` |
+| Secrets leaking into the prompt or the report | Config is redacted through the existing redaction path before composition; transcripts are already redacted at write time; `source_token`/`env` values are never included |
+| Cost of the analysis itself | Effort levels, transcript budgets, and a cost line printed at the end of every run; `quick` is a single call over aggregates only |
+| Thin data early on | Minimum-sample thresholds per finding; the command says plainly when the window has too few runs instead of inventing conclusions |
+| Config rewritten while the daemon runs | Apply warns and prints the restart command |
+| A soul or skill edit degrades behaviour, and no lint can catch it | Diff-by-default; the critic pass at `deep`; the effect measurement in §7 scores the change against the same metrics that motivated it, so a regression surfaces on the next run |
+| Reviewing a large multi-file diff is hard | Findings and their patches are rendered together — each diff hunk arrives with the metric that justified it, grouped by file, so the diff is read as an argument rather than a blob |
+
+---
+
+## Open Questions
+
+1. **Command name** — `apiary improve` reads well and is unclaimed. `apiary review` and
+   `apiary tune` are alternatives; `review` collides conceptually with PR review workflows.
+2. **Default effort** — `standard` assumed. If typical histories are small, `quick` may be
+   the better default.
+3. **Skill-file resolution** — skills are declared as bare names (`agents[].skills`) and
+   resolved by the runner, so the workspace walker has to search the same directories the
+   runner does (`.claude/skills/<name>/SKILL.md`, plugin skill dirs). A skill that cannot
+   be located is reported as unresolved rather than silently skipped, but the search paths
+   need confirming against each runner adapter.
+4. **Where reports live** — `<data-dir>/improve/<run-id>/` assumed, alongside transcripts.

--- a/openspec/changes/self-improvement-advisor/tasks.md
+++ b/openspec/changes/self-improvement-advisor/tasks.md
@@ -1,0 +1,298 @@
+# Implementation Plan: Self-Improvement Advisor
+
+Companion to [proposal.md](proposal.md). Phases are ordered so each one ends at a
+shippable state — Phase 1 is a useful diagnostic on its own, and nothing before Phase 4
+can write to disk.
+
+**Conventions.** One feature branch per phase, PR per phase (`git worktree` per the
+project's git workflow), squash merge. No Go CI in this repo — `make check` (build + test)
+locally before every PR. New DB columns/tables go in the idempotent `migrations` slice in
+`internal/db/schema.go`, never in the `schema` const.
+
+---
+
+## Phase 1 — Metrics engine (no LLM)
+
+New package `internal/improve`. Everything here is deterministic and unit-testable against
+a seeded database.
+
+### 1.1 Types — `internal/improve/evidence.go`
+
+- [ ] `EvidencePack` — top-level struct: `Window`, `Scope`, `Workflows []WorkflowMetrics`,
+      `Steps []StepMetrics`, `Agents []AgentMetrics`, `Failures []FailureCluster`,
+      `Waits []WaitMetrics`, `Transcripts []TranscriptExcerpt`, `Config ConfigSnapshot`,
+      `Digest string`
+- [ ] `StepMetrics` — `WorkflowID`, `StepID`, `AgentID`, `Runs`, `PassRate`, `FailRate`,
+      `SkipRate`, `CachedSkipRate`, `DurationP50/P95`, `MeanTokens`, `TotalCost`,
+      `MeanTurns`, `MeanToolCalls`, `CacheReuseRatio`, `PromptWeightRatio`,
+      `FailoverRate`, `FailureKinds map[string]int`, `MaxTurnsSaturation`
+- [ ] `WorkflowMetrics` — instance counts by terminal state, e2e `DurationP50/P95`,
+      `CostPerCompleted`, `ReworkLoops []ReworkLoop`, `ParallelCandidates []StepPair`,
+      `DeadSteps []string`
+- [ ] `AgentMetrics`, `WaitMetrics`, `FailureCluster`, `TranscriptExcerpt`
+- [ ] `Digest()` — stable hash over the pack (sorted keys, window excluded) for
+      reproducibility and for `improvement_runs.evidence_digest`
+
+### 1.2 Queries — `internal/improve/metrics.go`
+
+Opens the existing DB read-only. All queries take `(ctx, window, scope)`.
+
+- [ ] `stepMetrics` — `step_runs` ⋈ `workflow_instances`, plus a `task_executions`
+      sub-select for `attempt > 1` failover rate and `failure_kind` distribution.
+      Percentiles computed in Go over the ordered durations (SQLite has no `percentile`).
+- [ ] `workflowMetrics` — instance terminal-state counts, e2e duration, cost per completed
+- [ ] `reworkLoops` — `GROUP BY workflow_instance_id, step_id HAVING COUNT(*) > 1`;
+      this is the `on_fail`/`goto` cycle signature
+- [ ] `agentMetrics` — `task_executions` grouped by `agent_id`, `runner`, `model`;
+      `max_turns` saturation needs the configured cap from `config`, joined in Go
+- [ ] `waitMetrics` — `ci_poll_checks` per (instance, step): poll count, terminal status
+      distribution, timeouts; approval latency from `approval_requests` ⋈
+      `approval_responses`
+- [ ] `deadPaths` — configured workflows/steps/agents/fallbacks with zero rows in the window
+- [ ] `failureClusters` — `error_message` from failed executions, normalised (strip
+      digits, hex, paths, UUIDs/ULIDs) then grouped with counts and one exemplar
+
+### 1.3 Static config analysis — `internal/improve/static.go`
+
+- [ ] `parallelCandidates(wf)` — consecutive sequential steps where no later step's
+      `Condition`/`FailWhen`/`If` or prompt references an earlier step's output.
+      Conservative: emit only when there is provably no reference; a false negative is
+      cheap, a false positive is a wrong recommendation.
+
+### 1.4 Transcript sampling — `internal/improve/transcripts.go`
+
+- [ ] `sampleTranscripts(hotspots, budget)` — reads `<log-dir>/transcripts/<task-id>/`,
+      picks the worst N failures plus one successful control per hotspot, truncates to a
+      per-excerpt character budget (head + tail, middle elided)
+- [ ] Hotspot ranking: cost × failure rate × run count, so a cheap flaky step and an
+      expensive reliable one both surface
+
+### 1.5 Minimum-sample gating
+
+- [ ] `MinRuns` threshold (default 5) — metrics below it are carried in the pack but
+      flagged `low_confidence`, and the report says so rather than dropping them silently
+
+### 1.6 CLI entry — `internal/cli/improve.go`
+
+- [ ] `newImproveCmd()`, registered in `root.go`'s `AddCommand` list
+- [ ] Flags per proposal §1; `--dump-evidence` prints the pack as indented JSON and exits
+- [ ] `--since` duration parsing accepting `7d`/`24h`/`90d`
+
+### 1.7 Tests — `internal/improve/*_test.go`
+
+- [ ] Seeded-DB fixture helper: N instances × M steps with controlled outcomes
+- [ ] Per-metric assertions (rates, percentiles, rework detection, dead paths)
+- [ ] Failure normalisation table test
+- [ ] `parallelCandidates` — positive and negative cases, especially a step referencing an
+      earlier output through an expression
+- [ ] `Digest` stability: same data → same digest; reordered rows → same digest
+
+**Done when** `apiary improve --dump-evidence --since 30d` prints a correct, stable pack on
+a real database, and `make check` passes.
+
+---
+
+## Phase 2 — Advisor agent
+
+### 2.1 Workspace discovery — `internal/improve/workspace.go`
+
+(Proposal §3. Landing it here rather than in Phase 3 because the prompt needs it.)
+
+- [ ] `Discover(cfg, configPath) (Workspace, error)` — walks config → workflow files
+      (transitive) → soul files → skill definitions → generated agent prompt files →
+      plugin manifests
+- [ ] Skill resolution: search `.claude/skills/<name>/SKILL.md` and the runner skill dirs;
+      unresolved skills recorded as `Unresolved []string`, never silently dropped
+      (see proposal open question 3)
+- [ ] `Excluded(path) bool` — `.env`, `*secret*`, `*credential*`, `.git/`, DB, logs,
+      transcripts, anything outside the workspace root
+- [ ] `RedactConfig(raw) string` — blanks `source_token`, `env` values, MCP env blocks
+      before the config text enters a prompt
+
+### 2.2 Prompt composition — `internal/improve/prompt.go`
+
+- [ ] Metrics rendered as compact markdown tables, not raw JSON — token cost matters and
+      tables read better for the model
+- [ ] Workspace files inlined with path headers, per-file truncation at high effort
+- [ ] Constraints block: exclusion list, "cite a metric for every finding", output contract
+- [ ] Ledger block (empty until Phase 5)
+- [ ] `OutputSchema` for the findings/recommendations JSON, reusing
+      `execution.OutputSchemaInstruction` so the sentinel instructions match the daemon's
+
+### 2.3 Advisor resolution — `internal/improve/advisor.go`
+
+Proposal §5. There is **no config-level default model** (`agents[].model` is required and
+`daemon.New` errors without it), so this resolves explicitly or fails loudly.
+
+- [ ] `ResolveAdvisor(cfg, flags) (Advisor, error)` in order: `--advisor` → `--runner` +
+      `--model` → `settings.improve.agent` → agent id `improver` → error naming all four
+      with a copy-pasteable config snippet
+- [ ] `--model` without `--runner` is a flag error (the runner determines the adapter)
+- [ ] `settings.ImproveSettings` on `config.Settings`: `Agent string`,
+      `EffortModels map[string]string`; validated in `internal/config/validate.go`
+      (agent must exist; effort keys ∈ {quick,standard,deep}; models must be listed in the
+      resolved runner's `models` when that runner declares any)
+- [ ] Apply `profiles.<name>` overrides when `--profile` is set, reusing the daemon's
+      overlay logic rather than re-implementing it
+- [ ] Effort → model: `effort_models[effort]` overrides `agents[].model` for the run;
+      unset falls through to the agent's own model
+
+### 2.4 Standalone runner invocation — `internal/improve/run.go`
+
+- [ ] Mirror the dispatcher's construction path: `runners[id]` → `rc.AdapterName()` →
+      `runnerimpl.New(adapter)` → `Configure(runnerConfigWithMCPs(...) + sandbox +
+      env_passthrough)`. Extract the shared piece from `daemon` if it can be done without
+      dragging in dispatcher state; otherwise duplicate deliberately and note why.
+- [ ] Build `model.RunRequest` (`SystemAppend`, `Model`, `MaxTurns` from effort,
+      `WorkingDir`, `Env`), call `Run`
+- [ ] Read `RunResult.StructuredOutput` directly — the runner already parses the
+      `APIARY_OUTPUT:` sentinel, so no marker parsing is needed here
+- [ ] Fallback chain: on a `RateLimited` / `CreditExhausted` classification from
+      `execution.FailureDetectorFor(adapter)`, advance through `agents[].fallbacks` then
+      `settings.default_fallbacks`. A `deep` run that trips the 5-hour limit mid-way must
+      not discard the work already done.
+- [ ] Accumulate `RunResult.Usage` across passes and fallback attempts for the cost line
+
+### 2.5 Effort levels — `internal/improve/effort.go`
+
+- [ ] `Effort` enum → knobs struct: window default, hotspot count, transcripts per hotspot,
+      excerpt budget, workspace read breadth, pass count, critic on/off, `MaxTurns`
+
+### 2.6 Report rendering — `internal/improve/report.go`
+
+- [ ] Markdown: summary → findings grouped by severity → recommendations with rationale
+      and expected effect → low-confidence section → cost line
+- [ ] `--output json` emits the structured result verbatim
+- [ ] Written to `<data-dir>/improve/<run-id>/` and echoed to stdout
+
+### 2.7 Default advisor soul — `internal/cli/assets/improver.md` (embedded)
+
+- [ ] Ships a working default so `apiary improve` needs no config; overridable by defining
+      an `improver` agent
+
+### 2.8 Tests
+
+- [ ] Prompt composition golden test (redaction verified: no token value appears)
+- [ ] Structured-output parsing: well-formed, malformed, missing
+- [ ] Effort knob table test
+- [ ] Workspace discovery against a fixture tree, including an unresolved skill
+- [ ] `ResolveAdvisor` precedence table: each of the four sources wins in turn; the
+      no-advisor case returns the actionable error, not a guessed model
+- [ ] `--model` without `--runner` is rejected
+- [ ] `effort_models` overrides the agent model; unset falls through
+- [ ] `--profile` overlay applies to the advisor
+
+**Done when** `apiary improve --output report` produces an evidence-backed markdown report.
+
+---
+
+## Phase 3 — Patches and validation
+
+### 3.1 Patch handling — `internal/improve/patch.go`
+
+- [ ] Parse unified diffs from recommendations; apply in-memory to current file content
+- [ ] Reject patches whose target fails `Excluded`/outside-workspace checks
+- [ ] Fuzzy-match tolerance: reject rather than guess when context does not match
+
+### 3.2 Validation gate — `internal/improve/validate.go`
+
+Five stages per proposal §6, short-circuiting with a recorded reason:
+
+- [ ] path check → 2. clean apply → 3. `config.Load` + `cfg.Validate()` on the candidate
+- [ ] `config.LintExpr` over the candidate's conditions (wire the same hook `cli` injects,
+      so a proposed `if`/`reject_when` that would hard-fail at runtime is caught here)
+- [ ] `cfg.WorkflowWarnings()` — new warnings surfaced alongside the diff
+- [ ] Prose targets (souls, skills) clear stages 1–2 only — document this in the output so
+      the reviewer knows which hunks were machine-checked and which were not
+
+### 3.3 Diff rendering
+
+- [ ] Grouped by file; each hunk preceded by the finding and metric that justified it
+- [ ] "Could not be validated" section listing rejected patches with reasons
+
+### 3.4 Tests
+
+- [ ] Patch application: clean, conflicting, excluded-path, outside-workspace
+- [ ] A patch introducing an invalid expression is rejected at stage 4
+- [ ] A patch removing a `soul_file` a config still references is rejected at stage 3
+
+**Done when** `apiary improve` (default `--output diff`) prints a validated, reviewable diff.
+
+---
+
+## Phase 4 — Apply
+
+### 4.1 `internal/improve/apply.go`
+
+- [ ] Write accepted patches to disk; print the list of modified files
+- [ ] Warn (do not refuse) when the workspace is not a git repository — version control is
+      the user's responsibility and the undo mechanism
+- [ ] Print the daemon-restart reminder when config changed
+- [ ] `--yes` skips the single confirmation prompt
+
+### 4.2 Tests
+
+- [ ] Apply writes exactly the expected bytes; non-git workspace produces the warning
+
+**Done when** `apiary improve --apply` modifies the workspace and `git diff` shows the change.
+
+---
+
+## Phase 5 — Ledger and effect measurement
+
+### 5.1 Migrations — `internal/db/schema.go`
+
+- [ ] `improvement_runs` and `improvement_findings` per proposal §7, appended to the
+      `migrations` slice (`CREATE TABLE IF NOT EXISTS` statements are safe there)
+- [ ] Indexes on `improvement_findings(run_id)` and `improvement_findings(scope, state)`
+
+### 5.2 Store — `internal/db/improvement.go`
+
+- [ ] `CreateImprovementRun`, `RecordFindings`, `MarkApplied`, `ListImprovementRuns`,
+      `GetImprovementRun`, `ListFindingsByScope`
+
+### 5.3 Effect comparison — `internal/improve/effect.go`
+
+- [ ] Recompute the Phase 1 metrics for each finding's `scope` over the window *since*
+      `applied_at`, diff against `baseline_metrics`, render the delta table
+- [ ] Guard against thin post-apply samples — say "not enough runs yet" rather than
+      reporting a meaningless delta
+
+### 5.4 Sub-commands
+
+- [ ] `apiary improve history|show <run-id>|effect <run-id>`
+
+### 5.5 Prompt feedback loop
+
+- [ ] Inject prior findings and their measured effect into the prompt so the advisor does
+      not re-propose something already tried and reverted
+
+### 5.6 Tests
+
+- [ ] Ledger round-trip; effect delta on a seeded before/after dataset; thin-sample guard
+
+**Done when** `apiary improve effect <run-id>` shows a real before/after delta.
+
+---
+
+## Phase 6 — Docs and defaults
+
+- [ ] `docs/improve.md` — what it measures, effort levels, the change surface, the git
+      assumption, worked example
+- [ ] Add to the docs nav in `mkdocs.yml`
+- [ ] `schema/apiary.json` regenerated for `settings.improve` (`agent`, `effort_models`)
+- [ ] Example config: an `improver` agent entry plus a `settings.improve` block
+- [ ] Archive the change in `openspec/CHANGELOG.md` (move from Ativas to Arquivadas)
+
+---
+
+## Sequencing notes
+
+- **Phases 1–4 are the minimum shippable feature**; Phase 5 is what makes it a loop rather
+  than a report generator, and it matters more than usual here because prose edits (souls,
+  skills) are in scope from day one and cannot be caught by any lint.
+- Workspace discovery (§2.1) is listed in Phase 2 because the prompt needs it, but it is
+  the natural thing to pull forward if Phase 1 finishes early.
+- The riskiest unknown is skill-path resolution across runner adapters (proposal open
+  question 3). Resolve it while building §2.1 — an unresolved skill must be reported, not
+  silently skipped, or the advisor will reason about an agent whose instructions it never saw.

--- a/src/internal/cli/improve.go
+++ b/src/internal/cli/improve.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/improve"
+)
+
+func newImproveCmd() *cobra.Command {
+	var (
+		since         string
+		workflows     []string
+		agents        []string
+		focus         string
+		dumpEvidence  bool
+		hotspots      int
+		transcripts   int
+		excerptBudget int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "improve",
+		Short: "Analyse execution history and suggest improvements",
+		Long: `Mine Apiary's own execution history — step timings, tokens, cost, failure
+kinds, rework loops, wait polling — into an evidence pack describing how the
+configured workflows and agents actually behave.
+
+  apiary improve --dump-evidence            print the evidence pack as JSON
+  apiary improve --dump-evidence --since 30d
+  apiary improve --dump-evidence --workflow review-pr
+
+The evidence pack is computed entirely in Go: no model is consulted, so the same
+database and window always produce the same pack. The advisor that reasons over
+it and proposes config changes arrives in a later phase.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !dumpEvidence {
+				return fmt.Errorf("only --dump-evidence is available so far; the advisor lands in a later phase")
+			}
+
+			window, err := improve.ParseWindow(since, time.Now())
+			if err != nil {
+				return err
+			}
+
+			// The config is optional: without it the pack still reports what ran,
+			// it just cannot report what was configured and never ran.
+			var cfg *config.Config
+			if loaded, err := config.Load(configFile); err == nil {
+				cfg = loaded
+			} else {
+				fmt.Fprintf(os.Stderr, "  ⚠ config not loaded (%v); dead-path and parallel analysis skipped\n", err)
+			}
+
+			dbPath := getDBPath()
+			if _, err := os.Stat(dbPath); err != nil {
+				return fmt.Errorf("no database at %s — has the daemon ever run?", dbPath)
+			}
+			db, err := improve.OpenReadOnly(dbPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+			defer cancel()
+
+			pack, err := improve.Build(ctx, db, improve.Options{
+				DBPath: dbPath,
+				LogDir: getLogDir(),
+				Config: cfg,
+				Window: window,
+				Scope: improve.Scope{
+					Workflows: workflows,
+					Agents:    agents,
+					Focus:     improve.Focus(focus),
+				},
+				HotspotLimit:          hotspots,
+				TranscriptsPerHotspot: transcripts,
+				TranscriptByteBudget:  excerptBudget,
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(os.Stderr, pack.Summary())
+			fmt.Fprintln(os.Stderr)
+
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(pack)
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "14d", "history window (e.g. 7d, 24h, 90d)")
+	cmd.Flags().StringSliceVar(&workflows, "workflow", nil, "restrict analysis to these workflow ids")
+	cmd.Flags().StringSliceVar(&agents, "agent", nil, "restrict analysis to these agents' runs")
+	cmd.Flags().StringVar(&focus, "focus", "all", "what to optimise for: cost|latency|reliability|quality|all")
+	cmd.Flags().BoolVar(&dumpEvidence, "dump-evidence", false, "print the evidence pack as JSON and exit")
+	cmd.Flags().IntVar(&hotspots, "hotspots", 0, "number of hotspot steps to sample transcripts for")
+	cmd.Flags().IntVar(&transcripts, "transcripts", 0, "transcripts to read per hotspot (0 disables sampling)")
+	cmd.Flags().IntVar(&excerptBudget, "transcript-bytes", 8000, "per-transcript character budget")
+
+	return cmd
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -63,6 +63,7 @@ func init() {
 		newTranscriptCmd(),
 		newPluginsCmd(),
 		newWorkerCmd(),
+		newImproveCmd(),
 	)
 }
 

--- a/src/internal/improve/build.go
+++ b/src/internal/improve/build.go
@@ -1,0 +1,238 @@
+package improve
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// Options configures a single evidence-pack build.
+type Options struct {
+	DBPath  string
+	LogDir  string
+	Config  *config.Config
+	Window  Window
+	Scope   Scope
+	Clock   func() time.Time
+
+	// TranscriptsPerHotspot and HotspotLimit are 0 in the metrics-only path
+	// (`--dump-evidence` at low effort); the advisor sets them from its effort level.
+	HotspotLimit          int
+	TranscriptsPerHotspot int
+	TranscriptByteBudget  int
+}
+
+// OpenReadOnly opens the Apiary database for analysis without touching it. The
+// improve command must never migrate, write or lock the database a running
+// daemon depends on, so it opens its own read-only connection rather than going
+// through db.Client (which initialises schema on open).
+func OpenReadOnly(dbPath string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_time_format=sqlite",
+		url.PathEscape(dbPath))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("open database %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+// Build assembles the complete evidence pack. Every number in the result is
+// computed here in Go — no model is consulted, so the same database and window
+// always produce the same pack (and the same digest).
+func Build(ctx context.Context, db source, opts Options) (*EvidencePack, error) {
+	clock := opts.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+
+	steps, err := StepMetricsFor(ctx, db, opts.Window, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+	workflows, err := WorkflowMetricsFor(ctx, db, opts.Window, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+	agents, err := AgentMetricsFor(ctx, db, opts.Window, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+	waits, err := WaitMetricsFor(ctx, db, opts.Window, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+	failures, err := FailureClustersFor(ctx, db, opts.Window, opts.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	pack := &EvidencePack{
+		GeneratedAt: clock().UTC(),
+		Window:      opts.Window,
+		Scope:       opts.Scope,
+		Steps:       steps,
+		Workflows:   workflows,
+		Agents:      agents,
+		Waits:       waits,
+		Failures:    failures,
+	}
+
+	// Config-dependent analysis. Without a config the pack is still valid — it
+	// just cannot say what *should* have run but didn't.
+	if opts.Config != nil {
+		if err := annotateFromConfig(ctx, db, pack, opts); err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.TranscriptsPerHotspot > 0 {
+		hotspots := RankHotspots(pack.Steps, opts.HotspotLimit)
+		excerpts, err := SampleTranscripts(ctx, db, opts.LogDir, opts.Window,
+			hotspots, opts.TranscriptsPerHotspot, opts.TranscriptByteBudget)
+		if err != nil {
+			return nil, err
+		}
+		pack.Transcripts = excerpts
+	}
+
+	pack.Digest = pack.computeDigest()
+	return pack, nil
+}
+
+// annotateFromConfig fills in everything that needs the configuration to
+// interpret: dead paths, parallel candidates, and turn-cap saturation.
+func annotateFromConfig(ctx context.Context, db source, pack *EvidencePack, opts Options) error {
+	cfg := opts.Config
+
+	ranWorkflows := map[string]bool{}
+	ranSteps := map[string]map[string]bool{}
+	for _, s := range pack.Steps {
+		ranWorkflows[s.WorkflowID] = true
+		if ranSteps[s.WorkflowID] == nil {
+			ranSteps[s.WorkflowID] = map[string]bool{}
+		}
+		ranSteps[s.WorkflowID][s.StepID] = true
+	}
+	ranAgents := map[string]bool{}
+	ranRunners := map[string]bool{}
+	for _, a := range pack.Agents {
+		ranAgents[a.AgentID] = true
+		if a.Runner != "" {
+			ranRunners[a.Runner] = true
+		}
+	}
+	for _, w := range pack.Workflows {
+		ranWorkflows[w.WorkflowID] = true
+	}
+
+	pack.Dead = DeadPathsFor(cfg, ranWorkflows, ranAgents, ranRunners)
+
+	byID := map[string]config.WorkflowConfig{}
+	for _, wf := range cfg.Workflows {
+		byID[wf.ID] = wf
+	}
+	for i := range pack.Workflows {
+		wf, ok := byID[pack.Workflows[i].WorkflowID]
+		if !ok {
+			continue // ran under a definition no longer in config
+		}
+		pack.Workflows[i].ParallelCandidates = ParallelCandidates(wf)
+		pack.Workflows[i].DeadSteps = DeadStepsFor(wf, ranSteps[wf.ID])
+	}
+
+	caps := TurnCaps(cfg)
+	saturation, err := TurnCapSaturationFor(ctx, db, opts.Window, opts.Scope, caps)
+	if err != nil {
+		return err
+	}
+	for i := range pack.Agents {
+		id := pack.Agents[i].AgentID
+		if c, ok := caps[id]; ok {
+			pack.Agents[i].ConfiguredMaxTurns = c
+			pack.Agents[i].MaxTurnsSaturation = saturation[id]
+		}
+	}
+	// Propagate each step's agent saturation, so a step-level reader does not
+	// have to cross-reference the agent table to notice a truncated step.
+	for i := range pack.Steps {
+		if v, ok := saturation[pack.Steps[i].AgentID]; ok {
+			pack.Steps[i].MaxTurnsSaturation = v
+		}
+	}
+	return nil
+}
+
+// ParseWindow resolves a --since duration string ("7d", "24h", "90m") into a
+// window ending now. Days are supported because that is how retention and
+// review periods are actually discussed; Go's ParseDuration stops at hours.
+func ParseWindow(since string, now time.Time) (Window, error) {
+	d, err := ParseDurationDays(since)
+	if err != nil {
+		return Window{}, err
+	}
+	return Window{Start: now.Add(-d).UTC(), End: now.UTC()}, nil
+}
+
+// ParseDurationDays extends time.ParseDuration with a "d" (day) suffix.
+func ParseDurationDays(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	if n := len(s); s[n-1] == 'd' {
+		var days float64
+		if _, err := fmt.Sscanf(s[:n-1], "%g", &days); err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("invalid duration %q: must be positive", s)
+		}
+		return time.Duration(days * 24 * float64(time.Hour)), nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid duration %q: must be positive", s)
+	}
+	return d, nil
+}
+
+// Summary renders the one-paragraph headline a human wants before the JSON: how
+// much history was covered and what the biggest cost centres are.
+func (p *EvidencePack) Summary() string {
+	var totalCost float64
+	var totalRuns int
+	for _, s := range p.Steps {
+		totalCost += s.TotalCostUSD
+		totalRuns += s.Runs
+	}
+
+	top := make([]StepMetrics, len(p.Steps))
+	copy(top, p.Steps)
+	sort.SliceStable(top, func(i, j int) bool { return top[i].TotalCostUSD > top[j].TotalCostUSD })
+	if len(top) > 3 {
+		top = top[:3]
+	}
+
+	out := fmt.Sprintf("%d step runs across %d workflows, $%.2f total, %s → %s",
+		totalRuns, len(p.Workflows), totalCost,
+		p.Window.Start.Format(time.DateOnly), p.Window.End.Format(time.DateOnly))
+	if totalRuns < MinRuns {
+		out += fmt.Sprintf("\n⚠ only %d runs in this window — too thin to draw conclusions from", totalRuns)
+	}
+	for _, s := range top {
+		out += fmt.Sprintf("\n  %s/%s: $%.2f over %d runs, %.0f%% fail",
+			s.WorkflowID, s.StepID, s.TotalCostUSD, s.Runs, s.FailRate*100)
+	}
+	return out
+}

--- a/src/internal/improve/build_test.go
+++ b/src/internal/improve/build_test.go
@@ -1,0 +1,265 @@
+package improve
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func fixedClock() func() time.Time { return func() time.Time { return base } }
+
+func TestBuildProducesCompletePack(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "review", state: "done", durationMs: 5000})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "lint", agentID: "eng",
+		state: "passed", durationMs: 1000, tokens: 100, cost: 0.10})
+	addExec(t, db, execOpts{agentID: "eng", runner: "claude", model: "opus",
+		instanceID: "i1", stepID: "lint", status: "success", cost: 0.10})
+
+	pack, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(pack.Steps) != 1 || len(pack.Workflows) != 1 || len(pack.Agents) != 1 {
+		t.Errorf("pack incomplete: %d steps, %d workflows, %d agents",
+			len(pack.Steps), len(pack.Workflows), len(pack.Agents))
+	}
+	if pack.Digest == "" {
+		t.Error("Digest must be set")
+	}
+}
+
+func TestBuildDigestIsStableAcrossRuns(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "a", agentID: "eng", cost: 0.1})
+	addStep(t, db, stepOpts{id: "s2", instanceID: "i1", stepID: "b", agentID: "eng", cost: 0.2})
+
+	first, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	second, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if first.Digest != second.Digest {
+		t.Errorf("digest is not stable: %s vs %s", first.Digest, second.Digest)
+	}
+}
+
+func TestBuildDigestIgnoresGenerationTimeAndWindowBounds(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "a", agentID: "eng"})
+
+	early, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// A different generation time and a wider window that still selects exactly
+	// the same rows must not change the digest — otherwise "same evidence" could
+	// never be recognised across two runs.
+	wider := Window{Start: base.Add(-48 * time.Hour), End: base.Add(48 * time.Hour)}
+	later, err := Build(ctx(), db, Options{Window: wider,
+		Clock: func() time.Time { return base.Add(time.Hour) }})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if early.Digest != later.Digest {
+		t.Errorf("digest changed with generation time / window bounds: %s vs %s",
+			early.Digest, later.Digest)
+	}
+}
+
+func TestBuildDigestChangesWithData(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "a", agentID: "eng"})
+
+	before, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	addStep(t, db, stepOpts{id: "s2", instanceID: "i1", stepID: "a", agentID: "eng", state: "failed"})
+	after, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if before.Digest == after.Digest {
+		t.Error("digest must change when the underlying rows change")
+	}
+}
+
+func TestBuildAnnotatesFromConfig(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "lint", agentID: "eng"})
+	addExec(t, db, execOpts{agentID: "eng", runner: "claude", instanceID: "i1", stepID: "lint", turns: 10})
+
+	cfg := &config.Config{
+		Workflows: []config.WorkflowConfig{
+			{ID: "wf", Steps: []config.StepConfig{
+				{ID: "lint", Agent: "eng", Prompt: "lint it"},
+				{ID: "typecheck", Agent: "eng", Prompt: "type check it"},
+			}},
+			{ID: "orphan"},
+		},
+		Agents: []config.AgentConfig{{ID: "eng", MaxTurns: 10}, {ID: "ghost"}},
+	}
+
+	pack, err := Build(ctx(), db, Options{Window: testWindow(), Config: cfg, Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if len(pack.Dead.Workflows) != 1 || pack.Dead.Workflows[0] != "orphan" {
+		t.Errorf("Dead.Workflows = %v, want [orphan]", pack.Dead.Workflows)
+	}
+	if len(pack.Dead.Agents) != 1 || pack.Dead.Agents[0] != "ghost" {
+		t.Errorf("Dead.Agents = %v, want [ghost]", pack.Dead.Agents)
+	}
+
+	wf := pack.Workflows[0]
+	if len(wf.DeadSteps) != 1 || wf.DeadSteps[0] != "typecheck" {
+		t.Errorf("DeadSteps = %v, want [typecheck]", wf.DeadSteps)
+	}
+	if len(wf.ParallelCandidates) != 1 {
+		t.Errorf("ParallelCandidates = %v, want the lint→typecheck pair", wf.ParallelCandidates)
+	}
+	// The single execution ran exactly to the configured 10-turn cap.
+	if !closeTo(pack.Agents[0].MaxTurnsSaturation, 1) {
+		t.Errorf("MaxTurnsSaturation = %v, want 1", pack.Agents[0].MaxTurnsSaturation)
+	}
+	if pack.Agents[0].ConfiguredMaxTurns != 10 {
+		t.Errorf("ConfiguredMaxTurns = %d, want 10", pack.Agents[0].ConfiguredMaxTurns)
+	}
+}
+
+func TestBuildWithoutConfigStillWorks(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "a", agentID: "eng"})
+
+	pack, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build without config: %v", err)
+	}
+	if len(pack.Steps) != 1 {
+		t.Errorf("want the step metrics regardless of config, got %d", len(pack.Steps))
+	}
+	if len(pack.Dead.Workflows) != 0 {
+		t.Error("without config there is nothing to call dead")
+	}
+}
+
+func TestParseDurationDays(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"7d", 7 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"0.5d", 12 * time.Hour, false},
+		{"24h", 24 * time.Hour, false},
+		{"90m", 90 * time.Minute, false},
+		{"", 0, true},
+		{"0d", 0, true},
+		{"-3d", 0, true},
+		{"-1h", 0, true},
+		{"banana", 0, true},
+		{"7days", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := ParseDurationDays(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("ParseDurationDays(%q) = %v, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDurationDays(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseDurationDays(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseWindowEndsAtNow(t *testing.T) {
+	w, err := ParseWindow("7d", base)
+	if err != nil {
+		t.Fatalf("ParseWindow: %v", err)
+	}
+	if !w.End.Equal(base.UTC()) {
+		t.Errorf("End = %v, want %v", w.End, base.UTC())
+	}
+	if got := w.End.Sub(w.Start); got != 7*24*time.Hour {
+		t.Errorf("span = %v, want 168h", got)
+	}
+}
+
+func TestSummaryFlagsThinWindows(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "a", agentID: "eng", cost: 0.5})
+
+	pack, err := Build(ctx(), db, Options{Window: testWindow(), Clock: fixedClock()})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	summary := pack.Summary()
+	if !strings.Contains(summary, "too thin") {
+		t.Errorf("a one-run window must say so plainly; got:\n%s", summary)
+	}
+}
+
+func TestRankHotspotsPrioritisesCostAndFailure(t *testing.T) {
+	steps := []StepMetrics{
+		{WorkflowID: "wf", StepID: "cheap-reliable", Runs: 10, TotalCostUSD: 0.10, FailRate: 0},
+		{WorkflowID: "wf", StepID: "costly-reliable", Runs: 10, TotalCostUSD: 5.00, FailRate: 0},
+		{WorkflowID: "wf", StepID: "cheap-flaky", Runs: 10, TotalCostUSD: 1.00, FailRate: 0.9},
+		{WorkflowID: "wf", StepID: "never-ran", Runs: 0},
+	}
+	got := RankHotspots(steps, 3)
+	if len(got) != 3 {
+		t.Fatalf("want 3 hotspots, got %d", len(got))
+	}
+	if got[0].StepID != "costly-reliable" {
+		t.Errorf("top hotspot = %s, want costly-reliable", got[0].StepID)
+	}
+	if got[1].StepID != "cheap-flaky" {
+		t.Errorf("second hotspot = %s, want cheap-flaky (failure weighting)", got[1].StepID)
+	}
+	for _, h := range got {
+		if h.StepID == "never-ran" {
+			t.Error("a step with no runs is not a hotspot")
+		}
+	}
+}
+
+func TestElideKeepsHeadAndTail(t *testing.T) {
+	s := strings.Repeat("a", 500) + strings.Repeat("z", 500)
+	got := elide(s, 200)
+	if len(got) > 250 {
+		t.Errorf("elided length = %d, want near the 200 budget", len(got))
+	}
+	if !strings.HasPrefix(got, "aaa") {
+		t.Error("head must be preserved")
+	}
+	if !strings.HasSuffix(got, "zzz") {
+		t.Error("tail must be preserved")
+	}
+	if !strings.Contains(got, "elided") {
+		t.Error("elision must be visible in the output")
+	}
+	if short := elide("tiny", 200); short != "tiny" {
+		t.Errorf("under-budget input must pass through unchanged, got %q", short)
+	}
+}

--- a/src/internal/improve/evidence.go
+++ b/src/internal/improve/evidence.go
@@ -1,0 +1,282 @@
+// Package improve mines Apiary's own execution history into an evidence pack:
+// a deterministic, LLM-free summary of how the configured workflows, steps and
+// agents actually behaved over a window. The pack is the sole input to the
+// advisor agent (see the self-improvement-advisor change), but it is useful on
+// its own — `apiary improve --dump-evidence` is a diagnostic that needs no model.
+//
+// Everything in this package is computed in Go from the SQLite database and the
+// on-disk transcripts. No LLM is involved in producing any number here, so the
+// metrics are reproducible and testable.
+package improve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"time"
+)
+
+// MinRuns is the sample size below which a metric is reported but flagged
+// LowConfidence. Findings drawn from three runs read exactly like findings drawn
+// from three hundred once they reach a prompt, so the distinction is carried in
+// the data rather than left to the reader.
+const MinRuns = 5
+
+// Focus narrows what the analysis optimises for. All is the default.
+type Focus string
+
+const (
+	FocusAll         Focus = "all"
+	FocusCost        Focus = "cost"
+	FocusLatency     Focus = "latency"
+	FocusReliability Focus = "reliability"
+	FocusQuality     Focus = "quality"
+)
+
+// Scope restricts the analysis to a subset of the history. Empty slices mean
+// "everything".
+type Scope struct {
+	Workflows []string `json:"workflows,omitempty"`
+	Agents    []string `json:"agents,omitempty"`
+	Focus     Focus    `json:"focus"`
+}
+
+// Window is the half-open time range [Start, End) the pack covers.
+type Window struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// EvidencePack is the complete deterministic input to the advisor.
+type EvidencePack struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	Window      Window    `json:"window"`
+	Scope       Scope     `json:"scope"`
+
+	Workflows   []WorkflowMetrics   `json:"workflows"`
+	Steps       []StepMetrics       `json:"steps"`
+	Agents      []AgentMetrics      `json:"agents"`
+	Waits       []WaitMetrics       `json:"waits"`
+	Failures    []FailureCluster    `json:"failure_clusters"`
+	Dead        DeadPaths           `json:"dead_paths"`
+	Transcripts []TranscriptExcerpt `json:"transcripts,omitempty"`
+
+	// Digest is a stable hash over the pack's content, excluding GeneratedAt and
+	// the window bounds. Two runs over the same rows produce the same digest,
+	// which is what makes an improvement run reproducible after the fact.
+	Digest string `json:"digest"`
+}
+
+// StepMetrics aggregates every run of one step of one workflow.
+type StepMetrics struct {
+	WorkflowID string `json:"workflow_id"`
+	StepID     string `json:"step_id"`
+	AgentID    string `json:"agent_id,omitempty"`
+
+	Runs           int `json:"runs"`
+	Passed         int `json:"passed"`
+	Failed         int `json:"failed"`
+	Skipped        int `json:"skipped"`
+	SkippedCached  int `json:"skipped_cached"`
+	LowConfidence  bool `json:"low_confidence"`
+
+	PassRate       float64 `json:"pass_rate"`
+	FailRate       float64 `json:"fail_rate"`
+	SkipRate       float64 `json:"skip_rate"`
+	CachedSkipRate float64 `json:"cached_skip_rate"`
+
+	DurationP50Ms int64 `json:"duration_p50_ms"`
+	DurationP95Ms int64 `json:"duration_p95_ms"`
+
+	MeanTokens    float64 `json:"mean_tokens"`
+	TotalTokens   int64   `json:"total_tokens"`
+	MeanCostUSD   float64 `json:"mean_cost_usd"`
+	TotalCostUSD  float64 `json:"total_cost_usd"`
+	MeanTurns     float64 `json:"mean_turns"`
+	MeanToolCalls float64 `json:"mean_tool_calls"`
+
+	// CacheReuseRatio is cache_read_tokens / input_tokens. A hot step with a low
+	// ratio is re-sending a prompt prefix that keeps changing — usually a sign
+	// the prompt embeds volatile context that could be hoisted or dropped.
+	CacheReuseRatio float64 `json:"cache_reuse_ratio"`
+	// PromptWeightRatio is mean input prompt bytes per output token. A large
+	// prompt yielding a tiny output is a prompt-design smell.
+	PromptWeightRatio float64 `json:"prompt_weight_ratio"`
+
+	// FailoverRate is the share of runs that needed more than one runner attempt.
+	FailoverRate float64        `json:"failover_rate"`
+	FailureKinds map[string]int `json:"failure_kinds,omitempty"`
+
+	// MaxTurnsSaturation is the share of runs that ended at exactly the agent's
+	// configured max_turns cap — the signature of a step being cut off rather
+	// than finishing. Zero when the agent has no cap.
+	MaxTurnsSaturation float64 `json:"max_turns_saturation"`
+}
+
+// WorkflowMetrics aggregates every instance of one workflow.
+type WorkflowMetrics struct {
+	WorkflowID string `json:"workflow_id"`
+
+	Instances     int            `json:"instances"`
+	ByState       map[string]int `json:"by_state"`
+	LowConfidence bool           `json:"low_confidence"`
+
+	DurationP50Ms int64 `json:"duration_p50_ms"`
+	DurationP95Ms int64 `json:"duration_p95_ms"`
+
+	CostPerCompletedUSD float64 `json:"cost_per_completed_usd"`
+	TotalCostUSD        float64 `json:"total_cost_usd"`
+
+	// ReworkLoops are steps that ran more than once inside a single instance —
+	// the direct signature of an on_fail/goto cycle.
+	ReworkLoops []ReworkLoop `json:"rework_loops,omitempty"`
+	// ParallelCandidates are adjacent sequential steps with no data dependency
+	// between them, computed statically from the config.
+	ParallelCandidates []StepPair `json:"parallel_candidates,omitempty"`
+	// DeadSteps are configured steps with no runs in the window.
+	DeadSteps []string `json:"dead_steps,omitempty"`
+}
+
+// ReworkLoop records a step that repeated within one instance.
+type ReworkLoop struct {
+	StepID string `json:"step_id"`
+	// Instances is how many instances repeated this step at all.
+	Instances int `json:"instances"`
+	// TotalRepeats is the number of runs beyond the first, summed across
+	// instances — the actual wasted work.
+	TotalRepeats int `json:"total_repeats"`
+	MaxRepeats   int `json:"max_repeats"`
+	// WastedCostUSD is the cost of the repeat runs only.
+	WastedCostUSD float64 `json:"wasted_cost_usd"`
+}
+
+// StepPair is an ordered pair of adjacent steps that could run concurrently.
+type StepPair struct {
+	First  string `json:"first"`
+	Second string `json:"second"`
+	Reason string `json:"reason"`
+}
+
+// AgentMetrics aggregates runner invocations grouped by agent, runner and model.
+type AgentMetrics struct {
+	AgentID string `json:"agent_id"`
+	Runner  string `json:"runner,omitempty"`
+	Model   string `json:"model,omitempty"`
+
+	Runs          int     `json:"runs"`
+	SuccessRate   float64 `json:"success_rate"`
+	LowConfidence bool    `json:"low_confidence"`
+
+	MeanDurationMs int64   `json:"mean_duration_ms"`
+	MeanCostUSD    float64 `json:"mean_cost_usd"`
+	TotalCostUSD   float64 `json:"total_cost_usd"`
+	MeanTurns      float64 `json:"mean_turns"`
+
+	ConfiguredMaxTurns int     `json:"configured_max_turns,omitempty"`
+	MaxTurnsSaturation float64 `json:"max_turns_saturation"`
+
+	FailureKinds map[string]int `json:"failure_kinds,omitempty"`
+}
+
+// WaitMetrics aggregates a wait_for step's polling behaviour.
+type WaitMetrics struct {
+	WorkflowID string `json:"workflow_id,omitempty"`
+	StepID     string `json:"step_id"`
+
+	Waits          int            `json:"waits"`
+	TotalPolls     int            `json:"total_polls"`
+	MeanPolls      float64        `json:"mean_polls"`
+	MaxPolls       int            `json:"max_polls"`
+	TerminalStatus map[string]int `json:"terminal_status,omitempty"`
+	Timeouts       int            `json:"timeouts"`
+}
+
+// FailureCluster groups failures whose messages normalise to the same shape, so
+// one recurring failure reads as a single line with a count rather than thirty
+// near-identical lines.
+type FailureCluster struct {
+	Normalized string `json:"normalized"`
+	Count      int    `json:"count"`
+	Exemplar   string `json:"exemplar"`
+	Agents     []string `json:"agents,omitempty"`
+}
+
+// DeadPaths lists configured things that never ran in the window. Config that
+// never executes is either obsolete or silently broken, and both are worth
+// surfacing.
+type DeadPaths struct {
+	Workflows []string `json:"workflows,omitempty"`
+	Agents    []string `json:"agents,omitempty"`
+	Fallbacks []string `json:"fallbacks,omitempty"`
+}
+
+// TranscriptExcerpt is a truncated agent session transcript attached to a
+// hotspot, so the advisor can reason about instructions and not only numbers.
+type TranscriptExcerpt struct {
+	WorkflowID string `json:"workflow_id,omitempty"`
+	StepID     string `json:"step_id,omitempty"`
+	TaskID     string `json:"task_id"`
+	File       string `json:"file"`
+	// Outcome is "failed" or "passed" — each hotspot samples failures plus one
+	// successful control, so the advisor can contrast them.
+	Outcome string `json:"outcome"`
+	Bytes   int    `json:"bytes"`
+	Content string `json:"content"`
+}
+
+// computeDigest hashes the pack's content, excluding the fields that legitimately
+// differ between two runs over identical data (generation time and the absolute
+// window bounds). Slices are already ordered deterministically by the queries
+// that build them.
+func (p *EvidencePack) computeDigest() string {
+	clone := *p
+	clone.GeneratedAt = time.Time{}
+	clone.Window = Window{}
+	clone.Digest = ""
+
+	raw, err := json.Marshal(clone)
+	if err != nil {
+		// Marshal of a plain struct tree cannot fail; degrade rather than panic
+		// in a diagnostic command.
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// rate divides safely, returning 0 for an empty denominator.
+func rate(n, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(n) / float64(total)
+}
+
+// mean divides safely, returning 0 for an empty denominator.
+func mean(sum float64, n int) float64 {
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
+}
+
+// percentile returns the p-th percentile (0..1) of an already-sorted slice using
+// nearest-rank. SQLite has no percentile function, so this runs in Go over the
+// ordered durations the query returns.
+func percentile(sorted []int64, p float64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	// Nearest-rank: ceil(p * n), 1-indexed.
+	rank := max(int(float64(len(sorted))*p+0.999999), 1)
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+	return sorted[rank-1]
+}

--- a/src/internal/improve/fixture_test.go
+++ b/src/internal/improve/fixture_test.go
@@ -1,0 +1,213 @@
+package improve
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// base is the anchor time for every fixture. Fixed rather than time.Now(), so
+// window arithmetic in the tests is exact.
+var base = time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+func testWindow() Window {
+	return Window{Start: base.Add(-24 * time.Hour), End: base.Add(24 * time.Hour)}
+}
+
+// seedDB creates an in-memory database with just the tables this package reads.
+// It mirrors the production schema's column names and types; using the real
+// schema here would drag the whole db package (and its migrations) into a
+// read-only analysis test for no benefit.
+func seedDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	// The database name is per-test. A shared name plus cache=shared would give
+	// every test in the package one database, so rows seeded by one test would
+	// silently appear in the next.
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared&_time_format=sqlite", url.PathEscape(t.Name()))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	stmts := []string{
+		`CREATE TABLE workflow_instances (
+			id TEXT PRIMARY KEY, workflow_id TEXT, cell_id TEXT, source_id TEXT,
+			state TEXT, parent_instance_id TEXT, resumed_from TEXT,
+			created_at TIMESTAMP, updated_at TIMESTAMP)`,
+		`CREATE TABLE step_runs (
+			id TEXT PRIMARY KEY, workflow_instance_id TEXT, step_id TEXT, agent_id TEXT,
+			state TEXT, output TEXT, structured_output TEXT, summary TEXT, exit_code INTEGER,
+			skipped_cached BOOLEAN DEFAULT 0, started_at TIMESTAMP, finished_at TIMESTAMP,
+			input_prompt TEXT, input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+			total_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0,
+			cache_read_tokens INTEGER DEFAULT 0, num_turns INTEGER DEFAULT 0,
+			num_tool_calls INTEGER DEFAULT 0, cost_usd REAL DEFAULT 0)`,
+		`CREATE TABLE task_executions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, agent_id TEXT, model TEXT,
+			runner TEXT, attempt INTEGER DEFAULT 1, status TEXT,
+			started_at TIMESTAMP, completed_at TIMESTAMP, duration_ms INTEGER,
+			error_message TEXT, workflow_instance_id TEXT, step_id TEXT,
+			input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+			total_tokens INTEGER DEFAULT 0, cache_read_tokens INTEGER DEFAULT 0,
+			num_turns INTEGER DEFAULT 0, num_tool_calls INTEGER DEFAULT 0,
+			cost_usd REAL DEFAULT 0, credit_exhausted INTEGER DEFAULT 0, failure_kind TEXT)`,
+		`CREATE TABLE ci_poll_checks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, workflow_instance_id TEXT, step_id TEXT,
+			status TEXT, pr_url TEXT, detail TEXT, checked_at TIMESTAMP)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create schema: %v", err)
+		}
+	}
+	return db
+}
+
+// instanceOpts describes one workflow instance to seed.
+type instanceOpts struct {
+	id         string
+	workflowID string
+	state      string
+	createdAt  time.Time
+	durationMs int64
+}
+
+func addInstance(t *testing.T, db *sql.DB, o instanceOpts) {
+	t.Helper()
+	if o.createdAt.IsZero() {
+		o.createdAt = base
+	}
+	updated := o.createdAt.Add(time.Duration(o.durationMs) * time.Millisecond)
+	_, err := db.Exec(`INSERT INTO workflow_instances (id, workflow_id, state, created_at, updated_at)
+	                   VALUES (?,?,?,?,?)`, o.id, o.workflowID, o.state, o.createdAt, updated)
+	if err != nil {
+		t.Fatalf("insert instance: %v", err)
+	}
+}
+
+// stepOpts describes one step run to seed.
+type stepOpts struct {
+	id         string
+	instanceID string
+	stepID     string
+	agentID    string
+	state      string
+	startedAt  time.Time
+	durationMs int64
+	tokens     int64
+	inputTok   int64
+	outputTok  int64
+	cacheRead  int64
+	prompt     string
+	cost       float64
+	turns      int64
+	toolCalls  int64
+	cached     bool
+}
+
+func addStep(t *testing.T, db *sql.DB, o stepOpts) {
+	t.Helper()
+	if o.startedAt.IsZero() {
+		o.startedAt = base
+	}
+	if o.state == "" {
+		o.state = "passed"
+	}
+	finished := o.startedAt.Add(time.Duration(o.durationMs) * time.Millisecond)
+	cached := 0
+	if o.cached {
+		cached = 1
+	}
+	_, err := db.Exec(`INSERT INTO step_runs
+		(id, workflow_instance_id, step_id, agent_id, state, skipped_cached,
+		 started_at, finished_at, input_prompt, input_tokens, output_tokens,
+		 total_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		o.id, o.instanceID, o.stepID, o.agentID, o.state, cached,
+		o.startedAt, finished, o.prompt, o.inputTok, o.outputTok,
+		o.tokens, o.cacheRead, o.turns, o.toolCalls, o.cost)
+	if err != nil {
+		t.Fatalf("insert step run: %v", err)
+	}
+}
+
+// execOpts describes one runner invocation to seed.
+type execOpts struct {
+	taskID      string
+	agentID     string
+	runner      string
+	model       string
+	attempt     int
+	status      string
+	startedAt   time.Time
+	durationMs  int64
+	errMessage  string
+	instanceID  string
+	stepID      string
+	turns       int64
+	cost        float64
+	failureKind string
+}
+
+func addExec(t *testing.T, db *sql.DB, o execOpts) {
+	t.Helper()
+	if o.startedAt.IsZero() {
+		o.startedAt = base
+	}
+	if o.attempt == 0 {
+		o.attempt = 1
+	}
+	if o.status == "" {
+		o.status = "success"
+	}
+	_, err := db.Exec(`INSERT INTO task_executions
+		(task_id, agent_id, runner, model, attempt, status, started_at, duration_ms,
+		 error_message, workflow_instance_id, step_id, num_turns, cost_usd, failure_kind)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		o.taskID, o.agentID, o.runner, o.model, o.attempt, o.status, o.startedAt,
+		o.durationMs, o.errMessage, o.instanceID, o.stepID, o.turns, o.cost, o.failureKind)
+	if err != nil {
+		t.Fatalf("insert execution: %v", err)
+	}
+}
+
+func addPoll(t *testing.T, db *sql.DB, instanceID, stepID, status string, at time.Time) {
+	t.Helper()
+	if at.IsZero() {
+		at = base
+	}
+	_, err := db.Exec(`INSERT INTO ci_poll_checks (workflow_instance_id, step_id, status, checked_at)
+	                   VALUES (?,?,?,?)`, instanceID, stepID, status, at)
+	if err != nil {
+		t.Fatalf("insert poll: %v", err)
+	}
+}
+
+// findStep returns the metrics for one (workflow, step) or fails the test.
+func findStep(t *testing.T, steps []StepMetrics, workflow, step string) StepMetrics {
+	t.Helper()
+	for _, s := range steps {
+		if s.WorkflowID == workflow && s.StepID == step {
+			return s
+		}
+	}
+	t.Fatalf("no metrics for %s/%s in %v", workflow, step, stepKeys(steps))
+	return StepMetrics{}
+}
+
+func stepKeys(steps []StepMetrics) []string {
+	out := make([]string, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, fmt.Sprintf("%s/%s", s.WorkflowID, s.StepID))
+	}
+	return out
+}
+
+func ctx() context.Context { return context.Background() }

--- a/src/internal/improve/metrics.go
+++ b/src/internal/improve/metrics.go
@@ -1,0 +1,732 @@
+package improve
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// source is the read-only database surface this package needs. *sql.DB satisfies
+// it; tests pass a seeded in-memory database.
+type source interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// stepAccumulator collects one step's rows before they are folded into a
+// StepMetrics. Durations are kept as a slice because percentiles need the full
+// ordered set, not a running sum.
+type stepAccumulator struct {
+	workflowID string
+	stepID     string
+	agentID    string
+
+	runs, passed, failed, skipped, cached int
+	durations                             []int64
+
+	tokens, inputTokens, cacheReadTokens int64
+	promptBytes                          int64
+	cost                                 float64
+	turns, toolCalls                     int64
+	outputTokens                         int64
+
+	withTurns int // runs that reported a turn count, for saturation math
+	turnCap   map[int64]int
+}
+
+// StepMetricsFor aggregates every step run in the window into per-(workflow,step)
+// metrics. Percentiles are computed in Go: SQLite ships no percentile function,
+// and pulling the ordered durations is cheap at these row counts.
+//
+// Failover rate and failure kinds come from task_executions, which holds one row
+// per runner invocation — so a step that failed over twice contributes three
+// execution rows to one step_runs row.
+func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepMetrics, error) {
+	where, args := stepFilter(w, sc)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT wi.workflow_id,
+		       sr.step_id,
+		       COALESCE(sr.agent_id, ''),
+		       sr.state,
+		       COALESCE(sr.skipped_cached, 0),
+		       CAST(ROUND(COALESCE((julianday(sr.finished_at) - julianday(sr.started_at)) * 86400000, 0)) AS INTEGER),
+		       COALESCE(sr.total_tokens, 0),
+		       COALESCE(sr.input_tokens, 0),
+		       COALESCE(sr.output_tokens, 0),
+		       COALESCE(sr.cache_read_tokens, 0),
+		       -- Byte length, not character length: LENGTH() on TEXT counts
+		       -- characters and stops at an embedded NUL, which would silently
+		       -- zero the prompt weight of any prompt carrying one.
+		       COALESCE(LENGTH(CAST(sr.input_prompt AS BLOB)), 0),
+		       COALESCE(sr.cost_usd, 0),
+		       COALESCE(sr.num_turns, 0),
+		       COALESCE(sr.num_tool_calls, 0)
+		FROM step_runs sr
+		JOIN workflow_instances wi ON wi.id = sr.workflow_instance_id
+		`+where+`
+		ORDER BY wi.workflow_id, sr.step_id, sr.id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query step runs: %w", err)
+	}
+	defer rows.Close()
+
+	acc := map[string]*stepAccumulator{}
+	var order []string
+
+	for rows.Next() {
+		var (
+			wf, step, agent, state          string
+			cachedFlag                      int
+			durMs                           int64
+			tokens, inTok, outTok, cacheTok int64
+			promptLen                       int64
+			cost                            float64
+			turns, tools                    int64
+		)
+		if err := rows.Scan(&wf, &step, &agent, &state, &cachedFlag, &durMs,
+			&tokens, &inTok, &outTok, &cacheTok, &promptLen, &cost, &turns, &tools); err != nil {
+			return nil, fmt.Errorf("scan step run: %w", err)
+		}
+
+		key := wf + "\x00" + step
+		a := acc[key]
+		if a == nil {
+			a = &stepAccumulator{workflowID: wf, stepID: step, agentID: agent, turnCap: map[int64]int{}}
+			acc[key] = a
+			order = append(order, key)
+		}
+		if a.agentID == "" {
+			a.agentID = agent
+		}
+
+		a.runs++
+		switch {
+		case state == "passed":
+			a.passed++
+		case state == "failed":
+			a.failed++
+		case state == "skipped_cached" || cachedFlag == 1:
+			a.cached++
+			a.skipped++
+		case state == "skipped":
+			a.skipped++
+		}
+
+		if durMs > 0 {
+			a.durations = append(a.durations, durMs)
+		}
+		a.tokens += tokens
+		a.inputTokens += inTok
+		a.outputTokens += outTok
+		a.cacheReadTokens += cacheTok
+		a.promptBytes += promptLen
+		a.cost += cost
+		a.turns += turns
+		a.toolCalls += tools
+		if turns > 0 {
+			a.withTurns++
+			a.turnCap[turns]++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate step runs: %w", err)
+	}
+
+	failover, err := stepFailovers(ctx, db, w, sc)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]StepMetrics, 0, len(order))
+	for _, key := range order {
+		a := acc[key]
+		slices.Sort(a.durations)
+
+		m := StepMetrics{
+			WorkflowID:     a.workflowID,
+			StepID:         a.stepID,
+			AgentID:        a.agentID,
+			Runs:           a.runs,
+			Passed:         a.passed,
+			Failed:         a.failed,
+			Skipped:        a.skipped,
+			SkippedCached:  a.cached,
+			LowConfidence:  a.runs < MinRuns,
+			PassRate:       rate(a.passed, a.runs),
+			FailRate:       rate(a.failed, a.runs),
+			SkipRate:       rate(a.skipped, a.runs),
+			CachedSkipRate: rate(a.cached, a.runs),
+			DurationP50Ms:  percentile(a.durations, 0.50),
+			DurationP95Ms:  percentile(a.durations, 0.95),
+			MeanTokens:     mean(float64(a.tokens), a.runs),
+			TotalTokens:    a.tokens,
+			MeanCostUSD:    mean(a.cost, a.runs),
+			TotalCostUSD:   a.cost,
+			MeanTurns:      mean(float64(a.turns), a.runs),
+			MeanToolCalls:  mean(float64(a.toolCalls), a.runs),
+		}
+		if a.inputTokens > 0 {
+			m.CacheReuseRatio = float64(a.cacheReadTokens) / float64(a.inputTokens)
+		}
+		if a.outputTokens > 0 {
+			m.PromptWeightRatio = float64(a.promptBytes) / float64(a.outputTokens)
+		}
+		if f, ok := failover[key]; ok {
+			m.FailoverRate = rate(f.multiAttempt, a.runs)
+			if len(f.kinds) > 0 {
+				m.FailureKinds = f.kinds
+			}
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+type failoverInfo struct {
+	multiAttempt int
+	kinds        map[string]int
+}
+
+// stepFailovers counts, per (workflow, step), how many logical step runs needed
+// more than one runner invocation, and what the provider rejections were.
+//
+// The signal is the NUMBER OF EXECUTION ROWS for one (instance, step), not the
+// `attempt` column. `attempt` is a per-task monotonic counter — beginExecution
+// sets it to the task's last attempt + 1 so a task's history accumulates across
+// steps — so the fifth step of a workflow carries attempt=5 having never failed
+// over even once. Reading it as a retry count marks almost every step as a
+// failover. One step run invoking the runner twice is what actually means the
+// first invocation was rejected.
+func stepFailovers(ctx context.Context, db source, w Window, sc Scope) (map[string]failoverInfo, error) {
+	where, args := executionFilter(w, sc, "te")
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT wi.workflow_id,
+		       te.step_id,
+		       COUNT(*) AS invocations,
+		       COALESCE(GROUP_CONCAT(te.failure_kind), '')
+		FROM task_executions te
+		JOIN workflow_instances wi ON wi.id = te.workflow_instance_id
+		`+where+`
+		  AND te.step_id IS NOT NULL AND te.step_id != ''
+		GROUP BY te.workflow_instance_id, te.step_id, wi.workflow_id
+		ORDER BY wi.workflow_id, te.step_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query step failovers: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]failoverInfo{}
+	for rows.Next() {
+		var wf, step, kinds string
+		var invocations int
+		if err := rows.Scan(&wf, &step, &invocations, &kinds); err != nil {
+			return nil, fmt.Errorf("scan step failover: %w", err)
+		}
+		key := wf + "\x00" + step
+		info, ok := out[key]
+		if !ok {
+			info = failoverInfo{kinds: map[string]int{}}
+		}
+		if invocations > 1 {
+			info.multiAttempt++
+		}
+		for k := range strings.SplitSeq(kinds, ",") {
+			k = strings.TrimSpace(k)
+			if k == "" || k == "none" {
+				continue
+			}
+			info.kinds[k]++
+		}
+		out[key] = info
+	}
+	return out, rows.Err()
+}
+
+// WorkflowMetricsFor aggregates workflow instances, their end-to-end duration
+// and the cost of the steps beneath them.
+func WorkflowMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]WorkflowMetrics, error) {
+	where, args := instanceFilter(w, sc)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT wi.workflow_id,
+		       wi.state,
+		       CAST(ROUND(COALESCE((julianday(wi.updated_at) - julianday(wi.created_at)) * 86400000, 0)) AS INTEGER),
+		       COALESCE((SELECT SUM(COALESCE(sr.cost_usd, 0)) FROM step_runs sr
+		                 WHERE sr.workflow_instance_id = wi.id), 0)
+		FROM workflow_instances wi
+		`+where+`
+		ORDER BY wi.workflow_id, wi.id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query workflow instances: %w", err)
+	}
+	defer rows.Close()
+
+	type acc struct {
+		instances int
+		byState   map[string]int
+		durations []int64
+		cost      float64
+		completed int
+	}
+	m := map[string]*acc{}
+	var order []string
+
+	for rows.Next() {
+		var wf, state string
+		var durMs int64
+		var cost float64
+		if err := rows.Scan(&wf, &state, &durMs, &cost); err != nil {
+			return nil, fmt.Errorf("scan workflow instance: %w", err)
+		}
+		a := m[wf]
+		if a == nil {
+			a = &acc{byState: map[string]int{}}
+			m[wf] = a
+			order = append(order, wf)
+		}
+		a.instances++
+		a.byState[state]++
+		if isTerminal(state) && durMs > 0 {
+			a.durations = append(a.durations, durMs)
+		}
+		a.cost += cost
+		if state == "done" {
+			a.completed++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workflow instances: %w", err)
+	}
+
+	loops, err := ReworkLoopsFor(ctx, db, w, sc)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]WorkflowMetrics, 0, len(order))
+	for _, wf := range order {
+		a := m[wf]
+		slices.Sort(a.durations)
+		out = append(out, WorkflowMetrics{
+			WorkflowID:          wf,
+			Instances:           a.instances,
+			ByState:             a.byState,
+			LowConfidence:       a.instances < MinRuns,
+			DurationP50Ms:       percentile(a.durations, 0.50),
+			DurationP95Ms:       percentile(a.durations, 0.95),
+			TotalCostUSD:        a.cost,
+			CostPerCompletedUSD: mean(a.cost, a.completed),
+			ReworkLoops:         loops[wf],
+		})
+	}
+	return out, nil
+}
+
+// ReworkLoopsFor finds steps that ran more than once within a single workflow
+// instance. That repetition is the direct signature of an on_fail/goto cycle,
+// and the repeat runs are pure waste — work the pipeline paid for twice.
+func ReworkLoopsFor(ctx context.Context, db source, w Window, sc Scope) (map[string][]ReworkLoop, error) {
+	where, args := stepFilter(w, sc)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT wf, step_id, COUNT(*) AS instances, SUM(runs - 1) AS repeats,
+		       MAX(runs - 1) AS max_repeats, SUM(repeat_cost) AS wasted
+		FROM (
+		  SELECT wi.workflow_id AS wf,
+		         sr.step_id AS step_id,
+		         sr.workflow_instance_id AS inst,
+		         COUNT(*) AS runs,
+		         COALESCE(SUM(sr.cost_usd), 0) - COALESCE(MAX(sr.cost_usd), 0) AS repeat_cost
+		  FROM step_runs sr
+		  JOIN workflow_instances wi ON wi.id = sr.workflow_instance_id
+		  `+where+`
+		  GROUP BY sr.workflow_instance_id, sr.step_id, wi.workflow_id
+		  HAVING COUNT(*) > 1
+		)
+		GROUP BY wf, step_id
+		ORDER BY wf, wasted DESC, step_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query rework loops: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string][]ReworkLoop{}
+	for rows.Next() {
+		var wf, step string
+		var instances, repeats, maxRepeats int
+		var wasted float64
+		if err := rows.Scan(&wf, &step, &instances, &repeats, &maxRepeats, &wasted); err != nil {
+			return nil, fmt.Errorf("scan rework loop: %w", err)
+		}
+		out[wf] = append(out[wf], ReworkLoop{
+			StepID:        step,
+			Instances:     instances,
+			TotalRepeats:  repeats,
+			MaxRepeats:    maxRepeats,
+			WastedCostUSD: wasted,
+		})
+	}
+	return out, rows.Err()
+}
+
+// AgentMetricsFor aggregates runner invocations by agent, runner and model. The
+// same agent on two models is two rows — comparing them is often the point.
+func AgentMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]AgentMetrics, error) {
+	where, args := executionFilter(w, sc, "te")
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT te.agent_id,
+		       COALESCE(te.runner, ''),
+		       COALESCE(te.model, ''),
+		       COUNT(*),
+		       SUM(CASE WHEN te.status = 'success' THEN 1 ELSE 0 END),
+		       COALESCE(AVG(te.duration_ms), 0),
+		       COALESCE(SUM(te.cost_usd), 0),
+		       COALESCE(AVG(te.num_turns), 0),
+		       COALESCE(GROUP_CONCAT(te.failure_kind), '')
+		FROM task_executions te
+		`+where+`
+		GROUP BY te.agent_id, te.runner, te.model
+		ORDER BY te.agent_id, te.runner, te.model`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query agent metrics: %w", err)
+	}
+	defer rows.Close()
+
+	var out []AgentMetrics
+	for rows.Next() {
+		var (
+			agent, runner, model, kinds string
+			runs, success               int
+			avgDur, totalCost, avgTurns float64
+		)
+		if err := rows.Scan(&agent, &runner, &model, &runs, &success,
+			&avgDur, &totalCost, &avgTurns, &kinds); err != nil {
+			return nil, fmt.Errorf("scan agent metrics: %w", err)
+		}
+		m := AgentMetrics{
+			AgentID:        agent,
+			Runner:         runner,
+			Model:          model,
+			Runs:           runs,
+			SuccessRate:    rate(success, runs),
+			LowConfidence:  runs < MinRuns,
+			MeanDurationMs: int64(avgDur),
+			MeanCostUSD:    mean(totalCost, runs),
+			TotalCostUSD:   totalCost,
+			MeanTurns:      avgTurns,
+		}
+		if counted := countKinds(kinds); len(counted) > 0 {
+			m.FailureKinds = counted
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// TurnCapSaturationFor reports, per agent, the share of runs that ended at
+// exactly a given turn count. The caller supplies the configured caps from
+// config, because the database has no idea what max_turns was set to; a run
+// stopping precisely at the cap is the signature of a step being cut off rather
+// than finishing.
+func TurnCapSaturationFor(ctx context.Context, db source, w Window, sc Scope, caps map[string]int) (map[string]float64, error) {
+	if len(caps) == 0 {
+		return nil, nil
+	}
+	where, args := executionFilter(w, sc, "te")
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT te.agent_id, COALESCE(te.num_turns, 0), COUNT(*)
+		FROM task_executions te
+		`+where+`
+		GROUP BY te.agent_id, te.num_turns`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query turn saturation: %w", err)
+	}
+	defer rows.Close()
+
+	total := map[string]int{}
+	atCap := map[string]int{}
+	for rows.Next() {
+		var agent string
+		var turns, n int
+		if err := rows.Scan(&agent, &turns, &n); err != nil {
+			return nil, fmt.Errorf("scan turn saturation: %w", err)
+		}
+		total[agent] += n
+		if c, ok := caps[agent]; ok && c > 0 && turns == c {
+			atCap[agent] += n
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := map[string]float64{}
+	for agent, n := range total {
+		if caps[agent] > 0 {
+			out[agent] = rate(atCap[agent], n)
+		}
+	}
+	return out, nil
+}
+
+// WaitMetricsFor aggregates how much polling each wait_for step actually did. A
+// wait that polls hundreds of times, or that usually ends in a timeout, is
+// costing wall-clock the config could avoid.
+func WaitMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]WaitMetrics, error) {
+	where, args := waitFilter(w, sc)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(wi.workflow_id, ''), c.step_id,
+		       c.workflow_instance_id, COUNT(*),
+		       COALESCE((SELECT c2.status FROM ci_poll_checks c2
+		                 WHERE c2.workflow_instance_id = c.workflow_instance_id
+		                   AND c2.step_id = c.step_id
+		                 ORDER BY c2.id DESC LIMIT 1), '')
+		FROM ci_poll_checks c
+		LEFT JOIN workflow_instances wi ON wi.id = c.workflow_instance_id
+		`+where+`
+		GROUP BY c.workflow_instance_id, c.step_id, wi.workflow_id
+		ORDER BY wi.workflow_id, c.step_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query wait metrics: %w", err)
+	}
+	defer rows.Close()
+
+	type acc struct {
+		workflowID string
+		waits      int
+		polls      int
+		maxPolls   int
+		terminal   map[string]int
+		timeouts   int
+	}
+	m := map[string]*acc{}
+	var order []string
+
+	for rows.Next() {
+		var wf, step, inst, terminal string
+		var polls int
+		if err := rows.Scan(&wf, &step, &inst, &polls, &terminal); err != nil {
+			return nil, fmt.Errorf("scan wait metrics: %w", err)
+		}
+		key := wf + "\x00" + step
+		a := m[key]
+		if a == nil {
+			a = &acc{workflowID: wf, terminal: map[string]int{}}
+			m[key] = a
+			order = append(order, key)
+		}
+		a.waits++
+		a.polls += polls
+		if polls > a.maxPolls {
+			a.maxPolls = polls
+		}
+		if terminal != "" {
+			a.terminal[terminal]++
+			if terminal == "timeout" {
+				a.timeouts++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]WaitMetrics, 0, len(order))
+	for _, key := range order {
+		a := m[key]
+		step := key[strings.Index(key, "\x00")+1:]
+		out = append(out, WaitMetrics{
+			WorkflowID:     a.workflowID,
+			StepID:         step,
+			Waits:          a.waits,
+			TotalPolls:     a.polls,
+			MeanPolls:      mean(float64(a.polls), a.waits),
+			MaxPolls:       a.maxPolls,
+			TerminalStatus: a.terminal,
+			Timeouts:       a.timeouts,
+		})
+	}
+	return out, nil
+}
+
+// FailureClustersFor groups failed executions by their normalised error message.
+// Thirty occurrences of the same failure with different task ids collapse into
+// one cluster with a count and an exemplar.
+func FailureClustersFor(ctx context.Context, db source, w Window, sc Scope) ([]FailureCluster, error) {
+	where, args := executionFilter(w, sc, "te")
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(te.error_message, ''), te.agent_id
+		FROM task_executions te
+		`+where+`
+		  AND te.status = 'failed'
+		  AND te.error_message IS NOT NULL AND te.error_message != ''
+		ORDER BY te.id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query failures: %w", err)
+	}
+	defer rows.Close()
+
+	type acc struct {
+		count    int
+		exemplar string
+		agents   map[string]struct{}
+	}
+	m := map[string]*acc{}
+	var order []string
+
+	for rows.Next() {
+		var msg, agent string
+		if err := rows.Scan(&msg, &agent); err != nil {
+			return nil, fmt.Errorf("scan failure: %w", err)
+		}
+		key := NormalizeFailure(msg)
+		a := m[key]
+		if a == nil {
+			a = &acc{exemplar: truncate(msg, 500), agents: map[string]struct{}{}}
+			m[key] = a
+			order = append(order, key)
+		}
+		a.count++
+		if agent != "" {
+			a.agents[agent] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]FailureCluster, 0, len(order))
+	for _, key := range order {
+		a := m[key]
+		agents := make([]string, 0, len(a.agents))
+		for id := range a.agents {
+			agents = append(agents, id)
+		}
+		sort.Strings(agents)
+		out = append(out, FailureCluster{
+			Normalized: key,
+			Count:      a.count,
+			Exemplar:   a.exemplar,
+			Agents:     agents,
+		})
+	}
+	// Most frequent first; ties broken by the normalised text so the ordering —
+	// and therefore the pack digest — is stable across runs.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Normalized < out[j].Normalized
+	})
+	return out, nil
+}
+
+func isTerminal(state string) bool {
+	return state == "done" || state == "failed" || state == "interrupted"
+}
+
+func countKinds(concat string) map[string]int {
+	out := map[string]int{}
+	for k := range strings.SplitSeq(concat, ",") {
+		k = strings.TrimSpace(k)
+		if k == "" || k == "none" {
+			continue
+		}
+		out[k]++
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// ── filters ──────────────────────────────────────────────────────────────────
+
+// stepFilter builds the WHERE clause for step_runs joined to workflow_instances.
+func stepFilter(w Window, sc Scope) (string, []any) {
+	clauses := []string{"sr.started_at >= ?", "sr.started_at < ?"}
+	args := []any{w.Start, w.End}
+
+	if len(sc.Workflows) > 0 {
+		clauses = append(clauses, "wi.workflow_id IN ("+placeholders(len(sc.Workflows))+")")
+		args = append(args, toAny(sc.Workflows)...)
+	}
+	if len(sc.Agents) > 0 {
+		clauses = append(clauses, "sr.agent_id IN ("+placeholders(len(sc.Agents))+")")
+		args = append(args, toAny(sc.Agents)...)
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// instanceFilter builds the WHERE clause for a bare workflow_instances scan.
+func instanceFilter(w Window, sc Scope) (string, []any) {
+	clauses := []string{"wi.created_at >= ?", "wi.created_at < ?"}
+	args := []any{w.Start, w.End}
+
+	if len(sc.Workflows) > 0 {
+		clauses = append(clauses, "wi.workflow_id IN ("+placeholders(len(sc.Workflows))+")")
+		args = append(args, toAny(sc.Workflows)...)
+	}
+	if len(sc.Agents) > 0 {
+		// An instance is in scope when any of its steps ran on a scoped agent.
+		clauses = append(clauses, "EXISTS (SELECT 1 FROM step_runs sr WHERE sr.workflow_instance_id = wi.id AND sr.agent_id IN ("+placeholders(len(sc.Agents))+"))")
+		args = append(args, toAny(sc.Agents)...)
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// executionFilter builds the WHERE clause for task_executions. The alias is
+// passed in so the same builder serves queries that join workflow_instances and
+// queries that do not.
+func executionFilter(w Window, sc Scope, alias string) (string, []any) {
+	clauses := []string{alias + ".started_at >= ?", alias + ".started_at < ?"}
+	args := []any{w.Start, w.End}
+
+	if len(sc.Agents) > 0 {
+		clauses = append(clauses, alias+".agent_id IN ("+placeholders(len(sc.Agents))+")")
+		args = append(args, toAny(sc.Agents)...)
+	}
+	if len(sc.Workflows) > 0 {
+		clauses = append(clauses, "EXISTS (SELECT 1 FROM workflow_instances wi2 WHERE wi2.id = "+alias+".workflow_instance_id AND wi2.workflow_id IN ("+placeholders(len(sc.Workflows))+"))")
+		args = append(args, toAny(sc.Workflows)...)
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func waitFilter(w Window, sc Scope) (string, []any) {
+	clauses := []string{"c.checked_at >= ?", "c.checked_at < ?"}
+	args := []any{w.Start, w.End}
+
+	if len(sc.Workflows) > 0 {
+		clauses = append(clauses, "wi.workflow_id IN ("+placeholders(len(sc.Workflows))+")")
+		args = append(args, toAny(sc.Workflows)...)
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func placeholders(n int) string {
+	if n <= 0 {
+		return "NULL"
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+func toAny(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/src/internal/improve/metrics_test.go
+++ b/src/internal/improve/metrics_test.go
@@ -1,0 +1,408 @@
+package improve
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestStepMetricsRatesAndTotals(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "review", state: "done"})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "review", state: "failed"})
+
+	// 4 runs of review/lint: 2 passed, 1 failed, 1 cached skip.
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "lint", agentID: "eng",
+		state: "passed", durationMs: 1000, tokens: 100, cost: 0.10, turns: 3, toolCalls: 5})
+	addStep(t, db, stepOpts{id: "s2", instanceID: "i1", stepID: "lint", agentID: "eng",
+		state: "passed", durationMs: 3000, tokens: 300, cost: 0.30, turns: 5, toolCalls: 9})
+	addStep(t, db, stepOpts{id: "s3", instanceID: "i2", stepID: "lint", agentID: "eng",
+		state: "failed", durationMs: 2000, tokens: 200, cost: 0.20, turns: 4, toolCalls: 7})
+	addStep(t, db, stepOpts{id: "s4", instanceID: "i2", stepID: "lint", agentID: "eng",
+		state: "skipped_cached", cached: true})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+
+	m := findStep(t, steps, "review", "lint")
+	if m.Runs != 4 {
+		t.Errorf("Runs = %d, want 4", m.Runs)
+	}
+	if m.Passed != 2 || m.Failed != 1 || m.SkippedCached != 1 {
+		t.Errorf("counts = %d/%d/%d, want 2/1/1", m.Passed, m.Failed, m.SkippedCached)
+	}
+	if got, want := m.PassRate, 0.5; !closeTo(got, want) {
+		t.Errorf("PassRate = %v, want %v", got, want)
+	}
+	if got, want := m.FailRate, 0.25; !closeTo(got, want) {
+		t.Errorf("FailRate = %v, want %v", got, want)
+	}
+	if m.TotalTokens != 600 {
+		t.Errorf("TotalTokens = %d, want 600", m.TotalTokens)
+	}
+	if !closeTo(m.TotalCostUSD, 0.60) {
+		t.Errorf("TotalCostUSD = %v, want 0.60", m.TotalCostUSD)
+	}
+	// Only three runs recorded a duration; the cached skip has none.
+	if m.DurationP50Ms != 2000 {
+		t.Errorf("DurationP50Ms = %d, want 2000", m.DurationP50Ms)
+	}
+	if m.DurationP95Ms != 3000 {
+		t.Errorf("DurationP95Ms = %d, want 3000", m.DurationP95Ms)
+	}
+	if !m.LowConfidence {
+		t.Error("4 runs is below MinRuns; want LowConfidence")
+	}
+}
+
+func TestStepMetricsCacheAndPromptRatios(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "big", agentID: "eng",
+		inputTok: 1000, cacheRead: 750, outputTok: 100, prompt: string(make([]byte, 4000))})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	m := findStep(t, steps, "wf", "big")
+	if !closeTo(m.CacheReuseRatio, 0.75) {
+		t.Errorf("CacheReuseRatio = %v, want 0.75", m.CacheReuseRatio)
+	}
+	if !closeTo(m.PromptWeightRatio, 40) {
+		t.Errorf("PromptWeightRatio = %v, want 40", m.PromptWeightRatio)
+	}
+}
+
+func TestStepMetricsZeroDenominatorsAreSafe(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	// A runner that reports no usage at all: every ratio denominator is zero.
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "quiet", agentID: "eng"})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	m := findStep(t, steps, "wf", "quiet")
+	if m.CacheReuseRatio != 0 || m.PromptWeightRatio != 0 || m.MeanTokens != 0 {
+		t.Errorf("want zeroed ratios, got cache=%v prompt=%v tokens=%v",
+			m.CacheReuseRatio, m.PromptWeightRatio, m.MeanTokens)
+	}
+}
+
+func TestStepMetricsFailoverAndFailureKinds(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "impl", agentID: "eng"})
+	addStep(t, db, stepOpts{id: "s2", instanceID: "i2", stepID: "impl", agentID: "eng"})
+
+	// i1's step needed two attempts (rate limit on the first); i2's took one.
+	addExec(t, db, execOpts{agentID: "eng", instanceID: "i1", stepID: "impl",
+		attempt: 1, status: "failed", failureKind: "rate_limited"})
+	addExec(t, db, execOpts{agentID: "eng", instanceID: "i1", stepID: "impl",
+		attempt: 2, status: "success", failureKind: "none"})
+	addExec(t, db, execOpts{agentID: "eng", instanceID: "i2", stepID: "impl",
+		attempt: 1, status: "success", failureKind: "none"})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	m := findStep(t, steps, "wf", "impl")
+	if !closeTo(m.FailoverRate, 0.5) {
+		t.Errorf("FailoverRate = %v, want 0.5 (1 of 2 runs failed over)", m.FailoverRate)
+	}
+	if m.FailureKinds["rate_limited"] != 1 {
+		t.Errorf("FailureKinds = %v, want rate_limited:1", m.FailureKinds)
+	}
+	if _, ok := m.FailureKinds["none"]; ok {
+		t.Error(`"none" is not a failure kind and must not be counted`)
+	}
+}
+
+// The `attempt` column is a per-task counter, not a per-step retry count:
+// beginExecution sets it to the task's last attempt + 1, so the fifth step of a
+// workflow carries attempt=5 having never failed over. Counting attempt>1 as a
+// failover marks nearly every step in every workflow as one.
+func TestFailoverIgnoresInheritedAttemptNumbers(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "s1", instanceID: "i1", stepID: "fifth", agentID: "eng"})
+
+	// One invocation, but it is the task's fifth execution overall.
+	addExec(t, db, execOpts{agentID: "eng", instanceID: "i1", stepID: "fifth",
+		attempt: 5, status: "success"})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	if m := findStep(t, steps, "wf", "fifth"); m.FailoverRate != 0 {
+		t.Errorf("FailoverRate = %v, want 0: a high attempt number inherited from "+
+			"the task's history is not a failover", m.FailoverRate)
+	}
+}
+
+func TestReworkLoopsDetectsRepeatedSteps(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "wf", state: "done"})
+
+	// i1 ran "review" three times (two loop-backs), i2 ran it once.
+	addStep(t, db, stepOpts{id: "a", instanceID: "i1", stepID: "review", state: "failed", cost: 0.10})
+	addStep(t, db, stepOpts{id: "b", instanceID: "i1", stepID: "review", state: "failed", cost: 0.10})
+	addStep(t, db, stepOpts{id: "c", instanceID: "i1", stepID: "review", state: "passed", cost: 0.10})
+	addStep(t, db, stepOpts{id: "d", instanceID: "i2", stepID: "review", state: "passed", cost: 0.10})
+
+	loops, err := ReworkLoopsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("ReworkLoopsFor: %v", err)
+	}
+	got := loops["wf"]
+	if len(got) != 1 {
+		t.Fatalf("want 1 rework loop, got %d: %+v", len(got), got)
+	}
+	if got[0].StepID != "review" {
+		t.Errorf("StepID = %q, want review", got[0].StepID)
+	}
+	if got[0].Instances != 1 {
+		t.Errorf("Instances = %d, want 1 (only i1 looped)", got[0].Instances)
+	}
+	if got[0].TotalRepeats != 2 {
+		t.Errorf("TotalRepeats = %d, want 2", got[0].TotalRepeats)
+	}
+	if !closeTo(got[0].WastedCostUSD, 0.20) {
+		t.Errorf("WastedCostUSD = %v, want 0.20", got[0].WastedCostUSD)
+	}
+}
+
+func TestReworkLoopsIgnoresSingleRuns(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "a", instanceID: "i1", stepID: "one", state: "passed"})
+	addStep(t, db, stepOpts{id: "b", instanceID: "i1", stepID: "two", state: "passed"})
+
+	loops, err := ReworkLoopsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("ReworkLoopsFor: %v", err)
+	}
+	if len(loops) != 0 {
+		t.Errorf("want no rework loops, got %+v", loops)
+	}
+}
+
+func TestWindowExcludesOutOfRangeRows(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addStep(t, db, stepOpts{id: "in", instanceID: "i1", stepID: "s", startedAt: base})
+	addStep(t, db, stepOpts{id: "old", instanceID: "i1", stepID: "s", startedAt: base.Add(-72 * time.Hour)})
+	addStep(t, db, stepOpts{id: "future", instanceID: "i1", stepID: "s", startedAt: base.Add(72 * time.Hour)})
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	if m := findStep(t, steps, "wf", "s"); m.Runs != 1 {
+		t.Errorf("Runs = %d, want 1 (window must exclude the old and future rows)", m.Runs)
+	}
+}
+
+func TestScopeFiltersByWorkflowAndAgent(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "alpha", state: "done"})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "beta", state: "done"})
+	addStep(t, db, stepOpts{id: "a", instanceID: "i1", stepID: "s", agentID: "eng"})
+	addStep(t, db, stepOpts{id: "b", instanceID: "i2", stepID: "s", agentID: "eng"})
+	addStep(t, db, stepOpts{id: "c", instanceID: "i2", stepID: "s", agentID: "reviewer"})
+
+	byWorkflow, err := StepMetricsFor(ctx(), db, testWindow(), Scope{Workflows: []string{"alpha"}})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	if len(byWorkflow) != 1 || byWorkflow[0].WorkflowID != "alpha" {
+		t.Errorf("workflow scope leaked: %v", stepKeys(byWorkflow))
+	}
+
+	byAgent, err := StepMetricsFor(ctx(), db, testWindow(), Scope{Agents: []string{"reviewer"}})
+	if err != nil {
+		t.Fatalf("StepMetricsFor: %v", err)
+	}
+	if len(byAgent) != 1 || byAgent[0].AgentID != "reviewer" {
+		t.Errorf("agent scope leaked: %+v", byAgent)
+	}
+}
+
+func TestWorkflowMetricsStatesAndCost(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done", durationMs: 10000})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "wf", state: "failed", durationMs: 30000})
+	addStep(t, db, stepOpts{id: "a", instanceID: "i1", stepID: "s", cost: 1.00})
+	addStep(t, db, stepOpts{id: "b", instanceID: "i2", stepID: "s", cost: 0.50})
+
+	got, err := WorkflowMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("WorkflowMetricsFor: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 workflow, got %d", len(got))
+	}
+	w := got[0]
+	if w.Instances != 2 {
+		t.Errorf("Instances = %d, want 2", w.Instances)
+	}
+	if w.ByState["done"] != 1 || w.ByState["failed"] != 1 {
+		t.Errorf("ByState = %v", w.ByState)
+	}
+	if !closeTo(w.TotalCostUSD, 1.50) {
+		t.Errorf("TotalCostUSD = %v, want 1.50", w.TotalCostUSD)
+	}
+	// One instance reached "done", so the whole spend is attributed to it.
+	if !closeTo(w.CostPerCompletedUSD, 1.50) {
+		t.Errorf("CostPerCompletedUSD = %v, want 1.50", w.CostPerCompletedUSD)
+	}
+}
+
+func TestAgentMetricsGroupsByRunnerAndModel(t *testing.T) {
+	db := seedDB(t)
+	addExec(t, db, execOpts{agentID: "eng", runner: "claude", model: "opus", status: "success", durationMs: 1000, cost: 1.0})
+	addExec(t, db, execOpts{agentID: "eng", runner: "claude", model: "opus", status: "failed", durationMs: 3000, cost: 1.0})
+	addExec(t, db, execOpts{agentID: "eng", runner: "claude", model: "haiku", status: "success", durationMs: 500, cost: 0.1})
+
+	got, err := AgentMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("AgentMetricsFor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 rows (one per model), got %d: %+v", len(got), got)
+	}
+	for _, m := range got {
+		switch m.Model {
+		case "opus":
+			if m.Runs != 2 || !closeTo(m.SuccessRate, 0.5) {
+				t.Errorf("opus: runs=%d success=%v, want 2 / 0.5", m.Runs, m.SuccessRate)
+			}
+			if m.MeanDurationMs != 2000 {
+				t.Errorf("opus MeanDurationMs = %d, want 2000", m.MeanDurationMs)
+			}
+		case "haiku":
+			if m.Runs != 1 || !closeTo(m.SuccessRate, 1) {
+				t.Errorf("haiku: runs=%d success=%v, want 1 / 1", m.Runs, m.SuccessRate)
+			}
+		}
+	}
+}
+
+func TestTurnCapSaturation(t *testing.T) {
+	db := seedDB(t)
+	// eng is capped at 10 turns; 2 of 4 runs stopped exactly there.
+	addExec(t, db, execOpts{agentID: "eng", turns: 10})
+	addExec(t, db, execOpts{agentID: "eng", turns: 10})
+	addExec(t, db, execOpts{agentID: "eng", turns: 4})
+	addExec(t, db, execOpts{agentID: "eng", turns: 7})
+	// uncapped agent must not appear at all.
+	addExec(t, db, execOpts{agentID: "free", turns: 99})
+
+	got, err := TurnCapSaturationFor(ctx(), db, testWindow(), Scope{}, map[string]int{"eng": 10})
+	if err != nil {
+		t.Fatalf("TurnCapSaturationFor: %v", err)
+	}
+	if !closeTo(got["eng"], 0.5) {
+		t.Errorf("eng saturation = %v, want 0.5", got["eng"])
+	}
+	if _, ok := got["free"]; ok {
+		t.Error("agent without a configured cap must not be reported")
+	}
+}
+
+func TestWaitMetricsCountsPolls(t *testing.T) {
+	db := seedDB(t)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "wf", state: "done"})
+	addInstance(t, db, instanceOpts{id: "i2", workflowID: "wf", state: "failed"})
+
+	for i := range 5 {
+		addPoll(t, db, "i1", "ci", "pending", base.Add(time.Duration(i)*time.Minute))
+	}
+	addPoll(t, db, "i1", "ci", "passed", base.Add(6*time.Minute))
+	addPoll(t, db, "i2", "ci", "timeout", base)
+
+	got, err := WaitMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("WaitMetricsFor: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 wait row, got %d: %+v", len(got), got)
+	}
+	w := got[0]
+	if w.Waits != 2 {
+		t.Errorf("Waits = %d, want 2", w.Waits)
+	}
+	if w.TotalPolls != 7 {
+		t.Errorf("TotalPolls = %d, want 7", w.TotalPolls)
+	}
+	if w.MaxPolls != 6 {
+		t.Errorf("MaxPolls = %d, want 6", w.MaxPolls)
+	}
+	if w.Timeouts != 1 {
+		t.Errorf("Timeouts = %d, want 1", w.Timeouts)
+	}
+	if w.TerminalStatus["passed"] != 1 {
+		t.Errorf("TerminalStatus = %v, want passed:1", w.TerminalStatus)
+	}
+}
+
+func TestFailureClustersGroupAndRank(t *testing.T) {
+	db := seedDB(t)
+	addExec(t, db, execOpts{agentID: "eng", status: "failed", errMessage: "task 4821 timed out after 1800s"})
+	addExec(t, db, execOpts{agentID: "eng", status: "failed", errMessage: "task 9134 timed out after 900s"})
+	addExec(t, db, execOpts{agentID: "rev", status: "failed", errMessage: "task 7 timed out after 60s"})
+	addExec(t, db, execOpts{agentID: "eng", status: "failed", errMessage: "permission denied"})
+	addExec(t, db, execOpts{agentID: "eng", status: "success", errMessage: ""})
+
+	got, err := FailureClustersFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("FailureClustersFor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 clusters, got %d: %+v", len(got), got)
+	}
+	// Most frequent first.
+	if got[0].Count != 3 {
+		t.Errorf("top cluster count = %d, want 3", got[0].Count)
+	}
+	if len(got[0].Agents) != 2 {
+		t.Errorf("top cluster agents = %v, want both eng and rev", got[0].Agents)
+	}
+	if got[1].Count != 1 {
+		t.Errorf("second cluster count = %d, want 1", got[1].Count)
+	}
+}
+
+func TestPercentileNearestRank(t *testing.T) {
+	cases := []struct {
+		name   string
+		sorted []int64
+		p      float64
+		want   int64
+	}{
+		{"empty", nil, 0.5, 0},
+		{"single", []int64{42}, 0.95, 42},
+		{"median odd", []int64{1, 2, 3}, 0.5, 2},
+		{"median even", []int64{1, 2, 3, 4}, 0.5, 2},
+		{"p95 of ten", []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 0.95, 10},
+		{"p0 clamps low", []int64{5, 6}, 0, 5},
+		{"p1 clamps high", []int64{5, 6}, 1, 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := percentile(tc.sorted, tc.p); got != tc.want {
+				t.Errorf("percentile(%v, %v) = %d, want %d", tc.sorted, tc.p, got, tc.want)
+			}
+		})
+	}
+}
+
+func closeTo(a, b float64) bool { return math.Abs(a-b) < 1e-9 }

--- a/src/internal/improve/static.go
+++ b/src/internal/improve/static.go
@@ -1,0 +1,219 @@
+package improve
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// ── failure normalisation ────────────────────────────────────────────────────
+
+// Volatile fragments are stripped in a fixed order — longest/most specific
+// patterns first, so a UUID is not shredded into digit runs before it is
+// recognised as a UUID.
+var failureScrubbers = []struct {
+	re   *regexp.Regexp
+	with string
+}{
+	{regexp.MustCompile(`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b`), "<uuid>"},
+	{regexp.MustCompile(`\b[0-9A-HJKMNP-TV-Z]{26}\b`), "<ulid>"},
+	{regexp.MustCompile(`\b[0-9a-fA-F]{7,40}\b`), "<hex>"},
+	{regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}\S*`), "<time>"},
+	{regexp.MustCompile(`(/[\w.@%+-]+){2,}/?`), "<path>"},
+	{regexp.MustCompile(`https?://\S+`), "<url>"},
+	{regexp.MustCompile(`\b\d+(\.\d+)?(ms|s|m|h)\b`), "<dur>"},
+	{regexp.MustCompile(`\b\d+\b`), "<n>"},
+	{regexp.MustCompile(`\s+`), " "},
+}
+
+// NormalizeFailure reduces an error message to its recurring shape by removing
+// the parts that differ between two occurrences of the same failure: ids, paths,
+// timestamps, durations and bare numbers. "task 4821 timed out after 1800s" and
+// "task 9134 timed out after 900s" collapse to one cluster key.
+func NormalizeFailure(msg string) string {
+	s := strings.TrimSpace(msg)
+	for _, sc := range failureScrubbers {
+		s = sc.re.ReplaceAllString(s, sc.with)
+	}
+	return truncate(strings.TrimSpace(s), 300)
+}
+
+// ── static config analysis ───────────────────────────────────────────────────
+
+// ParallelCandidates reports adjacent sequential agent steps that appear to have
+// no data dependency, and so could plausibly run concurrently.
+//
+// This is deliberately conservative: a pair is emitted only when the later step
+// provably does not reference the earlier one anywhere the engine could read it
+// (prompt, condition, fail_when, memory config, env values, sub-workflow inputs).
+// A missed opportunity costs nothing; a wrong one is a recommendation to
+// parallelise steps that genuinely depend on each other, so uncertainty always
+// resolves to silence.
+func ParallelCandidates(wf config.WorkflowConfig) []StepPair {
+	var out []StepPair
+
+	for i := 0; i+1 < len(wf.Steps); i++ {
+		first, second := wf.Steps[i], wf.Steps[i+1]
+
+		// Only plain agent steps are considered. Control-flow steps (split,
+		// foreach, approval, wait_for, sub-workflow) carry ordering semantics
+		// that a static reference scan cannot reason about.
+		if !isPlainAgentStep(first) || !isPlainAgentStep(second) {
+			continue
+		}
+		// An explicit branch or edge on the first step means the order is
+		// intentional, not incidental.
+		if first.OnPass != nil || first.OnFail != nil || first.OnConflict != nil {
+			continue
+		}
+		// A step that publishes or spawns has an effect the next step may observe
+		// through the source rather than through memory. Not statically knowable.
+		if hasSideEffect(first) || hasSideEffect(second) {
+			continue
+		}
+		if referencesStep(second, first.ID) {
+			continue
+		}
+		// A later step reading arbitrary prior output through a bare `outputs`
+		// or `memory` reference is treated as a dependency, since the scan
+		// cannot tell which producer it means.
+		if readsSharedState(second) {
+			continue
+		}
+
+		out = append(out, StepPair{
+			First:  first.ID,
+			Second: second.ID,
+			Reason: "adjacent agent steps; the second makes no reference to the first",
+		})
+	}
+	return out
+}
+
+func isPlainAgentStep(s config.StepConfig) bool {
+	return (s.Type == "" || s.Type == "agent") && s.Agent != ""
+}
+
+func hasSideEffect(s config.StepConfig) bool {
+	if s.Publish != "" && s.Publish != "off" {
+		return true
+	}
+	return s.Spawn != "" || s.Materialize != ""
+}
+
+// referencesStep reports whether the step mentions the given step id anywhere
+// the engine evaluates or interpolates.
+func referencesStep(s config.StepConfig, id string) bool {
+	if id == "" {
+		return true // unknown producer: assume dependency
+	}
+	for _, field := range referenceFields(s) {
+		if strings.Contains(field, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// sharedStateRe matches a reference to prior state whose producer cannot be
+// determined statically.
+//
+// Note this deliberately scans only the step's own authored text. Every agent
+// step reads the memory document by default, so treating memory-read as a
+// dependency would suppress every candidate and make the analysis useless. What
+// distinguishes a real dependency is the step *saying* it consumes prior state.
+var sharedStateRe = regexp.MustCompile(`\b(outputs|memory|steps)\b`)
+
+func readsSharedState(s config.StepConfig) bool {
+	for _, field := range referenceFields(s) {
+		if sharedStateRe.MatchString(field) {
+			return true
+		}
+	}
+	return false
+}
+
+// referenceFields returns every string on a step that could carry a reference to
+// an earlier step's output.
+func referenceFields(s config.StepConfig) []string {
+	fields := []string{s.Prompt, s.Condition, s.FailWhen, s.SummaryPrompt, s.Items, s.Message}
+	for _, v := range s.Env {
+		fields = append(fields, v)
+	}
+	for _, v := range s.With {
+		if str, ok := v.(string); ok {
+			fields = append(fields, str)
+		}
+	}
+	return fields
+}
+
+// DeadPathsFor reports configured workflows, agents and fallback runners that
+// produced no runs in the window. Config that never executes is either obsolete
+// or silently broken; both are worth a look.
+func DeadPathsFor(cfg *config.Config, ranWorkflows, ranAgents, ranRunners map[string]bool) DeadPaths {
+	var d DeadPaths
+
+	for _, wf := range cfg.Workflows {
+		if !ranWorkflows[wf.ID] {
+			d.Workflows = append(d.Workflows, wf.ID)
+		}
+	}
+	for _, a := range cfg.Agents {
+		if !ranAgents[a.ID] {
+			d.Agents = append(d.Agents, a.ID)
+		}
+	}
+
+	// A fallback that never fired is reported once, no matter how many agents
+	// declare it — the interesting fact is that the chain is untested, not which
+	// agent owns it.
+	seen := map[string]bool{}
+	for _, a := range cfg.Agents {
+		for _, fb := range a.Fallbacks {
+			if fb.Runner == "" || ranRunners[fb.Runner] || seen[fb.Runner] {
+				continue
+			}
+			seen[fb.Runner] = true
+			d.Fallbacks = append(d.Fallbacks, fb.Runner)
+		}
+	}
+	for _, fb := range cfg.Settings.DefaultFallbacks {
+		if fb.Runner == "" || ranRunners[fb.Runner] || seen[fb.Runner] {
+			continue
+		}
+		seen[fb.Runner] = true
+		d.Fallbacks = append(d.Fallbacks, fb.Runner)
+	}
+
+	sort.Strings(d.Workflows)
+	sort.Strings(d.Agents)
+	sort.Strings(d.Fallbacks)
+	return d
+}
+
+// DeadStepsFor reports configured steps of one workflow that never ran.
+func DeadStepsFor(wf config.WorkflowConfig, ran map[string]bool) []string {
+	var out []string
+	for _, s := range wf.Steps {
+		if s.ID != "" && !ran[s.ID] {
+			out = append(out, s.ID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TurnCaps returns each agent's configured max_turns, skipping agents with no
+// cap (0 means unlimited).
+func TurnCaps(cfg *config.Config) map[string]int {
+	out := map[string]int{}
+	for _, a := range cfg.Agents {
+		if a.MaxTurns > 0 {
+			out[a.ID] = a.MaxTurns
+		}
+	}
+	return out
+}

--- a/src/internal/improve/static_test.go
+++ b/src/internal/improve/static_test.go
@@ -1,0 +1,187 @@
+package improve
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func TestNormalizeFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		same bool
+	}{
+		{"ids and durations differ", "task 4821 timed out after 1800s", "task 9134 timed out after 900s", true},
+		{"paths differ", "cannot read /home/alice/repo/x.go", "cannot read /home/bob/other/y.go", true},
+		{"uuids differ", "run 550e8400-e29b-41d4-a716-446655440000 failed", "run 6ba7b810-9dad-11d1-80b4-00c04fd430c8 failed", true},
+		{"hex shas differ", "commit a1b2c3d4e5f rejected", "commit f9e8d7c6b5a rejected", true},
+		{"urls differ", "GET https://api.example.com/a failed", "GET https://api.other.org/b failed", true},
+		{"timestamps differ", "at 2026-08-01T10:00:00Z the run died", "at 2026-07-14T22:31:09Z the run died", true},
+		{"genuinely different failures", "permission denied", "out of credits", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			na, nb := NormalizeFailure(tc.a), NormalizeFailure(tc.b)
+			if (na == nb) != tc.same {
+				t.Errorf("normalize(%q)=%q vs normalize(%q)=%q: same=%v, want %v",
+					tc.a, na, tc.b, nb, na == nb, tc.same)
+			}
+		})
+	}
+}
+
+func TestParallelCandidatesFindsIndependentSteps(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "wf",
+		Steps: []config.StepConfig{
+			{ID: "lint", Agent: "eng", Prompt: "run the linter"},
+			{ID: "typecheck", Agent: "eng", Prompt: "run the type checker"},
+		},
+	}
+	got := ParallelCandidates(wf)
+	if len(got) != 1 {
+		t.Fatalf("want 1 candidate, got %d: %+v", len(got), got)
+	}
+	if got[0].First != "lint" || got[0].Second != "typecheck" {
+		t.Errorf("pair = %s→%s, want lint→typecheck", got[0].First, got[0].Second)
+	}
+}
+
+func TestParallelCandidatesRespectsDependencies(t *testing.T) {
+	cases := []struct {
+		name  string
+		steps []config.StepConfig
+	}{
+		{
+			"prompt names the earlier step",
+			[]config.StepConfig{
+				{ID: "plan", Agent: "eng", Prompt: "write a plan"},
+				{ID: "build", Agent: "eng", Prompt: "implement what plan produced"},
+			},
+		},
+		{
+			"condition references the earlier step",
+			[]config.StepConfig{
+				{ID: "plan", Agent: "eng", Prompt: "write a plan"},
+				{ID: "build", Agent: "eng", Prompt: "build", Condition: `plan.approved == true`},
+			},
+		},
+		{
+			"fail_when references the earlier step",
+			[]config.StepConfig{
+				{ID: "plan", Agent: "eng", Prompt: "plan"},
+				{ID: "build", Agent: "eng", Prompt: "build", FailWhen: `plan.blocked`},
+			},
+		},
+		{
+			"second step reads shared state with an unknown producer",
+			[]config.StepConfig{
+				{ID: "a", Agent: "eng", Prompt: "do a"},
+				{ID: "b", Agent: "eng", Prompt: "use the prior outputs"},
+			},
+		},
+		{
+			"env value references the earlier step",
+			[]config.StepConfig{
+				{ID: "a", Agent: "eng", Prompt: "do a"},
+				{ID: "b", Agent: "eng", Prompt: "do b", Env: map[string]string{"REF": "${{ a.sha }}"}},
+			},
+		},
+		{
+			"first step has an explicit failure edge",
+			[]config.StepConfig{
+				{ID: "a", Agent: "eng", Prompt: "do a", OnFail: &config.StepOutcome{}},
+				{ID: "b", Agent: "eng", Prompt: "do b"},
+			},
+		},
+		{
+			"first step publishes back to the source",
+			[]config.StepConfig{
+				{ID: "a", Agent: "eng", Prompt: "do a", Publish: "auto"},
+				{ID: "b", Agent: "eng", Prompt: "do b"},
+			},
+		},
+		{
+			"first step spawns children",
+			[]config.StepConfig{
+				{ID: "a", Agent: "eng", Prompt: "decompose", Spawn: "await"},
+				{ID: "b", Agent: "eng", Prompt: "do b"},
+			},
+		},
+		{
+			"control-flow step is never a candidate",
+			[]config.StepConfig{
+				{ID: "gate", Type: "approval", Message: "ok?"},
+				{ID: "b", Agent: "eng", Prompt: "do b"},
+			},
+		},
+		{
+			"wait_for step is never a candidate",
+			[]config.StepConfig{
+				{ID: "ci", Type: "wait_for"},
+				{ID: "b", Agent: "eng", Prompt: "do b"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParallelCandidates(config.WorkflowConfig{ID: "wf", Steps: tc.steps})
+			if len(got) != 0 {
+				t.Errorf("want no candidates (dependency present), got %+v", got)
+			}
+		})
+	}
+}
+
+func TestDeadPathsReportsUnusedConfig(t *testing.T) {
+	cfg := &config.Config{
+		Workflows: []config.WorkflowConfig{{ID: "used"}, {ID: "never"}},
+		Agents: []config.AgentConfig{
+			{ID: "busy"},
+			{ID: "idle", Fallbacks: []config.FallbackConfig{{Runner: "backup"}}},
+		},
+	}
+	got := DeadPathsFor(cfg,
+		map[string]bool{"used": true},
+		map[string]bool{"busy": true},
+		map[string]bool{"claude": true})
+
+	if len(got.Workflows) != 1 || got.Workflows[0] != "never" {
+		t.Errorf("Workflows = %v, want [never]", got.Workflows)
+	}
+	if len(got.Agents) != 1 || got.Agents[0] != "idle" {
+		t.Errorf("Agents = %v, want [idle]", got.Agents)
+	}
+	if len(got.Fallbacks) != 1 || got.Fallbacks[0] != "backup" {
+		t.Errorf("Fallbacks = %v, want [backup]", got.Fallbacks)
+	}
+}
+
+func TestDeadPathsReportsEachFallbackOnce(t *testing.T) {
+	cfg := &config.Config{
+		Agents: []config.AgentConfig{
+			{ID: "a", Fallbacks: []config.FallbackConfig{{Runner: "backup"}}},
+			{ID: "b", Fallbacks: []config.FallbackConfig{{Runner: "backup"}}},
+		},
+	}
+	got := DeadPathsFor(cfg, nil, map[string]bool{"a": true, "b": true}, nil)
+	if len(got.Fallbacks) != 1 {
+		t.Errorf("Fallbacks = %v, want one entry for the shared runner", got.Fallbacks)
+	}
+}
+
+func TestTurnCapsSkipsUncappedAgents(t *testing.T) {
+	cfg := &config.Config{Agents: []config.AgentConfig{
+		{ID: "capped", MaxTurns: 20},
+		{ID: "uncapped", MaxTurns: 0},
+	}}
+	caps := TurnCaps(cfg)
+	if caps["capped"] != 20 {
+		t.Errorf("capped = %d, want 20", caps["capped"])
+	}
+	if _, ok := caps["uncapped"]; ok {
+		t.Error("max_turns 0 means unlimited and must not be reported as a cap")
+	}
+}

--- a/src/internal/improve/transcripts.go
+++ b/src/internal/improve/transcripts.go
@@ -1,0 +1,201 @@
+package improve
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Hotspot is a step worth reading transcripts for, ranked by how much it costs
+// the pipeline overall.
+type Hotspot struct {
+	WorkflowID string
+	StepID     string
+	Score      float64
+}
+
+// RankHotspots orders steps by cost × (1 + fail rate) × log-ish run weight, so
+// both a cheap step that fails constantly and an expensive step that always
+// passes surface. Ranking on cost alone would hide the flaky-but-cheap steps
+// that waste the most wall-clock.
+func RankHotspots(steps []StepMetrics, limit int) []Hotspot {
+	out := make([]Hotspot, 0, len(steps))
+	for _, s := range steps {
+		if s.Runs == 0 {
+			continue
+		}
+		// Reworked/failed runs weigh double: a failure costs its own tokens and
+		// then whatever the retry costs.
+		score := s.TotalCostUSD * (1 + 2*s.FailRate)
+		// A step with no recorded cost (a runner that reports none) still matters
+		// if it fails; fall back to run count so it is not invisible.
+		if score == 0 {
+			score = float64(s.Runs) * s.FailRate
+		}
+		out = append(out, Hotspot{WorkflowID: s.WorkflowID, StepID: s.StepID, Score: score})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		if out[i].WorkflowID != out[j].WorkflowID {
+			return out[i].WorkflowID < out[j].WorkflowID
+		}
+		return out[i].StepID < out[j].StepID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// transcriptRef points at one transcript file on disk together with the outcome
+// of the run that produced it.
+type transcriptRef struct {
+	taskID  string
+	file    string
+	outcome string
+}
+
+// SampleTranscripts reads up to perHotspot transcripts for each hotspot: the
+// most recent failures first, plus one successful run as a control. The control
+// matters — an advisor shown only failures will confidently explain a difference
+// that is not there.
+//
+// Missing transcript files are skipped silently: transcripts are pruned by log
+// retention while the rows that reference them survive, so their absence is
+// normal rather than an error.
+func SampleTranscripts(ctx context.Context, db source, logDir string, w Window, hotspots []Hotspot, perHotspot, byteBudget int) ([]TranscriptExcerpt, error) {
+	if perHotspot <= 0 || len(hotspots) == 0 {
+		return nil, nil
+	}
+
+	var out []TranscriptExcerpt
+	for _, h := range hotspots {
+		refs, err := transcriptRefs(ctx, db, logDir, w, h, perHotspot)
+		if err != nil {
+			return nil, err
+		}
+		for _, ref := range refs {
+			path := filepath.Join(logDir, "transcripts", ref.taskID, ref.file)
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue // pruned by retention, or never written
+			}
+			content := elide(string(data), byteBudget)
+			out = append(out, TranscriptExcerpt{
+				WorkflowID: h.WorkflowID,
+				StepID:     h.StepID,
+				TaskID:     ref.taskID,
+				File:       ref.file,
+				Outcome:    ref.outcome,
+				Bytes:      len(data),
+				Content:    content,
+			})
+		}
+	}
+	return out, nil
+}
+
+// transcriptRefs finds the task ids whose runs of this step are worth reading:
+// the most recent failures, then one success.
+func transcriptRefs(ctx context.Context, db source, logDir string, w Window, h Hotspot, n int) ([]transcriptRef, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(te.task_id, ''), sr.state
+		FROM step_runs sr
+		JOIN workflow_instances wi ON wi.id = sr.workflow_instance_id
+		LEFT JOIN task_executions te
+		       ON te.workflow_instance_id = sr.workflow_instance_id
+		      AND te.step_id = sr.step_id
+		WHERE wi.workflow_id = ? AND sr.step_id = ?
+		  AND sr.started_at >= ? AND sr.started_at < ?
+		  AND sr.state IN ('failed', 'passed')
+		GROUP BY sr.id
+		ORDER BY CASE sr.state WHEN 'failed' THEN 0 ELSE 1 END, sr.started_at DESC`,
+		h.WorkflowID, h.StepID, w.Start, w.End)
+	if err != nil {
+		return nil, fmt.Errorf("query transcript refs: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []transcriptRef
+	failures, successes := 0, 0
+	// n-1 failures plus exactly one success, so every hotspot carries a control.
+	maxFailures := n - 1
+	if maxFailures < 1 {
+		maxFailures = 1
+	}
+
+	for rows.Next() {
+		var taskID, state string
+		if err := rows.Scan(&taskID, &state); err != nil {
+			return nil, fmt.Errorf("scan transcript ref: %w", err)
+		}
+		if taskID == "" {
+			continue
+		}
+		if state == "failed" && failures >= maxFailures {
+			continue
+		}
+		if state == "passed" && successes >= 1 {
+			continue
+		}
+		file := latestTranscriptFile(filepath.Join(logDir, "transcripts", taskID))
+		if file == "" {
+			continue
+		}
+		if state == "failed" {
+			failures++
+		} else {
+			successes++
+		}
+		refs = append(refs, transcriptRef{taskID: taskID, file: file, outcome: state})
+		if len(refs) >= n {
+			break
+		}
+	}
+	return refs, rows.Err()
+}
+
+// latestTranscriptFile returns the most recently modified .md transcript in a
+// task's transcript directory, or "" when there is none. Transcripts are written
+// per step run, and the newest is the one that matches the run being sampled.
+func latestTranscriptFile(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	var newest string
+	var newestMod int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if mod := info.ModTime().UnixNano(); mod > newestMod {
+			newestMod, newest = mod, e.Name()
+		}
+	}
+	return newest
+}
+
+// elide truncates a transcript to a byte budget, keeping the head and the tail.
+// The middle of an agent session is usually repetitive tool traffic; the setup
+// and the outcome are where the signal is.
+func elide(s string, budget int) string {
+	if budget <= 0 || len(s) <= budget {
+		return s
+	}
+	const marker = "\n\n… [middle elided] …\n\n"
+	half := (budget - len(marker)) / 2
+	if half <= 0 {
+		return s[:budget]
+	}
+	return s[:half] + marker + s[len(s)-half:]
+}


### PR DESCRIPTION
Phase 1 of #401. Closes #402.

Adds `internal/improve`: a deterministic, LLM-free evidence pack computed from the tables Apiary already writes, exposed as `apiary improve --dump-evidence`. No model is consulted, so the same database and window always produce the same pack — which also makes the whole layer testable without one.

Also lands the design docs for the epic (`openspec/changes/self-improvement-advisor/`) and the CHANGELOG entry.

## What it measures

- **Step metrics** — pass/fail/skip rates, duration p50/p95, tokens, cost, turns, tool calls, cache-reuse ratio, prompt-weight ratio, failover rate, failure-kind distribution
- **Workflow metrics** — terminal-state counts, e2e duration, cost per completed instance, and **rework loops**: a step running more than once inside one instance, which is the direct signature of an `on_fail`/`goto` cycle
- **Agent metrics** — grouped by runner *and* model, with `max_turns` saturation (runs ending exactly at the cap)
- **Waits** — poll counts and terminal status per `wait_for` step, from `ci_poll_checks`
- **Failure clusters** — error messages normalised (ids, paths, timestamps, durations, numbers stripped) so one recurring failure reads as a single line with a count
- **Dead paths** — configured workflows, agents and fallback chains with zero runs in the window
- **Parallel candidates** — adjacent sequential steps with no data dependency, computed statically and conservatively

## Three bugs the real data caught

Validating against a live 30-day database (2172 step runs, $1690) rather than only fixtures:

1. **`attempt` is not a retry count.** It is a per-task monotonic counter — [`beginExecution`](src/internal/daemon/workflow.go#L593) sets it to the task's last attempt + 1 so a task's history accumulates across steps, meaning the fifth step of a workflow carries `attempt=5` having never failed over. Counting `attempt > 1` reported **42–70% failover** where the true figure is **0–23%**. Failover is now counted from the number of execution rows per `(instance, step)`. Regression test added.
2. **`julianday()` differences land a fraction of a millisecond low**, so `CAST` truncated every duration one millisecond short. Fixed with `ROUND` before `CAST`.
3. **`LENGTH()` on TEXT counts characters and stops at an embedded NUL**, silently zeroing prompt weight. Prompt bytes now use `LENGTH(CAST(... AS BLOB))`.

## Notes

- Opens its own **read-only** connection rather than going through `db.Client`, which would run migrations against a database a running daemon may be using.
- Percentiles are computed in Go — SQLite ships no `percentile` function.
- The pack carries a stable digest over its content, excluding generation time and window bounds, so "same evidence" is recognisable across runs.
- `ParallelCandidates` is deliberately conservative: a pair is emitted only when the later step provably references nothing from the earlier one. A missed opportunity costs nothing; a false positive is a recommendation to parallelise genuinely dependent steps.

## Sample output

Against a real database:

```
2172 step runs across 8 workflows, $1690.62 total, 2026-07-08 → 2026-08-07
  implementation/implement: $837.33 over 615 runs, 2% fail
```

with `implementation/implement` showing **$267.78 of rework** across 102 instances — 23% of that workflow's spend going to loop-backs.

## Testing

`make check` green. 30 new tests: seeded-DB fixtures (isolated per test — a shared in-memory name had them contending, 3.8s → 0.48s), rate/percentile/rework assertions, failure-normalisation table, `ParallelCandidates` positive and ten negative cases, digest stability and sensitivity, duration parsing, window and scope filtering. Also verified under `-race`.

## Next

#403 (advisor agent) → #404 (patches + validation) → #405 (apply) → #406 (ledger + effect) → #407 (docs).