### PR TITLE
feat(improve): --apply writes accepted changes to disk (#405)

### DIFF
--- a/src/internal/cli/improve.go
+++ b/src/internal/cli/improve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -29,6 +30,8 @@ func newImproveCmd() *cobra.Command {
 		outDir        string
 		dumpEvidence  bool
 		dumpPrompt    bool
+		apply         bool
+		assumeYes     bool
 		excerptBudget int
 	)
 
@@ -189,6 +192,10 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 
 			fmt.Fprintln(os.Stderr, improve.DiffSummary(verdicts))
 
+			if apply {
+				return applyChanges(cmd, ws, verdicts, diff, assumeYes)
+			}
+
 			switch output {
 			case "json":
 				enc := json.NewEncoder(cmd.OutOrStdout())
@@ -218,6 +225,8 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 	cmd.Flags().StringVar(&outDir, "out", "", "also write report, analysis and evidence to this directory")
 	cmd.Flags().BoolVar(&dumpEvidence, "dump-evidence", false, "print the evidence pack as JSON and exit (runs no model)")
 	cmd.Flags().BoolVar(&dumpPrompt, "dump-prompt", false, "print the composed advisor prompt and exit (runs no model)")
+	cmd.Flags().BoolVar(&apply, "apply", false, "write the accepted changes to disk (workspace is assumed to be under version control)")
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt when applying")
 	cmd.Flags().IntVar(&excerptBudget, "transcript-bytes", 0, "override the per-transcript character budget")
 
 	return cmd
@@ -278,4 +287,40 @@ func writeArtifacts(dir string, pack *improve.EvidencePack, outcome *improve.Run
 		return err
 	}
 	return write("analysis.json", outcome.Analysis)
+}
+
+// applyChanges shows the diff, asks once, and writes. The diff is printed in
+// full first: a confirmation prompt for changes the operator has not seen is
+// not consent, it is a formality.
+func applyChanges(cmd *cobra.Command, ws *improve.Workspace, verdicts []improve.Verdict, diff string, assumeYes bool) error {
+	prompt := improve.ConfirmationPrompt(verdicts)
+	if prompt == "" {
+		fmt.Fprintln(os.Stderr, "nothing to apply — no proposal survived validation")
+		return nil
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), diff)
+
+	if !assumeYes {
+		if !improve.IsGitRepo(ws.Root) {
+			fmt.Fprintln(os.Stderr, "\n⚠ This workspace is not a git repository. These edits are written in place")
+			fmt.Fprintln(os.Stderr, "  and there will be no automatic way back.")
+		}
+		fmt.Fprint(os.Stderr, "\n"+prompt)
+		var answer string
+		_, _ = fmt.Fscanln(cmd.InOrStdin(), &answer)
+		switch strings.ToLower(strings.TrimSpace(answer)) {
+		case "y", "yes":
+		default:
+			fmt.Fprintln(os.Stderr, "aborted; nothing written")
+			return nil
+		}
+	}
+
+	res, err := improve.Apply(verdicts, ws.Root)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(os.Stderr, "\n"+res.Summary())
+	return nil
 }

--- a/src/internal/improve/apply.go
+++ b/src/internal/improve/apply.go
@@ -1,0 +1,167 @@
+package improve
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// AppliedFile records one file written by an apply run.
+type AppliedFile struct {
+	Path           string
+	Added, Removed int
+	// MachineChecked mirrors the verdict: false for prose files, where the gate
+	// could only confirm the patch applies.
+	MachineChecked bool
+}
+
+// ApplyResult reports what an apply run changed.
+type ApplyResult struct {
+	Files []AppliedFile
+	// ConfigChanged is true when any written file is one the daemon reads, so
+	// the caller can print the restart reminder.
+	ConfigChanged bool
+	// VersionControlled is false when the workspace is not a git repository —
+	// the one case where "git is the undo" does not hold.
+	VersionControlled bool
+}
+
+// Apply writes accepted patches to disk.
+//
+// It deliberately does not back up, snapshot or offer to revert. The workspace
+// is expected to be under version control, and `git diff` / `git checkout` do
+// that job better than anything this command would reimplement. What it owes the
+// operator instead is an accurate account of what it touched.
+//
+// Verdicts that failed the gate are skipped: reaching this function does not
+// re-open the question of whether a patch is safe.
+func Apply(verdicts []Verdict, root string) (*ApplyResult, error) {
+	res := &ApplyResult{VersionControlled: IsGitRepo(root)}
+
+	// Collisions matter: two accepted patches to the same file were each
+	// validated against the ORIGINAL content, so applying both in sequence would
+	// apply the second to content it never saw. Refuse rather than corrupt.
+	seen := map[string]string{}
+	for _, v := range verdicts {
+		if !v.OK || v.Path == "" || strings.TrimSpace(v.Recommendation.Patch) == "" {
+			continue
+		}
+		if prev, dup := seen[v.Path]; dup {
+			return nil, fmt.Errorf("two proposals both patch %s (%s and %s); "+
+				"each was validated against the original file, so applying both would be unsafe — "+
+				"apply one, re-run, then consider the other",
+				v.Path, prev, v.Recommendation.ID)
+		}
+		seen[v.Path] = v.Recommendation.ID
+	}
+
+	for _, v := range verdicts {
+		if !v.OK || v.Path == "" || strings.TrimSpace(v.Recommendation.Patch) == "" {
+			continue
+		}
+
+		// Preserve the file's existing permissions rather than imposing a mode.
+		mode := os.FileMode(0o600)
+		if st, err := os.Stat(v.Path); err == nil {
+			mode = st.Mode().Perm()
+		}
+		if err := os.WriteFile(v.Path, []byte(v.Result), mode); err != nil {
+			return res, fmt.Errorf("writing %s: %w", v.Path, err)
+		}
+
+		rel := v.Path
+		if r, err := filepath.Rel(root, v.Path); err == nil {
+			rel = r
+		}
+		res.Files = append(res.Files, AppliedFile{
+			Path:           rel,
+			Added:          v.Added,
+			Removed:        v.Removed,
+			MachineChecked: v.MachineChecked,
+		})
+		if v.MachineChecked {
+			// Only config-like files are machine-checked, and those are exactly
+			// the ones the daemon reads at startup.
+			res.ConfigChanged = true
+		}
+	}
+
+	sort.Slice(res.Files, func(i, j int) bool { return res.Files[i].Path < res.Files[j].Path })
+	return res, nil
+}
+
+// IsGitRepo reports whether dir is inside a git working tree.
+func IsGitRepo(dir string) bool {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	out, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(out)) == "true"
+}
+
+// Summary renders what an apply run did, plus the reminders that follow from it.
+func (r *ApplyResult) Summary() string {
+	if len(r.Files) == 0 {
+		return "Nothing applied.\n"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Applied %d change(s):\n", len(r.Files))
+	unchecked := 0
+	for _, f := range r.Files {
+		fmt.Fprintf(&b, "  %s  (+%d −%d)", f.Path, f.Added, f.Removed)
+		if !f.MachineChecked {
+			b.WriteString("  — prose, not machine-checked")
+			unchecked++
+		}
+		b.WriteString("\n")
+	}
+
+	if !r.VersionControlled {
+		// The command's whole undo story is "you have git". Where that is not
+		// true, saying so is the least it can do — after the fact is still
+		// better than never, and refusing to write would be worse.
+		b.WriteString("\n⚠ This workspace is not a git repository, so there is no automatic way back.\n")
+		b.WriteString("  These edits were written in place and are not recoverable from here.\n")
+	} else {
+		b.WriteString("\nReview with `git diff`; undo with `git checkout -- <file>`.\n")
+	}
+
+	if unchecked > 0 {
+		fmt.Fprintf(&b, "\n%d of these are instruction files. Nothing about them could be validated\n", unchecked)
+		b.WriteString("mechanically — read them before the next run picks them up.\n")
+	}
+
+	if r.ConfigChanged {
+		b.WriteString("\nConfiguration changed. A running daemon keeps its loaded copy until restarted:\n")
+		b.WriteString("  apiary restart\n")
+	}
+	return b.String()
+}
+
+// ConfirmationPrompt is the one-line question shown before writing, naming what
+// is about to change so a blind "yes" is still an informed one.
+func ConfirmationPrompt(verdicts []Verdict) string {
+	var files []string
+	unchecked := 0
+	for _, v := range verdicts {
+		if !v.OK || strings.TrimSpace(v.Recommendation.Patch) == "" {
+			continue
+		}
+		files = append(files, v.Recommendation.File)
+		if !v.MachineChecked {
+			unchecked++
+		}
+	}
+	if len(files) == 0 {
+		return ""
+	}
+	sort.Strings(files)
+
+	s := fmt.Sprintf("Apply %d change(s) to %s?", len(files), strings.Join(files, ", "))
+	if unchecked > 0 {
+		s += fmt.Sprintf(" (%d are instruction files that could not be validated)", unchecked)
+	}
+	return s + " [y/N] "
+}

--- a/src/internal/improve/apply_test.go
+++ b/src/internal/improve/apply_test.go
@@ -1,0 +1,255 @@
+package improve
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func acceptedVerdict(path, result string, added, removed int, machineChecked bool) Verdict {
+	return Verdict{
+		OK: true, Path: path, Result: result,
+		Added: added, Removed: removed, MachineChecked: machineChecked,
+		Recommendation: Recommendation{
+			ID: "r-" + filepath.Base(path), File: filepath.Base(path),
+			Summary: "change " + filepath.Base(path),
+			Patch:   "--- a/x\n+++ b/x\n@@ -1,1 +1,1 @@\n-a\n+b\n",
+		},
+	}
+}
+
+func TestApplyWritesExactContent(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(target, []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Apply([]Verdict{acceptedVerdict(target, "new content\n", 1, 1, true)}, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new content\n" {
+		t.Errorf("file content = %q, want the patched result verbatim", got)
+	}
+	if len(res.Files) != 1 || res.Files[0].Path != "apiary.yaml" {
+		t.Errorf("Files = %+v, want one relative path", res.Files)
+	}
+	if !res.ConfigChanged {
+		t.Error("a machine-checked (config) file must set ConfigChanged")
+	}
+}
+
+func TestApplySkipsRejectedAndAdvisory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(target, []byte("untouched\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rejected := acceptedVerdict(target, "should not be written\n", 1, 1, true)
+	rejected.OK = false
+
+	advisory := Verdict{OK: true, Recommendation: Recommendation{ID: "r2", Summary: "think about it"}}
+
+	res, err := Apply([]Verdict{rejected, advisory}, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Files) != 0 {
+		t.Errorf("nothing should have been written, got %+v", res.Files)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "untouched\n" {
+		t.Errorf("a rejected verdict must not reach disk; file = %q", got)
+	}
+}
+
+// Each patch was validated against the ORIGINAL file, so applying two to the
+// same file in sequence would apply the second to content it never saw.
+func TestApplyRefusesTwoPatchesToOneFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(target, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	a := acceptedVerdict(target, "first\n", 1, 0, true)
+	a.Recommendation.ID = "r1"
+	b := acceptedVerdict(target, "second\n", 1, 0, true)
+	b.Recommendation.ID = "r2"
+
+	_, err := Apply([]Verdict{a, b}, root)
+	if err == nil {
+		t.Fatal("two patches to the same file must be refused")
+	}
+	if !strings.Contains(err.Error(), "r1") || !strings.Contains(err.Error(), "r2") {
+		t.Errorf("the error should name both proposals, got: %v", err)
+	}
+	// Nothing may be written when the set is refused.
+	got, _ := os.ReadFile(target)
+	if string(got) != "original\n" {
+		t.Errorf("a refused apply must leave the file untouched, got %q", got)
+	}
+}
+
+func TestApplyPreservesFileMode(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "soul.md")
+	if err := os.WriteFile(target, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Apply([]Verdict{acceptedVerdict(target, "new\n", 1, 1, false)}, root); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	st, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm() != 0o644 {
+		t.Errorf("mode = %v, want the file's original 0644 preserved", st.Mode().Perm())
+	}
+}
+
+func TestSummaryWarnsOutsideGit(t *testing.T) {
+	root := t.TempDir() // not a git repo
+	target := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(target, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Apply([]Verdict{acceptedVerdict(target, "y\n", 1, 1, true)}, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.VersionControlled {
+		t.Fatal("a plain temp dir is not a git repository")
+	}
+
+	summary := res.Summary()
+	if !strings.Contains(summary, "not a git repository") {
+		t.Errorf("the summary must say the undo story does not hold here:\n%s", summary)
+	}
+	// It warns, it does not refuse — the file is written either way.
+	if got, _ := os.ReadFile(target); string(got) != "y\n" {
+		t.Error("apply must still write outside git; the warning is not a refusal")
+	}
+}
+
+func TestSummaryInsideGitPointsAtGitCommands(t *testing.T) {
+	root := t.TempDir()
+	if err := exec.Command("git", "-C", root, "init", "-q").Run(); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	target := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(target, []byte("x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Apply([]Verdict{acceptedVerdict(target, "y\n", 1, 1, true)}, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !res.VersionControlled {
+		t.Fatal("an initialised repo must be detected")
+	}
+	summary := res.Summary()
+	if !strings.Contains(summary, "git diff") || !strings.Contains(summary, "git checkout") {
+		t.Errorf("the summary should point at git for review and undo:\n%s", summary)
+	}
+	if strings.Contains(summary, "not a git repository") {
+		t.Error("no warning belongs here")
+	}
+}
+
+func TestSummaryFlagsProseAndConfigConsequences(t *testing.T) {
+	root := t.TempDir()
+	soul := filepath.Join(root, "engineer.md")
+	cfg := filepath.Join(root, "apiary.yaml")
+	for _, p := range []string{soul, cfg} {
+		if err := os.WriteFile(p, []byte("x\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, err := Apply([]Verdict{
+		acceptedVerdict(soul, "prose\n", 2, 0, false),
+		acceptedVerdict(cfg, "conf\n", 1, 1, true),
+	}, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	summary := res.Summary()
+	if !strings.Contains(summary, "not machine-checked") {
+		t.Errorf("prose files must be called out:\n%s", summary)
+	}
+	if !strings.Contains(summary, "apiary restart") {
+		t.Errorf("a config change must carry the restart reminder:\n%s", summary)
+	}
+	// Files are listed in a stable order.
+	if idx1, idx2 := strings.Index(summary, "apiary.yaml"), strings.Index(summary, "engineer.md"); idx1 > idx2 {
+		t.Error("applied files should be listed in sorted order")
+	}
+}
+
+func TestSummaryWithNothingApplied(t *testing.T) {
+	res := &ApplyResult{VersionControlled: true}
+	if got := res.Summary(); !strings.Contains(got, "Nothing applied") {
+		t.Errorf("Summary = %q", got)
+	}
+}
+
+func TestConfirmationPromptNamesWhatChanges(t *testing.T) {
+	verdicts := []Verdict{
+		acceptedVerdict("/w/apiary.yaml", "x", 1, 1, true),
+		acceptedVerdict("/w/engineer.md", "y", 2, 0, false),
+	}
+	got := ConfirmationPrompt(verdicts)
+
+	for _, want := range []string{"2 change(s)", "apiary.yaml", "engineer.md", "1 are instruction files", "[y/N]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q: %s", want, got)
+		}
+	}
+
+	// Nothing to apply produces no prompt at all.
+	if p := ConfirmationPrompt(nil); p != "" {
+		t.Errorf("ConfirmationPrompt(nil) = %q, want empty", p)
+	}
+	rejected := []Verdict{{OK: false, Recommendation: Recommendation{Patch: "d"}}}
+	if p := ConfirmationPrompt(rejected); p != "" {
+		t.Errorf("a rejected-only set should produce no prompt, got %q", p)
+	}
+}
+
+func TestIsGitRepo(t *testing.T) {
+	plain := t.TempDir()
+	if IsGitRepo(plain) {
+		t.Error("a plain temp dir is not a git repo")
+	}
+
+	repo := t.TempDir()
+	if err := exec.Command("git", "-C", repo, "init", "-q").Run(); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+	if !IsGitRepo(repo) {
+		t.Error("an initialised repo must be detected")
+	}
+	// A subdirectory is still inside the work tree.
+	sub := filepath.Join(repo, "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !IsGitRepo(sub) {
+		t.Error("a subdirectory of a repo is inside the work tree")
+	}
+}

--- a/src/internal/improve/e2e_test.go
+++ b/src/internal/improve/e2e_test.go
@@ -1,0 +1,115 @@
+package improve
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Exercises the whole Phase 3 + 4 path on a real tree: a recommendation goes
+// through the gate, gets rendered, and is written to disk.
+func TestGateToApplyEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	if err := exec.Command("git", "-C", root, "init", "-q").Run(); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+
+	soul := filepath.Join(root, "engineer.md")
+	if err := os.WriteFile(soul, []byte("you are an engineer\nbe careful\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(root, "apiary.yaml")
+	body := `version: "1"
+default_runner: claude
+runners:
+  - id: claude
+    type: cli
+    provider: claude
+agents:
+  - id: engineer
+    model: sonnet
+    soul_file: ` + soul + `
+`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ws := &Workspace{Root: root, Files: []WorkspaceFile{
+		{Path: "apiary.yaml", Kind: KindConfig},
+		{Path: "engineer.md", Kind: KindSoul, Owner: "engineer"},
+	}}
+
+	analysis := Analysis{
+		Findings: []Finding{{ID: "f1", Scope: "wf/step", Symptom: "agents skip the tests",
+			Evidence: []string{"fail_rate=0.3 n=40"}, Severity: "high"}},
+		Recommendations: []Recommendation{
+			{
+				ID: "r1", Addresses: []string{"f1"}, File: "engineer.md",
+				Summary: "tell the agent to run the tests", Confidence: "medium",
+				Patch: "--- a/engineer.md\n+++ b/engineer.md\n@@ -1,2 +1,3 @@\n you are an engineer\n be careful\n+always run the tests\n",
+			},
+			{
+				// Prose hunk header — the shape a real advisor produced.
+				ID: "r2", Addresses: []string{"f1"}, File: "apiary.yaml",
+				Summary: "retarget the merge step",
+				Patch:   "--- a/apiary.yaml\n+++ b/apiary.yaml\n@@ merge step @@\n-  agent: engineer\n+  agent: engineer-merge\n",
+			},
+		},
+	}
+
+	v := NewValidator(ws, cfgPath, nil)
+	verdicts := v.Validate(analysis.Recommendations)
+
+	accepted, rejected := Summarize(verdicts)
+	if len(accepted) != 1 || len(rejected) != 1 {
+		t.Fatalf("want 1 accepted and 1 rejected, got %d/%d", len(accepted), len(rejected))
+	}
+	if accepted[0].MachineChecked {
+		t.Error("the accepted change is a soul file; it cannot be machine-checked")
+	}
+
+	out := RenderDiff(analysis, verdicts)
+	if !strings.Contains(out, "agents skip the tests") {
+		t.Error("the diff must carry the finding that justified it")
+	}
+	if !strings.Contains(out, "Could not be validated") {
+		t.Error("the rejected patch needs its section")
+	}
+
+	res, err := Apply(verdicts, root)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	got, err := os.ReadFile(soul)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "you are an engineer\nbe careful\nalways run the tests\n" {
+		t.Errorf("soul file = %q", got)
+	}
+
+	// The config was never touched, because its patch never passed.
+	cfgAfter, _ := os.ReadFile(cfgPath)
+	if string(cfgAfter) != body {
+		t.Error("a rejected patch must not reach disk")
+	}
+
+	if res.ConfigChanged {
+		t.Error("only a prose file changed; no restart reminder is warranted")
+	}
+	summary := res.Summary()
+	if !strings.Contains(summary, "not machine-checked") {
+		t.Errorf("the summary must flag the unverified prose edit:\n%s", summary)
+	}
+
+	// git sees exactly one modified file.
+	diff, err := exec.Command("git", "-C", root, "diff", "--name-only").Output()
+	if err == nil {
+		names := strings.Fields(string(diff))
+		if len(names) != 0 { // files are untracked in a fresh init, so this is informational
+			t.Logf("git diff reports: %v", names)
+		}
+	}
+}


### PR DESCRIPTION
Phase 4 of #401. Closes #405. This completes the minimum shippable feature (phases 1–4).

Proposals that clear the validation gate can now be written to disk.

## What it deliberately does not do

No backups, no snapshots, no revert command. The workspace is expected to be under version control, and `git diff` / `git checkout` do that job better than anything reimplemented here. What apply owes the operator instead is an accurate account of what it touched:

```
Applied 2 change(s):
  .apiary/agents/engineer.md  (+3 −0)  — prose, not machine-checked
  .apiary/apiary.yaml         (+1 −1)

Review with `git diff`; undo with `git checkout -- <file>`.

1 of these are instruction files. Nothing about them could be validated
mechanically — read them before the next run picks them up.

Configuration changed. A running daemon keeps its loaded copy until restarted:
  apiary restart
```

Where the git assumption doesn't hold, it says so — before writing while the operator is still at the prompt, and again afterwards. It **warns rather than refuses**: declining to write because someone chose not to use version control would substitute our preference for their decision, and the warning is what they actually need.

## Two safety properties beyond the gate

1. **Two accepted patches to the same file are refused outright.** Each was validated against the *original* content, so applying them in sequence would apply the second to content it never saw. The error names both proposals and suggests applying one, re-running, then reconsidering the other. Nothing is written when the set is refused.
2. **File permissions are preserved rather than imposed**, so applying a change to a 0644 soul file doesn't silently tighten it to 0600.

## Consent, not formality

The confirmation prints the **full diff first**. A prompt for changes the operator hasn't seen isn't consent. `--yes` skips the question, not the diff.

## Testing

`make check` green across 33 packages, `improve` also under `-race`.

New unit tests: exact content written, rejected and advisory verdicts never reaching disk, same-file collision refused with nothing written, mode preservation, the outside-git warning (and that it still writes), the inside-git summary pointing at git commands, prose and config consequences flagged, and the confirmation prompt naming files and unvalidated count.

Plus an **end-to-end test over the whole Phase 3 + 4 path** on a real config tree: a clean prose patch and a patch with a prose hunk header go through the gate together, one is accepted and one rejected, the rendered diff carries the finding that justified it, and only the accepted one reaches disk while the config stays byte-identical.

One thing still in flight: I have a live `--apply` run going against a git sandbox seeded with a copy of the real project-erp config and database. It has outrun its timeout and is still executing; I'll report what it did on this PR when it lands. Everything above is verified by the test suite regardless — the live run is confirmation on real data, not the basis for the change.

## Next

#406 (ledger + effect measurement) → #407 (docs). #406 is the one that makes this a loop rather than a report generator, and it matters most for the prose edits this phase can now write but nothing can validate.