### PR TITLE
feat: record and surface per-step wall-clock attribution (#399)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,38 @@ apiary instances <instance-id>
 States: `pending`, `running`, `approval_waiting`, `interrupted`, `done`,
 `failed`.
 
+### `apiary profile`
+
+Show where a run's wall clock actually went — per step, plus the slowest
+individual calls across the whole run:
+
+```sh
+apiary profile <instance-id> [--json]
+```
+
+```
+STEP               TOTAL     THINK     WRITE     TOOLS     OTHER
+plan               3m0s      67%       33%       —         —
+implement          1h22m42s  6%        24%       63%       7%
+  63% with background work outstanding (overlaps the above)
+
+Slowest calls
+  9m54s      background  implement       workflow:verify  ·  run the full test suite
+  8m0s       tool        implement       Bash  ·  ./gradlew test
+```
+
+Use it before tuning a slow step: the fix for a thinking-heavy step (model or
+effort), a writing-heavy one (a tighter prompt) and a wait-heavy one (fix the
+thing being waited on) have nothing in common, and guessing wrong costs another
+full-length run to disprove.
+
+Steps recorded before this data existed, and runners that stream no events,
+report as `not measured` rather than as a breakdown of zeros. See
+[Wall-clock attribution](data-model.md#wall-clock-attribution) for what each
+bucket covers and why the background figure overlaps the others.
+
+`--json` emits the full breakdown, for the analysis this table does not do.
+
 ### `apiary task`
 
 Show a task's full workflow history — all instances, steps, and scoped logs.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -118,6 +118,13 @@ erDiagram
         INTEGER num_turns
         INTEGER num_tool_calls
         REAL cost_usd
+        INTEGER time_thinking_ms "wall-clock attribution, summed"
+        INTEGER time_writing_ms
+        INTEGER time_model_ms "latency with no thinking signal"
+        INTEGER time_tool_wait_ms
+        INTEGER time_other_ms
+        INTEGER time_background_ms "overlaps the buckets above"
+        TEXT slow_tools "JSON: slowest calls"
         TIMESTAMP started_at
         TIMESTAMP finished_at
     }
@@ -219,6 +226,45 @@ Per-step cost/usage detail is recorded in **both** layers:
 
 The cost figure originates from the harness: the CLI runner parses the model's
 streamed `total_cost_usd` and token counts — it is reported, not estimated.
+
+### Wall-clock attribution
+
+Alongside the token columns, both layers record **where a step's minutes went**.
+Agent steps routinely run 45–90 minutes, and tokens alone cannot tell you whether
+that time was thinking, writing, or waiting on a subprocess the agent launched —
+three problems with three completely different fixes.
+
+| Column | Meaning |
+|---|---|
+| `time_thinking_ms` | Model producing thinking tokens |
+| `time_writing_ms` | Model producing its visible output |
+| `time_model_ms` | Model latency with no thinking signal to split on — **un-attributed**, not a third kind of model work |
+| `time_tool_wait_ms` | Blocked on a tool call the agent made |
+| `time_other_ms` | Process spawn, prompt upload, teardown |
+| `time_background_ms` | At least one background task outstanding |
+| `slow_tools` | JSON list of the slowest individual calls |
+
+The first five are **exclusive**: every instant of wall clock is counted in
+exactly one of them, and they sum to the run's total. `time_background_ms` is
+**not** one of them — it is the union of the intervals with background work
+outstanding, and it overlaps the others by design (the model writes while a test
+suite runs), so it must never be added in.
+
+Two consequences worth knowing:
+
+- **Per-call durations in `slow_tools` overlap freely.** Parallel tool calls and
+  concurrent background tasks are each measured in full, so those durations can
+  add up to more than the step took. That is correct: the list answers "which
+  call should I go and fix", not "how was the wall clock divided".
+- **Zeros are ambiguous without checking.** Rows written before these columns
+  existed, and runners with no event stream to attribute (the API-based ones),
+  leave every bucket at zero. `apiary profile` reports those steps as *not
+  measured* rather than as a breakdown of zeros.
+
+The thinking/writing split comes from the CLI's `system:thinking_tokens` events.
+Those are emitted for some thinking and not all, and not at all by some
+providers; when the signal is missing the latency is reported as `time_model_ms`
+rather than being guessed into one bucket or the other.
 
 ### CI poll history (wait_for steps)
 

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Ativas
 
+- **step-wallclock-attribution** — Atribuição de wall-clock por step (thinking / writing / esperas de tool / tarefas em background) gravada em `task_executions` e `step_runs` ao lado das colunas de token, lista das chamadas mais lentas, payload do evento `system:task_started` no log, e comando `apiary profile <instance-id> [--json]`. GitHub issue #399.
+
 ## Arquivadas
 
 ### 2026-07-22

--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -202,6 +202,9 @@ func showInstance(id string, asJSON bool) error {
 				}
 				fmt.Printf("       %s\n", instMuted.Render(usage))
 			}
+			if line := timingSummary(s.Timing); line != "" {
+				fmt.Printf("       %s\n", instMuted.Render(line))
+			}
 		}
 	}
 	printCIPolls(detail.CIPolls)

--- a/src/internal/cli/profile.go
+++ b/src/internal/cli/profile.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/daemon"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// `apiary profile` answers "where did this run's hours go?" (issue #399).
+//
+// Agent steps here routinely run 45–90 minutes, and until the wall clock was
+// attributed the only way to find out what a long step had been doing was to
+// hand-parse the daemon log with a throwaway script. The diagnosis that motivated
+// this — a step that was 62% blocked on background tasks it had launched and only
+// 6.5% thinking — pointed at three concrete fixes; the tuning everyone assumed was
+// needed would have addressed the 6.5%.
+//
+// --json exists so the next question nobody anticipated can be answered with jq
+// instead of another log parser.
+func newProfileCmd() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "profile <instance-id>",
+		Short: "Show where a workflow run's wall clock went",
+		Long: "Break a run's wall clock down per step — thinking, writing, tool waits — " +
+			"and list the slowest individual calls, so a long step can be diagnosed " +
+			"instead of guessed at.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showProfile(args[0], asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	return cmd
+}
+
+// ProfileStep is one step's timing in the --json payload. It is a projection of
+// the instance detail rather than a new endpoint: the daemon already serves the
+// timing on the step rows, and a second source for the same numbers is a second
+// thing to keep in agreement.
+type ProfileStep struct {
+	StepID  string        `json:"step_id"`
+	AgentID string        `json:"agent_id"`
+	State   string        `json:"state"`
+	Timing  *model.Timing `json:"timing"`
+}
+
+// ProfileReport is the --json payload.
+type ProfileReport struct {
+	InstanceID string        `json:"instance_id"`
+	Workflow   string        `json:"workflow"`
+	Steps      []ProfileStep `json:"steps"`
+	Total      model.Timing  `json:"total"`
+	// SlowestCalls is the worst calls across every step, each tagged with the step
+	// it came from — the "what should I actually fix" list.
+	SlowestCalls []ProfileCall `json:"slowest_calls"`
+}
+
+// ProfileCall is one entry in the cross-step slowest-calls list.
+type ProfileCall struct {
+	StepID string `json:"step_id"`
+	model.ToolTiming
+}
+
+// profileSlowestCalls caps the cross-step list. Long enough to cover the handful
+// of calls that explain a long run, short enough to still be a shortlist.
+const profileSlowestCalls = 10
+
+func showProfile(id string, asJSON bool) error {
+	var detail daemon.InstanceDetail
+	if err := ipcGetJSON("/instances/"+url.PathEscape(id), &detail); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			fmt.Println(instErr.Render("Instance not found: ") + id)
+			os.Exit(2)
+		}
+		return daemonDownHint()
+	}
+
+	report := buildProfile(detail)
+	if asJSON {
+		line, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Println(string(line))
+		return nil
+	}
+	printProfile(detail, report)
+	return nil
+}
+
+func buildProfile(detail daemon.InstanceDetail) ProfileReport {
+	report := ProfileReport{InstanceID: detail.ID, Workflow: detail.Workflow}
+	var calls []ProfileCall
+	for _, s := range detail.Steps {
+		report.Steps = append(report.Steps, ProfileStep{
+			StepID: s.StepID, AgentID: s.AgentID, State: s.State, Timing: s.Timing,
+		})
+		if s.Timing == nil {
+			continue
+		}
+		report.Total.ThinkingMS += s.Timing.ThinkingMS
+		report.Total.WritingMS += s.Timing.WritingMS
+		report.Total.ModelMS += s.Timing.ModelMS
+		report.Total.ToolWaitMS += s.Timing.ToolWaitMS
+		report.Total.OtherMS += s.Timing.OtherMS
+		// Steps run one after another, so their background intervals cannot
+		// overlap and summing them is safe at this level.
+		report.Total.BackgroundMS += s.Timing.BackgroundMS
+		report.Total.TotalMS += s.Timing.TotalMS
+		for _, c := range s.Timing.SlowTools {
+			calls = append(calls, ProfileCall{StepID: s.StepID, ToolTiming: c})
+		}
+	}
+	sort.SliceStable(calls, func(i, j int) bool { return calls[i].DurationMS > calls[j].DurationMS })
+	if len(calls) > profileSlowestCalls {
+		calls = calls[:profileSlowestCalls]
+	}
+	report.SlowestCalls = calls
+	return report
+}
+
+func printProfile(detail daemon.InstanceDetail, report ProfileReport) {
+	cell := detail.CellID
+	if detail.Title != "" {
+		cell += " — " + detail.Title
+	}
+	fmt.Printf("%s  %s\n", instMuted.Render("Instance:"), detail.ID)
+	fmt.Printf("%s  %s\n", instMuted.Render("Workflow:"), detail.Workflow)
+	fmt.Printf("%s      %s\n\n", instMuted.Render("Cell:"), cell)
+
+	measured := 0
+	for _, s := range report.Steps {
+		if s.Timing != nil {
+			measured++
+		}
+	}
+	if measured == 0 {
+		fmt.Println(instMuted.Render("No timing recorded for this run."))
+		fmt.Println(instMuted.Render("Steps that ran before wall-clock attribution existed carry none, " +
+			"as do runners that stream no events."))
+		return
+	}
+
+	fmt.Println(instHeader.Render(fmt.Sprintf("%-18s %-9s %-9s %-9s %-9s %-9s", "STEP", "TOTAL", "THINK", "WRITE", "TOOLS", "OTHER")))
+	for _, s := range report.Steps {
+		if s.Timing == nil {
+			fmt.Printf("%-18s %s\n", truncate(s.StepID, 18), instMuted.Render("not measured"))
+			continue
+		}
+		fmt.Printf("%-18s %-9s %-9s %-9s %-9s %-9s\n",
+			truncate(s.StepID, 18),
+			durationCell(s.Timing.TotalMS),
+			shareCell(s.Timing.ThinkingMS, s.Timing.TotalMS),
+			shareCell(s.Timing.WritingMS, s.Timing.TotalMS),
+			shareCell(s.Timing.ToolWaitMS, s.Timing.TotalMS),
+			shareCell(s.Timing.OtherMS, s.Timing.TotalMS),
+		)
+		// Un-attributed model latency is called out rather than folded into
+		// thinking or writing, so the breakdown never overstates what it knows.
+		if s.Timing.ModelMS > 0 {
+			fmt.Printf("  %s\n", instMuted.Render(fmt.Sprintf("%s model latency with no thinking signal to split on",
+				shareCell(s.Timing.ModelMS, s.Timing.TotalMS))))
+		}
+		if s.Timing.BackgroundMS > 0 {
+			fmt.Printf("  %s\n", instMuted.Render(fmt.Sprintf("%s with background work outstanding (overlaps the above)",
+				shareCell(s.Timing.BackgroundMS, s.Timing.TotalMS))))
+		}
+	}
+
+	fmt.Printf("\n%-18s %-9s %-9s %-9s %-9s %-9s\n",
+		instHeader.Render("TOTAL"),
+		durationCell(report.Total.TotalMS),
+		shareCell(report.Total.ThinkingMS, report.Total.TotalMS),
+		shareCell(report.Total.WritingMS, report.Total.TotalMS),
+		shareCell(report.Total.ToolWaitMS, report.Total.TotalMS),
+		shareCell(report.Total.OtherMS, report.Total.TotalMS),
+	)
+
+	if len(report.SlowestCalls) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Println(instHeader.Render("Slowest calls"))
+	for _, c := range report.SlowestCalls {
+		kind := "tool"
+		if c.Background {
+			kind = "background"
+		}
+		line := fmt.Sprintf("  %-9s  %-10s  %-14s  %s",
+			durationCell(c.DurationMS), kind, truncate(c.StepID, 14), c.Name)
+		if c.Label != "" {
+			line += instMuted.Render("  ·  " + truncate(c.Label, 60))
+		}
+		fmt.Println(line)
+	}
+}
+
+// timingSummary renders a step's attribution as one line for `apiary instances`.
+// Empty when the step carries no timing, so an unmeasured step prints nothing
+// rather than a row of zeros.
+func timingSummary(t *model.Timing) string {
+	if t == nil || t.TotalMS == 0 {
+		return ""
+	}
+	parts := []string{
+		"think " + shareCell(t.ThinkingMS, t.TotalMS),
+		"write " + shareCell(t.WritingMS, t.TotalMS),
+		"tools " + shareCell(t.ToolWaitMS, t.TotalMS),
+	}
+	if t.ModelMS > 0 {
+		parts = append(parts, "unsplit "+shareCell(t.ModelMS, t.TotalMS))
+	}
+	if t.BackgroundMS > 0 {
+		parts = append(parts, "background "+shareCell(t.BackgroundMS, t.TotalMS))
+	}
+	return strings.Join(parts, "  ·  ")
+}
+
+// durationCell renders a millisecond count as a compact human duration.
+func durationCell(ms int64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		return d.Round(100 * time.Millisecond).String()
+	}
+	return d.Round(time.Second).String()
+}
+
+// shareCell renders a bucket as a percentage of the total. Percentages are what
+// make a breakdown actionable — "19.6 minutes writing" only means something once
+// you know it was a quarter of the step.
+func shareCell(ms, total int64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	if total <= 0 {
+		return durationCell(ms)
+	}
+	return fmt.Sprintf("%.0f%%", float64(ms)/float64(total)*100)
+}

--- a/src/internal/cli/profile_test.go
+++ b/src/internal/cli/profile_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/daemon"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func TestBuildProfileTotalsStepsAndRanksCallsAcrossThem(t *testing.T) {
+	detail := daemon.InstanceDetail{
+		InstanceSummary: daemon.InstanceSummary{ID: "wi_1", Workflow: "implement"},
+		Steps: []daemon.StepRunView{
+			{
+				StepID: "plan",
+				Timing: &model.Timing{
+					ThinkingMS: 60_000, WritingMS: 30_000, TotalMS: 90_000,
+					SlowTools: []model.ToolTiming{{Name: "Read", DurationMS: 4_000}},
+				},
+			},
+			{
+				StepID: "implement",
+				Timing: &model.Timing{
+					ThinkingMS: 10_000, WritingMS: 20_000, ToolWaitMS: 570_000,
+					BackgroundMS: 500_000, TotalMS: 600_000,
+					SlowTools: []model.ToolTiming{
+						{Name: "Bash", Label: "full suite", DurationMS: 400_000, Background: true},
+					},
+				},
+			},
+			// A step from before attribution existed, mixed in with measured ones.
+			{StepID: "review"},
+		},
+	}
+
+	got := buildProfile(detail)
+
+	if got.Total.TotalMS != 690_000 {
+		t.Errorf("Total.TotalMS = %d, want 690000", got.Total.TotalMS)
+	}
+	if got.Total.ThinkingMS != 70_000 || got.Total.ToolWaitMS != 570_000 {
+		t.Errorf("totals = %+v", got.Total)
+	}
+	if got.Total.BackgroundMS != 500_000 {
+		t.Errorf("Total.BackgroundMS = %d, want 500000", got.Total.BackgroundMS)
+	}
+	if len(got.Steps) != 3 {
+		t.Fatalf("got %d steps, want 3 (including the unmeasured one)", len(got.Steps))
+	}
+	if got.Steps[2].Timing != nil {
+		t.Error("unmeasured step should carry nil timing, not a zeroed breakdown")
+	}
+	if len(got.SlowestCalls) != 2 {
+		t.Fatalf("SlowestCalls = %+v, want 2", got.SlowestCalls)
+	}
+	// The list is what to go and fix, so the worst call leads regardless of which
+	// step it came from.
+	if got.SlowestCalls[0].StepID != "implement" || got.SlowestCalls[0].DurationMS != 400_000 {
+		t.Errorf("slowest call = %+v, want the implement step's 400s suite", got.SlowestCalls[0])
+	}
+}
+
+func TestBuildProfileHandlesARunWithNoTiming(t *testing.T) {
+	detail := daemon.InstanceDetail{
+		InstanceSummary: daemon.InstanceSummary{ID: "wi_1"},
+		Steps:           []daemon.StepRunView{{StepID: "plan"}, {StepID: "implement"}},
+	}
+	got := buildProfile(detail)
+
+	if got.Total.TotalMS != 0 {
+		t.Errorf("Total.TotalMS = %d, want 0", got.Total.TotalMS)
+	}
+	if len(got.SlowestCalls) != 0 {
+		t.Errorf("SlowestCalls = %+v, want none", got.SlowestCalls)
+	}
+}
+
+func TestTimingSummaryOmitsUnmeasuredSteps(t *testing.T) {
+	if got := timingSummary(nil); got != "" {
+		t.Errorf("timingSummary(nil) = %q, want empty", got)
+	}
+	if got := timingSummary(&model.Timing{}); got != "" {
+		t.Errorf("timingSummary(zero) = %q, want empty", got)
+	}
+}
+
+func TestTimingSummaryReportsSharesAndFlagsUnsplitLatency(t *testing.T) {
+	got := timingSummary(&model.Timing{
+		ThinkingMS: 250, WritingMS: 250, ToolWaitMS: 250, ModelMS: 250, TotalMS: 1_000,
+	})
+	for _, want := range []string{"think 25%", "write 25%", "tools 25%", "unsplit 25%"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timingSummary = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestShareCellAndDurationCell(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"zero share reads as absent, not as 0%", shareCell(0, 1_000), "—"},
+		{"share of a total", shareCell(625, 1_000), "62%"},
+		{"share with no total falls back to the duration", shareCell(5_000, 0), "5s"},
+		{"sub-minute duration", durationCell(4_500), "4.5s"},
+		{"long duration rounds to seconds", durationCell(4_920_000), "1h22m0s"},
+		{"no duration", durationCell(0), "—"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -48,6 +48,7 @@ func init() {
 		newValidateCmd(),
 		newCellsCmd(),
 		newInstancesCmd(),
+		newProfileCmd(),
 		newTaskCmd(),
 		newResumeCmd(),
 		newClearCmd(),

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -464,6 +464,12 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 	// winning attempt. Per-attempt detail stays in each task_executions row.
 	var summedUsage model.Usage
 	var anyUsage bool
+	// Wall-clock attribution accumulates the same way, so a step that burned an
+	// hour in a rate-limited attempt before failing over reports that hour rather
+	// than only the winning attempt's minutes. Attempts run strictly one after
+	// another, so adding their timings double-counts nothing.
+	var summedTiming db.StepTiming
+	var anyTiming bool
 	for i, c := range candidates {
 		last := i == len(candidates)-1
 		if !last && x.d.runnerPausedUntil(c.runnerType).After(time.Now()) {
@@ -504,6 +510,10 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 			summedUsage.NumTurns += out.Usage.NumTurns
 			summedUsage.NumToolCalls += out.Usage.NumToolCalls
 			summedUsage.CostUSD += out.Usage.CostUSD
+		}
+		if out.Timing != nil {
+			anyTiming = true
+			summedTiming.Add(db.TimingFrom(out.Timing))
 		}
 
 		// Classify the failure and either fail over or stop. A run that was
@@ -563,13 +573,18 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		u := summedUsage
 		usage = &u
 	}
+	var timing *model.Timing
+	if anyTiming {
+		t := summedTiming.ToModel()
+		timing = &t
+	}
 
 	// A malformed APIARY_SPAWN block is a step-level error so the workflow fails
 	// with a descriptive message rather than silently dropping the request. The
 	// step's memorize requests still travel — persisted knowledge should survive
 	// an unrelated spawn failure.
 	if res.SpawnError != nil {
-		return workflow.StepResult{Success: false, Output: res.Output, Usage: usage, InputPrompt: res.InputPrompt,
+		return workflow.StepResult{Success: false, Output: res.Output, Usage: usage, Timing: timing, InputPrompt: res.InputPrompt,
 			MemorizeRequests: memorizeRequests, MemorizeError: memorizeError, Err: res.SpawnError}
 	}
 
@@ -584,6 +599,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		MemorizeRequests: memorizeRequests,
 		MemorizeError:    memorizeError,
 		Usage:            usage,
+		Timing:           timing,
 		InputPrompt:      res.InputPrompt,
 		Err:              res.Error,
 	}
@@ -633,6 +649,9 @@ func (x *wfStepExecutor) finishExecution(ctx context.Context, exec *db.Execution
 		if res.Error != nil {
 			exec.ErrorMsg = res.Error.Error()
 		}
+	}
+	if res.Timing != nil {
+		exec.StepTiming = db.TimingFrom(res.Timing)
 	}
 	if res.Usage != nil {
 		exec.InputTokens = res.Usage.InputTokens

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -32,24 +32,28 @@ type InstanceSummary struct {
 
 // StepRunView is one step row in an instance detail.
 type StepRunView struct {
-	StepID              string     `json:"step_id"`
-	AgentID             string     `json:"agent_id"`
-	State               string     `json:"state"`
-	Duration            string     `json:"duration"`
-	Cached              bool       `json:"cached"`
-	Output              string     `json:"output"`
-	Summary             string     `json:"summary"`
-	InputPrompt         string     `json:"input_prompt,omitempty"`
-	InputTokens         int        `json:"input_tokens"`
-	OutputTokens        int        `json:"output_tokens"`
-	TotalTokens         int        `json:"total_tokens"`
-	CacheCreationTokens int        `json:"cache_creation_tokens"`
-	CacheReadTokens     int        `json:"cache_read_tokens"`
-	CostUSD             float64    `json:"cost_usd"`
-	NumTurns            int        `json:"num_turns"`
-	NumToolCalls        int        `json:"num_tool_calls"`
-	StartedAt           *time.Time `json:"started_at"`
-	FinishedAt          *time.Time `json:"finished_at"`
+	StepID              string  `json:"step_id"`
+	AgentID             string  `json:"agent_id"`
+	State               string  `json:"state"`
+	Duration            string  `json:"duration"`
+	Cached              bool    `json:"cached"`
+	Output              string  `json:"output"`
+	Summary             string  `json:"summary"`
+	InputPrompt         string  `json:"input_prompt,omitempty"`
+	InputTokens         int     `json:"input_tokens"`
+	OutputTokens        int     `json:"output_tokens"`
+	TotalTokens         int     `json:"total_tokens"`
+	CacheCreationTokens int     `json:"cache_creation_tokens"`
+	CacheReadTokens     int     `json:"cache_read_tokens"`
+	CostUSD             float64 `json:"cost_usd"`
+	NumTurns            int     `json:"num_turns"`
+	NumToolCalls        int     `json:"num_tool_calls"`
+	// Timing is the step's wall-clock attribution (issue #399), nil for steps
+	// recorded before it existed or run by a runner that reports none. Nil means
+	// "not measured" and must render as such, not as a breakdown of zeros.
+	Timing     *model.Timing `json:"timing,omitempty"`
+	StartedAt  *time.Time    `json:"started_at"`
+	FinishedAt *time.Time    `json:"finished_at"`
 }
 
 // CIPollView is one recorded wait_for CI poll, surfaced in instance and
@@ -366,6 +370,13 @@ func (d *Dispatcher) stepRunView(ctx context.Context, instanceID string, s db.St
 		InputPrompt: s.InputPrompt,
 		StartedAt:   s.StartedAt,
 		FinishedAt:  s.FinishedAt,
+	}
+	// Wall-clock attribution, when the step was measured. Steps recorded before it
+	// existed leave Timing nil so the caller can say "not measured" rather than
+	// present a breakdown of zeros as a finding.
+	if s.HasTiming() {
+		t := s.ToModel()
+		srv.Timing = &t
 	}
 	// Prefer the step's own usage rollup (summed across failover attempts). Fall
 	// back to the latest task_execution for rows written before step_runs carried

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -204,6 +204,9 @@ type Execution struct {
 	// failures. Persisted for diagnostic and budget-tracking use.
 	CreditExhausted bool
 	FailureKind     string
+	// StepTiming is this attempt's wall-clock attribution (issue #399). Zero for
+	// runners that report none.
+	StepTiming
 }
 
 func (c *Client) CreateExecution(ctx context.Context, taskID, agentID, title, number, taskURL, model, runner string, attempt int) (*Execution, error) {
@@ -244,13 +247,17 @@ func (c *Client) UpdateExecution(ctx context.Context, exec *Execution) error {
 		    input_tokens = ?, output_tokens = ?, total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
 		    num_turns = ?, num_tool_calls = ?, cost_usd = ?,
 		    input_prompt = ?, output_text = ?,
-		    credit_exhausted = ?, failure_kind = ?
+		    credit_exhausted = ?, failure_kind = ?,
+		    time_thinking_ms = ?, time_writing_ms = ?, time_model_ms = ?,
+		    time_tool_wait_ms = ?, time_other_ms = ?, time_background_ms = ?, slow_tools = ?
 		WHERE id = ?
 	`, exec.Status, exec.CompletedAt, exec.DurationMs, exec.ErrorMsg, exec.CanRetry, exec.NextRetryAt,
 		exec.InputTokens, exec.OutputTokens, exec.TotalTokens, exec.CacheCreationTokens, exec.CacheReadTokens,
 		exec.NumTurns, exec.NumToolCalls, exec.CostUSD,
 		nullStr(exec.InputPrompt), nullStr(exec.OutputText),
 		boolToInt(exec.CreditExhausted), nullStr(exec.FailureKind),
+		exec.ThinkingMS, exec.WritingMS, exec.ModelMS, exec.ToolWaitMS, exec.OtherMS,
+		exec.BackgroundMS, nullStr(exec.SlowTools),
 		exec.ID)
 	return err
 }

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -431,6 +431,32 @@ var migrations = []string{
 	// "aborted".
 	`ALTER TABLE task_executions ADD COLUMN credit_exhausted INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE task_executions ADD COLUMN failure_kind TEXT`,
+	// Wall-clock attribution (issue #399): where a step's minutes went, alongside
+	// the token columns above. The buckets are exclusive and sum to the run's wall
+	// clock; time_background_ms is the union of the intervals with background work
+	// outstanding and deliberately OVERLAPS them (the model writes while a suite
+	// runs), so it must never be added to the others. time_model_ms is latency that
+	// carried no thinking signal and so could not be split — un-attributed, not a
+	// third kind of model work.
+	//
+	// Fixed columns rather than one JSON blob because these roll up across a step's
+	// failover attempts by plain summation, exactly as the token columns do, and
+	// aggregate queries over them should not need JSON extraction. The slowest-call
+	// list is the variable-shape part, so that alone is JSON.
+	`ALTER TABLE task_executions ADD COLUMN time_thinking_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN time_writing_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN time_model_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN time_tool_wait_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN time_other_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN time_background_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE task_executions ADD COLUMN slow_tools TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN time_thinking_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN time_writing_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN time_model_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN time_tool_wait_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN time_other_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN time_background_ms INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE step_runs ADD COLUMN slow_tools TEXT`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/db/timing.go
+++ b/src/internal/db/timing.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"encoding/json"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// StepTiming is the persisted wall-clock attribution for a step or a single
+// runner attempt (issue #399): where the minutes went, alongside the token and
+// cost columns that already sit next to it.
+//
+// It is embedded in both Execution (one runner invocation) and StepRun (the
+// logical step, summed across that step's failover attempts), so the two carry
+// the same shape and the rollup is a plain field-wise addition — the same
+// treatment the token columns get.
+//
+// ThinkingMS, WritingMS, ModelMS, ToolWaitMS and OtherMS are exclusive: each
+// instant of wall clock lands in exactly one of them. BackgroundMS is NOT one of
+// them — it is the union of the intervals during which background work was
+// outstanding, which overlaps the others by design, so adding it in would
+// double-count. See model.Timing for how the attribution is derived.
+type StepTiming struct {
+	ThinkingMS   int64
+	WritingMS    int64
+	ModelMS      int64
+	ToolWaitMS   int64
+	OtherMS      int64
+	BackgroundMS int64
+	// SlowTools is the JSON-encoded slowest-calls list (see model.ToolTiming).
+	// Stored as JSON rather than as columns because it is a variable-length list
+	// nothing aggregates over — the buckets above are what queries sum.
+	SlowTools string
+}
+
+// TotalMS is the run's attributed wall clock: the exclusive buckets only.
+// BackgroundMS is excluded deliberately; it overlaps them.
+func (t StepTiming) TotalMS() int64 {
+	return t.ThinkingMS + t.WritingMS + t.ModelMS + t.ToolWaitMS + t.OtherMS
+}
+
+// HasTiming reports whether any wall-clock attribution was recorded. Rows written
+// before this data existed leave every bucket at zero, and callers must tell that
+// apart from a genuine measurement — a step rendered as "0% thinking" reads as a
+// finding when it actually means "not measured".
+func (t StepTiming) HasTiming() bool {
+	return t.TotalMS() > 0 || t.BackgroundMS > 0
+}
+
+// SlowToolList decodes the persisted slowest-calls list, returning nil when the
+// row carries none or the payload is unreadable. Timing data is diagnostic, so a
+// malformed blob degrades to "no detail" rather than failing the caller.
+func (t StepTiming) SlowToolList() []model.ToolTiming {
+	if t.SlowTools == "" {
+		return nil
+	}
+	var out []model.ToolTiming
+	if err := json.Unmarshal([]byte(t.SlowTools), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// TimingFrom converts a runner's reported timing into its persisted form.
+// Returns the zero value for runners that report none (the API-based runners,
+// which have no event stream to attribute).
+func TimingFrom(t *model.Timing) StepTiming {
+	if t == nil {
+		return StepTiming{}
+	}
+	out := StepTiming{
+		ThinkingMS:   t.ThinkingMS,
+		WritingMS:    t.WritingMS,
+		ModelMS:      t.ModelMS,
+		ToolWaitMS:   t.ToolWaitMS,
+		OtherMS:      t.OtherMS,
+		BackgroundMS: t.BackgroundMS,
+	}
+	if len(t.SlowTools) > 0 {
+		if raw, err := json.Marshal(t.SlowTools); err == nil {
+			out.SlowTools = string(raw)
+		}
+	}
+	return out
+}
+
+// ToModel converts a persisted rollup back into the runner-facing shape, so a
+// step-level total can travel the same path a single run's timing does. TotalMS
+// is recomputed rather than stored — it is always the sum of the exclusive
+// buckets, and deriving it removes any chance of a row whose total disagrees with
+// its own parts.
+func (t StepTiming) ToModel() model.Timing {
+	return model.Timing{
+		ThinkingMS:   t.ThinkingMS,
+		WritingMS:    t.WritingMS,
+		ModelMS:      t.ModelMS,
+		ToolWaitMS:   t.ToolWaitMS,
+		OtherMS:      t.OtherMS,
+		BackgroundMS: t.BackgroundMS,
+		TotalMS:      t.TotalMS(),
+		SlowTools:    t.SlowToolList(),
+	}
+}
+
+// Add folds one attempt's timing into a step-level rollup, mirroring how the
+// token columns are summed across a step's failover attempts. The slowest-call
+// lists are merged and re-ranked so the step reports the worst calls across every
+// attempt, not just the winning one — a step that burned an hour in a failed
+// attempt should say so.
+func (t *StepTiming) Add(other StepTiming) {
+	t.ThinkingMS += other.ThinkingMS
+	t.WritingMS += other.WritingMS
+	t.ModelMS += other.ModelMS
+	t.ToolWaitMS += other.ToolWaitMS
+	t.OtherMS += other.OtherMS
+	// Attempts run one after another, never concurrently, so their background
+	// intervals cannot overlap and summing is safe here (unlike within one run,
+	// where the union is taken).
+	t.BackgroundMS += other.BackgroundMS
+
+	merged := append(t.SlowToolList(), other.SlowToolList()...)
+	if len(merged) == 0 {
+		return
+	}
+	for i := 1; i < len(merged); i++ {
+		entry := merged[i]
+		j := i - 1
+		for j >= 0 && merged[j].DurationMS < entry.DurationMS {
+			merged[j+1] = merged[j]
+			j--
+		}
+		merged[j+1] = entry
+	}
+	if len(merged) > maxPersistedSlowTools {
+		merged = merged[:maxPersistedSlowTools]
+	}
+	if raw, err := json.Marshal(merged); err == nil {
+		t.SlowTools = string(raw)
+	}
+}
+
+// maxPersistedSlowTools bounds the rolled-up list so a step with many failover
+// attempts cannot grow an unbounded blob in the row.
+const maxPersistedSlowTools = 5

--- a/src/internal/db/timing_test.go
+++ b/src/internal/db/timing_test.go
@@ -1,0 +1,141 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func sampleTiming() *model.Timing {
+	return &model.Timing{
+		ThinkingMS:   5_000,
+		WritingMS:    20_000,
+		ModelMS:      1_000,
+		ToolWaitMS:   60_000,
+		OtherMS:      2_000,
+		BackgroundMS: 45_000,
+		SlowTools: []model.ToolTiming{
+			{Name: "Bash", Label: "go test ./...", DurationMS: 40_000},
+			{Name: "workflow:verify", Label: "full suite", DurationMS: 30_000, Background: true},
+		},
+	}
+}
+
+func TestStepTimingRoundTripsThroughAStepRun(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	inst := &WorkflowInstance{ID: "wi_1", WorkflowID: "wf", State: InstanceStateRunning}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	sr := &StepRun{
+		ID: "sr_1", WorkflowInstanceID: "wi_1", StepID: "implement",
+		State: StepStatePassed, StepTiming: TimingFrom(sampleTiming()),
+	}
+	if err := c.CreateStepRun(ctx, sr); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+
+	runs, err := c.ListStepRuns(ctx, "wi_1")
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("got %d step runs, want 1", len(runs))
+	}
+	got := runs[0].StepTiming
+
+	if got.ThinkingMS != 5_000 || got.WritingMS != 20_000 || got.ToolWaitMS != 60_000 {
+		t.Errorf("buckets did not round-trip: %+v", got)
+	}
+	if got.BackgroundMS != 45_000 {
+		t.Errorf("BackgroundMS = %d, want 45000", got.BackgroundMS)
+	}
+	if got.TotalMS() != 88_000 {
+		t.Errorf("TotalMS = %d, want 88000 (exclusive buckets only, no background)", got.TotalMS())
+	}
+	tools := got.SlowToolList()
+	if len(tools) != 2 || tools[0].Name != "Bash" || !tools[1].Background {
+		t.Errorf("slow tools did not round-trip: %+v", tools)
+	}
+}
+
+// A step run written before this data existed must be distinguishable from one
+// that was measured and genuinely spent no time — otherwise the UI renders "0%
+// thinking" for a step nobody measured, which reads as a finding.
+func TestStepTimingReportsWhetherItWasMeasured(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	inst := &WorkflowInstance{ID: "wi_1", WorkflowID: "wf", State: InstanceStateRunning}
+	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	sr := &StepRun{ID: "sr_1", WorkflowInstanceID: "wi_1", StepID: "implement", State: StepStatePassed}
+	if err := c.CreateStepRun(ctx, sr); err != nil {
+		t.Fatalf("create step run: %v", err)
+	}
+
+	runs, err := c.ListStepRuns(ctx, "wi_1")
+	if err != nil {
+		t.Fatalf("list step runs: %v", err)
+	}
+	if runs[0].HasTiming() {
+		t.Error("HasTiming() = true for a row with no timing recorded")
+	}
+	if got := TimingFrom(sampleTiming()); !got.HasTiming() {
+		t.Error("HasTiming() = false for a measured row")
+	}
+}
+
+func TestStepTimingAddSumsAttemptsAndKeepsTheWorstCalls(t *testing.T) {
+	first := TimingFrom(&model.Timing{
+		ThinkingMS: 1_000, ToolWaitMS: 10_000, BackgroundMS: 5_000,
+		SlowTools: []model.ToolTiming{{Name: "Bash", Label: "suite", DurationMS: 9_000}},
+	})
+	second := TimingFrom(&model.Timing{
+		ThinkingMS: 2_000, ToolWaitMS: 30_000, BackgroundMS: 7_000,
+		SlowTools: []model.ToolTiming{{Name: "Bash", Label: "slower suite", DurationMS: 25_000}},
+	})
+	first.Add(second)
+
+	if first.ThinkingMS != 3_000 || first.ToolWaitMS != 40_000 {
+		t.Errorf("buckets = %+v, want summed across attempts", first)
+	}
+	// Attempts are sequential, so their background intervals cannot overlap.
+	if first.BackgroundMS != 12_000 {
+		t.Errorf("BackgroundMS = %d, want 12000", first.BackgroundMS)
+	}
+	tools := first.SlowToolList()
+	if len(tools) != 2 {
+		t.Fatalf("slow tools = %+v, want both attempts' calls", tools)
+	}
+	// The failed attempt's 25s call is the worst thing that happened to this step,
+	// so it must lead — reporting only the winning attempt would hide it.
+	if tools[0].DurationMS != 25_000 {
+		t.Errorf("slow tools not re-ranked across attempts: %+v", tools)
+	}
+}
+
+func TestStepTimingAddBoundsThePersistedList(t *testing.T) {
+	var total StepTiming
+	for i := 0; i < maxPersistedSlowTools+4; i++ {
+		total.Add(TimingFrom(&model.Timing{
+			SlowTools: []model.ToolTiming{{Name: "Bash", DurationMS: int64(1_000 * (i + 1))}},
+		}))
+	}
+	if got := len(total.SlowToolList()); got != maxPersistedSlowTools {
+		t.Errorf("kept %d entries after many attempts, want %d", got, maxPersistedSlowTools)
+	}
+}
+
+// Timing is diagnostic: an unreadable blob must degrade to "no detail" rather
+// than propagate an error into a caller that only wanted to render a row.
+func TestStepTimingToleratesAnUnreadableBlob(t *testing.T) {
+	timing := StepTiming{SlowTools: "{not json"}
+	if got := timing.SlowToolList(); got != nil {
+		t.Errorf("SlowToolList = %+v, want nil", got)
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -86,8 +86,11 @@ type StepRun struct {
 	NumTurns            int
 	NumToolCalls        int
 	CostUSD             float64
-	StartedAt           *time.Time
-	FinishedAt          *time.Time
+	// StepTiming is the wall-clock attribution rollup, summed across the step's
+	// failover attempts alongside the token columns above (issue #399).
+	StepTiming
+	StartedAt  *time.Time
+	FinishedAt *time.Time
 }
 
 // CreateWorkflowInstance inserts a new workflow instance. The caller supplies
@@ -529,14 +532,17 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 		   summary, exit_code, skipped_cached, publish_payload, publish_state, spawned_task_id,
 		   input_prompt, input_tokens, output_tokens, total_tokens,
 		   cache_creation_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd,
+		   time_thinking_ms, time_writing_ms, time_model_ms, time_tool_wait_ms,
+		   time_other_ms, time_background_ms, slow_tools,
 		   started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
 		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
-		sr.CostUSD, sr.StartedAt, sr.FinishedAt)
+		sr.CostUSD, sr.ThinkingMS, sr.WritingMS, sr.ModelMS, sr.ToolWaitMS, sr.OtherMS,
+		sr.BackgroundMS, nullStr(sr.SlowTools), sr.StartedAt, sr.FinishedAt)
 	if err == nil {
 		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
 	}
@@ -555,13 +561,16 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		    spawned_task_id = ?, input_prompt = ?, input_tokens = ?, output_tokens = ?,
 		    total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
 		    num_turns = ?, num_tool_calls = ?, cost_usd = ?,
+		    time_thinking_ms = ?, time_writing_ms = ?, time_model_ms = ?,
+		    time_tool_wait_ms = ?, time_other_ms = ?, time_background_ms = ?, slow_tools = ?,
 		    started_at = ?, finished_at = ?
 		WHERE id = ?
 	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
 		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
-		sr.CostUSD, sr.StartedAt, sr.FinishedAt, sr.ID)
+		sr.CostUSD, sr.ThinkingMS, sr.WritingMS, sr.ModelMS, sr.ToolWaitMS, sr.OtherMS,
+		sr.BackgroundMS, nullStr(sr.SlowTools), sr.StartedAt, sr.FinishedAt, sr.ID)
 	if err == nil && previous != sr.State {
 		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
 	}
@@ -649,6 +658,9 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 		       COALESCE(input_tokens,0), COALESCE(output_tokens,0), COALESCE(total_tokens,0),
 		       COALESCE(cache_creation_tokens,0), COALESCE(cache_read_tokens,0),
 		       COALESCE(num_turns,0), COALESCE(num_tool_calls,0), COALESCE(cost_usd,0.0),
+		       COALESCE(time_thinking_ms,0), COALESCE(time_writing_ms,0), COALESCE(time_model_ms,0),
+		       COALESCE(time_tool_wait_ms,0), COALESCE(time_other_ms,0),
+		       COALESCE(time_background_ms,0), COALESCE(slow_tools,''),
 		       started_at, finished_at
 		FROM step_runs WHERE workflow_instance_id = ? ORDER BY rowid ASC
 	`, instanceID)
@@ -665,7 +677,9 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.InputPrompt,
 			&sr.InputTokens, &sr.OutputTokens, &sr.TotalTokens,
 			&sr.CacheCreationTokens, &sr.CacheReadTokens, &sr.NumTurns, &sr.NumToolCalls,
-			&sr.CostUSD, &sr.StartedAt, &sr.FinishedAt); err != nil {
+			&sr.CostUSD, &sr.ThinkingMS, &sr.WritingMS, &sr.ModelMS, &sr.ToolWaitMS,
+			&sr.OtherMS, &sr.BackgroundMS, &sr.SlowTools,
+			&sr.StartedAt, &sr.FinishedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, sr)

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -97,15 +97,17 @@ type Timing struct {
 
 // ToolTiming is one entry in Timing.SlowTools: how long a single call took, and
 // enough of a handle to recognise which call it was.
+// The JSON tags are a storage and wire format: entries are persisted as a blob on
+// the step row and served over the daemon's IPC API, so the names are stable.
 type ToolTiming struct {
-	Name  string
-	Label string
+	Name  string `json:"name"`
+	Label string `json:"label,omitempty"`
 	// DurationMS is the call's own wall clock. For background tasks it is the
 	// task's self-reported duration when it provides one.
-	DurationMS int64
+	DurationMS int64 `json:"duration_ms"`
 	// Background marks a task the agent launched in the background rather than a
 	// foreground tool call it blocked on.
-	Background bool
+	Background bool `json:"background,omitempty"`
 }
 
 // FailureKind classifies why a runner invocation failed to produce useful work.

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -67,6 +67,47 @@ type Usage struct {
 	CostUSD             float64
 }
 
+// Timing is the wall-clock attribution for one runner invocation: where the step's
+// minutes actually went, alongside the tokens Usage already records. Populated by
+// runners that stream provider events (the CLI runners); nil elsewhere.
+//
+// ThinkingMS, WritingMS, ModelMS, ToolWaitMS and OtherMS are exclusive — each
+// instant of wall clock is counted in exactly one of them, and they sum to
+// TotalMS. BackgroundMS is NOT part of that sum: it is the union of the intervals
+// during which at least one background task was live, which overlaps the others by
+// design (the model may be writing while a test suite runs).
+//
+// ModelMS is model latency that carried no thinking signal and so could not be
+// split into thinking vs writing — it is un-attributed time, not a third kind of
+// model work. Callers should show it as such rather than folding it into either.
+type Timing struct {
+	ThinkingMS   int64
+	WritingMS    int64
+	ModelMS      int64
+	ToolWaitMS   int64
+	OtherMS      int64
+	BackgroundMS int64
+	TotalMS      int64
+	// SlowTools is the handful of slowest individual calls — foreground tool calls
+	// and background tasks alike — ordered slowest first. Durations here overlap
+	// each other freely: parallel tool calls and concurrent background tasks are
+	// each measured in full.
+	SlowTools []ToolTiming
+}
+
+// ToolTiming is one entry in Timing.SlowTools: how long a single call took, and
+// enough of a handle to recognise which call it was.
+type ToolTiming struct {
+	Name  string
+	Label string
+	// DurationMS is the call's own wall clock. For background tasks it is the
+	// task's self-reported duration when it provides one.
+	DurationMS int64
+	// Background marks a task the agent launched in the background rather than a
+	// foreground tool call it blocked on.
+	Background bool
+}
+
 // FailureKind classifies why a runner invocation failed to produce useful work.
 type FailureKind int
 
@@ -99,7 +140,8 @@ type RunResult struct {
 	Logs     []LogEntry
 	Duration time.Duration
 	Error    error
-	Usage    *Usage // populated by runners that support usage reporting
+	Usage    *Usage  // populated by runners that support usage reporting
+	Timing   *Timing // wall-clock attribution; nil for runners that don't stream events
 
 	// InputPrompt is the full composed prompt the runner sent to the agent (system
 	// prepend + cell details + system append, exactly as buildPrompt assembled it).

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -302,6 +302,11 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		// goroutine).
 		rateLimited       bool
 		rateLimitResetsAt int64
+		// timing attributes the run's wall clock across thinking/writing/tool waits
+		// from the same stream events the usage accumulator reads (issue #399). Its
+		// timeline opens at `start` so process spawn and prompt upload — the gap
+		// before the first event — are accounted for instead of vanishing.
+		timing = newTimingTracker(start, time.Now)
 	)
 
 	emit := func(level, msg string) {
@@ -379,6 +384,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 				mu.Unlock()
 			}
 			accumulateStreamUsage(line, &usage)
+			timing.Feed(line)
 			if pretty, ok := formatStreamLine(line); ok {
 				emit("debug", pretty)
 			} else {
@@ -419,6 +425,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		Logs:        logs,
 		Duration:    time.Since(start),
 		Usage:       usagePtr,
+		Timing:      timing.Finish(time.Now()),
 		InputPrompt: prompt,
 		RateLimited: rateLimited,
 	}
@@ -630,6 +637,9 @@ func formatStreamLine(line string) (string, bool) {
 		if label == "" {
 			label = "system"
 		}
+		if detail := systemDetail(trimmed); detail != "" {
+			return fmt.Sprintf("[system:%s] %s", label, detail), true
+		}
 		if ev.Model != "" {
 			return fmt.Sprintf("[system:%s] model=%s", label, ev.Model), true
 		}
@@ -692,6 +702,49 @@ func formatStreamLine(line string) (string, bool) {
 		return out, true
 	}
 	return "", false
+}
+
+// systemDetail renders the payload of a background-task bookend into the log line,
+// returning "" for system events that carry nothing worth naming.
+//
+// Background tasks are the single largest wall-clock sink in a long agent step
+// (issue #399), and until now `[system:task_started]` was logged with no payload at
+// all — so the most expensive thing in a run was the one thing you could not
+// identify from the log. Working out what those waits had been meant correlating
+// their durations against build logs the agent happened to leave in /tmp.
+//
+// Only the identifying fields are rendered. The event also carries the subagent's
+// full `prompt`, which is a whole task description and would bury the log; it stays
+// in the transcript, where there is room for it.
+func systemDetail(line string) string {
+	var ev timingEvent
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		return ""
+	}
+	var parts []string
+	switch ev.Subtype {
+	case "task_started":
+		parts = append(parts, backgroundName(ev))
+		if d := toolLabel(ev.Description); d != "" {
+			parts = append(parts, d)
+		}
+	case "task_notification":
+		status := ev.Status
+		if status == "" {
+			status = "settled"
+		}
+		parts = append(parts, status)
+		if ev.Usage != nil && ev.Usage.DurationMs > 0 {
+			parts = append(parts, "duration="+
+				(time.Duration(ev.Usage.DurationMs)*time.Millisecond).Round(time.Second).String())
+		}
+	default:
+		return ""
+	}
+	if ev.TaskID != "" {
+		parts = append(parts, "task="+ev.TaskID)
+	}
+	return strings.Join(parts, " · ")
 }
 
 func finalResultText(line string) (string, bool) {

--- a/src/internal/runner/execution/timing.go
+++ b/src/internal/runner/execution/timing.go
@@ -1,0 +1,384 @@
+package execution
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// Wall-clock attribution for a CLI run (issue #399).
+//
+// step_runs already records tokens, cost, turns and tool-call counts — everything
+// except where the wall clock actually went. A step that takes 80 minutes gives no
+// hint whether the model was thinking, writing, or blocked on a subprocess it
+// launched, and the three have completely different fixes (effort/model, prompt
+// size, and fixing the thing being waited on respectively). This tracker folds the
+// provider's stream-json events into that breakdown as they are scanned, using
+// data the runner already parses and throws away.
+//
+// # How the attribution works
+//
+// The CLIs emit COMPLETE-message events (`assistant`, `user`, `result`), not token
+// deltas, so there is no direct "model started writing" signal. What we have is the
+// arrival time of each event, and the tracker attributes the gap between two
+// consecutive events to whatever was outstanding when the gap opened:
+//
+//   - Any foreground tool call open (an `assistant` message emitted `tool_use`
+//     blocks whose `tool_result`s have not all come back) → tool wait.
+//   - Otherwise the model is the only thing that can be busy → model latency,
+//     split into thinking vs writing by the `system:thinking_tokens` events the
+//     CLI emits while a thinking block is streaming (see splitting note below).
+//   - The head and tail of the run — process spawn before the first event, and
+//     teardown after the last — land in Other, so the buckets sum to roughly the
+//     run's wall clock rather than to "time we happened to understand".
+//
+// # Overlap is real, so buckets are a timeline, not a sum of durations
+//
+// One `assistant` message can carry several `tool_use` blocks that run
+// concurrently, and a background task keeps running while the model writes. Summing
+// per-tool durations would therefore exceed the run's wall clock and produce
+// percentages over 100%. The buckets above are exclusive — each instant of wall
+// clock is counted once, in exactly one bucket — while per-call durations are
+// reported separately in SlowTools, where overlap is expected and fine.
+//
+// BackgroundMS is deliberately the one non-exclusive figure: it is the union of
+// the intervals where at least one background task was live, and it overlaps the
+// exclusive buckets by design (the model may well be writing while a test suite
+// runs). It answers "how much of this step had background work outstanding",
+// which is not the same question as "what was the step waiting on".
+//
+// # Thinking vs writing is a heuristic
+//
+// `system:thinking_tokens` is documented by the CLI as a live estimate emitted
+// during the redacted-thinking phase, so it is present for some thinking and absent
+// for other thinking, and entirely absent on providers that do not emit it (the
+// Cursor CLI). Rather than silently splitting a gap 0/100 when the signal is
+// missing, unsplittable model latency is reported as ModelMS and the caller
+// displays it as un-attributed. Thinking/Writing are only ever populated from a
+// real signal.
+type timingTracker struct {
+	mu  sync.Mutex
+	now func() time.Time
+
+	// last is the timestamp of the most recently observed event; the gap between
+	// it and the next event is what gets attributed.
+	last time.Time
+	// lastWasThinking records whether the event that closed the previous gap was a
+	// thinking_tokens frame, which is what lets the next gap count as writing.
+	lastWasThinking bool
+
+	thinking, writing, model, toolWait, other time.Duration
+
+	openTools map[string]*openCall
+	openTasks map[string]*openCall
+	// bg holds the closed intervals during which at least one background task was
+	// live, in arrival order; overlapping entries are merged when reported.
+	bg []interval
+	// finished records completed calls (foreground tools and background tasks)
+	// for the slowest-N report.
+	finished []model.ToolTiming
+}
+
+type openCall struct {
+	name    string
+	label   string
+	started time.Time
+	// background distinguishes a task_started bookend from a foreground tool call,
+	// so the slowest-N list can say which of the two a long entry was.
+	background bool
+}
+
+type interval struct{ start, end time.Time }
+
+// maxSlowTools caps how many of the slowest calls are kept. Five was enough to
+// explain two thirds of the 82-minute step in issue #399; the point is to name the
+// handful of calls worth acting on, not to mirror the whole transcript.
+const maxSlowTools = 5
+
+// slowToolMinDuration filters out the noise floor. Sub-second calls can never be
+// the reason a step took 80 minutes, and letting them into the list on a fast step
+// would push out the entries that matter.
+const slowToolMinDuration = time.Second
+
+// newTimingTracker starts a tracker whose timeline opens at start — the moment the
+// runner spawned the provider process, so the gap before the first stream event
+// (process spawn, prompt upload, connection setup) is accounted for rather than
+// silently dropped.
+func newTimingTracker(start time.Time, now func() time.Time) *timingTracker {
+	if now == nil {
+		now = time.Now
+	}
+	return &timingTracker{
+		now:       now,
+		last:      start,
+		openTools: map[string]*openCall{},
+		openTasks: map[string]*openCall{},
+	}
+}
+
+// timingEvent decodes the stream-json fields the tracker needs. It is deliberately
+// separate from streamEvent and transcriptEvent: those decode content for usage
+// totals and for rendering, while this one needs the tool_use/tool_result
+// correlation ids and the background-task bookend payloads that neither of them
+// looks at.
+type timingEvent struct {
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	Message struct {
+		Content []struct {
+			Type      string          `json:"type"`
+			Name      string          `json:"name"`
+			ID        string          `json:"id"`
+			Input     json.RawMessage `json:"input"`
+			ToolUseID string          `json:"tool_use_id"`
+		} `json:"content"`
+	} `json:"message"`
+
+	// Background-task bookends. The CLI emits system:task_started when the agent
+	// launches background work (a Task-tool subagent, a workflow) and
+	// system:task_notification when it settles, correlated by task_id.
+	TaskID       string `json:"task_id"`
+	Description  string `json:"description"`
+	TaskType     string `json:"task_type"`
+	SubagentType string `json:"subagent_type"`
+	WorkflowName string `json:"workflow_name"`
+	Status       string `json:"status"`
+	// Usage rides on task_notification and carries the task's own measured
+	// duration, which is more accurate than our arrival-time delta.
+	Usage *struct {
+		DurationMs int64 `json:"duration_ms"`
+	} `json:"usage"`
+}
+
+// Feed consumes one raw provider stdout line, attributing the wall clock since the
+// previous event. Safe for concurrent use; the CliRunner calls it from the stdout
+// scanning goroutine.
+func (t *timingTracker) Feed(line string) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return
+	}
+	var ev timingEvent
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil || ev.Type == "" {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	at := t.now()
+	isThinking := ev.Type == "system" && ev.Subtype == "thinking_tokens"
+	t.attribute(at, isThinking)
+
+	switch ev.Type {
+	case "assistant":
+		for _, c := range ev.Message.Content {
+			if c.Type != "tool_use" || c.ID == "" {
+				continue
+			}
+			t.openTools[c.ID] = &openCall{
+				name:    c.Name,
+				label:   toolLabel(truncateInput(c.Input)),
+				started: at,
+			}
+		}
+	case "user":
+		for _, c := range ev.Message.Content {
+			if c.Type != "tool_result" || c.ToolUseID == "" {
+				continue
+			}
+			if call, ok := t.openTools[c.ToolUseID]; ok {
+				delete(t.openTools, c.ToolUseID)
+				t.record(call, at.Sub(call.started))
+			}
+		}
+	case "system":
+		switch ev.Subtype {
+		case "task_started":
+			if ev.TaskID == "" {
+				break
+			}
+			t.openTasks[ev.TaskID] = &openCall{
+				name:       backgroundName(ev),
+				label:      toolLabel(ev.Description),
+				started:    at,
+				background: true,
+			}
+		case "task_notification":
+			call, ok := t.openTasks[ev.TaskID]
+			if !ok {
+				break
+			}
+			delete(t.openTasks, ev.TaskID)
+			t.bg = append(t.bg, interval{start: call.started, end: at})
+			// Prefer the task's self-reported duration: our bookends are bounded by
+			// when the CLI got round to emitting them, the task's own measurement is
+			// not.
+			d := at.Sub(call.started)
+			if ev.Usage != nil && ev.Usage.DurationMs > 0 {
+				d = time.Duration(ev.Usage.DurationMs) * time.Millisecond
+			}
+			if ev.Status != "" && ev.Status != "completed" {
+				call.label = strings.TrimSpace(call.label + " (" + ev.Status + ")")
+			}
+			t.record(call, d)
+		}
+	}
+}
+
+// attribute charges the wall clock since the previous event to the right bucket.
+// endsThinking marks that the event closing this gap is a thinking_tokens frame,
+// which means the model spent the gap producing thinking tokens.
+func (t *timingTracker) attribute(at time.Time, endsThinking bool) {
+	gap := at.Sub(t.last)
+	t.last = at
+	wasThinking := t.lastWasThinking
+	t.lastWasThinking = endsThinking
+	if gap <= 0 {
+		return
+	}
+	switch {
+	case len(t.openTools) > 0:
+		// A tool call is outstanding, so nothing else can be the reason we waited.
+		t.toolWait += gap
+	case endsThinking:
+		// The gap ended with the model reporting thinking-token progress, so it was
+		// spent thinking.
+		t.thinking += gap
+	case wasThinking:
+		// Thinking was streaming and has now stopped: the model is producing its
+		// visible output.
+		t.writing += gap
+	default:
+		// No thinking signal either side of the gap — model latency we cannot split.
+		t.model += gap
+	}
+}
+
+func (t *timingTracker) record(call *openCall, d time.Duration) {
+	if d < slowToolMinDuration {
+		return
+	}
+	t.finished = append(t.finished, model.ToolTiming{
+		Name:       call.name,
+		Label:      call.label,
+		DurationMS: d.Milliseconds(),
+		Background: call.background,
+	})
+}
+
+// Finish closes the timeline at end (the moment the provider process exited),
+// charging the tail to Other and closing any call still outstanding — a run that
+// was killed mid-tool should still report what it was stuck on. It returns nil when
+// the stream carried nothing attributable, so runners that emit no usable events
+// record no timing rather than a misleading all-Other row.
+func (t *timingTracker) Finish(end time.Time) *model.Timing {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if gap := end.Sub(t.last); gap > 0 {
+		// Whatever is still open was open when the process exited; the tail is
+		// teardown, not a wait on a tool that will never answer.
+		t.other += gap
+		t.last = end
+	}
+	for id, call := range t.openTools {
+		delete(t.openTools, id)
+		t.record(call, end.Sub(call.started))
+	}
+	for id, call := range t.openTasks {
+		delete(t.openTasks, id)
+		t.bg = append(t.bg, interval{start: call.started, end: end})
+		t.record(call, end.Sub(call.started))
+	}
+
+	out := model.Timing{
+		ThinkingMS:   t.thinking.Milliseconds(),
+		WritingMS:    t.writing.Milliseconds(),
+		ModelMS:      t.model.Milliseconds(),
+		ToolWaitMS:   t.toolWait.Milliseconds(),
+		OtherMS:      t.other.Milliseconds(),
+		BackgroundMS: mergedDuration(t.bg).Milliseconds(),
+		SlowTools:    t.slowest(),
+	}
+	out.TotalMS = out.ThinkingMS + out.WritingMS + out.ModelMS + out.ToolWaitMS + out.OtherMS
+	if out.TotalMS == 0 && len(out.SlowTools) == 0 {
+		return nil
+	}
+	return &out
+}
+
+func (t *timingTracker) slowest() []model.ToolTiming {
+	if len(t.finished) == 0 {
+		return nil
+	}
+	out := make([]model.ToolTiming, len(t.finished))
+	copy(out, t.finished)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].DurationMS > out[j].DurationMS })
+	if len(out) > maxSlowTools {
+		out = out[:maxSlowTools]
+	}
+	return out
+}
+
+// mergedDuration returns the total wall clock covered by the union of the
+// intervals. Background tasks routinely overlap each other, so adding their
+// durations would double-count time during which two suites ran side by side.
+func mergedDuration(in []interval) time.Duration {
+	if len(in) == 0 {
+		return 0
+	}
+	ordered := make([]interval, len(in))
+	copy(ordered, in)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].start.Before(ordered[j].start) })
+	var total time.Duration
+	cur := ordered[0]
+	for _, iv := range ordered[1:] {
+		if iv.start.After(cur.end) {
+			total += cur.end.Sub(cur.start)
+			cur = iv
+			continue
+		}
+		if iv.end.After(cur.end) {
+			cur.end = iv.end
+		}
+	}
+	total += cur.end.Sub(cur.start)
+	return total
+}
+
+// backgroundName labels a background task by what it actually is, preferring the
+// most specific identifier the payload carries: the workflow's name, then the
+// subagent type, then the generic task type.
+func backgroundName(ev timingEvent) string {
+	switch {
+	case ev.WorkflowName != "":
+		return "workflow:" + ev.WorkflowName
+	case ev.SubagentType != "":
+		return "agent:" + ev.SubagentType
+	case ev.TaskType != "":
+		return "task:" + ev.TaskType
+	}
+	return "task"
+}
+
+// toolLabelLimit keeps labels short enough to sit in a terminal table cell. The
+// full tool input is already in the task log and the transcript; this is a
+// recognisable handle, not a record.
+const toolLabelLimit = 120
+
+// toolLabel trims a tool input or task description down to a display handle,
+// stripping bearer tokens on the way through — labels are persisted and rendered,
+// and agents routinely export credentials in Bash calls.
+func toolLabel(s string) string {
+	s = strings.TrimSpace(jwtPattern.ReplaceAllString(s, "«redacted-jwt»"))
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > toolLabelLimit {
+		return s[:toolLabelLimit] + "…"
+	}
+	return s
+}

--- a/src/internal/runner/execution/timing_test.go
+++ b/src/internal/runner/execution/timing_test.go
@@ -1,0 +1,339 @@
+package execution
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeClock advances by a fixed step each time it is read, so a test can express
+// "this event arrived N seconds after the last one" by feeding lines through a
+// clock it drives explicitly.
+type fakeClock struct {
+	at time.Time
+}
+
+func (c *fakeClock) now() time.Time { return c.at }
+
+func (c *fakeClock) advance(d time.Duration) { c.at = c.at.Add(d) }
+
+// feed drives lines through the tracker, advancing the clock by the paired gap
+// BEFORE each line — i.e. gaps[i] is how long the run waited for lines[i].
+func feed(t *testing.T, tr *timingTracker, c *fakeClock, gaps []time.Duration, lines []string) {
+	t.Helper()
+	if len(gaps) != len(lines) {
+		t.Fatalf("test bug: %d gaps for %d lines", len(gaps), len(lines))
+	}
+	for i, line := range lines {
+		c.advance(gaps[i])
+		tr.Feed(line)
+	}
+}
+
+func newTestTracker() (*timingTracker, *fakeClock) {
+	c := &fakeClock{at: time.Date(2026, 8, 7, 12, 0, 0, 0, time.UTC)}
+	return newTimingTracker(c.at, c.now), c
+}
+
+func toolUse(id, name, input string) string {
+	return fmt.Sprintf(`{"type":"assistant","message":{"content":[{"type":"tool_use","id":%q,"name":%q,"input":%s}]}}`, id, name, input)
+}
+
+func toolResult(id string) string {
+	return fmt.Sprintf(`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":%q,"content":"ok"}]}}`, id)
+}
+
+const (
+	assistantText  = `{"type":"assistant","message":{"content":[{"type":"text","text":"working on it"}]}}`
+	thinkingTokens = `{"type":"system","subtype":"thinking_tokens","estimated_tokens":120,"estimated_tokens_delta":40}`
+)
+
+func TestTimingAttributesToolWaitToTheOpenCall(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{2 * time.Second, 30 * time.Second},
+		[]string{toolUse("t1", "Bash", `{"command":"go test ./..."}`), toolResult("t1")},
+	)
+	got := tr.Finish(c.at)
+
+	if got == nil {
+		t.Fatal("expected timing")
+	}
+	if got.ToolWaitMS != 30_000 {
+		t.Errorf("ToolWaitMS = %d, want 30000", got.ToolWaitMS)
+	}
+	// The 2s before the tool call is the model deciding to make it, and there was no
+	// thinking signal, so it is un-attributed model latency rather than writing.
+	if got.ModelMS != 2_000 {
+		t.Errorf("ModelMS = %d, want 2000", got.ModelMS)
+	}
+	if len(got.SlowTools) != 1 {
+		t.Fatalf("SlowTools = %+v, want 1 entry", got.SlowTools)
+	}
+	if got.SlowTools[0].Name != "Bash" || got.SlowTools[0].DurationMS != 30_000 {
+		t.Errorf("slow tool = %+v", got.SlowTools[0])
+	}
+	if got.SlowTools[0].Background {
+		t.Error("foreground tool call marked as background")
+	}
+}
+
+// Parallel tool calls overlap, so their individual durations must each be recorded
+// in full while the exclusive wall-clock bucket counts the overlap only once.
+// Getting this wrong is how a breakdown ends up summing past 100%.
+func TestTimingCountsOverlappingToolCallsOnceInTheBucket(t *testing.T) {
+	tr, c := newTestTracker()
+	both := `{"type":"assistant","message":{"content":[` +
+		`{"type":"tool_use","id":"a","name":"Bash","input":{"command":"suite-a"}},` +
+		`{"type":"tool_use","id":"b","name":"Bash","input":{"command":"suite-b"}}]}}`
+	feed(t, tr, c,
+		[]time.Duration{time.Second, 60 * time.Second, 30 * time.Second},
+		[]string{both, toolResult("a"), toolResult("b")},
+	)
+	got := tr.Finish(c.at)
+
+	if got.ToolWaitMS != 90_000 {
+		t.Errorf("ToolWaitMS = %d, want 90000 (wall clock, counted once)", got.ToolWaitMS)
+	}
+	if len(got.SlowTools) != 2 {
+		t.Fatalf("SlowTools = %+v, want 2", got.SlowTools)
+	}
+	// 60s + 90s of individual durations against 90s of wall clock: overlap is
+	// expected in the per-call list and must not be normalised away.
+	if got.SlowTools[0].DurationMS != 90_000 || got.SlowTools[1].DurationMS != 60_000 {
+		t.Errorf("per-call durations = %d, %d; want 90000, 60000 slowest-first",
+			got.SlowTools[0].DurationMS, got.SlowTools[1].DurationMS)
+	}
+	if got.TotalMS != got.ThinkingMS+got.WritingMS+got.ModelMS+got.ToolWaitMS+got.OtherMS {
+		t.Errorf("TotalMS %d is not the sum of the exclusive buckets", got.TotalMS)
+	}
+}
+
+func TestTimingSplitsThinkingFromWriting(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{10 * time.Second, 5 * time.Second, 20 * time.Second},
+		[]string{thinkingTokens, thinkingTokens, assistantText},
+	)
+	got := tr.Finish(c.at)
+
+	// Both gaps that END on a thinking frame are thinking; the gap from the last
+	// thinking frame to the visible message is writing.
+	if got.ThinkingMS != 15_000 {
+		t.Errorf("ThinkingMS = %d, want 15000", got.ThinkingMS)
+	}
+	if got.WritingMS != 20_000 {
+		t.Errorf("WritingMS = %d, want 20000", got.WritingMS)
+	}
+	if got.ModelMS != 0 {
+		t.Errorf("ModelMS = %d, want 0 when the thinking signal is present", got.ModelMS)
+	}
+}
+
+// Providers that never emit thinking_tokens (the Cursor CLI) must report their
+// model latency as un-attributed rather than have it silently land in one bucket.
+func TestTimingLeavesModelLatencyUnsplitWithoutTheThinkingSignal(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c, []time.Duration{25 * time.Second}, []string{assistantText})
+	got := tr.Finish(c.at)
+
+	if got.ModelMS != 25_000 {
+		t.Errorf("ModelMS = %d, want 25000", got.ModelMS)
+	}
+	if got.ThinkingMS != 0 || got.WritingMS != 0 {
+		t.Errorf("thinking/writing = %d/%d, want 0/0 with no signal to split on",
+			got.ThinkingMS, got.WritingMS)
+	}
+}
+
+func TestTimingPairsBackgroundTaskBookends(t *testing.T) {
+	tr, c := newTestTracker()
+	started := `{"type":"system","subtype":"task_started","task_id":"bg1","description":"run the full suite","task_type":"local_workflow","workflow_name":"verify"}`
+	// The task reports 9m50s of its own; our bookends bracket 10m of arrival time.
+	// The self-reported figure is the accurate one and must win.
+	notified := `{"type":"system","subtype":"task_notification","task_id":"bg1","status":"completed","output_file":"/tmp/x","summary":"done","usage":{"total_tokens":10,"tool_uses":2,"duration_ms":590000}}`
+	feed(t, tr, c,
+		[]time.Duration{time.Second, 10 * time.Minute},
+		[]string{started, notified},
+	)
+	got := tr.Finish(c.at)
+
+	if got.BackgroundMS != 600_000 {
+		t.Errorf("BackgroundMS = %d, want 600000 (bookend to bookend)", got.BackgroundMS)
+	}
+	if len(got.SlowTools) != 1 {
+		t.Fatalf("SlowTools = %+v, want the background task", got.SlowTools)
+	}
+	entry := got.SlowTools[0]
+	if entry.DurationMS != 590_000 {
+		t.Errorf("DurationMS = %d, want the task's self-reported 590000", entry.DurationMS)
+	}
+	if !entry.Background {
+		t.Error("background task not marked as background")
+	}
+	if entry.Name != "workflow:verify" {
+		t.Errorf("Name = %q, want workflow:verify", entry.Name)
+	}
+	if entry.Label != "run the full suite" {
+		t.Errorf("Label = %q", entry.Label)
+	}
+}
+
+// BackgroundMS is a union, not a sum: two suites running side by side for ten
+// minutes is ten minutes of background work, not twenty.
+func TestTimingMergesOverlappingBackgroundTasks(t *testing.T) {
+	tr, c := newTestTracker()
+	start := func(id string) string {
+		return fmt.Sprintf(`{"type":"system","subtype":"task_started","task_id":%q,"description":"suite","task_type":"local_workflow"}`, id)
+	}
+	done := func(id string) string {
+		return fmt.Sprintf(`{"type":"system","subtype":"task_notification","task_id":%q,"status":"completed","output_file":"","summary":""}`, id)
+	}
+	feed(t, tr, c,
+		[]time.Duration{0, time.Minute, 4 * time.Minute, 5 * time.Minute},
+		[]string{start("a"), start("b"), done("a"), done("b")},
+	)
+	got := tr.Finish(c.at)
+
+	if got.BackgroundMS != 10*60*1000 {
+		t.Errorf("BackgroundMS = %d, want 600000 (union of a:0-5m and b:1m-10m)", got.BackgroundMS)
+	}
+}
+
+// A run killed mid-tool is exactly when you most want to know what it was stuck
+// on, so an unclosed call must still be reported rather than dropped.
+func TestTimingClosesOutstandingCallsOnFinish(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c, []time.Duration{time.Second}, []string{toolUse("t1", "Bash", `{"command":"sleep 9999"}`)})
+	c.advance(5 * time.Minute)
+	got := tr.Finish(c.at)
+
+	if len(got.SlowTools) != 1 || got.SlowTools[0].DurationMS != 300_000 {
+		t.Fatalf("SlowTools = %+v, want the unclosed Bash call at 300000ms", got.SlowTools)
+	}
+	// The tail after the last event is teardown, not a wait on a tool result that
+	// is never coming.
+	if got.OtherMS != 300_000 {
+		t.Errorf("OtherMS = %d, want 300000", got.OtherMS)
+	}
+	if got.ToolWaitMS != 0 {
+		t.Errorf("ToolWaitMS = %d, want 0", got.ToolWaitMS)
+	}
+}
+
+func TestTimingKeepsOnlyTheSlowestCalls(t *testing.T) {
+	tr, c := newTestTracker()
+	for i := 0; i < maxSlowTools+3; i++ {
+		id := fmt.Sprintf("t%d", i)
+		c.advance(time.Second)
+		tr.Feed(toolUse(id, "Bash", `{"command":"x"}`))
+		c.advance(time.Duration(i+1) * time.Second)
+		tr.Feed(toolResult(id))
+	}
+	got := tr.Finish(c.at)
+
+	if len(got.SlowTools) != maxSlowTools {
+		t.Fatalf("kept %d slow tools, want %d", len(got.SlowTools), maxSlowTools)
+	}
+	for i := 1; i < len(got.SlowTools); i++ {
+		if got.SlowTools[i-1].DurationMS < got.SlowTools[i].DurationMS {
+			t.Fatalf("SlowTools not ordered slowest-first: %+v", got.SlowTools)
+		}
+	}
+}
+
+// Sub-second calls can never explain a long step, and letting them in would push
+// out the entries that can.
+func TestTimingIgnoresTrivialCalls(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{0, 10 * time.Millisecond},
+		[]string{toolUse("t1", "Read", `{"file_path":"/x"}`), toolResult("t1")},
+	)
+	if got := tr.Finish(c.at); len(got.SlowTools) != 0 {
+		t.Errorf("SlowTools = %+v, want none", got.SlowTools)
+	}
+}
+
+// Labels are persisted and rendered, and agents routinely export tokens in Bash
+// calls, so a credential in a tool input must not survive into one.
+func TestTimingRedactsCredentialsInLabels(t *testing.T) {
+	tr, c := newTestTracker()
+	jwt := "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	feed(t, tr, c,
+		[]time.Duration{0, 5 * time.Second},
+		[]string{toolUse("t1", "Bash", fmt.Sprintf(`{"command":"curl -H 'Authorization: Bearer %s' x"}`, jwt)), toolResult("t1")},
+	)
+	got := tr.Finish(c.at)
+
+	if len(got.SlowTools) != 1 {
+		t.Fatalf("SlowTools = %+v", got.SlowTools)
+	}
+	if label := got.SlowTools[0].Label; strings.Contains(label, "eyJ") {
+		t.Errorf("label leaked a credential: %q", label)
+	}
+}
+
+// A provider whose stream we understand nothing of should record no timing at all,
+// rather than a row that is 100% "other" and reads as a real measurement.
+func TestTimingReturnsNilWithoutUsableEvents(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{0, 0},
+		[]string{"not json at all", `{"no_type":"here"}`},
+	)
+	if got := tr.Finish(c.at); got != nil {
+		t.Errorf("Finish = %+v, want nil", got)
+	}
+}
+
+func TestSystemDetailNamesBackgroundTasks(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "task_started names the workflow and its description",
+			line: `{"type":"system","subtype":"task_started","task_id":"bg1","description":"run the full test suite","task_type":"local_workflow","workflow_name":"verify"}`,
+			want: "workflow:verify · run the full test suite · task=bg1",
+		},
+		{
+			name: "subagent task falls back to the agent type",
+			line: `{"type":"system","subtype":"task_started","task_id":"bg2","description":"explore the auth code","subagent_type":"Explore"}`,
+			want: "agent:Explore · explore the auth code · task=bg2",
+		},
+		{
+			name: "task_notification carries the outcome and measured duration",
+			line: `{"type":"system","subtype":"task_notification","task_id":"bg1","status":"failed","output_file":"/tmp/o","summary":"boom","usage":{"total_tokens":1,"tool_uses":1,"duration_ms":90000}}`,
+			want: "failed · duration=1m30s · task=bg1",
+		},
+		{
+			name: "unrelated system events stay as they were",
+			line: `{"type":"system","subtype":"init","model":"claude-opus-5"}`,
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := systemDetail(tc.line); got != tc.want {
+				t.Errorf("systemDetail = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The whole point of issue #399's third ask: the log line for a background task
+// must name what the task actually is.
+func TestFormatStreamLineIncludesBackgroundTaskPayload(t *testing.T) {
+	line := `{"type":"system","subtype":"task_started","task_id":"bg1","description":"run the full test suite","task_type":"local_workflow","workflow_name":"verify"}`
+	got, ok := formatStreamLine(line)
+	if !ok {
+		t.Fatal("formatStreamLine did not handle a system event")
+	}
+	want := "[system:task_started] workflow:verify · run the full test suite · task=bg1"
+	if got != want {
+		t.Errorf("formatStreamLine = %q, want %q", got, want)
+	}
+}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -173,6 +173,10 @@ type StepResult struct {
 	// failover attempts (each attempt is also its own task_executions row). Nil
 	// when the runner reported no usage. The engine persists it onto the step run.
 	Usage *model.Usage
+	// Timing is the wall-clock attribution for the step, accumulated across the
+	// same failover attempts as Usage (issue #399). Nil when no attempt reported
+	// any — runners without an event stream to attribute.
+	Timing *model.Timing
 	// InputPrompt is the composed prompt of the final (winning) attempt, persisted
 	// onto the step run for cost auditing and replay.
 	InputPrompt string
@@ -619,6 +623,9 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	sr.Output = res.Output
 	sr.Summary = res.Summary
 	sr.InputPrompt = res.InputPrompt
+	if res.Timing != nil {
+		sr.StepTiming = db.TimingFrom(res.Timing)
+	}
 	if res.Usage != nil {
 		sr.InputTokens = res.Usage.InputTokens
 		sr.OutputTokens = res.Usage.OutputTokens


### PR DESCRIPTION
Closes #399

`step_runs` recorded tokens, cost, turns and tool-call counts — everything except where the wall clock went. A step that took 82 minutes gave no hint whether the model was thinking, writing, or blocked on a subprocess it launched, and those three have completely different fixes. This records the breakdown, names the background tasks in the log, and surfaces both.

## Attribution

`execution/timing.go` folds the arrival times of the stream events the runner already parses into an exclusive wall-clock breakdown, fed from the same stdout scan loop as the usage accumulator.

Two design points worth reviewing:

**Overlap is handled as a timeline, not a sum.** One `assistant` message can carry several `tool_use` blocks that run concurrently, and background tasks keep running while the model writes. Summing per-call durations would exceed the run's wall clock and produce percentages over 100%. So the buckets (`thinking` / `writing` / `model` / `tool_wait` / `other`) are exclusive — every instant counted once — while per-call durations in `slow_tools` overlap freely, because that list answers "which call should I fix", not "how was the wall clock divided". `time_background_ms` is the one deliberately non-exclusive figure: the union of intervals with background work outstanding, which overlaps the buckets by design.

**Thinking vs writing is only ever split from a real signal.** `system:thinking_tokens` is emitted for some thinking and not all, and not at all by some providers. When it is absent the latency is reported as `time_model_ms` — un-attributed, not a third kind of model work — rather than being guessed 0/100 into one bucket.

## Naming background tasks in the log (issue item 3)

`[system:task_started]` was logged with no payload at all, so the largest time sink in a run was the one thing the log could not identify. The CLI's own schemas gave the exact shape:

- `task_started` carries `task_id`, `description`, `task_type`, `subagent_type`, `workflow_name` — now rendered into the log line.
- `task_notification` is the closing bookend and carries `usage.duration_ms`, the task's own measurement. Background durations are read from it rather than inferred from arrival-time deltas.

The subagent's full `prompt` is deliberately *not* logged — it is a whole task description and would bury the line. It stays in the transcript.

## Persistence

Additive columns on `task_executions` (one attempt) and `step_runs` (the logical step, summed across failover attempts), mirroring the token columns. Fixed columns rather than one JSON blob, because they roll up by plain summation and aggregate queries over them should not need JSON extraction; the variable-shape slowest-call list is the only JSON part.

`HasTiming()` keeps rows written before this existed distinguishable from rows measured as genuinely zero — a step rendered "0% thinking" reads as a finding when it actually means nobody measured it.

## Surfacing

`apiary profile <instance-id> [--json]`, plus a per-step timing line on `apiary instances <id>`.

```
STEP               TOTAL     THINK     WRITE     TOOLS     OTHER
plan               3m0s      67%       33%       —         —
implement          1h22m42s  6%        24%       63%       7%
  63% with background work outstanding (overlaps the above)
review             not measured

Slowest calls
  9m54s      background  implement       workflow:verify  ·  run the full test suite
  8m0s       tool        implement       Bash  ·  ./gradlew test
```

`--json` is there so the next question nobody anticipated gets answered with jq rather than another throwaway log parser.

## Scope

- The API-based runners (`execution/api.go`) have no event stream — timing stays zero there, documented, not faked.
- The Cursor CLI emits a subset; buckets degrade to `model` + `tool_wait` rather than erroring.
- Tool labels are run through the existing JWT redaction, since labels are persisted and rendered and agents routinely export tokens in Bash calls.

## Verification

`go build`, `go vet` and the full `go test ./...` are green; 25 new tests cover the attribution rules, the overlap handling, the rollup across attempts, and the rendering.

**The tests are synthetic.** The tracker was built against the CLI's shipped schemas, not against captured output — the attribution logic is exercised, but "do these events actually arrive in this order in a live run" is unverified. Worth putting one real step through it before merging.
