### PR TITLE
feat(improve): advisor agent — reason over the evidence and report (#403)

### DIFF
--- a/src/internal/cli/improve.go
+++ b/src/internal/cli/improve.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -19,9 +20,15 @@ func newImproveCmd() *cobra.Command {
 		workflows     []string
 		agents        []string
 		focus         string
+		effortFlag    string
+		advisorID     string
+		runnerID      string
+		modelID       string
+		profile       string
+		output        string
+		outDir        string
 		dumpEvidence  bool
-		hotspots      int
-		transcripts   int
+		dumpPrompt    bool
 		excerptBudget int
 	)
 
@@ -29,33 +36,52 @@ func newImproveCmd() *cobra.Command {
 		Use:   "improve",
 		Short: "Analyse execution history and suggest improvements",
 		Long: `Mine Apiary's own execution history — step timings, tokens, cost, failure
-kinds, rework loops, wait polling — into an evidence pack describing how the
-configured workflows and agents actually behave.
+kinds, rework loops, wait polling — and have an agent reason over it, proposing
+changes to the configuration that produced it.
 
-  apiary improve --dump-evidence            print the evidence pack as JSON
-  apiary improve --dump-evidence --since 30d
-  apiary improve --dump-evidence --workflow review-pr
+  apiary improve                          analyse and print findings
+  apiary improve --effort deep --since 30d
+  apiary improve --workflow implementation
+  apiary improve --dump-evidence          print the metrics as JSON, run no model
 
-The evidence pack is computed entirely in Go: no model is consulted, so the same
-database and window always produce the same pack. The advisor that reasons over
-it and proposes config changes arrives in a later phase.`,
+The evidence is computed entirely in Go, so --dump-evidence needs no advisor and
+no model. The advisor is a normal Apiary agent, resolved from --advisor, an
+ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
+"improver".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !dumpEvidence {
-				return fmt.Errorf("only --dump-evidence is available so far; the advisor lands in a later phase")
+			effort, err := improve.ParseEffort(effortFlag)
+			if err != nil {
+				return err
+			}
+			knobs := effort.Expand()
+			if excerptBudget > 0 {
+				knobs.TranscriptByteBudget = excerptBudget
 			}
 
+			// --since defaults per effort: a quick pass over 90 days is a waste,
+			// and a deep pass over 7 days usually has too little to chew on.
+			if since == "" {
+				since = knobs.DefaultWindow
+			}
 			window, err := improve.ParseWindow(since, time.Now())
 			if err != nil {
 				return err
 			}
 
-			// The config is optional: without it the pack still reports what ran,
-			// it just cannot report what was configured and never ran.
-			var cfg *config.Config
-			if loaded, err := config.Load(configFile); err == nil {
-				cfg = loaded
-			} else {
-				fmt.Fprintf(os.Stderr, "  ⚠ config not loaded (%v); dead-path and parallel analysis skipped\n", err)
+			cfg, cfgErr := config.Load(configFile)
+			if cfgErr != nil && !dumpEvidence {
+				return fmt.Errorf("loading config: %w", cfgErr)
+			}
+			if cfgErr != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ config not loaded (%v); dead-path and parallel analysis skipped\n", cfgErr)
+			}
+			if cfg != nil && profile != "" {
+				applied, found := config.ApplyProfile(cfg, profile)
+				if !found {
+					fmt.Fprintf(os.Stderr, "  ⚠ profile %q not found — continuing with base config\n", profile)
+				} else {
+					fmt.Fprintf(os.Stderr, "  active profile: %s (%d agent overrides)\n", profile, applied)
+				}
 			}
 
 			dbPath := getDBPath()
@@ -68,44 +94,161 @@ it and proposes config changes arrives in a later phase.`,
 			}
 			defer db.Close()
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
 			defer cancel()
 
+			scope := improve.Scope{Workflows: workflows, Agents: agents, Focus: improve.Focus(focus)}
 			pack, err := improve.Build(ctx, db, improve.Options{
-				DBPath: dbPath,
-				LogDir: getLogDir(),
-				Config: cfg,
-				Window: window,
-				Scope: improve.Scope{
-					Workflows: workflows,
-					Agents:    agents,
-					Focus:     improve.Focus(focus),
-				},
-				HotspotLimit:          hotspots,
-				TranscriptsPerHotspot: transcripts,
-				TranscriptByteBudget:  excerptBudget,
+				DBPath:                dbPath,
+				LogDir:                getLogDir(),
+				Config:                cfg,
+				Window:                window,
+				Scope:                 scope,
+				HotspotLimit:          knobs.HotspotLimit,
+				TranscriptsPerHotspot: knobs.TranscriptsPerHotspot,
+				TranscriptByteBudget:  knobs.TranscriptByteBudget,
+			})
+			if err != nil {
+				return err
+			}
+
+			if dumpEvidence {
+				fmt.Fprintln(os.Stderr, pack.Summary())
+				fmt.Fprintln(os.Stderr)
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(pack)
+			}
+
+			ws, err := improve.Discover(cfg, configFile)
+			if err != nil {
+				return err
+			}
+			files := ws.Filter(knobs.WorkspaceBreadth, activeAgents(pack), flaggedAgents(pack))
+			prompt := improve.ComposePrompt(pack, ws, files, knobs)
+
+			// --dump-prompt runs no model, so it needs no advisor. It exists so the
+			// exact text that would be sent can be reviewed first — including
+			// confirming that the config reached it redacted.
+			if dumpPrompt {
+				fmt.Fprint(cmd.OutOrStdout(), prompt)
+				return nil
+			}
+
+			adv, err := improve.ResolveAdvisor(cfg, improve.AdvisorFlags{
+				Advisor: advisorID, Runner: runnerID, Model: modelID, Effort: effort,
 			})
 			if err != nil {
 				return err
 			}
 
 			fmt.Fprintln(os.Stderr, pack.Summary())
-			fmt.Fprintln(os.Stderr)
+			fmt.Fprintf(os.Stderr, "\nanalysing with %s (%s / %s), effort %s, %d config files, %d transcripts…\n",
+				adv.AgentID, adv.RunnerID, adv.Model, effort, len(files), len(pack.Transcripts))
+			for _, s := range ws.UnresolvedSkills {
+				fmt.Fprintf(os.Stderr, "  ⚠ skill not found on disk: %s\n", s)
+			}
 
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-			return enc.Encode(pack)
+			outcome, runErr := improve.RunAdvisor(ctx, cfg, adv, prompt, knobs, filepath.Dir(configFile))
+			if runErr != nil {
+				if outcome != nil && outcome.RawOutput != "" {
+					fmt.Fprintf(os.Stderr, "\n--- advisor raw output ---\n%s\n", outcome.RawOutput)
+				}
+				return runErr
+			}
+
+			report := improve.RenderReport(pack, adv, outcome, effort)
+
+			if outDir != "" {
+				if err := writeArtifacts(outDir, pack, outcome, report); err != nil {
+					return err
+				}
+				fmt.Fprintf(os.Stderr, "written to %s\n", outDir)
+			}
+
+			switch output {
+			case "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(outcome.Analysis)
+			default:
+				fmt.Fprint(cmd.OutOrStdout(), report)
+				return nil
+			}
 		},
 	}
 
-	cmd.Flags().StringVar(&since, "since", "14d", "history window (e.g. 7d, 24h, 90d)")
+	cmd.Flags().StringVar(&since, "since", "", "history window (e.g. 7d, 24h, 90d); defaults per effort")
 	cmd.Flags().StringSliceVar(&workflows, "workflow", nil, "restrict analysis to these workflow ids")
 	cmd.Flags().StringSliceVar(&agents, "agent", nil, "restrict analysis to these agents' runs")
 	cmd.Flags().StringVar(&focus, "focus", "all", "what to optimise for: cost|latency|reliability|quality|all")
-	cmd.Flags().BoolVar(&dumpEvidence, "dump-evidence", false, "print the evidence pack as JSON and exit")
-	cmd.Flags().IntVar(&hotspots, "hotspots", 0, "number of hotspot steps to sample transcripts for")
-	cmd.Flags().IntVar(&transcripts, "transcripts", 0, "transcripts to read per hotspot (0 disables sampling)")
-	cmd.Flags().IntVar(&excerptBudget, "transcript-bytes", 8000, "per-transcript character budget")
+	cmd.Flags().StringVar(&effortFlag, "effort", "standard", "depth of analysis: quick|standard|deep")
+	cmd.Flags().StringVar(&advisorID, "advisor", "", "agent that performs the analysis")
+	cmd.Flags().StringVar(&runnerID, "runner", "", "ad-hoc runner for the analysis (requires --model)")
+	cmd.Flags().StringVar(&modelID, "model", "", "ad-hoc model for the analysis (requires --runner)")
+	cmd.Flags().StringVar(&profile, "profile", "", "activate a named runner profile from config profiles.<name>")
+	cmd.Flags().StringVar(&output, "output", "report", "what to print: report|json")
+	cmd.Flags().StringVar(&outDir, "out", "", "also write report, analysis and evidence to this directory")
+	cmd.Flags().BoolVar(&dumpEvidence, "dump-evidence", false, "print the evidence pack as JSON and exit (runs no model)")
+	cmd.Flags().BoolVar(&dumpPrompt, "dump-prompt", false, "print the composed advisor prompt and exit (runs no model)")
+	cmd.Flags().IntVar(&excerptBudget, "transcript-bytes", 0, "override the per-transcript character budget")
 
 	return cmd
+}
+
+// activeAgents are the agents that ran at all in the window.
+func activeAgents(pack *improve.EvidencePack) map[string]bool {
+	out := map[string]bool{}
+	for _, a := range pack.Agents {
+		out[a.AgentID] = true
+	}
+	return out
+}
+
+// flaggedAgents are the agents attached to a step that looks worth explaining:
+// it fails, it gets truncated at the turn cap, or it fails over. At quick effort
+// only these agents' instructions are worth the tokens.
+func flaggedAgents(pack *improve.EvidencePack) map[string]bool {
+	out := map[string]bool{}
+	for _, s := range pack.Steps {
+		if s.AgentID == "" {
+			continue
+		}
+		if s.FailRate > 0 || s.MaxTurnsSaturation > 0 || s.FailoverRate > 0 {
+			out[s.AgentID] = true
+		}
+	}
+	for _, w := range pack.Workflows {
+		if len(w.ReworkLoops) == 0 {
+			continue
+		}
+		for _, s := range pack.Steps {
+			for _, l := range w.ReworkLoops {
+				if s.WorkflowID == w.WorkflowID && s.StepID == l.StepID && s.AgentID != "" {
+					out[s.AgentID] = true
+				}
+			}
+		}
+	}
+	return out
+}
+
+func writeArtifacts(dir string, pack *improve.EvidencePack, outcome *improve.RunOutcome, report string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+	write := func(name string, v any) error {
+		raw, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dir, name), raw, 0o600)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "report.md"), []byte(report), 0o600); err != nil {
+		return err
+	}
+	if err := write("evidence.json", pack); err != nil {
+		return err
+	}
+	return write("analysis.json", outcome.Analysis)
 }

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -355,6 +355,7 @@ type Settings struct {
 	Approvals     ApprovalSettings   `yaml:"approvals"`
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
+	Improve       ImproveSettings    `yaml:"improve"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
 	Queue         QueueSettings      `yaml:"queue"`
 	// DefaultFallbacks is a fallback chain applied to every agent that does not
@@ -491,6 +492,24 @@ func (g GitHooksSettings) Enabled() bool {
 // matching usage events to run time windows. Best-effort: the endpoint is
 // undocumented, and overlapping concurrent cursor runs leave ambiguous events
 // unattributed (cost becomes a lower bound). Disabled by default.
+// ImproveSettings configures `apiary improve`, the self-improvement advisor.
+// Everything here is optional: the command also accepts an advisor on the
+// command line, and needs none at all for --dump-evidence.
+type ImproveSettings struct {
+	// Agent is the id of the agent that performs the analysis. It is resolved
+	// like any other agent (runner, model, fallbacks, MCPs), so the advisor is
+	// not a special case in the config. Empty falls back to an agent literally
+	// named "improver", and failing that the command errors rather than guessing
+	// — there is no default model to fall back to.
+	Agent string `yaml:"agent,omitempty"`
+	// EffortModels optionally maps an effort level (quick|standard|deep) to a
+	// model, overriding the advisor agent's own model for that run. Reading
+	// aggregate tables at "quick" and reasoning over transcripts and prose at
+	// "deep" are different jobs; paying deep prices for a quick run is waste.
+	// Unset levels fall through to the agent's model.
+	EffortModels map[string]string `yaml:"effort_models,omitempty"`
+}
+
 type CursorCostSettings struct {
 	Enabled bool `yaml:"enabled"`
 	// SessionToken is the WorkosCursorSessionToken cookie from a logged-in

--- a/src/internal/config/improve_validate_test.go
+++ b/src/internal/config/improve_validate_test.go
@@ -1,0 +1,44 @@
+package config
+
+import "testing"
+
+func TestValidateImprove(t *testing.T) {
+	cases := []struct {
+		name    string
+		improve ImproveSettings
+		agents  []AgentConfig
+		wantErr bool
+	}{
+		{"empty is fine", ImproveSettings{}, nil, false},
+		{"known agent", ImproveSettings{Agent: "improver"}, []AgentConfig{{ID: "improver"}}, false},
+		{"unknown agent", ImproveSettings{Agent: "ghost"}, []AgentConfig{{ID: "improver"}}, true},
+		{
+			"valid effort keys",
+			ImproveSettings{EffortModels: map[string]string{"quick": "haiku", "deep": "opus"}},
+			nil, false,
+		},
+		{
+			// A typo here would otherwise be silently ignored, leaving the operator
+			// believing they pinned a cheap model while paying for the default.
+			"typo in effort key",
+			ImproveSettings{EffortModels: map[string]string{"stanadrd": "sonnet"}},
+			nil, true,
+		},
+		{
+			"empty model",
+			ImproveSettings{EffortModels: map[string]string{"quick": ""}},
+			nil, true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Agents: tc.agents}
+			cfg.Settings.Improve = tc.improve
+			errs := validateImprove(cfg)
+			if got := len(errs) > 0; got != tc.wantErr {
+				t.Errorf("validateImprove errors = %v, wantErr %v", errs, tc.wantErr)
+			}
+		})
+	}
+}

--- a/src/internal/config/profile.go
+++ b/src/internal/config/profile.go
@@ -1,0 +1,40 @@
+package config
+
+// ApplyProfile overlays a named runner profile onto the config's agents,
+// overriding runner, model, fallbacks and fallback strategy for each agent the
+// profile names. It returns how many agents were overridden and whether the
+// profile existed at all, leaving the logging decision to the caller.
+//
+// NOTE: daemon.New carries an equivalent inline block. It is not collapsed onto
+// this function here because dispatcher.New is a critical-risk symbol (7 direct
+// callers across cli, daemon and plugin); that refactor belongs in its own PR.
+func ApplyProfile(cfg *Config, name string) (applied int, found bool) {
+	if name == "" || cfg == nil {
+		return 0, true
+	}
+	profile, ok := cfg.Profiles[name]
+	if !ok {
+		return 0, false
+	}
+	for i := range cfg.Agents {
+		ac := &cfg.Agents[i]
+		overrides, ok := profile[ac.ID]
+		if !ok {
+			continue
+		}
+		if overrides.Runner != "" {
+			ac.Runner = overrides.Runner
+		}
+		if overrides.Model != "" {
+			ac.Model = overrides.Model
+		}
+		if overrides.Fallbacks != nil {
+			ac.Fallbacks = overrides.Fallbacks
+		}
+		if overrides.FallbackStrategy != "" {
+			ac.FallbackStrategy = overrides.FallbackStrategy
+		}
+		applied++
+	}
+	return applied, true
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -153,6 +153,8 @@ func (c *Config) Validate() []error {
 		errs = append(errs, fmt.Errorf("default_runner %q: not defined in runners", c.DefaultRunner))
 	}
 
+	errs = append(errs, validateImprove(c)...)
+
 	// Enabled plugin instance ids, for plugin-bridged source references.
 	enabledPlugins := map[string]bool{}
 	for _, p := range c.Plugins {
@@ -423,6 +425,40 @@ func (c *Config) validateNotifications() []error {
 			}
 		default:
 			errs = append(errs, fmt.Errorf("notifications.channels[%d]: unknown type %q (only \"command\" is supported)", i, ch.Type))
+		}
+	}
+	return errs
+}
+
+// validateImprove checks settings.improve. The advisor agent must exist, and an
+// effort key must be one the command actually accepts — a typo like
+// `effort_models.stanadrd` would otherwise be silently ignored, leaving the
+// operator believing they had pinned a cheaper model while paying for the
+// agent's default.
+func validateImprove(c *Config) []error {
+	var errs []error
+	im := c.Settings.Improve
+
+	if im.Agent != "" {
+		found := false
+		for _, a := range c.Agents {
+			if a.ID == im.Agent {
+				found = true
+				break
+			}
+		}
+		if !found {
+			errs = append(errs, fmt.Errorf("settings.improve.agent %q: not defined in agents", im.Agent))
+		}
+	}
+
+	valid := map[string]bool{"quick": true, "standard": true, "deep": true}
+	for effort, model := range im.EffortModels {
+		if !valid[effort] {
+			errs = append(errs, fmt.Errorf("settings.improve.effort_models: unknown effort %q (want quick, standard or deep)", effort))
+		}
+		if model == "" {
+			errs = append(errs, fmt.Errorf("settings.improve.effort_models.%s: model is empty", effort))
 		}
 	}
 	return errs

--- a/src/internal/improve/advisor.go
+++ b/src/internal/improve/advisor.go
@@ -1,0 +1,223 @@
+package improve
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// DefaultAdvisorAgentID is the agent id looked up when nothing else names an
+// advisor. Defining an agent with this id is enough to make `apiary improve`
+// work with no further configuration.
+const DefaultAdvisorAgentID = "improver"
+
+// Advisor is the resolved identity that will perform the analysis: which runner
+// adapter to instantiate, with what configuration, on which model.
+type Advisor struct {
+	AgentID  string
+	RunnerID string
+	Model    string
+	MaxTurns int
+
+	// Runner is the resolved runner block. Nil only for an ad-hoc --runner that
+	// names a runner absent from config, which ResolveAdvisor rejects.
+	Runner *config.RunnerConfig
+	// Agent is the resolved agent block, or nil for an ad-hoc --runner/--model
+	// pair with no corresponding agent.
+	Agent *config.AgentConfig
+	// Fallbacks is the chain to try when the primary runner is rejected, already
+	// resolved from the agent's own chain or the global default.
+	Fallbacks []config.FallbackConfig
+	// Source records how the advisor was chosen, for the "analysing with …" line.
+	Source string
+}
+
+// AdvisorFlags carries the command-line overrides that participate in
+// resolution.
+type AdvisorFlags struct {
+	Advisor string
+	Runner  string
+	Model   string
+	Effort  Effort
+}
+
+// ResolveAdvisor decides which agent performs the analysis, in this order:
+//
+//	1. --advisor <agent-id>
+//	2. --runner <id> --model <name>   (ad-hoc, no config entry needed)
+//	3. settings.improve.agent
+//	4. an agent whose id is "improver"
+//	5. error
+//
+// It never invents a model. `agents[].model` is required config-wide and there
+// is no global default — daemon.New hard-errors with "agent %q: model is
+// required" — so a command that guessed one would be picking a model the
+// operator never chose, and billing them for it.
+func ResolveAdvisor(cfg *config.Config, flags AdvisorFlags) (*Advisor, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("no configuration loaded: `apiary improve` needs %s to resolve the analysing agent", "apiary.yaml")
+	}
+
+	// 2. Ad-hoc runner/model pair. Checked before the config sources so an
+	// explicit command line always wins.
+	if flags.Runner != "" || flags.Model != "" {
+		if flags.Runner == "" {
+			return nil, fmt.Errorf("--model requires --runner: the runner determines which adapter runs the model")
+		}
+		if flags.Model == "" {
+			return nil, fmt.Errorf("--runner requires --model: there is no default model to fall back to")
+		}
+		rc := findRunner(cfg, flags.Runner)
+		if rc == nil {
+			return nil, fmt.Errorf("runner %q is not defined in runners (available: %s)",
+				flags.Runner, strings.Join(runnerIDs(cfg), ", "))
+		}
+		if err := checkModelAllowed(rc, flags.Model); err != nil {
+			return nil, err
+		}
+		return &Advisor{
+			AgentID:  "(ad-hoc)",
+			RunnerID: rc.ID,
+			Model:    flags.Model,
+			Runner:   rc,
+			Source:   "--runner/--model",
+		}, nil
+	}
+
+	agentID, source := "", ""
+	switch {
+	case flags.Advisor != "":
+		agentID, source = flags.Advisor, "--advisor"
+	case cfg.Settings.Improve.Agent != "":
+		agentID, source = cfg.Settings.Improve.Agent, "settings.improve.agent"
+	case findAgent(cfg, DefaultAdvisorAgentID) != nil:
+		agentID, source = DefaultAdvisorAgentID, "agents[improver]"
+	default:
+		return nil, noAdvisorError(cfg)
+	}
+
+	ac := findAgent(cfg, agentID)
+	if ac == nil {
+		return nil, fmt.Errorf("advisor agent %q (%s) is not defined in agents (available: %s)",
+			agentID, source, strings.Join(agentIDs(cfg), ", "))
+	}
+
+	runnerID := ac.Runner
+	if runnerID == "" {
+		runnerID = cfg.DefaultRunner
+	}
+	if runnerID == "" {
+		return nil, fmt.Errorf("agent %q specifies no runner and default_runner is not set", agentID)
+	}
+	rc := findRunner(cfg, runnerID)
+	if rc == nil {
+		return nil, fmt.Errorf("agent %q: runner %q is not defined in runners (available: %s)",
+			agentID, runnerID, strings.Join(runnerIDs(cfg), ", "))
+	}
+
+	model := ac.Model
+	if model == "" {
+		return nil, fmt.Errorf("agent %q has no model: `model` is required and there is no global default", agentID)
+	}
+	// Effort may override the model — analysing aggregates and reasoning over
+	// prose are different jobs and need not share a model.
+	if m := cfg.Settings.Improve.EffortModels[string(flags.Effort)]; m != "" {
+		if err := checkModelAllowed(rc, m); err != nil {
+			return nil, fmt.Errorf("settings.improve.effort_models.%s: %w", flags.Effort, err)
+		}
+		model = m
+		source += fmt.Sprintf(" + effort_models.%s", flags.Effort)
+	}
+
+	fallbacks := ac.Fallbacks
+	if len(fallbacks) == 0 {
+		fallbacks = cfg.Settings.DefaultFallbacks
+	}
+
+	return &Advisor{
+		AgentID:   ac.ID,
+		RunnerID:  rc.ID,
+		Model:     model,
+		MaxTurns:  ac.MaxTurns,
+		Runner:    rc,
+		Agent:     ac,
+		Fallbacks: fallbacks,
+		Source:    source,
+	}, nil
+}
+
+// noAdvisorError explains all four ways to name an advisor rather than failing
+// with a bare "not found". This is the first wall a new user hits, so it carries
+// a config snippet they can paste.
+func noAdvisorError(cfg *config.Config) error {
+	var b strings.Builder
+	b.WriteString("no advisor agent configured — `apiary improve` needs to know which agent performs the analysis.\n\n")
+	b.WriteString("Any one of these works:\n")
+	b.WriteString("  1. apiary improve --advisor <agent-id>\n")
+	b.WriteString("  2. apiary improve --runner <id> --model <name>\n")
+	b.WriteString("  3. settings.improve.agent: <agent-id>\n")
+	b.WriteString("  4. define an agent with id \"improver\":\n\n")
+	b.WriteString("       agents:\n")
+	b.WriteString("         - id: improver\n")
+	b.WriteString("           description: \"Analyses execution metrics and proposes improvements\"\n")
+	b.WriteString("           soul_file: .apiary/agents/improver.md\n")
+	b.WriteString("           model: <model>\n")
+	if ids := agentIDs(cfg); len(ids) > 0 {
+		fmt.Fprintf(&b, "\nAgents currently defined: %s", strings.Join(ids, ", "))
+	}
+	b.WriteString("\n\n(`--dump-evidence` needs no advisor at all — it runs no model.)")
+	return fmt.Errorf("%s", b.String())
+}
+
+// checkModelAllowed rejects a model the runner does not list. A runner with no
+// `models` block accepts anything, which is the common case.
+func checkModelAllowed(rc *config.RunnerConfig, model string) error {
+	if len(rc.Models) == 0 {
+		return nil
+	}
+	for _, m := range rc.Models {
+		if m == model {
+			return nil
+		}
+	}
+	return fmt.Errorf("model %q is not listed for runner %q (allowed: %s)",
+		model, rc.ID, strings.Join(rc.Models, ", "))
+}
+
+func findAgent(cfg *config.Config, id string) *config.AgentConfig {
+	for i := range cfg.Agents {
+		if cfg.Agents[i].ID == id {
+			return &cfg.Agents[i]
+		}
+	}
+	return nil
+}
+
+func findRunner(cfg *config.Config, id string) *config.RunnerConfig {
+	for i := range cfg.Runners {
+		if cfg.Runners[i].ID == id {
+			return &cfg.Runners[i]
+		}
+	}
+	return nil
+}
+
+func agentIDs(cfg *config.Config) []string {
+	out := make([]string, 0, len(cfg.Agents))
+	for _, a := range cfg.Agents {
+		out = append(out, a.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func runnerIDs(cfg *config.Config) []string {
+	out := make([]string, 0, len(cfg.Runners))
+	for _, r := range cfg.Runners {
+		out = append(out, r.ID)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/src/internal/improve/advisor_test.go
+++ b/src/internal/improve/advisor_test.go
@@ -1,0 +1,243 @@
+package improve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func baseCfg() *config.Config {
+	return &config.Config{
+		DefaultRunner: "claude",
+		Runners: []config.RunnerConfig{
+			{ID: "claude", Type: "cli", Provider: "claude"},
+			{ID: "codex", Type: "cli", Provider: "codex", Models: []string{"gpt-5.5"}},
+		},
+		Agents: []config.AgentConfig{
+			{ID: "engineer", Model: "sonnet"},
+			{ID: "improver", Model: "opus", MaxTurns: 40},
+		},
+	}
+}
+
+func TestResolveAdvisorPrecedence(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*config.Config)
+		flags      AdvisorFlags
+		wantAgent  string
+		wantModel  string
+		wantRunner string
+	}{
+		{
+			name:       "--advisor wins over everything",
+			mutate:     func(c *config.Config) { c.Settings.Improve.Agent = "improver" },
+			flags:      AdvisorFlags{Advisor: "engineer"},
+			wantAgent:  "engineer",
+			wantModel:  "sonnet",
+			wantRunner: "claude",
+		},
+		{
+			name:       "ad-hoc runner/model wins over config",
+			mutate:     func(c *config.Config) { c.Settings.Improve.Agent = "improver" },
+			flags:      AdvisorFlags{Runner: "codex", Model: "gpt-5.5"},
+			wantAgent:  "(ad-hoc)",
+			wantModel:  "gpt-5.5",
+			wantRunner: "codex",
+		},
+		{
+			name:       "settings.improve.agent wins over the improver convention",
+			mutate:     func(c *config.Config) { c.Settings.Improve.Agent = "engineer" },
+			flags:      AdvisorFlags{},
+			wantAgent:  "engineer",
+			wantModel:  "sonnet",
+			wantRunner: "claude",
+		},
+		{
+			name:       "falls back to an agent named improver",
+			mutate:     func(*config.Config) {},
+			flags:      AdvisorFlags{},
+			wantAgent:  "improver",
+			wantModel:  "opus",
+			wantRunner: "claude",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseCfg()
+			tc.mutate(cfg)
+			adv, err := ResolveAdvisor(cfg, tc.flags)
+			if err != nil {
+				t.Fatalf("ResolveAdvisor: %v", err)
+			}
+			if adv.AgentID != tc.wantAgent || adv.Model != tc.wantModel || adv.RunnerID != tc.wantRunner {
+				t.Errorf("got %s/%s/%s, want %s/%s/%s",
+					adv.AgentID, adv.RunnerID, adv.Model, tc.wantAgent, tc.wantRunner, tc.wantModel)
+			}
+		})
+	}
+}
+
+// The command must never invent a model: `model` is required per agent and there
+// is no global default, so a guess would bill the user for a model they never
+// chose.
+func TestResolveAdvisorErrorsWithoutAnAdvisor(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Agents = []config.AgentConfig{{ID: "engineer", Model: "sonnet"}}
+
+	_, err := ResolveAdvisor(cfg, AdvisorFlags{})
+	if err == nil {
+		t.Fatal("want an error when no advisor is configured")
+	}
+	msg := err.Error()
+	for _, want := range []string{"--advisor", "--runner", "settings.improve.agent", "improver", "dump-evidence"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should mention %q so the user knows the way out; got:\n%s", want, msg)
+		}
+	}
+	if !strings.Contains(msg, "engineer") {
+		t.Error("error should list the agents that do exist")
+	}
+}
+
+func TestResolveAdvisorRejectsHalfAnAdHocPair(t *testing.T) {
+	cfg := baseCfg()
+
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Model: "opus"}); err == nil {
+		t.Error("--model without --runner must be rejected: the runner picks the adapter")
+	}
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Runner: "claude"}); err == nil {
+		t.Error("--runner without --model must be rejected: there is no default model")
+	}
+}
+
+func TestResolveAdvisorRejectsUnknownNames(t *testing.T) {
+	cfg := baseCfg()
+
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Advisor: "ghost"}); err == nil {
+		t.Error("unknown advisor agent must be rejected")
+	}
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Runner: "ghost", Model: "x"}); err == nil {
+		t.Error("unknown runner must be rejected")
+	}
+}
+
+func TestResolveAdvisorEnforcesRunnerModelList(t *testing.T) {
+	cfg := baseCfg()
+	// codex declares models: [gpt-5.5], so anything else is a config error.
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Runner: "codex", Model: "opus"}); err == nil {
+		t.Error("a model absent from the runner's models list must be rejected")
+	}
+	// claude declares none, so it accepts anything.
+	if _, err := ResolveAdvisor(cfg, AdvisorFlags{Runner: "claude", Model: "anything"}); err != nil {
+		t.Errorf("a runner with no models list accepts any model: %v", err)
+	}
+}
+
+func TestEffortModelsOverrideAgentModel(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.Improve.EffortModels = map[string]string{"quick": "haiku"}
+
+	quick, err := ResolveAdvisor(cfg, AdvisorFlags{Effort: EffortQuick})
+	if err != nil {
+		t.Fatalf("ResolveAdvisor: %v", err)
+	}
+	if quick.Model != "haiku" {
+		t.Errorf("quick model = %q, want haiku", quick.Model)
+	}
+
+	// An effort with no mapping falls through to the agent's own model.
+	deep, err := ResolveAdvisor(cfg, AdvisorFlags{Effort: EffortDeep})
+	if err != nil {
+		t.Fatalf("ResolveAdvisor: %v", err)
+	}
+	if deep.Model != "opus" {
+		t.Errorf("deep model = %q, want the agent's own opus", deep.Model)
+	}
+}
+
+func TestAdvisorInheritsFallbacks(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.DefaultFallbacks = []config.FallbackConfig{{Runner: "codex", Model: "gpt-5.5"}}
+
+	adv, err := ResolveAdvisor(cfg, AdvisorFlags{})
+	if err != nil {
+		t.Fatalf("ResolveAdvisor: %v", err)
+	}
+	if len(adv.Fallbacks) != 1 || adv.Fallbacks[0].Runner != "codex" {
+		t.Errorf("advisor should inherit settings.default_fallbacks, got %+v", adv.Fallbacks)
+	}
+
+	// An agent's own chain takes precedence over the global default.
+	cfg.Agents[1].Fallbacks = []config.FallbackConfig{{Runner: "claude"}}
+	adv, err = ResolveAdvisor(cfg, AdvisorFlags{})
+	if err != nil {
+		t.Fatalf("ResolveAdvisor: %v", err)
+	}
+	if len(adv.Fallbacks) != 1 || adv.Fallbacks[0].Runner != "claude" {
+		t.Errorf("agent fallbacks should win over the default, got %+v", adv.Fallbacks)
+	}
+}
+
+func TestApplyProfileOverlaysAgents(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Profiles = map[string]map[string]config.ProfileConfig{
+		"cheap": {"improver": {Runner: "codex", Model: "gpt-5.5"}},
+	}
+
+	applied, found := config.ApplyProfile(cfg, "cheap")
+	if !found || applied != 1 {
+		t.Fatalf("ApplyProfile = %d,%v; want 1,true", applied, found)
+	}
+	adv, err := ResolveAdvisor(cfg, AdvisorFlags{})
+	if err != nil {
+		t.Fatalf("ResolveAdvisor: %v", err)
+	}
+	if adv.RunnerID != "codex" || adv.Model != "gpt-5.5" {
+		t.Errorf("profile overlay not applied: got %s/%s", adv.RunnerID, adv.Model)
+	}
+}
+
+func TestApplyProfileUnknownNameIsReported(t *testing.T) {
+	cfg := baseCfg()
+	if _, found := config.ApplyProfile(cfg, "nope"); found {
+		t.Error("an unknown profile must report found=false so the caller can warn")
+	}
+	// An empty name is a no-op, not an error.
+	if _, found := config.ApplyProfile(cfg, ""); !found {
+		t.Error("an empty profile name is a no-op")
+	}
+}
+
+func TestParseEffort(t *testing.T) {
+	for _, s := range []string{"quick", "standard", "deep"} {
+		if _, err := ParseEffort(s); err != nil {
+			t.Errorf("ParseEffort(%q): %v", s, err)
+		}
+	}
+	if e, err := ParseEffort(""); err != nil || e != EffortStandard {
+		t.Errorf(`ParseEffort("") = %q,%v; want standard,nil`, e, err)
+	}
+	if _, err := ParseEffort("exhaustive"); err == nil {
+		t.Error("an unknown effort must be rejected")
+	}
+}
+
+func TestEffortKnobsScale(t *testing.T) {
+	quick, std, deep := EffortQuick.Expand(), EffortStandard.Expand(), EffortDeep.Expand()
+
+	if quick.TranscriptsPerHotspot != 0 {
+		t.Error("quick reads no transcripts — it is aggregates only")
+	}
+	if !(std.TranscriptsPerHotspot < deep.TranscriptsPerHotspot) {
+		t.Error("deep must read more transcripts than standard")
+	}
+	if !(quick.WorkspaceBreadth < std.WorkspaceBreadth && std.WorkspaceBreadth < deep.WorkspaceBreadth) {
+		t.Error("workspace breadth must widen with effort")
+	}
+	if deep.Critic != true || std.Critic != false {
+		t.Error("the critic pass is a deep-effort feature")
+	}
+}

--- a/src/internal/improve/effort.go
+++ b/src/internal/improve/effort.go
@@ -1,0 +1,99 @@
+package improve
+
+import "fmt"
+
+// Effort selects how much history is mined, how much of the workspace is read,
+// and how hard each proposal is scrutinised.
+//
+// Effort scales *how much* is read — never *which kinds* of file may change.
+// Even at quick the advisor may propose a soul or skill edit if the metrics
+// point there; it just reads less to reach that conclusion.
+type Effort string
+
+const (
+	EffortQuick    Effort = "quick"
+	EffortStandard Effort = "standard"
+	EffortDeep     Effort = "deep"
+)
+
+// Knobs are the concrete parameters an effort level expands into.
+type Knobs struct {
+	// DefaultWindow is used when --since was not given.
+	DefaultWindow string
+	// HotspotLimit caps how many steps get transcripts read.
+	HotspotLimit int
+	// TranscriptsPerHotspot includes one successful control run, so a value of 1
+	// means "the control only" and 3 means "two failures plus a control".
+	TranscriptsPerHotspot int
+	// TranscriptByteBudget truncates each excerpt (head + tail, middle elided).
+	TranscriptByteBudget int
+	// WorkspaceBreadth decides which prose files are inlined into the prompt.
+	WorkspaceBreadth Breadth
+	// MaxTurns caps the advisor's own agent turns. 0 means the agent's own cap.
+	MaxTurns int
+	// Critic runs a second pass that argues against each proposal before it is
+	// shown. Prose edits cannot be validated mechanically, so at deep effort
+	// this is the only automated check standing between a plausible-sounding
+	// instruction rewrite and a silent behaviour regression.
+	Critic bool
+}
+
+// Breadth selects how much of the config workspace reaches the prompt.
+type Breadth int
+
+const (
+	// BreadthFlagged reads souls and skills only for agents that appear in a
+	// finding-worthy metric.
+	BreadthFlagged Breadth = iota
+	// BreadthActive reads souls and skills for every agent with runs in the window.
+	BreadthActive
+	// BreadthAll reads the entire config workspace.
+	BreadthAll
+)
+
+// ParseEffort validates an effort string.
+func ParseEffort(s string) (Effort, error) {
+	switch Effort(s) {
+	case EffortQuick, EffortStandard, EffortDeep:
+		return Effort(s), nil
+	case "":
+		return EffortStandard, nil
+	default:
+		return "", fmt.Errorf("invalid effort %q: want quick, standard or deep", s)
+	}
+}
+
+// Expand returns the knobs for an effort level.
+func (e Effort) Expand() Knobs {
+	switch e {
+	case EffortQuick:
+		return Knobs{
+			DefaultWindow:         "7d",
+			HotspotLimit:          0,
+			TranscriptsPerHotspot: 0, // aggregates only — no transcripts, one agent call
+			WorkspaceBreadth:      BreadthFlagged,
+			MaxTurns:              0,
+			Critic:                false,
+		}
+	case EffortDeep:
+		return Knobs{
+			DefaultWindow:         "90d",
+			HotspotLimit:          15,
+			TranscriptsPerHotspot: 5,
+			TranscriptByteBudget:  12000,
+			WorkspaceBreadth:      BreadthAll,
+			MaxTurns:              0,
+			Critic:                true,
+		}
+	default: // EffortStandard
+		return Knobs{
+			DefaultWindow:         "14d",
+			HotspotLimit:          5,
+			TranscriptsPerHotspot: 2,
+			TranscriptByteBudget:  8000,
+			WorkspaceBreadth:      BreadthActive,
+			MaxTurns:              0,
+			Critic:                false,
+		}
+	}
+}

--- a/src/internal/improve/evidence.go
+++ b/src/internal/improve/evidence.go
@@ -103,6 +103,15 @@ type StepMetrics struct {
 	// prompt yielding a tiny output is a prompt-design smell.
 	PromptWeightRatio float64 `json:"prompt_weight_ratio"`
 
+	// Wall-clock attribution (issue #399): where the step's minutes actually
+	// went. Shares of the attributed total, so they sum to ~1 for runners that
+	// report timing and are all zero for those that don't. "Slow" means something
+	// different for a step that is 80% tool waits than for one that is 80%
+	// thinking, and only this split tells them apart.
+	ThinkingShare float64 `json:"thinking_share"`
+	WritingShare  float64 `json:"writing_share"`
+	ToolWaitShare float64 `json:"tool_wait_share"`
+
 	// FailoverRate is the share of runs that needed more than one runner attempt.
 	FailoverRate float64        `json:"failover_rate"`
 	FailureKinds map[string]int `json:"failure_kinds,omitempty"`

--- a/src/internal/improve/fixture_test.go
+++ b/src/internal/improve/fixture_test.go
@@ -48,7 +48,11 @@ func seedDB(t *testing.T) *sql.DB {
 			input_prompt TEXT, input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
 			total_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0,
 			cache_read_tokens INTEGER DEFAULT 0, num_turns INTEGER DEFAULT 0,
-			num_tool_calls INTEGER DEFAULT 0, cost_usd REAL DEFAULT 0)`,
+			num_tool_calls INTEGER DEFAULT 0, cost_usd REAL DEFAULT 0,
+			time_thinking_ms INTEGER DEFAULT 0, time_writing_ms INTEGER DEFAULT 0,
+			time_model_ms INTEGER DEFAULT 0, time_tool_wait_ms INTEGER DEFAULT 0,
+			time_other_ms INTEGER DEFAULT 0, time_background_ms INTEGER DEFAULT 0,
+			slow_tools TEXT)`,
 		`CREATE TABLE task_executions (
 			id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, agent_id TEXT, model TEXT,
 			runner TEXT, attempt INTEGER DEFAULT 1, status TEXT,
@@ -110,6 +114,9 @@ type stepOpts struct {
 	turns      int64
 	toolCalls  int64
 	cached     bool
+	thinkingMS int64
+	writingMS  int64
+	toolWaitMS int64
 }
 
 func addStep(t *testing.T, db *sql.DB, o stepOpts) {
@@ -128,11 +135,13 @@ func addStep(t *testing.T, db *sql.DB, o stepOpts) {
 	_, err := db.Exec(`INSERT INTO step_runs
 		(id, workflow_instance_id, step_id, agent_id, state, skipped_cached,
 		 started_at, finished_at, input_prompt, input_tokens, output_tokens,
-		 total_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		 total_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd,
+		 time_thinking_ms, time_writing_ms, time_tool_wait_ms)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		o.id, o.instanceID, o.stepID, o.agentID, o.state, cached,
 		o.startedAt, finished, o.prompt, o.inputTok, o.outputTok,
-		o.tokens, o.cacheRead, o.turns, o.toolCalls, o.cost)
+		o.tokens, o.cacheRead, o.turns, o.toolCalls, o.cost,
+		o.thinkingMS, o.writingMS, o.toolWaitMS)
 	if err != nil {
 		t.Fatalf("insert step run: %v", err)
 	}

--- a/src/internal/improve/metrics.go
+++ b/src/internal/improve/metrics.go
@@ -15,6 +15,37 @@ type source interface {
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 }
 
+// hasColumn reports whether a table carries a column.
+//
+// This matters because the improve command opens the database READ-ONLY and so
+// never runs migrations, unlike every other entry point. A database written by
+// an older binary is missing the newer columns, and selecting one is a hard SQL
+// error rather than a null — so any column added after the first release has to
+// be probed before it is selected. Degrading to "that metric is unavailable" is
+// correct here; refusing to analyse an older database is not.
+func hasColumn(ctx context.Context, db source, table, column string) bool {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			cid                        int
+			name, ctype                string
+			notnull, pk                int
+			dflt                       sql.NullString
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}
+
 // stepAccumulator collects one step's rows before they are folded into a
 // StepMetrics. Durations are kept as a slice because percentiles need the full
 // ordered set, not a running sum.
@@ -27,6 +58,8 @@ type stepAccumulator struct {
 	durations                             []int64
 
 	tokens, inputTokens, cacheReadTokens int64
+	thinkingMS, writingMS, toolWaitMS    int64
+	otherMS                              int64
 	promptBytes                          int64
 	cost                                 float64
 	turns, toolCalls                     int64
@@ -46,6 +79,18 @@ type stepAccumulator struct {
 func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepMetrics, error) {
 	where, args := stepFilter(w, sc)
 
+	// Wall-clock attribution arrived after the first release (#399). A database
+	// written by an older binary has no such columns, and this command never
+	// migrates, so select them only when they exist.
+	timingCols := `0, 0, 0, 0`
+	hasTiming := hasColumn(ctx, db, "step_runs", "time_thinking_ms")
+	if hasTiming {
+		timingCols = `COALESCE(sr.time_thinking_ms, 0),
+		       COALESCE(sr.time_writing_ms, 0),
+		       COALESCE(sr.time_tool_wait_ms, 0),
+		       COALESCE(sr.time_model_ms, 0) + COALESCE(sr.time_other_ms, 0)`
+	}
+
 	rows, err := db.QueryContext(ctx, `
 		SELECT wi.workflow_id,
 		       sr.step_id,
@@ -63,7 +108,8 @@ func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepM
 		       COALESCE(LENGTH(CAST(sr.input_prompt AS BLOB)), 0),
 		       COALESCE(sr.cost_usd, 0),
 		       COALESCE(sr.num_turns, 0),
-		       COALESCE(sr.num_tool_calls, 0)
+		       COALESCE(sr.num_tool_calls, 0),
+		       `+timingCols+`
 		FROM step_runs sr
 		JOIN workflow_instances wi ON wi.id = sr.workflow_instance_id
 		`+where+`
@@ -85,9 +131,11 @@ func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepM
 			promptLen                       int64
 			cost                            float64
 			turns, tools                    int64
+			thinkMS, writeMS, waitMS, othMS int64
 		)
 		if err := rows.Scan(&wf, &step, &agent, &state, &cachedFlag, &durMs,
-			&tokens, &inTok, &outTok, &cacheTok, &promptLen, &cost, &turns, &tools); err != nil {
+			&tokens, &inTok, &outTok, &cacheTok, &promptLen, &cost, &turns, &tools,
+			&thinkMS, &writeMS, &waitMS, &othMS); err != nil {
 			return nil, fmt.Errorf("scan step run: %w", err)
 		}
 
@@ -126,6 +174,10 @@ func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepM
 		a.cost += cost
 		a.turns += turns
 		a.toolCalls += tools
+		a.thinkingMS += thinkMS
+		a.writingMS += writeMS
+		a.toolWaitMS += waitMS
+		a.otherMS += othMS
 		if turns > 0 {
 			a.withTurns++
 			a.turnCap[turns]++
@@ -173,6 +225,14 @@ func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepM
 		}
 		if a.outputTokens > 0 {
 			m.PromptWeightRatio = float64(a.promptBytes) / float64(a.outputTokens)
+		}
+		// Attributed wall clock. Runners that don't stream provider events report
+		// nothing here, leaving all three shares at zero rather than a misleading
+		// even split.
+		if attributed := a.thinkingMS + a.writingMS + a.toolWaitMS + a.otherMS; attributed > 0 {
+			m.ThinkingShare = float64(a.thinkingMS) / float64(attributed)
+			m.WritingShare = float64(a.writingMS) / float64(attributed)
+			m.ToolWaitShare = float64(a.toolWaitMS) / float64(attributed)
 		}
 		if f, ok := failover[key]; ok {
 			m.FailoverRate = rate(f.multiAttempt, a.runs)

--- a/src/internal/improve/prompt.go
+++ b/src/internal/improve/prompt.go
@@ -1,0 +1,291 @@
+package improve
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Analysis is the advisor's structured output.
+type Analysis struct {
+	Findings        []Finding        `json:"findings"`
+	Recommendations []Recommendation `json:"recommendations"`
+}
+
+// Finding is an observation with a metric behind it.
+type Finding struct {
+	ID       string   `json:"id"`
+	Scope    string   `json:"scope"`
+	Symptom  string   `json:"symptom"`
+	Evidence []string `json:"evidence"`
+	Severity string   `json:"severity"`
+	Focus    string   `json:"focus,omitempty"`
+	// LowConfidence marks a finding drawn from a thin sample.
+	LowConfidence bool `json:"low_confidence,omitempty"`
+}
+
+// Recommendation proposes a change addressing one or more findings.
+type Recommendation struct {
+	ID             string   `json:"id"`
+	Addresses      []string `json:"addresses"`
+	File           string   `json:"file"`
+	Summary        string   `json:"summary"`
+	Rationale      string   `json:"rationale"`
+	Confidence     string   `json:"confidence"`
+	ExpectedEffect string   `json:"expected_effect,omitempty"`
+	Patch          string   `json:"patch,omitempty"`
+}
+
+// outputContract is the APIARY_OUTPUT shape the advisor must emit. It is spelled
+// out rather than derived from a schema struct so the example stays readable —
+// the advisor is being asked for prose-heavy JSON, and a worked example teaches
+// that better than a type listing.
+const outputContract = "APIARY_OUTPUT: " + `{"findings":[{"id":"f1","scope":"workflow:<id>/step:<id>","symptom":"<what is wrong, in one sentence>","evidence":["<metric>=<value> n=<runs>"],"severity":"high|medium|low","focus":"cost|latency|reliability|quality","low_confidence":false}],"recommendations":[{"id":"r1","addresses":["f1"],"file":"<path within the workspace>","summary":"<the change, in one sentence>","rationale":"<why this addresses the finding>","confidence":"high|medium|low","expected_effect":"<quantified where possible>","patch":"<unified diff>"}]}`
+
+// ComposePrompt builds the advisor's prompt: the evidence, the configuration
+// that produced it, and the rules that keep the analysis honest.
+func ComposePrompt(pack *EvidencePack, ws *Workspace, files []WorkspaceFile, k Knobs) string {
+	var b strings.Builder
+
+	b.WriteString("# Task\n\n")
+	b.WriteString("Analyse how this Apiary pipeline has actually been running and propose ")
+	b.WriteString("configuration changes that make it cheaper, faster or more reliable.\n\n")
+	b.WriteString("You are given two things: metrics computed from the execution history, ")
+	b.WriteString("and the configuration files that produced them.\n\n")
+
+	b.WriteString("# Rules\n\n")
+	b.WriteString("1. Every finding must cite a metric from the evidence below. If the evidence does not support a claim, do not make it.\n")
+	b.WriteString(fmt.Sprintf("2. Samples under %d runs are marked low_confidence. You may still report them, but say the sample is thin.\n", MinRuns))
+	b.WriteString("3. Correlation is not causation. A step may be expensive because its work is genuinely hard. Where the same agent runs in more than one workflow, compare them before blaming configuration.\n")
+	b.WriteString("4. Never propose a change to a secret: tokens, env values, credentials. They are redacted below and must stay that way.\n")
+	b.WriteString("5. Prefer fewer, better findings. Three solid ones beat twelve guesses. If the window is too thin to conclude anything, say exactly that and stop.\n")
+	b.WriteString("6. Patches must be unified diffs against a file listed under \"Configuration\". Anything else is dropped.\n\n")
+
+	b.WriteString("# What tends to be worth looking at\n\n")
+	b.WriteString("- **Rework loops** — a step running repeatedly inside one instance is an on_fail/goto cycle. The repeat runs are pure waste; the transcripts show why the step does not pass first time.\n")
+	b.WriteString("- **max_turns saturation** — runs ending exactly at the cap were cut off, not finished.\n")
+	b.WriteString("- **Low cache reuse on a hot step** — the prompt prefix keeps changing between runs, usually volatile context that could be hoisted out.\n")
+	b.WriteString("- **Heavy prompt, small output** — many input bytes per output token suggests an inflated prompt.\n")
+	b.WriteString("- **Wall-clock split** — a step dominated by tool waits has a different problem from one dominated by thinking.\n")
+	b.WriteString("- **Dead paths** — config that never runs is obsolete or silently broken. Both are worth saying.\n")
+	b.WriteString("- **Expensive waits** — hundreds of polls, or frequent timeouts, is wall-clock the config could avoid.\n\n")
+
+	b.WriteString("# Evidence\n\n")
+	b.WriteString(pack.RenderTables())
+
+	b.WriteString("\n# Configuration\n\n")
+	if len(ws.UnresolvedSkills) > 0 {
+		b.WriteString("⚠ These skills are declared by agents but could not be located on disk, ")
+		b.WriteString("so their instructions are NOT included below. Do not assume what they contain:\n")
+		for _, s := range ws.UnresolvedSkills {
+			b.WriteString("  - " + s + "\n")
+		}
+		b.WriteString("\n")
+	}
+	for _, f := range files {
+		fmt.Fprintf(&b, "## %s (%s", f.Path, f.Kind)
+		if f.Owner != "" {
+			fmt.Fprintf(&b, ", %s", f.Owner)
+		}
+		b.WriteString(")\n\n```\n")
+		b.WriteString(f.Content)
+		if !strings.HasSuffix(f.Content, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString("```\n\n")
+	}
+
+	b.WriteString("# Output\n\n")
+	b.WriteString("Emit exactly one line of the following form, as the last thing you produce:\n\n")
+	b.WriteString(outputContract + "\n\n")
+	b.WriteString("Findings may exist without recommendations — reporting a problem you cannot ")
+	b.WriteString("confidently fix is useful. A recommendation without a patch is also fine when ")
+	b.WriteString("the change needs human judgement; say so in the rationale.\n")
+
+	return b.String()
+}
+
+// RenderTables renders the evidence as compact markdown tables. Tables beat raw
+// JSON here on both token count and readability.
+func (p *EvidencePack) RenderTables() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Window: %s → %s\n\n", p.Window.Start.Format("2006-01-02"), p.Window.End.Format("2006-01-02"))
+
+	b.WriteString("## Workflows\n\n")
+	b.WriteString("| workflow | instances | states | p50 | p95 | total $ | rework $ |\n|---|---|---|---|---|---|---|\n")
+	for _, w := range sortedWorkflows(p.Workflows) {
+		rework := 0.0
+		for _, r := range w.ReworkLoops {
+			rework += r.WastedCostUSD
+		}
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s | %.2f | %.2f |\n",
+			w.WorkflowID, w.Instances, compactStates(w.ByState),
+			dur(w.DurationP50Ms), dur(w.DurationP95Ms), w.TotalCostUSD, rework)
+	}
+
+	b.WriteString("\n## Steps\n\n")
+	b.WriteString("| workflow/step | agent | runs | pass | fail | p50 | p95 | total $ | turns | cache | prompt/out | failover | thin |\n")
+	b.WriteString("|---|---|---|---|---|---|---|---|---|---|---|---|---|\n")
+	for _, s := range sortedSteps(p.Steps) {
+		thin := ""
+		if s.LowConfidence {
+			thin = "⚠"
+		}
+		fmt.Fprintf(&b, "| %s/%s | %s | %d | %.0f%% | %.0f%% | %s | %s | %.2f | %.0f | %.2f | %.0f | %.0f%% | %s |\n",
+			s.WorkflowID, s.StepID, s.AgentID, s.Runs, s.PassRate*100, s.FailRate*100,
+			dur(s.DurationP50Ms), dur(s.DurationP95Ms), s.TotalCostUSD,
+			s.MeanTurns, s.CacheReuseRatio, s.PromptWeightRatio, s.FailoverRate*100, thin)
+	}
+
+	if loops := allReworkLoops(p.Workflows); len(loops) > 0 {
+		b.WriteString("\n## Rework loops (a step repeating inside one instance)\n\n")
+		b.WriteString("| workflow/step | instances looped | extra runs | worst | wasted $ |\n|---|---|---|---|---|\n")
+		for _, l := range loops {
+			fmt.Fprintf(&b, "| %s | %d | %d | %d | %.2f |\n",
+				l.scope, l.ReworkLoop.Instances, l.ReworkLoop.TotalRepeats, l.ReworkLoop.MaxRepeats, l.ReworkLoop.WastedCostUSD)
+		}
+	}
+
+	b.WriteString("\n## Agents\n\n")
+	b.WriteString("| agent | runner | model | runs | success | total $ | mean turns | max_turns | at cap |\n|---|---|---|---|---|---|---|---|---|\n")
+	for _, a := range p.Agents {
+		cap := "—"
+		if a.ConfiguredMaxTurns > 0 {
+			cap = fmt.Sprint(a.ConfiguredMaxTurns)
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %d | %.0f%% | %.2f | %.1f | %s | %.0f%% |\n",
+			a.AgentID, a.Runner, a.Model, a.Runs, a.SuccessRate*100,
+			a.TotalCostUSD, a.MeanTurns, cap, a.MaxTurnsSaturation*100)
+	}
+
+	if len(p.Waits) > 0 {
+		b.WriteString("\n## Waits\n\n")
+		b.WriteString("| workflow/step | waits | polls | mean | max | outcomes | timeouts |\n|---|---|---|---|---|---|---|\n")
+		for _, w := range p.Waits {
+			wf := w.WorkflowID
+			if wf == "" {
+				wf = "(pruned instance)"
+			}
+			fmt.Fprintf(&b, "| %s/%s | %d | %d | %.1f | %d | %s | %d |\n",
+				wf, w.StepID, w.Waits, w.TotalPolls, w.MeanPolls, w.MaxPolls,
+				compactStates(w.TerminalStatus), w.Timeouts)
+		}
+	}
+
+	if len(p.Failures) > 0 {
+		b.WriteString("\n## Failure clusters\n\n")
+		b.WriteString("| count | agents | normalised message |\n|---|---|---|\n")
+		for _, f := range p.Failures {
+			fmt.Fprintf(&b, "| %d | %s | %s |\n", f.Count, strings.Join(f.Agents, ","),
+				strings.ReplaceAll(truncate(f.Normalized, 160), "|", "\\|"))
+		}
+	}
+
+	if d := p.Dead; len(d.Workflows)+len(d.Agents)+len(d.Fallbacks) > 0 {
+		b.WriteString("\n## Never ran in this window\n\n")
+		if len(d.Workflows) > 0 {
+			fmt.Fprintf(&b, "- workflows: %s\n", strings.Join(d.Workflows, ", "))
+		}
+		if len(d.Agents) > 0 {
+			fmt.Fprintf(&b, "- agents: %s\n", strings.Join(d.Agents, ", "))
+		}
+		if len(d.Fallbacks) > 0 {
+			fmt.Fprintf(&b, "- fallback runners: %s\n", strings.Join(d.Fallbacks, ", "))
+		}
+	}
+
+	if cands := allParallelCandidates(p.Workflows); len(cands) > 0 {
+		b.WriteString("\n## Possibly parallelisable (static analysis, conservative)\n\n")
+		for _, c := range cands {
+			fmt.Fprintf(&b, "- %s: `%s` → `%s` (%s)\n", c.workflow, c.StepPair.First, c.StepPair.Second, c.StepPair.Reason)
+		}
+	}
+
+	if len(p.Transcripts) > 0 {
+		b.WriteString("\n## Transcript excerpts\n\n")
+		for _, t := range p.Transcripts {
+			fmt.Fprintf(&b, "### %s/%s — %s (task %s, %d bytes)\n\n```\n%s\n```\n\n",
+				t.WorkflowID, t.StepID, t.Outcome, t.TaskID, t.Bytes, t.Content)
+		}
+	}
+
+	return b.String()
+}
+
+type scopedLoop struct {
+	scope string
+	ReworkLoop
+}
+
+func allReworkLoops(ws []WorkflowMetrics) []scopedLoop {
+	var out []scopedLoop
+	for _, w := range ws {
+		for _, l := range w.ReworkLoops {
+			out = append(out, scopedLoop{scope: w.WorkflowID + "/" + l.StepID, ReworkLoop: l})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].WastedCostUSD > out[j].WastedCostUSD })
+	return out
+}
+
+type scopedPair struct {
+	workflow string
+	StepPair
+}
+
+func allParallelCandidates(ws []WorkflowMetrics) []scopedPair {
+	var out []scopedPair
+	for _, w := range ws {
+		for _, c := range w.ParallelCandidates {
+			out = append(out, scopedPair{workflow: w.WorkflowID, StepPair: c})
+		}
+	}
+	return out
+}
+
+func sortedWorkflows(ws []WorkflowMetrics) []WorkflowMetrics {
+	out := make([]WorkflowMetrics, len(ws))
+	copy(out, ws)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TotalCostUSD > out[j].TotalCostUSD })
+	return out
+}
+
+func sortedSteps(ss []StepMetrics) []StepMetrics {
+	out := make([]StepMetrics, len(ss))
+	copy(out, ss)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].TotalCostUSD > out[j].TotalCostUSD })
+	return out
+}
+
+func compactStates(m map[string]int) string {
+	if len(m) == 0 {
+		return "—"
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s:%d", k, m[k]))
+	}
+	return strings.Join(parts, " ")
+}
+
+// dur renders a millisecond duration in the largest unit that stays readable.
+func dur(ms int64) string {
+	switch {
+	case ms <= 0:
+		return "—"
+	case ms < 1000:
+		return fmt.Sprintf("%dms", ms)
+	case ms < 60_000:
+		return fmt.Sprintf("%.0fs", float64(ms)/1000)
+	case ms < 3_600_000:
+		return fmt.Sprintf("%.0fm", float64(ms)/60000)
+	default:
+		return fmt.Sprintf("%.1fh", float64(ms)/3_600_000)
+	}
+}

--- a/src/internal/improve/prompt_test.go
+++ b/src/internal/improve/prompt_test.go
@@ -1,0 +1,231 @@
+package improve
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+func samplePack() *EvidencePack {
+	return &EvidencePack{
+		Window: testWindow(),
+		Steps: []StepMetrics{{
+			WorkflowID: "impl", StepID: "implement", AgentID: "engineer",
+			Runs: 100, PassRate: 0.9, FailRate: 0.1, TotalCostUSD: 42.5,
+			DurationP50Ms: 90_000, DurationP95Ms: 600_000, MeanTurns: 30,
+			CacheReuseRatio: 0.95, PromptWeightRatio: 12, FailoverRate: 0.05,
+		}},
+		Workflows: []WorkflowMetrics{{
+			WorkflowID: "impl", Instances: 50, ByState: map[string]int{"done": 45, "failed": 5},
+			TotalCostUSD: 42.5,
+			ReworkLoops: []ReworkLoop{{
+				StepID: "implement", Instances: 12, TotalRepeats: 20, MaxRepeats: 4, WastedCostUSD: 8.25,
+			}},
+			ParallelCandidates: []StepPair{{First: "lint", Second: "typecheck", Reason: "no reference"}},
+		}},
+		Agents: []AgentMetrics{{
+			AgentID: "engineer", Runner: "claude", Model: "sonnet", Runs: 100,
+			SuccessRate: 0.9, TotalCostUSD: 42.5, MeanTurns: 30,
+			ConfiguredMaxTurns: 30, MaxTurnsSaturation: 0.4,
+		}},
+		Failures: []FailureCluster{{Normalized: "task <n> timed out", Count: 7, Agents: []string{"engineer"}}},
+		Dead:     DeadPaths{Workflows: []string{"legacy"}, Agents: []string{"ghost"}},
+		Waits: []WaitMetrics{{
+			WorkflowID: "impl", StepID: "check-ci", Waits: 30, TotalPolls: 700,
+			MeanPolls: 23.3, MaxPolls: 200, Timeouts: 2,
+			TerminalStatus: map[string]int{"passed": 28, "timeout": 2},
+		}},
+	}
+}
+
+func TestComposePromptCarriesEvidenceAndRules(t *testing.T) {
+	ws := &Workspace{Root: "/repo"}
+	files := []WorkspaceFile{{Path: "apiary.yaml", Kind: KindConfig, Content: "version: \"1\"\n"}}
+
+	got := ComposePrompt(samplePack(), ws, files, EffortStandard.Expand())
+
+	// The evidence must actually be present, not merely referenced.
+	for _, want := range []string{
+		"impl/implement", "engineer", "42.50", // step row
+		"Rework loops", "8.25", // the rework table
+		"check-ci",           // waits
+		"task <n> timed out", // failure clusters
+		"legacy", "ghost",    // dead paths
+		"lint` → `typecheck", // parallel candidates
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt is missing evidence %q", want)
+		}
+	}
+
+	// The rules that keep the analysis honest.
+	for _, want := range []string{
+		"must cite a metric", "low_confidence", "Correlation is not causation",
+		"Never propose a change to a secret", "Three solid ones beat twelve guesses",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt is missing rule %q", want)
+		}
+	}
+
+	// The output contract.
+	if !strings.Contains(got, "APIARY_OUTPUT:") {
+		t.Error("prompt must state the output sentinel")
+	}
+	if !strings.Contains(got, "apiary.yaml") {
+		t.Error("prompt must inline the config file")
+	}
+}
+
+func TestComposePromptWarnsAboutUnresolvedSkills(t *testing.T) {
+	ws := &Workspace{Root: "/repo", UnresolvedSkills: []string{"deploying (declared by engineer)"}}
+	got := ComposePrompt(samplePack(), ws, nil, EffortStandard.Expand())
+
+	if !strings.Contains(got, "deploying (declared by engineer)") {
+		t.Error("unresolved skills must be named in the prompt")
+	}
+	if !strings.Contains(got, "Do not assume what they contain") {
+		t.Error("the advisor must be told not to guess at instructions it cannot see")
+	}
+}
+
+// The prompt is the last place a credential should appear. Discover redacts
+// config content on the way in; this guards the whole path end to end.
+func TestComposePromptNeverCarriesASecret(t *testing.T) {
+	raw := "agents:\n  - id: a\n    source_token: ghp_supersecret\n    env:\n      KEY: sk-live-xyz\n"
+	files := []WorkspaceFile{{Path: "apiary.yaml", Kind: KindConfig, Content: RedactConfig(raw)}}
+
+	got := ComposePrompt(samplePack(), &Workspace{}, files, EffortStandard.Expand())
+	for _, secret := range []string{"ghp_supersecret", "sk-live-xyz"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("secret %q reached the prompt", secret)
+		}
+	}
+}
+
+func TestRenderTablesHandlesEmptyPack(t *testing.T) {
+	empty := &EvidencePack{Window: testWindow()}
+	got := empty.RenderTables()
+	if got == "" {
+		t.Error("an empty pack should still render its headers rather than nothing")
+	}
+	if strings.Contains(got, "NaN") || strings.Contains(got, "+Inf") {
+		t.Errorf("empty pack produced a degenerate number:\n%s", got)
+	}
+}
+
+func TestDurRendersReadableUnits(t *testing.T) {
+	cases := []struct{ ms int64; want string }{
+		{0, "—"}, {-1, "—"}, {500, "500ms"}, {1500, "2s"},
+		{90_000, "2m"}, {3_600_000, "1.0h"}, {9_000_000, "2.5h"},
+	}
+	for _, tc := range cases {
+		if got := dur(tc.ms); got != tc.want {
+			t.Errorf("dur(%d) = %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}
+
+func TestDecodeAnalysis(t *testing.T) {
+	good := map[string]any{
+		"findings": []any{map[string]any{
+			"id": "f1", "scope": "workflow:x/step:y", "symptom": "fails often",
+			"evidence": []any{"fail_rate=0.4 n=88"}, "severity": "high",
+		}},
+		"recommendations": []any{map[string]any{
+			"id": "r1", "addresses": []any{"f1"}, "file": "apiary.yaml",
+			"summary": "gate it", "confidence": "medium",
+		}},
+	}
+	a, err := decodeAnalysis(good)
+	if err != nil {
+		t.Fatalf("decodeAnalysis: %v", err)
+	}
+	if len(a.Findings) != 1 || a.Findings[0].ID != "f1" {
+		t.Errorf("findings not decoded: %+v", a.Findings)
+	}
+	if len(a.Recommendations) != 1 || a.Recommendations[0].Addresses[0] != "f1" {
+		t.Errorf("recommendations not decoded: %+v", a.Recommendations)
+	}
+
+	// An advisor that returns a well-formed but empty result is a failure, not a
+	// clean run — silence here would read as "nothing to improve".
+	if _, err := decodeAnalysis(map[string]any{}); err == nil {
+		t.Error("an empty analysis must be an error")
+	}
+	if _, err := decodeAnalysis(map[string]any{"findings": "not-a-list"}); err == nil {
+		t.Error("a malformed analysis must be an error")
+	}
+}
+
+func TestRenderReportGroupsRecommendationsUnderFindings(t *testing.T) {
+	adv := &Advisor{AgentID: "improver", RunnerID: "claude", Model: "opus"}
+	out := &RunOutcome{
+		Analysis: Analysis{
+			Findings: []Finding{
+				{ID: "f1", Scope: "impl/implement", Symptom: "loops often", Severity: "high",
+					Evidence: []string{"rework=20 n=50"}},
+				{ID: "f2", Scope: "impl/lint", Symptom: "minor", Severity: "low", LowConfidence: true},
+			},
+			Recommendations: []Recommendation{
+				{ID: "r1", Addresses: []string{"f1"}, File: "apiary.yaml",
+					Summary: "add a gate", Rationale: "because", Confidence: "medium",
+					Patch: "--- a\n+++ b\n"},
+				{ID: "r2", Summary: "unattached idea"},
+			},
+		},
+		Usage: model.Usage{TotalTokens: 1234, CostUSD: 0.42},
+	}
+
+	got := RenderReport(samplePack(), adv, out, EffortStandard)
+
+	if !strings.Contains(got, "loops often") || !strings.Contains(got, "add a gate") {
+		t.Error("finding and its recommendation must both appear")
+	}
+	// High severity sorts above low.
+	if strings.Index(got, "loops often") > strings.Index(got, "minor") {
+		t.Error("findings must be ordered by severity")
+	}
+	if !strings.Contains(got, "thin sample") {
+		t.Error("a low-confidence finding must be marked")
+	}
+	// An unattached recommendation is shown, but separately and with a caveat —
+	// it has no evidence behind it.
+	if !strings.Contains(got, "Recommendations without a stated finding") {
+		t.Error("orphaned recommendations need their own section")
+	}
+	if !strings.Contains(got, "unattached idea") {
+		t.Error("orphaned recommendation should still be shown")
+	}
+	// The analysis reports its own cost.
+	if !strings.Contains(got, "1234 tokens") || !strings.Contains(got, "$0.42") {
+		t.Errorf("report must state what the analysis itself cost:\n%s", got)
+	}
+}
+
+func TestRenderReportHandlesNoFindings(t *testing.T) {
+	adv := &Advisor{AgentID: "improver", RunnerID: "claude", Model: "opus"}
+	out := &RunOutcome{Analysis: Analysis{}}
+	got := RenderReport(samplePack(), adv, out, EffortQuick)
+	if !strings.Contains(got, "No findings") {
+		t.Error("an empty analysis should say so plainly")
+	}
+}
+
+func TestDescribeAttemptsNamesTheFallbackChain(t *testing.T) {
+	out := &RunOutcome{Attempts: []AttemptRecord{
+		{RunnerID: "claude", Failure: "rate_limited"},
+		{RunnerID: "codex", Success: true},
+	}}
+	got := out.DescribeAttempts()
+	if !strings.Contains(got, "claude (rate_limited)") || !strings.Contains(got, "codex") {
+		t.Errorf("DescribeAttempts = %q, want the chain with its reason", got)
+	}
+
+	// A single successful attempt needs no chain line.
+	single := &RunOutcome{Attempts: []AttemptRecord{{RunnerID: "claude", Success: true}}}
+	if single.DescribeAttempts() != "" {
+		t.Error("a single attempt should not render a chain")
+	}
+}

--- a/src/internal/improve/report.go
+++ b/src/internal/improve/report.go
@@ -1,0 +1,136 @@
+package improve
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// severityRank orders findings for display; unknown severities sort last.
+var severityRank = map[string]int{"high": 0, "medium": 1, "low": 2}
+
+// RenderReport turns an analysis into the markdown a human reads. Findings come
+// first and carry their evidence, because a recommendation whose justification
+// is out of sight cannot be reviewed.
+func RenderReport(pack *EvidencePack, adv *Advisor, out *RunOutcome, effort Effort) string {
+	var b strings.Builder
+
+	b.WriteString("# Pipeline improvement report\n\n")
+	fmt.Fprintf(&b, "%s → %s · effort `%s` · advisor `%s` (%s / %s)\n\n",
+		pack.Window.Start.Format(time.DateOnly), pack.Window.End.Format(time.DateOnly),
+		effort, adv.AgentID, adv.RunnerID, adv.Model)
+	b.WriteString(pack.Summary() + "\n\n")
+
+	findings := make([]Finding, len(out.Analysis.Findings))
+	copy(findings, out.Analysis.Findings)
+	sort.SliceStable(findings, func(i, j int) bool {
+		ri, ok := severityRank[strings.ToLower(findings[i].Severity)]
+		if !ok {
+			ri = 3
+		}
+		rj, ok := severityRank[strings.ToLower(findings[j].Severity)]
+		if !ok {
+			rj = 3
+		}
+		return ri < rj
+	})
+
+	byFinding := map[string][]Recommendation{}
+	var orphaned []Recommendation
+	for _, r := range out.Analysis.Recommendations {
+		if len(r.Addresses) == 0 {
+			orphaned = append(orphaned, r)
+			continue
+		}
+		for _, id := range r.Addresses {
+			byFinding[id] = append(byFinding[id], r)
+		}
+	}
+
+	if len(findings) == 0 {
+		b.WriteString("No findings. The advisor did not identify anything worth changing.\n\n")
+	} else {
+		b.WriteString("## Findings\n\n")
+		for _, f := range findings {
+			sev := strings.ToUpper(f.Severity)
+			if sev == "" {
+				sev = "UNRATED"
+			}
+			fmt.Fprintf(&b, "### [%s] %s\n\n", sev, f.Symptom)
+			fmt.Fprintf(&b, "**Scope:** `%s`", f.Scope)
+			if f.Focus != "" {
+				fmt.Fprintf(&b, " · **Focus:** %s", f.Focus)
+			}
+			if f.LowConfidence {
+				b.WriteString(" · ⚠ **thin sample**")
+			}
+			b.WriteString("\n\n")
+			if len(f.Evidence) > 0 {
+				b.WriteString("**Evidence:**\n")
+				for _, e := range f.Evidence {
+					b.WriteString("- `" + e + "`\n")
+				}
+				b.WriteString("\n")
+			}
+			for _, r := range byFinding[f.ID] {
+				writeRecommendation(&b, r)
+			}
+		}
+	}
+
+	if len(orphaned) > 0 {
+		b.WriteString("## Recommendations without a stated finding\n\n")
+		b.WriteString("These were proposed without citing a finding, so the evidence behind them is not shown. Treat them as suggestions rather than conclusions.\n\n")
+		for _, r := range orphaned {
+			writeRecommendation(&b, r)
+		}
+	}
+
+	b.WriteString("---\n\n")
+	b.WriteString(costLine(out))
+	return b.String()
+}
+
+func writeRecommendation(b *strings.Builder, r Recommendation) {
+	fmt.Fprintf(b, "**→ %s**\n\n", r.Summary)
+	if r.File != "" {
+		fmt.Fprintf(b, "- file: `%s`\n", r.File)
+	}
+	if r.Confidence != "" {
+		fmt.Fprintf(b, "- confidence: %s\n", r.Confidence)
+	}
+	if r.ExpectedEffect != "" {
+		fmt.Fprintf(b, "- expected effect: %s\n", r.ExpectedEffect)
+	}
+	if r.Rationale != "" {
+		fmt.Fprintf(b, "\n%s\n", r.Rationale)
+	}
+	if r.Patch != "" {
+		b.WriteString("\n<details><summary>proposed patch</summary>\n\n```diff\n")
+		b.WriteString(r.Patch)
+		if !strings.HasSuffix(r.Patch, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString("```\n\n</details>\n")
+	}
+	b.WriteString("\n")
+}
+
+// costLine reports what the analysis itself cost. A tool that spends money to
+// tell you how you spend money should say what it spent.
+func costLine(out *RunOutcome) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Analysis took %s", out.Duration.Round(time.Second))
+	if out.Usage.TotalTokens > 0 {
+		fmt.Fprintf(&b, ", %d tokens", out.Usage.TotalTokens)
+	}
+	if out.Usage.CostUSD > 0 {
+		fmt.Fprintf(&b, ", $%.4f", out.Usage.CostUSD)
+	}
+	if chain := out.DescribeAttempts(); chain != "" {
+		fmt.Fprintf(&b, " · runner chain: %s", chain)
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/src/internal/improve/run.go
+++ b/src/internal/improve/run.go
@@ -1,0 +1,277 @@
+package improve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
+	"github.com/orlandoburli/apiary/internal/runner/execution"
+)
+
+// RunOutcome is the result of one advisor invocation.
+type RunOutcome struct {
+	Analysis Analysis
+	// Attempts records every runner invocation, including the ones rejected by a
+	// provider before a fallback took over.
+	Attempts []AttemptRecord
+	Usage    model.Usage
+	Duration time.Duration
+	// RawOutput is the advisor's text with the sentinel stripped. Kept so a run
+	// that produced no parseable output can still be inspected.
+	RawOutput string
+}
+
+// AttemptRecord is one runner invocation.
+type AttemptRecord struct {
+	RunnerID string
+	Adapter  string
+	Model    string
+	Success  bool
+	Failure  string
+	Err      string
+	Duration time.Duration
+}
+
+// RunAdvisor invokes the advisor agent and parses its structured output.
+//
+// It mirrors the dispatcher's construction path — resolve the runner block,
+// derive the adapter name, instantiate, Configure with the MCP/sandbox/env
+// overlay — but deliberately does not go through the dispatcher, queue or
+// workflow engine: this is a one-shot analysis that must work with the daemon
+// stopped and must not consume a dispatch slot when it is running.
+func RunAdvisor(ctx context.Context, cfg *config.Config, adv *Advisor, prompt string, k Knobs, workDir string) (*RunOutcome, error) {
+	candidates := candidateChain(cfg, adv)
+	out := &RunOutcome{}
+	started := time.Now()
+
+	var lastErr error
+	for _, c := range candidates {
+		res, err := runOnce(ctx, cfg, c, prompt, k, workDir)
+
+		rec := AttemptRecord{RunnerID: c.runnerID, Adapter: c.adapter, Model: c.model}
+		if res != nil {
+			rec.Duration = res.Duration
+			rec.Success = res.Success
+			if res.Usage != nil {
+				addUsage(&out.Usage, res.Usage)
+			}
+		}
+		if err != nil {
+			rec.Err = err.Error()
+		}
+
+		// Classify the failure the same way the daemon does, so a provider
+		// rejection advances the chain instead of aborting the whole run. A deep
+		// analysis that trips the 5-hour limit halfway through must not discard
+		// what it already spent.
+		if res != nil {
+			kind, _ := execution.FailureDetectorFor(c.adapter).Detect(model.RunRequest{}, res)
+			if kind != model.FailureNone {
+				rec.Failure = kind.String()
+			}
+			out.Attempts = append(out.Attempts, rec)
+
+			if kind == model.FailureRateLimited || kind == model.FailureCreditExhausted {
+				lastErr = fmt.Errorf("runner %s: %s", c.runnerID, kind)
+				continue
+			}
+			if res.Success {
+				out.Duration = time.Since(started)
+				out.RawOutput = res.Output
+				if res.StructuredOutput == nil {
+					return out, fmt.Errorf("advisor produced no APIARY_OUTPUT block; "+
+						"see the raw output above (%d bytes)", len(res.Output))
+				}
+				analysis, err := decodeAnalysis(res.StructuredOutput)
+				if err != nil {
+					return out, err
+				}
+				out.Analysis = analysis
+				return out, nil
+			}
+			lastErr = fmt.Errorf("runner %s failed: %v", c.runnerID, res.Error)
+			continue
+		}
+
+		out.Attempts = append(out.Attempts, rec)
+		lastErr = err
+	}
+
+	out.Duration = time.Since(started)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no runner candidates available")
+	}
+	return out, lastErr
+}
+
+type candidate struct {
+	runnerID string
+	adapter  string
+	model    string
+	rc       *config.RunnerConfig
+	agent    *config.AgentConfig
+}
+
+// candidateChain is the primary runner followed by its fallbacks, skipping any
+// fallback whose runner is not defined.
+func candidateChain(cfg *config.Config, adv *Advisor) []candidate {
+	out := []candidate{{
+		runnerID: adv.RunnerID, adapter: adv.Runner.AdapterName(),
+		model: adv.Model, rc: adv.Runner, agent: adv.Agent,
+	}}
+	for _, fb := range adv.Fallbacks {
+		rc := findRunner(cfg, fb.Runner)
+		if rc == nil {
+			continue
+		}
+		m := fb.Model
+		if m == "" {
+			m = adv.Model
+		}
+		out = append(out, candidate{
+			runnerID: rc.ID, adapter: rc.AdapterName(), model: m, rc: rc, agent: adv.Agent,
+		})
+	}
+	return out
+}
+
+func runOnce(ctx context.Context, cfg *config.Config, c candidate, prompt string, k Knobs, workDir string) (*model.RunResult, error) {
+	ra, ok := runnerimpl.New(c.adapter)
+	if !ok {
+		return nil, fmt.Errorf("runner adapter %q not registered (runner %q)", c.adapter, c.runnerID)
+	}
+
+	var agentMCPs []model.MCPServer
+	var env map[string]string
+	maxTurns := k.MaxTurns
+	if c.agent != nil {
+		agentMCPs = c.agent.MCPs
+		env = c.agent.Env
+		if maxTurns == 0 {
+			maxTurns = c.agent.MaxTurns
+		}
+	}
+
+	cfgMap := runnerConfigWithMCPs(c.rc.Config, c.rc.MCPs, agentMCPs)
+	cfgMap = injectRunnerSecurity(cfgMap, c.rc.Sandbox, c.rc.EnvPassthrough)
+	if err := ra.Configure(cfgMap); err != nil {
+		return nil, fmt.Errorf("configure runner %q: %w", c.runnerID, err)
+	}
+
+	soul := ""
+	if c.agent != nil && c.agent.SoulFile != "" {
+		if data, err := os.ReadFile(c.agent.SoulFile); err == nil {
+			soul = string(data)
+		}
+	}
+	if soul == "" {
+		soul = DefaultAdvisorSoul
+	}
+
+	req := model.RunRequest{
+		Cell: model.SourceItem{
+			ID:    "improve",
+			Title: "Pipeline self-improvement analysis",
+		},
+		WorkerID:      "improve",
+		Model:         c.model,
+		MaxTurns:      maxTurns,
+		SystemPrepend: soul,
+		SystemAppend:  prompt,
+		WorkingDir:    workDir,
+		Env:           env,
+	}
+
+	res, err := ra.Run(ctx, req)
+	return &res, err
+}
+
+// decodeAnalysis converts the runner's parsed structured output into the typed
+// analysis. Round-tripping through JSON keeps the field mapping in one place
+// (the struct tags) rather than duplicating it as map lookups.
+func decodeAnalysis(structured map[string]any) (Analysis, error) {
+	raw, err := json.Marshal(structured)
+	if err != nil {
+		return Analysis{}, fmt.Errorf("re-encode advisor output: %w", err)
+	}
+	var a Analysis
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return Analysis{}, fmt.Errorf("advisor output did not match the expected shape: %w", err)
+	}
+	if len(a.Findings) == 0 && len(a.Recommendations) == 0 {
+		return a, fmt.Errorf("advisor returned neither findings nor recommendations")
+	}
+	return a, nil
+}
+
+func addUsage(dst *model.Usage, src *model.Usage) {
+	dst.InputTokens += src.InputTokens
+	dst.OutputTokens += src.OutputTokens
+	dst.TotalTokens += src.TotalTokens
+	dst.CacheCreationTokens += src.CacheCreationTokens
+	dst.CacheReadTokens += src.CacheReadTokens
+	dst.NumTurns += src.NumTurns
+	dst.NumToolCalls += src.NumToolCalls
+	dst.CostUSD += src.CostUSD
+}
+
+// runnerConfigWithMCPs merges runner-scope and agent-scope MCP servers into the
+// runner's config map, agent overriding runner by name.
+//
+// This mirrors the daemon helper of the same name. It is duplicated rather than
+// shared because the daemon's copy is a private method on a package whose
+// constructor is a critical-risk symbol; hoisting it is a separate change.
+func runnerConfigWithMCPs(base map[string]any, runnerMCPs, agentMCPs []model.MCPServer) map[string]any {
+	merged := model.MergeMCPServers(runnerMCPs, agentMCPs)
+	if len(merged) == 0 {
+		return base
+	}
+	out := make(map[string]any, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["mcps"] = merged
+	return out
+}
+
+// injectRunnerSecurity threads the sandbox and env-passthrough settings into the
+// runner config, so an advisor run is contained exactly like a daemon run.
+func injectRunnerSecurity(base map[string]any, sandbox *config.SandboxConfig, envPassthrough []string) map[string]any {
+	if sandbox == nil && len(envPassthrough) == 0 {
+		return base
+	}
+	out := make(map[string]any, len(base)+2)
+	for k, v := range base {
+		out[k] = v
+	}
+	if sandbox != nil {
+		out["sandbox"] = sandbox
+	}
+	if len(envPassthrough) > 0 {
+		out["env_passthrough"] = envPassthrough
+	}
+	return out
+}
+
+// DescribeAttempts renders the runner chain for the cost line, naming any
+// fallback that had to take over.
+func (o *RunOutcome) DescribeAttempts() string {
+	if len(o.Attempts) <= 1 {
+		return ""
+	}
+	parts := make([]string, 0, len(o.Attempts))
+	for _, a := range o.Attempts {
+		s := a.RunnerID
+		if a.Failure != "" {
+			s += " (" + a.Failure + ")"
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, " → ")
+}

--- a/src/internal/improve/schema_compat_test.go
+++ b/src/internal/improve/schema_compat_test.go
@@ -1,0 +1,85 @@
+package improve
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// The improve command opens the database read-only and so never migrates it.
+// A database written by an older binary is missing columns added since, and
+// selecting one is a hard SQL error rather than a null — so every post-release
+// column must be probed before use. Without this the command fails outright on
+// any database that predates the newest migration.
+func TestMetricsToleratePreTimingSchema(t *testing.T) {
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared&_time_format=sqlite", url.PathEscape(t.Name()))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// step_runs exactly as it looked before the wall-clock columns (#399).
+	stmts := []string{
+		`CREATE TABLE workflow_instances (
+			id TEXT PRIMARY KEY, workflow_id TEXT, state TEXT,
+			created_at TIMESTAMP, updated_at TIMESTAMP)`,
+		`CREATE TABLE step_runs (
+			id TEXT PRIMARY KEY, workflow_instance_id TEXT, step_id TEXT, agent_id TEXT,
+			state TEXT, skipped_cached BOOLEAN DEFAULT 0,
+			started_at TIMESTAMP, finished_at TIMESTAMP, input_prompt TEXT,
+			input_tokens INTEGER DEFAULT 0, output_tokens INTEGER DEFAULT 0,
+			total_tokens INTEGER DEFAULT 0, cache_read_tokens INTEGER DEFAULT 0,
+			num_turns INTEGER DEFAULT 0, num_tool_calls INTEGER DEFAULT 0,
+			cost_usd REAL DEFAULT 0)`,
+		`CREATE TABLE task_executions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, task_id TEXT, agent_id TEXT, model TEXT,
+			runner TEXT, attempt INTEGER DEFAULT 1, status TEXT, started_at TIMESTAMP,
+			duration_ms INTEGER, error_message TEXT, workflow_instance_id TEXT,
+			step_id TEXT, num_turns INTEGER DEFAULT 0, cost_usd REAL DEFAULT 0,
+			failure_kind TEXT)`,
+		`CREATE TABLE ci_poll_checks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, workflow_instance_id TEXT,
+			step_id TEXT, status TEXT, checked_at TIMESTAMP)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create legacy schema: %v", err)
+		}
+	}
+
+	if _, err := db.Exec(`INSERT INTO workflow_instances (id, workflow_id, state, created_at, updated_at)
+	                      VALUES ('i1','wf','done',?,?)`, base, base); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO step_runs
+		(id, workflow_instance_id, step_id, agent_id, state, started_at, finished_at, cost_usd)
+		VALUES ('s1','i1','implement','engineer','passed',?,?,0.5)`, base, base); err != nil {
+		t.Fatalf("seed step: %v", err)
+	}
+
+	if got := hasColumn(ctx(), db, "step_runs", "time_thinking_ms"); got {
+		t.Fatal("fixture is not actually a legacy schema")
+	}
+
+	steps, err := StepMetricsFor(ctx(), db, testWindow(), Scope{})
+	if err != nil {
+		t.Fatalf("StepMetricsFor must work against a pre-timing database: %v", err)
+	}
+	m := findStep(t, steps, "wf", "implement")
+	if m.Runs != 1 {
+		t.Errorf("Runs = %d, want 1", m.Runs)
+	}
+	// The timing metrics are simply absent, not wrong.
+	if m.ThinkingShare != 0 || m.WritingShare != 0 || m.ToolWaitShare != 0 {
+		t.Errorf("timing shares should be zero on a legacy schema, got %v/%v/%v",
+			m.ThinkingShare, m.WritingShare, m.ToolWaitShare)
+	}
+
+	// The whole pack must build, not just the step query.
+	if _, err := Build(ctx(), db, Options{Window: testWindow(), Clock: func() time.Time { return base }}); err != nil {
+		t.Fatalf("Build must work against a pre-timing database: %v", err)
+	}
+}

--- a/src/internal/improve/soul.go
+++ b/src/internal/improve/soul.go
@@ -1,0 +1,39 @@
+package improve
+
+// DefaultAdvisorSoul is used when the advisor agent defines no soul file, so
+// `apiary improve` works before anything has been configured for it.
+//
+// It is deliberately short. The prompt already carries the rules and the
+// evidence; what belongs here is the disposition — what kind of analyst to be,
+// and what failure mode to avoid.
+const DefaultAdvisorSoul = `You analyse how an agent pipeline has actually been running, and propose
+configuration changes that make it cheaper, faster or more reliable.
+
+You are not reviewing code and you are not doing the pipeline's work. Your
+subject is the pipeline itself: its workflows, its agents' instructions, and the
+numbers those produced.
+
+The failure mode to avoid is confident noise. It is always possible to generate
+a dozen plausible-sounding suggestions from any dataset; that is worse than
+useless here, because someone will act on them. A short analysis that names two
+real problems and admits what it cannot explain is worth more than a thorough
+one built on inference.
+
+So:
+
+- Anchor every claim to a number you were given. If you find yourself reasoning
+  from what usually happens in pipelines rather than from what happened in this
+  one, stop and drop the finding.
+- Distinguish what the data shows from what you suspect. Both are worth saying;
+  conflating them is not.
+- A small sample is a small sample. Say so rather than hedging with vague
+  language.
+- When you propose changing an agent's instructions, quote the line you would
+  change and say which runs made you think so. Prose edits cannot be validated
+  mechanically — a reviewer has only your reasoning to go on, so show it.
+- Expensive is not the same as wasteful. A step that costs a lot doing genuinely
+  hard work is fine. Look for waste: repetition, truncation, work thrown away,
+  waiting.
+
+Write for someone who knows this pipeline better than you do and has ten minutes.
+`

--- a/src/internal/improve/workspace.go
+++ b/src/internal/improve/workspace.go
@@ -1,0 +1,291 @@
+package improve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// FileKind classifies a workspace file by what changing it would affect.
+type FileKind string
+
+const (
+	KindConfig   FileKind = "config"
+	KindWorkflow FileKind = "workflow"
+	KindSoul     FileKind = "soul"
+	KindSkill    FileKind = "skill"
+)
+
+// WorkspaceFile is one file the advisor may read and propose edits to.
+type WorkspaceFile struct {
+	Path    string   `json:"path"`
+	Kind    FileKind `json:"kind"`
+	Owner   string   `json:"owner,omitempty"` // agent or workflow the file belongs to
+	Content string   `json:"-"`
+	Bytes   int      `json:"bytes"`
+}
+
+// Workspace is the complete set of files that shape agent behaviour.
+type Workspace struct {
+	Root  string          `json:"root"`
+	Files []WorkspaceFile `json:"files"`
+	// UnresolvedSkills are skills declared by an agent that could not be located
+	// on disk. They are reported rather than dropped: an advisor reasoning about
+	// an agent whose instructions it never saw is worse than one that knows a
+	// piece is missing.
+	UnresolvedSkills []string `json:"unresolved_skills,omitempty"`
+}
+
+// skillSearchDirs lists where a declared skill name may live, relative to the
+// workspace root plus the user's home.
+//
+// Apiary itself never resolves skills: agents[].skills is passed through to the
+// runner as bare names (the opencode agent file carries them verbatim), and the
+// runner applies its own conventions. So this mirrors those conventions rather
+// than reusing an apiary resolver — there is none. A name that matches nothing
+// is reported in UnresolvedSkills.
+var skillSearchDirs = []string{
+	".claude/skills",
+	".opencode/skills",
+	".apiary/skills",
+}
+
+// Discover walks the configuration to find every file that shapes agent
+// behaviour: the config itself, referenced workflow files, soul files and
+// resolvable skill definitions.
+func Discover(cfg *config.Config, configFile string) (*Workspace, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("no configuration loaded")
+	}
+	abs, err := filepath.Abs(configFile)
+	if err != nil {
+		abs = configFile
+	}
+	root := filepath.Dir(abs)
+	if filepath.Base(root) == ".apiary" {
+		root = filepath.Dir(root)
+	}
+
+	ws := &Workspace{Root: root}
+	seen := map[string]bool{}
+
+	add := func(path string, kind FileKind, owner string) {
+		if path == "" {
+			return
+		}
+		full := path
+		if !filepath.IsAbs(full) {
+			full = filepath.Join(root, path)
+		}
+		full = filepath.Clean(full)
+		if seen[full] || Excluded(full, root) {
+			return
+		}
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return // referenced but absent; cfg.Validate reports soul files properly
+		}
+		seen[full] = true
+		content := string(data)
+		if kind == KindConfig {
+			content = RedactConfig(content)
+		}
+		rel, err := filepath.Rel(root, full)
+		if err != nil {
+			rel = full
+		}
+		ws.Files = append(ws.Files, WorkspaceFile{
+			Path: rel, Kind: kind, Owner: owner, Content: content, Bytes: len(data),
+		})
+	}
+
+	add(abs, KindConfig, "")
+
+	for _, wf := range cfg.Workflows {
+		for _, s := range wf.Steps {
+			if s.Uses != "" {
+				// `uses` is relative to the declaring YAML, not the root.
+				add(filepath.Join(filepath.Dir(abs), s.Uses), KindWorkflow, wf.ID)
+			}
+		}
+	}
+
+	for _, a := range cfg.Agents {
+		add(a.SoulFile, KindSoul, a.ID)
+		for _, skill := range a.Skills {
+			if path := resolveSkill(root, skill); path != "" {
+				add(path, KindSkill, a.ID)
+			} else {
+				ws.UnresolvedSkills = append(ws.UnresolvedSkills,
+					fmt.Sprintf("%s (declared by %s)", skill, a.ID))
+			}
+		}
+	}
+
+	sort.Strings(ws.UnresolvedSkills)
+	ws.UnresolvedSkills = dedupe(ws.UnresolvedSkills)
+	return ws, nil
+}
+
+// resolveSkill looks for a declared skill name in the conventional locations.
+func resolveSkill(root, name string) string {
+	if name == "" {
+		return ""
+	}
+	home, _ := os.UserHomeDir()
+	roots := []string{root}
+	if home != "" {
+		roots = append(roots, home)
+	}
+	for _, r := range roots {
+		for _, dir := range skillSearchDirs {
+			for _, candidate := range []string{
+				filepath.Join(r, dir, name, "SKILL.md"),
+				filepath.Join(r, dir, name+".md"),
+			} {
+				if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+					return candidate
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// excludedNames matches files that must never reach a prompt or a patch,
+// regardless of where they sit.
+var excludedNames = regexp.MustCompile(`(^|/)(\.env(\..*)?|.*\.env|.*secret.*|.*credential.*|.*\.pem|.*\.key)$`)
+
+// excludedDirs are directories whose contents are never part of the workspace.
+var excludedDirs = []string{".git/", "/logs/", "/transcripts/", "/memory/", "node_modules/"}
+
+// Excluded reports whether a path must be kept out of the workspace: secrets,
+// version-control internals, and the runtime data directories. It also rejects
+// anything outside the workspace root, so a patch cannot escape upward.
+func Excluded(path, root string) bool {
+	clean := filepath.Clean(path)
+	slashed := filepath.ToSlash(clean)
+
+	if root != "" {
+		rel, err := filepath.Rel(root, clean)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+			return true
+		}
+	}
+	if excludedNames.MatchString(slashed) {
+		return true
+	}
+	for _, d := range excludedDirs {
+		if strings.Contains(slashed+"/", d) {
+			return true
+		}
+	}
+	// The database and its WAL sidecars.
+	if ext := filepath.Ext(slashed); ext == ".db" || ext == ".db-wal" || ext == ".db-shm" || ext == ".sock" {
+		return true
+	}
+	return false
+}
+
+// secretKeys are config keys whose values are blanked before the config text
+// enters a prompt. The advisor never needs a token's value to reason about
+// configuration, and a prompt is the last place a credential should appear.
+var secretKeys = regexp.MustCompile(`(?i)^(\s*(?:-\s*)?)(source_token|token|api_key|apikey|password|secret|.*_token|.*_key)(\s*:\s*)(.+)$`)
+
+// envValueLine matches an indented `KEY: value` pair, used to blank the bodies
+// of env: blocks without needing a YAML round-trip (which would reorder keys
+// and strip the comments the advisor benefits from reading).
+var envValueLine = regexp.MustCompile(`^(\s+)([A-Za-z_][A-Za-z0-9_]*)(\s*:\s*)(.+)$`)
+
+// RedactConfig blanks secret-bearing values in raw config text, preserving
+// structure, ordering and comments so the advisor still sees the shape of the
+// file it may be asked to patch.
+func RedactConfig(raw string) string {
+	lines := strings.Split(raw, "\n")
+	inEnvBlock := false
+	envIndent := 0
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Track env:/mcps env blocks, whose values are all potentially secret.
+		if trimmed == "env:" || strings.HasSuffix(trimmed, " env:") {
+			inEnvBlock = true
+			envIndent = indentOf(line)
+			continue
+		}
+		if inEnvBlock {
+			if trimmed == "" {
+				continue
+			}
+			if indentOf(line) <= envIndent {
+				inEnvBlock = false
+			} else if m := envValueLine.FindStringSubmatch(line); m != nil {
+				lines[i] = m[1] + m[2] + m[3] + redactedFor(m[4])
+				continue
+			}
+		}
+
+		if m := secretKeys.FindStringSubmatch(line); m != nil {
+			lines[i] = m[1] + m[2] + m[3] + redactedFor(m[4])
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// redactedFor keeps a pure ${VAR} reference visible — it names an environment
+// variable rather than carrying a secret, and the advisor may legitimately want
+// to reason about which variable an agent uses.
+func redactedFor(value string) string {
+	v := strings.TrimSpace(value)
+	if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") && !strings.Contains(v, " ") {
+		return v
+	}
+	return "<redacted>"
+}
+
+func indentOf(s string) int {
+	return len(s) - len(strings.TrimLeft(s, " \t"))
+}
+
+func dedupe(ss []string) []string {
+	if len(ss) == 0 {
+		return nil
+	}
+	out := ss[:1]
+	for _, s := range ss[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// Filter returns the workspace files relevant at a given breadth, given the set
+// of agents that actually ran.
+func (w *Workspace) Filter(breadth Breadth, active map[string]bool, flagged map[string]bool) []WorkspaceFile {
+	if breadth == BreadthAll {
+		return w.Files
+	}
+	want := active
+	if breadth == BreadthFlagged {
+		want = flagged
+	}
+	var out []WorkspaceFile
+	for _, f := range w.Files {
+		switch f.Kind {
+		case KindConfig, KindWorkflow:
+			out = append(out, f) // always in scope: it is what gets patched
+		default:
+			if f.Owner == "" || want[f.Owner] {
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}

--- a/src/internal/improve/workspace_test.go
+++ b/src/internal/improve/workspace_test.go
@@ -1,0 +1,213 @@
+package improve
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func TestRedactConfigBlanksSecrets(t *testing.T) {
+	raw := `agents:
+  - id: engineer
+    model: sonnet
+    source_token: ghp_realsecretvalue123
+    source_email: a@b.com
+    env:
+      API_KEY: sk-live-abcdef
+      LOG_LEVEL: debug
+  - id: qa
+    source_token: ${GITHUB_TOKEN_QA}
+settings:
+  api_key: literal-secret
+`
+	got := RedactConfig(raw)
+
+	for _, secret := range []string{"ghp_realsecretvalue123", "sk-live-abcdef", "literal-secret"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("secret %q survived redaction:\n%s", secret, got)
+		}
+	}
+	// A ${VAR} reference names an environment variable rather than carrying a
+	// secret, and the advisor may legitimately reason about which var an agent
+	// uses — so it stays.
+	if !strings.Contains(got, "${GITHUB_TOKEN_QA}") {
+		t.Error("a pure ${VAR} reference should be preserved")
+	}
+	// Non-secret structure must survive, or the advisor cannot patch the file.
+	for _, keep := range []string{"id: engineer", "model: sonnet", "source_email: a@b.com"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("redaction removed non-secret content %q:\n%s", keep, got)
+		}
+	}
+
+	// Every value inside an env: block is blanked, including innocuous ones like
+	// LOG_LEVEL. This over-redacts deliberately: env blocks routinely carry
+	// tokens and there is no reliable way to tell from the key name, so the safe
+	// default is to blank them all. The KEY NAMES survive, so the advisor can
+	// still see which variables a step sets and reason about them — it just
+	// never sees a value.
+	if strings.Contains(got, "LOG_LEVEL: debug") {
+		t.Error("env values should be blanked wholesale, not filtered by key name")
+	}
+	if !strings.Contains(got, "LOG_LEVEL: <redacted>") {
+		t.Errorf("the env key name must survive so the advisor sees what is set:\n%s", got)
+	}
+}
+
+func TestRedactConfigLeavesEnvBlockAfterDedent(t *testing.T) {
+	raw := `agents:
+  - id: a
+    env:
+      SECRET_THING: hunter2
+    model: sonnet
+workflows:
+  - id: w
+`
+	got := RedactConfig(raw)
+	if strings.Contains(got, "hunter2") {
+		t.Error("env value inside the block must be redacted")
+	}
+	// `model` sits at a shallower indent than the env entries, so it must not be
+	// swallowed by the env block.
+	if !strings.Contains(got, "model: sonnet") {
+		t.Errorf("dedent should end the env block:\n%s", got)
+	}
+}
+
+func TestExcludedPaths(t *testing.T) {
+	root := "/repo"
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/repo/apiary.yaml", false},
+		{"/repo/.apiary/agents/engineer.md", false},
+		{"/repo/.claude/skills/foo/SKILL.md", false},
+		{"/repo/.env", true},
+		{"/repo/.env.local", true},
+		{"/repo/config.env", true},
+		{"/repo/my-secret-file.yaml", true},
+		{"/repo/aws-credentials", true},
+		{"/repo/key.pem", true},
+		{"/repo/.git/config", true},
+		{"/repo/.apiary/apiary.db", true},
+		{"/repo/.apiary/apiary.db-wal", true},
+		{"/repo/.apiary/logs/apiary.log", true},
+		{"/repo/.apiary/logs/transcripts/t1/a.md", true},
+		{"/repo/.apiary/memory/MEMORY.md", true},
+		{"/etc/passwd", true},              // outside the root
+		{"/repo/../elsewhere/x.yaml", true}, // escapes the root
+	}
+	for _, tc := range cases {
+		if got := Excluded(tc.path, root); got != tc.want {
+			t.Errorf("Excluded(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestDiscoverWalksTheWorkspace(t *testing.T) {
+	root := t.TempDir()
+	mkdir := func(p string) { os.MkdirAll(filepath.Join(root, p), 0o755) }
+	write := func(p, s string) {
+		if err := os.WriteFile(filepath.Join(root, p), []byte(s), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkdir(".apiary/agents")
+	mkdir(".claude/skills/deploying")
+	write(".apiary/apiary.yaml", "version: \"1\"\n")
+	write(".apiary/agents/engineer.md", "you are an engineer\n")
+	write(".claude/skills/deploying/SKILL.md", "how to deploy\n")
+
+	cfg := &config.Config{Agents: []config.AgentConfig{{
+		ID:       "engineer",
+		SoulFile: filepath.Join(root, ".apiary/agents/engineer.md"),
+		Skills:   []string{"deploying", "nonexistent-skill"},
+	}}}
+
+	ws, err := Discover(cfg, filepath.Join(root, ".apiary/apiary.yaml"))
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+
+	kinds := map[FileKind]int{}
+	for _, f := range ws.Files {
+		kinds[f.Kind]++
+	}
+	if kinds[KindConfig] != 1 {
+		t.Errorf("want the config file, got %d", kinds[KindConfig])
+	}
+	if kinds[KindSoul] != 1 {
+		t.Errorf("want the soul file, got %d", kinds[KindSoul])
+	}
+	if kinds[KindSkill] != 1 {
+		t.Errorf("want the resolvable skill, got %d", kinds[KindSkill])
+	}
+
+	// A skill that cannot be located must be reported, never silently dropped:
+	// an advisor reasoning about an agent whose instructions it never saw is
+	// worse than one that knows a piece is missing.
+	if len(ws.UnresolvedSkills) != 1 || !strings.Contains(ws.UnresolvedSkills[0], "nonexistent-skill") {
+		t.Errorf("UnresolvedSkills = %v, want the missing skill reported", ws.UnresolvedSkills)
+	}
+	if !strings.Contains(ws.UnresolvedSkills[0], "engineer") {
+		t.Error("an unresolved skill should name the agent that declared it")
+	}
+}
+
+func TestDiscoverSkipsExcludedSoulFile(t *testing.T) {
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, ".apiary"), 0o755)
+	os.WriteFile(filepath.Join(root, ".apiary/apiary.yaml"), []byte("version: \"1\"\n"), 0o600)
+	os.WriteFile(filepath.Join(root, ".env"), []byte("TOKEN=abc\n"), 0o600)
+
+	cfg := &config.Config{Agents: []config.AgentConfig{{
+		ID: "sneaky", SoulFile: filepath.Join(root, ".env"),
+	}}}
+
+	ws, err := Discover(cfg, filepath.Join(root, ".apiary/apiary.yaml"))
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, f := range ws.Files {
+		if strings.Contains(f.Content, "TOKEN=abc") {
+			t.Fatal(".env content reached the workspace through a soul_file reference")
+		}
+	}
+}
+
+func TestWorkspaceFilterByBreadth(t *testing.T) {
+	ws := &Workspace{Files: []WorkspaceFile{
+		{Path: "apiary.yaml", Kind: KindConfig},
+		{Path: "wf.yaml", Kind: KindWorkflow, Owner: "impl"},
+		{Path: "a.md", Kind: KindSoul, Owner: "busy"},
+		{Path: "b.md", Kind: KindSoul, Owner: "idle"},
+		{Path: "c.md", Kind: KindSkill, Owner: "flagged"},
+	}}
+	active := map[string]bool{"busy": true, "flagged": true}
+	flagged := map[string]bool{"flagged": true}
+
+	all := ws.Filter(BreadthAll, active, flagged)
+	if len(all) != 5 {
+		t.Errorf("BreadthAll = %d files, want all 5", len(all))
+	}
+
+	act := ws.Filter(BreadthActive, active, flagged)
+	if len(act) != 4 {
+		t.Errorf("BreadthActive = %d files, want 4 (idle agent's soul dropped)", len(act))
+	}
+
+	flg := ws.Filter(BreadthFlagged, active, flagged)
+	if len(flg) != 3 {
+		t.Errorf("BreadthFlagged = %d files, want 3 (config, workflow, flagged skill)", len(flg))
+	}
+	// Config and workflow files are always in scope — they are what gets patched.
+	for _, f := range flg {
+		if f.Kind == KindSoul {
+			t.Error("BreadthFlagged should not carry an unflagged agent's soul")
+		}
+	}
+}


### PR DESCRIPTION
Phase 2 of #401. Closes #403. Phase 1 (#408) built the evidence pack; this adds the agent that reads it, the configuration it reads alongside it, and the report it produces.

## Advisor resolution — fails loudly rather than guessing

In order: `--advisor` → ad-hoc `--runner`+`--model` → `settings.improve.agent` → an agent named `improver` → **error**.

It never invents a model. `agents[].model` is required config-wide and there is no global default (`daemon.New` hard-errors with `agent %q: model is required`), so a guess would bill for a model the operator never chose. The error names all four ways out and carries a paste-ready snippet.

Because the advisor is an ordinary agent, two things work by reuse rather than reimplementation:
- **Profiles** — new `config.ApplyProfile` applies `profiles.<name>`
- **Fallbacks** — a rejection classified by `execution.FailureDetectorFor` advances the chain instead of aborting. A `deep` run that trips the 5-hour limit must not discard what it already spent.

## Config workspace

Walks config → workflow files → souls → skills. Skills resolve against the *runner's* conventions (`.claude/skills/<name>/SKILL.md` and siblings) because **apiary has no skill resolver of its own** — it passes bare names straight through to the runner. That answers the open question flagged in the proposal. A skill that can't be located is **reported, never silently dropped**: an advisor reasoning about an agent whose instructions it never saw is worse than one that knows a piece is missing.

Redaction blanks **every** value inside an `env:` block rather than filtering by key name — env blocks routinely carry tokens and the key name doesn't tell you. Key names survive, so the advisor still sees which variables a step sets.

Verified against the real project-erp config: 96KB prompt, zero literal token values, `${VAR}` references correctly preserved.

## Two things the real database found

1. **The read-only connection never migrates.** A database written before #409 lacks the wall-clock columns, and selecting a missing column is a hard SQL error, not a null — so `apiary improve` failed outright on any database predating the newest migration. Post-release columns are now probed with `hasColumn` first, with a regression test that builds the whole pack against a pre-timing schema. Every entry point except this one migrates on open, which is exactly why it was easy to miss.
2. **Wall-clock attribution from #409 is folded in** as thinking/writing/tool-wait shares. A step that is 80% tool waits has a different problem from one that is 80% thinking, and only this split tells them apart.

## Effort

Scales *how much* is read and how hard proposals are scrutinised — never *which kinds* of file may change:

| | quick | standard | deep |
|---|---|---|---|
| window | 7d | 14d | 90d |
| transcripts | none | 2 × 5 hotspots | 5 × 15 hotspots |
| workspace | flagged agents | active agents | everything |
| critic pass | — | — | ✓ |

`settings.improve.effort_models` optionally picks a cheaper model per level; validated so a typo like `stanadrd` is an error rather than silently ignored (which would leave you believing you'd pinned a cheap model while paying for the default).

## --dump-prompt

New flag that composes the prompt and exits without running a model, so the exact text — and the redaction — can be reviewed before paying for a run. It's also how the redaction check above was done.

## Deliberately not done

`dispatcher.New` carries an equivalent inline profile-overlay block. gitnexus `impact` returns **CRITICAL** on it (23 impacted symbols, 7 direct callers, 8 processes), so collapsing the two onto `config.ApplyProfile` is left to its own PR where that risk gets a focused review. Same reasoning for the `runnerConfigWithMCPs`/`injectRunnerSecurity` helpers, which are duplicated with a comment saying why.

## Testing

`make check` green across 33 packages; `improve` and `config` also under `-race`. New tests cover advisor precedence (all four sources, plus the no-advisor error naming every way out), half-an-ad-hoc-pair rejection, runner model lists, effort-model override, fallback inheritance, profile overlay, workspace discovery with an unresolved skill, `.env`-via-soul_file exclusion, redaction (including that a `.env` referenced as a soul file can't sneak in), prompt composition and secret-freedom, report grouping and ordering, and the legacy-schema compatibility path.

## Next

#404 (patches + five-stage validation) → #405 (apply) → #406 (ledger + effect) → #407 (docs).