### PR TITLE
feat(dispatch): manual workflow runs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,12 +205,58 @@ routing without starting an agent.
 
 ### `apiary dispatch`
 
-Manually dispatch a task, bypassing routing. Useful for testing a
-configuration.
+Start one named workflow right now, whether or not anything would have triggered
+it. Same action as `W` in the dashboard.
 
 ```sh
-apiary dispatch --cell <source-id>/<task-id> --worker <worker-id>
+apiary dispatch triage --item CDT-123     # run `triage` on an existing item
+apiary dispatch nightly-audit             # run standalone, with no source item
+apiary dispatch report --input scope=q3   # standalone, with structured input
 ```
+
+A manual run skips **every** gate the poll loop applies:
+
+| Skipped | Meaning |
+|---------|---------|
+| the trigger's `match` block | states, labels, types, `title_regex`, source — the item does not have to look like something the trigger would select |
+| exclusive-trigger suppression | a higher-priority `exclusive: true` trigger does not claim the task away |
+| the live-instance guard | a workflow already running on the task starts a **second concurrent instance** |
+| `once: true` | a spent one-shot workflow runs again |
+| the consecutive-failure cap | `settings.max_attempts` does not block the run |
+
+Every bypass is printed, so none of them is silent:
+
+```
+✓ Started workflow triage on CDT-123 (10042)
+  ! this workflow was already running on the task — a second instance is now live
+  ! bypassed guard: trigger match (state/labels/filters)
+  ! bypassed guard: exclusive trigger suppression
+  ! bypassed guard: active instance / in-flight
+  ! bypassed guard: once
+  ! bypassed guard: consecutive-failure cap
+  → follow it with: apiary instances
+```
+
+**With `--item`** the run binds an existing source item and behaves exactly like
+an automatic dispatch of that workflow: it sees the item's live labels and state,
+and side effects (comments, state locks, sub-issues) write back to the source.
+The value is the item's human reference (`CDT-123`, `#1953`) or its cell id — the
+same vocabulary [`apiary restart`](#apiary-restart) accepts. A reference that
+resolves to nothing fails and creates nothing.
+
+**Without `--item`** the workflow runs standalone on a fresh internal task with no
+source binding. Nothing writes back to a source: comment and state-lock steps are
+no-ops and sub-issues cannot be materialized. Pass `--input key=value` (repeatable)
+for values the steps read as `${{ input.<key> }}`, and `--title` to name the task.
+
+This is what makes a **trigger-less workflow** useful: a workflow with no
+`trigger:` block never starts on its own — `apiary validate` warns about exactly
+that — but `apiary dispatch <id>` runs it on demand.
+
+Because guards are skipped rather than overridden, nothing in the daemon prevents
+two runs of the same workflow on the same task from racing. Where that matters —
+steps that mutate the same branch, comment, or item state — start the second run
+after the first settles.
 
 ### `apiary restart`
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -69,6 +69,7 @@ The dashboard has four tabs along the top. Use the keyboard to move:
 | `PgUp` / `PgDn`             | Page up / down                                    |
 | `Ctrl+U` / `Ctrl+D` / `Space` | Alternative page up / down                      |
 | `r`                          | Refresh now                                       |
+| `W` (Shift+W)               | [Start a workflow manually](#starting-a-workflow-manually) |
 | `q` / `Ctrl+C`              | Quit                                              |
 
 The active tab refreshes on its own every couple of seconds. The footer shows
@@ -114,6 +115,7 @@ From the list you can drill into the selected task:
 | `Enter` or `l`         | **Logs** — the per-task log lines for that run     |
 | `o`                    | **Open** the task in your browser (its source URL) |
 | `R` (Shift+R)          | **Force restart** — cancel and re-dispatch the task (with confirmation) |
+| `W` (Shift+W)          | **Start a workflow** on the task, ignoring triggers and guards |
 | `C`                    | **Clear logs** — delete all logs for the task (with confirmation) |
 | `Esc` / `Backspace` / `h` / `←` | Back to the list                          |
 
@@ -182,6 +184,29 @@ genuinely running is not started a second time.
 
 Pressing **`C`** on a selected task works the same way — confirm with `y` / `Y`
 to delete the task's logs and execution records, or any other key to cancel.
+
+#### Starting a workflow manually
+
+**`W`** (Shift+W) opens a picker listing every configured workflow. `↑` / `↓`
+select, `Enter` starts, `Esc` cancels. It works from any tab.
+
+Where `R` re-runs *whatever matches* an item, `W` runs *the workflow you name* —
+matched or not. It skips the trigger's `match` block, exclusive suppression, the
+live-instance guard, `once`, and the failure cap. Starting a workflow that is
+already running on the task is allowed: the banner says so, and you get a second
+concurrent instance.
+
+The header of the picker names the target before you commit to it:
+
+- **`item <id>`** — the task focused when you pressed `W`. The run binds it and
+  writes back to the source like any other dispatch.
+- **`standalone — no source item`** — no task was focused, or you pressed `s` to
+  detach from it. The workflow runs on a fresh internal task; comments, state
+  locks and sub-issues are no-ops for that run.
+
+The result appears as the usual banner, e.g. `✓ Started triage on CDT-123 (10042)
+(bypassed triggers and guards)`. Use [`apiary dispatch`](cli.md#apiary-dispatch)
+for the same thing from a shell, where you can also pass `--input`.
 
 #### Watching the live conversation (debug mode)
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -48,6 +48,10 @@ trigger:
     labels: [backend, bug]
 ```
 
+A workflow with **no** `trigger:` block never starts on its own. That is a valid
+configuration — see [Manual runs](#manual-runs) — but `apiary validate` warns
+about it, since an unreachable workflow is usually a mistake.
+
 ### `match` fields
 
 | Field | Description |
@@ -99,6 +103,31 @@ which are not reconsidered; nothing will run for this task until the reason clea
 If you want the lower-priority workflow to take over in that state, make the
 handover explicit — narrow the exclusive trigger's `match` so it stops matching
 once its work is done (e.g. on a label the workflow itself sets).
+
+### Manual runs
+
+Everything above describes when a workflow starts **on its own**. Any workflow
+can also be started by hand, which skips all of it:
+
+```sh
+apiary dispatch triage --item CDT-123   # this workflow, this item, right now
+apiary dispatch nightly-audit           # standalone: no source item at all
+```
+
+The same action is `W` in the dashboard. A manual run ignores the trigger's
+`match` block, exclusive suppression, the live-instance guard, `once`, and the
+consecutive-failure cap — so it starts a **second concurrent instance** of a
+workflow that is already running, by design. Every bypass is reported.
+
+Two consequences worth knowing:
+
+- A workflow with no `trigger:` block is perfectly usable as a **manual-only**
+  workflow: maintenance jobs, audits, one-off reports.
+- A standalone run (no `--item`) has no source binding, so steps that write back
+  to a source — comments, state locks, `materialize: sub_issue` — are no-ops.
+  Pass `--input key=value` for the values those workflows need instead.
+
+See [`apiary dispatch`](cli.md#apiary-dispatch) for the full behaviour.
 
 ### PR event triggers (`on:`)
 

--- a/src/internal/cli/dispatch.go
+++ b/src/internal/cli/dispatch.go
@@ -1,33 +1,138 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/daemon"
 )
 
 func newDispatchCmd() *cobra.Command {
 	var (
-		cell   string
-		worker string
+		item   string
+		title  string
+		inputs []string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "dispatch",
-		Short: "Manually dispatch a task to a worker",
+		Use:   "dispatch <workflow-id>",
+		Short: "Start a workflow manually",
+		Long: `Start one named workflow right now, whether or not anything would have
+triggered it.
+
+A manual run skips every gate the poll loop applies:
+
+  • the trigger's match block — states, labels, type, title_regex, source
+  • exclusive-trigger suppression
+  • the live-instance guard, so a workflow already running on the task starts a
+    SECOND concurrent instance
+  • ` + "`once: true`" + `, and the consecutive-failure cap (settings.max_attempts)
+
+With --item the run binds an existing source item and behaves exactly like an
+automatic dispatch of that workflow: the same live labels and state, and side
+effects (comments, state locks, sub-issues) write back to the source. <item> is
+the source item id or its human reference (CDT-123, #1953), the same vocabulary
+` + "`apiary restart`" + ` accepts.
+
+Without --item the workflow runs standalone on a fresh internal task with no
+source binding. Nothing writes back to a source: comment and state-lock steps
+are no-ops and sub-issues cannot be materialized. Use --input to pass values the
+steps read as ${{ input.<key> }}.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cell == "" {
-				return fmt.Errorf("--cell is required (format: <source-id>/<task-id>)")
+			workflowID := strings.TrimSpace(args[0])
+			if workflowID == "" {
+				return fmt.Errorf("a workflow id is required")
 			}
-			if worker == "" {
-				return fmt.Errorf("--worker is required")
+			input, err := parseInputPairs(inputs)
+			if err != nil {
+				return err
 			}
-			fmt.Printf("dispatching cell %q to worker %q (not yet implemented)\n", cell, worker)
+
+			body, err := json.Marshal(map[string]any{"input": input, "title": title})
+			if err != nil {
+				return fmt.Errorf("encoding request: %w", err)
+			}
+
+			socketPath := daemon.SocketPath(config.DataDir(configFile))
+			transport := &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+				},
+			}
+			client := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+
+			url := "http://apiary/workflows/" + neturl.PathEscape(workflowID) + "/run"
+			if item != "" {
+				url += "?item=" + neturl.QueryEscape(item)
+			}
+			resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+			if err != nil {
+				return fmt.Errorf("cannot reach daemon: %w", err)
+			}
+			defer resp.Body.Close()
+
+			payload, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			if resp.StatusCode != http.StatusAccepted {
+				if msg := strings.TrimSpace(string(payload)); msg != "" {
+					return fmt.Errorf("dispatch failed: %s", msg)
+				}
+				return fmt.Errorf("dispatch failed: HTTP %d", resp.StatusCode)
+			}
+
+			var res daemon.ManualRunResult
+			if err := json.Unmarshal(payload, &res); err != nil {
+				fmt.Printf("✓ Started workflow %s\n", workflowID)
+				return nil
+			}
+
+			fmt.Printf("✓ Started workflow %s on %s\n", res.WorkflowID, res.Label())
+			if res.Concurrent {
+				fmt.Printf("  ! this workflow was already running on the task — a second instance is now live\n")
+			}
+			if res.Standalone {
+				fmt.Printf("  → no source item bound: comments, state locks and sub-issues are no-ops for this run\n")
+			}
+			for _, b := range res.Bypassed {
+				fmt.Printf("  ! bypassed guard: %s\n", b)
+			}
+			fmt.Printf("  → follow it with: apiary instances\n")
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&cell, "cell", "", "cell to dispatch (source-id/task-id)")
-	cmd.Flags().StringVar(&worker, "worker", "", "worker id to invoke")
+	cmd.Flags().StringVar(&item, "item", "", "source item to run against (item id or reference like CDT-123, #1953); omit to run standalone")
+	cmd.Flags().StringVar(&title, "title", "", "title for the task created by a standalone run")
+	cmd.Flags().StringArrayVar(&inputs, "input", nil, "key=value passed to a standalone run's task input, readable as ${{ input.<key> }} (repeatable)")
 	return cmd
+}
+
+// parseInputPairs turns repeated --input key=value flags into the task input map.
+// Values stay strings: the flag has no type information, and a workflow reading
+// ${{ input.x }} interpolates it as text either way.
+func parseInputPairs(pairs []string) (map[string]any, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]any, len(pairs))
+	for _, p := range pairs {
+		key, value, ok := strings.Cut(p, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid --input %q: expected key=value", p)
+		}
+		out[key] = value
+	}
+	return out, nil
 }

--- a/src/internal/cli/dispatch_test.go
+++ b/src/internal/cli/dispatch_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import "testing"
+
+func TestParseInputPairs(t *testing.T) {
+	got, err := parseInputPairs([]string{"scope=q3", "dry_run=true", "note=a=b"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["scope"] != "q3" || got["dry_run"] != "true" {
+		t.Errorf("parsed = %v", got)
+	}
+	// Only the first '=' separates: a value may legitimately contain more.
+	if got["note"] != "a=b" {
+		t.Errorf("note = %q, want %q", got["note"], "a=b")
+	}
+}
+
+func TestParseInputPairs_Empty(t *testing.T) {
+	got, err := parseInputPairs(nil)
+	if err != nil || got != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil) so no input field is sent", got, err)
+	}
+}
+
+func TestParseInputPairs_Invalid(t *testing.T) {
+	for _, bad := range []string{"noequals", "=novalue"} {
+		if _, err := parseInputPairs([]string{bad}); err == nil {
+			t.Errorf("parseInputPairs(%q) accepted a malformed pair", bad)
+		}
+	}
+}

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -794,8 +794,8 @@ func (c *Config) WorkflowWarnings() []string {
 		}
 		if wf.Trigger == nil && !referenced[wf.ID] {
 			warnings = append(warnings, fmt.Sprintf(
-				"workflow %q has no trigger and is not referenced as a sub-workflow; it will never run",
-				wf.ID))
+				"workflow %q has no trigger and is not referenced as a sub-workflow; it will never run on its own (start it with `apiary dispatch %s`)",
+				wf.ID, wf.ID))
 		}
 	}
 	return warnings

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1655,7 +1655,10 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(d.WorkflowList())
 	})
-	// MANUAL_RUN_ROUTE_PLACEHOLDER
+	// POST /workflows/{id}/run — start one named workflow on demand, bypassing
+	// every trigger and pre-dispatch guard. Registered on the subtree so the
+	// exact-match /workflows listing above keeps its own handler.
+	mux.HandleFunc("/workflows/", d.manualRunHandler(ctx))
 	mux.HandleFunc("/instances/stop/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -851,10 +851,14 @@ func (d *Dispatcher) RunOnce(ctx context.Context) error {
 				d.inFlight.Delete(cell.ID)
 				continue
 			}
-			d.fanOut(ctx, cell, adapter, task, persisted, matches, &wg, func(id string) {
-				mu.Lock()
-				failedIDs = append(failedIDs, id)
-				mu.Unlock()
+			d.fanOut(ctx, cell, adapter, task, persisted, matches, fanOutOpts{
+				wg: &wg,
+				onFail: func(id string) {
+					mu.Lock()
+					failedIDs = append(failedIDs, id)
+					mu.Unlock()
+				},
+				ownsInFlight: true,
 			})
 		}
 	}
@@ -1293,7 +1297,7 @@ func (d *Dispatcher) redispatchCell(ctx context.Context, cell model.SourceItem, 
 	}
 	d.dropNotified.Delete(task.ID)
 	aplog.Info("force-restart %s: dispatching %d workflow(s): %v", cell.LogLabel(), len(ids), ids)
-	d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+	d.fanOut(ctx, cell, adapter, task, persisted, matches, fanOutOpts{ownsInFlight: true})
 	return len(ids), ids, overridden
 }
 
@@ -1651,6 +1655,7 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(d.WorkflowList())
 	})
+	// MANUAL_RUN_ROUTE_PLACEHOLDER
 	mux.HandleFunc("/instances/stop/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1856,7 +1861,7 @@ func (d *Dispatcher) poll(ctx context.Context, sc config.SourceConfig, adapter s
 			continue
 		}
 		d.dropNotified.Delete(task.ID)
-		d.fanOut(ctx, cell, adapter, task, persisted, matches, nil, nil)
+		d.fanOut(ctx, cell, adapter, task, persisted, matches, fanOutOpts{ownsInFlight: true})
 	}
 
 	// PR events (trigger.on: pr_*) ride the same poll cadence, after item
@@ -1903,14 +1908,44 @@ func (d *Dispatcher) WaitBackground(timeout time.Duration) bool {
 	}
 }
 
-func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, persisted bool, matches []router.Match, wg *sync.WaitGroup, onFail func(cellID string)) {
+// fanOutOpts carries the knobs that differ between fan-out callers. It exists so
+// the manual-run path can join the same dispatch machinery — queue, semaphores,
+// activeRuns, outstanding accounting — while differing on the two things a manual
+// run must not share with a poll: the in-flight marker it does not own, and the
+// queue idempotency key it must not collide with.
+type fanOutOpts struct {
+	// wg, when non-nil, is signalled per dispatch AND forces inline dispatch:
+	// callers that wait on the runs cannot have them handed to a queue worker.
+	wg *sync.WaitGroup
+	// onFail is called with the cell id for every dispatch that returns
+	// Success == false.
+	onFail func(cellID string)
+	// idemSuffix widens the queue idempotency key beyond taskID:generation:routeID.
+	// Empty for poll and restart, which rely on that key to de-duplicate overlapping
+	// rounds; set per run by a manual dispatch, whose whole point is that a second
+	// identical run is a second run and not a duplicate.
+	idemSuffix string
+	// ownsInFlight reports whether this fan-out stored d.inFlight[cell.ID] and may
+	// therefore clear it when the dispatches finish. A manual run never stores it,
+	// and clearing another path's marker would release a concurrent poll's guard
+	// early — the next tick would then dispatch the cell a second time.
+	ownsInFlight bool
+}
+
+func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter source.Adapter, task model.InternalTask, persisted bool, matches []router.Match, opts fanOutOpts) {
+	wg, onFail := opts.wg, opts.onFail
+	releaseInFlight := func() {
+		if opts.ownsInFlight {
+			d.inFlight.Delete(cell.ID)
+		}
+	}
 	if len(matches) == 0 {
-		d.inFlight.Delete(cell.ID)
+		releaseInFlight()
 		return
 	}
 	if persisted && d.dispatchQueue != nil && wg == nil {
-		d.enqueueFanOut(ctx, cell, task, matches)
-		d.inFlight.Delete(cell.ID)
+		d.enqueueFanOut(ctx, cell, task, matches, opts.idemSuffix)
+		releaseInFlight()
 		return
 	}
 
@@ -1978,7 +2013,7 @@ func (d *Dispatcher) fanOut(ctx context.Context, cell model.SourceItem, adapter 
 	// the cell can be re-polled (and re-routed against its refreshed task).
 	d.goBackground(func() {
 		inner.Wait()
-		d.inFlight.Delete(cell.ID)
+		releaseInFlight()
 	})
 }
 

--- a/src/internal/daemon/manual_run.go
+++ b/src/internal/daemon/manual_run.go
@@ -1,0 +1,365 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// ErrUnknownWorkflow is returned when the requested workflow id is not in the
+// live config. It must fail closed: resolveWorkflow answers an unknown id with a
+// zero WorkflowConfig, which would create an instance with no steps that reports
+// success having done nothing.
+var ErrUnknownWorkflow = errors.New("unknown workflow")
+
+// ManualRunRequest asks the daemon to start one named workflow on demand.
+type ManualRunRequest struct {
+	// WorkflowID names the workflow to run. Required.
+	WorkflowID string `json:"workflow_id"`
+	// ItemRef optionally targets an existing source item — a cell id or the
+	// item's human reference (CDT-123, #1953), the same vocabulary `apiary
+	// restart` accepts. Empty runs the workflow standalone on a fresh internal
+	// task with no source binding.
+	ItemRef string `json:"item_ref,omitempty"`
+	// Input seeds a standalone run's task input, readable from steps as
+	// ${{ input.* }}. Ignored when ItemRef is set — that task's input belongs to
+	// the source binding.
+	Input map[string]any `json:"input,omitempty"`
+	// Title overrides the generated title of a standalone run's task.
+	Title string `json:"title,omitempty"`
+}
+
+// ManualRunResult reports what a manual run actually targeted. Dispatch itself is
+// asynchronous — the run outlives the request that started it — so this describes
+// the target and the guards bypassed, not the outcome.
+type ManualRunResult struct {
+	WorkflowID string `json:"workflow_id"`
+	TaskID     string `json:"task_id"`
+	CellID     string `json:"cell_id,omitempty"`
+	Ref        string `json:"ref,omitempty"`
+	// Standalone reports that no source item is bound: side effects that write
+	// back to a source (comments, state locks, sub-issues) are no-ops for this run.
+	Standalone bool `json:"standalone"`
+	// Concurrent reports that the workflow already had a live instance on this
+	// task when the run started, so this is a second one. Manual runs allow that
+	// deliberately; callers surface it as a warning.
+	Concurrent bool `json:"concurrent"`
+	// Bypassed names the pre-dispatch guards this run did not evaluate, so a
+	// bypass is never silent (mirrors RestartResult.Overridden).
+	Bypassed []string `json:"bypassed,omitempty"`
+}
+
+// manualRunHandler serves POST /workflows/{id}/run.
+//
+// runCtx must be the daemon's lifetime context: dispatch is asynchronous, so a
+// run started from the request context would be cancelled the moment the caller
+// disconnects. Same reasoning as the /resume/ handler.
+func (d *Dispatcher) manualRunHandler(runCtx context.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		rest := strings.TrimPrefix(r.URL.Path, "/workflows/")
+		wfID, action, _ := strings.Cut(rest, "/")
+		// Unescape: a workflow id is config-authored and may contain characters
+		// the caller had to escape on the way in.
+		if unescaped, err := url.PathUnescape(wfID); err == nil {
+			wfID = unescaped
+		}
+		if action != "run" {
+			http.Error(w, "not found: expected /workflows/{id}/run", http.StatusNotFound)
+			return
+		}
+
+		req := ManualRunRequest{WorkflowID: wfID, ItemRef: r.URL.Query().Get("item")}
+		// A body is optional; only a malformed one is an error.
+		if body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20)); len(bytes.TrimSpace(body)) > 0 {
+			var payload struct {
+				Input map[string]any `json:"input"`
+				Title string         `json:"title"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			req.Input, req.Title = payload.Input, payload.Title
+		}
+
+		res, err := d.RunWorkflowManual(runCtx, req)
+		if err != nil {
+			http.Error(w, err.Error(), manualRunHTTPStatus(err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(res)
+	}
+}
+
+// manualRunHTTPStatus maps a manual-run error to its IPC HTTP status, mirroring
+// resumeHTTPStatus.
+func manualRunHTTPStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrUnknownWorkflow):
+		return http.StatusNotFound
+	case errors.Is(err, ErrUnknownCell), errors.Is(err, ErrAmbiguousRef):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// Label returns the reference to show a human for the run's target.
+func (r ManualRunResult) Label() string {
+	switch {
+	case r.Standalone:
+		return "standalone task " + r.TaskID
+	case r.Ref != "" && r.Ref != r.CellID:
+		return fmt.Sprintf("%s (%s)", r.Ref, r.CellID)
+	case r.CellID != "":
+		return r.CellID
+	default:
+		return r.TaskID
+	}
+}
+
+// manualBypassed is what a manual run skips, in the order the poll loop would
+// have applied them. It is a constant rather than a computed list: the manual
+// path never evaluates these guards at all, so there is nothing to observe.
+var manualBypassed = []string{
+	"trigger match (state/labels/filters)",
+	"exclusive trigger suppression",
+	"active instance / in-flight",
+	"once",
+	"consecutive-failure cap",
+}
+
+// RunWorkflowManual starts one named workflow immediately, regardless of whether
+// anything would have triggered it.
+//
+// Every guard the poll loop applies lives on the poll path — trigger matching in
+// Router.RouteAll, then dropAutoResumingMatches / dropActiveMatches /
+// dropOnceMatches / dropCappedMatches. A manual run does not switch them off; it
+// never enters that path. It resolves the workflow by name, builds the Match by
+// hand (router.ManualMatch) and fans out directly, so a workflow runs even when
+// its trigger does not match the item's current state, when its `once` is spent,
+// when it is capped by consecutive failures, when an exclusive trigger would have
+// claimed the task — and even when the same workflow is already running on the
+// same task, which yields a second concurrent instance.
+//
+// Everything downstream of the guards is shared with an automatic dispatch: the
+// queue (when enabled), agent semaphores, activeRuns, outstanding-workflow
+// accounting, transcripts and execution events.
+//
+// Dispatch is asynchronous. ctx must be the daemon's lifetime context, not a
+// request context, or the run is cancelled when the caller disconnects.
+func (d *Dispatcher) RunWorkflowManual(ctx context.Context, req ManualRunRequest) (ManualRunResult, error) {
+	wfID := strings.TrimSpace(req.WorkflowID)
+	res := ManualRunResult{WorkflowID: wfID, Bypassed: manualBypassed}
+
+	wf, ok := d.workflowByID(wfID)
+	if !ok {
+		return res, fmt.Errorf("%w: %q (known: %s)", ErrUnknownWorkflow, wfID, strings.Join(d.workflowIDs(), ", "))
+	}
+	match, ok := router.ManualMatch(wf)
+	if !ok {
+		// Only reachable for a workflow with an empty id, which config validation
+		// rejects; guard anyway rather than dispatch something unresolvable.
+		return res, fmt.Errorf("%w: %q cannot be resolved to a route", ErrUnknownWorkflow, wfID)
+	}
+
+	var (
+		cell      model.SourceItem
+		adapter   source.Adapter
+		task      model.InternalTask
+		persisted bool
+		err       error
+	)
+	if strings.TrimSpace(req.ItemRef) == "" {
+		task, err = d.standaloneTask(ctx, wf, req)
+		if err != nil {
+			return res, err
+		}
+		persisted = true
+		res.Standalone = true
+		// The engine's sourceItemView falls back to the task when there are no
+		// bindings; mirroring that here keeps logs and activeRuns readable.
+		cell = model.SourceItem{ID: task.ID, Title: task.Title}
+	} else {
+		cell, adapter, task, persisted, err = d.manualTargetItem(ctx, req.ItemRef)
+		if err != nil {
+			return res, err
+		}
+		res.CellID = cell.ID
+	}
+	res.TaskID = task.ID
+	if res.Ref == "" && res.CellID != "" {
+		if _, number, refErr := d.resolveCellRef(ctx, req.ItemRef); refErr == nil {
+			res.Ref = number
+		}
+	}
+
+	// Report — never block on — an existing live instance. Starting a second one
+	// is the documented behaviour, but an operator who did not mean to should see
+	// it in the response, not discover it later in the instance list.
+	if persisted && d.db != nil {
+		if active, err := d.db.HasActiveInstanceForRoute(ctx, task.ID, wf.ID); err != nil {
+			aplog.Debug("manual run %s: checking live instances: %v", wf.ID, err)
+		} else {
+			res.Concurrent = active
+		}
+	}
+
+	aplog.Info("manual run: dispatching workflow %s on %s [agent %s] — bypassing %s%s",
+		wf.ID, res.Label(), match.Route.Agent, strings.Join(manualBypassed, ", "),
+		map[bool]string{true: " (a live instance already exists — starting a second)", false: ""}[res.Concurrent])
+
+	// A per-run nonce, so a repeat manual run is a second job rather than a
+	// duplicate swallowed by the queue's idempotency key. Bumping the dispatch
+	// generation would free the key too, but that is restart's semantics — it
+	// invalidates the keys of rounds that are legitimately in flight.
+	d.fanOut(ctx, cell, adapter, task, persisted, []router.Match{match}, fanOutOpts{
+		idemSuffix: "manual-" + manualRunNonce(),
+		// The manual path never stores d.inFlight[cell.ID]: it does not use it as
+		// a guard, and clearing an entry a concurrent poll owns would let the next
+		// tick dispatch that cell a second time.
+		ownsInFlight: false,
+	})
+	return res, nil
+}
+
+// workflowIDs returns every configured workflow id, sorted — the "did you mean"
+// list on an unknown id.
+func (d *Dispatcher) workflowIDs() []string {
+	if d.cfg == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(d.cfg.Workflows))
+	for _, wf := range d.cfg.Workflows {
+		if wf.ID != "" {
+			ids = append(ids, wf.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// standaloneTask creates the internal task a source-less manual run executes
+// against. It follows the spawned-task convention (model.InternalTask): no
+// binding, no source in metadata, structured Input readable as ${{ input.* }}.
+func (d *Dispatcher) standaloneTask(ctx context.Context, wf config.WorkflowConfig, req ManualRunRequest) (model.InternalTask, error) {
+	if d.db == nil {
+		return model.InternalTask{}, errors.New("manual run without an item needs a database — none is configured")
+	}
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		title = "manual run: " + wf.ID
+	}
+	task := model.InternalTask{
+		Title:       title,
+		Description: wf.Description,
+		Input:       req.Input,
+		State:       model.TaskStateRegistered,
+		Metadata:    model.TaskMetadata{Type: "manual"},
+	}
+	if err := d.db.InternalTasks().CreateTask(ctx, &task); err != nil {
+		return model.InternalTask{}, fmt.Errorf("create task for manual run of %s: %w", wf.ID, err)
+	}
+	aplog.Info("manual run: created standalone task %s (%q) for workflow %s", task.ID, task.Title, wf.ID)
+	return task, nil
+}
+
+// manualTargetItem resolves an item reference to the cell, adapter and bound task
+// a manual run executes against — the same binding a poll of that item produces,
+// so the run sees live labels and state.
+//
+// It fails closed. A reference that resolves to no known item returns
+// ErrUnknownCell and creates nothing: silently falling back to a standalone task
+// would run the workflow against an empty target while reporting success, which
+// is the mis-targeting class of bug #377 was about.
+func (d *Dispatcher) manualTargetItem(ctx context.Context, ref string) (model.SourceItem, source.Adapter, model.InternalTask, bool, error) {
+	cellID, _, err := d.resolveCellRef(ctx, ref)
+	if err != nil {
+		return model.SourceItem{}, nil, model.InternalTask{}, false, err
+	}
+	if err := d.assertKnownCell(ctx, cellID); err != nil {
+		return model.SourceItem{}, nil, model.InternalTask{}, false, err
+	}
+
+	cell, adapter, ok := d.fetchCell(ctx, cellID)
+	if !ok {
+		// No source can read the item right now (no TaskPoller, or the fetch
+		// failed). The binding still knows what the task is, so the workflow can
+		// run — it just routes on the last-known attributes and cannot write back
+		// through an adapter.
+		aplog.Warn("manual run: no source could fetch item %s — running on its last known state", cellID)
+		cell = model.SourceItem{ID: cellID}
+		if b, err := d.db.SourceBindings().GetBindingBySourceItemID(ctx, cellID); err == nil && b != nil {
+			cell.SourceID = b.SourceID
+			if t, err := d.db.InternalTasks().GetTask(ctx, b.TaskID); err == nil && t != nil {
+				return cell, nil, *t, true, nil
+			}
+		}
+	}
+
+	task, persisted := d.bindItem(ctx, cell)
+	return cell, adapter, task, persisted, nil
+}
+
+// fetchCell reads a source item from whichever configured source can poll it,
+// returning the adapter alongside so side effects can write back. It is the
+// read-only half of ForceRestart's label-stripping loop: same TaskPoller scan and
+// same refusal to accept a substituted item, without touching anything.
+func (d *Dispatcher) fetchCell(ctx context.Context, cellID string) (model.SourceItem, source.Adapter, bool) {
+	for _, sc := range d.cfg.Sources {
+		adapter, ok := d.sources[sc.ID]
+		if !ok {
+			continue
+		}
+		poller, ok := adapter.(source.TaskPoller)
+		if !ok {
+			continue
+		}
+		cell, err := poller.PollTask(ctx, cellID)
+		if err != nil {
+			aplog.Debug("manual run: %s cannot fetch item %s: %v", sc.ID, cellID, err)
+			continue
+		}
+		if cell.ID != "" && cell.ID != cellID {
+			aplog.Error("manual run: %s returned item %s for %s — ignoring it", sc.ID, cell.ID, cellID)
+			continue
+		}
+		cell.ID = cellID
+		return cell, adapter, true
+	}
+	return model.SourceItem{}, nil, false
+}
+
+// manualRunNonce returns 64 bits of randomness as hex — enough to keep two manual
+// runs of the same workflow on the same task from sharing a queue idempotency key.
+func manualRunNonce() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand does not fail in practice; if it ever does, a colliding key
+		// only means the second run de-duplicates, which is safe.
+		return "0"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/src/internal/daemon/manual_run_test.go
+++ b/src/internal/daemon/manual_run_test.go
@@ -1,0 +1,320 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+// manualDispatcher wires the queue harness with a source that can also fetch a
+// single item, which is what an item-bound manual run needs.
+func manualDispatcher(t *testing.T) (*Dispatcher, *pollableAdapter, *db.Client) {
+	t.Helper()
+	d, base, dbc := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+	return d, adapter, dbc
+}
+
+// A manual run starts the workflow it names, not the one the item matches. The
+// harness item carries `ai-ready`, so `impl` (label ai-implement) would never be
+// routed to it by a poll.
+func TestRunWorkflowManual_IgnoresTriggerMatch(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := manualDispatcher(t)
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{}) // binds the item
+	if got := len(jobsFor(t, d, "impl")); got != 0 {
+		t.Fatalf("setup: %d impl job(s) from the poll, want 0 — the item does not match its trigger", got)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "impl", ItemRef: "c1"})
+	if err != nil {
+		t.Fatalf("manual run: %v", err)
+	}
+	if res.TaskID != task.ID {
+		t.Errorf("bound task = %q, want the item's task %q", res.TaskID, task.ID)
+	}
+	if res.Standalone {
+		t.Error("run reported standalone despite an item reference")
+	}
+	if got := len(jobsFor(t, d, "impl")); got != 1 {
+		t.Fatalf("manual run produced %d impl job(s), want 1", got)
+	}
+	if len(res.Bypassed) == 0 {
+		t.Error("result named no bypassed guards; a silent bypass is the thing to avoid")
+	}
+}
+
+// "We can even start more than one, if there is one already running": two manual
+// runs of the same workflow on the same task are two runs, not a duplicate the
+// queue's idempotency key swallows.
+func TestRunWorkflowManual_StartsConcurrentInstance(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, dbc := manualDispatcher(t)
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	if got := len(jobsFor(t, d, "triage")); got != 1 {
+		t.Fatalf("setup: %d triage job(s) after the poll, want 1", got)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	// A live instance for the route — exactly what dropActiveMatches blocks on.
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "inst-live", WorkflowID: "triage", TaskID: task.ID, CellID: "c1", SourceID: "src",
+		State: db.InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("seed live instance: %v", err)
+	}
+
+	first, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "c1"})
+	if err != nil {
+		t.Fatalf("first manual run: %v", err)
+	}
+	if !first.Concurrent {
+		t.Error("Concurrent = false, want true — a running instance existed and the caller must be told")
+	}
+	second, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "c1"})
+	if err != nil {
+		t.Fatalf("second manual run: %v", err)
+	}
+	if second.TaskID != first.TaskID {
+		t.Fatalf("second run targeted task %q, want the same task %q", second.TaskID, first.TaskID)
+	}
+
+	// One job from the poll plus one per manual run, each with its own key.
+	jobs := jobsFor(t, d, "triage")
+	if len(jobs) != 3 {
+		t.Fatalf("got %d triage job(s), want 3 (poll + two manual runs)", len(jobs))
+	}
+	keys := map[string]bool{}
+	for _, job := range jobs {
+		if keys[job.IdempotencyKey] {
+			t.Fatalf("duplicate idempotency key %q — the second manual run was de-duplicated away", job.IdempotencyKey)
+		}
+		keys[job.IdempotencyKey] = true
+	}
+}
+
+// A manual run must not clear an in-flight marker a poll owns: doing so would
+// release the poll's guard early and let the next tick dispatch the cell again.
+func TestRunWorkflowManual_LeavesForeignInFlightMarker(t *testing.T) {
+	ctx := context.Background()
+	d, adapter, _ := manualDispatcher(t)
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	d.inFlight.Store("c1", time.Now()) // stand in for a poll still working the cell
+
+	if _, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "impl", ItemRef: "c1"}); err != nil {
+		t.Fatalf("manual run: %v", err)
+	}
+	if _, held := d.inFlight.Load("c1"); !held {
+		t.Fatal("manual run cleared the in-flight marker it did not own")
+	}
+}
+
+// Without an item the run gets its own task, with no source binding.
+func TestRunWorkflowManual_StandaloneCreatesTask(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := manualDispatcher(t)
+
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{
+		WorkflowID: "triage",
+		Input:      map[string]any{"scope": "q3"},
+		Title:      "audit run",
+	})
+	if err != nil {
+		t.Fatalf("standalone run: %v", err)
+	}
+	if !res.Standalone {
+		t.Error("Standalone = false for a run with no item reference")
+	}
+	if res.CellID != "" {
+		t.Errorf("CellID = %q, want empty for a standalone run", res.CellID)
+	}
+
+	task, err := dbc.InternalTasks().GetTask(ctx, res.TaskID)
+	if err != nil || task == nil {
+		t.Fatalf("get created task: %v", err)
+	}
+	if task.Title != "audit run" {
+		t.Errorf("task title = %q, want the requested title", task.Title)
+	}
+	if task.Metadata.Type != "manual" {
+		t.Errorf("task type = %q, want %q", task.Metadata.Type, "manual")
+	}
+	if task.Metadata.Source != "" {
+		t.Errorf("task source = %q, want empty — a standalone run has no source", task.Metadata.Source)
+	}
+	if got, ok := task.Input["scope"]; !ok || got != "q3" {
+		t.Errorf("task input = %v, want scope=q3", task.Input)
+	}
+	if bindings, err := dbc.ListBindingsByTask(ctx, task.ID); err != nil {
+		t.Fatalf("list bindings: %v", err)
+	} else if len(bindings) != 0 {
+		t.Errorf("standalone task has %d source binding(s), want 0", len(bindings))
+	}
+
+	jobs := jobsFor(t, d, "triage")
+	if len(jobs) != 1 {
+		t.Fatalf("standalone run produced %d job(s), want 1", len(jobs))
+	}
+	if jobs[0].TaskID != task.ID {
+		t.Errorf("job task = %q, want the standalone task %q", jobs[0].TaskID, task.ID)
+	}
+}
+
+// An unknown workflow id must fail closed: resolveWorkflow answers it with an
+// empty definition, which would run an instance with no steps and report success.
+func TestRunWorkflowManual_UnknownWorkflow(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := manualDispatcher(t)
+
+	_, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "nope"})
+	if !errors.Is(err, ErrUnknownWorkflow) {
+		t.Fatalf("error = %v, want ErrUnknownWorkflow", err)
+	}
+	// The message names the alternatives, which is the whole recovery path.
+	if !strings.Contains(err.Error(), "triage") || !strings.Contains(err.Error(), "impl") {
+		t.Errorf("error %q does not list the known workflows", err)
+	}
+	if jobs, _ := d.db.Queue().ListJobs(ctx, "", 100); len(jobs) != 0 {
+		t.Fatalf("unknown workflow still enqueued %d job(s)", len(jobs))
+	}
+}
+
+// An item reference that resolves to nothing must not silently degrade into a
+// standalone run against an empty target (the mis-targeting class of #377).
+func TestRunWorkflowManual_UnknownItem(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := manualDispatcher(t)
+
+	_, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "ghost"})
+	if !errors.Is(err, ErrUnknownCell) {
+		t.Fatalf("error = %v, want ErrUnknownCell", err)
+	}
+	if jobs, _ := d.db.Queue().ListJobs(ctx, "", 100); len(jobs) != 0 {
+		t.Fatalf("unknown item still enqueued %d job(s)", len(jobs))
+	}
+	if tasks, err := dbc.InternalTasks().ListTasks(ctx, 100); err != nil {
+		t.Fatalf("list tasks: %v", err)
+	} else if len(tasks) != 0 {
+		t.Fatalf("unknown item created %d task(s), want 0", len(tasks))
+	}
+}
+
+func TestManualRunHandler(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := manualDispatcher(t)
+	handler := d.manualRunHandler(ctx)
+
+	t.Run("starts a standalone run", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/triage/run",
+			strings.NewReader(`{"title":"from http","input":{"scope":"q3"}}`)))
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+		}
+		var res ManualRunResult
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if res.WorkflowID != "triage" || !res.Standalone {
+			t.Fatalf("result = %+v, want a standalone triage run", res)
+		}
+		task, err := dbc.InternalTasks().GetTask(ctx, res.TaskID)
+		if err != nil || task == nil {
+			t.Fatalf("get task: %v", err)
+		}
+		if task.Title != "from http" {
+			t.Errorf("title = %q, want the body's title", task.Title)
+		}
+	})
+
+	t.Run("empty body is fine", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/triage/run", nil))
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("unknown workflow is 404", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/nope/run", nil))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("unknown item is 400", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/triage/run?item=ghost", nil))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("malformed body is 400", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/triage/run", strings.NewReader("{oops")))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("missing the run suffix is 404", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodPost, "/workflows/triage", nil))
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("GET is not allowed", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		handler(w, httptest.NewRequest(http.MethodGet, "/workflows/triage/run", nil))
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status = %d, want 405", w.Code)
+		}
+	})
+}
+
+// `once: true` is spent after a completed instance; a manual run ignores it.
+func TestRunWorkflowManual_IgnoresSpentOnce(t *testing.T) {
+	ctx := context.Background()
+	d, base, dbc := newQueueDispatcher(t, true) // triage is once: true
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	job := queueJobFor(t, dbc, "triage")
+	if res := d.ExecuteQueuedJob(ctx, job, "w1"); !res.Success {
+		t.Fatalf("triage job failed: %+v", res)
+	}
+	task := taskForCell(t, dbc, "src", "c1")
+
+	// A poll now drops the workflow: `once` is spent.
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Now())
+	if got := len(jobsFor(t, d, "triage")); got != 1 {
+		t.Fatalf("setup: re-poll of a spent `once` workflow produced %d job(s), want 1", got)
+	}
+
+	if _, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "c1"}); err != nil {
+		t.Fatalf("manual run: %v", err)
+	}
+	if got := len(jobsFor(t, d, "triage")); got != 2 {
+		t.Fatalf("manual run of a spent `once` workflow produced %d job(s) in total, want 2", got)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 1 {
+		t.Fatalf("sanity: %d instance(s) before the queued manual job runs, want 1", got)
+	}
+}

--- a/src/internal/daemon/nonblocking_dispatch_test.go
+++ b/src/internal/daemon/nonblocking_dispatch_test.go
@@ -35,7 +35,7 @@ func TestFanOut_DoesNotBlockOnSaturatedAgent(t *testing.T) {
 	go func() {
 		// persisted=false → no DB side effects; the dispatch goroutine parks on
 		// the saturated semaphore until ctx is cancelled.
-		d.fanOut(ctx, cell, nil, task, false, matches, nil, nil)
+		d.fanOut(ctx, cell, nil, task, false, matches, fanOutOpts{ownsInFlight: true})
 		close(done)
 	}()
 

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -84,7 +84,28 @@ func (d *Dispatcher) queuePolicy() queue.ConcurrencyPolicy {
 	return policy
 }
 
-func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, task model.InternalTask, matches []router.Match) {
+// dispatchIdempotencyKey is the queue's de-duplication key for one dispatch:
+// task + dispatch generation + workflow. Two polls that overlap on the same
+// round produce the same key, and the second enqueue is correctly swallowed;
+// a new round frees the key by bumping the generation.
+//
+// suffix opts out of that de-duplication for callers where a repeat is the
+// intent rather than an accident — a manual run passes a per-run nonce, so
+// starting the same workflow on the same task twice yields two jobs. It is
+// empty on every automatic path, which keeps those keys byte-identical to what
+// they were before the suffix existed (live queue rows keep matching).
+func dispatchIdempotencyKey(taskID string, generation int, workflowID, suffix string) string {
+	key := fmt.Sprintf("%s:%d:%s", taskID, generation, workflowID)
+	if suffix != "" {
+		key += ":" + suffix
+	}
+	return key
+}
+
+// enqueueFanOut hands each match to the dispatch queue instead of running it in
+// the daemon. idemSuffix widens the idempotency key (see dispatchIdempotencyKey);
+// it is empty for every automatic path.
+func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, task model.InternalTask, matches []router.Match, idemSuffix string) {
 	if _, err := d.db.InternalTasks().IncrementOutstanding(ctx, task.ID, len(matches)); err != nil {
 		aplog.Error("task %s: increment outstanding by %d before enqueue: %v", task.ID, len(matches), err)
 		return
@@ -100,7 +121,7 @@ func (d *Dispatcher) enqueueFanOut(ctx context.Context, cell model.SourceItem, t
 			continue
 		}
 		pool, labels, capabilities, affinity := d.requirementsForMatch(task.ID, match)
-		job := &queue.Job{IdempotencyKey: fmt.Sprintf("%s:%d:%s", task.ID, generation, match.Route.ID), ProjectID: d.queueProjectID, SourceID: cell.SourceID, TaskID: task.ID, WorkflowID: match.Route.ID, AgentID: match.Route.Agent, RunnerID: d.agentRunner[match.Route.Agent], Pool: pool, RequiredLabels: labels, RequiredCapabilities: capabilities, AffinityKey: affinity, PayloadVersion: dispatchPayloadVersion, Payload: payload, Priority: -match.Route.Priority, MaxAttempts: d.cfg.Settings.MaxAttempts}
+		job := &queue.Job{IdempotencyKey: dispatchIdempotencyKey(task.ID, generation, match.Route.ID, idemSuffix), ProjectID: d.queueProjectID, SourceID: cell.SourceID, TaskID: task.ID, WorkflowID: match.Route.ID, AgentID: match.Route.Agent, RunnerID: d.agentRunner[match.Route.Agent], Pool: pool, RequiredLabels: labels, RequiredCapabilities: capabilities, AffinityKey: affinity, PayloadVersion: dispatchPayloadVersion, Payload: payload, Priority: -match.Route.Priority, MaxAttempts: d.cfg.Settings.MaxAttempts}
 		created, err := d.dispatchQueue.Enqueue(ctx, job)
 		if err != nil {
 			d.rollbackQueuedOutstanding(ctx, task.ID, fmt.Errorf("enqueue workflow %s: %w", match.Route.ID, err))

--- a/src/internal/daemon/queue_idempotency_test.go
+++ b/src/internal/daemon/queue_idempotency_test.go
@@ -1,0 +1,24 @@
+package daemon
+
+import "testing"
+
+// The automatic paths must keep the exact key they had before the suffix existed,
+// or every job already in a live queue stops de-duplicating against re-polls.
+func TestDispatchIdempotencyKey_UnsuffixedIsUnchanged(t *testing.T) {
+	if got, want := dispatchIdempotencyKey("task-1", 3, "triage", ""), "task-1:3:triage"; got != want {
+		t.Errorf("key = %q, want %q", got, want)
+	}
+}
+
+// A suffix widens the key, so a caller that means to repeat a dispatch is not
+// de-duplicated against the round already queued for the same task+workflow.
+func TestDispatchIdempotencyKey_SuffixWidensTheKey(t *testing.T) {
+	plain := dispatchIdempotencyKey("task-1", 3, "triage", "")
+	suffixed := dispatchIdempotencyKey("task-1", 3, "triage", "manual-ab")
+	if suffixed == plain {
+		t.Fatalf("suffixed key %q did not differ from %q", suffixed, plain)
+	}
+	if suffixed != "task-1:3:triage:manual-ab" {
+		t.Errorf("suffixed key = %q", suffixed)
+	}
+}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -564,6 +564,24 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	// The workflow picker owns every key while it is open, like the confirm modal.
+	if a.model.pickerActive {
+		return a.handleWorkflowPickerKey(key)
+	}
+
+	// Start a workflow manually (Shift+W): pick one, run it now regardless of
+	// triggers, guards, or whether it is already running.
+	if key == "W" {
+		if len(a.pickerWorkflows()) == 0 {
+			return a, noticeCmd("No workflows are configured", true)
+		}
+		a.model.pickerActive = true
+		a.model.pickerIdx = 0
+		a.model.pickerStandalone = false
+		a.model.pickerTaskID, _ = a.focusedTaskID()
+		return a, nil
+	}
+
 	// Force-restart the focused task: cancel and re-dispatch (Shift+R).
 	if key == "R" {
 		if id, ok := a.focusedTaskID(); ok {
@@ -2971,6 +2989,9 @@ func (a *App) View() string {
 	if a.model.confirmAction != "" {
 		view = a.renderConfirmModal(view)
 	}
+	if a.model.pickerActive {
+		view = a.renderWorkflowPicker(view)
+	}
 	return view
 }
 
@@ -5027,12 +5048,12 @@ func (a *App) footerKeys() []fkey {
 				return append(keys, fkey{"-/+", "split"}, fkey{"r", "refresh"}, fkey{"X", "stop"}, fkey{"R", "restart"}, fkey{"esc", "back"}, fkey{"q", "quit"})
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"W", "run wf"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
 	case "Workflows":
 		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
 			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}
 		}
-		return []fkey{{"↑/↓", "workflow"}, {"enter/→", "steps"}, {"tab", "next tab"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "workflow"}, {"enter/→", "steps"}, {"W", "run now"}, {"tab", "next tab"}, {"q", "quit"}}
 	case "Agents":
 		if ag := a.model.agentsTab; ag != nil {
 			switch ag.View {
@@ -5064,7 +5085,7 @@ func (a *App) footerKeys() []fkey {
 		}
 		return []fkey{{"w", wrap}, {"←/→", "scroll"}, {"↑/↓", "lines"}, {"pgup/dn", "page"}, {"home/end", "ends"}, {"tab", "switch"}, {"q", "quit"}}
 	default: // Overview
-		return []fkey{{"tab", "next"}, {"⇧tab", "prev"}, {"r", "refresh"}, {"q", "quit"}}
+		return []fkey{{"tab", "next"}, {"⇧tab", "prev"}, {"W", "run wf"}, {"r", "refresh"}, {"q", "quit"}}
 	}
 }
 

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -27,6 +27,14 @@ type Model struct {
 	confirmAction string // "restart" or "clear" or "stop" when awaiting confirmation
 	confirmTaskID string
 
+	// Manual workflow picker (W). Unlike confirmAction's yes/no prompt this one
+	// selects among the configured workflows, then starts the chosen one on the
+	// task that was focused when it opened — or standalone, with no source item.
+	pickerActive     bool
+	pickerIdx        int
+	pickerTaskID     string // focused task at open time; empty means nothing was focused
+	pickerStandalone bool   // run with no source item even though one is focused
+
 	notice      string    // one-line result banner for the last IPC action
 	noticeIsErr bool      // render the banner as an error
 	noticeUntil time.Time // banner expiry; zero means no banner

--- a/src/internal/dashboard/workflow_picker.go
+++ b/src/internal/dashboard/workflow_picker.go
@@ -1,0 +1,223 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	neturl "net/url"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/orlandoburli/apiary/internal/daemon"
+)
+
+// The manual workflow picker (Shift+W). It starts a chosen workflow immediately,
+// skipping the trigger match and every pre-dispatch guard — including the one
+// that normally prevents a second concurrent instance. `R` (restart) re-runs
+// whatever matches an item; this runs the workflow you name, matched or not.
+
+// noticeCmd returns a command that shows a one-line banner.
+func noticeCmd(text string, isErr bool) tea.Cmd {
+	return func() tea.Msg { return noticeMsg{text: text, isErr: isErr} }
+}
+
+// pickerWorkflows lists the workflow ids the picker offers. It prefers the tab's
+// already-loaded config items (fetchWorkflowsConfig populates them at startup)
+// and falls back to the live config, so the picker works before the Workflows
+// tab has ever been visited.
+func (a *App) pickerWorkflows() []string {
+	if a.model.workflowsTab != nil && len(a.model.workflowsTab.Workflows) > 0 {
+		ids := make([]string, 0, len(a.model.workflowsTab.Workflows))
+		for _, wf := range a.model.workflowsTab.Workflows {
+			if wf.ID != "" {
+				ids = append(ids, wf.ID)
+			}
+		}
+		return ids
+	}
+	if a.cfg == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(a.cfg.Workflows))
+	for _, wf := range a.cfg.Workflows {
+		if wf.ID != "" {
+			ids = append(ids, wf.ID)
+		}
+	}
+	return ids
+}
+
+// pickerTarget returns the item reference the run will bind, and whether the run
+// is standalone (no source item).
+func (a *App) pickerTarget() (ref string, standalone bool) {
+	if a.model.pickerStandalone || a.model.pickerTaskID == "" {
+		return "", true
+	}
+	return a.model.pickerTaskID, false
+}
+
+func (a *App) closeWorkflowPicker() {
+	a.model.pickerActive = false
+	a.model.pickerIdx = 0
+	a.model.pickerTaskID = ""
+	a.model.pickerStandalone = false
+}
+
+// handleWorkflowPickerKey consumes every key while the picker is open, the same
+// way the confirm modal does — a half-open overlay that lets navigation keys
+// through would move the selection underneath it.
+func (a *App) handleWorkflowPickerKey(key string) (tea.Model, tea.Cmd) {
+	ids := a.pickerWorkflows()
+	if len(ids) == 0 {
+		a.closeWorkflowPicker()
+		return a, nil
+	}
+	if a.model.pickerIdx >= len(ids) {
+		a.model.pickerIdx = len(ids) - 1
+	}
+
+	switch key {
+	case "up", "k":
+		if a.model.pickerIdx > 0 {
+			a.model.pickerIdx--
+		}
+	case "down", "j":
+		if a.model.pickerIdx < len(ids)-1 {
+			a.model.pickerIdx++
+		}
+	case "home", "g":
+		a.model.pickerIdx = 0
+	case "end", "G":
+		a.model.pickerIdx = len(ids) - 1
+	case "s":
+		// Toggle between the focused item and a standalone run. Only meaningful
+		// when something is focused; with no focus the run is standalone anyway.
+		if a.model.pickerTaskID != "" {
+			a.model.pickerStandalone = !a.model.pickerStandalone
+		}
+	case "enter":
+		workflowID := ids[a.model.pickerIdx]
+		ref, _ := a.pickerTarget()
+		a.closeWorkflowPicker()
+		return a, a.runWorkflowCmd(workflowID, ref)
+	case "esc":
+		a.closeWorkflowPicker()
+	}
+	return a, nil
+}
+
+// runWorkflowCmd asks the daemon to start a workflow manually and reports the
+// outcome as a noticeMsg. Like restartTaskCmd, the daemon's own message is the
+// whole diagnosis on failure and goes to the user verbatim.
+func (a *App) runWorkflowCmd(workflowID, itemRef string) tea.Cmd {
+	socketPath := a.socketPath
+	return func() tea.Msg {
+		transport := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		}
+		client := &http.Client{Transport: transport, Timeout: 10 * time.Second}
+
+		url := "http://apiary/workflows/" + neturl.PathEscape(workflowID) + "/run"
+		if itemRef != "" {
+			url += "?item=" + neturl.QueryEscape(itemRef)
+		}
+		resp, err := client.Post(url, "application/json", nil)
+		if err != nil {
+			return noticeMsg{text: fmt.Sprintf("Start %s failed: cannot reach daemon: %v", workflowID, err), isErr: true}
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if resp.StatusCode != http.StatusAccepted {
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			}
+			return noticeMsg{text: fmt.Sprintf("Start %s failed: %s", workflowID, msg), isErr: true}
+		}
+
+		var res daemon.ManualRunResult
+		if err := json.Unmarshal(body, &res); err != nil {
+			return noticeMsg{text: "Started workflow " + workflowID}
+		}
+		text := fmt.Sprintf("Started %s on %s (bypassed triggers and guards)", res.WorkflowID, res.Label())
+		if res.Concurrent {
+			text += " — it was already running, this is a second instance"
+		}
+		return noticeMsg{text: text}
+	}
+}
+
+// renderWorkflowPicker overlays the workflow list, centred like the confirm
+// modal. The header states the target up front: starting a workflow on the wrong
+// item, or standalone when the user meant to bind one, is the mistake worth
+// making unmissable.
+func (a *App) renderWorkflowPicker(view string) string {
+	ids := a.pickerWorkflows()
+	ref, standalone := a.pickerTarget()
+
+	target := "standalone — no source item"
+	if !standalone {
+		target = "item " + ref
+	}
+
+	// Cap the visible list so a long config cannot outgrow the screen; scroll it
+	// around the selection.
+	const maxRows = 12
+	start := 0
+	if len(ids) > maxRows && a.model.pickerIdx >= maxRows {
+		start = a.model.pickerIdx - maxRows + 1
+	}
+	end := min(start+maxRows, len(ids))
+
+	rows := make([]string, 0, maxRows+1)
+	for i := start; i < end; i++ {
+		line := "  " + ids[i]
+		if i == a.model.pickerIdx {
+			line = StyleFooterKey.Render(" ▸ " + ids[i] + " ")
+		}
+		rows = append(rows, line)
+	}
+	if end < len(ids) {
+		rows = append(rows, StyleFooterDim.Render(fmt.Sprintf("  … %d more", len(ids)-end)))
+	}
+
+	toggle := ""
+	if a.model.pickerTaskID != "" {
+		toggle = "  " + StyleFooterKey.Render(" s ") + " " + StyleFooterLbl.Render("standalone")
+	}
+
+	dialog := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(ColorWarning).
+		Padding(1, 3).
+		Width(52).
+		Render(
+			lipgloss.JoinVertical(lipgloss.Left,
+				StyleBoxTitle.Render(" Start a workflow "),
+				StyleFooterDim.Render("target: "+target),
+				StyleFooterDim.Render("runs now, ignoring triggers and guards"),
+				"",
+				strings.Join(rows, "\n"),
+				"",
+				StyleFooterKey.Render(" ↑↓ ")+" "+StyleFooterLbl.Render("select")+"  "+
+					StyleFooterKey.Render(" ⏎ ")+" "+StyleFooterLbl.Render("start")+"  "+
+					StyleFooterKey.Render(" esc ")+" "+StyleFooterLbl.Render("cancel")+toggle,
+			),
+		)
+
+	topPad := (a.model.height - lipgloss.Height(dialog)) / 2
+	if topPad < 0 {
+		topPad = 0
+	}
+	return strings.Repeat("\n", topPad) +
+		lipgloss.NewStyle().Width(a.model.width).Align(lipgloss.Center).Render(dialog)
+}

--- a/src/internal/dashboard/workflow_picker_test.go
+++ b/src/internal/dashboard/workflow_picker_test.go
@@ -1,0 +1,109 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func pickerApp(t *testing.T) *App {
+	t.Helper()
+	a := newTestApp(100, 30)
+	a.model.workflowsTab = &WorkflowsTab{Workflows: []WorkflowConfigItem{
+		{ID: "triage"}, {ID: "implement"}, {ID: "nightly-audit"},
+	}}
+	return a
+}
+
+func TestWorkflowPicker_OpensOnW(t *testing.T) {
+	a := pickerApp(t)
+
+	a.handleKeyMsg(keyPress("W"))
+	if !a.model.pickerActive {
+		t.Fatal("W did not open the workflow picker")
+	}
+
+	out := stripANSI(a.renderWorkflowPicker(""))
+	for _, id := range []string{"triage", "implement", "nightly-audit"} {
+		if !strings.Contains(out, id) {
+			t.Errorf("picker does not list %q; got:\n%s", id, out)
+		}
+	}
+	// With nothing focused the run has no item, and the header must say so
+	// before the user commits to it.
+	if !strings.Contains(out, "standalone") {
+		t.Errorf("picker does not name the standalone target; got:\n%s", out)
+	}
+}
+
+func TestWorkflowPicker_NavigatesAndCancels(t *testing.T) {
+	a := pickerApp(t)
+	a.handleKeyMsg(keyPress("W"))
+
+	a.handleKeyMsg(keyPress("down"))
+	a.handleKeyMsg(keyPress("down"))
+	if a.model.pickerIdx != 2 {
+		t.Errorf("pickerIdx = %d after two downs, want 2", a.model.pickerIdx)
+	}
+	// The selection stops at the end rather than wrapping into an invalid index.
+	a.handleKeyMsg(keyPress("down"))
+	if a.model.pickerIdx != 2 {
+		t.Errorf("pickerIdx = %d past the last row, want 2", a.model.pickerIdx)
+	}
+	a.handleKeyMsg(keyPress("up"))
+	if a.model.pickerIdx != 1 {
+		t.Errorf("pickerIdx = %d after up, want 1", a.model.pickerIdx)
+	}
+
+	a.handleKeyMsg(keyPress("esc"))
+	if a.model.pickerActive {
+		t.Fatal("esc did not close the picker")
+	}
+}
+
+// While the picker is open it owns every key, like the confirm modal — otherwise
+// navigation keys move the list underneath the overlay.
+func TestWorkflowPicker_SwallowsKeysWhileOpen(t *testing.T) {
+	a := pickerApp(t)
+	a.handleKeyMsg(keyPress("W"))
+
+	a.handleKeyMsg(keyPress("R"))
+	if a.model.confirmAction != "" {
+		t.Errorf("R leaked past the open picker and armed a %q confirmation", a.model.confirmAction)
+	}
+	if !a.model.pickerActive {
+		t.Error("picker closed on an unrelated key")
+	}
+}
+
+// `s` detaches the run from the focused item, for a workflow that should not
+// bind one.
+func TestWorkflowPicker_TogglesStandalone(t *testing.T) {
+	a := pickerApp(t)
+	a.model.pickerActive = true
+	a.model.pickerTaskID = "CDT-123"
+
+	if ref, standalone := a.pickerTarget(); standalone || ref != "CDT-123" {
+		t.Fatalf("target = (%q, standalone=%v), want the focused item", ref, standalone)
+	}
+	if !strings.Contains(stripANSI(a.renderWorkflowPicker("")), "item CDT-123") {
+		t.Error("picker does not name the item it will bind")
+	}
+
+	a.handleKeyMsg(keyPress("s"))
+	if ref, standalone := a.pickerTarget(); !standalone || ref != "" {
+		t.Fatalf("target = (%q, standalone=%v) after `s`, want standalone", ref, standalone)
+	}
+	a.handleKeyMsg(keyPress("s"))
+	if _, standalone := a.pickerTarget(); standalone {
+		t.Error("`s` did not toggle back to the focused item")
+	}
+}
+
+func TestWorkflowPicker_NoWorkflowsDoesNotOpen(t *testing.T) {
+	a := newTestApp(100, 30) // no workflows tab, no config
+
+	a.handleKeyMsg(keyPress("W"))
+	if a.model.pickerActive {
+		t.Fatal("picker opened with no workflows to pick from")
+	}
+}

--- a/src/internal/router/manual_match_test.go
+++ b/src/internal/router/manual_match_test.go
@@ -1,0 +1,77 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// A trigger-less workflow is invisible to New (it synthesizes routes from
+// triggers only), which is exactly the workflow a manual run has to reach.
+func TestManualMatch_TriggerlessWorkflow(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "nightly-audit",
+		Steps: []config.StepConfig{
+			{ID: "gate", Type: config.StepTypeApproval},
+			{ID: "scan", Agent: "auditor"},
+			{ID: "report", Agent: "writer"},
+		},
+	}
+
+	r, err := New(&config.Config{Workflows: []config.WorkflowConfig{wf}})
+	if err != nil {
+		t.Fatalf("router: %v", err)
+	}
+	if len(r.routes) != 0 {
+		t.Fatalf("setup: %d route(s) for a trigger-less workflow, want 0", len(r.routes))
+	}
+
+	m, ok := ManualMatch(wf)
+	if !ok {
+		t.Fatal("ManualMatch refused a trigger-less workflow")
+	}
+	if m.Route.ID != "nightly-audit" {
+		t.Errorf("route id = %q, want the workflow id (resolveWorkflow keys on it)", m.Route.ID)
+	}
+	// The first *agent* step, not the first step: the id feeds the agent
+	// semaphore and runner lookup.
+	if m.Route.Agent != "auditor" {
+		t.Errorf("agent = %q, want %q", m.Route.Agent, "auditor")
+	}
+}
+
+// A triggered workflow keeps its priority and match block, so a manual dispatch
+// logs and queues the same way an automatic one does.
+func TestManualMatch_CarriesTriggerAttributes(t *testing.T) {
+	wf := config.WorkflowConfig{
+		ID: "triage",
+		Trigger: &config.TriggerConfig{
+			Priority: 7,
+			Once:     true,
+			Match:    config.RouteMatch{Labels: []string{"ai-ready"}},
+		},
+		Steps: []config.StepConfig{{ID: "run", Agent: "a"}},
+	}
+
+	m, ok := ManualMatch(wf)
+	if !ok {
+		t.Fatal("ManualMatch refused a triggered workflow")
+	}
+	if m.Route.Priority != 7 {
+		t.Errorf("priority = %d, want 7", m.Route.Priority)
+	}
+	if len(m.Route.Match.Labels) != 1 || m.Route.Match.Labels[0] != "ai-ready" {
+		t.Errorf("match labels = %v, want [ai-ready]", m.Route.Match.Labels)
+	}
+	// `once` is deliberately NOT carried over: it is a guard the poll loop
+	// evaluates, and a manual run must not be droppable by it.
+	if m.Route.Once {
+		t.Error("Once carried into the manual match — a manual run must not be guarded by it")
+	}
+}
+
+func TestManualMatch_RejectsWorkflowWithoutID(t *testing.T) {
+	if _, ok := ManualMatch(config.WorkflowConfig{Steps: []config.StepConfig{{ID: "run", Agent: "a"}}}); ok {
+		t.Fatal("ManualMatch accepted a workflow with no id; resolveWorkflow could not resolve it back")
+	}
+}

--- a/src/internal/router/router.go
+++ b/src/internal/router/router.go
@@ -116,6 +116,31 @@ func firstAgentStep(wf config.WorkflowConfig) string {
 	return wf.ID
 }
 
+// ManualMatch builds the Match a manual run dispatches with: the same synthetic
+// route New derives from a trigger — id = workflow id, agent = first agent step —
+// but for any workflow, including one with no trigger at all, which New skips
+// entirely (see the loop in New).
+//
+// No matching happens here by design. A manual run names the workflow it wants;
+// whether the target looks like something the trigger would have selected is
+// exactly the question it exists to bypass. The Match still carries the trigger's
+// Match and Priority so logs, queue priority and requirement lookups read the
+// same as an automatic dispatch of the same workflow.
+//
+// Returns false only for a workflow with no id, which cannot be resolved back to
+// a definition by resolveWorkflow and so must never be dispatched.
+func ManualMatch(wf config.WorkflowConfig) (Match, bool) {
+	if wf.ID == "" {
+		return Match{}, false
+	}
+	route := config.RouteConfig{ID: wf.ID, Agent: firstAgentStep(wf)}
+	if wf.Trigger != nil {
+		route.Priority = wf.Trigger.Priority
+		route.Match = wf.Trigger.Match
+	}
+	return Match{Route: route}, true
+}
+
 // Route evaluates all rules against the SourceItem and returns the first match.
 // Returns (zero, false) if no rule matches.
 func (r *Router) Route(item model.SourceItem) (Match, bool) {


### PR DESCRIPTION
Start a named workflow on demand, whether or not anything would have triggered it.

```sh
apiary dispatch triage --item CDT-123     # this workflow, this item, right now
apiary dispatch nightly-audit             # standalone: no source item at all
apiary dispatch report --input scope=q3   # standalone, with structured input
```

…or press `W` in the dashboard to pick one from a list.

## Why

The only way to make a workflow run has been to make its trigger match. `apiary restart` re-routes an item and runs *whatever* matches — it cannot name a workflow, cannot run one whose trigger does not match the item's current state, and deliberately refuses to run one that already has a live instance.

## How

A manual run doesn't switch guards off — it never enters the path they live on. `RunWorkflowManual` resolves the workflow by name, builds the `router.Match` by hand (`router.ManualMatch`, which also reaches trigger-less workflows that `router.New` skips) and fans out directly.

Bypassed, each one reported back to the caller:

| Guard | Normally applied by |
|---|---|
| trigger `match` (states, labels, types, `title_regex`, source) | `Router.RouteAll` |
| exclusive-trigger suppression | `RouteAllWithSuppressed` |
| live instance / in-flight — so a **second concurrent instance** starts | `dropActiveMatches` |
| `once: true` | `dropOnceMatches` |
| consecutive-failure cap | `dropCappedMatches` |

Everything downstream is shared with an automatic dispatch: the queue, agent semaphores, `activeRuns`, outstanding accounting, transcripts and execution events.

With `--item` the run binds the real item and writes back to the source as usual; a reference that resolves to nothing fails and creates nothing, rather than degrading into a run against an empty target (the mis-targeting class of #377). Without one it runs on a fresh internal task with no binding, so comments, state locks and sub-issues are no-ops — `--input` carries the values those workflows need instead. That makes a trigger-less workflow a usable *manual-only* workflow, so the validate warning now says "never run on its own" and points at the command.

Replaces the `apiary dispatch` stub, which printed `not yet implemented`.

## Commits

Split for review, since the first one touches the hot path:

1. **`refactor(daemon): give fanOut an options struct and a widenable queue key`** — no behaviour change, but `impact(fanOut, upstream)` is **CRITICAL** (3 direct callers, 5 execution flows), so it is worth reading on its own. Two knobs any non-poll caller needs:
   - `ownsInFlight` — `fanOut` unconditionally cleared `d.inFlight[cell.ID]`; a caller that never stored it would release another path's guard early and let the next tick double-dispatch.
   - `idemSuffix` — the queue de-duplicates on `taskID:generation:workflowID`, so a deliberate repeat was swallowed. The key moves into `dispatchIdempotencyKey`, which appends an optional suffix. **Every automatic path passes `""` and keeps a byte-identical key**, so jobs already in a live queue go on de-duplicating. Bumping the generation instead (what restart does) would have invalidated keys of rounds legitimately in flight.
2. **`feat(dispatch): manual workflow runs`** — the feature: `RunWorkflowManual`, `POST /workflows/{id}/run`, `router.ManualMatch`, the CLI command, the dashboard picker, docs.

## Known limitation

Nothing serializes two manual runs of the same workflow on the same task — that is the requested behaviour, but where steps mutate the same branch, comment, or item state they will race. Documented in `docs/cli.md`.

## Verification

`go build ./... && go vet ./... && go test ./...` clean on each commit independently.

19 new tests: trigger bypass, concurrent instances with distinct queue keys, the foreign in-flight marker, standalone task creation, spent-`once`, fail-closed on unknown workflow/item, the HTTP status matrix, `ManualMatch` on a trigger-less workflow, and the picker's key handling and render.

End-to-end against a live daemon on an isolated config: dispatched a trigger-less workflow, a never-matching one, and a repeat run — all three reached their approval gates; `GET /workflows` still works alongside the new subtree route; unknown ids fail with the right messages and status codes.