### PR TITLE
fix(improve): sample the transcript of the step being analysed (#403)

### DIFF
--- a/src/internal/improve/effort.go
+++ b/src/internal/improve/effort.go
@@ -26,6 +26,10 @@ type Knobs struct {
 	// means "the control only" and 3 means "two failures plus a control".
 	TranscriptsPerHotspot int
 	// TranscriptByteBudget truncates each excerpt (head + tail, middle elided).
+	// Agent sessions for a substantial step routinely run to hundreds of
+	// kilobytes, so a small budget keeps a percent or two of the file and the
+	// excerpt stops being evidence of anything. These are sized to keep enough
+	// of both ends to see how a run started and how it ended.
 	TranscriptByteBudget int
 	// WorkspaceBreadth decides which prose files are inlined into the prompt.
 	WorkspaceBreadth Breadth
@@ -80,7 +84,7 @@ func (e Effort) Expand() Knobs {
 			DefaultWindow:         "90d",
 			HotspotLimit:          15,
 			TranscriptsPerHotspot: 5,
-			TranscriptByteBudget:  12000,
+			TranscriptByteBudget:  40000,
 			WorkspaceBreadth:      BreadthAll,
 			MaxTurns:              0,
 			Critic:                true,
@@ -90,7 +94,7 @@ func (e Effort) Expand() Knobs {
 			DefaultWindow:         "14d",
 			HotspotLimit:          5,
 			TranscriptsPerHotspot: 2,
-			TranscriptByteBudget:  8000,
+			TranscriptByteBudget:  24000,
 			WorkspaceBreadth:      BreadthActive,
 			MaxTurns:              0,
 			Critic:                false,

--- a/src/internal/improve/transcripts.go
+++ b/src/internal/improve/transcripts.go
@@ -143,7 +143,7 @@ func transcriptRefs(ctx context.Context, db source, logDir string, w Window, h H
 		if state == "passed" && successes >= 1 {
 			continue
 		}
-		file := latestTranscriptFile(filepath.Join(logDir, "transcripts", taskID))
+		file := transcriptForStep(filepath.Join(logDir, "transcripts", taskID), h.StepID)
 		if file == "" {
 			continue
 		}
@@ -160,29 +160,42 @@ func transcriptRefs(ctx context.Context, db source, logDir string, w Window, h H
 	return refs, rows.Err()
 }
 
-// latestTranscriptFile returns the most recently modified .md transcript in a
-// task's transcript directory, or "" when there is none. Transcripts are written
-// per step run, and the newest is the one that matches the run being sampled.
-func latestTranscriptFile(dir string) string {
+// transcriptForStep returns the transcript belonging to a specific step of a
+// task, or "" when there is none.
+//
+// A task's transcript directory holds one file per step run, named
+// "<instance>_<n>-<stepID>.md". Selecting by modification time instead returns
+// whichever step ran LAST — almost always the final step of the workflow — so
+// every hotspot receives the same terminal transcript regardless of which step
+// was being sampled. That silently replaces the evidence the analysis depends
+// on: an "implement" hotspot gets handed the "merge" session, and the whole
+// point of reading transcripts is lost.
+//
+// When several runs of the same step exist (a rework loop — precisely the case
+// worth reading), the most recent is returned, since that is the attempt whose
+// outcome the metrics describe.
+func transcriptForStep(dir, stepID string) string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return ""
 	}
-	var newest string
-	var newestMod int64
+	suffix := "-" + stepID + ".md"
+
+	var best string
+	var bestMod int64
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
 			continue
 		}
 		info, err := e.Info()
 		if err != nil {
 			continue
 		}
-		if mod := info.ModTime().UnixNano(); mod > newestMod {
-			newestMod, newest = mod, e.Name()
+		if mod := info.ModTime().UnixNano(); mod > bestMod {
+			bestMod, best = mod, e.Name()
 		}
 	}
-	return newest
+	return best
 }
 
 // elide truncates a transcript to a byte budget, keeping the head and the tail.

--- a/src/internal/improve/transcripts_test.go
+++ b/src/internal/improve/transcripts_test.go
@@ -1,0 +1,110 @@
+package improve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A task's transcript directory holds one file per step. Selecting by
+// modification time returns whichever step ran LAST — almost always the final
+// step of the workflow — so every hotspot receives the same terminal transcript
+// no matter which step is being sampled. That silently substitutes the evidence
+// the whole analysis rests on.
+//
+// Observed against a real database: sampling implement, validate, review and
+// triage all returned the same 4618-byte "merge" transcript, while the 103KB
+// implement transcript that would have explained the rework was never read. The
+// advisor noticed before the tests did — it reported "root cause not visible in
+// provided transcripts, which cover only merge steps".
+func TestTranscriptForStepMatchesTheStepNotTheNewestFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Real naming: <instance>_<n>-<stepID>.md, written in execution order so
+	// merge is the newest.
+	files := []struct {
+		name string
+		age  time.Duration
+	}{
+		{"wf_1786129309127914000_190-implement.md", 20 * time.Minute},
+		{"wf_1786129309127914000_190-validate.md", 10 * time.Minute},
+		{"wf_1786129309127914000_190-review.md", 5 * time.Minute},
+		{"wf_1786129309127914000_190-merge.md", 1 * time.Minute},
+	}
+	now := time.Now()
+	for _, f := range files {
+		path := filepath.Join(dir, f.name)
+		if err := os.WriteFile(path, []byte("# "+f.name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mod := now.Add(-f.age)
+		if err := os.Chtimes(path, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, step := range []string{"implement", "validate", "review", "merge"} {
+		got := transcriptForStep(dir, step)
+		want := "wf_1786129309127914000_190-" + step + ".md"
+		if got != want {
+			t.Errorf("transcriptForStep(%q) = %q, want %q", step, got, want)
+		}
+	}
+}
+
+// A rework loop writes several transcripts for the same step. The most recent is
+// the attempt whose outcome the metrics describe.
+func TestTranscriptForStepPrefersTheLatestRunOfThatStep(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+
+	for i, f := range []struct {
+		name string
+		age  time.Duration
+	}{
+		{"wf_1_1-implement.md", 30 * time.Minute},
+		{"wf_1_2-implement.md", 20 * time.Minute}, // the retry
+		{"wf_1_3-merge.md", 1 * time.Minute},      // newer, but a different step
+	} {
+		path := filepath.Join(dir, f.name)
+		if err := os.WriteFile(path, []byte{byte(i)}, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mod := now.Add(-f.age)
+		if err := os.Chtimes(path, mod, mod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := transcriptForStep(dir, "implement"); got != "wf_1_2-implement.md" {
+		t.Errorf("transcriptForStep = %q, want the latest implement run", got)
+	}
+}
+
+func TestTranscriptForStepMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "wf_1_1-merge.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := transcriptForStep(dir, "implement"); got != "" {
+		t.Errorf("transcriptForStep = %q, want empty when the step has no transcript", got)
+	}
+	if got := transcriptForStep(filepath.Join(dir, "nope"), "implement"); got != "" {
+		t.Errorf("transcriptForStep = %q, want empty for a missing directory", got)
+	}
+}
+
+// A step id that is a suffix of another must not match it: "validate" and
+// "revalidate" are different steps.
+func TestTranscriptForStepDoesNotMatchSuffixCollisions(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"wf_1_1-revalidate.md", "wf_1_2-validate.md"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := transcriptForStep(dir, "validate"); got != "wf_1_2-validate.md" {
+		t.Errorf("transcriptForStep = %q, want the exact step match", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #412. Found by running `--effort standard` against a real database.

## The bug

Transcript sampling selected each task's **most recently modified** transcript instead of the one belonging to the step being sampled. A task's directory holds one file per step (`<instance>_<n>-<stepID>.md`), so the newest is whichever step ran *last* — almost always the workflow's final step. Every hotspot received the same terminal transcript regardless of which step it was for.

On a real 7-day window, sampling `implement`, `validate`, `review` and `triage` all returned the same **4618-byte `merge`** transcript. The **653KB `implement`** transcript that would explain the rework was never read. The tell was four different steps reporting identical byte counts.

The advisor noticed before the tests did:

> root cause not visible in provided transcripts, which cover only merge steps

That is the failure mode this feature is supposed to prevent — the evidence the analysis rests on was silently replaced with something unrelated, and every number around it still looked right.

## The fix

`transcriptForStep` matches on the `-<stepID>.md` suffix. Where a step ran several times in one task — a rework loop, precisely the case worth reading — it returns the most recent attempt, since that is the one the metrics describe.

Also raises the per-excerpt budgets: **standard 8KB → 24KB, deep 12KB → 40KB**. Agent sessions for a substantial step routinely run to hundreds of kilobytes, so 8KB kept ~1% of the file and the excerpt stopped being evidence of anything.

## Effect, measured

Same window, same effort, same model — before and after:

| | before | after |
|---|---|---|
| findings | 3 (one being "root cause not visible") | 3, all with root causes |
| recommendations | 2, both cosmetic merge-step fixes | 3, each quoting a specific transcript |

After the fix it found:

1. **reviewer soul missing `--repo` on `gh pr list`** — three consecutive reviewer sessions in task 4147 opening with `fatal: not a git repository` before any work completes
2. **gitnexus impact failing on every run** — the main project-erp path is absent from the index, only stale worktrees are registered; agents retry 3–5 times then abandon. I verified this independently with `list_repos`: only `task-2696` (2026-07-02) and `k3s-worker-config` (2026-07-22) are indexed, and I hit the same `Multiple repositories indexed` error myself earlier in this session
3. **engineer-10x looping `git fetch`** — eight consecutive `git log origin/agent/task-4218` calls for a branch that existed only locally and had never been pushed

None of these were reachable before, at any effort level.

## Testing

Four new tests, including the exact shape that broke: a directory with implement/validate/review/merge where merge is newest, asserting each step resolves to its own file. Plus latest-run-of-the-same-step, missing step, missing directory, and a suffix-collision case (`validate` must not match `revalidate`).

`make check` green across 33 packages.