### PR TITLE
fix(examples): pin spec-decompose to a source that can host sub-issues

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -509,13 +509,18 @@ workflows:
   # no inline workflow runs. The created sub-issues carry agent:* labels, so the
   # normal poll→route loop dispatches the right implementer on the next cycle — the
   # same path a human-filed issue takes.
+  #
+  # The trigger pins the github source: `materialize: sub_issue` needs an adapter
+  # that implements source.SubIssueCreator, and github is the only one that does —
+  # `apiary validate` rejects the workflow when it is pinned to a source without
+  # that capability (plane, jira, and the read-only alert sources).
   - id: spec-decompose
     description: "Turn a spec issue into a deduplicated set of implementer sub-issues."
     trigger:
       priority: 15
       once: true
       match:
-        source: project-erp
+        source: my-repo
         labels: [agent:po]
     steps:
       - id: spec

--- a/src/internal/cli/examples_validate_test.go
+++ b/src/internal/cli/examples_validate_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+
+	// Register every source adapter cmd/apiary registers, so the capability
+	// probes wired in init() see the real adapters the examples reference.
+	_ "github.com/orlandoburli/apiary/internal/source/dynatrace"
+	_ "github.com/orlandoburli/apiary/internal/source/github"
+	_ "github.com/orlandoburli/apiary/internal/source/jira"
+	_ "github.com/orlandoburli/apiary/internal/source/plane"
+	_ "github.com/orlandoburli/apiary/internal/source/pluginsource"
+	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
+)
+
+// TestExampleConfigsValidate loads every shipped .apiary/example-*.yaml through
+// the same path `apiary validate` uses (config.Load + Config.Validate, with the
+// cli init() hooks wired) and requires it to be error-free. These files are the
+// reference users copy from — docs/SCHEMA_SETUP.md presents them as such — so an
+// example that no longer validates teaches the wrong config and undermines
+// `apiary validate` itself. This catches the drift a new lint would otherwise
+// introduce silently (e.g. the #357 source-capability check, which left
+// example-apiary-full.yaml pinning a `materialize: sub_issue` step to a plane
+// source that cannot host it).
+//
+// Plugin validation (configuredPlugins) is deliberately not run: it discovers
+// binaries on disk and is environment-dependent, not a property of the file.
+func TestExampleConfigsValidate(t *testing.T) {
+	// Run from the repo root: the examples carry root-relative paths
+	// (soul_file: .apiary/souls/…) that only resolve where the daemon runs.
+	t.Chdir(filepath.Join("..", "..", ".."))
+
+	paths, err := filepath.Glob(filepath.Join(".apiary", "example-*.yaml"))
+	if err != nil {
+		t.Fatalf("glob example configs: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no .apiary/example-*.yaml found — has the examples directory moved?")
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			cfg, err := config.Load(path)
+			if err != nil {
+				t.Fatalf("config.Load(%s): %v", path, err)
+			}
+			for _, e := range cfg.Validate() {
+				t.Errorf("validation error: %v", e)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The shipped example config fails validation on `main`:

```
apiary --config .apiary/example-apiary-full.yaml validate
✗ workflows[8] "spec-decompose": step "spec" (materialize: sub_issue) requires a capability
  that source "project-erp" (type "plane") does not support
```

`materialize: sub_issue` requires an adapter implementing `source.SubIssueCreator`, and github is the only one that does — plane, jira, prometheus, dynatrace and plugin sources all lack it. The workflow's own comments describe creating "a real GitHub issue under the parent", so the trigger pin to the plane source was the bug, not the step.

The examples are the reference users copy from (`docs/SCHEMA_SETUP.md` presents them as such), so shipping one that does not validate teaches the wrong config and undermines `apiary validate`.

## Changes

- Retarget the `spec-decompose` trigger at the `my-repo` github source already defined in the same file, and note the capability requirement in a comment so the next reader knows why the pin matters.
- Add `TestExampleConfigsValidate`: globs every `.apiary/example-*.yaml` and runs it through the same path the validate command uses (`config.Load` + `Config.Validate`, with the cli `init()` capability hooks and all real source adapters registered). A new lint can no longer silently invalidate a shipped example.
  - It `t.Chdir`s to the repo root — the examples carry root-relative `soul_file:` paths that only resolve from where the daemon runs.
  - It skips `configuredPlugins`, which the validate command also runs: plugin discovery inspects binaries on disk and is environment-dependent, not a property of the file.

The other two examples (`example-with-recovery.yaml`, `example-workflow.yaml`) already validated and are unchanged.

## Verification

- `make check` green (full build + test suite).
- All three examples pass `apiary validate` via the CLI.
- Confirmed the new test catches the regression: reverting the source pin makes it fail with exactly the original error.

One pre-existing, unrelated warning remains on the full example — `collect-logs` has no trigger and is not referenced as a sub-workflow (it is dispatched by name via `APIARY_SPAWN`, which the lint cannot see). Warning, not an error; validation passes.