### PR TITLE
fix(daemon): track dispatch goroutines so test teardown is deterministic

### DIFF
--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -80,6 +80,12 @@ type Dispatcher struct {
 
 	sem        chan struct{}            // poll concurrency (size 1)
 	agentSem   map[string]chan struct{} // per-agent dispatch concurrency
+	// bg tracks every goroutine the dispatcher spawns to carry a dispatch
+	// forward off the poll loop (fan-out runs, PR-event runs, parked
+	// approval/wait advances, resumes). Waiting on it gives callers — chiefly
+	// tests, which own the DB's lifetime — a deterministic point at which no
+	// dispatch work is still touching the store.
+	bg         sync.WaitGroup
 	active     atomic.Int32
 	inFlight   sync.Map
 	activeRuns sync.Map
@@ -1867,6 +1873,36 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 // semaphore and tracked as an active run. The cell's in-flight marker is cleared
 // only after every dispatch finishes. When wg is non-nil each dispatch joins it
 // (so RunOnce can wait); onFail, if set, is called with the cell ID per failure.
+// goBackground runs fn on its own goroutine, tracked by d.bg so WaitBackground
+// can tell when all in-flight dispatch work has finished. Every dispatcher
+// goroutine that outlives the call that started it — and touches the DB — must
+// go through here; otherwise it can still be running when the store closes.
+func (d *Dispatcher) goBackground(fn func()) {
+	d.bg.Add(1)
+	go func() {
+		defer d.bg.Done()
+		fn()
+	}()
+}
+
+// WaitBackground blocks until every goroutine started through goBackground has
+// returned, or timeout elapses; it reports whether they all finished. Callers
+// that own the dispatcher's DB (tests, one-shot runs) use it to close the store
+// only once no dispatch is still writing to it.
+func (d *Dispatcher) WaitBackground(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		d.bg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, persisted bool, matches []router.Match, wg *sync.WaitGroup, onFail func(cellID string)) {
 	if len(matches) == 0 {
 		d.inFlight.Delete(cell.ID)
@@ -1895,7 +1931,9 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 		}
 		runID := d.nextRunID()
 
+		d.bg.Add(1)
 		go func(runID string, match router.Match, agentCh chan struct{}) {
+			defer d.bg.Done()
 			if wg != nil {
 				defer wg.Done()
 			}
@@ -1938,10 +1976,10 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 
 	// Release the in-flight marker once all of this cell's dispatches finish, so
 	// the cell can be re-polled (and re-routed against its refreshed task).
-	go func() {
+	d.goBackground(func() {
 		inner.Wait()
 		d.inFlight.Delete(cell.ID)
-	}()
+	})
 }
 
 // transientTask builds an unpersisted InternalTask from a source item, mapping

--- a/src/internal/daemon/pr_events.go
+++ b/src/internal/daemon/pr_events.go
@@ -163,7 +163,7 @@ func (d *Dispatcher) dispatchPREvent(ctx context.Context, ev model.SourceEvent, 
 		cell.ID = fmt.Sprintf("pr-%d", ev.PRNumber)
 	}
 
-	go func() {
+	d.goBackground(func() {
 		if agentCh != nil {
 			select {
 			case agentCh <- struct{}{}:
@@ -198,7 +198,7 @@ func (d *Dispatcher) dispatchPREvent(ctx context.Context, ev model.SourceEvent, 
 			return
 		}
 		aplog.Info("event %s: workflow instance %s started (success=%v)", ev.ID, instID, success)
-	}()
+	})
 }
 
 // prEventEnv is the environment payload exported to every step of an

--- a/src/internal/daemon/pr_events_test.go
+++ b/src/internal/daemon/pr_events_test.go
@@ -38,7 +38,6 @@ func newEventDispatcher(t *testing.T) (*Dispatcher, *db.Client, *envRecordingRun
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = dbc.Close() })
 
 	cfg := &config.Config{
 		Version: "1",
@@ -65,6 +64,17 @@ func newEventDispatcher(t *testing.T) (*Dispatcher, *db.Client, *envRecordingRun
 		agentSem:    map[string]chan struct{}{},
 		stats:       map[string]*sourceStat{},
 	}
+	// Teardown order matters: a dispatch runs on its own goroutine and keeps
+	// writing (execution events, outstanding counters) after routePREvent
+	// returns. Closing the store first leaves those writes failing with
+	// "sql: database is closed" and lets the goroutine race the next test, so
+	// wait for the dispatcher to go idle before closing.
+	t.Cleanup(func() {
+		if !d.WaitBackground(10 * time.Second) {
+			t.Error("dispatcher goroutines still running 10s after the test finished")
+		}
+		_ = dbc.Close()
+	})
 	d.binder = source.NewSourceBinder(dbc)
 	return d, dbc, runner
 }
@@ -75,6 +85,18 @@ func testEvent(id string) model.SourceEvent {
 		PRNumber: 7, PRURL: "https://github.com/o/r/pull/7",
 		Author: "alice", AuthorAssociation: "COLLABORATOR",
 		Body: "@apiary fix the lint errors", SubmittedAt: time.Now(),
+	}
+}
+
+// waitIdle blocks until every dispatch the test kicked off has finished, so
+// assertions observe the completed run rather than a half-written one. Waiting
+// on the dispatcher's own goroutines is deterministic: polling the DB for the
+// instance row only proves the run *started*, and under load the agent step can
+// still be pending when the row appears.
+func waitIdle(t *testing.T, d *Dispatcher) {
+	t.Helper()
+	if !d.WaitBackground(10 * time.Second) {
+		t.Fatal("dispatch did not finish within 10s")
 	}
 }
 
@@ -110,6 +132,7 @@ func TestRoutePREvent_ExactlyOnceAndEnvPayload(t *testing.T) {
 	d.routePREvent(ctx, ev)
 	d.routePREvent(ctx, ev) // duplicate delivery must be a no-op
 
+	waitIdle(t, d)
 	insts := waitForInstances(t, dbc, 1)
 	if insts[0].WorkflowID != "fix-feedback" {
 		t.Errorf("instance workflow = %q", insts[0].WorkflowID)
@@ -150,13 +173,15 @@ func TestRoutePREvent_MaxDispatchesBudget(t *testing.T) {
 	d, dbc, _ := newEventDispatcher(t)
 
 	d.routePREvent(ctx, testEvent("comment-1"))
+	waitIdle(t, d)
 	waitForInstances(t, dbc, 1)
 	d.routePREvent(ctx, testEvent("comment-2"))
+	waitIdle(t, d)
 	waitForInstances(t, dbc, 2)
 
 	// Budget is 2: the third event on the same PR must not dispatch.
 	d.routePREvent(ctx, testEvent("comment-3"))
-	time.Sleep(150 * time.Millisecond)
+	waitIdle(t, d)
 	waitForInstances(t, dbc, 2)
 }
 
@@ -178,6 +203,7 @@ func TestRoutePREvent_BindsRelatedTask(t *testing.T) {
 	ev.RelatedItemID = "42"
 	d.routePREvent(ctx, ev)
 
+	waitIdle(t, d)
 	insts := waitForInstances(t, dbc, 1)
 	if insts[0].TaskID != issueTask.ID {
 		t.Errorf("instance task = %q, want the originating issue's task %q", insts[0].TaskID, issueTask.ID)

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -278,7 +278,7 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 			continue
 		}
 		agentCh := d.agentSem[p.AgentID]
-		go func() {
+		d.goBackground(func() {
 			defer d.approvalAdvancing.Delete(p.InstanceID)
 
 			// Cheap re-evaluation, ungated. Still waiting → leave it parked.
@@ -313,7 +313,7 @@ func (d *Dispatcher) checkApprovals(ctx context.Context) {
 			} else {
 				_, _ = d.engine.ResolveApproval(ctx, p.InstanceID, decision)
 			}
-		}()
+		})
 	}
 }
 
@@ -345,7 +345,7 @@ func (d *Dispatcher) checkWaits(ctx context.Context) {
 			continue
 		}
 		agentCh := d.agentSem[w.AgentID]
-		go func() {
+		d.goBackground(func() {
 			defer d.waitAdvancing.Delete(w.InstanceID)
 
 			// Cheap CI re-check, ungated. Still pending → leave it parked.
@@ -365,7 +365,7 @@ func (d *Dispatcher) checkWaits(ctx context.Context) {
 				defer func() { <-agentCh }()
 			}
 			d.engine.WakeWait(ctx, w.InstanceID)
-		}()
+		})
 	}
 }
 

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -196,7 +196,7 @@ func (d *Dispatcher) startResume(ctx context.Context, id string, opts ResumeOpti
 	}
 	newID := d.workflowEngine().NewInstanceID()
 
-	go func() {
+	d.goBackground(func() {
 		if onDone != nil {
 			defer onDone()
 		}
@@ -209,7 +209,7 @@ func (d *Dispatcher) startResume(ctx context.Context, id string, opts ResumeOpti
 			return
 		}
 		aplog.Info("resume %s: descendant %s finished (success=%v; may be awaiting approval)", id, newID, success)
-	}()
+	})
 	return newID, nil
 }
 


### PR DESCRIPTION
## Problem

`TestRoutePREvent_ExactlyOnceAndEnvPayload` was intermittently flaky when the full `internal/daemon` package ran (`make check`), but passed reliably under `-run`. Reproduced with `go test ./internal/daemon/ -count=8`:

```
--- FAIL: TestRoutePREvent_ExactlyOnceAndEnvPayload (0.02s)
    pr_events_test.go:130: expected 1 agent run, got 0
```

It is not a dedup bug in the PR-event path. Two clarifications on the symptoms:

- The two `workflow instance ... started` lines for event `comment-1` come from **two different tests** — `TestRoutePREvent_MaxDispatchesBudget` also dispatches an event with that id, into its own temp DB. Logs are process-global, so they interleave; each DB still held exactly one instance.
- `waitForInstances` waits on the `workflow_instances` row, which `RunInstanceForEvent` writes when the run *starts*. The agent step can still be pending when the row appears, so `runner.envs` was empty. An idle machine always let the step win; under full-package load it didn't.

The `sql: database is closed` errors are the second half of the same defect: `dispatchPREvent` spawned an untracked goroutine, so `t.Cleanup` closed the store while the dispatch was still writing execution events and decrementing outstanding counters (`cell pr-7 #7: create execution record: sql: database is closed`). Those goroutines outlived their test and raced whatever ran next.

## Fix

Dispatcher-owned `bg sync.WaitGroup` with `goBackground` / `WaitBackground`. Every dispatch goroutine that outlives the call that started it and touches the DB now goes through it:

- `fanOut`'s per-match runs and its in-flight releaser
- `dispatchPREvent`
- the parked approval and parked wait advances in `workflow.go`
- `startResume`

No signatures changed — `fanOut`'s existing optional `wg` parameter behaves exactly as before.

The PR-event tests wait for the dispatcher to go idle before asserting and before closing the store (failing loudly if it doesn't within 10s), which also removes a `time.Sleep(150ms)` from the budget test.

## Risk

`impact` flags `fanOut` as CRITICAL (3 direct callers — `poll`, `RunOnce`, `redispatchCell`; 5 execution flows), so the change there is deliberately accounting-only. `detect_changes` reports low risk, no affected processes.

## Verification

Local only (no Go CI in this repo):

- `go test ./internal/daemon/ -count=10` — ok, no `database is closed` in the log
- `go test -race ./internal/daemon/ -count=4` — ok (261s), no data races
- `make check` — full suite green

## Not #392

Issue #392 is already closed and has a different root cause — a timing assertion in `internal/worker`'s drain path, not a leaked goroutine. `go test -race ./internal/worker/ -run TestRuntimeGracefulDrainWaitsForActiveJob -count=20` passes 20/20 on this branch.