### PR TITLE
docs(improve): document the self-improvement advisor (#407)

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -301,6 +301,16 @@ agents:
     model: opencode-go/deepseek-v4-pro
     skills: [git-workflow, gitnexus-codebase]
 
+  # The self-improvement advisor. No workflow triggers it and no label routes to
+  # it — it runs on demand via `apiary improve`, outside the daemon, so it never
+  # takes a dispatch slot. It reads the local database and config and does not
+  # talk to the source, so it needs no source_token.
+  - id: improver
+    description: "Analyses execution metrics and proposes configuration improvements"
+    soul_file: .apiary/souls/improver.md
+    model: claude-sonnet-4-6
+    max_workers: 1
+
 # ── Workflows ──────────────────────────────────────────────────────────────────
 # Single-agent workflows (formerly `routes:`) — each matches on the agent: label.
 workflows:
@@ -564,6 +574,19 @@ settings:
     # max_inject_chars: 4000         # prompt budget for the recall sections
     # max_entry_bytes: 16384         # cap on a single memorized fact
     # task_retention: 720h           # prune task notes this long after the task ends
+  # Self-improvement advisor (`apiary improve`): which agent analyses the
+  # execution history and proposes configuration changes. Optional in full —
+  # the advisor can also be named on the command line, and `--dump-evidence`
+  # needs none of it because it runs no model. Without any of these, the
+  # command errors rather than guessing a model you never chose.
+  improve:
+    agent: improver
+    # Effort can pick a cheaper model: reading aggregate tables at "quick" and
+    # reasoning over transcripts and prose at "deep" are different jobs.
+    # effort_models:
+    #   quick:    claude-haiku-4-5
+    #   standard: claude-sonnet-4-6
+    #   deep:     claude-opus-4-1
   # Cursor cost back-fill (opt-in): the Cursor agent CLI streams token counts
   # but no dollar cost, so cursor-cli runs record $0.00. On usage-based Cursor
   # plans the daemon can recover real billed amounts from the cursor.com

--- a/.apiary/souls/improver.md
+++ b/.apiary/souls/improver.md
@@ -1,0 +1,55 @@
+You analyse how this agent pipeline has actually been running, and propose
+configuration changes that make it cheaper, faster or more reliable.
+
+You are not reviewing code and you are not doing the pipeline's work. Your
+subject is the pipeline itself: its workflows, its agents' instructions, and the
+numbers those produced.
+
+The failure mode to avoid is confident noise. It is always possible to generate
+a dozen plausible-sounding suggestions from any dataset, and that is worse than
+useless here, because someone will act on them. A short analysis naming two real
+problems and admitting what it cannot explain is worth more than a thorough one
+built on inference.
+
+So:
+
+- **Anchor every claim to a number you were given.** If you find yourself
+  reasoning from what usually happens in pipelines rather than from what
+  happened in this one, drop the finding.
+- **Separate what the data shows from what you suspect.** Both are worth saying;
+  conflating them is not.
+- **A small sample is a small sample.** Say so plainly rather than hedging with
+  vague language.
+- **Quote what you would change.** When proposing an instruction edit, name the
+  line and the runs that made you think so. Prose changes cannot be validated
+  mechanically — a reviewer has only your reasoning to go on, so show it.
+- **Expensive is not the same as wasteful.** A step that costs a lot doing
+  genuinely hard work is fine. Look for waste: repetition, truncation, work
+  thrown away, waiting.
+
+## Signals that usually repay attention
+
+- **Rework loops** — a step running several times in one instance is an
+  `on_fail`/`goto` cycle. The repeat runs are pure waste; the transcripts show
+  why the step does not pass first time.
+- **`max_turns` saturation** — runs ending exactly at the cap were cut off, not
+  finished. Either the cap is too low or the prompt is asking too much.
+- **Low cache reuse on a hot step** — the prompt prefix is changing between
+  runs, usually volatile context that could be hoisted out.
+- **Heavy prompt, small output** — many input bytes per output token suggests an
+  inflated prompt.
+- **Wall-clock split** — a step dominated by tool waits has a different problem
+  from one dominated by thinking.
+- **Dead paths** — a workflow, agent or fallback chain that never ran is either
+  obsolete or silently broken. Both are worth saying.
+- **Expensive waits** — hundreds of polls, or frequent timeouts, is wall-clock
+  the configuration could avoid.
+
+## Output
+
+Order findings by severity, and be concrete about the expected effect where the
+evidence supports a number. For each recommendation, make clear which part is
+measured and which part is your judgement.
+
+Write for someone who knows this pipeline better than you do and has ten
+minutes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,36 @@ apiary task --source github --item 1948
 apiary task <id> --json
 ```
 
+### `apiary improve`
+
+Analyse the execution history and propose configuration changes. Standalone —
+it opens the database read-only, works with the daemon stopped, and takes no
+dispatch slot when it is running.
+
+```sh
+apiary improve                          # analyse; print findings and a diff
+apiary improve --effort deep --since 30d
+apiary improve --apply                  # write the accepted changes
+apiary improve --dump-evidence          # just the metrics, as JSON, no model
+apiary improve --dump-prompt            # the composed prompt, no model
+```
+
+The evidence is computed entirely in Go, so `--dump-evidence` needs no advisor
+and costs nothing. Everything else needs an agent to reason with: `--advisor`,
+an ad-hoc `--runner`/`--model` pair, `settings.improve.agent`, or an agent named
+`improver`.
+
+Past runs are recorded so their effect can be measured later:
+
+```sh
+apiary improve history
+apiary improve show <run-id>
+apiary improve effect <run-id>
+```
+
+See [Self-Improvement](improve.md) for the evidence pack, effort levels, the
+validation gate and what applying does.
+
 ## Intervening
 
 ### `apiary resume`

--- a/docs/improve.md
+++ b/docs/improve.md
@@ -1,0 +1,302 @@
+# Self-Improvement Advisor
+
+Apiary records everything needed to judge how well its own agents and workflows
+perform: step timings, tokens, cache breakdown, turns, tool calls, cost, exit
+state, the full composed prompt, and a markdown transcript of every session.
+Until now that data only answered *what happened to this task*.
+
+`apiary improve` asks the cross-cutting question instead:
+
+> Across the last N runs, which steps are wasting money, which agent
+> instructions keep producing rework, and what should change in `apiary.yaml`,
+> the soul files and the skills?
+
+It mines the execution history, has an agent reason over it, and emits an
+evidence-backed report plus a validated diff — or applies the diff for you.
+
+```bash
+apiary improve                          # analyse and print findings + diff
+apiary improve --effort deep --since 30d
+apiary improve --workflow implementation
+apiary improve --dump-evidence          # just the metrics, as JSON, no model
+```
+
+The command is **standalone**. It opens the database read-only, invokes a runner
+directly, and writes its output locally. It works with the daemon stopped and
+takes no dispatch slot when it is running.
+
+## The evidence pack
+
+Everything the advisor reasons over is computed in Go. **No model is involved in
+producing any number**, so the same database and window always produce the same
+pack — and the whole metrics layer is inspectable without paying for a run:
+
+```bash
+apiary improve --dump-evidence --since 30d
+```
+
+| Group | What it carries |
+|---|---|
+| **Steps** | pass/fail/skip rates, duration p50/p95, tokens, cost, turns, tool calls, cache-reuse ratio, prompt-weight ratio, failover rate, failure kinds, wall-clock split (thinking / writing / tool waits) |
+| **Workflows** | instance counts by terminal state, end-to-end duration, cost per completed instance, **rework loops**, dead steps, parallel candidates |
+| **Agents** | success rate, cost and duration by runner *and* model, `max_turns` saturation |
+| **Waits** | poll counts and terminal status per `wait_for` step |
+| **Failures** | error messages normalised and clustered, with counts and an exemplar |
+| **Dead paths** | configured workflows, agents and fallback chains that never ran |
+
+Two of these deserve a note.
+
+**Rework loops** are the same step running more than once inside one workflow
+instance — the direct signature of an `on_fail`/`goto` cycle. The repeat runs
+are pure waste, and the pack prices them. On a real 30-day window this was the
+single largest finding: 27% of one workflow's spend went to loop-backs.
+
+**`max_turns` saturation** is the share of runs ending at exactly the configured
+cap. Those runs were cut off, not finished — a different problem from a step
+that is merely slow, and invisible in a duration metric.
+
+Metrics below `MinRuns` (5) are carried but flagged `low_confidence`, and the
+advisor is told to say when a sample is thin rather than dress it up.
+
+## Effort levels
+
+Effort scales **how much is read and how hard proposals are scrutinised** —
+never *which kinds of file may change*. Even `quick` can propose a soul edit if
+the metrics point there; it just reads less to get to that conclusion.
+
+| | `quick` | `standard` (default) | `deep` |
+|---|---|---|---|
+| Default window | 7d | 14d | 90d |
+| Transcripts | none | 2 per hotspot, top 5 | 5 per hotspot, top 15 |
+| Excerpt budget | — | 24 KB | 40 KB |
+| Config workspace read | flagged agents | agents that ran | everything |
+| Critic pass | — | — | ✓ |
+
+`--since` overrides the window; `--transcript-bytes` overrides the budget.
+
+Transcripts are what let the advisor say something about *instructions* rather
+than only about numbers. At `quick` it has aggregates alone, which is often
+enough to find dead config and cost concentration but rarely enough to explain
+*why* a step keeps failing.
+
+## The config workspace
+
+The advisor reads — and may propose changes to — everything that shapes agent
+behaviour, discovered from the config rather than hard-coded:
+
+| Source | Discovered from |
+|---|---|
+| Main config | `--config` / the default resolution |
+| Workflow files | `uses:` references, resolved transitively |
+| Soul files | `agents[].soul_file` |
+| Skill definitions | `agents[].skills`, resolved against `.claude/skills/<name>/SKILL.md` and siblings |
+
+Apiary itself has no skill resolver — it passes bare skill names through to the
+runner — so discovery mirrors the runner's own conventions. **A skill that
+cannot be located is reported, never silently skipped**, because an advisor
+reasoning about an agent whose instructions it never saw is worse than one that
+knows a piece is missing.
+
+**Excluded, always:** `.env` and anything matching `*secret*`, `*credential*`,
+`*.pem`, `*.key`; `.git/`; the database, logs and transcripts; anything outside
+the workspace root.
+
+**Secrets are redacted** before the config text reaches a prompt. Every value
+inside an `env:` block is blanked rather than filtered by key name — env blocks
+routinely carry tokens and the key name does not tell you. Key names survive, so
+the advisor still sees *which* variables a step sets. A pure `${VAR}` reference
+is preserved, since it names an environment variable rather than carrying a
+secret.
+
+To see exactly what would be sent, including the redaction:
+
+```bash
+apiary improve --dump-prompt
+```
+
+## Who performs the analysis
+
+The advisor is an ordinary Apiary agent, resolved in this order:
+
+1. `--advisor <agent-id>`
+2. `--runner <id> --model <name>` — ad-hoc, no config entry needed
+3. `settings.improve.agent`
+4. an agent whose id is `improver`
+5. **error**
+
+It never invents a model. `agents[].model` is required per agent and there is no
+global default, so a guess would bill you for a model you never chose. The error
+names all four options and carries a config snippet.
+
+```yaml
+settings:
+  improve:
+    agent: improver
+    effort_models:            # optional: effort picks the model
+      quick:    claude-haiku-4-5
+      standard: claude-sonnet-5
+      deep:     claude-opus-5
+
+agents:
+  - id: improver
+    description: "Analyses execution metrics and proposes improvements"
+    soul_file: .apiary/agents/improver.md
+    model: claude-sonnet-5
+    max_workers: 1
+```
+
+No workflow triggers this agent, so the daemon never dispatches it and it adds
+nothing to your concurrency. Each agent gets its own semaphore, so an agent that
+never dispatches costs nothing.
+
+Because the advisor is a normal agent, `--profile` overlays and
+`agents[].fallbacks` work unchanged. A provider rejection advances the fallback
+chain rather than aborting, so a `deep` run that trips a rate limit does not
+discard what it already spent.
+
+A default soul ships with the binary, so the command works before you configure
+anything.
+
+## Validation
+
+Every proposal passes a gate before you see it:
+
+| Stage | Check |
+|---|---|
+| `path` | inside the workspace, not excluded, and a file the advisor was actually shown |
+| `apply` | the diff applies cleanly to current content |
+| `config` | the patched tree parses and passes `cfg.Validate()` |
+| `expr` | conditions still lint |
+| `warnings` | new workflow warnings the patch introduces, shown beside it |
+
+Patch application does **no fuzzy matching and no offset search**. A hunk whose
+context does not match is rejected, because a patch that lands in the wrong
+place is worse than one that does not land at all — the diff you reviewed would
+no longer describe what the file became.
+
+Failed proposals are not hidden. They appear under *Could not be validated* with
+the stage and reason, because the observation behind a rejected patch is often
+still worth acting on by hand.
+
+### Prose cannot be validated
+
+Souls and skills clear the first two stages only. **Nothing in a markdown
+instruction file can be checked mechanically**, and the rendered diff says so
+per file:
+
+> _prose file — only checked that the patch applies; nothing here can be
+> validated mechanically_
+
+This is the common case, not the edge case — instruction edits are frequently
+the highest-value change the advisor finds. Two things mitigate it: the critic
+pass at `deep` effort, which argues against each surviving proposal, and effect
+measurement, which scores the change against the metric that motivated it.
+
+## Applying
+
+```bash
+apiary improve --apply          # prints the diff, asks once, writes
+apiary improve --apply --yes    # skips the question, not the diff
+```
+
+Apply does not back up, snapshot, or offer to revert. **Your workspace is
+expected to be under version control**, and `git diff` / `git checkout` do that
+job better than anything Apiary would reimplement. What it owes you instead is
+an accurate account of what it touched:
+
+```
+Applied 2 change(s):
+  .apiary/agents/engineer.md  (+3 −0)  — prose, not machine-checked
+  .apiary/apiary.yaml         (+1 −1)
+
+Review with `git diff`; undo with `git checkout -- <file>`.
+
+Configuration changed. A running daemon keeps its loaded copy until restarted:
+  apiary restart
+```
+
+Where the git assumption does not hold it says so — before writing and again
+afterwards. It warns rather than refuses.
+
+Two proposals patching the same file are refused outright: each was validated
+against the *original* content, so applying both in sequence would apply the
+second to content it never saw.
+
+## Measuring whether it helped
+
+Every run is recorded with the metrics that justified each proposal, so a later
+run can recompute them and compare:
+
+```bash
+apiary improve history          # past runs, newest first
+apiary improve show <run-id>    # that run's findings and their fate
+apiary improve effect <run-id>  # before/after for an applied run
+```
+
+```
+## workflow:implementation/step:implement
+
+n: 88 before → 61 after
+
+| metric      | before  | after   | change        |
+|---|---|---|---|
+| fail rate   | 42%     | 6%      | ↓ 86% better  |
+| cost/run    | $0.310  | $0.190  | ↓ 39% better  |
+```
+
+This is what makes the advisor a loop rather than a report generator, and it
+matters most for instruction edits: since nothing could validate them when they
+were applied, these numbers are the first evidence either way.
+
+A post-apply window below `MinRuns` is labelled *shown for completeness, not as
+a result* — a percentage off two runs reads as a finding when it is noise.
+
+Applied findings are also fed back into the next run's prompt, so the advisor
+does not re-propose something already tried. If a problem persists after its fix
+was applied, that is worth knowing: the fix did not work, and the reason matters
+more than another attempt at the same idea.
+
+## Flags
+
+```
+scope
+  --since 30d                    history window; defaults per effort
+  --workflow <id>                restrict to these workflows (repeatable)
+  --agent <id>                   restrict to these agents' runs (repeatable)
+  --focus cost|latency|reliability|quality|all
+
+who analyses
+  --advisor <agent-id>
+  --runner <id> --model <name>   ad-hoc pair
+  --profile <name>
+
+depth and delivery
+  --effort quick|standard|deep   default: standard
+  --output diff|report|json      default: diff
+  --apply                        write the accepted changes
+  --yes                          skip the confirmation
+  --out <dir>                    also write report, analysis and evidence
+  --dump-evidence                print the metrics as JSON, run no model
+  --dump-prompt                  print the composed prompt, run no model
+  --transcript-bytes <n>         override the per-excerpt budget
+```
+
+## What it will not do
+
+- Change Go source, or anything outside the config workspace
+- Touch secrets — `.env`, tokens, credential files
+- Run unattended. There is no scheduled mode; every run is operator-initiated,
+  and applying is opt-in on top of that
+- Claim a thin sample is a result
+
+## Reading the output well
+
+The advisor is asked to cite a metric for every finding, to declare thin
+samples, and to prefer three solid findings over twelve guesses. It generally
+does. What it cannot do is know why a step is hard: a step may be expensive
+because the work is genuinely difficult, not because it is misconfigured. Where
+the same agent runs in more than one workflow the pack makes that comparison
+available, but the judgement is yours.
+
+Treat a recommendation as an argument with evidence attached, not a conclusion —
+which is why the diff renders each hunk next to the number that motivated it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Tasks & Fan-out: tasks-and-fanout.md
       - Agent Memory: memory.md
       - Rate Limits & Resilience: resilience.md
+      - Self-Improvement: improve.md
       - Distributed Workers: distributed-workers.md
   - Sources:
       - Supported Integrations: supported-integrations.md

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## Ativas
 
 - **step-wallclock-attribution** — Atribuição de wall-clock por step (thinking / writing / esperas de tool / tarefas em background) gravada em `task_executions` e `step_runs` ao lado das colunas de token, lista das chamadas mais lentas, payload do evento `system:task_started` no log, e comando `apiary profile <instance-id> [--json]`. GitHub issue #399.
-- **self-improvement-advisor** — `apiary improve`: standalone command that mines the execution history (step/instance/execution metrics, failure clusters, sampled transcripts), has an agent reason over it at a configurable effort level, and emits an evidence-backed report plus a validated unified diff over the whole config workspace (`apiary.yaml`, workflow files, soul files, skill definitions) — or applies it with `--apply`, leaving undo to git. Ledger tables record what was proposed and applied so `apiary improve effect` measures the before/after delta.
 
 ## Arquivadas
+
+### 2026-08-07
+
+- **self-improvement-advisor** — `apiary improve`: standalone command that mines Apiary's own execution history and proposes configuration changes. Deterministic evidence pack computed in Go (step/workflow/agent metrics, rework loops, wait polling, normalised failure clusters, dead paths, wall-clock split, sampled transcripts) exposed via `--dump-evidence`; advisor resolved as an ordinary agent (`--advisor`, ad-hoc `--runner`/`--model`, `settings.improve.agent`, or an agent named `improver`) with profiles, fallbacks and per-effort models; config workspace discovery over `apiary.yaml`, workflow files, souls and skills with secrets redacted; five-stage validation gate (path → apply → `cfg.Validate` → expr lint → new warnings) with strict patch parsing and no fuzzy matching; critic pass at deep effort; `--apply` writing in place with git as the undo story; and an improvement ledger with `improve history|show|effect` measuring the before/after delta of applied changes. Six phases, GitHub issues #401-#407 (PRs #408, #412, #413, #414, #416, #417).
 
 ### 2026-07-22
 

--- a/openspec/changes/self-improvement-advisor/tasks.md
+++ b/openspec/changes/self-improvement-advisor/tasks.md
@@ -1,5 +1,13 @@
 # Implementation Plan: Self-Improvement Advisor
 
+**Status: complete.** All six phases shipped (PRs #408, #412, #413, #414, #416,
+#417). Checkboxes are retained as a record of what was built. Two things landed
+that this plan did not anticipate, both found by running the tool against a real
+database rather than fixtures: `--dump-prompt`, and probing for post-release
+columns because the read-only connection never migrates. One planned item moved:
+collapsing the daemon's duplicate profile overlay onto `config.ApplyProfile` was
+deferred to its own PR after `impact` returned CRITICAL on `dispatcher.New`.
+
 Companion to [proposal.md](proposal.md). Phases are ordered so each one ends at a
 shippable state — Phase 1 is a useful diagnostic on its own, and nothing before Phase 4
 can write to disk.
@@ -18,74 +26,74 @@ a seeded database.
 
 ### 1.1 Types — `internal/improve/evidence.go`
 
-- [ ] `EvidencePack` — top-level struct: `Window`, `Scope`, `Workflows []WorkflowMetrics`,
+- [x] `EvidencePack` — top-level struct: `Window`, `Scope`, `Workflows []WorkflowMetrics`,
       `Steps []StepMetrics`, `Agents []AgentMetrics`, `Failures []FailureCluster`,
       `Waits []WaitMetrics`, `Transcripts []TranscriptExcerpt`, `Config ConfigSnapshot`,
       `Digest string`
-- [ ] `StepMetrics` — `WorkflowID`, `StepID`, `AgentID`, `Runs`, `PassRate`, `FailRate`,
+- [x] `StepMetrics` — `WorkflowID`, `StepID`, `AgentID`, `Runs`, `PassRate`, `FailRate`,
       `SkipRate`, `CachedSkipRate`, `DurationP50/P95`, `MeanTokens`, `TotalCost`,
       `MeanTurns`, `MeanToolCalls`, `CacheReuseRatio`, `PromptWeightRatio`,
       `FailoverRate`, `FailureKinds map[string]int`, `MaxTurnsSaturation`
-- [ ] `WorkflowMetrics` — instance counts by terminal state, e2e `DurationP50/P95`,
+- [x] `WorkflowMetrics` — instance counts by terminal state, e2e `DurationP50/P95`,
       `CostPerCompleted`, `ReworkLoops []ReworkLoop`, `ParallelCandidates []StepPair`,
       `DeadSteps []string`
-- [ ] `AgentMetrics`, `WaitMetrics`, `FailureCluster`, `TranscriptExcerpt`
-- [ ] `Digest()` — stable hash over the pack (sorted keys, window excluded) for
+- [x] `AgentMetrics`, `WaitMetrics`, `FailureCluster`, `TranscriptExcerpt`
+- [x] `Digest()` — stable hash over the pack (sorted keys, window excluded) for
       reproducibility and for `improvement_runs.evidence_digest`
 
 ### 1.2 Queries — `internal/improve/metrics.go`
 
 Opens the existing DB read-only. All queries take `(ctx, window, scope)`.
 
-- [ ] `stepMetrics` — `step_runs` ⋈ `workflow_instances`, plus a `task_executions`
+- [x] `stepMetrics` — `step_runs` ⋈ `workflow_instances`, plus a `task_executions`
       sub-select for `attempt > 1` failover rate and `failure_kind` distribution.
       Percentiles computed in Go over the ordered durations (SQLite has no `percentile`).
-- [ ] `workflowMetrics` — instance terminal-state counts, e2e duration, cost per completed
-- [ ] `reworkLoops` — `GROUP BY workflow_instance_id, step_id HAVING COUNT(*) > 1`;
+- [x] `workflowMetrics` — instance terminal-state counts, e2e duration, cost per completed
+- [x] `reworkLoops` — `GROUP BY workflow_instance_id, step_id HAVING COUNT(*) > 1`;
       this is the `on_fail`/`goto` cycle signature
-- [ ] `agentMetrics` — `task_executions` grouped by `agent_id`, `runner`, `model`;
+- [x] `agentMetrics` — `task_executions` grouped by `agent_id`, `runner`, `model`;
       `max_turns` saturation needs the configured cap from `config`, joined in Go
-- [ ] `waitMetrics` — `ci_poll_checks` per (instance, step): poll count, terminal status
+- [x] `waitMetrics` — `ci_poll_checks` per (instance, step): poll count, terminal status
       distribution, timeouts; approval latency from `approval_requests` ⋈
       `approval_responses`
-- [ ] `deadPaths` — configured workflows/steps/agents/fallbacks with zero rows in the window
-- [ ] `failureClusters` — `error_message` from failed executions, normalised (strip
+- [x] `deadPaths` — configured workflows/steps/agents/fallbacks with zero rows in the window
+- [x] `failureClusters` — `error_message` from failed executions, normalised (strip
       digits, hex, paths, UUIDs/ULIDs) then grouped with counts and one exemplar
 
 ### 1.3 Static config analysis — `internal/improve/static.go`
 
-- [ ] `parallelCandidates(wf)` — consecutive sequential steps where no later step's
+- [x] `parallelCandidates(wf)` — consecutive sequential steps where no later step's
       `Condition`/`FailWhen`/`If` or prompt references an earlier step's output.
       Conservative: emit only when there is provably no reference; a false negative is
       cheap, a false positive is a wrong recommendation.
 
 ### 1.4 Transcript sampling — `internal/improve/transcripts.go`
 
-- [ ] `sampleTranscripts(hotspots, budget)` — reads `<log-dir>/transcripts/<task-id>/`,
+- [x] `sampleTranscripts(hotspots, budget)` — reads `<log-dir>/transcripts/<task-id>/`,
       picks the worst N failures plus one successful control per hotspot, truncates to a
       per-excerpt character budget (head + tail, middle elided)
-- [ ] Hotspot ranking: cost × failure rate × run count, so a cheap flaky step and an
+- [x] Hotspot ranking: cost × failure rate × run count, so a cheap flaky step and an
       expensive reliable one both surface
 
 ### 1.5 Minimum-sample gating
 
-- [ ] `MinRuns` threshold (default 5) — metrics below it are carried in the pack but
+- [x] `MinRuns` threshold (default 5) — metrics below it are carried in the pack but
       flagged `low_confidence`, and the report says so rather than dropping them silently
 
 ### 1.6 CLI entry — `internal/cli/improve.go`
 
-- [ ] `newImproveCmd()`, registered in `root.go`'s `AddCommand` list
-- [ ] Flags per proposal §1; `--dump-evidence` prints the pack as indented JSON and exits
-- [ ] `--since` duration parsing accepting `7d`/`24h`/`90d`
+- [x] `newImproveCmd()`, registered in `root.go`'s `AddCommand` list
+- [x] Flags per proposal §1; `--dump-evidence` prints the pack as indented JSON and exits
+- [x] `--since` duration parsing accepting `7d`/`24h`/`90d`
 
 ### 1.7 Tests — `internal/improve/*_test.go`
 
-- [ ] Seeded-DB fixture helper: N instances × M steps with controlled outcomes
-- [ ] Per-metric assertions (rates, percentiles, rework detection, dead paths)
-- [ ] Failure normalisation table test
-- [ ] `parallelCandidates` — positive and negative cases, especially a step referencing an
+- [x] Seeded-DB fixture helper: N instances × M steps with controlled outcomes
+- [x] Per-metric assertions (rates, percentiles, rework detection, dead paths)
+- [x] Failure normalisation table test
+- [x] `parallelCandidates` — positive and negative cases, especially a step referencing an
       earlier output through an expression
-- [ ] `Digest` stability: same data → same digest; reordered rows → same digest
+- [x] `Digest` stability: same data → same digest; reordered rows → same digest
 
 **Done when** `apiary improve --dump-evidence --since 30d` prints a correct, stable pack on
 a real database, and `make check` passes.
@@ -98,25 +106,25 @@ a real database, and `make check` passes.
 
 (Proposal §3. Landing it here rather than in Phase 3 because the prompt needs it.)
 
-- [ ] `Discover(cfg, configPath) (Workspace, error)` — walks config → workflow files
+- [x] `Discover(cfg, configPath) (Workspace, error)` — walks config → workflow files
       (transitive) → soul files → skill definitions → generated agent prompt files →
       plugin manifests
-- [ ] Skill resolution: search `.claude/skills/<name>/SKILL.md` and the runner skill dirs;
+- [x] Skill resolution: search `.claude/skills/<name>/SKILL.md` and the runner skill dirs;
       unresolved skills recorded as `Unresolved []string`, never silently dropped
       (see proposal open question 3)
-- [ ] `Excluded(path) bool` — `.env`, `*secret*`, `*credential*`, `.git/`, DB, logs,
+- [x] `Excluded(path) bool` — `.env`, `*secret*`, `*credential*`, `.git/`, DB, logs,
       transcripts, anything outside the workspace root
-- [ ] `RedactConfig(raw) string` — blanks `source_token`, `env` values, MCP env blocks
+- [x] `RedactConfig(raw) string` — blanks `source_token`, `env` values, MCP env blocks
       before the config text enters a prompt
 
 ### 2.2 Prompt composition — `internal/improve/prompt.go`
 
-- [ ] Metrics rendered as compact markdown tables, not raw JSON — token cost matters and
+- [x] Metrics rendered as compact markdown tables, not raw JSON — token cost matters and
       tables read better for the model
-- [ ] Workspace files inlined with path headers, per-file truncation at high effort
-- [ ] Constraints block: exclusion list, "cite a metric for every finding", output contract
-- [ ] Ledger block (empty until Phase 5)
-- [ ] `OutputSchema` for the findings/recommendations JSON, reusing
+- [x] Workspace files inlined with path headers, per-file truncation at high effort
+- [x] Constraints block: exclusion list, "cite a metric for every finding", output contract
+- [x] Ledger block (empty until Phase 5)
+- [x] `OutputSchema` for the findings/recommendations JSON, reusing
       `execution.OutputSchemaInstruction` so the sentinel instructions match the daemon's
 
 ### 2.3 Advisor resolution — `internal/improve/advisor.go`
@@ -124,63 +132,63 @@ a real database, and `make check` passes.
 Proposal §5. There is **no config-level default model** (`agents[].model` is required and
 `daemon.New` errors without it), so this resolves explicitly or fails loudly.
 
-- [ ] `ResolveAdvisor(cfg, flags) (Advisor, error)` in order: `--advisor` → `--runner` +
+- [x] `ResolveAdvisor(cfg, flags) (Advisor, error)` in order: `--advisor` → `--runner` +
       `--model` → `settings.improve.agent` → agent id `improver` → error naming all four
       with a copy-pasteable config snippet
-- [ ] `--model` without `--runner` is a flag error (the runner determines the adapter)
-- [ ] `settings.ImproveSettings` on `config.Settings`: `Agent string`,
+- [x] `--model` without `--runner` is a flag error (the runner determines the adapter)
+- [x] `settings.ImproveSettings` on `config.Settings`: `Agent string`,
       `EffortModels map[string]string`; validated in `internal/config/validate.go`
       (agent must exist; effort keys ∈ {quick,standard,deep}; models must be listed in the
       resolved runner's `models` when that runner declares any)
-- [ ] Apply `profiles.<name>` overrides when `--profile` is set, reusing the daemon's
+- [x] Apply `profiles.<name>` overrides when `--profile` is set, reusing the daemon's
       overlay logic rather than re-implementing it
-- [ ] Effort → model: `effort_models[effort]` overrides `agents[].model` for the run;
+- [x] Effort → model: `effort_models[effort]` overrides `agents[].model` for the run;
       unset falls through to the agent's own model
 
 ### 2.4 Standalone runner invocation — `internal/improve/run.go`
 
-- [ ] Mirror the dispatcher's construction path: `runners[id]` → `rc.AdapterName()` →
+- [x] Mirror the dispatcher's construction path: `runners[id]` → `rc.AdapterName()` →
       `runnerimpl.New(adapter)` → `Configure(runnerConfigWithMCPs(...) + sandbox +
       env_passthrough)`. Extract the shared piece from `daemon` if it can be done without
       dragging in dispatcher state; otherwise duplicate deliberately and note why.
-- [ ] Build `model.RunRequest` (`SystemAppend`, `Model`, `MaxTurns` from effort,
+- [x] Build `model.RunRequest` (`SystemAppend`, `Model`, `MaxTurns` from effort,
       `WorkingDir`, `Env`), call `Run`
-- [ ] Read `RunResult.StructuredOutput` directly — the runner already parses the
+- [x] Read `RunResult.StructuredOutput` directly — the runner already parses the
       `APIARY_OUTPUT:` sentinel, so no marker parsing is needed here
-- [ ] Fallback chain: on a `RateLimited` / `CreditExhausted` classification from
+- [x] Fallback chain: on a `RateLimited` / `CreditExhausted` classification from
       `execution.FailureDetectorFor(adapter)`, advance through `agents[].fallbacks` then
       `settings.default_fallbacks`. A `deep` run that trips the 5-hour limit mid-way must
       not discard the work already done.
-- [ ] Accumulate `RunResult.Usage` across passes and fallback attempts for the cost line
+- [x] Accumulate `RunResult.Usage` across passes and fallback attempts for the cost line
 
 ### 2.5 Effort levels — `internal/improve/effort.go`
 
-- [ ] `Effort` enum → knobs struct: window default, hotspot count, transcripts per hotspot,
+- [x] `Effort` enum → knobs struct: window default, hotspot count, transcripts per hotspot,
       excerpt budget, workspace read breadth, pass count, critic on/off, `MaxTurns`
 
 ### 2.6 Report rendering — `internal/improve/report.go`
 
-- [ ] Markdown: summary → findings grouped by severity → recommendations with rationale
+- [x] Markdown: summary → findings grouped by severity → recommendations with rationale
       and expected effect → low-confidence section → cost line
-- [ ] `--output json` emits the structured result verbatim
-- [ ] Written to `<data-dir>/improve/<run-id>/` and echoed to stdout
+- [x] `--output json` emits the structured result verbatim
+- [x] Written to `<data-dir>/improve/<run-id>/` and echoed to stdout
 
 ### 2.7 Default advisor soul — `internal/cli/assets/improver.md` (embedded)
 
-- [ ] Ships a working default so `apiary improve` needs no config; overridable by defining
+- [x] Ships a working default so `apiary improve` needs no config; overridable by defining
       an `improver` agent
 
 ### 2.8 Tests
 
-- [ ] Prompt composition golden test (redaction verified: no token value appears)
-- [ ] Structured-output parsing: well-formed, malformed, missing
-- [ ] Effort knob table test
-- [ ] Workspace discovery against a fixture tree, including an unresolved skill
-- [ ] `ResolveAdvisor` precedence table: each of the four sources wins in turn; the
+- [x] Prompt composition golden test (redaction verified: no token value appears)
+- [x] Structured-output parsing: well-formed, malformed, missing
+- [x] Effort knob table test
+- [x] Workspace discovery against a fixture tree, including an unresolved skill
+- [x] `ResolveAdvisor` precedence table: each of the four sources wins in turn; the
       no-advisor case returns the actionable error, not a guessed model
-- [ ] `--model` without `--runner` is rejected
-- [ ] `effort_models` overrides the agent model; unset falls through
-- [ ] `--profile` overlay applies to the advisor
+- [x] `--model` without `--runner` is rejected
+- [x] `effort_models` overrides the agent model; unset falls through
+- [x] `--profile` overlay applies to the advisor
 
 **Done when** `apiary improve --output report` produces an evidence-backed markdown report.
 
@@ -190,31 +198,31 @@ Proposal §5. There is **no config-level default model** (`agents[].model` is re
 
 ### 3.1 Patch handling — `internal/improve/patch.go`
 
-- [ ] Parse unified diffs from recommendations; apply in-memory to current file content
-- [ ] Reject patches whose target fails `Excluded`/outside-workspace checks
-- [ ] Fuzzy-match tolerance: reject rather than guess when context does not match
+- [x] Parse unified diffs from recommendations; apply in-memory to current file content
+- [x] Reject patches whose target fails `Excluded`/outside-workspace checks
+- [x] Fuzzy-match tolerance: reject rather than guess when context does not match
 
 ### 3.2 Validation gate — `internal/improve/validate.go`
 
 Five stages per proposal §6, short-circuiting with a recorded reason:
 
-- [ ] path check → 2. clean apply → 3. `config.Load` + `cfg.Validate()` on the candidate
-- [ ] `config.LintExpr` over the candidate's conditions (wire the same hook `cli` injects,
+- [x] path check → 2. clean apply → 3. `config.Load` + `cfg.Validate()` on the candidate
+- [x] `config.LintExpr` over the candidate's conditions (wire the same hook `cli` injects,
       so a proposed `if`/`reject_when` that would hard-fail at runtime is caught here)
-- [ ] `cfg.WorkflowWarnings()` — new warnings surfaced alongside the diff
-- [ ] Prose targets (souls, skills) clear stages 1–2 only — document this in the output so
+- [x] `cfg.WorkflowWarnings()` — new warnings surfaced alongside the diff
+- [x] Prose targets (souls, skills) clear stages 1–2 only — document this in the output so
       the reviewer knows which hunks were machine-checked and which were not
 
 ### 3.3 Diff rendering
 
-- [ ] Grouped by file; each hunk preceded by the finding and metric that justified it
-- [ ] "Could not be validated" section listing rejected patches with reasons
+- [x] Grouped by file; each hunk preceded by the finding and metric that justified it
+- [x] "Could not be validated" section listing rejected patches with reasons
 
 ### 3.4 Tests
 
-- [ ] Patch application: clean, conflicting, excluded-path, outside-workspace
-- [ ] A patch introducing an invalid expression is rejected at stage 4
-- [ ] A patch removing a `soul_file` a config still references is rejected at stage 3
+- [x] Patch application: clean, conflicting, excluded-path, outside-workspace
+- [x] A patch introducing an invalid expression is rejected at stage 4
+- [x] A patch removing a `soul_file` a config still references is rejected at stage 3
 
 **Done when** `apiary improve` (default `--output diff`) prints a validated, reviewable diff.
 
@@ -224,15 +232,15 @@ Five stages per proposal §6, short-circuiting with a recorded reason:
 
 ### 4.1 `internal/improve/apply.go`
 
-- [ ] Write accepted patches to disk; print the list of modified files
-- [ ] Warn (do not refuse) when the workspace is not a git repository — version control is
+- [x] Write accepted patches to disk; print the list of modified files
+- [x] Warn (do not refuse) when the workspace is not a git repository — version control is
       the user's responsibility and the undo mechanism
-- [ ] Print the daemon-restart reminder when config changed
-- [ ] `--yes` skips the single confirmation prompt
+- [x] Print the daemon-restart reminder when config changed
+- [x] `--yes` skips the single confirmation prompt
 
 ### 4.2 Tests
 
-- [ ] Apply writes exactly the expected bytes; non-git workspace produces the warning
+- [x] Apply writes exactly the expected bytes; non-git workspace produces the warning
 
 **Done when** `apiary improve --apply` modifies the workspace and `git diff` shows the change.
 
@@ -242,34 +250,34 @@ Five stages per proposal §6, short-circuiting with a recorded reason:
 
 ### 5.1 Migrations — `internal/db/schema.go`
 
-- [ ] `improvement_runs` and `improvement_findings` per proposal §7, appended to the
+- [x] `improvement_runs` and `improvement_findings` per proposal §7, appended to the
       `migrations` slice (`CREATE TABLE IF NOT EXISTS` statements are safe there)
-- [ ] Indexes on `improvement_findings(run_id)` and `improvement_findings(scope, state)`
+- [x] Indexes on `improvement_findings(run_id)` and `improvement_findings(scope, state)`
 
 ### 5.2 Store — `internal/db/improvement.go`
 
-- [ ] `CreateImprovementRun`, `RecordFindings`, `MarkApplied`, `ListImprovementRuns`,
+- [x] `CreateImprovementRun`, `RecordFindings`, `MarkApplied`, `ListImprovementRuns`,
       `GetImprovementRun`, `ListFindingsByScope`
 
 ### 5.3 Effect comparison — `internal/improve/effect.go`
 
-- [ ] Recompute the Phase 1 metrics for each finding's `scope` over the window *since*
+- [x] Recompute the Phase 1 metrics for each finding's `scope` over the window *since*
       `applied_at`, diff against `baseline_metrics`, render the delta table
-- [ ] Guard against thin post-apply samples — say "not enough runs yet" rather than
+- [x] Guard against thin post-apply samples — say "not enough runs yet" rather than
       reporting a meaningless delta
 
 ### 5.4 Sub-commands
 
-- [ ] `apiary improve history|show <run-id>|effect <run-id>`
+- [x] `apiary improve history|show <run-id>|effect <run-id>`
 
 ### 5.5 Prompt feedback loop
 
-- [ ] Inject prior findings and their measured effect into the prompt so the advisor does
+- [x] Inject prior findings and their measured effect into the prompt so the advisor does
       not re-propose something already tried and reverted
 
 ### 5.6 Tests
 
-- [ ] Ledger round-trip; effect delta on a seeded before/after dataset; thin-sample guard
+- [x] Ledger round-trip; effect delta on a seeded before/after dataset; thin-sample guard
 
 **Done when** `apiary improve effect <run-id>` shows a real before/after delta.
 
@@ -277,12 +285,12 @@ Five stages per proposal §6, short-circuiting with a recorded reason:
 
 ## Phase 6 — Docs and defaults
 
-- [ ] `docs/improve.md` — what it measures, effort levels, the change surface, the git
+- [x] `docs/improve.md` — what it measures, effort levels, the change surface, the git
       assumption, worked example
-- [ ] Add to the docs nav in `mkdocs.yml`
-- [ ] `schema/apiary.json` regenerated for `settings.improve` (`agent`, `effort_models`)
-- [ ] Example config: an `improver` agent entry plus a `settings.improve` block
-- [ ] Archive the change in `openspec/CHANGELOG.md` (move from Ativas to Arquivadas)
+- [x] Add to the docs nav in `mkdocs.yml`
+- [x] `schema/apiary.json` regenerated for `settings.improve` (`agent`, `effort_models`)
+- [x] Example config: an `improver` agent entry plus a `settings.improve` block
+- [x] Archive the change in `openspec/CHANGELOG.md` (move from Ativas to Arquivadas)
 
 ---
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -659,6 +659,27 @@
             }
           }
         },
+        "improve": {
+          "type": "object",
+          "description": "Configuration for `apiary improve`, the self-improvement advisor. Optional in full: the advisor can also be named on the command line, and --dump-evidence needs none of it because it runs no model",
+          "additionalProperties": false,
+          "properties": {
+            "agent": {
+              "type": "string",
+              "description": "Id of the agent that performs the analysis. Resolved like any other agent (runner, model, fallbacks, MCPs), so the advisor is not a special case. Empty falls back to an agent literally named \"improver\"; failing that the command errors rather than guessing, because model is required per agent and there is no global default to fall back to"
+            },
+            "effort_models": {
+              "type": "object",
+              "description": "Optional per-effort model override, replacing the advisor agent's own model for that run. Reading aggregate tables at \"quick\" and reasoning over transcripts and prose at \"deep\" are different jobs, so paying deep prices for a quick run is waste. Unset levels fall through to the agent's model",
+              "additionalProperties": false,
+              "properties": {
+                "quick": { "type": "string" },
+                "standard": { "type": "string" },
+                "deep": { "type": "string" }
+              }
+            }
+          }
+        },
         "git_hooks": {
           "type": "object",
           "description": "Enforce a shared git hooks directory on the agents' repo checkouts. At startup the daemon sets core.hooksPath of every repo matched by 'repos' to 'dir' (and marks the scripts executable), so hooks like a pre-push running local lint/tests mechanically gate agent pushes — prompt rules alone are advisory. Both keys are required together",


### PR DESCRIPTION
Final phase of #401. Closes #407 and closes the epic.

## What's here

- **`docs/improve.md`** — the evidence pack and what each metric means, effort levels, the config workspace and its exclusions, advisor resolution, the five-stage gate, applying, and effect measurement. It ends with a section on reading the output well: a recommendation is an argument with evidence attached, not a conclusion, and the advisor cannot know whether a step is expensive because it's misconfigured or because the work is genuinely hard.
- **`docs/cli.md`** — an `apiary improve` entry under *Inspecting work*, with sub-commands and a pointer to the full page.
- **`mkdocs.yml`** — nav entry under Guide.
- **`schema/apiary.json`** — `settings.improve` (`agent`, `effort_models`).
- **`.apiary/example-apiary-full.yaml`** — a `settings.improve` block and an `improver` agent, with `.apiary/souls/improver.md` alongside so the example still validates. The comments explain why the agent is inert: no workflow triggers it, so the daemon never dispatches it and it takes no dispatch slot.

## Two notes on how this was done

**The schema was edited in place, not regenerated.** A JSON round-trip reformatted the entire file — expanding every compact array — turning a 21-line addition into a 478-line diff. The surgical edit keeps the review honest.

**The example config now validates as well as it did before.** `apiary validate` reports exactly one failure, and it's pre-existing on clean main:

```
✗ workflows[8] "spec-decompose": step "spec" (materialize: sub_issue) requires a
  capability that source "project-erp" (type "plane") does not support
```

Filed separately — a shipped example that fails validation teaches the wrong thing, and `docs/SCHEMA_SETUP.md` presents these files as the reference. Worth a test that validates every `.apiary/example-*.yaml` so they can't drift again.

`mkdocs build --strict` produces the same 3 warnings as clean main (all about `index.md` and `development.md`, which `pages.yml` generates at build time) and none from the new page.

## Epic closed

| Phase | PR |
|---|---|
| 1 — evidence pack | #408 |
| 2 — advisor agent | #412 |
| — transcript fix | #413 |
| 3 — patches + validation gate | #414 |
| 4 — apply | #416 |
| 5 — ledger + effect | #417 |
| 6 — docs | this |

`openspec/CHANGELOG.md` moves the change to Arquivadas; `tasks.md` is marked complete with a note on what the plan didn't anticipate — `--dump-prompt` and the read-only schema probing, both found by running against a real database rather than fixtures — and on the daemon profile-overlay de-duplication, deferred to its own PR after `impact` returned CRITICAL on `dispatcher.New`.

`make check` green across 33 packages.