### PR TITLE
fix(runner): correct the documented task_timeout and add a stall bound (#411)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,7 +267,8 @@ settings:
   log_level: info
   state_lock: true
   result_comment: true
-  task_timeout: 30m
+  task_timeout: 2h
+  stall_timeout: 20m
   max_attempts: 3
   log_max_size_mb: 50
   log_max_backups: 5
@@ -280,7 +281,8 @@ settings:
 | `log_level` | `info` | `debug` \| `info` \| `warn` \| `error` |
 | `state_lock` | `false` | Add an `in-progress` label on the source item when work starts |
 | `result_comment` | `false` | Post the agent's final output back as a comment |
-| `task_timeout` | `30m` | Default per-run timeout (e.g. `2h`) |
+| `task_timeout` | `2h` | Total bound on one runner invocation. A runaway backstop, not a service-level target — an implementation step legitimately runs for an hour, so a short value kills real work |
+| `stall_timeout` | — (off) | Kill a run that has produced **no output at all** for this long, independent of `task_timeout`. Off by default because a runner that buffers rather than streams would look permanently stalled; enable it for the streaming CLI runners |
 | `max_attempts` | 3 | Stop re-dispatching a `(task, workflow)` after this many **consecutive failed** instances; `<=0` disables — see [resilience](resilience.md#re-dispatch-failure-cap) |
 | `refuse_root` | `false` | Make running as root (euid 0) a startup **error** instead of a warning. Agent CLIs inherit the daemon's uid, so a prompt-injected agent would execute as root. Default warns so existing root service installs keep working |
 | `least_privilege_agents` | `false` | Deny `edit`/`bash`/`webfetch` by default for agents on runners that support per-agent permissions (OpenCode). Individual agents override via `agents[].permissions` |

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -225,9 +225,40 @@ Daemon restarts (crash, upgrade, reboot) don't lose in-flight work:
 
 ## Timeouts
 
-Every run is bounded by `settings.task_timeout` (default 30m) so a hung
-subprocess cannot hold an agent slot forever. Approval steps and CI waits
-carry their own explicit `timeout` / `max_duration` budgets.
+Every run is bounded by `settings.task_timeout` (default **2h**) so a hung
+subprocess cannot hold an agent slot forever. Approval steps and CI waits carry
+their own explicit `timeout` / `max_duration` budgets.
+
+Two hours is deliberately generous: an implementation step routinely runs for an
+hour or more, and a short total bound kills real work rather than runaway work.
+That makes `task_timeout` a poor instrument for catching a *hung* process, which
+is what `settings.stall_timeout` is for:
+
+```yaml
+settings:
+  task_timeout: 2h      # total bound — the backstop
+  stall_timeout: 20m    # no output at all for this long — the hang detector
+```
+
+A step streaming tool calls for ninety minutes is working. A step that has
+emitted nothing for twenty is usually wedged. Only the second is worth killing
+early, and only `stall_timeout` can tell them apart.
+
+`stall_timeout` is **off by default**. It measures silence, so a runner that
+buffers its output until exit instead of streaming would look permanently
+stalled — enabling it globally would kill those runs on upgrade. Turn it on for
+the streaming CLI runners (`claude`, `codex`, `cursor`, `opencode`).
+
+Both bounds are logged at step start, so the log answers "is this step bounded
+at all?" without reading the config:
+
+```
+step implement: timeout 2h0m0s, stall timeout 20m0s
+```
+
+When either fires, the run is recorded as timed out with the bound that fired
+and how long it ran — not as a bare `signal: killed`, which is indistinguishable
+from a crash.
 
 ## What to monitor
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -542,7 +542,12 @@
         },
         "task_timeout": {
           "type": "string",
-          "description": "Default task timeout (e.g., '2h'). Defaults to 120m",
+          "description": "Total bound on one runner invocation (e.g. '2h'). Defaults to 120m. This is a runaway backstop, not a service-level target: an implementation step legitimately runs for an hour or more, so a short value kills real work rather than runaway work. To catch a genuinely hung process, use stall_timeout, which measures silence instead of duration",
+          "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+        },
+        "stall_timeout": {
+          "type": "string",
+          "description": "Kill a run that has produced no output at all for this long (e.g. '20m'), independent of task_timeout. A step streaming tool calls for ninety minutes is working; one silent for twenty is usually wedged. Off by default — it measures silence, so a runner that buffers its output until exit rather than streaming would look permanently stalled. Enable it for the streaming CLI runners",
           "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
         },
         "refuse_root": {

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -337,7 +337,22 @@ type Settings struct {
 	// agents[].permissions regardless of this setting.
 	LeastPrivilegeAgents bool   `yaml:"least_privilege_agents,omitempty"`
 	ResultComment        bool   `yaml:"result_comment"`
-	TaskTimeout          string `yaml:"task_timeout"`
+	// TaskTimeout bounds a single runner invocation end to end. Default 2h.
+	// It is a runaway backstop, not a service-level target: an implementation
+	// step legitimately runs for an hour or more, so a short total bound kills
+	// real work. For catching a genuinely hung process, StallTimeout is the
+	// better instrument — it measures silence rather than duration.
+	TaskTimeout string `yaml:"task_timeout"`
+	// StallTimeout kills a run that has produced no output at all for this long,
+	// independent of TaskTimeout. A step streaming tool calls for ninety minutes
+	// is working; one that has emitted nothing for twenty is usually wedged, and
+	// only the second is worth killing early.
+	//
+	// Disabled by default (empty or "0"). It stays opt-in because a runner that
+	// buffers its output instead of streaming would look permanently stalled,
+	// and silently killing those on upgrade would be worse than the problem it
+	// solves. Enable it for the streaming CLI runners.
+	StallTimeout string `yaml:"stall_timeout,omitempty"`
 	// MaxAttempts caps how many consecutive FAILED workflow instances a single
 	// (task, workflow) pair may accumulate before the dispatcher stops
 	// re-dispatching it and applies the workflow's on_fail hook. Rate-limited
@@ -598,13 +613,30 @@ func (s *Settings) CreditExhaustedCooldownDuration() time.Duration {
 	return d
 }
 
+// DefaultTaskTimeout is the total per-run bound applied when task_timeout is
+// unset. Two hours: long enough that a real implementation step is never cut
+// off, short enough that a wedged process cannot hold an agent slot forever.
+const DefaultTaskTimeout = 120 * time.Minute
+
 func (s *Settings) TaskTimeoutDuration() time.Duration {
 	if s.TaskTimeout == "" {
-		return 120 * time.Minute
+		return DefaultTaskTimeout
 	}
 	d, err := time.ParseDuration(s.TaskTimeout)
 	if err != nil {
-		return 120 * time.Minute
+		return DefaultTaskTimeout
+	}
+	return d
+}
+
+// StallTimeoutDuration returns the no-output bound, or 0 when disabled.
+func (s *Settings) StallTimeoutDuration() time.Duration {
+	if s.StallTimeout == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s.StallTimeout)
+	if err != nil || d <= 0 {
+		return 0
 	}
 	return d
 }

--- a/src/internal/config/timeout_test.go
+++ b/src/internal/config/timeout_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// The reported bug (#411) was a documentation mismatch, not a broken mechanism:
+// the docs said the default was 30m in three places while the code used 2h, so
+// steps running 66-84 minutes were never cut off and the operator had no way to
+// know why. Pinning the real value here means the docs and the code can only
+// drift again through a deliberate edit.
+func TestTaskTimeoutDefault(t *testing.T) {
+	var s Settings
+	if got := s.TaskTimeoutDuration(); got != DefaultTaskTimeout {
+		t.Errorf("unset task_timeout = %v, want %v", got, DefaultTaskTimeout)
+	}
+	if DefaultTaskTimeout != 2*time.Hour {
+		t.Errorf("DefaultTaskTimeout = %v; docs/configuration.md, docs/resilience.md "+
+			"and schema/apiary.json all state this value and must be updated together",
+			DefaultTaskTimeout)
+	}
+}
+
+func TestTaskTimeoutParsing(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", DefaultTaskTimeout},
+		{"30m", 30 * time.Minute},
+		{"2h", 2 * time.Hour},
+		{"90s", 90 * time.Second},
+		{"nonsense", DefaultTaskTimeout}, // unparseable falls back rather than disabling the bound
+	}
+	for _, tc := range cases {
+		s := Settings{TaskTimeout: tc.in}
+		if got := s.TaskTimeoutDuration(); got != tc.want {
+			t.Errorf("task_timeout %q = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestStallTimeoutDefaultsOff(t *testing.T) {
+	var s Settings
+	if got := s.StallTimeoutDuration(); got != 0 {
+		t.Errorf("unset stall_timeout = %v, want 0 (disabled)", got)
+	}
+}
+
+func TestStallTimeoutParsing(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{"20m", 20 * time.Minute},
+		{"-5m", 0},        // negative is meaningless; treat as disabled
+		{"nonsense", 0},   // unparseable must not silently enable a killer
+	}
+	for _, tc := range cases {
+		s := Settings{StallTimeout: tc.in}
+		if got := s.StallTimeoutDuration(); got != tc.want {
+			t.Errorf("stall_timeout %q = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -404,6 +404,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		WorkingDir:         "/",
 		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
+		StallTimeout:       x.d.cfg.Settings.StallTimeoutDuration(),
 	}
 
 	if x.d.logger != nil {
@@ -485,6 +486,15 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 			execID := exec.ID
 			rr.SetPID = func(pid int) { _ = x.d.db.SetPID(ctx, execID, pid) }
 			rr.Heartbeat = func() { _ = x.d.db.SendHeartbeat(ctx, execID) }
+		}
+
+		// Say what bound is in force before the step runs. Without this there is
+		// no way to tell from the log whether a step is bounded at all, which is
+		// exactly the question asked when one has been running for an hour.
+		if rr.StallTimeout > 0 {
+			aplog.Info("step %s: timeout %s, stall timeout %s", req.Step.ID, rr.Timeout, rr.StallTimeout)
+		} else {
+			aplog.Info("step %s: timeout %s (no stall timeout; set settings.stall_timeout to bound silence)", req.Step.ID, rr.Timeout)
 		}
 
 		runCtx, cancel := context.WithTimeout(ctx, rr.Timeout)

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -10,7 +10,14 @@ type RunRequest struct {
 	SystemAppend  string
 	WorkingDir    string
 	Env           map[string]string
-	Timeout       time.Duration
+	// Timeout bounds the whole invocation. The caller enforces it by cancelling
+	// the context it passes to Run; runners need not check it themselves.
+	Timeout time.Duration
+	// StallTimeout kills the run when it has produced no output at all for this
+	// long, independent of Timeout. Zero disables it. Only meaningful for runners
+	// that stream output as they work — a runner that buffers everything until
+	// exit would look permanently stalled.
+	StallTimeout time.Duration
 	AgentMetadata map[string]any
 
 	// SystemPrepend is injected at the very start of the prompt, before the cell
@@ -174,6 +181,11 @@ type RunResult struct {
 	// engine treats SpawnRequest and SpawnRequests uniformly: each request becomes
 	// one deduped child.
 	SpawnRequests []SpawnRequest
+	// TimedOut marks a run the caller cut off — either at Timeout or at
+	// StallTimeout — rather than one that failed on its own. A killed process
+	// reports only "signal: killed", so without this a bound firing is
+	// indistinguishable from a crash in the run history.
+	TimedOut bool
 	// SpawnError is set when an APIARY_SPAWN block was present but its body was
 	// not valid JSON. The workflow executor turns this into a failed step.
 	SpawnError error

--- a/src/internal/runner/execution/cli.go
+++ b/src/internal/runner/execution/cli.go
@@ -339,7 +339,50 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	if req.SetPID != nil {
 		req.SetPID(cmd.Process.Pid)
 	}
+	// lastOutput is the wall-clock of the most recent line on either stream. The
+	// stall watchdog reads it to tell a working step from a wedged one: a step
+	// streaming tool calls for ninety minutes is fine, one silent for twenty is
+	// usually dead.
+	var lastOutputMu sync.Mutex
+	lastOutput := time.Now()
+	noteOutput := func() {
+		lastOutputMu.Lock()
+		lastOutput = time.Now()
+		lastOutputMu.Unlock()
+	}
+
+	// done is closed once the process is reaped, stopping both the heartbeat
+	// ticker and the stall watchdog.
 	heartbeatDone := make(chan struct{})
+
+	// stalled is closed by the watchdog when it kills the process, so the result
+	// can say "stalled" rather than reporting a bare "signal: killed".
+	stalled := make(chan struct{})
+	var stalledOnce sync.Once
+	if req.StallTimeout > 0 {
+		go func() {
+			ticker := time.NewTicker(min(req.StallTimeout/4, 30*time.Second))
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					lastOutputMu.Lock()
+					idle := time.Since(lastOutput)
+					lastOutputMu.Unlock()
+					if idle >= req.StallTimeout {
+						stalledOnce.Do(func() { close(stalled) })
+						if cmd.Process != nil {
+							_ = cmd.Process.Kill()
+						}
+						return
+					}
+				case <-heartbeatDone:
+					return
+				}
+			}
+		}()
+	}
+
 	if req.Heartbeat != nil {
 		go func() {
 			ticker := time.NewTicker(15 * time.Second)
@@ -364,6 +407,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
+			noteOutput()
 			mu.Lock()
 			outBuf.WriteString(line + "\n")
 			mu.Unlock()
@@ -398,6 +442,7 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 		scanner := bufio.NewScanner(stderrPipe)
 		for scanner.Scan() {
 			line := scanner.Text()
+			noteOutput()
 			mu.Lock()
 			errBuf.WriteString(line + "\n")
 			mu.Unlock()
@@ -432,7 +477,30 @@ func (r *CliRunner) Run(ctx context.Context, req model.RunRequest) (model.RunRes
 	if rateLimited && rateLimitResetsAt > 0 {
 		result.RateLimitResetsAt = time.Unix(rateLimitResetsAt, 0)
 	}
+	// A killed process reports "signal: killed" and nothing else, so a timeout
+	// and a stall and a crash all look identical in the run history. Name the
+	// cause while it is still known — this is the difference between "the step
+	// failed" and "the step was cut off at its bound", which call for opposite
+	// responses.
 	if runErr != nil {
+		select {
+		case <-stalled:
+			result.TimedOut = true
+			result.Error = fmt.Errorf("killed after producing no output for %s (settings.stall_timeout); "+
+				"ran for %s in total", req.StallTimeout, result.Duration.Round(time.Second))
+			result.FailureKind = model.FailureAborted
+			return result, nil
+		default:
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			result.TimedOut = true
+			bound := req.Timeout
+			result.Error = fmt.Errorf("killed at the %s run timeout (settings.task_timeout) after %s",
+				bound, result.Duration.Round(time.Second))
+			result.FailureKind = model.FailureAborted
+			return result, nil
+		}
+
 		// claude often exits non-zero with an empty stderr, leaving a bare
 		// "exit status 1" with no clue why. Fall back to the most meaningful
 		// stdout (final result / last assistant text) so the recorded error is

--- a/src/internal/runner/execution/timeout_test.go
+++ b/src/internal/runner/execution/timeout_test.go
@@ -1,0 +1,143 @@
+package execution
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// shellRunner builds a CliRunner that executes a shell snippet, so timeout
+// behaviour can be exercised against a real subprocess rather than a fake.
+func shellRunner(t *testing.T, script string) *CliRunner {
+	t.Helper()
+	r := &CliRunner{}
+	if err := r.Configure(map[string]any{
+		"command":      "/bin/sh",
+		"args":         []any{"-c", script},
+		"args_replace": true,
+	}); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+	return r
+}
+
+// A killed process reports only "signal: killed", so without explicit handling
+// a timeout, a stall and a crash are indistinguishable in the run history —
+// and they call for opposite responses.
+func TestRunReportsTimeoutDistinctly(t *testing.T) {
+	r := shellRunner(t, "sleep 30")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	res, _ := r.Run(ctx, model.RunRequest{Timeout: 300 * time.Millisecond})
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("the run was not cut off: took %v", elapsed)
+	}
+	if !res.TimedOut {
+		t.Error("a run cut off at its deadline must be marked TimedOut")
+	}
+	if res.Success {
+		t.Error("a timed-out run is not a success")
+	}
+	if res.Error == nil {
+		t.Fatal("want an error explaining the timeout")
+	}
+	msg := res.Error.Error()
+	if !strings.Contains(msg, "run timeout") || !strings.Contains(msg, "task_timeout") {
+		t.Errorf("the error should name the bound that fired and the setting behind it, got: %s", msg)
+	}
+	if strings.Contains(msg, "signal: killed") {
+		t.Errorf("a bare kill signal is not a diagnosis, got: %s", msg)
+	}
+	if res.FailureKind != model.FailureAborted {
+		t.Errorf("FailureKind = %v, want aborted", res.FailureKind)
+	}
+}
+
+// A step streaming tool calls for ninety minutes is working; one silent for
+// twenty is usually wedged. The stall bound measures silence, not duration.
+func TestStallTimeoutKillsASilentRun(t *testing.T) {
+	r := shellRunner(t, "sleep 30")
+
+	start := time.Now()
+	res, _ := r.Run(context.Background(), model.RunRequest{
+		Timeout:      time.Minute,
+		StallTimeout: 400 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 10*time.Second {
+		t.Fatalf("the stall watchdog did not fire: took %v", elapsed)
+	}
+	if !res.TimedOut {
+		t.Error("a stalled run must be marked TimedOut")
+	}
+	if res.Error == nil || !strings.Contains(res.Error.Error(), "no output") {
+		t.Errorf("the error should say the run went silent, got: %v", res.Error)
+	}
+	if res.Error != nil && !strings.Contains(res.Error.Error(), "stall_timeout") {
+		t.Errorf("the error should name the setting that fired, got: %v", res.Error)
+	}
+}
+
+// The whole point of measuring silence rather than duration: a run that keeps
+// producing output must survive well past its stall bound.
+func TestStallTimeoutSparesAChattyRun(t *testing.T) {
+	// Emits a line every 100ms for ~1.2s, with a 400ms stall bound. Total
+	// runtime far exceeds the bound; the gaps never do.
+	r := shellRunner(t, "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do echo line$i; sleep 0.1; done")
+
+	res, err := r.Run(context.Background(), model.RunRequest{
+		Timeout:      time.Minute,
+		StallTimeout: 400 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.TimedOut {
+		t.Error("a run that keeps producing output must not be killed as stalled")
+	}
+	if !res.Success {
+		t.Errorf("want success, got error: %v", res.Error)
+	}
+	if !strings.Contains(res.Output, "line12") {
+		t.Errorf("the run should have completed, output: %q", res.Output)
+	}
+}
+
+func TestStallTimeoutDisabledByDefault(t *testing.T) {
+	// No StallTimeout: a silent run is bounded only by the context.
+	r := shellRunner(t, "sleep 0.5; echo done")
+
+	res, err := r.Run(context.Background(), model.RunRequest{Timeout: time.Minute})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.TimedOut {
+		t.Error("with no stall timeout configured, a quiet run must not be killed")
+	}
+	if !strings.Contains(res.Output, "done") {
+		t.Errorf("output = %q, want the run to complete", res.Output)
+	}
+}
+
+// A normal non-zero exit must keep its diagnosable error, not be relabelled as
+// a timeout.
+func TestOrdinaryFailureIsNotReportedAsATimeout(t *testing.T) {
+	r := shellRunner(t, "echo 'something broke' >&2; exit 3")
+
+	res, _ := r.Run(context.Background(), model.RunRequest{Timeout: time.Minute})
+	if res.TimedOut {
+		t.Error("an ordinary non-zero exit is not a timeout")
+	}
+	if res.Error == nil || !strings.Contains(res.Error.Error(), "something broke") {
+		t.Errorf("the stderr detail should survive, got: %v", res.Error)
+	}
+}


### PR DESCRIPTION
Closes #411.

## What was actually wrong

The mechanism works. The dispatcher wraps every run in `context.WithTimeout(ctx, rr.Timeout)` ([workflow.go](src/internal/daemon/workflow.go)) and the CLI runner uses `exec.CommandContext`, so cancellation does kill the subprocess.

**The default is 2h, not the documented 30m.** `docs/configuration.md` and `docs/resilience.md` both state 30m; `schema/apiary.json` was the only place telling the truth. The reported 66/82/84-minute steps were all under the real bound, so nothing fired — and nothing in the log explained why.

## Why the docs changed and not the default

The reporter's own data is the argument: `implement` steps legitimately run 66–84 minutes. Dropping the default to 30m would kill working pipelines on upgrade — a silent, destructive behaviour change made in the name of fixing a documentation typo.

`TaskTimeoutDuration`'s value is now a named constant with a test asserting it, so the code and the docs can only diverge again through a deliberate edit.

## The real complaint, addressed

2h *is* a weak runaway bound. But a total timeout is the wrong instrument for catching a hung process — it can't distinguish a step doing an hour of work from one wedged for an hour.

`settings.stall_timeout` measures **silence instead of duration**: a run producing no output at all for the configured period is killed.

```yaml
settings:
  task_timeout: 2h      # total bound — the backstop
  stall_timeout: 20m    # no output at all for this long — the hang detector
```

A step streaming tool calls for ninety minutes survives. One silent for twenty does not. That's exactly the distinction the issue asked for.

**It's opt-in**, and deliberately so: it only makes sense for runners that stream as they work, and a runner buffering until exit would look permanently stalled. Enabling it globally would kill those runs on upgrade to fix a problem they don't have. Defaulting it on for the streaming CLI runners is a reasonable follow-up once each adapter's behaviour is confirmed.

## Both asks in the issue

**1. Log the effective bound at step start.** The question being asked when a step has run an hour is *whether it is bounded at all*, and the log couldn't answer it:

```
step implement: timeout 2h0m0s, stall timeout 20m0s
step implement: timeout 2h0m0s (no stall timeout; set settings.stall_timeout to bound silence)
```

**2. A stall bound separate from total runtime** — above.

## A bound that fires now says so

A killed process reports only `signal: killed`, so a timeout, a stall and a crash were indistinguishable in the run history despite calling for opposite responses. Now:

```
killed at the 2h0m0s run timeout (settings.task_timeout) after 2h0m1s
killed after producing no output for 20m0s (settings.stall_timeout); ran for 47m12s in total
```

This also explains something I saw in real failure data while building the advisor: opaque `signal: killed: {raw JSON…}` clusters, where the error detail had fallen back to scraped stdout because there was no real message. Those were very likely timeouts.

## Testing

`make check` green (33 packages). The runner tests also pass under `-race`, which matters because the stall watchdog is a goroutine reading shared state.

Behavioural tests against real subprocesses, not fakes:
- a timeout is reported as a timeout, naming the bound and the setting, with no bare `signal: killed`
- a silent run is killed by the stall bound
- **a chatty run survives well past its stall bound** — the test that proves this measures silence rather than duration
- with no stall timeout configured, a quiet run is untouched
- an ordinary non-zero exit keeps its diagnosable stderr and is *not* relabelled a timeout

Plus config tests pinning the real default and the parsing edge cases (unparseable `task_timeout` falls back to the default rather than disabling the bound; unparseable or negative `stall_timeout` stays disabled rather than silently enabling a killer).