### PR TITLE
feat(dispatch): fetch an unpolled item, and --source to say where from

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -209,7 +209,7 @@ Start one named workflow right now, whether or not anything would have triggered
 it. Same action as `W` in the dashboard.
 
 ```sh
-apiary dispatch triage --item CDT-123     # run `triage` on an existing item
+apiary dispatch triage --item PSP-199     # run `triage` on a source item
 apiary dispatch nightly-audit             # run standalone, with no source item
 apiary dispatch report --input scope=q3   # standalone, with structured input
 ```
@@ -227,7 +227,7 @@ A manual run skips **every** gate the poll loop applies:
 Every bypass is printed, so none of them is silent:
 
 ```
-✓ Started workflow triage on CDT-123 (10042)
+✓ Started workflow triage on PSP-199 (10042) in jira
   ! this workflow was already running on the task — a second instance is now live
   ! bypassed guard: trigger match (state/labels/filters)
   ! bypassed guard: exclusive trigger suppression
@@ -237,12 +237,40 @@ Every bypass is printed, so none of them is silent:
   → follow it with: apiary instances
 ```
 
-**With `--item`** the run binds an existing source item and behaves exactly like
-an automatic dispatch of that workflow: it sees the item's live labels and state,
+**With `--item`** the run binds a source item and behaves exactly like an
+automatic dispatch of that workflow: it sees the item's live labels and state,
 and side effects (comments, state locks, sub-issues) write back to the source.
-The value is the item's human reference (`CDT-123`, `#1953`) or its cell id — the
-same vocabulary [`apiary restart`](#apiary-restart) accepts. A reference that
-resolves to nothing fails and creates nothing.
+The value is the item's human reference (`PSP-199`, `#1953`) or its cell id — the
+same vocabulary [`apiary restart`](#apiary-restart) accepts, matched
+case-insensitively with a leading `#` ignored.
+
+The item does **not** have to be one apiary is already tracking. A reference it
+has never polled — a ticket outside the source's `filters`, in an excluded state,
+or created since the last tick — is fetched from the source and bound on the
+spot, exactly as a poll would have bound it:
+
+```sh
+apiary dispatch triage --item PSP-199                 # one source: inferred
+apiary dispatch triage --item PSP-199 --source jira   # several: name it
+```
+
+`--source` is optional when exactly one configured source can fetch a single
+item. When several can, apiary asks rather than guesses — fetching a different
+project's `PSP-199` and running a workflow over it is not a mistake anyone
+catches quickly:
+
+```
+Error: dispatch failed: source required: 2 sources could hold it (jira, my-repo)
+  — pass --source to say which
+```
+
+`--source` also disambiguates a reference that exists in more than one source,
+which previously required looking up the cell id by hand.
+
+A reference no source can produce an item for still fails and creates nothing.
+The source that answered is named in the output and on the binding — with Jira
+the key you typed (`PSP-199`) and the cell id it resolved to (the opaque numeric
+issue id) are both reported, since only one of them appears in Jira's UI.
 
 **Without `--item`** the workflow runs standalone on a fresh internal task with no
 source binding. Nothing writes back to a source: comment and state-lock steps are

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -110,7 +110,7 @@ Everything above describes when a workflow starts **on its own**. Any workflow
 can also be started by hand, which skips all of it:
 
 ```sh
-apiary dispatch triage --item CDT-123   # this workflow, this item, right now
+apiary dispatch triage --item PSP-199   # this workflow, this item, right now
 apiary dispatch nightly-audit           # standalone: no source item at all
 ```
 
@@ -118,6 +118,11 @@ The same action is `W` in the dashboard. A manual run ignores the trigger's
 `match` block, exclusive suppression, the live-instance guard, `once`, and the
 consecutive-failure cap — so it starts a **second concurrent instance** of a
 workflow that is already running, by design. Every bypass is reported.
+
+The item does not have to be one apiary is already tracking: a reference it has
+never polled is fetched from its source and bound on the spot, so a manual run
+reaches tickets outside the source's `filters`. Add `--source` when more than one
+source could hold the reference.
 
 Two consequences worth knowing:
 

--- a/src/internal/cli/dispatch.go
+++ b/src/internal/cli/dispatch.go
@@ -20,9 +20,10 @@ import (
 
 func newDispatchCmd() *cobra.Command {
 	var (
-		item   string
-		title  string
-		inputs []string
+		item     string
+		sourceID string
+		title    string
+		inputs   []string
 	)
 
 	cmd := &cobra.Command{
@@ -39,11 +40,18 @@ A manual run skips every gate the poll loop applies:
     SECOND concurrent instance
   • ` + "`once: true`" + `, and the consecutive-failure cap (settings.max_attempts)
 
-With --item the run binds an existing source item and behaves exactly like an
-automatic dispatch of that workflow: the same live labels and state, and side
-effects (comments, state locks, sub-issues) write back to the source. <item> is
-the source item id or its human reference (CDT-123, #1953), the same vocabulary
+With --item the run binds a source item and behaves exactly like an automatic
+dispatch of that workflow: the same live labels and state, and side effects
+(comments, state locks, sub-issues) write back to the source. <item> is the
+source item id or its human reference (PSP-199, #1953), the same vocabulary
 ` + "`apiary restart`" + ` accepts.
+
+The item does not have to be one apiary is already tracking. A reference it has
+never polled — a ticket outside the source's filters, or created since the last
+tick — is fetched from the source and bound on the spot. Use --source to say
+which source to ask; with a single configured source it is optional, and with
+several apiary asks rather than guess. --source also disambiguates a reference
+that exists in more than one source.
 
 Without --item the workflow runs standalone on a fresh internal task with no
 source binding. Nothing writes back to a source: comment and state-lock steps
@@ -74,8 +82,15 @@ steps read as ${{ input.<key> }}.`,
 			client := &http.Client{Transport: transport, Timeout: 30 * time.Second}
 
 			url := "http://apiary/workflows/" + neturl.PathEscape(workflowID) + "/run"
+			query := neturl.Values{}
 			if item != "" {
-				url += "?item=" + neturl.QueryEscape(item)
+				query.Set("item", item)
+			}
+			if sourceID != "" {
+				query.Set("source", sourceID)
+			}
+			if len(query) > 0 {
+				url += "?" + query.Encode()
 			}
 			resp, err := client.Post(url, "application/json", bytes.NewReader(body))
 			if err != nil {
@@ -97,7 +112,14 @@ steps read as ${{ input.<key> }}.`,
 				return nil
 			}
 
-			fmt.Printf("✓ Started workflow %s on %s\n", res.WorkflowID, res.Label())
+			target := res.Label()
+			if res.SourceID != "" {
+				// Name the source even when it was inferred: with --item on an item
+				// apiary had not seen, which source answered is the one thing the
+				// caller cannot check from the reference alone.
+				target += " in " + res.SourceID
+			}
+			fmt.Printf("✓ Started workflow %s on %s\n", res.WorkflowID, target)
 			if res.Concurrent {
 				fmt.Printf("  ! this workflow was already running on the task — a second instance is now live\n")
 			}
@@ -112,7 +134,8 @@ steps read as ${{ input.<key> }}.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&item, "item", "", "source item to run against (item id or reference like CDT-123, #1953); omit to run standalone")
+	cmd.Flags().StringVar(&item, "item", "", "source item to run against (item id or reference like PSP-199, #1953); omit to run standalone")
+	cmd.Flags().StringVar(&sourceID, "source", "", "source the --item belongs to; optional with one configured source, required when several could hold it")
 	cmd.Flags().StringVar(&title, "title", "", "title for the task created by a standalone run")
 	cmd.Flags().StringArrayVar(&inputs, "input", nil, "key=value passed to a standalone run's task input, readable as ${{ input.<key> }} (repeatable)")
 	return cmd

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -985,7 +985,10 @@ var ErrAmbiguousRef = errors.New("ambiguous item reference")
 // ever sees: the Jira adapter binds on the opaque numeric issue id, so `apiary
 // restart CDT-123` — the only form a user could reasonably type — failed as an
 // unknown cell while the id that did work appeared nowhere in the UI.
-func (d *Dispatcher) resolveCellRef(ctx context.Context, ref string) (cellID, number string, err error) {
+// sourceID, when set, scopes the lookup to one source: it is how a caller
+// resolves an ErrAmbiguousRef ("PSP-199 exists in two sources") rather than
+// having to find the cell id by hand.
+func (d *Dispatcher) resolveCellRef(ctx context.Context, ref, sourceID string) (cellID, number string, err error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" || d.db == nil {
 		return ref, "", nil
@@ -995,15 +998,26 @@ func (d *Dispatcher) resolveCellRef(ctx context.Context, ref string) (cellID, nu
 	// numbers overlap (GitHub, where both derive from the issue number) must not
 	// take the slower path.
 	if b, err := d.db.SourceBindings().GetBindingBySourceItemID(ctx, ref); err == nil && b != nil {
-		return b.SourceItemID, b.SourceItemNumber, nil
+		if sourceID == "" || b.SourceID == sourceID {
+			return b.SourceItemID, b.SourceItemNumber, nil
+		}
 	}
 
 	bindings, err := d.db.SourceBindings().ListBindingsBySourceItemNumber(ctx, ref)
 	if err != nil {
 		return ref, "", fmt.Errorf("restart %s: looking up item reference: %w", ref, err)
 	}
+	if sourceID != "" {
+		scoped := bindings[:0]
+		for _, b := range bindings {
+			if b.SourceID == sourceID {
+				scoped = append(scoped, b)
+			}
+		}
+		bindings = scoped
+	}
 	if len(bindings) == 0 {
-		return ref, "", nil // not a known reference; assertKnownCell decides
+		return ref, "", nil // not a known reference; the caller decides
 	}
 
 	// Several bindings are fine when they are the same item (one item can be bound
@@ -1018,7 +1032,7 @@ func (d *Dispatcher) resolveCellRef(ctx context.Context, ref string) (cellID, nu
 			opts = append(opts, fmt.Sprintf("%s:%s", b.SourceID, b.SourceItemID))
 		}
 		sort.Strings(opts)
-		return ref, "", fmt.Errorf("%w: %q matches %d items (%s) — restart the cell id directly",
+		return ref, "", fmt.Errorf("%w: %q matches %d items (%s) — name the source, or use the cell id directly",
 			ErrAmbiguousRef, ref, len(distinct), strings.Join(opts, ", "))
 	}
 
@@ -1052,7 +1066,7 @@ func (d *Dispatcher) resolveCellRef(ctx context.Context, ref string) (cellID, nu
 // id; that, and anything else that resolves to nothing, returns ErrUnknownCell
 // and touches nothing.
 func (d *Dispatcher) ForceRestart(ctx context.Context, ref string) (RestartResult, error) {
-	cellID, number, err := d.resolveCellRef(ctx, ref)
+	cellID, number, err := d.resolveCellRef(ctx, ref, "")
 	if err != nil {
 		return RestartResult{CellID: ref}, err
 	}

--- a/src/internal/daemon/manual_run.go
+++ b/src/internal/daemon/manual_run.go
@@ -28,6 +28,14 @@ import (
 // success having done nothing.
 var ErrUnknownWorkflow = errors.New("unknown workflow")
 
+// ErrUnknownSource is returned when an explicitly named source is not configured.
+var ErrUnknownSource = errors.New("unknown source")
+
+// ErrSourceRequired is returned when an item reference is not a known cell and
+// more than one source could hold it. Guessing would mean fetching some other
+// project's PSP-199 and running a workflow over it, so the caller is asked.
+var ErrSourceRequired = errors.New("source required")
+
 // ManualRunRequest asks the daemon to start one named workflow on demand.
 type ManualRunRequest struct {
 	// WorkflowID names the workflow to run. Required.
@@ -37,6 +45,10 @@ type ManualRunRequest struct {
 	// restart` accepts. Empty runs the workflow standalone on a fresh internal
 	// task with no source binding.
 	ItemRef string `json:"item_ref,omitempty"`
+	// SourceID optionally names which source ItemRef belongs to. It is needed
+	// only when the reference is ambiguous, or when it names an item apiary has
+	// never polled and more than one source could fetch it.
+	SourceID string `json:"source_id,omitempty"`
 	// Input seeds a standalone run's task input, readable from steps as
 	// ${{ input.* }}. Ignored when ItemRef is set — that task's input belongs to
 	// the source binding.
@@ -53,6 +65,9 @@ type ManualRunResult struct {
 	TaskID     string `json:"task_id"`
 	CellID     string `json:"cell_id,omitempty"`
 	Ref        string `json:"ref,omitempty"`
+	// SourceID is the source the item was resolved against — worth echoing back
+	// when it was inferred rather than named.
+	SourceID string `json:"source_id,omitempty"`
 	// Standalone reports that no source item is bound: side effects that write
 	// back to a source (comments, state locks, sub-issues) are no-ops for this run.
 	Standalone bool `json:"standalone"`
@@ -88,7 +103,11 @@ func (d *Dispatcher) manualRunHandler(runCtx context.Context) http.HandlerFunc {
 			return
 		}
 
-		req := ManualRunRequest{WorkflowID: wfID, ItemRef: r.URL.Query().Get("item")}
+		req := ManualRunRequest{
+			WorkflowID: wfID,
+			ItemRef:    r.URL.Query().Get("item"),
+			SourceID:   r.URL.Query().Get("source"),
+		}
 		// A body is optional; only a malformed one is an error.
 		if body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20)); len(bytes.TrimSpace(body)) > 0 {
 			var payload struct {
@@ -119,7 +138,8 @@ func manualRunHTTPStatus(err error) int {
 	switch {
 	case errors.Is(err, ErrUnknownWorkflow):
 		return http.StatusNotFound
-	case errors.Is(err, ErrUnknownCell), errors.Is(err, ErrAmbiguousRef):
+	case errors.Is(err, ErrUnknownCell), errors.Is(err, ErrUnknownSource),
+		errors.Is(err, ErrAmbiguousRef), errors.Is(err, ErrSourceRequired):
 		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
@@ -203,15 +223,17 @@ func (d *Dispatcher) RunWorkflowManual(ctx context.Context, req ManualRunRequest
 		// bindings; mirroring that here keeps logs and activeRuns readable.
 		cell = model.SourceItem{ID: task.ID, Title: task.Title}
 	} else {
-		cell, adapter, task, persisted, err = d.manualTargetItem(ctx, req.ItemRef)
+		cell, adapter, task, persisted, err = d.manualTargetItem(ctx, req.ItemRef, req.SourceID)
 		if err != nil {
 			return res, err
 		}
-		res.CellID = cell.ID
+		res.CellID, res.SourceID, res.Ref = cell.ID, cell.SourceID, cell.Number
 	}
 	res.TaskID = task.ID
 	if res.Ref == "" && res.CellID != "" {
-		if _, number, refErr := d.resolveCellRef(ctx, req.ItemRef); refErr == nil {
+		// The item carried no human reference of its own; fall back to whatever
+		// the binding recorded.
+		if _, number, refErr := d.resolveCellRef(ctx, req.ItemRef, req.SourceID); refErr == nil {
 			res.Ref = number
 		}
 	}
@@ -290,20 +312,43 @@ func (d *Dispatcher) standaloneTask(ctx context.Context, wf config.WorkflowConfi
 // a manual run executes against — the same binding a poll of that item produces,
 // so the run sees live labels and state.
 //
-// It fails closed. A reference that resolves to no known item returns
-// ErrUnknownCell and creates nothing: silently falling back to a standalone task
-// would run the workflow against an empty target while reporting success, which
-// is the mis-targeting class of bug #377 was about.
-func (d *Dispatcher) manualTargetItem(ctx context.Context, ref string) (model.SourceItem, source.Adapter, model.InternalTask, bool, error) {
-	cellID, _, err := d.resolveCellRef(ctx, ref)
-	if err != nil {
+// An item apiary has never polled is fetched from its source and bound on the
+// spot (discoverItem), which is how `--item PSP-199` works for a ticket outside
+// the source's poll filters. It still fails closed: a reference no source can
+// produce an item for returns ErrUnknownCell and creates nothing, rather than
+// running the workflow against an empty target and reporting success (the
+// mis-targeting class of bug #377 was about).
+//
+// sourceID scopes both halves: it disambiguates a reference that exists in more
+// than one source, and it names which source to fetch an unknown one from.
+func (d *Dispatcher) manualTargetItem(ctx context.Context, ref, sourceID string) (model.SourceItem, source.Adapter, model.InternalTask, bool, error) {
+	fail := func(err error) (model.SourceItem, source.Adapter, model.InternalTask, bool, error) {
 		return model.SourceItem{}, nil, model.InternalTask{}, false, err
 	}
-	if err := d.assertKnownCell(ctx, cellID); err != nil {
-		return model.SourceItem{}, nil, model.InternalTask{}, false, err
+	if sourceID != "" {
+		if _, err := d.manualSource(sourceID); err != nil {
+			return fail(err)
+		}
 	}
 
-	cell, adapter, ok := d.fetchCell(ctx, cellID)
+	cellID, _, err := d.resolveCellRef(ctx, ref, sourceID)
+	if err != nil {
+		return fail(err)
+	}
+	if err := d.assertKnownCell(ctx, cellID); err != nil {
+		if !errors.Is(err, ErrUnknownCell) {
+			return fail(err)
+		}
+		// Not a cell apiary has seen. Ask a source for it before giving up.
+		cell, adapter, derr := d.discoverItem(ctx, ref, sourceID)
+		if derr != nil {
+			return fail(derr)
+		}
+		task, persisted := d.bindItem(ctx, cell)
+		return cell, adapter, task, persisted, nil
+	}
+
+	cell, adapter, ok := d.fetchCell(ctx, cellID, sourceID)
 	if !ok {
 		// No source can read the item right now (no TaskPoller, or the fetch
 		// failed). The binding still knows what the task is, so the workflow can
@@ -323,12 +368,119 @@ func (d *Dispatcher) manualTargetItem(ctx context.Context, ref string) (model.So
 	return cell, adapter, task, persisted, nil
 }
 
-// fetchCell reads a source item from whichever configured source can poll it,
+// discoverItem fetches an item apiary has never polled, straight from its source.
+//
+// This is the difference between "run a workflow on a task apiary is tracking"
+// and "run a workflow on PSP-199": a ticket outside the source's poll filters, in
+// a state the filters exclude, or created since the last tick has no binding, so
+// reference resolution finds nothing. The adapter can still resolve it — Jira's
+// /issue/{idOrKey} takes the key, GitHub's /issues/{n} the number — so ask.
+//
+// Unlike fetchCell this accepts the id the adapter reports rather than requiring
+// it to equal what was asked for: the caller passed a human reference (PSP-199)
+// precisely because it does not know the cell id (the opaque numeric issue id),
+// and resolving one to the other is what the fetch is for. The returned item is
+// echoed back to the caller and logged, so a fetch that resolved to something
+// unexpected is visible rather than silent.
+func (d *Dispatcher) discoverItem(ctx context.Context, ref, sourceID string) (model.SourceItem, source.Adapter, error) {
+	id, err := d.manualSourceForDiscovery(sourceID)
+	if err != nil {
+		return model.SourceItem{}, nil, err
+	}
+	adapter := d.sources[id]
+
+	cell, err := adapter.(source.TaskPoller).PollTask(ctx, strings.TrimSpace(ref))
+	if err != nil {
+		return model.SourceItem{}, nil, fmt.Errorf("%w: %s could not fetch %q: %w", ErrUnknownCell, id, ref, err)
+	}
+	if cell.ID == "" {
+		// A source that answers with no id has nothing to bind or write back to.
+		return model.SourceItem{}, nil, fmt.Errorf("%w: %s returned no item for %q", ErrUnknownCell, id, ref)
+	}
+	// The source we asked is authoritative, not the one the item claims: the
+	// binding and the adapter that later writes comments and state back must name
+	// the same source, or the run reads from one and writes to another.
+	if cell.SourceID != "" && cell.SourceID != id {
+		aplog.Warn("manual run: %s returned an item tagged source %q for %q — binding it to %s, the source that answered",
+			id, cell.SourceID, ref, id)
+	}
+	cell.SourceID = id
+	aplog.Info("manual run: %q is not a known cell — fetched it from source %s as %s (%q)",
+		ref, id, cell.LogLabel(), cell.Title)
+	return cell, adapter, nil
+}
+
+// manualSource returns the configured, connected source with this id.
+func (d *Dispatcher) manualSource(id string) (source.Adapter, error) {
+	if adapter, ok := d.sources[id]; ok {
+		return adapter, nil
+	}
+	return nil, fmt.Errorf("%w: %q (configured: %s)", ErrUnknownSource, id, strings.Join(d.sourceIDs(), ", "))
+}
+
+// manualSourceForDiscovery picks the source to fetch an unknown reference from.
+//
+// Named explicitly, it must exist and be able to fetch a single item. Left out,
+// it is inferred only when the answer is unambiguous — exactly one source can do
+// it. With several, the caller is asked rather than guessed at: fetching the
+// wrong project's PSP-199 and running a workflow over it is not an error anyone
+// would catch quickly.
+func (d *Dispatcher) manualSourceForDiscovery(sourceID string) (string, error) {
+	if sourceID != "" {
+		adapter, err := d.manualSource(sourceID)
+		if err != nil {
+			return "", err
+		}
+		if _, ok := adapter.(source.TaskPoller); !ok {
+			return "", fmt.Errorf("%w: source %q cannot fetch a single item (no TaskPoller)", ErrUnknownCell, sourceID)
+		}
+		return sourceID, nil
+	}
+
+	var candidates []string
+	for _, sc := range d.cfg.Sources {
+		if adapter, ok := d.sources[sc.ID]; ok {
+			if _, ok := adapter.(source.TaskPoller); ok {
+				candidates = append(candidates, sc.ID)
+			}
+		}
+	}
+	switch len(candidates) {
+	case 1:
+		return candidates[0], nil
+	case 0:
+		return "", fmt.Errorf("%w: no configured source can fetch a single item", ErrUnknownCell)
+	default:
+		sort.Strings(candidates)
+		return "", fmt.Errorf("%w: %d sources could hold it (%s) — pass --source to say which",
+			ErrSourceRequired, len(candidates), strings.Join(candidates, ", "))
+	}
+}
+
+// sourceIDs returns every configured source id, sorted.
+func (d *Dispatcher) sourceIDs() []string {
+	if d.cfg == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(d.cfg.Sources))
+	for _, sc := range d.cfg.Sources {
+		ids = append(ids, sc.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// fetchCell reads a known cell from whichever configured source can poll it,
 // returning the adapter alongside so side effects can write back. It is the
 // read-only half of ForceRestart's label-stripping loop: same TaskPoller scan and
 // same refusal to accept a substituted item, without touching anything.
-func (d *Dispatcher) fetchCell(ctx context.Context, cellID string) (model.SourceItem, source.Adapter, bool) {
+//
+// sourceID, when set, restricts the scan to that source.
+func (d *Dispatcher) fetchCell(ctx context.Context, cellID, sourceID string) (model.SourceItem, source.Adapter, bool) {
 	for _, sc := range d.cfg.Sources {
+		if sourceID != "" && sc.ID != sourceID {
+			continue
+		}
 		adapter, ok := d.sources[sc.ID]
 		if !ok {
 			continue

--- a/src/internal/daemon/manual_run_test.go
+++ b/src/internal/daemon/manual_run_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 // manualDispatcher wires the queue harness with a source that can also fetch a
@@ -191,7 +194,138 @@ func TestRunWorkflowManual_UnknownWorkflow(t *testing.T) {
 	}
 }
 
-// An item reference that resolves to nothing must not silently degrade into a
+// keyedAdapter resolves a human reference (a Jira-style key) to an item whose
+// own id is different — the case that makes discovery necessary and that
+// fetchCell's substitution guard would otherwise reject.
+type keyedAdapter struct {
+	mutableAdapter
+	id, key string
+	calls   []string
+}
+
+func (a *keyedAdapter) PollTask(_ context.Context, ref string) (model.SourceItem, error) {
+	a.calls = append(a.calls, ref)
+	if ref != a.id && !strings.EqualFold(ref, a.key) {
+		return model.SourceItem{}, fmt.Errorf("issue %q does not exist", ref)
+	}
+	return model.SourceItem{ID: a.id, SourceID: "src", Number: a.key, Title: "Fix the thing", State: "todo"}, nil
+}
+
+// The point of --item PSP-199: a ticket apiary has never polled is fetched from
+// its source and bound on the spot, and the run binds the item the source
+// resolved the key to — not the key itself.
+func TestRunWorkflowManual_DiscoversUnpolledItem(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := newQueueDispatcher(t, false)
+	adapter := &keyedAdapter{id: "10042", key: "PSP-199"}
+	d.sources["src"] = adapter
+
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "PSP-199"})
+	if err != nil {
+		t.Fatalf("manual run on an unpolled item: %v", err)
+	}
+	if res.CellID != "10042" {
+		t.Errorf("cell = %q, want the id the source resolved the key to (10042)", res.CellID)
+	}
+	if res.Ref != "PSP-199" {
+		t.Errorf("ref = %q, want PSP-199", res.Ref)
+	}
+	if res.SourceID != "src" {
+		t.Errorf("source = %q, want src", res.SourceID)
+	}
+	if res.Standalone {
+		t.Error("Standalone = true; a discovered item must be bound, not run standalone")
+	}
+
+	// It is bound like any polled item, so the next run resolves it from the DB.
+	binding, err := dbc.SourceBindings().GetBindingBySourceItem(ctx, "src", "10042")
+	if err != nil || binding == nil {
+		t.Fatalf("discovered item was not bound: %v", err)
+	}
+	if binding.SourceItemNumber != "PSP-199" {
+		t.Errorf("binding number = %q, want PSP-199", binding.SourceItemNumber)
+	}
+	if got := len(jobsFor(t, d, "triage")); got != 1 {
+		t.Fatalf("discovered run produced %d job(s), want 1", got)
+	}
+}
+
+// Case-insensitively, too — the same courtesy the binding lookup already gives.
+func TestRunWorkflowManual_DiscoveryIsCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := newQueueDispatcher(t, false)
+	d.sources["src"] = &keyedAdapter{id: "10042", key: "PSP-199"}
+
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "psp-199"})
+	if err != nil {
+		t.Fatalf("manual run: %v", err)
+	}
+	if res.CellID != "10042" {
+		t.Errorf("cell = %q, want 10042", res.CellID)
+	}
+}
+
+// A known item must not be re-fetched through discovery: the binding already
+// answers, and the substitution guard still applies on that path.
+func TestRunWorkflowManual_KnownItemSkipsDiscovery(t *testing.T) {
+	ctx := context.Background()
+	d, base, dbc := newQueueDispatcher(t, false)
+	adapter := &pollableAdapter{mutableAdapter: *base}
+	d.sources["src"] = adapter
+	d.poll(ctx, d.cfg.Sources[0], adapter, time.Time{})
+	task := taskForCell(t, dbc, "src", "c1")
+
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "impl", ItemRef: "c1"})
+	if err != nil {
+		t.Fatalf("manual run: %v", err)
+	}
+	if res.TaskID != task.ID {
+		t.Errorf("task = %q, want the already-bound task %q — discovery created a new one", res.TaskID, task.ID)
+	}
+}
+
+// With several sources able to fetch, guessing could mean running a workflow
+// over some other project's PSP-199. Ask instead.
+func TestRunWorkflowManual_AmbiguousSourceAsksForOne(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := newQueueDispatcher(t, false)
+	d.cfg.Sources = append(d.cfg.Sources, config.SourceConfig{ID: "other", Type: "fake"})
+	d.sources["src"] = &keyedAdapter{id: "10042", key: "PSP-199"}
+	d.sources["other"] = &keyedAdapter{id: "77", key: "PSP-199"}
+
+	_, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "PSP-199"})
+	if !errors.Is(err, ErrSourceRequired) {
+		t.Fatalf("error = %v, want ErrSourceRequired", err)
+	}
+	if !strings.Contains(err.Error(), "src") || !strings.Contains(err.Error(), "other") {
+		t.Errorf("error %q does not name the candidate sources", err)
+	}
+
+	// Naming one resolves it, and the named source is the one that answers.
+	res, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "PSP-199", SourceID: "other"})
+	if err != nil {
+		t.Fatalf("manual run with --source: %v", err)
+	}
+	if res.CellID != "77" || res.SourceID != "other" {
+		t.Errorf("resolved to %s/%s, want other/77", res.SourceID, res.CellID)
+	}
+}
+
+func TestRunWorkflowManual_UnknownSource(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := newQueueDispatcher(t, false)
+	d.sources["src"] = &keyedAdapter{id: "10042", key: "PSP-199"}
+
+	_, err := d.RunWorkflowManual(ctx, ManualRunRequest{WorkflowID: "triage", ItemRef: "PSP-199", SourceID: "nope"})
+	if !errors.Is(err, ErrUnknownSource) {
+		t.Fatalf("error = %v, want ErrUnknownSource", err)
+	}
+	if jobs, _ := d.db.Queue().ListJobs(ctx, "", 100); len(jobs) != 0 {
+		t.Fatalf("unknown source still enqueued %d job(s)", len(jobs))
+	}
+}
+
+// An item reference no source can produce must not silently degrade into a
 // standalone run against an empty target (the mis-targeting class of #377).
 func TestRunWorkflowManual_UnknownItem(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
Follow-up to #423. `apiary dispatch --item PSP-199` now works for a ticket apiary has never polled.

## The gap

Reference resolution goes through `source_bindings`, so `--item PSP-199` only resolved if PSP-199 had already been polled and bound. A ticket outside the source's `filters`, in an excluded state, or created since the last tick resolved to nothing and `assertKnownCell` refused the run — even though the adapter could have fetched it perfectly well (Jira's `/issue/{idOrKey}` takes the key, GitHub's `/issues/{n}` the number).

```
Error: dispatch failed: unknown cell: PSP-199
```

## What changed

An unknown reference is fetched from its source and bound on the spot, exactly as a poll would have bound it.

```sh
apiary dispatch triage --item PSP-199                 # one source: inferred
apiary dispatch triage --item PSP-199 --source jira   # several: name it
```

`--source` is optional when exactly one configured source can fetch a single item. When several can, apiary asks rather than guesses:

```
Error: dispatch failed: source required: 2 sources could hold it (jira, my-repo)
  — pass --source to say which
```

It also disambiguates a reference that exists in more than one source, which previously meant looking up the cell id by hand — so `resolveCellRef` takes a source scope (`ForceRestart` passes none; unchanged).

## Two decisions worth reviewing

**The discovery path accepts the id the adapter reports**, unlike `fetchCell`, which rejects a substituted item. The caller typed a human reference precisely because it does not know the cell id — resolving `PSP-199` → `10042` is what the fetch is *for*, so requiring them to match would defeat it. Mitigations: the source is either named explicitly or the only candidate, and the resolved id and title are logged and returned (`✓ Started workflow triage on PSP-199 (10042) in jira`), so a fetch that landed somewhere unexpected is visible rather than silent.

**The source that answered wins over the source the item claims.** A test caught the inconsistency: the binding and the adapter that later writes comments and state back must name the same source, or a run reads from one and writes to another. A disagreement is logged.

Still fails closed — a reference no source can produce an item for returns `ErrUnknownCell` and creates nothing.

## Verification

`go build ./... && go test ./...` clean. Six new tests: discovery of an unpolled key, case-insensitivity, that a *known* item still skips discovery (no duplicate task), the ambiguous-source error naming its candidates, that naming one resolves to that source's item, and unknown-source failing closed with nothing enqueued.

End-to-end against a live two-source daemon: ambiguous ref asks for `--source`; a named source that 404s fails closed with the adapter's own message; unknown source lists the configured ones; standalone runs unaffected.