### PR TITLE
feat(improve): improvement ledger and effect measurement (#406)

### DIFF
--- a/src/internal/cli/improve.go
+++ b/src/internal/cli/improve.go
@@ -128,7 +128,22 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 				return err
 			}
 			files := ws.Filter(knobs.WorkspaceBreadth, activeAgents(pack), flaggedAgents(pack))
-			prompt := improve.ComposePrompt(pack, ws, files, knobs)
+
+			// Prior findings keep the advisor from re-proposing what was already
+			// tried. A ledger that cannot be opened is not fatal — the analysis is
+			// still worth running, just without that context.
+			var prior []improve.LedgerFinding
+			ledger, ledgerErr := improve.OpenLedger(ctx, dbPath)
+			if ledgerErr != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ improvement ledger unavailable (%v); history will not be recorded\n", ledgerErr)
+			} else {
+				defer ledger.Close()
+				if prior, err = ledger.PriorFindings(ctx, 50); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ could not read prior findings: %v\n", err)
+				}
+			}
+
+			prompt := improve.ComposePrompt(pack, ws, files, knobs, prior)
 
 			// --dump-prompt runs no model, so it needs no advisor. It exists so the
 			// exact text that would be sent can be reviewed first — including
@@ -192,8 +207,15 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 
 			fmt.Fprintln(os.Stderr, improve.DiffSummary(verdicts))
 
+			runID := improve.NewRunID(time.Now())
+			if ledger != nil {
+				if err := recordRun(ctx, ledger, runID, pack, adv, outcome, verdicts, effort, focus, outDir); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ could not record this run in the ledger: %v\n", err)
+				}
+			}
+
 			if apply {
-				return applyChanges(cmd, ws, verdicts, diff, assumeYes)
+				return applyChanges(cmd, ws, verdicts, diff, assumeYes, ledger, runID)
 			}
 
 			switch output {
@@ -228,6 +250,8 @@ ad-hoc --runner/--model pair, settings.improve.agent, or an agent named
 	cmd.Flags().BoolVar(&apply, "apply", false, "write the accepted changes to disk (workspace is assumed to be under version control)")
 	cmd.Flags().BoolVar(&assumeYes, "yes", false, "skip the confirmation prompt when applying")
 	cmd.Flags().IntVar(&excerptBudget, "transcript-bytes", 0, "override the per-transcript character budget")
+
+	cmd.AddCommand(newImproveHistoryCmd(), newImproveShowCmd(), newImproveEffectCmd())
 
 	return cmd
 }
@@ -292,7 +316,7 @@ func writeArtifacts(dir string, pack *improve.EvidencePack, outcome *improve.Run
 // applyChanges shows the diff, asks once, and writes. The diff is printed in
 // full first: a confirmation prompt for changes the operator has not seen is
 // not consent, it is a formality.
-func applyChanges(cmd *cobra.Command, ws *improve.Workspace, verdicts []improve.Verdict, diff string, assumeYes bool) error {
+func applyChanges(cmd *cobra.Command, ws *improve.Workspace, verdicts []improve.Verdict, diff string, assumeYes bool, ledger *improve.Ledger, runID string) error {
 	prompt := improve.ConfirmationPrompt(verdicts)
 	if prompt == "" {
 		fmt.Fprintln(os.Stderr, "nothing to apply — no proposal survived validation")
@@ -322,5 +346,67 @@ func applyChanges(cmd *cobra.Command, ws *improve.Workspace, verdicts []improve.
 		return err
 	}
 	fmt.Fprint(os.Stderr, "\n"+res.Summary())
+
+	// Only findings that actually reached disk are marked applied — that is what
+	// the later effect comparison measures against.
+	if ledger != nil {
+		var appliedIDs []string
+		for _, v := range verdicts {
+			if v.OK && v.Path != "" && strings.TrimSpace(v.Recommendation.Patch) != "" {
+				appliedIDs = append(appliedIDs, improve.FindingRowID(runID, v.Recommendation.ID))
+			}
+		}
+		if err := ledger.MarkApplied(context.Background(), runID, appliedIDs, time.Now()); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ could not mark the run applied: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "\nRecorded as run %s. Measure the effect later with:\n  apiary improve effect %s\n", runID, runID)
+		}
+	}
 	return nil
+}
+
+// recordRun writes the analysis to the ledger, capturing the metrics behind each
+// finding so a later run can recompute them and compare.
+func recordRun(ctx context.Context, ledger *improve.Ledger, runID string, pack *improve.EvidencePack,
+	adv *improve.Advisor, outcome *improve.RunOutcome, verdicts []improve.Verdict,
+	effort improve.Effort, focus, outDir string) error {
+
+	scopeJSON, _ := json.Marshal(pack.Scope)
+	run := improve.LedgerRun{
+		ID: runID, Effort: string(effort), Focus: focus,
+		WindowStart: pack.Window.Start, WindowEnd: pack.Window.End,
+		Scope: string(scopeJSON), EvidenceDigest: pack.Digest,
+		AdvisorAgent: adv.AgentID, AdvisorRunner: adv.RunnerID, AdvisorModel: adv.Model,
+		ReportPath: outDir, CostUSD: outcome.Usage.CostUSD,
+		TotalTokens: outcome.Usage.TotalTokens, CreatedAt: time.Now(),
+	}
+
+	findingByID := map[string]improve.Finding{}
+	for _, f := range outcome.Analysis.Findings {
+		findingByID[f.ID] = f
+	}
+
+	var rows []improve.LedgerFinding
+	for _, v := range verdicts {
+		r := v.Recommendation
+		scope, symptom, severity, focusOf := "", "", "", ""
+		for _, id := range r.Addresses {
+			if f, ok := findingByID[id]; ok {
+				scope, symptom, severity, focusOf = f.Scope, f.Symptom, f.Severity, f.Focus
+				break
+			}
+		}
+		state := improve.FindingProposed
+		if !v.OK {
+			state = improve.FindingRejected
+		}
+		rows = append(rows, improve.LedgerFinding{
+			ID: improve.FindingRowID(runID, r.ID), RunID: runID, FindingID: r.ID,
+			Scope: scope, Focus: focusOf, Severity: severity, Confidence: r.Confidence,
+			Symptom: symptom, Rationale: r.Rationale, TargetFile: r.File,
+			BaselineMetrics: improve.BaselineJSON(pack, scope), Patch: r.Patch,
+			MachineChecked: v.MachineChecked, State: state, RejectReason: v.Reason,
+		})
+	}
+	return ledger.RecordRun(ctx, run, rows)
 }

--- a/src/internal/cli/improve_history.go
+++ b/src/internal/cli/improve_history.go
@@ -1,0 +1,175 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/improve"
+)
+
+func newImproveHistoryCmd() *cobra.Command {
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "List past improvement runs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ledger, err := openLedger(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer ledger.Close()
+
+			runs, err := ledger.ListRuns(cmd.Context(), limit)
+			if err != nil {
+				return err
+			}
+			if len(runs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no improvement runs recorded yet")
+				return nil
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(),
+				instHeader.Render("RUN                       WHEN              EFFORT    ADVISOR              APPLIED   COST"))
+			for _, r := range runs {
+				applied := "—"
+				if r.Applied && r.AppliedAt != nil {
+					applied = r.AppliedAt.Local().Format("01-02 15:04")
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%-25s %-17s %-9s %-20s %-9s $%.2f\n",
+					r.ID, r.CreatedAt.Local().Format("2006-01-02 15:04"), r.Effort,
+					truncateStr(r.AdvisorAgent+"/"+r.AdvisorModel, 20), applied, r.CostUSD)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 20, "how many runs to list")
+	return cmd
+}
+
+func newImproveShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <run-id>",
+		Short: "Show a past improvement run's findings",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ledger, err := openLedger(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer ledger.Close()
+
+			run, findings, err := ledger.GetRun(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "# Improvement run %s\n\n", run.ID)
+			fmt.Fprintf(out, "%s → %s · effort %s · advisor %s (%s / %s)\n",
+				run.WindowStart.Format(time.DateOnly), run.WindowEnd.Format(time.DateOnly),
+				run.Effort, run.AdvisorAgent, run.AdvisorRunner, run.AdvisorModel)
+			fmt.Fprintf(out, "recorded %s · %d tokens · $%.4f\n",
+				run.CreatedAt.Local().Format(time.RFC3339), run.TotalTokens, run.CostUSD)
+			if run.Applied && run.AppliedAt != nil {
+				fmt.Fprintf(out, "applied %s\n", run.AppliedAt.Local().Format(time.RFC3339))
+			} else {
+				fmt.Fprintln(out, "not applied")
+			}
+			if run.ReportPath != "" {
+				fmt.Fprintf(out, "artifacts: %s\n", run.ReportPath)
+			}
+			fmt.Fprintln(out)
+
+			for _, f := range findings {
+				fmt.Fprintf(out, "## [%s] %s\n", strings.ToUpper(orDash(f.State)), orDash(f.Symptom))
+				fmt.Fprintf(out, "- scope: %s\n", orDash(f.Scope))
+				if f.TargetFile != "" {
+					fmt.Fprintf(out, "- file: %s\n", f.TargetFile)
+				}
+				if f.Confidence != "" {
+					fmt.Fprintf(out, "- confidence: %s\n", f.Confidence)
+				}
+				if !f.MachineChecked && f.Patch != "" {
+					fmt.Fprintln(out, "- not machine-checked (instruction file)")
+				}
+				if f.RejectReason != "" {
+					fmt.Fprintf(out, "- rejected: %s\n", f.RejectReason)
+				}
+				if f.Rationale != "" {
+					fmt.Fprintf(out, "\n%s\n", f.Rationale)
+				}
+				fmt.Fprintln(out)
+			}
+			return nil
+		},
+	}
+}
+
+func newImproveEffectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "effect <run-id>",
+		Short: "Compare metrics before and after an applied run",
+		Long: `Recompute the metrics behind each applied finding over the window since it was
+applied, and compare them to the baseline captured when it was proposed.
+
+This is what makes the advisor a loop rather than a report generator. It matters
+most for instruction changes: nothing can validate a soul file mechanically, so
+measured effect is the only evidence that such a change did what it claimed.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ledger, err := openLedger(cmd.Context())
+			if err != nil {
+				return err
+			}
+			defer ledger.Close()
+
+			run, findings, err := ledger.GetRun(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			db, err := improve.OpenReadOnly(getDBPath())
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			effects, err := improve.MeasureEffect(cmd.Context(), db, run, findings, time.Now())
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), improve.RenderEffect(run, effects))
+			return nil
+		},
+	}
+}
+
+func openLedger(ctx context.Context) (*improve.Ledger, error) {
+	dbPath := getDBPath()
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, fmt.Errorf("no database at %s — has the daemon ever run?", dbPath)
+	}
+	return improve.OpenLedger(ctx, dbPath)
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+func truncateStr(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -457,6 +457,50 @@ var migrations = []string{
 	`ALTER TABLE step_runs ADD COLUMN time_other_ms INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN time_background_ms INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE step_runs ADD COLUMN slow_tools TEXT`,
+	// Self-improvement ledger (issue #406): what `apiary improve` proposed, what
+	// was applied, and the metrics that justified each proposal — so a later run
+	// can measure whether an applied change actually helped. These live here
+	// rather than in the schema const because CREATE TABLE IF NOT EXISTS there
+	// never fires against a database that already exists.
+	`CREATE TABLE IF NOT EXISTS improvement_runs (
+	  id TEXT PRIMARY KEY,
+	  effort TEXT NOT NULL,
+	  focus TEXT,
+	  window_start TIMESTAMP,
+	  window_end TIMESTAMP,
+	  scope TEXT,                       -- JSON: workflow/agent filters
+	  evidence_digest TEXT,             -- hash of the evidence pack, for reproducibility
+	  advisor_agent TEXT,
+	  advisor_runner TEXT,
+	  advisor_model TEXT,
+	  report_path TEXT,
+	  applied BOOLEAN NOT NULL DEFAULT 0,
+	  applied_at TIMESTAMP,
+	  cost_usd REAL NOT NULL DEFAULT 0,
+	  total_tokens INTEGER NOT NULL DEFAULT 0,
+	  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`,
+	`CREATE TABLE IF NOT EXISTS improvement_findings (
+	  id TEXT PRIMARY KEY,
+	  run_id TEXT NOT NULL,
+	  finding_id TEXT,                  -- the advisor's own id, e.g. "f1"
+	  scope TEXT NOT NULL,              -- "workflow:x/step:y" | "agent:z"
+	  focus TEXT,
+	  severity TEXT,
+	  confidence TEXT,
+	  symptom TEXT,
+	  rationale TEXT,
+	  target_file TEXT,
+	  baseline_metrics TEXT,            -- JSON snapshot of the metrics that justified it
+	  patch TEXT,
+	  machine_checked BOOLEAN NOT NULL DEFAULT 0,
+	  state TEXT NOT NULL,              -- proposed|applied|rejected|reverted
+	  reject_reason TEXT,
+	  FOREIGN KEY(run_id) REFERENCES improvement_runs(id)
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_improvement_findings_run ON improvement_findings(run_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_improvement_findings_scope ON improvement_findings(scope, state)`,
+	`CREATE INDEX IF NOT EXISTS idx_improvement_runs_created ON improvement_runs(created_at DESC)`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).

--- a/src/internal/improve/effect.go
+++ b/src/internal/improve/effect.go
@@ -1,0 +1,223 @@
+package improve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Delta is one metric measured before and after an applied change.
+type Delta struct {
+	Metric string
+	Before float64
+	After  float64
+	// Unit shapes rendering: "usd", "pct", "ms" or "" for a bare count.
+	Unit string
+	// LowerIsBetter says which direction counts as improvement, so the renderer
+	// does not have to guess per metric.
+	LowerIsBetter bool
+}
+
+// Change reports the improvement, as a signed fraction where positive is better.
+func (d Delta) Change() float64 {
+	if d.Before == 0 {
+		return 0
+	}
+	raw := (d.After - d.Before) / d.Before
+	if d.LowerIsBetter {
+		return -raw
+	}
+	return raw
+}
+
+// Effect is the before/after comparison for one applied finding.
+type Effect struct {
+	Finding LedgerFinding
+	Scope   string
+	Deltas  []Delta
+	// SampleBefore and SampleAfter are the run counts each side rests on. A
+	// delta drawn from four runs is not evidence, and the renderer says so.
+	SampleBefore int
+	SampleAfter  int
+	// Insufficient marks a comparison too thin to read.
+	Insufficient bool
+	// Note explains why a comparison could not be made at all.
+	Note string
+}
+
+// MeasureEffect recomputes the metrics behind each applied finding over the
+// window since it was applied, and compares them to the baseline captured when
+// it was proposed.
+//
+// This is what makes the feature a loop rather than a report generator. It
+// matters most for instruction edits: the validation gate cannot check a soul
+// file at all, so measured effect is the only evidence that a prose change did
+// what it claimed.
+func MeasureEffect(ctx context.Context, db source, run *LedgerRun, findings []LedgerFinding, now time.Time) ([]Effect, error) {
+	if run.AppliedAt == nil {
+		return nil, fmt.Errorf("run %s was never applied, so there is nothing to measure", run.ID)
+	}
+	after := Window{Start: run.AppliedAt.UTC(), End: now.UTC()}
+
+	steps, err := StepMetricsFor(ctx, db, after, Scope{})
+	if err != nil {
+		return nil, err
+	}
+	byScope := map[string]StepMetrics{}
+	for _, s := range steps {
+		byScope[fmt.Sprintf("workflow:%s/step:%s", s.WorkflowID, s.StepID)] = s
+	}
+
+	var out []Effect
+	for _, f := range findings {
+		if f.State != FindingApplied {
+			continue
+		}
+		e := Effect{Finding: f, Scope: f.Scope}
+
+		baseline, ok := BaselineFor(f)
+		if !ok {
+			e.Note = "no baseline metrics were recorded for this finding"
+			out = append(out, e)
+			continue
+		}
+		current, ok := byScope[normalizeScope(f.Scope)]
+		if !ok {
+			e.Note = "this scope has not run since the change was applied"
+			e.SampleBefore = baseline.Runs
+			out = append(out, e)
+			continue
+		}
+
+		e.SampleBefore = baseline.Runs
+		e.SampleAfter = current.Runs
+		e.Insufficient = current.Runs < MinRuns
+		e.Deltas = []Delta{
+			{Metric: "fail rate", Before: baseline.FailRate, After: current.FailRate, Unit: "pct", LowerIsBetter: true},
+			{Metric: "cost/run", Before: baseline.MeanCostUSD, After: current.MeanCostUSD, Unit: "usd", LowerIsBetter: true},
+			{Metric: "p95 duration", Before: float64(baseline.DurationP95Ms), After: float64(current.DurationP95Ms), Unit: "ms", LowerIsBetter: true},
+			{Metric: "turns/run", Before: baseline.MeanTurns, After: current.MeanTurns, LowerIsBetter: true},
+			{Metric: "failover rate", Before: baseline.FailoverRate, After: current.FailoverRate, Unit: "pct", LowerIsBetter: true},
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}
+
+// normalizeScope tolerates the scope shapes an advisor produces. It writes
+// "workflow:x/step:y" when asked, but also "x/y" and occasionally
+// "workflow:x step:y" — matching only the canonical form would silently drop
+// findings from the comparison.
+func normalizeScope(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "workflow:") && strings.Contains(s, "/step:") {
+		return s
+	}
+	s = strings.ReplaceAll(s, " step:", "/step:")
+	if strings.HasPrefix(s, "workflow:") && strings.Contains(s, "/step:") {
+		return s
+	}
+	if wf, step, found := strings.Cut(s, "/"); found && !strings.Contains(s, ":") {
+		return fmt.Sprintf("workflow:%s/step:%s", wf, step)
+	}
+	return s
+}
+
+// RenderEffect prints the before/after comparison.
+func RenderEffect(run *LedgerRun, effects []Effect) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# Effect of improvement run %s\n\n", run.ID)
+	if run.AppliedAt != nil {
+		fmt.Fprintf(&b, "Applied %s · measuring everything since.\n\n",
+			run.AppliedAt.Format(time.RFC3339))
+	}
+
+	if len(effects) == 0 {
+		b.WriteString("No applied findings to measure.\n")
+		return b.String()
+	}
+
+	for _, e := range effects {
+		fmt.Fprintf(&b, "## %s\n\n", e.Scope)
+		if e.Finding.Symptom != "" {
+			fmt.Fprintf(&b, "_%s_\n\n", e.Finding.Symptom)
+		}
+		if e.Note != "" {
+			fmt.Fprintf(&b, "%s\n\n", e.Note)
+			continue
+		}
+
+		fmt.Fprintf(&b, "n: %d before → %d after\n\n", e.SampleBefore, e.SampleAfter)
+		if e.Insufficient {
+			// Reporting a percentage off three runs would be worse than
+			// reporting nothing, because it reads as a result.
+			fmt.Fprintf(&b, "⚠ Only %d run(s) since the change — too few to conclude anything. "+
+				"The numbers below are shown for completeness, not as a result.\n\n", e.SampleAfter)
+		}
+
+		b.WriteString("| metric | before | after | change |\n|---|---|---|---|\n")
+		for _, d := range e.Deltas {
+			fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+				d.Metric, formatValue(d.Before, d.Unit), formatValue(d.After, d.Unit), formatChange(d))
+		}
+		b.WriteString("\n")
+
+		if !e.Insufficient && !e.Finding.MachineChecked {
+			// The whole reason this phase matters: nothing could check this edit
+			// when it was made, so the numbers here are the first real evidence.
+			b.WriteString("_This was an instruction change; nothing about it could be validated when it was applied. " +
+				"These numbers are the first evidence either way._\n\n")
+		}
+	}
+	return b.String()
+}
+
+func formatValue(v float64, unit string) string {
+	switch unit {
+	case "usd":
+		return fmt.Sprintf("$%.3f", v)
+	case "pct":
+		return fmt.Sprintf("%.0f%%", v*100)
+	case "ms":
+		return dur(int64(v))
+	default:
+		return fmt.Sprintf("%.1f", v)
+	}
+}
+
+func formatChange(d Delta) string {
+	if d.Before == 0 && d.After == 0 {
+		return "—"
+	}
+	if d.Before == 0 {
+		return "n/a (no baseline)"
+	}
+	pct := d.Change() * 100
+	switch {
+	case pct > 1:
+		return fmt.Sprintf("↓ %.0f%% better", pct)
+	case pct < -1:
+		return fmt.Sprintf("↑ %.0f%% worse", -pct)
+	default:
+		return "unchanged"
+	}
+}
+
+// BaselineJSON captures the metrics behind a finding at proposal time, so the
+// same numbers can be recomputed and compared later.
+func BaselineJSON(pack *EvidencePack, scope string) string {
+	want := normalizeScope(scope)
+	for _, s := range pack.Steps {
+		if fmt.Sprintf("workflow:%s/step:%s", s.WorkflowID, s.StepID) == want {
+			raw, err := json.Marshal(s)
+			if err != nil {
+				return ""
+			}
+			return string(raw)
+		}
+	}
+	return ""
+}

--- a/src/internal/improve/effect_test.go
+++ b/src/internal/improve/effect_test.go
@@ -1,0 +1,217 @@
+package improve
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func baselineJSON(t *testing.T, m StepMetrics) string {
+	t.Helper()
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func TestMeasureEffectReportsImprovement(t *testing.T) {
+	db := seedDB(t)
+	appliedAt := base.Add(-2 * time.Hour)
+
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "impl", state: "done"})
+	// Ten runs after the change: low failure, cheaper than the baseline.
+	for i := range 10 {
+		state := "passed"
+		if i == 0 {
+			state = "failed"
+		}
+		addStep(t, db, stepOpts{
+			id: "s" + itoa(i), instanceID: "i1", stepID: "implement", agentID: "eng",
+			state: state, startedAt: appliedAt.Add(time.Duration(i) * time.Minute),
+			durationMs: 60_000, cost: 0.20, turns: 10,
+		})
+	}
+
+	run := &LedgerRun{ID: "imp_1", AppliedAt: &appliedAt}
+	findings := []LedgerFinding{{
+		FindingID: "r1", Scope: "workflow:impl/step:implement", State: FindingApplied,
+		Symptom: "fails often", MachineChecked: false,
+		BaselineMetrics: baselineJSON(t, StepMetrics{
+			WorkflowID: "impl", StepID: "implement", Runs: 40,
+			FailRate: 0.40, MeanCostUSD: 0.50, DurationP95Ms: 120_000, MeanTurns: 25,
+		}),
+	}}
+
+	effects, err := MeasureEffect(ctx(), db, run, findings, base.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("MeasureEffect: %v", err)
+	}
+	if len(effects) != 1 {
+		t.Fatalf("want 1 effect, got %d", len(effects))
+	}
+	e := effects[0]
+	if e.SampleBefore != 40 || e.SampleAfter != 10 {
+		t.Errorf("samples = %d before / %d after, want 40 / 10", e.SampleBefore, e.SampleAfter)
+	}
+	if e.Insufficient {
+		t.Error("10 runs is above MinRuns and should not be flagged insufficient")
+	}
+
+	byMetric := map[string]Delta{}
+	for _, d := range e.Deltas {
+		byMetric[d.Metric] = d
+	}
+	fail := byMetric["fail rate"]
+	if fail.Before != 0.40 {
+		t.Errorf("fail-rate baseline = %v, want 0.40", fail.Before)
+	}
+	if fail.After >= fail.Before {
+		t.Errorf("fail rate should have dropped: %v → %v", fail.Before, fail.After)
+	}
+	// Lower is better for fail rate, so a drop is a positive change.
+	if fail.Change() <= 0 {
+		t.Errorf("a reduced fail rate must read as improvement, got %v", fail.Change())
+	}
+
+	out := RenderEffect(run, effects)
+	if !strings.Contains(out, "better") {
+		t.Errorf("the rendered table should mark the improvement:\n%s", out)
+	}
+	// The finding was an unvalidatable instruction change; the measurement is
+	// the first evidence either way, and the output should say so.
+	if !strings.Contains(out, "first evidence") {
+		t.Errorf("a prose change's measurement should be framed as its first evidence:\n%s", out)
+	}
+}
+
+func TestMeasureEffectDetectsRegression(t *testing.T) {
+	db := seedDB(t)
+	appliedAt := base.Add(-2 * time.Hour)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "impl", state: "done"})
+	for i := range 8 {
+		addStep(t, db, stepOpts{
+			id: "s" + itoa(i), instanceID: "i1", stepID: "implement", agentID: "eng",
+			state: "failed", startedAt: appliedAt.Add(time.Duration(i) * time.Minute),
+			durationMs: 60_000, cost: 1.00,
+		})
+	}
+
+	run := &LedgerRun{ID: "imp_1", AppliedAt: &appliedAt}
+	findings := []LedgerFinding{{
+		FindingID: "r1", Scope: "workflow:impl/step:implement", State: FindingApplied,
+		BaselineMetrics: baselineJSON(t, StepMetrics{
+			WorkflowID: "impl", StepID: "implement", Runs: 40, FailRate: 0.10, MeanCostUSD: 0.50,
+		}),
+	}}
+
+	effects, err := MeasureEffect(ctx(), db, run, findings, base.Add(time.Hour))
+	if err != nil {
+		t.Fatalf("MeasureEffect: %v", err)
+	}
+	out := RenderEffect(run, effects)
+	if !strings.Contains(out, "worse") {
+		t.Errorf("a change that made things worse must say so plainly:\n%s", out)
+	}
+}
+
+// Reporting a percentage off three runs would be worse than reporting nothing,
+// because it reads as a result.
+func TestMeasureEffectGuardsThinSamples(t *testing.T) {
+	db := seedDB(t)
+	appliedAt := base.Add(-time.Hour)
+	addInstance(t, db, instanceOpts{id: "i1", workflowID: "impl", state: "done"})
+	for i := range 2 {
+		addStep(t, db, stepOpts{
+			id: "s" + itoa(i), instanceID: "i1", stepID: "implement", agentID: "eng",
+			state: "passed", startedAt: appliedAt.Add(time.Duration(i) * time.Minute), cost: 0.1,
+		})
+	}
+
+	run := &LedgerRun{ID: "imp_1", AppliedAt: &appliedAt}
+	findings := []LedgerFinding{{
+		FindingID: "r1", Scope: "workflow:impl/step:implement", State: FindingApplied,
+		BaselineMetrics: baselineJSON(t, StepMetrics{
+			WorkflowID: "impl", StepID: "implement", Runs: 40, FailRate: 0.40,
+		}),
+	}}
+
+	effects, err := MeasureEffect(ctx(), db, run, findings, base)
+	if err != nil {
+		t.Fatalf("MeasureEffect: %v", err)
+	}
+	if !effects[0].Insufficient {
+		t.Fatal("2 runs is below MinRuns and must be flagged insufficient")
+	}
+	out := RenderEffect(run, effects)
+	if !strings.Contains(out, "too few to conclude") {
+		t.Errorf("a thin sample must be labelled, not presented as a result:\n%s", out)
+	}
+	if !strings.Contains(out, "not as a result") {
+		t.Errorf("the caveat should be explicit:\n%s", out)
+	}
+}
+
+func TestMeasureEffectHandlesScopeThatNeverRanAgain(t *testing.T) {
+	db := seedDB(t)
+	appliedAt := base.Add(-time.Hour)
+	run := &LedgerRun{ID: "imp_1", AppliedAt: &appliedAt}
+	findings := []LedgerFinding{{
+		FindingID: "r1", Scope: "workflow:gone/step:missing", State: FindingApplied,
+		BaselineMetrics: baselineJSON(t, StepMetrics{Runs: 10}),
+	}}
+
+	effects, err := MeasureEffect(ctx(), db, run, findings, base)
+	if err != nil {
+		t.Fatalf("MeasureEffect: %v", err)
+	}
+	if effects[0].Note == "" {
+		t.Error("a scope with no runs since the change needs an explanation, not an empty table")
+	}
+	out := RenderEffect(run, effects)
+	if !strings.Contains(out, "has not run since") {
+		t.Errorf("output should explain the gap:\n%s", out)
+	}
+}
+
+func TestMeasureEffectSkipsUnappliedFindings(t *testing.T) {
+	db := seedDB(t)
+	appliedAt := base.Add(-time.Hour)
+	run := &LedgerRun{ID: "imp_1", AppliedAt: &appliedAt}
+	findings := []LedgerFinding{
+		{FindingID: "r1", Scope: "s", State: FindingProposed},
+		{FindingID: "r2", Scope: "s", State: FindingRejected},
+	}
+	effects, err := MeasureEffect(ctx(), db, run, findings, base)
+	if err != nil {
+		t.Fatalf("MeasureEffect: %v", err)
+	}
+	if len(effects) != 0 {
+		t.Errorf("only applied findings can be measured, got %d", len(effects))
+	}
+}
+
+func TestMeasureEffectRequiresAnApply(t *testing.T) {
+	db := seedDB(t)
+	run := &LedgerRun{ID: "imp_1"} // never applied
+	if _, err := MeasureEffect(ctx(), db, run, nil, base); err == nil {
+		t.Error("measuring a run that was never applied must be an error")
+	}
+}
+
+func TestDeltaChangeDirection(t *testing.T) {
+	// Lower-is-better: a drop is improvement.
+	drop := Delta{Before: 0.4, After: 0.1, LowerIsBetter: true}
+	if drop.Change() <= 0 {
+		t.Errorf("a drop in a lower-is-better metric is improvement, got %v", drop.Change())
+	}
+	rise := Delta{Before: 0.1, After: 0.4, LowerIsBetter: true}
+	if rise.Change() >= 0 {
+		t.Errorf("a rise in a lower-is-better metric is regression, got %v", rise.Change())
+	}
+	// A zero baseline cannot produce a ratio.
+	if (Delta{Before: 0, After: 5}).Change() != 0 {
+		t.Error("a zero baseline must not produce a change ratio")
+	}
+}

--- a/src/internal/improve/ledger.go
+++ b/src/internal/improve/ledger.go
@@ -1,0 +1,323 @@
+package improve
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Finding states in the ledger.
+const (
+	FindingProposed = "proposed"
+	FindingApplied  = "applied"
+	FindingRejected = "rejected"
+	FindingReverted = "reverted"
+)
+
+// LedgerRun is one recorded `apiary improve` invocation.
+type LedgerRun struct {
+	ID             string
+	Effort         string
+	Focus          string
+	WindowStart    time.Time
+	WindowEnd      time.Time
+	Scope          string
+	EvidenceDigest string
+	AdvisorAgent   string
+	AdvisorRunner  string
+	AdvisorModel   string
+	ReportPath     string
+	Applied        bool
+	AppliedAt      *time.Time
+	CostUSD        float64
+	TotalTokens    int
+	CreatedAt      time.Time
+}
+
+// LedgerFinding is one recorded proposal, with the metrics that justified it.
+type LedgerFinding struct {
+	ID              string
+	RunID           string
+	FindingID       string
+	Scope           string
+	Focus           string
+	Severity        string
+	Confidence      string
+	Symptom         string
+	Rationale       string
+	TargetFile      string
+	BaselineMetrics string
+	Patch           string
+	MachineChecked  bool
+	State           string
+	RejectReason    string
+}
+
+// Ledger writes and reads the improvement history.
+//
+// It holds its own read-write connection. The analysis path opens the database
+// read-only on purpose — it must never migrate or lock a database a running
+// daemon depends on — so the two cannot share a handle, and the writer is only
+// opened when there is something to record.
+type Ledger struct {
+	db *sql.DB
+}
+
+// OpenLedger opens the database for writing and ensures the ledger tables exist.
+func OpenLedger(ctx context.Context, dbPath string) (*Ledger, error) {
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_time_format=sqlite",
+		url.PathEscape(dbPath))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open ledger: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("open ledger %s: %w", dbPath, err)
+	}
+	l := &Ledger{db: db}
+	if err := l.ensureTables(ctx); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *Ledger) Close() error { return l.db.Close() }
+
+// ensureTables creates the ledger tables when the database predates them. The
+// daemon's migration list covers the normal case; this covers a database that
+// has not been opened by a daemon carrying the migration yet, so `apiary
+// improve` never fails merely because nothing has migrated it.
+func (l *Ledger) ensureTables(ctx context.Context) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS improvement_runs (
+		  id TEXT PRIMARY KEY, effort TEXT NOT NULL, focus TEXT,
+		  window_start TIMESTAMP, window_end TIMESTAMP, scope TEXT,
+		  evidence_digest TEXT, advisor_agent TEXT, advisor_runner TEXT,
+		  advisor_model TEXT, report_path TEXT,
+		  applied BOOLEAN NOT NULL DEFAULT 0, applied_at TIMESTAMP,
+		  cost_usd REAL NOT NULL DEFAULT 0, total_tokens INTEGER NOT NULL DEFAULT 0,
+		  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)`,
+		`CREATE TABLE IF NOT EXISTS improvement_findings (
+		  id TEXT PRIMARY KEY, run_id TEXT NOT NULL, finding_id TEXT,
+		  scope TEXT NOT NULL, focus TEXT, severity TEXT, confidence TEXT,
+		  symptom TEXT, rationale TEXT, target_file TEXT,
+		  baseline_metrics TEXT, patch TEXT,
+		  machine_checked BOOLEAN NOT NULL DEFAULT 0,
+		  state TEXT NOT NULL, reject_reason TEXT,
+		  FOREIGN KEY(run_id) REFERENCES improvement_runs(id))`,
+		`CREATE INDEX IF NOT EXISTS idx_improvement_findings_run ON improvement_findings(run_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_improvement_findings_scope ON improvement_findings(scope, state)`,
+		`CREATE INDEX IF NOT EXISTS idx_improvement_runs_created ON improvement_runs(created_at DESC)`,
+	}
+	for _, s := range stmts {
+		if _, err := l.db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("create ledger tables: %w", err)
+		}
+	}
+	return nil
+}
+
+// RecordRun writes a run and its findings in one transaction, so a partial
+// record can never look like a complete one.
+func (l *Ledger) RecordRun(ctx context.Context, run LedgerRun, findings []LedgerFinding) error {
+	tx, err := l.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin ledger transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after a successful commit
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO improvement_runs
+		  (id, effort, focus, window_start, window_end, scope, evidence_digest,
+		   advisor_agent, advisor_runner, advisor_model, report_path,
+		   applied, applied_at, cost_usd, total_tokens, created_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		run.ID, run.Effort, run.Focus, run.WindowStart, run.WindowEnd, run.Scope,
+		run.EvidenceDigest, run.AdvisorAgent, run.AdvisorRunner, run.AdvisorModel,
+		run.ReportPath, run.Applied, run.AppliedAt, run.CostUSD, run.TotalTokens,
+		run.CreatedAt); err != nil {
+		return fmt.Errorf("insert improvement run: %w", err)
+	}
+
+	for _, f := range findings {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO improvement_findings
+			  (id, run_id, finding_id, scope, focus, severity, confidence, symptom,
+			   rationale, target_file, baseline_metrics, patch, machine_checked,
+			   state, reject_reason)
+			VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+			f.ID, run.ID, f.FindingID, f.Scope, f.Focus, f.Severity, f.Confidence,
+			f.Symptom, f.Rationale, f.TargetFile, f.BaselineMetrics, f.Patch,
+			f.MachineChecked, f.State, f.RejectReason); err != nil {
+			return fmt.Errorf("insert improvement finding: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// ListRuns returns recent runs, newest first.
+func (l *Ledger) ListRuns(ctx context.Context, limit int) ([]LedgerRun, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := l.db.QueryContext(ctx, `
+		SELECT id, effort, COALESCE(focus,''), window_start, window_end,
+		       COALESCE(evidence_digest,''), COALESCE(advisor_agent,''),
+		       COALESCE(advisor_runner,''), COALESCE(advisor_model,''),
+		       COALESCE(report_path,''), applied, applied_at,
+		       cost_usd, total_tokens, created_at
+		FROM improvement_runs ORDER BY created_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list improvement runs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LedgerRun
+	for rows.Next() {
+		var r LedgerRun
+		var appliedAt sql.NullTime
+		if err := rows.Scan(&r.ID, &r.Effort, &r.Focus, &r.WindowStart, &r.WindowEnd,
+			&r.EvidenceDigest, &r.AdvisorAgent, &r.AdvisorRunner, &r.AdvisorModel,
+			&r.ReportPath, &r.Applied, &appliedAt, &r.CostUSD, &r.TotalTokens,
+			&r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan improvement run: %w", err)
+		}
+		if appliedAt.Valid {
+			t := appliedAt.Time
+			r.AppliedAt = &t
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// GetRun returns one run and its findings.
+func (l *Ledger) GetRun(ctx context.Context, id string) (*LedgerRun, []LedgerFinding, error) {
+	runs, err := l.ListRuns(ctx, 1000)
+	if err != nil {
+		return nil, nil, err
+	}
+	var run *LedgerRun
+	for i := range runs {
+		if runs[i].ID == id {
+			run = &runs[i]
+			break
+		}
+	}
+	if run == nil {
+		return nil, nil, fmt.Errorf("no improvement run %q", id)
+	}
+
+	rows, err := l.db.QueryContext(ctx, `
+		SELECT id, run_id, COALESCE(finding_id,''), scope, COALESCE(focus,''),
+		       COALESCE(severity,''), COALESCE(confidence,''), COALESCE(symptom,''),
+		       COALESCE(rationale,''), COALESCE(target_file,''),
+		       COALESCE(baseline_metrics,''), COALESCE(patch,''),
+		       machine_checked, state, COALESCE(reject_reason,'')
+		FROM improvement_findings WHERE run_id = ? ORDER BY id`, id)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list improvement findings: %w", err)
+	}
+	defer rows.Close()
+
+	var findings []LedgerFinding
+	for rows.Next() {
+		var f LedgerFinding
+		if err := rows.Scan(&f.ID, &f.RunID, &f.FindingID, &f.Scope, &f.Focus,
+			&f.Severity, &f.Confidence, &f.Symptom, &f.Rationale, &f.TargetFile,
+			&f.BaselineMetrics, &f.Patch, &f.MachineChecked, &f.State,
+			&f.RejectReason); err != nil {
+			return nil, nil, fmt.Errorf("scan improvement finding: %w", err)
+		}
+		findings = append(findings, f)
+	}
+	return run, findings, rows.Err()
+}
+
+// PriorFindings returns the applied findings from earlier runs, so the advisor
+// can be told what has already been tried. Without this it re-proposes the same
+// change every run, and a suggestion that was applied and did not help looks
+// identical to one that was never tried.
+func (l *Ledger) PriorFindings(ctx context.Context, limit int) ([]LedgerFinding, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := l.db.QueryContext(ctx, `
+		SELECT f.id, f.run_id, COALESCE(f.finding_id,''), f.scope, COALESCE(f.focus,''),
+		       COALESCE(f.severity,''), COALESCE(f.confidence,''), COALESCE(f.symptom,''),
+		       COALESCE(f.rationale,''), COALESCE(f.target_file,''),
+		       COALESCE(f.baseline_metrics,''), '', f.machine_checked, f.state,
+		       COALESCE(f.reject_reason,'')
+		FROM improvement_findings f
+		JOIN improvement_runs r ON r.id = f.run_id
+		WHERE f.state IN ('applied','reverted')
+		ORDER BY r.created_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list prior findings: %w", err)
+	}
+	defer rows.Close()
+
+	var out []LedgerFinding
+	for rows.Next() {
+		var f LedgerFinding
+		if err := rows.Scan(&f.ID, &f.RunID, &f.FindingID, &f.Scope, &f.Focus,
+			&f.Severity, &f.Confidence, &f.Symptom, &f.Rationale, &f.TargetFile,
+			&f.BaselineMetrics, &f.Patch, &f.MachineChecked, &f.State,
+			&f.RejectReason); err != nil {
+			return nil, fmt.Errorf("scan prior finding: %w", err)
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// MarkApplied flips a run and the given findings to applied.
+func (l *Ledger) MarkApplied(ctx context.Context, runID string, findingIDs []string, at time.Time) error {
+	tx, err := l.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after a successful commit
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE improvement_runs SET applied = 1, applied_at = ? WHERE id = ?`, at, runID); err != nil {
+		return fmt.Errorf("mark run applied: %w", err)
+	}
+	for _, id := range findingIDs {
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE improvement_findings SET state = ? WHERE run_id = ? AND id = ?`,
+			FindingApplied, runID, id); err != nil {
+			return fmt.Errorf("mark finding applied: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
+// BaselineFor decodes a finding's stored baseline metrics.
+func BaselineFor(f LedgerFinding) (StepMetrics, bool) {
+	if f.BaselineMetrics == "" {
+		return StepMetrics{}, false
+	}
+	var m StepMetrics
+	if err := json.Unmarshal([]byte(f.BaselineMetrics), &m); err != nil {
+		return StepMetrics{}, false
+	}
+	return m, true
+}
+
+// NewRunID derives a sortable run identifier from a timestamp. Improvement runs
+// are operator-initiated and never concurrent, so second resolution is enough
+// and a readable id is worth more than a ULID here.
+func NewRunID(t time.Time) string {
+	return "imp_" + t.UTC().Format("20060102T150405")
+}
+
+// FindingRowID is the ledger primary key for one recommendation within a run.
+func FindingRowID(runID, recommendationID string) string {
+	return runID + ":" + recommendationID
+}

--- a/src/internal/improve/ledger_test.go
+++ b/src/internal/improve/ledger_test.go
@@ -1,0 +1,209 @@
+package improve
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func openTestLedger(t *testing.T) *Ledger {
+	t.Helper()
+	l, err := OpenLedger(ctx(), filepath.Join(t.TempDir(), "apiary.db"))
+	if err != nil {
+		t.Fatalf("OpenLedger: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+	return l
+}
+
+func sampleRun(id string, at time.Time) LedgerRun {
+	return LedgerRun{
+		ID: id, Effort: "standard", Focus: "all",
+		WindowStart: at.Add(-14 * 24 * time.Hour), WindowEnd: at,
+		EvidenceDigest: "abc123", AdvisorAgent: "improver",
+		AdvisorRunner: "claude", AdvisorModel: "sonnet",
+		CostUSD: 0.95, TotalTokens: 146815, CreatedAt: at,
+	}
+}
+
+func TestLedgerRoundTrip(t *testing.T) {
+	l := openTestLedger(t)
+	at := base
+
+	run := sampleRun("imp_1", at)
+	findings := []LedgerFinding{
+		{
+			ID: FindingRowID("imp_1", "r1"), FindingID: "r1",
+			Scope: "workflow:impl/step:implement", Severity: "high", Confidence: "medium",
+			Symptom: "loops often", TargetFile: ".apiary/agents/engineer.md",
+			BaselineMetrics: `{"runs":100,"fail_rate":0.3}`, Patch: "--- a\n+++ b\n",
+			MachineChecked: false, State: FindingProposed,
+		},
+		{
+			ID: FindingRowID("imp_1", "r2"), FindingID: "r2",
+			Scope: "workflow:impl/step:merge", State: FindingRejected,
+			RejectReason: "malformed hunk header",
+		},
+	}
+	if err := l.RecordRun(ctx(), run, findings); err != nil {
+		t.Fatalf("RecordRun: %v", err)
+	}
+
+	gotRun, gotFindings, err := l.GetRun(ctx(), "imp_1")
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if gotRun.Effort != "standard" || gotRun.AdvisorModel != "sonnet" {
+		t.Errorf("run round-trip lost fields: %+v", gotRun)
+	}
+	if gotRun.CostUSD != 0.95 || gotRun.TotalTokens != 146815 {
+		t.Errorf("cost/token round-trip: %v / %d", gotRun.CostUSD, gotRun.TotalTokens)
+	}
+	if gotRun.Applied {
+		t.Error("a fresh run must not be marked applied")
+	}
+	if len(gotFindings) != 2 {
+		t.Fatalf("want 2 findings, got %d", len(gotFindings))
+	}
+	if gotFindings[0].RejectReason != "" && gotFindings[0].State != FindingRejected {
+		t.Error("reject reason should only accompany a rejected finding")
+	}
+}
+
+func TestLedgerMarkAppliedOnlyTouchesNamedFindings(t *testing.T) {
+	l := openTestLedger(t)
+	run := sampleRun("imp_2", base)
+	findings := []LedgerFinding{
+		{ID: FindingRowID("imp_2", "r1"), FindingID: "r1", Scope: "s1", State: FindingProposed},
+		{ID: FindingRowID("imp_2", "r2"), FindingID: "r2", Scope: "s2", State: FindingRejected},
+	}
+	if err := l.RecordRun(ctx(), run, findings); err != nil {
+		t.Fatalf("RecordRun: %v", err)
+	}
+
+	// Only r1 reached disk.
+	if err := l.MarkApplied(ctx(), "imp_2", []string{FindingRowID("imp_2", "r1")}, base); err != nil {
+		t.Fatalf("MarkApplied: %v", err)
+	}
+
+	gotRun, gotFindings, err := l.GetRun(ctx(), "imp_2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gotRun.Applied || gotRun.AppliedAt == nil {
+		t.Error("the run must be marked applied with a timestamp")
+	}
+	states := map[string]string{}
+	for _, f := range gotFindings {
+		states[f.FindingID] = f.State
+	}
+	if states["r1"] != FindingApplied {
+		t.Errorf("r1 state = %q, want applied", states["r1"])
+	}
+	if states["r2"] != FindingRejected {
+		t.Errorf("r2 state = %q, want it left rejected — it never reached disk", states["r2"])
+	}
+}
+
+// Without prior findings the advisor re-proposes the same change every run, and
+// a suggestion that was applied and did not help looks identical to one never
+// tried.
+func TestLedgerPriorFindingsReturnsOnlyAppliedOnes(t *testing.T) {
+	l := openTestLedger(t)
+
+	if err := l.RecordRun(ctx(), sampleRun("imp_a", base.Add(-48*time.Hour)), []LedgerFinding{
+		{ID: "imp_a:r1", FindingID: "r1", Scope: "s1", Symptom: "old applied", State: FindingApplied},
+		{ID: "imp_a:r2", FindingID: "r2", Scope: "s2", Symptom: "old rejected", State: FindingRejected},
+		{ID: "imp_a:r3", FindingID: "r3", Scope: "s3", Symptom: "never applied", State: FindingProposed},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prior, err := l.PriorFindings(ctx(), 50)
+	if err != nil {
+		t.Fatalf("PriorFindings: %v", err)
+	}
+	if len(prior) != 1 {
+		t.Fatalf("want only the applied finding, got %d: %+v", len(prior), prior)
+	}
+	if prior[0].Symptom != "old applied" {
+		t.Errorf("prior = %q", prior[0].Symptom)
+	}
+}
+
+func TestLedgerGetRunUnknownID(t *testing.T) {
+	l := openTestLedger(t)
+	if _, _, err := l.GetRun(ctx(), "nope"); err == nil {
+		t.Error("an unknown run id must be an error")
+	}
+}
+
+func TestLedgerListRunsNewestFirst(t *testing.T) {
+	l := openTestLedger(t)
+	for i, id := range []string{"imp_old", "imp_mid", "imp_new"} {
+		r := sampleRun(id, base.Add(time.Duration(i)*time.Hour))
+		if err := l.RecordRun(ctx(), r, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runs, err := l.ListRuns(ctx(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 3 || runs[0].ID != "imp_new" {
+		t.Errorf("want newest first, got %v", []string{runs[0].ID})
+	}
+}
+
+func TestNewRunIDIsSortable(t *testing.T) {
+	earlier := NewRunID(base)
+	later := NewRunID(base.Add(time.Hour))
+	if !(earlier < later) {
+		t.Errorf("run ids must sort chronologically: %q vs %q", earlier, later)
+	}
+	if !strings.HasPrefix(earlier, "imp_") {
+		t.Errorf("run id = %q, want an imp_ prefix", earlier)
+	}
+}
+
+func TestBaselineJSONCapturesTheScopedStep(t *testing.T) {
+	pack := &EvidencePack{Steps: []StepMetrics{
+		{WorkflowID: "impl", StepID: "implement", Runs: 100, FailRate: 0.3, MeanCostUSD: 1.5},
+		{WorkflowID: "impl", StepID: "review", Runs: 50},
+	}}
+
+	raw := BaselineJSON(pack, "workflow:impl/step:implement")
+	if raw == "" {
+		t.Fatal("want the metrics for the named scope")
+	}
+	var m StepMetrics
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("baseline is not decodable: %v", err)
+	}
+	if m.Runs != 100 || m.FailRate != 0.3 {
+		t.Errorf("baseline captured the wrong step: %+v", m)
+	}
+
+	if got := BaselineJSON(pack, "workflow:impl/step:nonexistent"); got != "" {
+		t.Errorf("an unknown scope should capture nothing, got %q", got)
+	}
+}
+
+// An advisor writes the canonical form when asked, but also produces "x/y" and
+// "workflow:x step:y". Matching only the canonical shape would silently drop
+// findings from the comparison.
+func TestNormalizeScopeTolerantOfAdvisorShapes(t *testing.T) {
+	want := "workflow:impl/step:implement"
+	for _, in := range []string{
+		"workflow:impl/step:implement",
+		"workflow:impl step:implement",
+		"impl/implement",
+		"  workflow:impl/step:implement  ",
+	} {
+		if got := normalizeScope(in); got != want {
+			t.Errorf("normalizeScope(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/src/internal/improve/prompt.go
+++ b/src/internal/improve/prompt.go
@@ -43,8 +43,9 @@ type Recommendation struct {
 const outputContract = "APIARY_OUTPUT: " + `{"findings":[{"id":"f1","scope":"workflow:<id>/step:<id>","symptom":"<what is wrong, in one sentence>","evidence":["<metric>=<value> n=<runs>"],"severity":"high|medium|low","focus":"cost|latency|reliability|quality","low_confidence":false}],"recommendations":[{"id":"r1","addresses":["f1"],"file":"<path within the workspace>","summary":"<the change, in one sentence>","rationale":"<why this addresses the finding>","confidence":"high|medium|low","expected_effect":"<quantified where possible>","patch":"<unified diff>"}]}`
 
 // ComposePrompt builds the advisor's prompt: the evidence, the configuration
-// that produced it, and the rules that keep the analysis honest.
-func ComposePrompt(pack *EvidencePack, ws *Workspace, files []WorkspaceFile, k Knobs) string {
+// that produced it, the history of what has already been tried, and the rules
+// that keep the analysis honest.
+func ComposePrompt(pack *EvidencePack, ws *Workspace, files []WorkspaceFile, k Knobs, prior []LedgerFinding) string {
 	var b strings.Builder
 
 	b.WriteString("# Task\n\n")
@@ -106,6 +107,24 @@ func ComposePrompt(pack *EvidencePack, ws *Workspace, files []WorkspaceFile, k K
 			b.WriteString("\n")
 		}
 		b.WriteString("```\n\n")
+	}
+
+	if len(prior) > 0 {
+		// Without this the advisor re-proposes the same change every run, and a
+		// suggestion that was applied and did not help is indistinguishable from
+		// one that was never tried.
+		b.WriteString("# Already tried\n\n")
+		b.WriteString("These changes were proposed and applied by earlier runs. Do not re-propose them. ")
+		b.WriteString("If a problem they addressed is still visible in the evidence above, that is worth saying — ")
+		b.WriteString("the fix did not work, and the reason matters more than another attempt at the same idea.\n\n")
+		for _, f := range prior {
+			fmt.Fprintf(&b, "- **%s** (%s, %s)", f.Symptom, f.Scope, f.State)
+			if f.TargetFile != "" {
+				fmt.Fprintf(&b, " — changed `%s`", f.TargetFile)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString("# Output\n\n")

--- a/src/internal/improve/prompt_test.go
+++ b/src/internal/improve/prompt_test.go
@@ -43,7 +43,7 @@ func TestComposePromptCarriesEvidenceAndRules(t *testing.T) {
 	ws := &Workspace{Root: "/repo"}
 	files := []WorkspaceFile{{Path: "apiary.yaml", Kind: KindConfig, Content: "version: \"1\"\n"}}
 
-	got := ComposePrompt(samplePack(), ws, files, EffortStandard.Expand())
+	got := ComposePrompt(samplePack(), ws, files, EffortStandard.Expand(), nil)
 
 	// The evidence must actually be present, not merely referenced.
 	for _, want := range []string{
@@ -80,7 +80,7 @@ func TestComposePromptCarriesEvidenceAndRules(t *testing.T) {
 
 func TestComposePromptWarnsAboutUnresolvedSkills(t *testing.T) {
 	ws := &Workspace{Root: "/repo", UnresolvedSkills: []string{"deploying (declared by engineer)"}}
-	got := ComposePrompt(samplePack(), ws, nil, EffortStandard.Expand())
+	got := ComposePrompt(samplePack(), ws, nil, EffortStandard.Expand(), nil)
 
 	if !strings.Contains(got, "deploying (declared by engineer)") {
 		t.Error("unresolved skills must be named in the prompt")
@@ -96,7 +96,7 @@ func TestComposePromptNeverCarriesASecret(t *testing.T) {
 	raw := "agents:\n  - id: a\n    source_token: ghp_supersecret\n    env:\n      KEY: sk-live-xyz\n"
 	files := []WorkspaceFile{{Path: "apiary.yaml", Kind: KindConfig, Content: RedactConfig(raw)}}
 
-	got := ComposePrompt(samplePack(), &Workspace{}, files, EffortStandard.Expand())
+	got := ComposePrompt(samplePack(), &Workspace{}, files, EffortStandard.Expand(), nil)
 	for _, secret := range []string{"ghp_supersecret", "sk-live-xyz"} {
 		if strings.Contains(got, secret) {
 			t.Errorf("secret %q reached the prompt", secret)


### PR DESCRIPTION
Phase 5 of #401. Closes #406. This is the one that makes the advisor a **loop** rather than a report generator.

Every run is now recorded along with the metrics that justified each proposal, so a later run can recompute them and say whether an applied change actually helped.

```
apiary improve history          past runs, newest first
apiary improve show <run-id>    that run's findings and their fate
apiary improve effect <run-id>  before/after comparison for an applied run
```

## Why this matters more here than it usually would

Prose edits have been in scope since #412, and the validation gate cannot check them **at all** — a soul-file change clears "the patch applies" and nothing else. Measured effect is the only evidence such a change did what it claimed.

That isn't hypothetical: all three recommendations from the last real advisor run were soul edits. So the effect output says it outright when the finding it's measuring was never machine-checked:

> _This was an instruction change; nothing about it could be validated when it was applied. These numbers are the first evidence either way._

## Guards that keep the comparison honest

- **Thin post-apply windows are labelled, not reported.** Below `MinRuns` the output says "shown for completeness, not as a result". A percentage off two runs reads as a finding when it's noise — worse than reporting nothing.
- **A scope that hasn't run since the change** gets an explanation rather than an empty table.
- **Only findings that actually reached disk are marked applied**, so the comparison measures what was really changed, not what was merely proposed.
- **`Delta` carries its own direction**, so a fall in fail rate reads as improvement and a fall in a higher-is-better metric wouldn't be misread as one.

## The feedback loop

Prior applied findings are injected into the advisor's prompt. Without them it re-proposes the same change every run, and a suggestion that was applied and didn't help is indistinguishable from one that was never tried. The prompt is explicit: if a problem persists after its fix was applied, **the reason matters more than another attempt at the same idea**.

## Implementation notes

The ledger holds its **own read-write connection**. The analysis path opens the database read-only on purpose — it must never migrate or lock a database a running daemon depends on — so the two can't share a handle, and the writer only opens when there's something to record.

`OpenLedger` also creates its tables when absent, so `apiary improve` works against a database that no daemon carrying the migration has opened yet. Verified against a copy of a real project-erp database: `improvement_runs` and `improvement_findings` were created on first use, and `improve history` correctly reported "no improvement runs recorded yet" rather than erroring.

`normalizeScope` tolerates the scope shapes an advisor actually produces (`workflow:x/step:y`, `x/y`, `workflow:x step:y`). Matching only the canonical form would silently drop findings from the comparison — a quiet failure, since the output would still look complete.

## Testing

`make check` green across 33 packages. New tests: ledger round-trip, `MarkApplied` touching only named findings, `PriorFindings` returning only applied ones, unknown run id, newest-first ordering, sortable run ids, baseline capture and its miss case, and scope normalisation across all four shapes. For effect: improvement detection, regression detection, the thin-sample guard, a scope that never ran again, unapplied findings being skipped, an unapplied run erroring, and delta direction including the zero-baseline case.

## Next

#407 (docs, schema, defaults) is the last phase — docs page, `mkdocs.yml` nav, `schema/apiary.json` regeneration for `settings.improve`, an example `improver` agent, and archiving the change in `openspec/CHANGELOG.md`.