### PR TITLE
feat(improve): patch parsing and the five-stage validation gate (#404)

### DIFF
--- a/src/internal/cli/improve.go
+++ b/src/internal/cli/improve.go
@@ -157,22 +157,49 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 				return runErr
 			}
 
+			// Validate every proposal before it is shown. A patch that cannot be
+			// applied, or that breaks the config, must not reach the reviewer
+			// looking actionable.
+			validator := improve.NewValidator(ws, configFile, cfg)
+			verdicts := validator.Validate(outcome.Analysis.Recommendations)
+
+			if knobs.Critic {
+				fmt.Fprintf(os.Stderr, "running critic pass over %d proposal(s)…\n", len(verdicts))
+				updated, criticOut, err := improve.RunCritic(ctx, cfg, adv, outcome.Analysis, verdicts,
+					files, knobs, filepath.Dir(configFile))
+				if err != nil {
+					// A failed critic must not discard a valid analysis.
+					fmt.Fprintf(os.Stderr, "  ⚠ critic pass failed (%v); proposals are shown unreviewed\n", err)
+				}
+				verdicts = updated
+				if criticOut != nil {
+					outcome.AddUsage(criticOut.Usage)
+				}
+			}
+
 			report := improve.RenderReport(pack, adv, outcome, effort)
+			diff := improve.RenderDiff(outcome.Analysis, verdicts)
 
 			if outDir != "" {
-				if err := writeArtifacts(outDir, pack, outcome, report); err != nil {
+				if err := writeArtifacts(outDir, pack, outcome, report+"\n"+diff); err != nil {
 					return err
 				}
 				fmt.Fprintf(os.Stderr, "written to %s\n", outDir)
 			}
+
+			fmt.Fprintln(os.Stderr, improve.DiffSummary(verdicts))
 
 			switch output {
 			case "json":
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				enc.SetIndent("", "  ")
 				return enc.Encode(outcome.Analysis)
-			default:
+			case "report":
 				fmt.Fprint(cmd.OutOrStdout(), report)
+				return nil
+			default: // diff
+				fmt.Fprint(cmd.OutOrStdout(), report)
+				fmt.Fprint(cmd.OutOrStdout(), "\n"+diff)
 				return nil
 			}
 		},
@@ -187,7 +214,7 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 	cmd.Flags().StringVar(&runnerID, "runner", "", "ad-hoc runner for the analysis (requires --model)")
 	cmd.Flags().StringVar(&modelID, "model", "", "ad-hoc model for the analysis (requires --runner)")
 	cmd.Flags().StringVar(&profile, "profile", "", "activate a named runner profile from config profiles.<name>")
-	cmd.Flags().StringVar(&output, "output", "report", "what to print: report|json")
+	cmd.Flags().StringVar(&output, "output", "diff", "what to print: diff|report|json")
 	cmd.Flags().StringVar(&outDir, "out", "", "also write report, analysis and evidence to this directory")
 	cmd.Flags().BoolVar(&dumpEvidence, "dump-evidence", false, "print the evidence pack as JSON and exit (runs no model)")
 	cmd.Flags().BoolVar(&dumpPrompt, "dump-prompt", false, "print the composed advisor prompt and exit (runs no model)")

--- a/src/internal/improve/critic.go
+++ b/src/internal/improve/critic.go
@@ -1,0 +1,152 @@
+package improve
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// Critique is a second opinion on one proposal.
+type Critique struct {
+	RecommendationID string `json:"recommendation_id"`
+	// Verdict is "sound", "weak" or "wrong".
+	Verdict string `json:"verdict"`
+	// Objection states the strongest case against the proposal. Required even
+	// when the verdict is "sound" — a critic that returns approval with no
+	// reasoning has not done the work.
+	Objection string `json:"objection"`
+	// Alternative is a different reading of the same evidence, when one exists.
+	Alternative string `json:"alternative,omitempty"`
+}
+
+// CritiqueSet is the critic's structured output.
+type CritiqueSet struct {
+	Critiques []Critique `json:"critiques"`
+}
+
+// criticPrompt asks for the case against each proposal.
+//
+// The critic exists mainly for prose edits. A YAML change is checked by the
+// validation gate: it parses, it validates, its expressions lint. A soul-file
+// edit clears none of that — nothing mechanical can tell a good instruction from
+// a plausible-sounding one. Until the effect measurement in a later phase can
+// score a change against the metric that motivated it, an adversarial reading is
+// the only automated check those edits get.
+func criticPrompt(analysis Analysis, verdicts []Verdict, workspace []WorkspaceFile) string {
+	var b strings.Builder
+
+	b.WriteString("# Task\n\nAnother analyst reviewed this pipeline's execution history and proposed the changes below. ")
+	b.WriteString("Your job is to argue against them.\n\n")
+	b.WriteString("For each proposal, state the strongest objection you can make. Consider:\n\n")
+	b.WriteString("- Does the evidence actually support the conclusion, or only correlate with it?\n")
+	b.WriteString("- Is the sample large enough to distinguish a pattern from noise?\n")
+	b.WriteString("- Would the change plausibly make something else worse — a step slower, an agent more likely to give up, a failure mode moved rather than removed?\n")
+	b.WriteString("- For an instruction change: would an agent reading the new text actually behave differently, or does it just read better to a human?\n")
+	b.WriteString("- Is there a simpler explanation for the metric that the proposal does not address?\n\n")
+	b.WriteString("Return \"sound\" only when you genuinely cannot mount an objection that survives inspection. ")
+	b.WriteString("You must give reasoning either way: an approval with no argument behind it is not useful.\n\n")
+
+	b.WriteString("# Proposals\n\n")
+	findingByID := map[string]Finding{}
+	for _, f := range analysis.Findings {
+		findingByID[f.ID] = f
+	}
+	for _, v := range verdicts {
+		if !v.OK {
+			continue
+		}
+		r := v.Recommendation
+		fmt.Fprintf(&b, "## %s — %s\n\n", r.ID, r.Summary)
+		fmt.Fprintf(&b, "- target: %s\n- confidence claimed: %s\n", r.File, r.Confidence)
+		if r.ExpectedEffect != "" {
+			fmt.Fprintf(&b, "- expected effect: %s\n", r.ExpectedEffect)
+		}
+		if !v.MachineChecked {
+			b.WriteString("- **prose file: nothing about this change can be checked mechanically**\n")
+		}
+		b.WriteString("\n")
+		for _, id := range r.Addresses {
+			if f, ok := findingByID[id]; ok {
+				fmt.Fprintf(&b, "Evidence offered: %s\n", f.Symptom)
+				for _, e := range f.Evidence {
+					fmt.Fprintf(&b, "  - %s\n", e)
+				}
+				if f.LowConfidence {
+					b.WriteString("  - (marked as a thin sample)\n")
+				}
+			}
+		}
+		if r.Rationale != "" {
+			fmt.Fprintf(&b, "\nStated rationale: %s\n", r.Rationale)
+		}
+		if r.Patch != "" {
+			fmt.Fprintf(&b, "\n```diff\n%s\n```\n", strings.TrimRight(r.Patch, "\n"))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(workspace) > 0 {
+		b.WriteString("# Current configuration\n\n")
+		for _, f := range workspace {
+			fmt.Fprintf(&b, "## %s\n\n```\n%s\n```\n\n", f.Path, f.Content)
+		}
+	}
+
+	b.WriteString("# Output\n\n")
+	b.WriteString("Emit exactly one line, as the last thing you produce:\n\n")
+	b.WriteString(`APIARY_OUTPUT: {"critiques":[{"recommendation_id":"r1","verdict":"sound|weak|wrong","objection":"<the strongest case against it>","alternative":"<a different reading of the same evidence, if one exists>"}]}` + "\n")
+	return b.String()
+}
+
+// RunCritic asks the advisor to argue against its own proposals and folds the
+// result into the verdicts. A "wrong" verdict demotes the proposal out of the
+// accepted set; "weak" keeps it but attaches the objection.
+func RunCritic(ctx context.Context, cfg *config.Config, adv *Advisor, analysis Analysis, verdicts []Verdict, workspace []WorkspaceFile, k Knobs, workDir string) ([]Verdict, *RunOutcome, error) {
+	anyAccepted := false
+	for _, v := range verdicts {
+		if v.OK && strings.TrimSpace(v.Recommendation.Patch) != "" {
+			anyAccepted = true
+			break
+		}
+	}
+	if !anyAccepted {
+		return verdicts, nil, nil
+	}
+
+	prompt := criticPrompt(analysis, verdicts, workspace)
+	outcome, err := runStructured(ctx, cfg, adv, prompt, k, workDir)
+	if err != nil {
+		// A failed critic must not discard a valid analysis. Report it and leave
+		// the proposals as they were, unannotated.
+		return verdicts, outcome, err
+	}
+
+	var set CritiqueSet
+	if err := decodeInto(outcome.Structured, &set); err != nil {
+		return verdicts, outcome, fmt.Errorf("critic output did not match the expected shape: %w", err)
+	}
+
+	byID := map[string]Critique{}
+	for _, c := range set.Critiques {
+		byID[c.RecommendationID] = c
+	}
+
+	out := make([]Verdict, 0, len(verdicts))
+	for _, v := range verdicts {
+		c, ok := byID[v.Recommendation.ID]
+		if !ok {
+			out = append(out, v)
+			continue
+		}
+		v.Critique = &c
+		if strings.EqualFold(c.Verdict, "wrong") {
+			v.OK = false
+			v.Reached = StageCritic
+			v.Reason = "rejected by the critic pass: " + c.Objection
+		}
+		out = append(out, v)
+	}
+	return out, outcome, nil
+}

--- a/src/internal/improve/diff.go
+++ b/src/internal/improve/diff.go
@@ -1,0 +1,169 @@
+package improve
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RenderDiff presents validated proposals as a reviewable diff.
+//
+// Each hunk arrives with the finding and metric that justified it, grouped by
+// file. A diff read on its own can only be judged on whether the change looks
+// sensible; read next to the number that motivated it, it can be judged on
+// whether it is warranted. That is the difference between reviewing a patch and
+// reviewing an argument.
+func RenderDiff(analysis Analysis, verdicts []Verdict) string {
+	accepted, rejected := Summarize(verdicts)
+
+	findingByID := map[string]Finding{}
+	for _, f := range analysis.Findings {
+		findingByID[f.ID] = f
+	}
+
+	byFile := map[string][]Verdict{}
+	var order []string
+	for _, v := range accepted {
+		if strings.TrimSpace(v.Recommendation.Patch) == "" {
+			continue
+		}
+		path := v.Recommendation.File
+		if path == "" {
+			path = "(unspecified)"
+		}
+		if _, seen := byFile[path]; !seen {
+			order = append(order, path)
+		}
+		byFile[path] = append(byFile[path], v)
+	}
+	sort.Strings(order)
+
+	var b strings.Builder
+
+	if len(order) == 0 {
+		b.WriteString("No applicable changes.\n\n")
+	}
+
+	for _, path := range order {
+		vs := byFile[path]
+		added, removed := 0, 0
+		machineChecked := true
+		for _, v := range vs {
+			added += v.Added
+			removed += v.Removed
+			if !v.MachineChecked {
+				machineChecked = false
+			}
+		}
+
+		fmt.Fprintf(&b, "## %s  (+%d −%d)\n", path, added, removed)
+		if machineChecked {
+			b.WriteString("_validated: parses, config checks and expression lint pass_\n\n")
+		} else {
+			// Saying this plainly is the point. A reviewer needs to know which
+			// hunks a machine agreed with and which merely applied cleanly.
+			b.WriteString("_prose file — only checked that the patch applies; nothing here can be validated mechanically_\n\n")
+		}
+
+		for _, v := range vs {
+			r := v.Recommendation
+			fmt.Fprintf(&b, "**%s**\n\n", r.Summary)
+
+			for _, id := range r.Addresses {
+				f, ok := findingByID[id]
+				if !ok {
+					continue
+				}
+				fmt.Fprintf(&b, "> %s", f.Symptom)
+				if f.LowConfidence {
+					b.WriteString(" _(thin sample)_")
+				}
+				b.WriteString("\n")
+				for _, e := range f.Evidence {
+					fmt.Fprintf(&b, "> · `%s`\n", e)
+				}
+				b.WriteString("\n")
+			}
+
+			if r.Confidence != "" || r.ExpectedEffect != "" {
+				parts := []string{}
+				if r.Confidence != "" {
+					parts = append(parts, "confidence "+r.Confidence)
+				}
+				if r.ExpectedEffect != "" {
+					parts = append(parts, r.ExpectedEffect)
+				}
+				fmt.Fprintf(&b, "%s\n\n", strings.Join(parts, " · "))
+			}
+
+			for _, w := range v.NewWarnings {
+				fmt.Fprintf(&b, "⚠ introduces a new config warning: %s\n\n", w)
+			}
+
+			b.WriteString("```diff\n")
+			b.WriteString(strings.TrimRight(r.Patch, "\n"))
+			b.WriteString("\n```\n\n")
+		}
+	}
+
+	// Advisory recommendations: accepted, but carrying no patch.
+	var advisory []Verdict
+	for _, v := range accepted {
+		if strings.TrimSpace(v.Recommendation.Patch) == "" {
+			advisory = append(advisory, v)
+		}
+	}
+	if len(advisory) > 0 {
+		b.WriteString("## Advisory (no patch proposed)\n\n")
+		for _, v := range advisory {
+			fmt.Fprintf(&b, "- **%s**", v.Recommendation.Summary)
+			if v.Recommendation.Rationale != "" {
+				fmt.Fprintf(&b, "\n  %s", v.Recommendation.Rationale)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(rejected) > 0 {
+		// A rejected patch is still a signal — the advisor saw something. Showing
+		// why it failed lets the reader judge whether the underlying observation
+		// is worth acting on by hand.
+		b.WriteString("## Could not be validated\n\n")
+		for _, v := range rejected {
+			fmt.Fprintf(&b, "- **%s**\n  - target: `%s`\n  - stopped at: %s\n  - reason: %s\n",
+				v.Recommendation.Summary, v.Recommendation.File, v.Reached, v.Reason)
+		}
+		b.WriteString("\nThese were not applied. The observation behind each may still be worth acting on by hand.\n\n")
+	}
+
+	return b.String()
+}
+
+// DiffSummary is the one-line tally printed after a run.
+func DiffSummary(verdicts []Verdict) string {
+	accepted, rejected := Summarize(verdicts)
+	patched, advisory, machineChecked := 0, 0, 0
+	for _, v := range accepted {
+		if strings.TrimSpace(v.Recommendation.Patch) == "" {
+			advisory++
+			continue
+		}
+		patched++
+		if v.MachineChecked {
+			machineChecked++
+		}
+	}
+
+	parts := []string{fmt.Sprintf("%d change(s)", patched)}
+	if machineChecked < patched {
+		parts = append(parts, fmt.Sprintf("%d machine-checked", machineChecked))
+	}
+	if advisory > 0 {
+		parts = append(parts, fmt.Sprintf("%d advisory", advisory))
+	}
+	if len(rejected) > 0 {
+		parts = append(parts, fmt.Sprintf("%d rejected", len(rejected)))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/src/internal/improve/diff_test.go
+++ b/src/internal/improve/diff_test.go
@@ -1,0 +1,128 @@
+package improve
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderDiffPairsHunksWithTheirEvidence(t *testing.T) {
+	analysis := Analysis{
+		Findings: []Finding{{
+			ID: "f1", Scope: "impl/implement", Symptom: "loops in 29 of 155 instances",
+			Evidence: []string{"rework_$=55.09 n=29", "extra_runs=61"},
+		}},
+	}
+	verdicts := []Verdict{{
+		OK: true, Reached: StageValidated, MachineChecked: true, Added: 3, Removed: 1,
+		Recommendation: Recommendation{
+			ID: "r1", Addresses: []string{"f1"}, File: "apiary.yaml",
+			Summary: "gate the step", Confidence: "medium", ExpectedEffect: "~$55/fortnight",
+			Patch: "--- a/apiary.yaml\n+++ b/apiary.yaml\n@@ -1,1 +1,1 @@\n-a\n+b\n",
+		},
+	}}
+
+	got := RenderDiff(analysis, verdicts)
+
+	// The change, the evidence for it, and the tally must travel together — a
+	// diff read next to the number that motivated it can be judged on whether it
+	// is warranted, not merely whether it looks sensible.
+	for _, want := range []string{
+		"apiary.yaml", "+3 −1", "gate the step",
+		"loops in 29 of 155 instances", "rework_$=55.09 n=29",
+		"confidence medium", "~$55/fortnight", "```diff",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered diff missing %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "validated:") {
+		t.Error("a machine-checked file should say so")
+	}
+}
+
+func TestRenderDiffFlagsProseAsUnverified(t *testing.T) {
+	verdicts := []Verdict{{
+		OK: true, MachineChecked: false, Added: 2,
+		Recommendation: Recommendation{
+			ID: "r1", File: "engineer.md", Summary: "add a rule",
+			Patch: "--- a/engineer.md\n+++ b/engineer.md\n@@ -1,1 +1,2 @@\n a\n+b\n",
+		},
+	}}
+	got := RenderDiff(Analysis{}, verdicts)
+	if !strings.Contains(got, "nothing here can be validated mechanically") {
+		t.Errorf("a prose patch must be labelled unverifiable:\n%s", got)
+	}
+}
+
+func TestRenderDiffShowsRejectionsWithReasons(t *testing.T) {
+	verdicts := []Verdict{{
+		OK: false, Reached: StageApply, Reason: "hunk 1 context mismatch at line 4",
+		Recommendation: Recommendation{ID: "r1", File: "apiary.yaml", Summary: "retarget the merge step"},
+	}}
+	got := RenderDiff(Analysis{}, verdicts)
+
+	if !strings.Contains(got, "Could not be validated") {
+		t.Error("rejected proposals need their own section")
+	}
+	for _, want := range []string{"retarget the merge step", "apply", "context mismatch"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rejection should carry %q:\n%s", want, got)
+		}
+	}
+	// A rejected patch is still a signal; the reader should be told it may be
+	// worth acting on by hand.
+	if !strings.Contains(got, "worth acting on by hand") {
+		t.Error("rejections should say the observation may still matter")
+	}
+}
+
+func TestRenderDiffSeparatesAdvisoryRecommendations(t *testing.T) {
+	verdicts := []Verdict{{
+		OK: true, Reason: "no patch — advisory only",
+		Recommendation: Recommendation{ID: "r1", Summary: "audit the transcripts", Rationale: "cannot verify statically"},
+	}}
+	got := RenderDiff(Analysis{}, verdicts)
+	if !strings.Contains(got, "Advisory (no patch proposed)") {
+		t.Errorf("advisory recommendations need their own section:\n%s", got)
+	}
+	if !strings.Contains(got, "audit the transcripts") {
+		t.Error("advisory content should be shown")
+	}
+}
+
+func TestRenderDiffHandlesNothingApplicable(t *testing.T) {
+	got := RenderDiff(Analysis{}, nil)
+	if !strings.Contains(got, "No applicable changes") {
+		t.Errorf("an empty verdict set should say so plainly:\n%s", got)
+	}
+}
+
+func TestDiffSummaryCounts(t *testing.T) {
+	verdicts := []Verdict{
+		{OK: true, MachineChecked: true, Recommendation: Recommendation{Patch: "d"}},
+		{OK: true, MachineChecked: false, Recommendation: Recommendation{Patch: "d"}},
+		{OK: true, Recommendation: Recommendation{}}, // advisory
+		{OK: false, Recommendation: Recommendation{Patch: "d"}},
+	}
+	got := DiffSummary(verdicts)
+	for _, want := range []string{"2 change(s)", "1 machine-checked", "1 advisory", "1 rejected"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("DiffSummary = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestNewWarningsAreSurfaced(t *testing.T) {
+	verdicts := []Verdict{{
+		OK: true, MachineChecked: true,
+		NewWarnings: []string{"workflow x: step y is unreachable"},
+		Recommendation: Recommendation{
+			ID: "r1", File: "apiary.yaml", Summary: "reorder",
+			Patch: "--- a/apiary.yaml\n+++ b/apiary.yaml\n@@ -1,1 +1,1 @@\n-a\n+b\n",
+		},
+	}}
+	got := RenderDiff(Analysis{}, verdicts)
+	if !strings.Contains(got, "introduces a new config warning") {
+		t.Errorf("a warning the patch introduces must be shown beside it:\n%s", got)
+	}
+}

--- a/src/internal/improve/patch.go
+++ b/src/internal/improve/patch.go
@@ -1,0 +1,260 @@
+package improve
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Hunk is one contiguous change within a patch.
+type Hunk struct {
+	// OldStart is the 1-based line in the original file where the hunk begins.
+	OldStart int
+	OldLines int
+	NewStart int
+	NewLines int
+	// Lines are the raw body lines, each still carrying its leading ' ', '-' or
+	// '+'. "\ No newline at end of file" markers are dropped during parsing.
+	Lines []string
+}
+
+// Patch is a parsed unified diff for a single file.
+type Patch struct {
+	// Path is the target, taken from the +++ header with any a/ or b/ prefix
+	// stripped.
+	Path  string
+	Hunks []Hunk
+}
+
+// ParsePatch reads a unified diff for one file.
+//
+// It is strict on purpose. A malformed hunk header is rejected rather than
+// guessed at, because the alternative — inferring where a change belongs — is
+// how a patch silently lands in the wrong place. Observed in practice: an
+// advisor emitted `@@ implementation/merge step @@` as a header, naming the
+// section in prose instead of giving line numbers. That must fail loudly.
+func ParsePatch(diff string) (*Patch, error) {
+	lines := strings.Split(strings.ReplaceAll(diff, "\r\n", "\n"), "\n")
+	p := &Patch{}
+	var current *Hunk
+	// Remaining body lines the open hunk expects, from its declared counts.
+	oldLeft, newLeft := 0, 0
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+
+		switch {
+		case strings.HasPrefix(line, "--- "):
+			continue // the old path is informational; +++ names the target
+
+		case strings.HasPrefix(line, "+++ "):
+			path := strings.TrimSpace(strings.TrimPrefix(line, "+++ "))
+			// Drop a trailing tab-separated timestamp, if present.
+			if idx := strings.IndexByte(path, '\t'); idx >= 0 {
+				path = path[:idx]
+			}
+			path = strings.TrimPrefix(strings.TrimPrefix(path, "a/"), "b/")
+			if path == "" || path == "/dev/null" {
+				return nil, fmt.Errorf("patch targets %q, which is not a file", path)
+			}
+			p.Path = path
+
+		case strings.HasPrefix(line, "@@"):
+			h, err := parseHunkHeader(line)
+			if err != nil {
+				return nil, err
+			}
+			p.Hunks = append(p.Hunks, h)
+			current = &p.Hunks[len(p.Hunks)-1]
+			oldLeft, newLeft = h.OldLines, h.NewLines
+
+		case strings.HasPrefix(line, "diff "), strings.HasPrefix(line, "index "),
+			strings.HasPrefix(line, "new file"), strings.HasPrefix(line, "deleted file"),
+			strings.HasPrefix(line, "similarity "), strings.HasPrefix(line, "rename "):
+			continue
+
+		case strings.HasPrefix(line, `\ No newline`):
+			continue
+
+		default:
+			// Prose around the diff is tolerated — models routinely wrap a patch
+			// in explanation — but only outside a hunk. Inside one, the hunk's
+			// declared line counts say exactly how many body lines to consume, so
+			// there is no need to guess where it ends. That matters for blank
+			// lines: one inside a hunk is an unprefixed context line for a blank
+			// source line, while one after the hunk is just spacing before prose,
+			// and only the counts distinguish them.
+			if current == nil || (oldLeft <= 0 && newLeft <= 0) {
+				current = nil
+				continue
+			}
+			if len(line) > 0 && !strings.ContainsAny(line[:1], " -+") {
+				current = nil
+				continue
+			}
+			if line == "" {
+				line = " "
+			}
+			switch line[0] {
+			case ' ':
+				oldLeft--
+				newLeft--
+			case '-':
+				oldLeft--
+			case '+':
+				newLeft--
+			}
+			current.Lines = append(current.Lines, line)
+		}
+	}
+
+	if p.Path == "" {
+		return nil, fmt.Errorf("patch has no +++ target header")
+	}
+	if len(p.Hunks) == 0 {
+		return nil, fmt.Errorf("patch for %s has no hunks", p.Path)
+	}
+	return p, nil
+}
+
+// parseHunkHeader parses "@@ -old,count +new,count @@ optional context".
+func parseHunkHeader(line string) (Hunk, error) {
+	rest := strings.TrimPrefix(line, "@@")
+	end := strings.Index(rest, "@@")
+	if end < 0 {
+		return Hunk{}, fmt.Errorf("malformed hunk header %q: missing closing @@", line)
+	}
+	spec := strings.Fields(strings.TrimSpace(rest[:end]))
+	if len(spec) != 2 {
+		return Hunk{}, fmt.Errorf("malformed hunk header %q: want @@ -old,count +new,count @@", line)
+	}
+	oldStart, oldLines, err := parseRange(spec[0], '-')
+	if err != nil {
+		return Hunk{}, fmt.Errorf("malformed hunk header %q: %w", line, err)
+	}
+	newStart, newLines, err := parseRange(spec[1], '+')
+	if err != nil {
+		return Hunk{}, fmt.Errorf("malformed hunk header %q: %w", line, err)
+	}
+	return Hunk{OldStart: oldStart, OldLines: oldLines, NewStart: newStart, NewLines: newLines}, nil
+}
+
+// parseRange parses "-12,7" or "+12" (count defaults to 1).
+func parseRange(s string, sign byte) (start, count int, err error) {
+	if len(s) == 0 || s[0] != sign {
+		return 0, 0, fmt.Errorf("range %q must begin with %q", s, string(sign))
+	}
+	body := s[1:]
+	count = 1
+	if idx := strings.IndexByte(body, ','); idx >= 0 {
+		if _, err := fmt.Sscanf(body[idx+1:], "%d", &count); err != nil {
+			return 0, 0, fmt.Errorf("range %q has a non-numeric count", s)
+		}
+		body = body[:idx]
+	}
+	if _, err := fmt.Sscanf(body, "%d", &start); err != nil {
+		return 0, 0, fmt.Errorf("range %q has a non-numeric start", s)
+	}
+	if start < 0 || count < 0 {
+		return 0, 0, fmt.Errorf("range %q is negative", s)
+	}
+	return start, count, nil
+}
+
+// Apply applies the patch to content in memory and returns the result.
+//
+// Context must match exactly. There is no fuzz factor and no offset search: a
+// hunk whose context does not match is an error, not an invitation to look
+// nearby. A patch that lands in the wrong place is worse than one that does not
+// land at all, because the diff shown to the reviewer would no longer describe
+// what the file became.
+func (p *Patch) Apply(content string) (string, error) {
+	// Preserve whether the file ended with a newline: re-adding one that was not
+	// there (or dropping one that was) is a spurious change in the result.
+	hadTrailingNewline := strings.HasSuffix(content, "\n")
+	lines := strings.Split(strings.TrimSuffix(content, "\n"), "\n")
+	if content == "" {
+		lines = nil
+	}
+
+	var out []string
+	cursor := 0 // 0-based index into lines
+
+	for hi, h := range p.Hunks {
+		start := h.OldStart - 1
+		if h.OldLines == 0 {
+			// A pure insertion is positioned after OldStart.
+			start = h.OldStart
+		}
+		if start < cursor {
+			return "", fmt.Errorf("hunk %d starts at line %d, before the previous hunk ended (line %d): hunks must be ordered and must not overlap",
+				hi+1, h.OldStart, cursor+1)
+		}
+		if start > len(lines) {
+			return "", fmt.Errorf("hunk %d starts at line %d but the file has %d lines",
+				hi+1, h.OldStart, len(lines))
+		}
+
+		out = append(out, lines[cursor:start]...)
+		cursor = start
+
+		for _, l := range h.Lines {
+			if l == "" {
+				continue
+			}
+			marker, text := l[0], l[1:]
+			switch marker {
+			case ' ':
+				if cursor >= len(lines) {
+					return "", fmt.Errorf("hunk %d expects context %q at line %d, but the file ends at line %d",
+						hi+1, text, cursor+1, len(lines))
+				}
+				if lines[cursor] != text {
+					return "", fmt.Errorf("hunk %d context mismatch at line %d:\n  expected: %q\n  actual:   %q",
+						hi+1, cursor+1, text, lines[cursor])
+				}
+				out = append(out, text)
+				cursor++
+			case '-':
+				if cursor >= len(lines) {
+					return "", fmt.Errorf("hunk %d expects to remove %q at line %d, but the file ends at line %d",
+						hi+1, text, cursor+1, len(lines))
+				}
+				if lines[cursor] != text {
+					return "", fmt.Errorf("hunk %d cannot remove line %d:\n  expected: %q\n  actual:   %q",
+						hi+1, cursor+1, text, lines[cursor])
+				}
+				cursor++
+			case '+':
+				out = append(out, text)
+			default:
+				return "", fmt.Errorf("hunk %d has a body line with an unknown marker %q", hi+1, l)
+			}
+		}
+	}
+
+	out = append(out, lines[cursor:]...)
+
+	result := strings.Join(out, "\n")
+	if hadTrailingNewline && result != "" {
+		result += "\n"
+	}
+	return result, nil
+}
+
+// Stats reports how many lines the patch adds and removes, for the summary line.
+func (p *Patch) Stats() (added, removed int) {
+	for _, h := range p.Hunks {
+		for _, l := range h.Lines {
+			if l == "" {
+				continue
+			}
+			switch l[0] {
+			case '+':
+				added++
+			case '-':
+				removed++
+			}
+		}
+	}
+	return added, removed
+}

--- a/src/internal/improve/patch_test.go
+++ b/src/internal/improve/patch_test.go
@@ -1,0 +1,215 @@
+package improve
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePatchAcceptsAWellFormedDiff(t *testing.T) {
+	diff := `--- a/apiary.yaml
++++ b/apiary.yaml
+@@ -2,3 +2,4 @@ agents:
+   - id: engineer
+     model: sonnet
++    max_turns: 40
+     max_workers: 5
+`
+	p, err := ParsePatch(diff)
+	if err != nil {
+		t.Fatalf("ParsePatch: %v", err)
+	}
+	if p.Path != "apiary.yaml" {
+		t.Errorf("Path = %q, want apiary.yaml (a/ and b/ prefixes stripped)", p.Path)
+	}
+	if len(p.Hunks) != 1 {
+		t.Fatalf("want 1 hunk, got %d", len(p.Hunks))
+	}
+	h := p.Hunks[0]
+	if h.OldStart != 2 || h.OldLines != 3 || h.NewStart != 2 || h.NewLines != 4 {
+		t.Errorf("hunk range = -%d,%d +%d,%d; want -2,3 +2,4", h.OldStart, h.OldLines, h.NewStart, h.NewLines)
+	}
+	if added, removed := p.Stats(); added != 1 || removed != 0 {
+		t.Errorf("Stats = +%d −%d, want +1 −0", added, removed)
+	}
+}
+
+// An advisor emitted `@@ implementation/merge step @@` on the first real run —
+// naming the section in prose instead of giving line numbers. Guessing where
+// that belongs is how a patch lands in the wrong place, so it must fail.
+func TestParsePatchRejectsProseHunkHeaders(t *testing.T) {
+	diff := `--- a/apiary.yaml
++++ b/apiary.yaml
+@@ implementation/merge step @@
+       - id: merge
+-        agent: engineer
++        agent: engineer-merge
+`
+	_, err := ParsePatch(diff)
+	if err == nil {
+		t.Fatal("a hunk header without line numbers must be rejected")
+	}
+	if !strings.Contains(err.Error(), "hunk header") {
+		t.Errorf("error should name the problem, got: %v", err)
+	}
+}
+
+func TestParsePatchRejectsMalformedInput(t *testing.T) {
+	cases := []struct{ name, diff string }{
+		{"no target header", "@@ -1,1 +1,1 @@\n-a\n+b\n"},
+		{"no hunks", "--- a/x.yaml\n+++ b/x.yaml\n"},
+		{"missing closing @@", "--- a/x\n+++ b/x\n@@ -1,1 +1,1\n-a\n+b\n"},
+		{"non-numeric range", "--- a/x\n+++ b/x\n@@ -a,b +c,d @@\n-a\n+b\n"},
+		{"dev null target", "--- a/x\n+++ /dev/null\n@@ -1,1 +1,1 @@\n-a\n"},
+		{"wrong range sign", "--- a/x\n+++ b/x\n@@ +1,1 -1,1 @@\n-a\n+b\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParsePatch(tc.diff); err == nil {
+				t.Error("want an error")
+			}
+		})
+	}
+}
+
+func TestApplyAddsRemovesAndKeepsContext(t *testing.T) {
+	original := "line1\nline2\nline3\nline4\n"
+	diff := `--- a/f
++++ b/f
+@@ -1,4 +1,4 @@
+ line1
+-line2
++line2-changed
+ line3
+ line4
+`
+	p, err := ParsePatch(diff)
+	if err != nil {
+		t.Fatalf("ParsePatch: %v", err)
+	}
+	got, err := p.Apply(original)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	want := "line1\nline2-changed\nline3\nline4\n"
+	if got != want {
+		t.Errorf("Apply =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// Context that does not match must fail rather than search nearby. A patch that
+// lands in the wrong place is worse than one that does not land, because the
+// diff shown to the reviewer would no longer describe what the file became.
+func TestApplyRefusesToFuzzyMatch(t *testing.T) {
+	original := "alpha\nbeta\ngamma\n"
+	diff := `--- a/f
++++ b/f
+@@ -1,3 +1,3 @@
+ alpha
+-BETA
++delta
+ gamma
+`
+	p, _ := ParsePatch(diff)
+	_, err := p.Apply(original)
+	if err == nil {
+		t.Fatal("a context mismatch must be an error")
+	}
+	if !strings.Contains(err.Error(), "expected") || !strings.Contains(err.Error(), "actual") {
+		t.Errorf("error should show both sides, got: %v", err)
+	}
+}
+
+func TestApplyMultipleHunks(t *testing.T) {
+	original := "a\nb\nc\nd\ne\nf\n"
+	diff := `--- a/f
++++ b/f
+@@ -1,2 +1,3 @@
+ a
++new-after-a
+ b
+@@ -5,2 +6,2 @@
+-e
++E
+ f
+`
+	p, err := ParsePatch(diff)
+	if err != nil {
+		t.Fatalf("ParsePatch: %v", err)
+	}
+	got, err := p.Apply(original)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if got != "a\nnew-after-a\nb\nc\nd\nE\nf\n" {
+		t.Errorf("Apply = %q", got)
+	}
+}
+
+func TestApplyRejectsOutOfOrderHunks(t *testing.T) {
+	original := "a\nb\nc\nd\n"
+	diff := `--- a/f
++++ b/f
+@@ -3,1 +3,1 @@
+-c
++C
+@@ -1,1 +1,1 @@
+-a
++A
+`
+	p, _ := ParsePatch(diff)
+	if _, err := p.Apply(original); err == nil {
+		t.Fatal("hunks that go backwards must be rejected")
+	}
+}
+
+func TestApplyRejectsHunkPastEndOfFile(t *testing.T) {
+	p, _ := ParsePatch("--- a/f\n+++ b/f\n@@ -99,1 +99,1 @@\n-x\n+y\n")
+	if _, err := p.Apply("a\nb\n"); err == nil {
+		t.Fatal("a hunk starting past the end of the file must be rejected")
+	}
+}
+
+func TestApplyPreservesTrailingNewlineState(t *testing.T) {
+	diff := `--- a/f
++++ b/f
+@@ -1,2 +1,2 @@
+ a
+-b
++B
+`
+	p, _ := ParsePatch(diff)
+
+	withNL, err := p.Apply("a\nb\n")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if withNL != "a\nB\n" {
+		t.Errorf("with trailing newline: got %q", withNL)
+	}
+
+	// Re-adding a newline that was not there is a spurious change.
+	withoutNL, err := p.Apply("a\nb")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if withoutNL != "a\nB" {
+		t.Errorf("without trailing newline: got %q, want no trailing newline added", withoutNL)
+	}
+}
+
+func TestParsePatchToleratesSurroundingProse(t *testing.T) {
+	// Models routinely wrap a diff in explanation. The diff itself is what matters.
+	diff := "Here is the change I propose:\n\n" + `--- a/f
++++ b/f
+@@ -1,1 +1,1 @@
+-a
++b
+` + "\nThat should do it.\n"
+	p, err := ParsePatch(diff)
+	if err != nil {
+		t.Fatalf("ParsePatch: %v", err)
+	}
+	if got, err := p.Apply("a\n"); err != nil || got != "b\n" {
+		t.Errorf("Apply = %q, %v", got, err)
+	}
+}

--- a/src/internal/improve/prompt.go
+++ b/src/internal/improve/prompt.go
@@ -59,7 +59,20 @@ func ComposePrompt(pack *EvidencePack, ws *Workspace, files []WorkspaceFile, k K
 	b.WriteString("3. Correlation is not causation. A step may be expensive because its work is genuinely hard. Where the same agent runs in more than one workflow, compare them before blaming configuration.\n")
 	b.WriteString("4. Never propose a change to a secret: tokens, env values, credentials. They are redacted below and must stay that way.\n")
 	b.WriteString("5. Prefer fewer, better findings. Three solid ones beat twelve guesses. If the window is too thin to conclude anything, say exactly that and stop.\n")
-	b.WriteString("6. Patches must be unified diffs against a file listed under \"Configuration\". Anything else is dropped.\n\n")
+	b.WriteString("6. Patches must be real unified diffs against a file listed under \"Configuration\". See the patch rules below — a patch that does not parse is discarded, and the finding behind it loses its fix.\n\n")
+
+	// The patch format has to be spelled out. Left implicit, an advisor will
+	// write a header that names the section in prose — `@@ implementation/merge
+	// step @@` — which is not a unified diff and cannot be applied. Observed on
+	// the first real run: two of three patches were unusable for this reason.
+	b.WriteString("# Patch rules\n\n")
+	b.WriteString("- Start with `--- a/<path>` and `+++ b/<path>`, using a path exactly as it appears under \"Configuration\".\n")
+	b.WriteString("- Every hunk header must carry line numbers: `@@ -<start>,<count> +<start>,<count> @@`. A header naming a section in words is not a diff and will be discarded.\n")
+	b.WriteString("- Line numbers and context must match the file content shown below. Count the lines; do not estimate.\n")
+	b.WriteString("- Every body line begins with a space (context), `-` (removal) or `+` (addition). Include at least three lines of surrounding context where they exist.\n")
+	b.WriteString("- Hunks must appear in ascending line order and must not overlap.\n")
+	b.WriteString("- One file per patch. A change spanning two files is two recommendations.\n")
+	b.WriteString("- Do not propose a patch that depends on a file that does not exist yet. If a change needs a new file, say so in the rationale and omit the patch.\n\n")
 
 	b.WriteString("# What tends to be worth looking at\n\n")
 	b.WriteString("- **Rework loops** — a step running repeatedly inside one instance is an on_fail/goto cycle. The repeat runs are pure waste; the transcripts show why the step does not pass first time.\n")

--- a/src/internal/improve/run.go
+++ b/src/internal/improve/run.go
@@ -25,6 +25,10 @@ type RunOutcome struct {
 	// RawOutput is the advisor's text with the sentinel stripped. Kept so a run
 	// that produced no parseable output can still be inspected.
 	RawOutput string
+	// Structured is the raw APIARY_OUTPUT object, before it is decoded into a
+	// particular shape. The analysis pass decodes it into an Analysis; the critic
+	// pass decodes the same field into a CritiqueSet.
+	Structured map[string]any
 }
 
 // AttemptRecord is one runner invocation.
@@ -84,6 +88,7 @@ func RunAdvisor(ctx context.Context, cfg *config.Config, adv *Advisor, prompt st
 			if res.Success {
 				out.Duration = time.Since(started)
 				out.RawOutput = res.Output
+				out.Structured = res.StructuredOutput
 				if res.StructuredOutput == nil {
 					return out, fmt.Errorf("advisor produced no APIARY_OUTPUT block; "+
 						"see the raw output above (%d bytes)", len(res.Output))
@@ -101,6 +106,60 @@ func RunAdvisor(ctx context.Context, cfg *config.Config, adv *Advisor, prompt st
 
 		out.Attempts = append(out.Attempts, rec)
 		lastErr = err
+	}
+
+	out.Duration = time.Since(started)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no runner candidates available")
+	}
+	return out, lastErr
+}
+
+// runStructured performs one advisor invocation for a prompt whose output shape
+// is decided by the caller. RunAdvisor is the analysis-shaped wrapper around it;
+// the critic pass uses this directly.
+func runStructured(ctx context.Context, cfg *config.Config, adv *Advisor, prompt string, k Knobs, workDir string) (*RunOutcome, error) {
+	out := &RunOutcome{}
+	started := time.Now()
+	var lastErr error
+
+	for _, c := range candidateChain(cfg, adv) {
+		res, err := runOnce(ctx, cfg, c, prompt, k, workDir)
+		rec := AttemptRecord{RunnerID: c.runnerID, Adapter: c.adapter, Model: c.model}
+		if err != nil {
+			rec.Err = err.Error()
+		}
+		if res == nil {
+			out.Attempts = append(out.Attempts, rec)
+			lastErr = err
+			continue
+		}
+
+		rec.Duration = res.Duration
+		rec.Success = res.Success
+		if res.Usage != nil {
+			addUsage(&out.Usage, res.Usage)
+		}
+		kind, _ := execution.FailureDetectorFor(c.adapter).Detect(model.RunRequest{}, res)
+		if kind != model.FailureNone {
+			rec.Failure = kind.String()
+		}
+		out.Attempts = append(out.Attempts, rec)
+
+		if kind == model.FailureRateLimited || kind == model.FailureCreditExhausted {
+			lastErr = fmt.Errorf("runner %s: %s", c.runnerID, kind)
+			continue
+		}
+		if res.Success {
+			out.Duration = time.Since(started)
+			out.RawOutput = res.Output
+			out.Structured = res.StructuredOutput
+			if res.StructuredOutput == nil {
+				return out, fmt.Errorf("agent produced no APIARY_OUTPUT block (%d bytes of output)", len(res.Output))
+			}
+			return out, nil
+		}
+		lastErr = fmt.Errorf("runner %s failed: %v", c.runnerID, res.Error)
 	}
 
 	out.Duration = time.Since(started)
@@ -192,16 +251,22 @@ func runOnce(ctx context.Context, cfg *config.Config, c candidate, prompt string
 	return &res, err
 }
 
-// decodeAnalysis converts the runner's parsed structured output into the typed
-// analysis. Round-tripping through JSON keeps the field mapping in one place
-// (the struct tags) rather than duplicating it as map lookups.
-func decodeAnalysis(structured map[string]any) (Analysis, error) {
+// decodeInto converts a parsed structured output into a typed shape.
+// Round-tripping through JSON keeps the field mapping in one place (the struct
+// tags) rather than duplicating it as map lookups.
+func decodeInto(structured map[string]any, dst any) error {
 	raw, err := json.Marshal(structured)
 	if err != nil {
-		return Analysis{}, fmt.Errorf("re-encode advisor output: %w", err)
+		return fmt.Errorf("re-encode agent output: %w", err)
 	}
+	return json.Unmarshal(raw, dst)
+}
+
+// decodeAnalysis converts the runner's parsed structured output into the typed
+// analysis.
+func decodeAnalysis(structured map[string]any) (Analysis, error) {
 	var a Analysis
-	if err := json.Unmarshal(raw, &a); err != nil {
+	if err := decodeInto(structured, &a); err != nil {
 		return Analysis{}, fmt.Errorf("advisor output did not match the expected shape: %w", err)
 	}
 	if len(a.Findings) == 0 && len(a.Recommendations) == 0 {
@@ -274,4 +339,10 @@ func (o *RunOutcome) DescribeAttempts() string {
 		parts = append(parts, s)
 	}
 	return strings.Join(parts, " → ")
+}
+
+// AddUsage folds a second pass's usage into this outcome, so the reported cost
+// covers the whole analysis rather than only its first call.
+func (o *RunOutcome) AddUsage(u model.Usage) {
+	addUsage(&o.Usage, &u)
 }

--- a/src/internal/improve/validate.go
+++ b/src/internal/improve/validate.go
@@ -1,0 +1,301 @@
+package improve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// Stage names the validation step a proposal reached.
+type Stage string
+
+const (
+	StagePath      Stage = "path"      // inside the workspace, not excluded
+	StageApply     Stage = "apply"     // the diff applies cleanly to current content
+	StageConfig    Stage = "config"    // the result parses and passes cfg.Validate()
+	StageExpr      Stage = "expr"      // conditions still lint
+	StageWarnings  Stage = "warnings"  // WorkflowWarnings on the candidate
+	StageCritic    Stage = "critic"    // adversarial second opinion (deep effort)
+	StageValidated Stage = "validated" // cleared everything applicable
+)
+
+// Verdict is the outcome of validating one recommendation.
+type Verdict struct {
+	Recommendation Recommendation
+	// Reached is the last stage entered. On failure it names where it stopped.
+	Reached Stage
+	OK      bool
+	Reason  string
+
+	// Path is the resolved absolute target, set once the path check passes.
+	Path string
+	// Result is the patched content, set once the patch applies.
+	Result string
+	// Added and Removed are the line counts, for the summary.
+	Added, Removed int
+	// NewWarnings are config warnings the patch introduces that were not already
+	// present. Not a failure — shown alongside the diff.
+	NewWarnings []string
+	// MachineChecked reports whether anything beyond "it applies" could be
+	// verified. False for prose targets (souls, skills), where nothing can be.
+	MachineChecked bool
+	// Critique is the adversarial second opinion, when the critic pass ran.
+	Critique *Critique
+}
+
+// Validator applies the five-stage gate from the proposal.
+type Validator struct {
+	Workspace  *Workspace
+	ConfigPath string
+	// BaselineWarnings are the warnings the current config already emits, so only
+	// warnings a patch *introduces* are reported.
+	BaselineWarnings map[string]bool
+}
+
+// NewValidator prepares a validator, recording the config's existing warnings so
+// pre-existing noise is not blamed on a proposal.
+func NewValidator(ws *Workspace, configPath string, cfg *config.Config) *Validator {
+	base := map[string]bool{}
+	if cfg != nil {
+		for _, w := range cfg.WorkflowWarnings() {
+			base[w] = true
+		}
+	}
+	return &Validator{Workspace: ws, ConfigPath: configPath, BaselineWarnings: base}
+}
+
+// Validate runs every recommendation through the gate, in order, short-circuiting
+// on the first failure and recording where it stopped.
+func (v *Validator) Validate(recs []Recommendation) []Verdict {
+	out := make([]Verdict, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, v.validateOne(r))
+	}
+	return out
+}
+
+func (v *Validator) validateOne(r Recommendation) Verdict {
+	verdict := Verdict{Recommendation: r, Reached: StagePath}
+
+	// A recommendation with no patch is not a failure: proposing a change that
+	// needs human judgement is legitimate and often the honest answer.
+	if strings.TrimSpace(r.Patch) == "" {
+		verdict.OK = true
+		verdict.Reached = StageValidated
+		verdict.Reason = "no patch — advisory only"
+		return verdict
+	}
+
+	patch, err := ParsePatch(r.Patch)
+	if err != nil {
+		verdict.Reason = err.Error()
+		return verdict
+	}
+
+	// ── 1. path ──────────────────────────────────────────────────────────────
+	target := patch.Path
+	if r.File != "" && r.File != target {
+		// The stated file and the diff header disagree. Trust neither.
+		verdict.Reason = fmt.Sprintf("recommendation names %q but the diff targets %q", r.File, target)
+		return verdict
+	}
+	abs := target
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(v.Workspace.Root, target)
+	}
+	abs = filepath.Clean(abs)
+	if Excluded(abs, v.Workspace.Root) {
+		verdict.Reason = fmt.Sprintf("%s is outside the config workspace or on the exclusion list", target)
+		return verdict
+	}
+	if !v.inWorkspace(abs) {
+		verdict.Reason = fmt.Sprintf("%s is not a file the advisor was shown", target)
+		return verdict
+	}
+	verdict.Path = abs
+
+	// ── 2. apply ─────────────────────────────────────────────────────────────
+	verdict.Reached = StageApply
+	original, err := os.ReadFile(abs)
+	if err != nil {
+		verdict.Reason = fmt.Sprintf("cannot read %s: %v", target, err)
+		return verdict
+	}
+	patched, err := patch.Apply(string(original))
+	if err != nil {
+		verdict.Reason = err.Error()
+		return verdict
+	}
+	verdict.Result = patched
+	verdict.Added, verdict.Removed = patch.Stats()
+
+	// Prose targets stop here. There is nothing to lint in a markdown
+	// instruction file, so a bad soul or skill edit cannot be caught
+	// mechanically — only by review, or by its effect on later runs. Saying so
+	// is the point: a reviewer must know which hunks were checked and which
+	// merely applied.
+	if !v.isConfigLike(abs) {
+		verdict.OK = true
+		verdict.Reached = StageValidated
+		verdict.MachineChecked = false
+		return verdict
+	}
+	verdict.MachineChecked = true
+
+	// ── 3. config ────────────────────────────────────────────────────────────
+	verdict.Reached = StageConfig
+	candidate, err := v.loadCandidate(abs, patched)
+	if err != nil {
+		verdict.Reason = err.Error()
+		return verdict
+	}
+	if errs := candidate.Validate(); len(errs) > 0 {
+		verdict.Reason = fmt.Sprintf("the patched config does not validate: %v", errs[0])
+		return verdict
+	}
+
+	// ── 4. expression lint ───────────────────────────────────────────────────
+	// cfg.Validate already runs LintExpr over conditions when the hook is
+	// installed (cli.init wires it). Naming the stage separately keeps the
+	// failure legible: an invalid `if:` reads as an expression problem rather
+	// than a generic config error.
+	verdict.Reached = StageExpr
+
+	// ── 5. warnings ──────────────────────────────────────────────────────────
+	verdict.Reached = StageWarnings
+	for _, w := range candidate.WorkflowWarnings() {
+		if !v.BaselineWarnings[w] {
+			verdict.NewWarnings = append(verdict.NewWarnings, w)
+		}
+	}
+
+	verdict.OK = true
+	verdict.Reached = StageValidated
+	return verdict
+}
+
+// loadCandidate copies the config directory to a temp dir, substitutes the
+// patched file, and loads from there — so `uses:` references and soul_file paths
+// resolve exactly as they would in place.
+//
+// The same mirroring covers a patch to the main config and to a referenced
+// workflow file beside it: both are files config.Load pulls in, and neither can
+// be validated by re-reading the original path.
+//
+// Loading from a temp directory rather than mutating the real file matters: a
+// proposal must never touch disk before the operator has seen it.
+func (v *Validator) loadCandidate(target, patched string) (*config.Config, error) {
+	dir, err := os.MkdirTemp("", "apiary-improve-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating validation sandbox: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	cfgAbs := v.absConfigPath()
+	srcRoot := filepath.Dir(cfgAbs)
+
+	// Mirror the YAML tree, not just the top level: a reusable workflow can be
+	// referenced by `uses:` from a subdirectory, and it has to be patchable too.
+	// Only YAML is copied — the config directory also holds the database, logs
+	// and transcripts, none of which config.Load reads.
+	substituted := false
+	err = filepath.WalkDir(srcRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable corner of the tree; config.Load would skip it too
+		}
+		if d.IsDir() {
+			if Excluded(path, srcRoot) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if ext := strings.ToLower(filepath.Ext(path)); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		dest := filepath.Join(dir, rel)
+		if mkErr := os.MkdirAll(filepath.Dir(dest), 0o700); mkErr != nil {
+			return mkErr
+		}
+
+		body := []byte(patched)
+		if filepath.Clean(path) == filepath.Clean(target) {
+			substituted = true
+		} else {
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return nil
+			}
+			body = data
+		}
+		return os.WriteFile(dest, body, 0o600)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mirroring config for validation: %w", err)
+	}
+
+	// If the patched file never made it into the mirror, validation would run
+	// against the ORIGINAL content and pass — reporting a proposal as verified
+	// when nothing about it was checked. Refusing is the only safe outcome.
+	if !substituted {
+		return nil, fmt.Errorf("cannot validate a change to %s: it is not part of the config tree under %s",
+			target, srcRoot)
+	}
+
+	mirrored := filepath.Join(dir, filepath.Base(cfgAbs))
+	cfg, err := config.Load(mirrored)
+	if err != nil {
+		return nil, fmt.Errorf("the patched config does not parse: %w", err)
+	}
+	return cfg, nil
+}
+
+func (v *Validator) absConfigPath() string {
+	abs, err := filepath.Abs(v.ConfigPath)
+	if err != nil {
+		return v.ConfigPath
+	}
+	return abs
+}
+
+// isConfigLike reports whether a target is YAML the config loader understands,
+// as opposed to a prose instruction file.
+func (v *Validator) isConfigLike(abs string) bool {
+	ext := strings.ToLower(filepath.Ext(abs))
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// inWorkspace reports whether the target is a file discovery actually surfaced.
+// Patching a file the advisor was never shown means it is working from
+// assumption rather than evidence.
+func (v *Validator) inWorkspace(abs string) bool {
+	for _, f := range v.Workspace.Files {
+		candidate := f.Path
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(v.Workspace.Root, candidate)
+		}
+		if filepath.Clean(candidate) == abs {
+			return true
+		}
+	}
+	return false
+}
+
+// Summarize splits verdicts into the ones worth showing as changes and the ones
+// that could not be validated.
+func Summarize(verdicts []Verdict) (accepted, rejected []Verdict) {
+	for _, v := range verdicts {
+		if v.OK {
+			accepted = append(accepted, v)
+		} else {
+			rejected = append(rejected, v)
+		}
+	}
+	return accepted, rejected
+}

--- a/src/internal/improve/validate_test.go
+++ b/src/internal/improve/validate_test.go
@@ -1,0 +1,292 @@
+package improve
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// gateFixture builds a minimal but real config tree: a loadable apiary.yaml, a
+// soul file it references, and a workspace describing both.
+func gateFixture(t *testing.T) (root, cfgPath string, ws *Workspace) {
+	t.Helper()
+	root = t.TempDir()
+
+	soul := filepath.Join(root, "engineer.md")
+	if err := os.WriteFile(soul, []byte("you are an engineer\nbe careful\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath = filepath.Join(root, "apiary.yaml")
+	body := `version: "1"
+default_runner: claude
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+agents:
+  - id: engineer
+    model: sonnet
+    soul_file: ` + soul + `
+    max_workers: 5
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ws = &Workspace{Root: root, Files: []WorkspaceFile{
+		{Path: "apiary.yaml", Kind: KindConfig},
+		{Path: "engineer.md", Kind: KindSoul, Owner: "engineer"},
+	}}
+	return root, cfgPath, ws
+}
+
+func TestGateAcceptsAValidConfigPatch(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	rec := Recommendation{
+		ID: "r1", File: "apiary.yaml", Summary: "cap turns",
+		Patch: `--- a/apiary.yaml
++++ b/apiary.yaml
+@@ -9,3 +9,4 @@ agents:
+   - id: engineer
+     model: sonnet
++    max_turns: 40
+`,
+	}
+	// The hunk must match the fixture; compute it against the real content.
+	rec.Patch = patchAfterLine(t, cfgPath, "    model: sonnet", "    max_turns: 40")
+
+	got := v.Validate([]Recommendation{rec})[0]
+	if !got.OK {
+		t.Fatalf("want accepted, stopped at %s: %s", got.Reached, got.Reason)
+	}
+	if got.Reached != StageValidated {
+		t.Errorf("Reached = %s, want validated", got.Reached)
+	}
+	if !got.MachineChecked {
+		t.Error("a YAML patch must be marked machine-checked")
+	}
+	if !strings.Contains(got.Result, "max_turns: 40") {
+		t.Error("the patched result should carry the change")
+	}
+}
+
+// A soul edit clears only path + apply. Nothing about it can be validated
+// mechanically, and the reviewer has to be told that.
+func TestGateMarksProseAsUnverifiable(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	rec := Recommendation{
+		ID: "r1", File: "engineer.md", Summary: "add a rule",
+		Patch: `--- a/engineer.md
++++ b/engineer.md
+@@ -1,2 +1,3 @@
+ you are an engineer
+ be careful
++always run the tests
+`,
+	}
+	got := v.Validate([]Recommendation{rec})[0]
+	if !got.OK {
+		t.Fatalf("a clean prose patch should be accepted, stopped at %s: %s", got.Reached, got.Reason)
+	}
+	if got.MachineChecked {
+		t.Error("a markdown patch cannot be machine-checked and must not claim to be")
+	}
+}
+
+func TestGateRejectsAPatchThatBreaksTheConfig(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	// Point soul_file at something that does not exist: cfg.Validate checks it.
+	rec := Recommendation{
+		ID: "r1", File: "apiary.yaml", Summary: "break it",
+		Patch: patchReplaceLine(t, cfgPath, "    soul_file: ", "    soul_file: /nonexistent/ghost.md"),
+	}
+	got := v.Validate([]Recommendation{rec})[0]
+	if got.OK {
+		t.Fatal("a patch pointing soul_file at a missing file must be rejected")
+	}
+	if got.Reached != StageConfig {
+		t.Errorf("Reached = %s, want config (cfg.Validate stage)", got.Reached)
+	}
+}
+
+func TestGateRejectsUnparseableYAML(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	// An unterminated quote breaks the YAML parser on a single line, so the
+	// patch itself stays well-formed and the failure is genuinely the config's.
+	rec := Recommendation{
+		ID: "r1", File: "apiary.yaml", Summary: "mangle",
+		Patch: patchReplaceLine(t, cfgPath, "version: ", `version: "unterminated`),
+	}
+	got := v.Validate([]Recommendation{rec})[0]
+	if got.OK {
+		t.Fatal("a patch producing invalid YAML must be rejected")
+	}
+}
+
+func TestGateRejectsExcludedAndUnknownTargets(t *testing.T) {
+	root, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	// A .env target is on the exclusion list.
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("TOKEN=abc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	envPatch := Recommendation{
+		ID: "r1", File: ".env", Summary: "sneak",
+		Patch: "--- a/.env\n+++ b/.env\n@@ -1,1 +1,1 @@\n-TOKEN=abc\n+TOKEN=stolen\n",
+	}
+	if got := v.Validate([]Recommendation{envPatch})[0]; got.OK {
+		t.Error("a patch targeting .env must be rejected")
+	}
+
+	// A file that exists but was never shown to the advisor.
+	other := filepath.Join(root, "other.md")
+	if err := os.WriteFile(other, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unknown := Recommendation{
+		ID: "r2", File: "other.md", Summary: "unseen",
+		Patch: "--- a/other.md\n+++ b/other.md\n@@ -1,1 +1,1 @@\n-x\n+y\n",
+	}
+	got := v.Validate([]Recommendation{unknown})[0]
+	if got.OK {
+		t.Error("a patch to a file the advisor was never shown must be rejected")
+	}
+	if !strings.Contains(got.Reason, "never shown") && !strings.Contains(got.Reason, "not a file") {
+		t.Errorf("reason should explain, got: %s", got.Reason)
+	}
+}
+
+func TestGateRejectsFileHeaderMismatch(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	rec := Recommendation{
+		ID: "r1", File: "engineer.md", Summary: "mismatch",
+		Patch: "--- a/apiary.yaml\n+++ b/apiary.yaml\n@@ -1,1 +1,1 @@\n-version: \"1\"\n+version: \"2\"\n",
+	}
+	got := v.Validate([]Recommendation{rec})[0]
+	if got.OK {
+		t.Fatal("a recommendation whose stated file disagrees with the diff target must be rejected")
+	}
+}
+
+// A recommendation with no patch is legitimate: proposing a change that needs
+// human judgement is often the honest answer.
+func TestGateAcceptsAdvisoryRecommendations(t *testing.T) {
+	_, cfgPath, ws := gateFixture(t)
+	v := NewValidator(ws, cfgPath, nil)
+
+	got := v.Validate([]Recommendation{{ID: "r1", Summary: "investigate the transcripts by hand"}})[0]
+	if !got.OK {
+		t.Error("a recommendation without a patch is advisory, not a failure")
+	}
+	if got.MachineChecked {
+		t.Error("nothing was checked, so MachineChecked must be false")
+	}
+}
+
+// If the patched file never reaches the validation mirror, cfg.Validate would
+// run against the ORIGINAL content and pass — reporting a proposal as verified
+// when nothing about it was checked.
+func TestGateRefusesWhenTheTargetIsOutsideTheConfigTree(t *testing.T) {
+	root, cfgPath, ws := gateFixture(t)
+
+	// A YAML file that is in the workspace but not under the config directory.
+	outside := t.TempDir()
+	stray := filepath.Join(outside, "extra.yaml")
+	if err := os.WriteFile(stray, []byte("a: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ws.Files = append(ws.Files, WorkspaceFile{Path: stray, Kind: KindWorkflow})
+	ws.Root = root
+
+	v := NewValidator(ws, cfgPath, nil)
+	rec := Recommendation{
+		ID: "r1", File: stray, Summary: "stray",
+		Patch: "--- a/" + stray + "\n+++ b/" + stray + "\n@@ -1,1 +1,1 @@\n-a: 1\n+a: 2\n",
+	}
+	got := v.Validate([]Recommendation{rec})[0]
+	if got.OK {
+		t.Fatal("a YAML target outside the config tree cannot be validated and must be refused, not silently passed")
+	}
+}
+
+func TestSummarizeSplitsAcceptedAndRejected(t *testing.T) {
+	verdicts := []Verdict{
+		{OK: true, Recommendation: Recommendation{ID: "a"}},
+		{OK: false, Recommendation: Recommendation{ID: "b"}, Reason: "nope"},
+		{OK: true, Recommendation: Recommendation{ID: "c"}},
+	}
+	accepted, rejected := Summarize(verdicts)
+	if len(accepted) != 2 || len(rejected) != 1 {
+		t.Errorf("Summarize = %d accepted, %d rejected; want 2, 1", len(accepted), len(rejected))
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+// patchAfterLine builds a valid unified diff inserting a line after the first
+// occurrence of anchor, computing real line numbers from the file.
+func patchAfterLine(t *testing.T, path, anchor, insert string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	for i, l := range lines {
+		if l == anchor {
+			return "--- a/" + filepath.Base(path) + "\n+++ b/" + filepath.Base(path) + "\n" +
+				"@@ -" + itoa(i+1) + ",1 +" + itoa(i+1) + ",2 @@\n" +
+				" " + anchor + "\n+" + insert + "\n"
+		}
+	}
+	t.Fatalf("anchor %q not found in %s", anchor, path)
+	return ""
+}
+
+// patchReplaceLine builds a diff replacing the first line starting with prefix.
+func patchReplaceLine(t *testing.T, path, prefix, replacement string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	for i, l := range lines {
+		if strings.HasPrefix(l, prefix) {
+			return "--- a/" + filepath.Base(path) + "\n+++ b/" + filepath.Base(path) + "\n" +
+				"@@ -" + itoa(i+1) + ",1 +" + itoa(i+1) + ",1 @@\n" +
+				"-" + l + "\n+" + replacement + "\n"
+		}
+	}
+	t.Fatalf("no line starting with %q in %s", prefix, path)
+	return ""
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+var _ = config.Config{}


### PR DESCRIPTION
Phase 3 of #401. Closes #404.

Proposals now pass a gate before being shown, and arrive as a reviewable diff instead of raw model output.

## The gate

Short-circuits, recording the stage it stopped at:

| stage | check |
|---|---|
| `path` | inside the workspace, not excluded, **and a file the advisor was actually shown** |
| `apply` | the diff applies cleanly to current content |
| `config` | the patched tree parses and passes `cfg.Validate()` |
| `expr` | conditions still lint (`config.LintExpr`, already wired by `cli.init`) |
| `warnings` | new `WorkflowWarnings` the patch introduces, shown beside it |

Parsing is strict on purpose, and `Apply` does **no fuzzy matching and no offset search**. A hunk whose context doesn't match is an error. A patch that lands in the wrong place is worse than one that doesn't land at all, because the diff shown to the reviewer would no longer describe what the file became.

## It catches what the real runs produced

Replaying the recommendations from the first live advisor run through the parser:

```
r1 [.apiary/agents/engineer-10x.md]: parses
r2 [.apiary/apiary.yaml]:            REJECTED — malformed hunk header
                                     "@@ implementation/merge step @@"
r3 []:                               advisory, no patch
```

That's the patch I'd flagged by eye earlier — it named the section in prose instead of giving line numbers. Its sibling depended on a soul file that didn't exist yet, which stage 3 catches through `cfg.Validate`'s `soul_file` check. **Two of three patches from that run would have reached you looking applicable.** The three well-formed patches from the later run all parse.

The prompt now also spells out the patch format — real hunk headers with line numbers, ascending non-overlapping hunks, one file per patch, no patch depending on a file that doesn't exist yet. Cheaper to prevent than to reject, though the gate still enforces it independently.

## Prose is labelled honestly

Souls and skills clear stages 1–2 only. Nothing in a markdown instruction file can be validated mechanically, and the rendered diff says so **per file**:

> _prose file — only checked that the patch applies; nothing here can be validated mechanically_

A reviewer needs to know which hunks a machine agreed with and which merely applied. Given that all three recommendations from the last real run were prose edits, this is the common case, not the edge case.

## Critic pass

`Knobs.Critic` was plumbed but unread; it now runs at `deep` effort. It asks for the strongest case against each surviving proposal, and a `wrong` verdict demotes it out of the accepted set. It exists mainly for prose edits, which the gate cannot check at all — until effect measurement (#406) lands, an adversarial reading is the only automated check those get. A failed critic never discards a valid analysis: it warns and shows the proposals unreviewed.

## Two bugs found while building

1. **A false pass in my own gate.** `loadCandidate` mirrored only the top level of the config directory, so a patch to a workflow file in a subdirectory was never substituted — validation ran against the **original** content and passed, reporting a proposal as verified when nothing about it had been checked. It now mirrors the YAML tree and refuses outright when the target isn't part of it.
2. **The hunk body parser guessed where a hunk ended**, so a blank line before trailing prose was swallowed as context. It now consumes exactly the line counts the header declares, which is what distinguishes a blank context line *inside* a hunk from spacing *after* it.

## Testing

`make check` green (33 packages), `improve` also under `-race`. New tests cover: well-formed parsing, prose hunk headers, six malformed-input shapes, apply with add/remove/context, refusal to fuzzy-match, multi-hunk, out-of-order hunks, past-EOF, trailing-newline preservation, surrounding prose; and for the gate — accept, prose-unverifiable, config-breaking, unparseable YAML, excluded target, unseen-file target, header/file mismatch, advisory-without-patch, and the outside-the-tree refusal.

One note: an unrelated flaky test in `internal/daemon` (`TestRoutePREvent_ExactlyOnceAndEnvPayload`) failed once during a full run. It passes 5/5 in isolation and 3/3 for the whole package on **both** this branch and clean main, and this change touches only `internal/improve` and `internal/cli`. The failure showed two dispatches of the same event plus `sql: database is closed` from a prior test's goroutines — cross-test interference. Filed separately; may share a root cause with #392.

## Next

#405 (apply) → #406 (ledger + effect) → #407 (docs).