### PR TITLE
fix(workflow): non-agent steps inside parallel groups, plus source-agnostic PR links

### DIFF
--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -70,7 +70,13 @@ visible to the API user and logs a warning.
   whitespace are rewritten with `-` (e.g. `needs review` → `needs-review`).
 - **No CI polling.** `wait_for` steps with `kind: ci` need a source that can
   see pull requests; Jira issues have no PR mapping, so host CI waits on a
-  GitHub source instead.
+  GitHub source instead. `apiary validate` rejects such a step against a
+  Jira-only config, so this surfaces at config time rather than at runtime.
+- **PRs link from the workflow.** Because the adapter cannot enumerate a task's
+  pull requests, the dashboard's `p` shortcut has nothing to open unless the
+  workflow reports the PR itself: point
+  [`pull_request_from`](workflows.md#linking-a-pr-pull_request_from) at the
+  output field carrying the PR URL on the step that opens it.
 - **Dependency waits work.** `wait_for` steps with
   [`kind: dependency`](workflows.md#wait_for-steps-waiting-on-blockers-kind-dependency)
   read the inward side of the issue's `Blocks` links (*"is blocked by"*;

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -634,7 +634,9 @@ How it works:
   which the dashboard shows in the task's detail view, so a long CI wait is
   fully auditable.
 - Poll statuses are `passed`, `failed`, `pending`, `timeout`, `error`,
-  `unknown`.
+  `unknown`, `unsupported`. `unsupported` means the source cannot poll CI at
+  all: the step fails at once with the cause logged and recorded, rather than
+  polling until `max_duration`.
 - Like approvals, parked CI waits **survive daemon restarts**.
 - `remove_label: <name>` clears a stale label from the task before polling
   begins.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -234,6 +234,7 @@ steps:
 | `on_missing_output` | What to do when `output` is declared but not satisfied: `warn` (default), `fail`, `ignore`. Under `warn` the step still passes, but a `reject_when` gate reading one of this step's own `memory.write` keys fails closed — see [review loops](#reject_when--on_reject--review-loops). `ignore` opts out of both |
 | `memory` | Which output fields to persist, and whether to inject memory — see [Workflow memory](#workflow-memory) |
 | `publish` / `spawn` | Control agent-emitted write-backs and child tasks — see [Tasks & fan-out](tasks-and-fanout.md) |
+| `pull_request_from` | Name of an output field holding the URL of a PR this step opened; links that PR to the task — see [Linking a PR](#linking-a-pr-pull_request_from) |
 | `env` | Step-scope environment variables (highest precedence) |
 | `idempotent` | Mark the step safe to re-run on [resume](#resuming-instances) |
 
@@ -246,6 +247,44 @@ APIARY_OUTPUT: {"complexity": "high", "approach": "refactor the dispatcher"}
 
 Apiary extracts and validates the payload against the schema. Validated
 fields listed in `memory.write` become workflow memory for later steps.
+
+#### Linking a PR (`pull_request_from`)
+
+Apiary links pull requests to a task so features like the dashboard's `p`
+shortcut ("open the task's PR") have something to open. It discovers them
+through the source — which only works for a source that can enumerate the PRs
+of one of its items. A GitHub source can; Jira and Plane cannot, so a task from
+those sources shows no PRs at all, however many its agents opened.
+
+`pull_request_from` closes that gap from the workflow side: point it at the
+output field carrying the PR URL, and the step registers its own PR.
+
+```yaml
+- id: implement
+  agent: engineer
+  prompt: "Implement the change and open a PR."
+  output:
+    type: object
+    properties:
+      pr_url: {type: string}
+    required: [pr_url]
+  pull_request_from: pr_url
+```
+
+- The URL is parsed for the PR number; GitHub, Codeberg/Forgejo, GitLab and
+  Bitbucket link shapes are recognised, self-hosted hosts included.
+- Re-reporting the same PR (a loop-back that re-runs the step) refreshes the
+  existing link instead of adding a duplicate. The most recently linked PR is
+  the one the shortcut opens.
+- Best-effort by design: a step that opened no PR simply leaves the field
+  empty, and a URL that cannot be parsed is logged and skipped — neither fails
+  a step whose real work succeeded. A failed step's PR is never linked.
+- `apiary validate` rejects a `pull_request_from` naming a field the step's
+  `output` schema does not declare.
+
+This does **not** enable `wait_for {kind: ci}` on those sources: polling check
+runs needs a source adapter that can talk to the forge, which is a separate
+capability from knowing a PR's URL.
 
 ### Workflow memory
 
@@ -357,6 +396,31 @@ Children run concurrently; `join` decides the group's outcome:
   expression that cannot be evaluated at runtime fails the parallel step.
   Note: expression accessors cannot reference child ids containing hyphens —
   use `snake_case` ids for children you test in a join expression.
+
+**Which children are allowed.** A group runs `agent` and `wait_for` children.
+Anything else — an `approval`, a `for_each:`, or a nested group — is rejected by
+`apiary validate`.
+
+A `wait_for` child parks the whole group until its wait resolves: the children
+that already finished are remembered, so a re-check re-polls only the wait and
+never re-runs a sibling that passed (this survives daemon restarts, like any
+other park). A group whose `join` is already decided by the children that
+finished does not wait at all — under `join: all` a failed review fails the
+group immediately instead of sitting on a two-hour CI budget.
+
+```yaml
+- id: gate
+  parallel:
+    - id: review
+      agent: reviewer
+      prompt: "Review the PR."
+    - id: await_ci
+      type: wait_for
+      wait_for:
+        kind: ci
+        max_duration: 2h
+  join: all
+```
 
 #### `for_each:` — iteration
 
@@ -561,6 +625,11 @@ How it works:
 
 - The PR is discovered through the issue's timeline (a PR that references
   the issue), so the agent just needs to open a PR that links the task.
+- `kind: ci` needs a source that can poll check runs (GitHub today). Against a
+  source that cannot — Jira, Plane, an alert source — `apiary validate` rejects
+  the step at config time, wherever it sits, including inside a `parallel:`
+  group. See [linking a PR by hand](#linking-a-pr-pull_request_from) for what
+  still works on those sources.
 - Each poll records a row of history — status, PR URL, per-check detail —
   which the dashboard shows in the task's detail view, so a long CI wait is
   fully auditable.

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -1006,6 +1006,10 @@
           "enum": ["auto", "await"],
           "default": "auto"
         },
+        "pull_request_from": {
+          "type": "string",
+          "description": "Name of a field in this step's structured output holding the URL of a pull request the step opened (e.g. pr_url). The engine parses it and links the PR to the task, which is what the dashboard's 'open PR' shortcut reads — so PR-linked features work even when the task's source (Jira, Plane) cannot enumerate pull requests itself. Only valid on type=agent; must name a field the step's output schema declares"
+        },
         "env": {
           "type": "object",
           "description": "Step-scope environment variables. Highest-precedence explicit scope: overrides workflow.env and agent.env for the same key",

--- a/src/internal/config/parallel_child_kind_test.go
+++ b/src/internal/config/parallel_child_kind_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// parallelChildConfig wraps children in a workflow whose only group is the
+// parallel step under test.
+func parallelChildConfig(children []config.StepConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Agents:  []config.AgentConfig{{ID: "eng"}},
+		Workflows: []config.WorkflowConfig{{
+			ID: "impl",
+			Steps: []config.StepConfig{
+				{ID: "implement", Agent: "eng"},
+				{ID: "gate", ParallelSteps: children},
+			},
+		}},
+	}
+}
+
+// A parallel group runs each child by its own type, but only agent and wait_for
+// children are supported. The rest must be rejected at config time rather than
+// failing in milliseconds at runtime and taking their siblings down with them
+// under join: all (#425).
+func TestParallelChild_RejectsUnsupportedKinds(t *testing.T) {
+	cases := []struct {
+		name  string
+		child config.StepConfig
+		want  string
+	}{
+		{
+			name:  "approval",
+			child: config.StepConfig{ID: "sign-off", Type: config.StepTypeApproval, Message: "ok?"},
+			want:  "cannot contain a approval step",
+		},
+		{
+			name:  "nested parallel",
+			child: config.StepConfig{ID: "inner", ParallelSteps: []config.StepConfig{{ID: "a", Agent: "eng"}}},
+			want:  "nested parallel: groups are not supported",
+		},
+		{
+			name:  "for_each",
+			child: config.StepConfig{ID: "loop", ForEachExpr: "${{ design.tasks }}", As: "task"},
+			want:  "for_each: is not supported inside a parallel group",
+		},
+		{
+			name:  "nested group",
+			child: config.StepConfig{ID: "group", SubSteps: []config.StepConfig{{ID: "a", Agent: "eng"}}},
+			want:  "nested steps: groups are not supported",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := parallelChildConfig([]config.StepConfig{
+				{ID: "review", Agent: "eng"},
+				tc.child,
+			})
+			errsContain(t, cfg.Validate(), tc.want)
+		})
+	}
+}
+
+// The two supported kinds still validate clean.
+func TestParallelChild_AcceptsAgentAndWaitFor(t *testing.T) {
+	cfg := parallelChildConfig([]config.StepConfig{
+		{ID: "review", Agent: "eng"},
+		{ID: "await-ci", Type: config.StepTypeWaitFor,
+			WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI, MaxDuration: "2h"}},
+	})
+	errs := cfg.Validate()
+	errsNotContain(t, errs, "parallel group")
+	errsNotContain(t, errs, "not supported")
+}

--- a/src/internal/config/pull_request_from_test.go
+++ b/src/internal/config/pull_request_from_test.go
@@ -1,0 +1,58 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+func prFromConfig(step config.StepConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Agents:  []config.AgentConfig{{ID: "eng"}},
+		Workflows: []config.WorkflowConfig{{
+			ID:    "impl",
+			Steps: []config.StepConfig{step},
+		}},
+	}
+}
+
+// pull_request_from must name a field the step declares, or the PR link would
+// silently never appear.
+func TestPullRequestFrom_RejectsUndeclaredField(t *testing.T) {
+	cfg := prFromConfig(config.StepConfig{
+		ID: "implement", Agent: "eng", PullRequestFrom: "pr_link",
+		OutputSchema: &config.OutputSchema{
+			Type:       "object",
+			Properties: map[string]config.SchemaField{"pr_url": {Type: "string"}},
+		},
+	})
+	errsContain(t, cfg.Validate(), `pull_request_from references "pr_link"`)
+}
+
+func TestPullRequestFrom_AcceptsDeclaredField(t *testing.T) {
+	cfg := prFromConfig(config.StepConfig{
+		ID: "implement", Agent: "eng", PullRequestFrom: "pr_url",
+		OutputSchema: &config.OutputSchema{
+			Type:       "object",
+			Properties: map[string]config.SchemaField{"pr_url": {Type: "string"}},
+		},
+	})
+	errsNotContain(t, cfg.Validate(), "pull_request_from")
+}
+
+// A step with no declared schema is accepted: the field is read from whatever
+// the agent emits.
+func TestPullRequestFrom_AcceptedWithoutOutputSchema(t *testing.T) {
+	cfg := prFromConfig(config.StepConfig{ID: "implement", Agent: "eng", PullRequestFrom: "pr_url"})
+	errsNotContain(t, cfg.Validate(), "pull_request_from")
+}
+
+// Only an agent step produces the structured output the mapping reads.
+func TestPullRequestFrom_RejectedOnNonAgentStep(t *testing.T) {
+	cfg := prFromConfig(config.StepConfig{
+		ID: "await-ci", Type: config.StepTypeWaitFor, PullRequestFrom: "pr_url",
+		WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI},
+	})
+	errsContain(t, cfg.Validate(), "pull_request_from is only valid on an agent step")
+}

--- a/src/internal/config/source_caps_validate.go
+++ b/src/internal/config/source_caps_validate.go
@@ -94,7 +94,7 @@ func workflowCapNeeds(w WorkflowConfig) []capNeed {
 	addHook("on_complete", w.OnComplete)
 	addHook("on_fail", w.OnFail)
 
-	for _, s := range w.Steps {
+	for _, s := range flattenSteps(w.Steps) {
 		sctx := fmt.Sprintf("step %q", s.ID)
 		switch s.StepType() {
 		case StepTypeApproval:
@@ -109,4 +109,28 @@ func workflowCapNeeds(w WorkflowConfig) []capNeed {
 		}
 	}
 	return needs
+}
+
+// flattenSteps returns every step in declaration order, descending into the
+// children of the group nodes the lowering pass produces: a parallel node keeps
+// its children in SubSteps and a foreach node keeps its body in Step, so a
+// walk over the top-level list alone misses them.
+//
+// A nested step reaches the very same source as a top-level one, so every
+// capability it needs must be linted too. Without this, a `wait_for {kind: ci}`
+// inside a parallel: group escaped the check entirely against a source that
+// cannot poll CI, and the operator learned about it only from a runtime failure
+// (#425).
+func flattenSteps(steps []StepConfig) []StepConfig {
+	out := make([]StepConfig, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, s)
+		if len(s.SubSteps) > 0 {
+			out = append(out, flattenSteps(s.SubSteps)...)
+		}
+		if s.Step != nil {
+			out = append(out, flattenSteps([]StepConfig{*s.Step})...)
+		}
+	}
+	return out
 }

--- a/src/internal/config/source_caps_validate_test.go
+++ b/src/internal/config/source_caps_validate_test.go
@@ -149,3 +149,70 @@ func TestSourceCaps_SkippedWhenHookNil(t *testing.T) {
 	errsNotContain(t, cfg.Validate(), "capability")
 	errsNotContain(t, cfg.Validate(), "no configured source supports")
 }
+
+// A wait_for ci step nested inside a parallel: group needs the CI capability
+// just like a top-level one. Before #425 the lint walked only the top-level
+// step list, so a Jira-sourced workflow with a `wait_for {kind: ci}` inside a
+// parallel group validated clean and failed at runtime instead.
+func TestSourceCaps_CIWaitNestedInParallelIsLinted(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "tickets", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID: "impl",
+			Steps: []config.StepConfig{
+				{ID: "implement", Agent: "eng"},
+				{ID: "gate", ParallelSteps: []config.StepConfig{
+					{ID: "review", Agent: "eng"},
+					{ID: "await-ci", Type: config.StepTypeWaitFor,
+						WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+				}},
+			},
+		},
+	)
+	errs := cfg.Validate()
+	errsContain(t, errs, `step "await-ci" (wait_for ci)`)
+	errsContain(t, errs, "no configured source supports")
+}
+
+// The same lint reaches a for_each body.
+func TestSourceCaps_CIWaitNestedInForeachIsLinted(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "tickets", Type: "alerts"}},
+		config.WorkflowConfig{
+			ID: "impl",
+			Steps: []config.StepConfig{
+				{ID: "design", Agent: "eng"},
+				{ID: "each", ForEachExpr: "${{ design.tasks }}", As: "task", SubSteps: []config.StepConfig{
+					{ID: "await-ci", Type: config.StepTypeWaitFor,
+						WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+				}},
+			},
+		},
+	)
+	errsContain(t, cfg.Validate(), `step "await-ci" (wait_for ci)`)
+}
+
+// A supported source keeps a nested wait_for ci valid.
+func TestSourceCaps_CIWaitNestedInParallelAcceptedWhenSupported(t *testing.T) {
+	withSourceCaps(t)
+
+	cfg := capsConfig(
+		[]config.SourceConfig{{ID: "tickets", Type: "ticket"}},
+		config.WorkflowConfig{
+			ID: "impl",
+			Steps: []config.StepConfig{
+				{ID: "implement", Agent: "eng"},
+				{ID: "gate", ParallelSteps: []config.StepConfig{
+					{ID: "review", Agent: "eng"},
+					{ID: "await-ci", Type: config.StepTypeWaitFor,
+						WaitFor: &config.WaitForConfig{Kind: config.WaitKindCI}},
+				}},
+			},
+		},
+	)
+	errsNotContain(t, cfg.Validate(), "wait_for ci")
+}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -248,6 +248,16 @@ type StepConfig struct {
 	// sub-issue carries the spawn request's labels, so the normal poll→route loop
 	// picks it up and dispatches the matching workflow.
 	Materialize string `yaml:"materialize,omitempty"`
+	// PullRequestFrom names a field of this step's structured output holding the
+	// URL of a pull request the step opened (e.g. `pull_request_from: pr_url`).
+	// The engine parses that URL and links the PR to the task, which is what the
+	// dashboard's "open PR" shortcut reads.
+	//
+	// It exists because PR discovery is otherwise a GitHub-source privilege: the
+	// PRs of a task sourced from Jira or Plane are invisible, since those
+	// adapters cannot enumerate them. Declaring the field the agent already
+	// emits makes the link work regardless of source type (#425).
+	PullRequestFrom string `yaml:"pull_request_from,omitempty"`
 	// Env is the step-scope environment overlay. It is the highest-precedence
 	// explicit scope: it overrides workflow.env and agent.env for the same key.
 	Env map[string]string `yaml:"env,omitempty"`

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -270,6 +270,12 @@ func (c *Config) validateStep(
 	// lowering on every step), so lint here rather than in a per-type validator.
 	errs = append(errs, lintStepExprs(sctx, s)...)
 
+	// pull_request_from reads the step's structured output, which only an agent
+	// step produces.
+	if s.PullRequestFrom != "" && s.StepType() != StepTypeAgent {
+		errs = append(errs, fmt.Errorf("%s: pull_request_from is only valid on an agent step", sctx))
+	}
+
 	// on_conflict applies to any step type, so validate it here rather than in a
 	// per-type validator. It is only meaningful on a wait_for step (the sole
 	// producer of a conflict) and otherwise mirrors on_fail (goto + max_retries).
@@ -306,6 +312,14 @@ func (c *Config) validateAgentStep(sctx string, s StepConfig, agentIDs, stepIDs 
 	case "", OnMissingOutputWarn, OnMissingOutputFail, OnMissingOutputIgnore:
 	default:
 		errs = append(errs, fmt.Errorf("%s: invalid on_missing_output %q (want warn|fail|ignore)", sctx, s.OnMissingOutput))
+	}
+
+	// pull_request_from must name a field the step actually emits, otherwise the
+	// PR link silently never appears.
+	if s.PullRequestFrom != "" && s.OutputSchema != nil {
+		if _, declared := s.OutputSchema.Properties[s.PullRequestFrom]; !declared {
+			errs = append(errs, fmt.Errorf("%s: pull_request_from references %q, which the step's output schema does not declare", sctx, s.PullRequestFrom))
+		}
 	}
 
 	switch s.Spawn {

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -596,7 +596,42 @@ func (c *Config) validateParallelStep(
 		childIDs[child.ID] = true
 	}
 	for j, child := range s.SubSteps {
+		errs = append(errs, validateParallelChildKind(sctx, child)...)
 		errs = append(errs, c.validateStep(sctx, j, child, wf, agentIDs, childIDs, wfByID)...)
+	}
+
+	return errs
+}
+
+// validateParallelChildKind rejects the child kinds a parallel group cannot
+// run. The group executes each child by its own type, but only agent and
+// wait_for children are supported: an approval child would need a second,
+// independent park regime inside a group that is already parked as a unit, and
+// a nested group (parallel:/steps:/for_each: inside a parallel child) is never
+// lowered — the lowering pass flattens only leaf children, so the node would
+// reach the engine with its authored v2 fields intact and run as an agent step.
+//
+// Before this check both cases failed at runtime in milliseconds with no usable
+// diagnostic, and under the default join: all they failed their passing
+// siblings with them (#425).
+func validateParallelChildKind(sctx string, child StepConfig) []error {
+	var errs []error
+	cctx := fmt.Sprintf("%s: child %q", sctx, child.ID)
+
+	switch child.StepType() {
+	case StepTypeAgent, StepTypeWaitFor:
+	default:
+		errs = append(errs, fmt.Errorf("%s: a parallel group cannot contain a %s step (only agent and wait_for children are supported)",
+			cctx, child.StepType()))
+	}
+
+	switch {
+	case len(child.ParallelSteps) > 0:
+		errs = append(errs, fmt.Errorf("%s: nested parallel: groups are not supported", cctx))
+	case child.ForEachExpr != "":
+		errs = append(errs, fmt.Errorf("%s: for_each: is not supported inside a parallel group", cctx))
+	case len(child.SubSteps) > 0 && child.Type == "":
+		errs = append(errs, fmt.Errorf("%s: nested steps: groups are not supported inside a parallel group", cctx))
 	}
 
 	return errs

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -39,7 +39,9 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			}
 			poller, ok := adapter.(source.CIStatusPoller)
 			if !ok {
-				return source.CIStatus{}, fmt.Errorf("source %q does not support CI status polling", sourceID)
+				// Permanent, not transient: fail the wait at once instead of
+				// polling a capability that will never appear (#425).
+				return source.CIStatus{}, fmt.Errorf("source %q cannot poll CI status: %w", sourceID, source.ErrUnsupported)
 			}
 			return poller.PollCIStatus(ctx, sourceItemID)
 		}))
@@ -51,7 +53,7 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			}
 			lister, ok := adapter.(source.BlockerLister)
 			if !ok {
-				return nil, fmt.Errorf("source %q does not support blocker listing (wait_for kind: dependency)", sourceID)
+				return nil, fmt.Errorf("source %q cannot list blockers (wait_for kind: dependency): %w", sourceID, source.ErrUnsupported)
 			}
 			return lister.ListBlockers(ctx, sourceItemID, linkType)
 		}))

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -750,6 +750,21 @@ func (s *wfSideEffects) PostComment(ctx context.Context, task model.InternalTask
 	return nil
 }
 
+// LinkPullRequest persists a PR a workflow step reported against the task. It
+// is attributed to the first binding's source — the task's primary source item,
+// which is what the dashboard groups PRs under.
+func (s *wfSideEffects) LinkPullRequest(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, pr source.PullRequestRef) error {
+	if s.d.db == nil || len(bindings) == 0 {
+		return nil
+	}
+	return s.d.db.UpsertTaskPullRequest(ctx, task.ID, db.TaskPullRequest{
+		SourceID: bindings[0].SourceID,
+		PRNumber: pr.Number,
+		PRURL:    pr.URL,
+		PRState:  pr.State,
+	})
+}
+
 func (s *wfSideEffects) ApplyHook(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, hook config.OnComplete) error {
 	for _, b := range bindings {
 		adapter := s.d.sources[b.SourceID]

--- a/src/internal/db/pullrequest_store.go
+++ b/src/internal/db/pullrequest_store.go
@@ -44,6 +44,49 @@ func (c *Client) ReplaceTaskPullRequests(ctx context.Context, taskID, sourceID s
 	return tx.Commit()
 }
 
+// UpsertTaskPullRequest links one pull request to a task, keyed by
+// (task_id, source_id, pr_number): a PR already linked has its URL and state
+// refreshed instead of being duplicated, so a step that re-runs (a loop-back
+// after a red CI) never stacks up rows for the same PR.
+//
+// Unlike ReplaceTaskPullRequests this is additive — it is fed by workflow steps
+// reporting the PR they opened (pull_request_from), one at a time, rather than
+// by a source listing that knows the complete set. New rows go to the end of
+// the seq order, so the newest PR stays the one the dashboard opens.
+func (c *Client) UpsertTaskPullRequest(ctx context.Context, taskID string, pr TaskPullRequest) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx, `
+		UPDATE task_pull_requests SET pr_url = ?, pr_state = COALESCE(?, pr_state)
+		WHERE task_id = ? AND source_id = ? AND pr_number = ?
+	`, pr.PRURL, nullStr(pr.PRState), taskID, pr.SourceID, pr.PRNumber)
+	if err != nil {
+		return err
+	}
+	if n, err := res.RowsAffected(); err == nil && n > 0 {
+		return tx.Commit()
+	}
+
+	var nextSeq int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(MAX(seq)+1, 0) FROM task_pull_requests WHERE task_id = ?`,
+		taskID).Scan(&nextSeq); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO task_pull_requests
+		  (id, task_id, source_id, pr_number, pr_url, pr_state, seq)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, newID(), taskID, pr.SourceID, pr.PRNumber, pr.PRURL, nullStr(pr.PRState), nextSeq); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // ListTaskPullRequests returns all PRs linked to a task across sources, ordered
 // oldest first (seq ASC). The tail is the most recent PR — what the dashboard's
 // "open PR" shortcut opens.

--- a/src/internal/db/pullrequest_store_test.go
+++ b/src/internal/db/pullrequest_store_test.go
@@ -84,3 +84,63 @@ func TestTaskPullRequests_PerSourceIsolation(t *testing.T) {
 		t.Fatalf("got %d rows, want 2 (one per source)", len(got))
 	}
 }
+
+// A workflow step reporting the PR it opened links it additively, and a
+// re-reported PR is refreshed rather than duplicated (#425).
+func TestTaskPullRequests_UpsertIsAdditiveAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	if err := c.UpsertTaskPullRequest(ctx, "task1",
+		TaskPullRequest{SourceID: "jira", PRNumber: 42, PRURL: "https://gh/pr/42"}); err != nil {
+		t.Fatalf("upsert 1: %v", err)
+	}
+	// Same PR again (a loop-back re-ran the step): refreshed in place.
+	if err := c.UpsertTaskPullRequest(ctx, "task1",
+		TaskPullRequest{SourceID: "jira", PRNumber: 42, PRURL: "https://gh/pr/42", PRState: "open"}); err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+	// A second, different PR on the same task.
+	if err := c.UpsertTaskPullRequest(ctx, "task1",
+		TaskPullRequest{SourceID: "jira", PRNumber: 43, PRURL: "https://gh/pr/43"}); err != nil {
+		t.Fatalf("upsert 3: %v", err)
+	}
+
+	got, err := c.ListTaskPullRequests(ctx, "task1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2 (the re-reported PR must not duplicate): %+v", len(got), got)
+	}
+	if got[0].PRNumber != 42 || got[0].PRState != "open" {
+		t.Errorf("first row = %+v, want PR 42 in state open", got[0])
+	}
+	// The newest link is the tail — what the dashboard's (p) shortcut opens.
+	if last := got[len(got)-1]; last.PRNumber != 43 {
+		t.Errorf("tail = %d, want 43", last.PRNumber)
+	}
+}
+
+// Upserted links coexist with a source listing's rows for another source.
+func TestTaskPullRequests_UpsertDoesNotDisturbOtherSources(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	if err := c.ReplaceTaskPullRequests(ctx, "task1", "github",
+		[]TaskPullRequest{{SourceID: "github", PRNumber: 1, PRURL: "https://gh/pr/1"}}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if err := c.UpsertTaskPullRequest(ctx, "task1",
+		TaskPullRequest{SourceID: "jira", PRNumber: 42, PRURL: "https://gh/pr/42"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := c.ListTaskPullRequests(ctx, "task1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(got), got)
+	}
+}

--- a/src/internal/source/prurl.go
+++ b/src/internal/source/prurl.go
@@ -1,0 +1,54 @@
+package source
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// prSegments are the path segments a forge puts before a pull request's number:
+// GitHub/Codeberg/Forgejo use "pull" (and "pulls" in API links), GitLab uses
+// "merge_requests", Bitbucket "pull-requests".
+var prSegments = map[string]bool{
+	"pull":           true,
+	"pulls":          true,
+	"merge_requests": true,
+	"pull-requests":  true,
+}
+
+// ParsePullRequestURL extracts the pull request number from a PR/MR browser
+// URL. It is forge-agnostic on purpose: an agent that opened a PR reports the
+// URL it got back, and the task it belongs to may come from a source (Jira,
+// Plane) that has no idea what a pull request is.
+//
+// A trailing sub-path such as /files or /commits is tolerated, so a URL copied
+// out of a browser tab still parses.
+func ParsePullRequestURL(raw string) (PullRequestRef, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return PullRequestRef{}, fmt.Errorf("empty pull request URL")
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return PullRequestRef{}, fmt.Errorf("invalid pull request URL %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return PullRequestRef{}, fmt.Errorf("pull request URL %q must be http(s)", raw)
+	}
+
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// Walk from the end so the number is taken from the LAST pull segment: a
+	// repository may itself be named "pull".
+	for i := len(segments) - 1; i > 0; i-- {
+		if !prSegments[segments[i-1]] {
+			continue
+		}
+		n, err := strconv.Atoi(segments[i])
+		if err != nil || n <= 0 {
+			return PullRequestRef{}, fmt.Errorf("pull request URL %q has no valid number", raw)
+		}
+		return PullRequestRef{Number: n, URL: trimmed}, nil
+	}
+	return PullRequestRef{}, fmt.Errorf("pull request URL %q does not look like a pull request link", raw)
+}

--- a/src/internal/source/prurl_test.go
+++ b/src/internal/source/prurl_test.go
@@ -1,0 +1,55 @@
+package source_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+func TestParsePullRequestURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"github", "https://github.com/acme/widgets/pull/42", 42},
+		{"github with sub-path", "https://github.com/acme/widgets/pull/42/files", 42},
+		{"codeberg", "https://codeberg.org/acme/widgets/pulls/7", 7},
+		{"gitlab", "https://gitlab.com/acme/group/widgets/-/merge_requests/13", 13},
+		{"bitbucket", "https://bitbucket.org/acme/widgets/pull-requests/5", 5},
+		{"self-hosted", "https://git.internal.example/acme/widgets/pull/1", 1},
+		{"repo named pull", "https://github.com/acme/pull/pull/9", 9},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr, err := source.ParsePullRequestURL(tc.raw)
+			if err != nil {
+				t.Fatalf("ParsePullRequestURL(%q): %v", tc.raw, err)
+			}
+			if pr.Number != tc.want {
+				t.Errorf("number = %d, want %d", pr.Number, tc.want)
+			}
+			if pr.URL != tc.raw {
+				t.Errorf("url = %q, want %q", pr.URL, tc.raw)
+			}
+		})
+	}
+}
+
+func TestParsePullRequestURL_Rejects(t *testing.T) {
+	cases := []struct{ name, raw string }{
+		{"empty", ""},
+		{"not a url", "not a url"},
+		{"no pull segment", "https://github.com/acme/widgets/issues/42"},
+		{"no number", "https://github.com/acme/widgets/pull/abc"},
+		{"zero", "https://github.com/acme/widgets/pull/0"},
+		{"non-http scheme", "ssh://git@github.com/acme/widgets/pull/42"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if pr, err := source.ParsePullRequestURL(tc.raw); err == nil {
+				t.Errorf("expected an error for %q, got %+v", tc.raw, pr)
+			}
+		})
+	}
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -71,6 +72,14 @@ type CIStatus struct {
 		Status string // "passed", "failed", "pending", "skipped"
 	}
 }
+
+// ErrUnsupported reports that a source adapter does not implement the optional
+// capability a workflow step asked for. It exists so the engine can tell a
+// permanent gap ("this source will never poll CI") apart from a transient
+// failure ("the token expired", "the forge is down"): the former is terminal
+// and must be surfaced to the operator, the latter is retried next cycle.
+// Wrap it with %w when reporting a missing capability.
+var ErrUnsupported = errors.New("capability not supported by source")
 
 // CIStatusPoller is an optional interface that sources may implement to check the
 // current CI status of a PR or branch. The workflow engine uses it for poll steps

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -50,6 +50,10 @@ type dagRun struct {
 
 	byID  map[string]config.StepConfig
 	order []string // step ids in declaration order (deterministic scheduling)
+	// childByID / parentOfChild index the children of parallel nodes, which are
+	// not graph nodes of their own (they live in the parent's SubSteps).
+	childByID     map[string]config.StepConfig
+	parentOfChild map[string]string // child step id → parallel parent id
 
 	state           map[string]string // step id → st* state
 	activated       map[string]bool   // control-flow has reached this step
@@ -63,6 +67,15 @@ type dagRun struct {
 
 	waitingStep string    // id of the approval/wait_for step currently parked, if any
 	parkedAt    time.Time // when the current approval parked (for timeout)
+	// waitingChild is set when waitingStep is a parallel node parked on a
+	// wait_for CHILD: it holds that child's id, so the re-check knows which
+	// wait_for config to poll. Empty when the parked step is a wait_for itself.
+	waitingChild string
+	// parallelDone memoizes the terminal results of a parked parallel group's
+	// finished children (parent step id → child id → result), so waking the
+	// group to re-poll its wait_for child does not re-run the siblings that
+	// already passed. Cleared once the group reaches a terminal join (#425).
+	parallelDone map[string]map[string]StepResult
 
 	// waitDeadline is the absolute time a parked wait_for step gives up waiting for
 	// CI (set when the wait first parks, preserved across re-checks, cleared once
@@ -94,11 +107,22 @@ func (e *Engine) initDAG(instID string, wf config.WorkflowConfig, task model.Int
 		conflictRetries: map[string]int{},
 		stepStates:      map[string]StepState{},
 		contrib:         map[string]MemoryStep{},
+		parallelDone:    map[string]map[string]StepResult{},
+		childByID:       map[string]config.StepConfig{},
+		parentOfChild:   map[string]string{},
 	}
 	for _, s := range wf.Steps {
 		r.byID[s.ID] = s
 		r.order = append(r.order, s.ID)
 		r.state[s.ID] = stPending
+		// Index a parallel node's children so the park/resume path can resolve a
+		// waiting child's config and restore its cached result by id alone.
+		if s.StepType() == config.StepTypeParallel {
+			for _, child := range s.SubSteps {
+				r.childByID[child.ID] = child
+				r.parentOfChild[child.ID] = s.ID
+			}
+		}
 	}
 	// Identify split targets: they are activated only when their split chooses
 	// them, never at workflow start.
@@ -130,6 +154,9 @@ type workerResult struct {
 	// parallelContribs is set for StepTypeParallel steps: the ordered list of
 	// memory contributions from its passed children (declaration order).
 	parallelContribs []MemoryStep
+	// parallel is set for StepTypeParallel steps: which child (if any) is parked
+	// on a pending wait_for, plus the results of the children that finished.
+	parallel parallelState
 	// foreachExitCode is the failed-item count for StepTypeForeach steps.
 	// Used to populate StepState.ExitCode (allows `steps.<id>.exit_code` in exprs).
 	foreachExitCode int
@@ -219,15 +246,17 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 			contribSnap := r.contribSnapshot()
 			waitDeadline := r.waitDeadline // captured for the wait worker (value copy, safe)
 			inFlight++
+			parallelCache := r.parallelSnapshot(id) // captured for the parallel worker
 			go func(step config.StepConfig, memSnap []MemoryStep, contribSnap map[string]MemoryStep) {
 				sem <- struct{}{}
 				defer func() { <-sem }()
 				var res StepResult
 				var parallelContribs []MemoryStep
+				var parallel parallelState
 				var foreachExitCode int
 				switch step.StepType() {
 				case config.StepTypeParallel:
-					res, parallelContribs = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
+					res, parallelContribs, parallel = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env, parallelCache, waitDeadline)
 				case config.StepTypeForeach:
 					var fr foreachResult
 					if step.Concurrency > 1 {
@@ -253,6 +282,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 					memSnap:          memSnap,
 					res:              res,
 					parallelContribs: parallelContribs,
+					parallel:         parallel,
 					foreachExitCode:  foreachExitCode,
 				}
 			}(step, snap, contribSnap)
@@ -315,6 +345,31 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		// an approval park. Drain any siblings first (wait_for workflows are sequential
 		// in practice, so this is normally a no-op). The deadline persists across
 		// re-checks via enterWait so the timeout is measured from the first park.
+		// Parallel group whose wait_for child has no answer yet: park the GROUP,
+		// remembering the results of the children that finished so the wake
+		// re-polls only the wait and never re-runs a passed sibling (#425).
+		if step.StepType() == config.StepTypeParallel && res.Pending {
+			for inFlight > 0 {
+				<-resultCh
+				inFlight--
+			}
+			r.parallelDone[step.ID] = wr.parallel.done
+			r.waitingChild = wr.parallel.waitingChild
+			e.enterWait(r, step)
+			return outcomeWaiting
+		}
+		// Terminal parallel join: drop the memoized child results so a later
+		// loop-back (on_fail.goto) re-runs the whole group from scratch.
+		if step.StepType() == config.StepTypeParallel {
+			if _, wasParked := r.parallelDone[step.ID]; wasParked {
+				// Clear the waiting window too, so a loop-back into this group
+				// starts a fresh one (mirrors the plain wait_for path below).
+				r.waitDeadline = time.Time{}
+				delete(r.parallelDone, step.ID)
+			}
+			r.waitingChild = ""
+		}
+
 		if step.StepType() == config.StepTypeWaitFor && res.Pending {
 			for inFlight > 0 {
 				<-resultCh
@@ -508,12 +563,50 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 func (e *Engine) enterWait(r *dagRun, step config.StepConfig) {
 	r.state[step.ID] = stWaiting
 	r.waitingStep = step.ID
-	if r.waitDeadline.IsZero() && step.WaitFor != nil {
-		if md := step.WaitFor.ParsedMaxDuration(); md > 0 {
+	// The wait config lives on the parked step itself, or — for a parallel group
+	// parked on a wait_for child — on that child.
+	waitStep, _ := r.waitStepConfig()
+	if r.waitDeadline.IsZero() && waitStep.WaitFor != nil {
+		if md := waitStep.WaitFor.ParsedMaxDuration(); md > 0 {
 			r.waitDeadline = e.now().Add(md)
 		}
 	}
+	if r.waitingChild != "" {
+		aplog.Info("workflow %s: instance %s parked at wait_for child %q of parallel step %q",
+			r.wf.ID, r.instID, r.waitingChild, step.ID)
+		return
+	}
 	aplog.Info("workflow %s: instance %s parked at wait_for step %q", r.wf.ID, r.instID, step.ID)
+}
+
+// waitStepConfig returns the step whose wait_for config governs the current
+// park: the parked step itself when it is a wait_for node, or the parked child
+// when the instance is parked at a parallel group (#425). Reports false when
+// the run is not parked on a wait at all.
+func (r *dagRun) waitStepConfig() (config.StepConfig, bool) {
+	if r.waitingStep == "" {
+		return config.StepConfig{}, false
+	}
+	if r.waitingChild != "" {
+		child, ok := r.childByID[r.waitingChild]
+		return child, ok
+	}
+	step := r.byID[r.waitingStep]
+	return step, step.StepType() == config.StepTypeWaitFor
+}
+
+// parallelSnapshot copies the memoized child results of a parked parallel group
+// so the worker goroutine reads them without touching dagRun.
+func (r *dagRun) parallelSnapshot(stepID string) map[string]StepResult {
+	done := r.parallelDone[stepID]
+	if len(done) == 0 {
+		return nil
+	}
+	out := make(map[string]StepResult, len(done))
+	for k, v := range done {
+		out[k] = v
+	}
+	return out
 }
 
 // resolveApproval applies an approval decision to the parked step so the run can
@@ -549,13 +642,24 @@ func (r *dagRun) firstRunnableApproval() (string, bool) {
 // instance is parked at: wait_for steps persist no step run of their own, so after the
 // cached passed steps are restored the waiting poll is simply the next runnable
 // poll. Returns false when none is runnable.
-func (r *dagRun) firstRunnableWait() (string, bool) {
+// It also matches a parallel group holding a wait_for child, returning that
+// child's id alongside the group's — an instance can park on a wait nested one
+// level inside a group (#425).
+func (r *dagRun) firstRunnableWait() (stepID, childID string, ok bool) {
 	for _, id := range r.pickAllRunnable() {
-		if r.byID[id].StepType() == config.StepTypeWaitFor {
-			return id, true
+		step := r.byID[id]
+		switch step.StepType() {
+		case config.StepTypeWaitFor:
+			return id, "", true
+		case config.StepTypeParallel:
+			for _, child := range step.SubSteps {
+				if child.StepType() == config.StepTypeWaitFor {
+					return id, child.ID, true
+				}
+			}
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 // pickAllRunnable returns the IDs of ALL currently runnable steps (activated,

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"time"
 
 	aplog "github.com/orlandoburli/apiary/internal/log"
 
@@ -17,12 +18,37 @@ type parallelChildResult struct {
 	res  StepResult
 }
 
+// parallelState is the per-child bookkeeping a parallel step hands back to the
+// scheduler. It exists because a wait_for child parks: the group cannot finish
+// in one pass, so the scheduler must remember which child is waiting and what
+// the other children already produced, and hand both back when the wait wakes.
+//
+//   - waitingChild is the id of the wait_for child that returned Pending (empty
+//     when the group reached a terminal join).
+//   - done are the terminal results of the children that did finish, keyed by
+//     child id. They are replayed as-is on the next pass, so a code review
+//     sibling is never re-run just because CI is still going (#425).
+type parallelState struct {
+	waitingChild string
+	done         map[string]StepResult
+}
+
 // runParallelStep executes a StepTypeParallel node's children concurrently and
 // applies the join policy. Children are NOT subject to the global semaphore —
 // the parallel step itself occupies one concurrency slot; its children run
-// freely within that slot. Returns the aggregate StepResult and the memory
+// freely within that slot. Returns the aggregate StepResult, the memory
 // contributions of passed children (in declaration order) to be merged into the
-// outer DAG's contrib map.
+// outer DAG's contrib map, and the parallelState the scheduler needs to park
+// and resume the group.
+//
+// Each child is dispatched by ITS OWN step type, not blindly as an agent step:
+// a wait_for child runs the CI/dependency check and can leave the group pending
+// (before #425 every child went through runStep, so a wait_for child ran as an
+// agent step with an empty agent: and failed in milliseconds with no
+// diagnostic, taking its passing siblings down with it under join: all).
+//
+// cached carries the results of children that already completed on an earlier
+// pass (see parallelState.done); those children are not re-run.
 //
 // runParallelStep is called from a worker goroutine and must NOT touch dagRun.
 func (e *Engine) runParallelStep(
@@ -30,26 +56,56 @@ func (e *Engine) runParallelStep(
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, wfEnv map[string]string,
-) (StepResult, []MemoryStep) {
+	cached map[string]StepResult, waitDeadline time.Time,
+) (StepResult, []MemoryStep, parallelState) {
 	children := step.SubSteps
 	if len(children) == 0 {
-		return StepResult{Success: true, Summary: "parallel: no children"}, nil
+		return StepResult{Success: true, Summary: "parallel: no children"}, nil, parallelState{}
 	}
 
 	resultCh := make(chan parallelChildResult, len(children))
 
+	pending := 0
+	results := make([]parallelChildResult, len(children))
 	for i, child := range children {
+		// Replay a child that already finished on an earlier pass of this group
+		// (i.e. before a sibling wait_for parked the instance).
+		if res, ok := cached[child.ID]; ok {
+			results[i] = parallelChildResult{idx: i, step: child, res: res}
+			continue
+		}
+		pending++
 		go func(i int, child config.StepConfig) {
-			res := e.runStep(ctx, instID, child, cell, task, bindings, memSnap, wfEnv)
+			res := e.runParallelChild(ctx, instID, child, cell, task, bindings, memSnap, wfEnv, waitDeadline)
 			resultCh <- parallelChildResult{idx: i, step: child, res: res}
 		}(i, child)
 	}
 
 	// Collect results (arrival order → sort by idx for determinism).
-	results := make([]parallelChildResult, len(children))
-	for range children {
+	for range pending {
 		cr := <-resultCh
 		results[cr.idx] = cr
+	}
+
+	// A wait_for child with no answer yet parks the whole group — unless the
+	// join is already decided by the children that did finish (join: all with a
+	// failure, join: any with a pass), in which case waiting hours for CI would
+	// only delay a foregone outcome.
+	state := parallelState{done: map[string]StepResult{}}
+	for _, cr := range results {
+		if cr.res.Pending {
+			state.waitingChild = cr.step.ID
+			continue
+		}
+		state.done[cr.step.ID] = cr.res
+	}
+	if state.waitingChild != "" {
+		if decided, ok := joinDecided(step.Join, results); ok {
+			aplog.Info("workflow: parallel %q: join already decided (%s) — not waiting on %q",
+				step.ID, passFail(decided), state.waitingChild)
+		} else {
+			return StepResult{Pending: true}, nil, state
+		}
 	}
 
 	// Apply join policy. A join expression that cannot be parsed or evaluated
@@ -58,7 +114,7 @@ func (e *Engine) runParallelStep(
 	passed, joinErr := applyJoinPolicy(step.Join, results, cell, memSnap)
 	if joinErr != nil {
 		aplog.Error("workflow: parallel %q join eval error %q: %v (failing step)", step.ID, step.Join, joinErr)
-		return StepResult{Success: false, Output: fmt.Sprintf("join eval error %q: %v", step.Join, joinErr)}, nil
+		return StepResult{Success: false, Output: fmt.Sprintf("join eval error %q: %v", step.Join, joinErr)}, nil, state
 	}
 
 	// Collect memory contributions from passed children in declaration order.
@@ -75,9 +131,67 @@ func (e *Engine) runParallelStep(
 	}
 
 	if passed {
-		return StepResult{Success: true, Summary: "parallel: joined"}, contribs
+		return StepResult{Success: true, Summary: "parallel: joined"}, contribs, state
 	}
-	return StepResult{Success: false}, nil
+	return StepResult{Success: false}, nil, state
+}
+
+// runParallelChild executes one child of a parallel group by its own step type.
+// Agent children take the normal runStep path; a wait_for child performs one
+// external check and may come back Pending, which parks the whole group.
+//
+// The step types a child may NOT have (approval, foreach, sub-workflow, a
+// nested group) are rejected by config validation, so reaching the default arm
+// means a config slipped through the lint: fail loudly and name the type rather
+// than running it as an agent step.
+func (e *Engine) runParallelChild(
+	ctx context.Context, instID string,
+	child config.StepConfig, cell model.SourceItem,
+	task model.InternalTask, bindings []model.SourceBinding,
+	memSnap []MemoryStep, wfEnv map[string]string, waitDeadline time.Time,
+) StepResult {
+	switch child.StepType() {
+	case config.StepTypeAgent:
+		return e.runStep(ctx, instID, child, cell, task, bindings, memSnap, wfEnv)
+	case config.StepTypeWaitFor:
+		res, err := e.RunWaitStep(ctx, instID, child, cell.SourceID, cell.ID, waitDeadline)
+		if err != nil {
+			aplog.Error("workflow: parallel child %q: wait_for step failed: %v", child.ID, err)
+			return StepResult{Success: false, Output: err.Error(), Err: err}
+		}
+		if res.Err != nil {
+			aplog.Error("workflow: parallel child %q: wait_for step failed: %v", child.ID, res.Err)
+		}
+		return res
+	default:
+		err := fmt.Errorf("step type %q is not supported inside a parallel group", child.StepType())
+		aplog.Error("workflow: parallel child %q: %v", child.ID, err)
+		return StepResult{Success: false, Output: err.Error(), Err: err}
+	}
+}
+
+// joinDecided reports whether the join outcome is already settled by the
+// children that finished, ignoring any child still pending. It lets a group
+// whose fate is sealed stop waiting on a long CI poll: under join: all one
+// failure decides it, under join: any one pass does. A join expression is
+// never treated as decided — it may read any child's output, so it is only
+// evaluated once every child is terminal.
+func joinDecided(join string, results []parallelChildResult) (passed bool, ok bool) {
+	switch join {
+	case config.JoinAny:
+		for _, cr := range results {
+			if cr.res.Success {
+				return true, true
+			}
+		}
+	case "", config.JoinAll:
+		for _, cr := range results {
+			if !cr.res.Pending && !cr.res.Success {
+				return false, true
+			}
+		}
+	}
+	return false, false
 }
 
 // applyJoinPolicy evaluates the join policy over the child results.

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -485,8 +485,10 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 		// matching waiting state so the right rehydration path picks it up after a
 		// restart (approval_waiting → rehydrateParkedApprovals, waiting →
 		// rehydrateParkedWaits).
+		// (A parallel group parked on a wait_for child counts as a wait park —
+		// waitStepConfig resolves the governing step for both shapes, #425.)
 		waitState := db.InstanceStateApprovalWaiting
-		if r.byID[r.waitingStep].StepType() == config.StepTypeWaitFor {
+		if _, isWait := r.waitStepConfig(); isWait {
 			waitState = db.InstanceStateWaiting
 		}
 		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, waitState)

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -236,6 +236,12 @@ type SideEffects interface {
 	// error when the source does not support sub-issue creation; a duplicate binding
 	// (a concurrent materialize) is treated as success.
 	MaterializeChild(ctx context.Context, parent model.InternalTask, parentBindings []model.SourceBinding, child model.InternalTask) error
+	// LinkPullRequest records a pull request a step opened against the task, so
+	// it shows up in PR-linked features (the dashboard's "open PR" shortcut)
+	// even when the task's source cannot enumerate pull requests itself. The PR
+	// is attributed to the first binding's source. Linking the same PR twice is
+	// a no-op.
+	LinkPullRequest(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, pr source.PullRequestRef) error
 }
 
 // ApprovalProvider delivers a provider-neutral approval request to an external
@@ -654,6 +660,7 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 	// Memorize runs before publish so knowledge is persisted even when the
 	// source write-back fails; neither outcome affects the step state.
 	e.memorizeStep(instID, task, step, res)
+	e.linkPullRequest(ctx, task, bindings, step, res)
 	e.publishStep(ctx, task, bindings, res, sr)
 	_ = e.store.UpdateStepRun(ctx, sr)
 	res.StepRunID = sr.ID
@@ -902,6 +909,34 @@ func (e *Engine) publishStep(ctx context.Context, task model.InternalTask, bindi
 		return
 	}
 	sr.PublishState = db.PublishStateSent
+}
+
+// linkPullRequest links the pull request a step reported (via the output field
+// named by pull_request_from) to the task, so PR-linked features work for tasks
+// whose source cannot enumerate pull requests on its own — a Jira- or
+// Plane-sourced task whose agents open PRs on some git forge (#425).
+//
+// Best-effort by design: a step that legitimately opened no PR (a no-op
+// implement run) simply has no field to read, and a malformed URL is logged and
+// skipped rather than failing a step whose real work succeeded.
+func (e *Engine) linkPullRequest(ctx context.Context, task model.InternalTask, bindings []model.SourceBinding, step config.StepConfig, res StepResult) {
+	if step.PullRequestFrom == "" || !res.Success || e.side == nil || len(bindings) == 0 {
+		return
+	}
+	raw, ok := res.StructuredOutput[step.PullRequestFrom].(string)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return
+	}
+	pr, err := source.ParsePullRequestURL(raw)
+	if err != nil {
+		aplog.Warn("step %q: pull_request_from %q: %v", step.ID, step.PullRequestFrom, err)
+		return
+	}
+	if err := e.side.LinkPullRequest(ctx, task, bindings, pr); err != nil {
+		aplog.Warn("step %q: linking pull request %s: %v", step.ID, pr.URL, err)
+		return
+	}
+	aplog.Info("step %q: linked pull request %s to task %s", step.ID, pr.URL, task.ID)
 }
 
 // applyCompletion applies the on_complete/on_fail hook and posts the on_complete

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
 )
 
 // errTest is a sentinel error for tests that script a failure.
@@ -193,6 +194,8 @@ type fakeSide struct {
 	hooks          []config.OnComplete
 	materialized   []model.InternalTask
 	materializeErr error
+	linkedPRs      []source.PullRequestRef
+	linkPRErr      error
 }
 
 func (f *fakeSide) StateLock(_ context.Context, _ model.InternalTask, _ []model.SourceBinding) error {
@@ -212,6 +215,13 @@ func (f *fakeSide) MaterializeChild(_ context.Context, _ model.InternalTask, _ [
 		return f.materializeErr
 	}
 	f.materialized = append(f.materialized, child)
+	return nil
+}
+func (f *fakeSide) LinkPullRequest(_ context.Context, _ model.InternalTask, _ []model.SourceBinding, pr source.PullRequestRef) error {
+	if f.linkPRErr != nil {
+		return f.linkPRErr
+	}
+	f.linkedPRs = append(f.linkedPRs, pr)
 	return nil
 }
 

--- a/src/internal/workflow/pull_request_link_test.go
+++ b/src/internal/workflow/pull_request_link_test.go
@@ -1,0 +1,138 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// prLinkWorkflow: one agent step that reports the PR it opened.
+func prLinkWorkflow(field string) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev", PullRequestFrom: field,
+			OutputSchema: &config.OutputSchema{
+				Type:       "object",
+				Properties: map[string]config.SchemaField{"pr_url": {Type: "string"}},
+			}},
+	}}
+}
+
+// prLinkEngine wires a store with one binding for task c1.
+func prLinkEngine(t *testing.T, exec StepExecutor, side SideEffects) (*Engine, *fakeStore) {
+	t.Helper()
+	store := newFakeStore()
+	store.bindings["c1"] = []model.SourceBinding{{TaskID: "c1", SourceID: "jira", SourceItemID: "PSP-49"}}
+	return testEngine(baseCfg(), store, exec, side), store
+}
+
+// The PR an agent reports is linked to the task, so PR-linked features work on
+// a source that cannot enumerate pull requests itself (#425).
+func TestPullRequestFrom_LinksReportedPR(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: true, StructuredOutput: map[string]any{
+			"pr_url": "https://github.com/acme/widgets/pull/42",
+		}},
+	}}
+	side := &fakeSide{}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	if _, _, err := eng.RunInstance(context.Background(), prLinkWorkflow("pr_url"), model.InternalTask{ID: "c1"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(side.linkedPRs) != 1 {
+		t.Fatalf("expected one linked PR, got %+v", side.linkedPRs)
+	}
+	if got := side.linkedPRs[0].Number; got != 42 {
+		t.Errorf("PR number = %d, want 42", got)
+	}
+	if got := side.linkedPRs[0].URL; got != "https://github.com/acme/widgets/pull/42" {
+		t.Errorf("PR url = %q", got)
+	}
+}
+
+// A step that declares the mapping but reports no PR (nothing to do, no PR
+// opened) links nothing and does not fail.
+func TestPullRequestFrom_NoURLIsNoOp(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: true, StructuredOutput: map[string]any{"pr_url": ""}},
+	}}
+	side := &fakeSide{}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	_, success, _ := eng.RunInstance(context.Background(), prLinkWorkflow("pr_url"), model.InternalTask{ID: "c1"})
+	if !success {
+		t.Fatal("a step that opened no PR must still pass")
+	}
+	if len(side.linkedPRs) != 0 {
+		t.Errorf("expected no linked PR, got %+v", side.linkedPRs)
+	}
+}
+
+// A malformed URL is skipped, not fatal: the step's real work succeeded.
+func TestPullRequestFrom_MalformedURLDoesNotFailStep(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: true, StructuredOutput: map[string]any{"pr_url": "see the PR I opened"}},
+	}}
+	side := &fakeSide{}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	_, success, _ := eng.RunInstance(context.Background(), prLinkWorkflow("pr_url"), model.InternalTask{ID: "c1"})
+	if !success {
+		t.Fatal("a malformed pr_url must not fail the step")
+	}
+	if len(side.linkedPRs) != 0 {
+		t.Errorf("expected no linked PR, got %+v", side.linkedPRs)
+	}
+}
+
+// A link that cannot be persisted is logged, not fatal — same rationale.
+func TestPullRequestFrom_LinkErrorDoesNotFailStep(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: true, StructuredOutput: map[string]any{
+			"pr_url": "https://github.com/acme/widgets/pull/42",
+		}},
+	}}
+	side := &fakeSide{linkPRErr: errors.New("db down")}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	if _, success, _ := eng.RunInstance(context.Background(), prLinkWorkflow("pr_url"), model.InternalTask{ID: "c1"}); !success {
+		t.Fatal("a failed PR link must not fail the step")
+	}
+}
+
+// A failed step's reported PR is not linked: the URL may name a PR that was
+// never opened.
+func TestPullRequestFrom_FailedStepLinksNothing(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: false, StructuredOutput: map[string]any{
+			"pr_url": "https://github.com/acme/widgets/pull/42",
+		}},
+	}}
+	side := &fakeSide{}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	_, _, _ = eng.RunInstance(context.Background(), prLinkWorkflow("pr_url"), model.InternalTask{ID: "c1"})
+	if len(side.linkedPRs) != 0 {
+		t.Errorf("expected no linked PR from a failed step, got %+v", side.linkedPRs)
+	}
+}
+
+// Without the mapping nothing is linked, even when the step emits a pr_url.
+func TestPullRequestFrom_UnsetLinksNothing(t *testing.T) {
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"implement": {Success: true, StructuredOutput: map[string]any{
+			"pr_url": "https://github.com/acme/widgets/pull/42",
+		}},
+	}}
+	side := &fakeSide{}
+	eng, _ := prLinkEngine(t, exec, side)
+
+	_, _, _ = eng.RunInstance(context.Background(), prLinkWorkflow(""), model.InternalTask{ID: "c1"})
+	if len(side.linkedPRs) != 0 {
+		t.Errorf("expected no linked PR without pull_request_from, got %+v", side.linkedPRs)
+	}
+}

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -124,6 +124,13 @@ func (e *Engine) restoreCachedSteps(r *dagRun, priorSteps []db.StepRun) []db.Ste
 		}
 		step, ok := r.byID[sr.StepID]
 		if !ok {
+			// A parallel group's child is not a graph node of its own. Restore it
+			// into the parent's memoized child results instead, so a group
+			// rehydrated mid-wait re-polls only its wait_for child and never
+			// re-runs the sibling that already passed (#425).
+			if child, isChild := r.childByID[sr.StepID]; isChild {
+				restoreParallelChild(r, child, sr)
+			}
 			continue // step no longer exists in the workflow definition
 		}
 		if step.StepType() == config.StepTypeSplit {
@@ -159,4 +166,26 @@ func (e *Engine) restoreCachedSteps(r *dagRun, priorSteps []db.StepRun) []db.Ste
 		restored = append(restored, sr)
 	}
 	return restored
+}
+
+// restoreParallelChild memoizes one passed child of a parallel group from its
+// persisted step run, so the group can be resumed without re-running it.
+func restoreParallelChild(r *dagRun, child config.StepConfig, sr db.StepRun) {
+	parent, ok := r.parentOfChild[child.ID]
+	if !ok {
+		return
+	}
+	var structured map[string]any
+	if sr.StructuredOutput != "" {
+		_ = json.Unmarshal([]byte(sr.StructuredOutput), &structured)
+	}
+	if r.parallelDone[parent] == nil {
+		r.parallelDone[parent] = map[string]StepResult{}
+	}
+	r.parallelDone[parent][child.ID] = StepResult{
+		Success:          true,
+		Output:           sr.Output,
+		Summary:          sr.Summary,
+		StructuredOutput: structured,
+	}
 }

--- a/src/internal/workflow/wait_park.go
+++ b/src/internal/workflow/wait_park.go
@@ -32,13 +32,17 @@ func (e *Engine) ParkedWaits() []ParkedWait {
 	defer e.mu.Unlock()
 	out := make([]ParkedWait, 0, len(e.parked))
 	for id, r := range e.parked {
-		if r.byID[r.waitingStep].StepType() != config.StepTypeWaitFor {
+		// Step is the wait_for step to re-check: the parked node itself, or the
+		// wait_for child of a parked parallel group (#425). Approval parks share
+		// the parked set and resolve to no wait step — skipped here.
+		waitStep, ok := r.waitStepConfig()
+		if !ok {
 			continue
 		}
 		out = append(out, ParkedWait{
 			InstanceID: id,
 			Task:       r.task,
-			Step:       r.byID[r.waitingStep],
+			Step:       waitStep,
 			Deadline:   r.waitDeadline,
 			AgentID:    representativeAgent(r.wf),
 		})
@@ -108,12 +112,12 @@ func (e *Engine) RecheckWait(ctx context.Context, instanceID string) (terminal b
 		e.mu.Unlock()
 		return false
 	}
-	step := r.byID[r.waitingStep]
+	step, isWait := r.waitStepConfig()
 	sourceID, itemID := r.cell.SourceID, r.cell.ID
 	deadline := r.waitDeadline
 	e.mu.Unlock()
 
-	if step.StepType() != config.StepTypeWaitFor {
+	if !isWait {
 		return false
 	}
 	res, _ := e.RunWaitStep(ctx, instanceID, step, sourceID, itemID, deadline)
@@ -144,7 +148,10 @@ func (e *Engine) WakeWait(ctx context.Context, instanceID string) {
 
 	step := r.waitingStep
 	r.waitingStep = ""
-	r.state[step] = stPending // re-arm the wait_for step for re-dispatch
+	// For a parked parallel group the waiting child is re-derived on the next
+	// pass; its finished siblings stay memoized in r.parallelDone.
+	r.waitingChild = ""
+	r.state[step] = stPending // re-arm the wait_for (or parallel) step for re-dispatch
 
 	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
 	outcome := e.driveDAG(ctx, r)
@@ -181,13 +188,15 @@ func (e *Engine) RehydrateWait(ctx context.Context, instID string, wf config.Wor
 	r := e.initDAG(instID, wf, task, bindings, nil, 0)
 	e.restoreCachedSteps(r, priorSteps)
 
-	stepID, ok := r.firstRunnableWait()
+	stepID, childID, ok := r.firstRunnableWait()
 	if !ok {
 		return ErrNoWaitStep
 	}
 	r.state[stepID] = stWaiting
 	r.waitingStep = stepID
-	if pc := r.byID[stepID].WaitFor; pc != nil {
+	r.waitingChild = childID
+	waitStep, _ := r.waitStepConfig()
+	if pc := waitStep.WaitFor; pc != nil {
 		if md := pc.ParsedMaxDuration(); md > 0 {
 			r.waitDeadline = e.now().Add(md)
 		}

--- a/src/internal/workflow/wait_park_parallel_test.go
+++ b/src/internal/workflow/wait_park_parallel_test.go
@@ -1,0 +1,217 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// parallelWaitWorkflow: implement (agent) → gate (parallel: review agent +
+// await-ci wait_for) → merge (agent). This is the shape from #425: a CI wait
+// running beside a code review, joined with the default join: all.
+func parallelWaitWorkflow(join string) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev"},
+		{ID: "gate", Type: config.StepTypeParallel, DependsOn: []string{"implement"}, Join: join, SubSteps: []config.StepConfig{
+			{ID: "review", Agent: "backend-dev"},
+			{ID: "await-ci", Type: config.StepTypeWaitFor,
+				WaitFor: &config.WaitForConfig{Kind: "ci", CheckInterval: "30s", MaxDuration: "2h"}},
+		}},
+		{ID: "merge", Agent: "backend-dev", DependsOn: []string{"gate"}},
+	}}
+}
+
+// countExecuted reports how many times a step id was executed.
+func countExecuted(seen []StepRequest, id string) int {
+	n := 0
+	for _, r := range seen {
+		if r.Step.ID == id {
+			n++
+		}
+	}
+	return n
+}
+
+// A wait_for child with no answer yet parks the whole group; its passing
+// sibling is remembered, so waking the group re-polls CI without re-running the
+// review agent. Before #425 the wait_for child ran as an agent step and the
+// group failed instantly.
+func TestParallelWaitChild_ParksGroupAndReusesSiblingResult(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	status := "pending"
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: status}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, success, _ := eng.RunInstance(context.Background(), parallelWaitWorkflow(""), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a group parked on a pending CI wait should not report success")
+	}
+	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateWaiting)
+	}
+	// The park names the waiting CHILD, so the dispatcher re-checks the right wait.
+	parked := eng.ParkedWaits()
+	if len(parked) != 1 || parked[0].Step.ID != "await-ci" {
+		t.Fatalf("expected one parked wait for await-ci, got %+v", parked)
+	}
+	if n := countExecuted(exec.seen, "review"); n != 1 {
+		t.Fatalf("review should have run exactly once while parked, ran %d times", n)
+	}
+	if contains(executedIDs(exec.seen), "merge") {
+		t.Error("merge must not run while the group is parked")
+	}
+
+	// Still pending → stays parked, and the review is NOT re-run.
+	eng.CheckParkedWaits(context.Background())
+	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+		t.Fatalf("expected still waiting, got %q", got)
+	}
+	if n := countExecuted(exec.seen, "review"); n != 1 {
+		t.Fatalf("review re-ran on a CI re-check (%d times) — the group's finished children must be memoized", n)
+	}
+
+	// CI turns green → the join passes and the workflow completes.
+	status = "passed"
+	eng.CheckParkedWaits(context.Background())
+	if got := store.instances[instID].State; got != db.InstanceStateDone {
+		t.Fatalf("expected done after CI passed, got %q", got)
+	}
+	if n := countExecuted(exec.seen, "review"); n != 1 {
+		t.Errorf("review ran %d times, want 1", n)
+	}
+	if n := countExecuted(exec.seen, "merge"); n != 1 {
+		t.Errorf("merge ran %d times, want 1", n)
+	}
+}
+
+// Under join: all a failed sibling already decides the group, so it must not
+// park for hours waiting on a CI result that cannot change the outcome.
+func TestParallelWaitChild_FailedSiblingDecidesJoinWithoutParking(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review": {Success: false, Output: "changes requested"},
+	}}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, success, _ := eng.RunInstance(context.Background(), parallelWaitWorkflow(""), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a group whose review failed must not report success")
+	}
+	if got := store.instances[instID].State; got == db.InstanceStateWaiting {
+		t.Fatal("group parked on CI although join: all was already decided by the failed review")
+	}
+	if len(eng.ParkedWaits()) != 0 {
+		t.Errorf("expected no parked wait, got %+v", eng.ParkedWaits())
+	}
+}
+
+// Under join: any a passing sibling decides the group the same way.
+func TestParallelWaitChild_PassingSiblingDecidesJoinAny(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, _, _ := eng.RunInstance(context.Background(), parallelWaitWorkflow(config.JoinAny), model.InternalTask{ID: "c1"})
+	if got := store.instances[instID].State; got != db.InstanceStateDone {
+		t.Fatalf("join: any with a passed child should complete, got %q", got)
+	}
+}
+
+// A CI failure inside the group fails the group (join: all) rather than
+// hanging: the wait's terminal result flows through the normal join.
+func TestParallelWaitChild_CIFailureFailsGroup(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	status := "pending"
+	ci := func() (source.CIStatus, error) { return source.CIStatus{Status: status}, nil }
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, _, _ := eng.RunInstance(context.Background(), parallelWaitWorkflow(""), model.InternalTask{ID: "c1"})
+	status = "failed"
+	eng.CheckParkedWaits(context.Background())
+
+	if got := store.instances[instID].State; got != db.InstanceStateFailed {
+		t.Fatalf("expected failed after CI failed, got %q", got)
+	}
+	if contains(executedIDs(exec.seen), "merge") {
+		t.Error("merge must not run after the gate failed")
+	}
+}
+
+// A daemon restart while a group is parked must resume the group without
+// re-running the review child that already passed: its persisted step run is
+// replayed into the group's memoized results.
+func TestParallelWaitChild_RehydrateSurvivesRestart(t *testing.T) {
+	store := newFakeStore()
+	clock := time.Unix(1000, 0)
+
+	exec1 := &fakeExecutor{}
+	ci1 := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
+	eng1 := waitForEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
+	instID, _, _ := eng1.RunInstance(context.Background(), parallelWaitWorkflow(""), model.InternalTask{ID: "c1"})
+	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+		t.Fatalf("expected waiting before restart, got %q", got)
+	}
+
+	// New engine, empty parked set, CI now green.
+	exec2 := &fakeExecutor{}
+	ci2 := func() (source.CIStatus, error) { return source.CIStatus{Status: "passed"}, nil }
+	eng2 := waitForEngine(baseCfg(), store, exec2, &fakeSide{}, &clock, ci2)
+
+	if err := eng2.RehydrateWait(context.Background(), instID, parallelWaitWorkflow(""),
+		model.InternalTask{ID: "c1"}, priorStepsFor(store, instID)); err != nil {
+		t.Fatalf("rehydrate: %v", err)
+	}
+	if pp := eng2.ParkedWaits(); len(pp) != 1 || pp[0].Step.ID != "await-ci" {
+		t.Fatalf("expected rehydrated park at await-ci, got %+v", pp)
+	}
+
+	eng2.CheckParkedWaits(context.Background())
+
+	if got := store.instances[instID].State; got != db.InstanceStateDone {
+		t.Fatalf("expected done after rehydrated wait passed, got %q", got)
+	}
+	if contains(executedIDs(exec2.seen), "implement") {
+		t.Error("implement must not re-run after rehydration (it already passed)")
+	}
+	if contains(executedIDs(exec2.seen), "review") {
+		t.Error("the parallel group's passed review child must not re-run after rehydration")
+	}
+	if !contains(executedIDs(exec2.seen), "merge") {
+		t.Error("merge should run once the rehydrated wait passed")
+	}
+}
+
+// An unsupported child kind that slipped past config validation fails loudly
+// with the type named, instead of silently running as an agent step.
+func TestParallelChild_UnsupportedKindFailsWithDiagnostic(t *testing.T) {
+	eng := waitForEngine(baseCfg(), newFakeStore(), &fakeExecutor{}, &fakeSide{},
+		func() *time.Time { t := time.Unix(1000, 0); return &t }(),
+		func() (source.CIStatus, error) { return source.CIStatus{}, nil })
+
+	res := eng.runParallelChild(context.Background(), "inst-1",
+		config.StepConfig{ID: "nested", Type: config.StepTypeForeach},
+		model.SourceItem{}, model.InternalTask{}, nil, nil, nil, time.Time{})
+
+	if res.Success {
+		t.Fatal("an unsupported parallel child must not report success")
+	}
+	if res.Err == nil {
+		t.Fatal("an unsupported parallel child must carry an error")
+	}
+	if !contains([]string{res.Output}, "step type \"foreach\" is not supported inside a parallel group") {
+		t.Errorf("error should name the offending type, got %q", res.Output)
+	}
+}

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -402,4 +404,38 @@ func countID(seen []StepRequest, id string) int {
 		}
 	}
 	return n
+}
+
+// A source that cannot poll CI fails the wait immediately with the cause
+// named and recorded, instead of polling until max_duration with nothing but a
+// warning per cycle (#425).
+func TestWaitFor_UnsupportedCapabilityFailsTerminally(t *testing.T) {
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	clock := time.Unix(1000, 0)
+	ci := func() (source.CIStatus, error) {
+		return source.CIStatus{}, fmt.Errorf("source %q cannot poll CI status: %w", "jira", source.ErrUnsupported)
+	}
+	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
+
+	instID, success, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
+	if success {
+		t.Fatal("a wait against a source without CI polling must not succeed")
+	}
+	if got := store.instances[instID].State; got == db.InstanceStateWaiting {
+		t.Fatalf("the wait parked instead of failing: state %q", got)
+	}
+	if len(eng.ParkedWaits()) != 0 {
+		t.Errorf("expected no parked wait, got %+v", eng.ParkedWaits())
+	}
+	// The cause is recorded in the wait's history, not only in the log.
+	var found bool
+	for _, p := range store.ciPolls {
+		if p.Status == "unsupported" && strings.Contains(p.Detail, "cannot poll CI status") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an 'unsupported' poll recording the cause, got %+v", store.ciPolls)
+	}
 }

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -52,10 +53,8 @@ func (e *Engine) checkCIWaitStep(
 	deadline time.Time,
 ) (StepResult, error) {
 	if e.ciChecker == nil {
-		return StepResult{
-			Success: false,
-			Err:     fmt.Errorf("CI status polling not configured"),
-		}, nil
+		return e.unsupportedWait(ctx, instID, step, "ci",
+			fmt.Errorf("CI status polling not configured")), nil
 	}
 
 	cfg := step.WaitFor
@@ -82,6 +81,14 @@ func (e *Engine) checkCIWaitStep(
 	}
 
 	status, err := e.ciChecker(ctx, sourceID, sourceItemID)
+	if errors.Is(err, source.ErrUnsupported) {
+		// The source will never gain the capability by waiting: fail now with the
+		// cause named, rather than polling until max_duration with a WARN a
+		// cycle. `apiary validate` normally catches this at config load; reaching
+		// here means the config was never linted (or the source changed under a
+		// running daemon), so the message has to stand on its own (#425).
+		return e.unsupportedWait(ctx, instID, step, "ci", err), nil
+	}
 	if err != nil {
 		// Surface at WARN (not DEBUG): a persistent error here — e.g. a token
 		// missing 'Pull requests: Read' (403) — would otherwise masquerade as an
@@ -149,6 +156,25 @@ func (e *Engine) checkCIWaitStep(
 	}
 }
 
+// unsupportedWait fails a wait_for step whose backing capability is missing.
+// The failure is logged and recorded as a poll with status "unsupported", so
+// the cause is visible in the daemon log AND in the wait's history — a wait
+// that dies in milliseconds with nothing written anywhere is the worst
+// possible diagnostic, and it is exactly what a wait_for/ci step used to do on
+// a source that cannot poll CI (#425).
+func (e *Engine) unsupportedWait(ctx context.Context, instID string, step config.StepConfig, kind string, cause error) StepResult {
+	aplog.Error("wait_for step %q (kind: %s): %v — failing the step", step.ID, kind, cause)
+	e.recordCIPoll(ctx, instID, step.ID, "unsupported", "", cause.Error())
+	return StepResult{
+		Success: false,
+		Err:     cause,
+		StructuredOutput: map[string]any{
+			"ci_status": "unsupported",
+			"reason":    cause.Error(),
+		},
+	}
+}
+
 // checkDependencyWaitStep performs a single blocker check for a wait_for step
 // with kind "dependency". Transient lookup errors and any still-unsatisfied
 // blocker both yield Pending (the instance stays parked and is re-checked next
@@ -165,10 +191,8 @@ func (e *Engine) checkDependencyWaitStep(
 	deadline time.Time,
 ) (StepResult, error) {
 	if e.depChecker == nil {
-		return StepResult{
-			Success: false,
-			Err:     fmt.Errorf("dependency (blocker) polling not configured"),
-		}, nil
+		return e.unsupportedWait(ctx, instID, step, "dependency",
+			fmt.Errorf("dependency (blocker) polling not configured")), nil
 	}
 
 	cfg := step.WaitFor
@@ -194,6 +218,9 @@ func (e *Engine) checkDependencyWaitStep(
 	}
 
 	blockers, err := e.depChecker(ctx, sourceID, sourceItemID, cfg.BlockerLinkType)
+	if errors.Is(err, source.ErrUnsupported) {
+		return e.unsupportedWait(ctx, instID, step, "dependency", err), nil
+	}
 	if err != nil {
 		// WARN, not DEBUG: a persistent error (missing scope, wrong link type)
 		// would otherwise masquerade as an endless wait with no visible cause.


### PR DESCRIPTION
## Summary

Closes #425.

**The 0s silent failure is not what the issue assumed.** In the daemon the CI
checker is always wired, so the `CI status polling not configured` branch is
unreachable in production. The real cause is `runParallelStep`: it sent **every**
child through the agent step path, ignoring the child's own type. A `wait_for`
child therefore ran as an agent step with an empty `agent:` and failed in
milliseconds with no CI log line — and under the default `join: all` it took its
passing review sibling down with it.

**The capability lint already existed**, with the exact phrasing the issue quotes.
It just never saw the step: lowering keeps a parallel group's children in the
node's `SubSteps` (and a foreach body in `.Step`), while the lint walked only the
top-level list.

### 1. Parallel children run by their own step type

Children are now dispatched by type. A `wait_for` child performs a real check and
may come back pending, which parks the whole group:

- the children that finished are memoized, so a re-check re-polls only the wait
  and never re-runs a passed sibling — across daemon restarts too, by replaying
  their persisted step runs;
- a group whose join is already decided by the finished children does not wait at
  all (under `join: all` a failed review fails the group immediately instead of
  sitting on a 2h CI budget);
- `apiary validate` rejects the child kinds a group cannot run (`approval`,
  `for_each:`, nested groups) — the nested ones were never lowered, so they would
  have reached the engine as agent steps;
- the source-capability lint walks nested steps, so `wait_for {kind: ci}` inside a
  `parallel:` group is checked against the source like a top-level one.

### 2. A missing capability fails the wait loudly

The daemon's checkers wrap the new `source.ErrUnsupported`, which the step treats
as permanent instead of transient: it fails at once, logs the cause with the
source named, and records an `unsupported` poll so the reason shows up in the
wait's history, not only in the daemon log. Transient errors keep retrying.

### 3. `pull_request_from` — link a PR regardless of source type

`task_pull_requests` is only ever populated by a source that can enumerate an
item's PRs, so a Jira- or Plane-sourced task shows none however many its agents
opened. A step can now name the output field holding the URL of the PR it opened:

```yaml
- id: implement
  agent: engineer
  output:
    type: object
    properties:
      pr_url: {type: string}
  pull_request_from: pr_url
```

The URL is parsed (GitHub, Codeberg/Forgejo, GitLab, Bitbucket shapes, self-hosted
hosts included) and linked through an additive upsert keyed by
`(task, source, number)`, so a loop-back that re-runs the step refreshes the link
instead of duplicating it. Best-effort by design: no PR, an unparseable URL, or a
failed link is logged and skipped rather than failing a step whose real work
succeeded; a failed step's PR is never linked. Validation rejects the field on a
non-agent step, or one the step's `output` schema does not declare.

This does **not** enable `wait_for {kind: ci}` on those sources — polling check
runs needs a forge-talking adapter, which the issue flagged as possibly out of
scope. Config-time rejection was the issue's fallback ask and is covered above.

## Test plan

`go build ./... && go test ./...` — full suite green. New coverage:

- **Parallel park** (`wait_park_parallel_test.go`): group parks on a pending CI
  child and names the child in `ParkedWaits`; the review sibling runs exactly once
  across re-checks; a failed sibling decides `join: all` without parking; a passing
  one decides `join: any`; a CI failure fails the group; a rehydrated group after a
  restart resumes without re-running the passed review; an unsupported child kind
  fails with the type named.
- **Validation** (`parallel_child_kind_test.go`, `source_caps_validate_test.go`):
  approval / nested parallel / `for_each:` / nested group children rejected, agent
  and wait_for accepted; `wait_for ci` linted inside `parallel:` and inside a
  `for_each` body, and accepted when the source supports it.
- **Unsupported capability** (`wait_park_test.go`): the wait fails terminally
  instead of parking, with the cause recorded as an `unsupported` poll.
- **PR linking** (`pull_request_link_test.go`, `prurl_test.go`,
  `pullrequest_store_test.go`): PR linked from the reported field; no-op on an
  empty field; malformed URL and link error do not fail the step; failed steps and
  unset mappings link nothing; parser accepts five forge shapes and rejects six
  malformed inputs; upsert is additive, idempotent, and leaves other sources' rows
  alone.
- **Docs/schema**: `pull_request_from` added to `schema/apiary.json`, the agent-step
  table, a new "Linking a PR" section, parallel-group child rules, and the Jira
  source's CI/PR notes.

Not run: no live daemon E2E against a real Jira site — the paths above are covered
by unit tests only.