### PR TITLE
fix(runner): correct thinking/writing split and de-duplicate backgrounded calls (#399)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -261,10 +261,18 @@ Two consequences worth knowing:
   leave every bucket at zero. `apiary profile` reports those steps as *not
   measured* rather than as a breakdown of zeros.
 
-The thinking/writing split comes from the CLI's `system:thinking_tokens` events.
-Those are emitted for some thinking and not all, and not at all by some
-providers; when the signal is missing the latency is reported as `time_model_ms`
-rather than being guessed into one bucket or the other.
+The thinking/writing split comes from the CLI's `system:thinking_tokens` events
+and from the separate `assistant` message a turn's thinking arrives in, ahead of
+the message carrying the answer. Those signals are emitted for some thinking and
+not all, and not at all by some providers; when they are missing the latency is
+reported as `time_model_ms` rather than being guessed into one bucket or the
+other.
+
+A background task the agent launched through a tool — a `Task` subagent, a
+backgrounded shell — is reported twice by the provider: once as the foreground
+tool call and once as a background bookend. The two are correlated by tool-use id
+and collapse into a single entry in `slow_tools`, so one piece of work does not
+read as two separate problems.
 
 ### CI poll history (wait_for steps)
 

--- a/src/internal/runner/execution/timing.go
+++ b/src/internal/runner/execution/timing.go
@@ -67,14 +67,22 @@ type timingTracker struct {
 	// last is the timestamp of the most recently observed event; the gap between
 	// it and the next event is what gets attributed.
 	last time.Time
-	// lastWasThinking records whether the event that closed the previous gap was a
-	// thinking_tokens frame, which is what lets the next gap count as writing.
-	lastWasThinking bool
+	// thinkingSeen records that a thinking frame has arrived during the current
+	// turn. It stays set until the turn ends, because the events between the last
+	// thinking frame and the model's message are not all thinking frames —
+	// post_turn_summary, hook bookends and status frames all interleave. Treating
+	// this as a one-shot flag consumed by the next event attributed a 20-second
+	// write as un-attributed latency, because one unrelated system frame landed in
+	// the middle of it.
+	thinkingSeen bool
 
 	thinking, writing, model, toolWait, other time.Duration
 
 	openTools map[string]*openCall
 	openTasks map[string]*openCall
+	// byToolUse indexes finished entries by tool_use id, so the two reports of one
+	// backgrounded call collapse into a single entry.
+	byToolUse map[string]int
 	// bg holds the closed intervals during which at least one background task was
 	// live, in arrival order; overlapping entries are merged when reported.
 	bg []interval
@@ -90,6 +98,11 @@ type openCall struct {
 	// background distinguishes a task_started bookend from a foreground tool call,
 	// so the slowest-N list can say which of the two a long entry was.
 	background bool
+	// toolUses is the tool_use id this call belongs to. A background task the agent
+	// launched through a tool (the Task tool, a backgrounded Bash) is reported
+	// BOTH as a foreground tool call and as a background bookend carrying the same
+	// id; it correlates the two so one piece of work produces one entry.
+	toolUses string
 }
 
 type interval struct{ start, end time.Time }
@@ -117,6 +130,7 @@ func newTimingTracker(start time.Time, now func() time.Time) *timingTracker {
 		last:      start,
 		openTools: map[string]*openCall{},
 		openTasks: map[string]*openCall{},
+		byToolUse: map[string]int{},
 	}
 }
 
@@ -141,7 +155,10 @@ type timingEvent struct {
 	// Background-task bookends. The CLI emits system:task_started when the agent
 	// launches background work (a Task-tool subagent, a workflow) and
 	// system:task_notification when it settles, correlated by task_id.
-	TaskID       string `json:"task_id"`
+	TaskID string `json:"task_id"`
+	// ToolUseID correlates a bookend with the tool call that launched the task, so
+	// the two reports of one wait can be collapsed into one entry.
+	ToolUseID    string `json:"tool_use_id"`
 	Description  string `json:"description"`
 	TaskType     string `json:"task_type"`
 	SubagentType string `json:"subagent_type"`
@@ -171,22 +188,35 @@ func (t *timingTracker) Feed(line string) {
 	defer t.mu.Unlock()
 
 	at := t.now()
-	isThinking := ev.Type == "system" && ev.Subtype == "thinking_tokens"
-	t.attribute(at, isThinking)
+	// A turn's thinking is delivered as its own `assistant` message, separate from
+	// and earlier than the message carrying the visible output — so a thinking-only
+	// message closes a stretch of thinking, exactly like a thinking_tokens frame,
+	// and must not be mistaken for the model having produced its answer.
+	thinkingOnly, hasOutput := assistantShape(ev)
+	t.attribute(at, (ev.Type == "system" && ev.Subtype == "thinking_tokens") || thinkingOnly)
 
 	switch ev.Type {
 	case "assistant":
+		// Only a message carrying real output ends the turn. Ending it on the
+		// thinking message instead left the whole write — 2.3 seconds of a
+		// 10-second run — attributed to nothing.
+		if hasOutput {
+			t.endTurn()
+		}
 		for _, c := range ev.Message.Content {
 			if c.Type != "tool_use" || c.ID == "" {
 				continue
 			}
 			t.openTools[c.ID] = &openCall{
-				name:    c.Name,
-				label:   toolLabel(truncateInput(c.Input)),
-				started: at,
+				name:     c.Name,
+				label:    toolLabel(truncateInput(c.Input)),
+				started:  at,
+				toolUses: c.ID,
 			}
 		}
 	case "user":
+		// Tool results feed the model a new turn.
+		t.endTurn()
 		for _, c := range ev.Message.Content {
 			if c.Type != "tool_result" || c.ToolUseID == "" {
 				continue
@@ -207,6 +237,7 @@ func (t *timingTracker) Feed(line string) {
 				label:      toolLabel(ev.Description),
 				started:    at,
 				background: true,
+				toolUses:   ev.ToolUseID,
 			}
 		case "task_notification":
 			call, ok := t.openTasks[ev.TaskID]
@@ -236,8 +267,9 @@ func (t *timingTracker) Feed(line string) {
 func (t *timingTracker) attribute(at time.Time, endsThinking bool) {
 	gap := at.Sub(t.last)
 	t.last = at
-	wasThinking := t.lastWasThinking
-	t.lastWasThinking = endsThinking
+	if endsThinking {
+		t.thinkingSeen = true
+	}
 	if gap <= 0 {
 		return
 	}
@@ -249,19 +281,70 @@ func (t *timingTracker) attribute(at time.Time, endsThinking bool) {
 		// The gap ended with the model reporting thinking-token progress, so it was
 		// spent thinking.
 		t.thinking += gap
-	case wasThinking:
-		// Thinking was streaming and has now stopped: the model is producing its
-		// visible output.
+	case t.thinkingSeen:
+		// Thinking streamed earlier in this turn and has stopped, so the model is
+		// now producing its visible output. This holds for the whole rest of the
+		// turn, not just until the next frame of any kind arrives.
 		t.writing += gap
 	default:
-		// No thinking signal either side of the gap — model latency we cannot split.
+		// No thinking signal anywhere in this turn — model latency we cannot split.
 		t.model += gap
 	}
 }
 
+// endTurn closes the current model turn, so thinking observed in it does not leak
+// into the attribution of the next one.
+func (t *timingTracker) endTurn() { t.thinkingSeen = false }
+
+// assistantShape classifies an `assistant` message by what it delivers.
+// thinkingOnly marks a message that carries nothing but thinking blocks — the
+// model reporting its reasoning, not its answer. hasOutput marks one carrying
+// visible text or a tool call, which is what actually ends a turn. Both are false
+// for every other event type.
+func assistantShape(ev timingEvent) (thinkingOnly, hasOutput bool) {
+	if ev.Type != "assistant" || len(ev.Message.Content) == 0 {
+		return false, false
+	}
+	sawThinking := false
+	for _, c := range ev.Message.Content {
+		switch c.Type {
+		case "thinking", "redacted_thinking":
+			sawThinking = true
+		default:
+			hasOutput = true
+		}
+	}
+	return sawThinking && !hasOutput, hasOutput
+}
+
+// record adds a completed call to the slowest-N candidates, merging it with the
+// other half of the same work when one piece of work was reported twice.
+//
+// Launching a subagent produces a foreground `Agent` tool call AND a background
+// task bookend for the same wait, correlated by tool_use id. Listing both spends
+// two of five slots on one thing and reads as two separate problems, so they
+// collapse into a single entry: the background half names it far better
+// ("agent:general-purpose · explore the auth code" against a blob of tool-call
+// JSON), while the foreground half spans the full wait including dispatch, so the
+// merged entry takes the better name and the longer duration.
 func (t *timingTracker) record(call *openCall, d time.Duration) {
 	if d < slowToolMinDuration {
 		return
+	}
+	if call.toolUses != "" {
+		if i, ok := t.byToolUse[call.toolUses]; ok {
+			existing := &t.finished[i]
+			if d.Milliseconds() > existing.DurationMS {
+				existing.DurationMS = d.Milliseconds()
+			}
+			if call.background {
+				existing.Name = call.name
+				existing.Label = call.label
+				existing.Background = true
+			}
+			return
+		}
+		t.byToolUse[call.toolUses] = len(t.finished)
 	}
 	t.finished = append(t.finished, model.ToolTiming{
 		Name:       call.name,

--- a/src/internal/runner/execution/timing_test.go
+++ b/src/internal/runner/execution/timing_test.go
@@ -47,6 +47,9 @@ func toolResult(id string) string {
 const (
 	assistantText  = `{"type":"assistant","message":{"content":[{"type":"text","text":"working on it"}]}}`
 	thinkingTokens = `{"type":"system","subtype":"thinking_tokens","estimated_tokens":120,"estimated_tokens_delta":40}`
+	// The model delivers a turn's thinking as its own assistant message, ahead of
+	// the one carrying the answer.
+	thinkingMessage = `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"let me work through it"}]}}`
 )
 
 func TestTimingAttributesToolWaitToTheOpenCall(t *testing.T) {
@@ -128,6 +131,95 @@ func TestTimingSplitsThinkingFromWriting(t *testing.T) {
 	}
 	if got.ModelMS != 0 {
 		t.Errorf("ModelMS = %d, want 0 when the thinking signal is present", got.ModelMS)
+	}
+}
+
+// A turn's thinking arrives as its own `assistant` message, ahead of the message
+// carrying the answer. Treating that first message as "the model has answered"
+// attributed the entire write to nothing: in a live 10-second run it put 2.3s of
+// writing into the un-attributed bucket and left WritingMS at 6ms.
+func TestTimingCountsWritingAfterTheThinkingMessage(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{4 * time.Second, 100 * time.Millisecond, 2500 * time.Millisecond},
+		[]string{thinkingTokens, thinkingMessage, assistantText},
+	)
+	got := tr.Finish(c.at)
+
+	// The thinking-only message closes a stretch of thinking, exactly as a
+	// thinking_tokens frame does.
+	if got.ThinkingMS != 4_100 {
+		t.Errorf("ThinkingMS = %d, want 4100", got.ThinkingMS)
+	}
+	if got.WritingMS != 2_500 {
+		t.Errorf("WritingMS = %d, want 2500 — the gap to the message carrying the answer", got.WritingMS)
+	}
+	if got.ModelMS != 0 {
+		t.Errorf("ModelMS = %d, want 0: this turn had a thinking signal throughout", got.ModelMS)
+	}
+}
+
+// Unrelated system frames interleave freely between the last thinking frame and
+// the model's output; none of them means thinking has stopped.
+func TestTimingKeepsWritingAttributionAcrossUnrelatedFrames(t *testing.T) {
+	tr, c := newTestTracker()
+	const postTurn = `{"type":"system","subtype":"post_turn_summary"}`
+	feed(t, tr, c,
+		[]time.Duration{time.Second, time.Second, 3 * time.Second},
+		[]string{thinkingTokens, postTurn, assistantText},
+	)
+	got := tr.Finish(c.at)
+
+	if got.WritingMS != 4_000 {
+		t.Errorf("WritingMS = %d, want 4000 across the intervening frame", got.WritingMS)
+	}
+	if got.ModelMS != 0 {
+		t.Errorf("ModelMS = %d, want 0", got.ModelMS)
+	}
+}
+
+// Thinking from one turn must not colour the next one: after the model delivers
+// an answer, a later gap with no thinking signal is un-attributed again.
+func TestTimingDoesNotLeakThinkingAcrossTurns(t *testing.T) {
+	tr, c := newTestTracker()
+	feed(t, tr, c,
+		[]time.Duration{time.Second, time.Second, 0, 5 * time.Second},
+		[]string{thinkingTokens, assistantText, toolResult("none"), assistantText},
+	)
+	got := tr.Finish(c.at)
+
+	if got.ModelMS != 5_000 {
+		t.Errorf("ModelMS = %d, want 5000: the second turn had no thinking signal", got.ModelMS)
+	}
+}
+
+// Launching a subagent is reported twice — once as the foreground tool call, once
+// as the background bookend — for the same wait. Listing both spends two of five
+// slots on one thing and reads as two separate problems.
+func TestTimingMergesATaskWithTheToolCallThatLaunchedIt(t *testing.T) {
+	tr, c := newTestTracker()
+	started := `{"type":"system","subtype":"task_started","task_id":"bg1","tool_use_id":"t1","description":"count the lines","subagent_type":"general-purpose"}`
+	notified := `{"type":"system","subtype":"task_notification","task_id":"bg1","tool_use_id":"t1","status":"completed","output_file":"","summary":""}`
+	feed(t, tr, c,
+		[]time.Duration{0, time.Second, 25 * time.Second, 2 * time.Second},
+		[]string{toolUse("t1", "Agent", `{"prompt":"count the lines in notes.txt"}`), started, notified, toolResult("t1")},
+	)
+	got := tr.Finish(c.at)
+
+	if len(got.SlowTools) != 1 {
+		t.Fatalf("SlowTools = %+v, want the two reports collapsed into one", got.SlowTools)
+	}
+	entry := got.SlowTools[0]
+	// The background half names it far better than the foreground call's raw input.
+	if entry.Name != "agent:general-purpose" || entry.Label != "count the lines" {
+		t.Errorf("merged entry = %+v, want the background naming", entry)
+	}
+	if !entry.Background {
+		t.Error("merged entry should be marked background")
+	}
+	// The foreground call spans the full wait including dispatch, so it wins.
+	if entry.DurationMS != 28_000 {
+		t.Errorf("DurationMS = %d, want 28000 (the longer of the two spans)", entry.DurationMS)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #409, which was squash-merged without this commit — the fixes were pushed to the branch shortly before the merge and did not make it into the squash. `main` currently carries the version both bugs were found in.

Both were found by running real agent steps through the tracker; both had passing synthetic tests over a wrong model of the stream. Full evidence in https://github.com/orlandoburli/apiary/issues/399#issuecomment-5221250706.

## The write was being attributed to nothing

A run that produced 6,838 characters in 25 seconds reported `WritingMS: 2, ModelMS: 20179`. The event trace shows why:

```
6.502s  system/thinking_tokens
6.508s  assistant/ thinking     ← thinking-block message, 6ms later
8.838s  assistant/ text         ← the actual output, 2.33s later
```

A turn's thinking arrives as its **own** `assistant` message, ahead of the message carrying the answer. Ending the turn on the first one dropped the real write into the un-attributed bucket. Now only a message carrying `text` or a `tool_use` ends a turn, and a thinking-only message closes a stretch of thinking exactly as a `thinking_tokens` frame does.

Thinking was also a one-shot flag consumed by whatever frame arrived next, and `post_turn_summary` / hook bookends interleave freely — so it is turn-scoped state now.

After: `ThinkingMS: 3637, WritingMS: 2325, ModelMS: 2315`, with `WritingMS` matching the observed gap exactly.

## One wait, listed twice

Launching a subagent is reported both as a foreground `Agent` tool call and as a background bookend for the same wait, spending two of five slots in the slowest-calls list on one piece of work and reading as two separate problems. They now collapse by tool-use id, keeping the background half's better naming and the longer of the two spans.

Four regression tests added. `go build`, `go vet` and the full suite are green.
