### PR TITLE
fix(workflow): apply on_missing_output to parallel and foreach children (#421)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -422,6 +422,12 @@ group immediately instead of sitting on a two-hour CI budget.
   join: all
 ```
 
+Children are full steps: a child that declares an `output` schema and emits no
+`APIARY_OUTPUT` honours its own `on_missing_output` exactly like a top-level
+step — `fail` fails the child (and, under `join: all`, the group), `warn`
+records a `step.missing_output` event, `ignore` opts out. The same applies to
+the inner step of a `for_each:`.
+
 #### `for_each:` — iteration
 
 ```yaml

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -256,7 +256,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				var foreachExitCode int
 				switch step.StepType() {
 				case config.StepTypeParallel:
-					res, parallelContribs, parallel = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env, parallelCache, waitDeadline)
+					res, parallelContribs, parallel = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.ID, r.wf.Env, parallelCache, waitDeadline)
 				case config.StepTypeForeach:
 					var fr foreachResult
 					if step.Concurrency > 1 {
@@ -385,23 +385,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 		}
 
 		// Missing structured output for a step that declared an output schema.
-		if res.Success && step.OutputSchema != nil && len(res.StructuredOutput) == 0 &&
-			step.OnMissingOutput != config.OnMissingOutputIgnore {
-			aplog.Error("workflow %s: step %q declared output_schema but emitted no APIARY_OUTPUT — conditions reading its fields will see empty values", r.wf.ID, step.ID)
-			// Beyond the log line: record it on the instance so it is visible in
-			// the dashboard / event stream, not only in the daemon log (#390).
-			e.recordStepExecutionEvent(ctx, r, step.ID, "step.missing_output", map[string]any{
-				"policy":       missingOutputPolicy(step),
-				"memory_write": step.MemoryWriteFields(),
-			})
-			// on_missing_output: fail — declared output schema required structured output.
-			if step.OnMissingOutput == config.OnMissingOutputFail {
-				res.Success = false
-				res.Output = fmt.Sprintf("on_missing_output=fail: step %q declared an output schema but emitted no APIARY_OUTPUT", step.ID)
-				aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", r.wf.ID, step.ID)
-				e.markStepRunFailed(ctx, res.StepRunID, res.Output)
-			}
-		}
+		res = e.applyMissingOutput(ctx, runIDs{taskID: r.task.ID, wfID: r.wf.ID, instID: r.instID}, step, res)
 
 		// fail_when (authored as reject_when) — evaluate on the scheduler
 		// goroutine after the agent runs.
@@ -1050,6 +1034,37 @@ func unevaluableGateKeys(gate *Expr, step config.StepConfig, res StepResult, par
 		}
 	}
 	return unset
+}
+
+// applyMissingOutput enforces on_missing_output for a step that declared an
+// output schema and finished without emitting APIARY_OUTPUT. It takes the ids
+// explicitly instead of a *dagRun so it can also run on a worker goroutine, for
+// the children of a parallel or foreach group — those never reach the scheduler
+// loop and used to skip the guard entirely: the child was recorded as passed
+// with a NULL structured output and nothing was logged (#421).
+//
+// A no-op for results that are already failed, carry structured output, declare
+// no schema, or opt out with on_missing_output: ignore.
+func (e *Engine) applyMissingOutput(ctx context.Context, ids runIDs, step config.StepConfig, res StepResult) StepResult {
+	if !res.Success || step.OutputSchema == nil || len(res.StructuredOutput) > 0 ||
+		step.OnMissingOutput == config.OnMissingOutputIgnore {
+		return res
+	}
+	aplog.Error("workflow %s: step %q declared output_schema but emitted no APIARY_OUTPUT — conditions reading its fields will see empty values", ids.wfID, step.ID)
+	// Beyond the log line: record it on the instance so it is visible in
+	// the dashboard / event stream, not only in the daemon log (#390).
+	e.recordStepExecutionEventFor(ctx, ids, step.ID, "step.missing_output", map[string]any{
+		"policy":       missingOutputPolicy(step),
+		"memory_write": step.MemoryWriteFields(),
+	})
+	// on_missing_output: fail — declared output schema required structured output.
+	if step.OnMissingOutput == config.OnMissingOutputFail {
+		res.Success = false
+		res.Output = fmt.Sprintf("on_missing_output=fail: step %q declared an output schema but emitted no APIARY_OUTPUT", step.ID)
+		aplog.Info("workflow %s: step %q failed: on_missing_output=fail and no structured output", ids.wfID, step.ID)
+		e.markStepRunFailed(ctx, res.StepRunID, res.Output)
+	}
+	return res
 }
 
 // missingOutputPolicy returns the effective on_missing_output policy of a step

--- a/src/internal/workflow/dag_group_missing_output_test.go
+++ b/src/internal/workflow/dag_group_missing_output_test.go
@@ -1,0 +1,179 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// These tests pin #421: on_missing_output was only enforced on the scheduler
+// loop, so children of a parallel (or foreach) group skipped it entirely — a
+// child that never emitted APIARY_OUTPUT was recorded as passed with a NULL
+// structured output and nothing was logged, and the group's reject_when then
+// compared an unset memory key against its failure value and read false.
+
+// groupChild builds one child of the validate group from the issue.
+func groupChild(id, agent, key, onMissing string) config.StepConfig {
+	return config.StepConfig{
+		ID: id, Agent: agent,
+		OnMissingOutput: onMissing,
+		OutputSchema: &config.OutputSchema{
+			Type:       "object",
+			Properties: map[string]config.SchemaField{key: {Type: "string"}},
+			Required:   []string{key},
+		},
+		Memory: &config.MemoryConfig{Write: []string{key}},
+	}
+}
+
+// missingOutputGroupWF is the shape from the issue: a parallel group whose children
+// each own a verdict key, joined with "all" and gated by reject_when.
+func missingOutputGroupWF(onMissing string) config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "validate-wf", Steps: []config.StepConfig{
+		{ID: "plan", Agent: "architect"},
+		{
+			ID: "validate", Type: config.StepTypeParallel, DependsOn: []string{"plan"},
+			SubSteps: []config.StepConfig{
+				groupChild("review", "reviewer", "verdict", onMissing),
+				groupChild("qa_validate", "qa", "qa_verdict", onMissing),
+			},
+			Join:     config.JoinAll,
+			FailWhen: `memory.verdict == "rejected" or memory.qa_verdict == "fail"`,
+		},
+	}}
+}
+
+// TestParallelChild_MissingOutputFailFailsTheJoin is the core regression: the
+// qa child ends early with no APIARY_OUTPUT, so on_missing_output: fail must
+// fail the child, and the "all" join must fail the group with it.
+func TestParallelChild_MissingOutputFailFailsTheJoin(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review":      {Success: true, StructuredOutput: map[string]any{"verdict": "approved"}},
+		"qa_validate": {Success: true, Output: "Still waiting on CI"},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	instID, success, err := eng.RunInstance(context.Background(),
+		missingOutputGroupWF(config.OnMissingOutputFail), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected failure: a group child with on_missing_output: fail emitted no structured output")
+	}
+	if store.instances[instID].State != db.InstanceStateFailed {
+		t.Errorf("instance state = %q, want failed", store.instances[instID].State)
+	}
+	if states := store.stepRunStates("qa_validate"); len(states) != 1 || states[0] != db.StepStateFailed {
+		t.Errorf("step_runs state for qa_validate = %v, want [failed]", states)
+	}
+}
+
+// TestParallelChild_MissingOutputWarnIsRecorded pins the "at minimum it must be
+// diagnosable" half: under the warn default the child still passes, but the
+// missing output is logged and recorded as an event against the child's id.
+func TestParallelChild_MissingOutputWarnIsRecorded(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review":      {Success: true, StructuredOutput: map[string]any{"verdict": "approved"}},
+		"qa_validate": {Success: true, StructuredOutput: map[string]any{"qa_verdict": "pass"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	// Only the review child goes missing this time.
+	exec.results["review"] = StepResult{Success: true}
+
+	if _, _, err := eng.RunInstance(context.Background(),
+		missingOutputGroupWF(config.OnMissingOutputWarn), model.InternalTask{ID: "c1"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	evs := store.eventsOfType("step.missing_output")
+	if len(evs) != 1 {
+		t.Fatalf("step.missing_output events = %d, want 1", len(evs))
+	}
+	if evs[0].StepID != "review" {
+		t.Errorf("event step_id = %q, want review", evs[0].StepID)
+	}
+	if got := evs[0].Metadata["policy"]; got != config.OnMissingOutputWarn {
+		t.Errorf("event policy = %v, want warn", got)
+	}
+}
+
+// TestParallelChild_MissingOutputIgnoreOptsOut keeps the documented escape
+// hatch working for children too.
+func TestParallelChild_MissingOutputIgnoreOptsOut(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := missingOutputGroupWF(config.OnMissingOutputIgnore)
+	wf.Steps[1].FailWhen = "" // the gate's own fail-closed check is #390's contract
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("on_missing_output: ignore must opt a group child out of the check")
+	}
+	if evs := store.eventsOfType("step.missing_output"); len(evs) != 0 {
+		t.Errorf("ignore must record no event, got %d", len(evs))
+	}
+}
+
+// TestParallelChildren_BothEmitOutputPasses is a control: with both verdicts
+// emitted the group joins and the gate reads false.
+func TestParallelChildren_BothEmitOutputPasses(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{
+		"review":      {Success: true, StructuredOutput: map[string]any{"verdict": "approved"}},
+		"qa_validate": {Success: true, StructuredOutput: map[string]any{"qa_verdict": "pass"}},
+	}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	_, success, err := eng.RunInstance(context.Background(),
+		missingOutputGroupWF(config.OnMissingOutputFail), model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if !success {
+		t.Fatal("both children emitted their verdicts: the group must pass")
+	}
+	if evs := store.eventsOfType("step.missing_output"); len(evs) != 0 {
+		t.Errorf("no child is missing output, got %d events", len(evs))
+	}
+}
+
+// TestForeachItem_MissingOutputFailFailsTheItem covers the other group kind:
+// foreach items run off the scheduler loop for the same reason.
+func TestForeachItem_MissingOutputFailFailsTheItem(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := newSeqExecutor()
+	exec.scripts["plan"] = []StepResult{planWithIssues(2)}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	inner := groupChild("", "backend-dev", "fixed", config.OnMissingOutputFail)
+	inner.Prompt = "Fix {{ issue.file }}"
+	wf := foreachWorkflow(config.StepConfig{As: "issue", Step: &inner})
+
+	_, success, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("expected failure: every foreach item emitted no structured output")
+	}
+	if evs := store.eventsOfType("step.missing_output"); len(evs) != 2 {
+		t.Errorf("step.missing_output events = %d, want 2 (one per item)", len(evs))
+	}
+}

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -55,7 +55,7 @@ func (e *Engine) runParallelStep(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
-	memSnap []MemoryStep, wfEnv map[string]string,
+	memSnap []MemoryStep, wfID string, wfEnv map[string]string,
 	cached map[string]StepResult, waitDeadline time.Time,
 ) (StepResult, []MemoryStep, parallelState) {
 	children := step.SubSteps
@@ -77,6 +77,10 @@ func (e *Engine) runParallelStep(
 		pending++
 		go func(i int, child config.StepConfig) {
 			res := e.runParallelChild(ctx, instID, child, cell, task, bindings, memSnap, wfEnv, waitDeadline)
+			// Children never pass through the scheduler loop, so the
+			// on_missing_output guard has to be applied here (#421). A pending
+			// wait_for child is not successful yet, so the guard skips it.
+			res = e.applyMissingOutput(ctx, runIDs{taskID: task.ID, wfID: wfID, instID: instID}, child, res)
 			resultCh <- parallelChildResult{idx: i, step: child, res: res}
 		}(i, child)
 	}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -688,12 +688,28 @@ func (e *Engine) markStepRunFailed(ctx context.Context, stepRunID, output string
 // recordStepExecutionEvent records a lifecycle event attributed to a specific
 // step (recordExecutionEvent attributes to the run's waiting step instead).
 func (e *Engine) recordStepExecutionEvent(ctx context.Context, r *dagRun, stepID, eventType string, metadata map[string]any) {
-	recorder, ok := e.store.(executionEventRecorder)
-	if !ok || r == nil {
+	if r == nil {
 		return
 	}
-	_ = recorder.RecordExecutionEvent(ctx, &db.ExecutionEvent{Type: eventType, TaskID: r.task.ID, WorkflowID: r.wf.ID,
-		WorkflowInstanceID: r.instID, StepID: stepID, Metadata: metadata})
+	e.recordStepExecutionEventFor(ctx, runIDs{taskID: r.task.ID, wfID: r.wf.ID, instID: r.instID}, stepID, eventType, metadata)
+}
+
+// runIDs carries the identifiers a dagRun would otherwise supply, for code that
+// runs on a worker goroutine and must not touch dagRun (parallel/foreach children).
+type runIDs struct {
+	taskID string
+	wfID   string
+	instID string
+}
+
+// recordStepExecutionEventFor is recordStepExecutionEvent without a dagRun.
+func (e *Engine) recordStepExecutionEventFor(ctx context.Context, ids runIDs, stepID, eventType string, metadata map[string]any) {
+	recorder, ok := e.store.(executionEventRecorder)
+	if !ok {
+		return
+	}
+	_ = recorder.RecordExecutionEvent(ctx, &db.ExecutionEvent{Type: eventType, TaskID: ids.taskID, WorkflowID: ids.wfID,
+		WorkflowInstanceID: ids.instID, StepID: stepID, Metadata: metadata})
 }
 
 // secretPattern returns the name of the first common credential pattern found

--- a/src/internal/workflow/foreach.go
+++ b/src/internal/workflow/foreach.go
@@ -89,6 +89,9 @@ func (e *Engine) executeForeachSequential(
 		sub.Prompt = renderItemTemplate(step.Step.Prompt, as, item)
 
 		res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, wfEnv)
+		// Items never pass through the scheduler loop, so the on_missing_output
+		// guard has to be applied here (#421).
+		res = e.applyMissingOutput(ctx, runIDs{taskID: task.ID, wfID: wfID, instID: instID}, sub, res)
 		if res.Success {
 			fr.passed++
 		} else {
@@ -150,6 +153,7 @@ func (e *Engine) executeForeachConcurrent(
 			defer func() { <-sem }()
 
 			res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, wfEnv)
+			res = e.applyMissingOutput(ctx, runIDs{taskID: task.ID, wfID: wfID, instID: instID}, sub, res)
 
 			mu.Lock()
 			if res.Success {


### PR DESCRIPTION
Closes #421.

## The bug

The `on_missing_output` guard lived inline on the scheduler loop in `driveDAG`, so it only ever saw top-level steps. Children of a `parallel:` group — and items of a `for_each:` — run on worker goroutines inside `runParallelStep` / `executeForeach*` and never pass through that loop, so a child that declared an `output` schema and finished without emitting `APIARY_OUTPUT` skipped the guard entirely: recorded as `passed` with a NULL `structured_output`, `memory.write` keys unset, and **nothing logged**. A `reject_when` over those keys then compared `""` against its failure value, read false, and passed a gate that never reached a verdict.

## The fix

Extract the guard as `Engine.applyMissingOutput`, taking the run ids explicitly (`runIDs`) instead of a `*dagRun` so it is safe on a worker goroutine, and call it for each parallel child and each foreach item. Behaviour per policy is identical to top level:

- `fail` — fails the child, marks its `step_runs` row failed, and fails the group under `join: all`
- `warn` (default) — child still passes, but the ERROR line is logged and a `step.missing_output` event is recorded against the child's step id
- `ignore` — unchanged opt-out

`recordStepExecutionEvent` now delegates to a `runIDs`-based variant; no behaviour change at the existing call sites.

## Tests

New `dag_group_missing_output_test.go` builds the exact workflow from the issue (parallel `review` + `qa_validate`, `join: all`, `reject_when` over both verdicts). All three fail without the fix:

- `TestParallelChild_MissingOutputFailFailsTheJoin` — child row was `passed`, now `failed`, instance fails
- `TestParallelChild_MissingOutputWarnIsRecorded` — 0 events before, 1 against the child now
- `TestForeachItem_MissingOutputFailFailsTheItem` — instance passed before, fails now

Plus controls for `ignore` and for both children emitting their verdicts. `go build ./... && go vet && go test ./...` all green.

## Docs

`docs/workflows.md`: note under `parallel:` that children are full steps and honour their own `on_missing_output`, same for the inner step of `for_each:`.