### PR TITLE
fix(dispatch): stop a reclaimed job from re-running a resumed workflow (#422)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,10 +96,22 @@ List workflow instances, or show one in step-level detail.
 ```sh
 apiary instances [--workflow id] [--state s] [--limit n] [--json]
 apiary instances <instance-id>
+apiary instances <instance-id> --cancel
 ```
 
 States: `pending`, `running`, `approval_waiting`, `interrupted`, `done`,
 `failed`.
+
+`--cancel` stops one running instance: its in-flight step is cancelled and the
+instance is marked `interrupted`, along with any queued or leased dispatch job
+for the same task and workflow. The source item is left alone — no labels are
+stripped and no state is reset — so unlike [`apiary restart`](#apiary-restart)
+nothing is re-dispatched, and the run can be picked up later with
+[`apiary resume <instance-id>`](#apiary-resume).
+
+Use it when a task has more than one live instance and you want to keep one of
+them: `restart` acts on the whole cell, and stopping the run from the dashboard
+targets the cell too.
 
 ### `apiary profile`
 

--- a/docs/distributed-workers.md
+++ b/docs/distributed-workers.md
@@ -14,6 +14,14 @@ with heartbeats. If a worker disappears, the control plane expires the attempt
 and makes the job available again; a late worker cannot heartbeat or finish the
 new attempt with its stale token.
 
+A redelivered job (attempt 2 and up) is checked against the control plane before
+it runs: it is skipped when the workflow has already completed for that task, and
+also when the task's run of that workflow is still alive — being auto-resumed
+after a restart, or recorded as a running or parked instance. Otherwise the run
+the first attempt started, and which a restart continued, would get a second agent
+on the same branch. A redelivery with nothing live behind it still executes, which
+is what makes a dead worker's job recoverable.
+
 This means workflow actions should remain idempotent. A process can fail after
 performing an external action but before acknowledging completion, causing a
 retry. Apiary's existing workflow instance, publish, spawn, and hook

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -215,6 +215,15 @@ Daemon restarts (crash, upgrade, reboot) don't lose in-flight work:
   stays put and the next poll dispatches a fresh run from step 1, so a
   long pipeline that must not restart from scratch should opt into
   `resume: auto`.
+- **Queue redelivery.** In [queue mode](distributed-workers.md) the job whose
+  run the crash killed is still leased; the next process reclaims it once the
+  lease expires and delivers it again. That redelivery is dropped when the same
+  task and workflow already has a live run — one being auto-resumed, or an
+  instance that is running or parked — so a reclaimed job cannot put a second
+  agent on the branch its first attempt is still working on. The embedded worker
+  starts only after every startup pass above, so it never claims a job before
+  those guards exist. A redelivery with nothing live behind it still runs: that
+  is the recovery path.
 - **Force restart.** From the [dashboard](dashboard.md) (`R` on a task) or
   `apiary restart <task>`, a stale task's running dispatch and queued jobs are
   cancelled, its non-terminal instances are interrupted, its control labels are

--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -33,13 +33,26 @@ func newInstancesCmd() *cobra.Command {
 		state    string
 		limit    int
 		asJSON   bool
+		cancel   bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "instances [instance-id]",
-		Short: "List workflow instances or show one in detail",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "List workflow instances, show one in detail, or cancel one",
+		Long: "List workflow instances, show one in detail, or cancel one.\n\n" +
+			"--cancel stops a single running instance: its in-flight step is cancelled\n" +
+			"and the instance is marked interrupted, without touching the source item's\n" +
+			"labels or state (unlike `apiary restart`, which acts on the whole cell).\n" +
+			"Queued or leased dispatch jobs for the same task and workflow are cancelled\n" +
+			"with it. A cancelled instance can be continued later with `apiary resume`.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cancel {
+				if len(args) != 1 {
+					return fmt.Errorf("--cancel needs an instance id: apiary instances <instance-id> --cancel")
+				}
+				return cancelInstance(args[0], asJSON)
+			}
 			if len(args) == 1 {
 				return showInstance(args[0], asJSON)
 			}
@@ -51,6 +64,7 @@ func newInstancesCmd() *cobra.Command {
 	cmd.Flags().StringVar(&state, "state", "", "filter by state (pending, running, approval_waiting, interrupted, done, failed)")
 	cmd.Flags().IntVar(&limit, "limit", 20, "max rows")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	cmd.Flags().BoolVar(&cancel, "cancel", false, "stop this instance and mark it interrupted")
 	cmd.AddCommand(newInstancesCompareCmd())
 	return cmd
 }
@@ -104,6 +118,37 @@ func compareInstances(beforeID, afterID string, asJSON bool) error {
 			fmt.Printf("  %s\n", instMuted.Render(fmt.Sprintf("model/runner: %s/%s → %s/%s", row.BeforeModel, row.BeforeRunner, row.AfterModel, row.AfterRunner)))
 		}
 	}
+	return nil
+}
+
+// cancelInstance stops one running instance through the daemon. It exists so a
+// duplicate run can be recovered from inside the tool: `apiary restart` acts on a
+// whole cell (and re-dispatches it), and `apiary instances` used to be read-only,
+// which left killing the agent's process by hand as the only option (issue #422).
+func cancelInstance(id string, asJSON bool) error {
+	var stopped struct {
+		Stopped string `json:"stopped"`
+	}
+	status, err := ipcDo(http.MethodPost, "/instances/stop/"+url.PathEscape(id), &stopped)
+	if err != nil {
+		switch status {
+		case http.StatusNotFound:
+			fmt.Println(instErr.Render("Instance not found: ") + id)
+			os.Exit(2)
+		case 0:
+			return daemonDownHint()
+		default:
+			fmt.Println(instErr.Render("Error: ") + err.Error())
+			os.Exit(1)
+		}
+	}
+	if asJSON {
+		line, _ := json.Marshal(map[string]string{"cancelled": id})
+		fmt.Println(string(line))
+		return nil
+	}
+	fmt.Println(instOK.Render("✓") + " Cancelled instance " + id +
+		instMuted.Render(" (marked interrupted; continue it with `apiary resume "+id+"`)"))
 	return nil
 }
 

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -90,6 +90,13 @@ type Dispatcher struct {
 	inFlight   sync.Map
 	activeRuns sync.Map
 	runCancel  sync.Map
+	// instanceCancel holds the same cancel funcs as runCancel, keyed by workflow
+	// instance id instead of cell id. One cell can carry two live instances (a
+	// resumed run and a re-dispatched one, issue #422), and the cell-keyed map
+	// only remembers whichever started last — so cancelling by cell cannot target
+	// one of them. `apiary instances <id> --cancel` uses this map to stop exactly
+	// the run the operator named.
+	instanceCancel sync.Map
 	// waitAdvancing guards a parked wait_for instance while its CI re-check (and any
 	// follow-on advance) is in flight, so overlapping poll cycles don't double-check
 	// or double-advance the same instance. Mirrors inFlight for polled cells.
@@ -495,15 +502,6 @@ func New(ctx context.Context, cfg *config.Config, configFile string, dbClient *d
 // Start launches one poll goroutine per source.
 // Cancel ctx to initiate a graceful shutdown; then call wg.Wait().
 func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
-	if d.localWorker != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := d.localWorker.Run(ctx); err != nil {
-				aplog.Error("embedded worker: %v", err)
-			}
-		}()
-	}
 	// Enforce the shared git hooks directory on the agents' repo checkouts
 	// (settings.git_hooks) before the first dispatch, so pre-push hooks gate
 	// agent pushes from the very first run.
@@ -598,6 +596,24 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// a fresh run from step 1 and discard the completed work (issue #376). Must
 	// run before the poll loops start so the dispatch guard is already claimed.
 	d.resumeAutoInterrupted(ctx)
+
+	// The embedded queue worker starts last, after every startup pass above.
+	// It reclaims leases the dead process left behind and re-delivers those jobs
+	// immediately, so starting it first (as it used to) raced the reconciles:
+	// a job could be claimed before its instance was even marked interrupted,
+	// and before auto-resume had claimed its dispatch guard — the redelivery
+	// then ran the workflow from step 1 alongside the run being resumed, two
+	// agents on one branch (issue #422). Nothing here dispatches work, so the
+	// delay only postpones the first claim by the length of the reconcile pass.
+	if d.localWorker != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := d.localWorker.Run(ctx); err != nil {
+				aplog.Error("embedded worker: %v", err)
+			}
+		}()
+	}
 
 	// Prune old service_logs/task_logs rows once at startup and then daily,
 	// mirroring the file-side retention (settings.log_max_age_days). Without
@@ -1684,7 +1700,11 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 			return
 		}
 		if err := d.StopInstance(ctx, instanceID); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			status := http.StatusInternalServerError
+			if errors.Is(err, ErrInstanceNotFound) {
+				status = http.StatusNotFound
+			}
+			http.Error(w, err.Error(), status)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -212,6 +212,26 @@ func (d *Dispatcher) ExecuteQueuedJob(ctx context.Context, job queue.Job, worker
 			return queue.FinishResult{Success: true, Note: "skipped: " + reason}
 		}
 	}
+	// Second redelivery guard: the run this job started may still be alive under
+	// a different instance. A daemon that dies mid-run leaves its jobs leased; the
+	// next process reclaims them once the lease expires and re-delivers them —
+	// while startup has already continued the interrupted instance (`resume: auto`)
+	// or a poll has re-dispatched it. Running the payload again then puts a second
+	// agent on the same task, the same worktree and the same branch (issue #422).
+	// Only redeliveries are checked: a first delivery's right to run was decided by
+	// the routing guards at enqueue time, and a manual run deliberately overrides
+	// them.
+	if d.db != nil && payload.Task.ID != "" && job.AttemptCount > 1 {
+		if reason, skip, err := d.redeliveryConflict(ctx, payload.Task.ID, payload.Match.Route.ID); err != nil {
+			return queue.FinishResult{Error: err.Error(), Retry: true}
+		} else if skip {
+			aplog.Info("queue job %s: not running workflow %s for task %s — %s; job finishes without creating an instance",
+				job.ID, payload.Match.Route.ID, payload.Task.ID, reason)
+			d.recordExecutionEvent(ctx, db.ExecutionEvent{Type: "dispatch.dropped", TaskID: payload.Task.ID, WorkflowID: payload.Match.Route.ID,
+				Metadata: map[string]any{"reason": "live run", "detail": reason, "job_id": job.ID, "attempt": job.AttemptCount}})
+			return queue.FinishResult{Success: true, Note: "skipped: " + reason}
+		}
+	}
 	d.active.Add(1)
 	defer d.active.Add(-1)
 	d.activeRuns.Store(job.ID, model.ActiveRun{ID: job.ID, Cell: payload.Cell, WorkerID: workerID, Model: payload.Match.Worker.Model, Status: model.RunStatusRunning, StartedAt: time.Now()})

--- a/src/internal/daemon/queue_redelivery_test.go
+++ b/src/internal/daemon/queue_redelivery_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/queue"
+)
+
+// redeliveredJob runs one poll, takes the job it enqueued for workflowID and
+// returns it as a redelivery — the shape a job has after the daemon that leased
+// it died and the next process reclaimed the expired lease.
+func redeliveredJob(t *testing.T, d *Dispatcher, dbc *db.Client, workflowID string) (queue.Job, *model.InternalTask) {
+	t.Helper()
+	ctx := context.Background()
+	d.poll(ctx, d.cfg.Sources[0], d.sources["src"], time.Time{})
+	job := queueJobFor(t, dbc, workflowID)
+	job.AttemptCount = 2
+	return job, taskForCell(t, dbc, "src", "c1")
+}
+
+// TestExecuteQueuedJob_RedeliverySkippedWhileAutoResuming is the regression for
+// issue #422: a daemon restart reclaims the lease of the job whose run it killed
+// and re-delivers it, while startup is already continuing that run under
+// `resume: auto`. Running the redelivery too puts a second agent on the same
+// task, worktree and branch.
+func TestExecuteQueuedJob_RedeliverySkippedWhileAutoResuming(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := newQueueDispatcher(t, false)
+
+	job, task := redeliveredJob(t, d, dbc, "triage")
+	d.autoResuming.Store(autoResumeKey(task.ID, "triage"), struct{}{})
+
+	res := d.ExecuteQueuedJob(ctx, job, "w1")
+	if !res.Success {
+		t.Fatalf("redelivery reported failure: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 0 {
+		t.Fatalf("redelivery started %d instance(s) alongside the auto-resume, want 0", got)
+	}
+}
+
+// TestExecuteQueuedJob_RedeliverySkippedWithLiveInstance covers the same hole
+// once the resume descendant (or a re-dispatch) is already recorded: the job's
+// original run has been continued as a live instance, so re-running the payload
+// would duplicate it.
+func TestExecuteQueuedJob_RedeliverySkippedWithLiveInstance(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := newQueueDispatcher(t, false)
+
+	job, task := redeliveredJob(t, d, dbc, "triage")
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "i-live", WorkflowID: "triage", CellID: "c1", SourceID: "src",
+		TaskID: task.ID, State: db.InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("create live instance: %v", err)
+	}
+
+	res := d.ExecuteQueuedJob(ctx, job, "w1")
+	if !res.Success {
+		t.Fatalf("redelivery reported failure: %+v", res)
+	}
+	if got := len(instancesFor(t, dbc, task.ID, "triage")); got != 1 {
+		t.Fatalf("redelivery started a second instance alongside the live one (total %d, want 1)", got)
+	}
+}
+
+// TestExecuteQueuedJob_RedeliveryRunsWhenNothingIsLive keeps the recovery path
+// the guards must not break: a job whose run died with the daemon, with nothing
+// continuing it, is re-delivered and runs.
+func TestExecuteQueuedJob_RedeliveryRunsWhenNothingIsLive(t *testing.T) {
+	ctx := context.Background()
+	d, _, dbc := newQueueDispatcher(t, false)
+
+	job, task := redeliveredJob(t, d, dbc, "triage")
+	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "i-orphan", WorkflowID: "triage", CellID: "c1", SourceID: "src",
+		TaskID: task.ID, State: db.InstanceStateInterrupted,
+	}); err != nil {
+		t.Fatalf("create interrupted instance: %v", err)
+	}
+
+	res := d.ExecuteQueuedJob(ctx, job, "w1")
+	if !res.Success {
+		t.Fatalf("redelivery reported failure: %+v", res)
+	}
+	instances := instancesFor(t, dbc, task.ID, "triage")
+	if len(instances) != 2 {
+		t.Fatalf("redelivery produced %d instance(s), want 2 (the orphan plus the re-run)", len(instances))
+	}
+}

--- a/src/internal/daemon/resume_auto.go
+++ b/src/internal/daemon/resume_auto.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
@@ -134,4 +135,27 @@ func (d *Dispatcher) dropAutoResumingMatches(taskID string, matches []router.Mat
 		out = append(out, m)
 	}
 	return out, dropped
+}
+
+// redeliveryConflict reports whether a re-delivered dispatch job would start a
+// second live run of the same (task, workflow). It answers the question the
+// completed-instance check cannot: the earlier run is not done, it is still
+// going — either being auto-resumed at startup (the descendant row may not exist
+// yet) or already running/parked as an instance of its own.
+//
+// It returns the reason to log when the job must be skipped. A query error is
+// returned to the caller, which retries the delivery rather than risking a
+// duplicate agent on the branch.
+func (d *Dispatcher) redeliveryConflict(ctx context.Context, taskID, workflowID string) (string, bool, error) {
+	if _, resuming := d.autoResuming.Load(autoResumeKey(taskID, workflowID)); resuming {
+		return "the interrupted run is being auto-resumed (resume: auto)", true, nil
+	}
+	active, err := d.db.HasActiveInstanceForRoute(ctx, taskID, workflowID)
+	if err != nil {
+		return "", false, fmt.Errorf("check live workflow instance: %w", err)
+	}
+	if active {
+		return "the workflow already has a live instance for this task", true, nil
+	}
+	return "", false, nil
 }

--- a/src/internal/daemon/stop_instance_test.go
+++ b/src/internal/daemon/stop_instance_test.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/db"
+)
+
+func stopInstanceFixture(t *testing.T) *Dispatcher {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "stop.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+	return &Dispatcher{db: dbc}
+}
+
+// TestStopInstance_CancelsOnlyTheNamedInstance is the recovery half of issue
+// #422: when a cell carries two live instances, stopping one must leave the
+// other running. Cancellation used to be keyed by cell alone, which held only
+// whichever run registered last.
+func TestStopInstance_CancelsOnlyTheNamedInstance(t *testing.T) {
+	ctx := context.Background()
+	d := stopInstanceFixture(t)
+
+	for _, id := range []string{"i-keep", "i-drop"} {
+		if err := d.db.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+			ID: id, WorkflowID: "impl", CellID: "c1", SourceID: "src",
+			TaskID: "T1", State: db.InstanceStateRunning,
+		}); err != nil {
+			t.Fatalf("create instance %s: %v", id, err)
+		}
+	}
+
+	keepCtx, keepCancel := context.WithCancel(ctx)
+	defer keepCancel()
+	dropCtx, dropCancel := context.WithCancel(ctx)
+	defer dropCancel()
+	d.instanceCancel.Store("i-keep", context.CancelFunc(keepCancel))
+	d.instanceCancel.Store("i-drop", context.CancelFunc(dropCancel))
+	// The cell-keyed map holds the run that started last, as the executor leaves it.
+	d.runCancel.Store("c1", context.CancelFunc(dropCancel))
+
+	if err := d.StopInstance(ctx, "i-drop"); err != nil {
+		t.Fatalf("stop instance: %v", err)
+	}
+	if dropCtx.Err() == nil {
+		t.Error("the named instance's step was not cancelled")
+	}
+	if keepCtx.Err() != nil {
+		t.Error("stopping one instance cancelled the sibling still running on the same cell")
+	}
+	inst, err := d.db.GetWorkflowInstance(ctx, "i-drop")
+	if err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if inst.State != db.InstanceStateInterrupted {
+		t.Errorf("stopped instance state = %q, want interrupted", inst.State)
+	}
+	keep, err := d.db.GetWorkflowInstance(ctx, "i-keep")
+	if err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if keep.State != db.InstanceStateRunning {
+		t.Errorf("sibling instance state = %q, want running", keep.State)
+	}
+}
+
+// TestStopInstance_FallsBackToTheCell keeps the pre-instance-keyed behavior for
+// a run that registered no per-instance cancel (nothing in flight for it).
+func TestStopInstance_FallsBackToTheCell(t *testing.T) {
+	ctx := context.Background()
+	d := stopInstanceFixture(t)
+	if err := d.db.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
+		ID: "i-1", WorkflowID: "impl", CellID: "c1", SourceID: "src",
+		TaskID: "T1", State: db.InstanceStateRunning,
+	}); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	d.runCancel.Store("c1", context.CancelFunc(cancel))
+
+	if err := d.StopInstance(ctx, "i-1"); err != nil {
+		t.Fatalf("stop instance: %v", err)
+	}
+	if runCtx.Err() == nil {
+		t.Error("the cell's in-flight run was not cancelled")
+	}
+}
+
+// TestStopInstance_UnknownID reports a missing instance instead of claiming a
+// run was stopped.
+func TestStopInstance_UnknownID(t *testing.T) {
+	d := stopInstanceFixture(t)
+	if err := d.StopInstance(context.Background(), "nope"); !errors.Is(err, ErrInstanceNotFound) {
+		t.Errorf("stop unknown instance: err = %v, want ErrInstanceNotFound", err)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -501,9 +501,17 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		// Register the cancel func so `apiary restart` / ForceRestart can interrupt
 		// an in-flight step. A single key per cell mirrors legacy behaviour.
 		x.d.runCancel.Store(req.Cell.ID, cancel)
+		// Also key it by instance, so a single run can be stopped when the cell
+		// carries more than one (issue #422).
+		if req.InstanceID != "" {
+			x.d.instanceCancel.Store(req.InstanceID, cancel)
+		}
 		out, err := c.adapter.Run(runCtx, rr)
 		cancel()
 		x.d.runCancel.Delete(req.Cell.ID)
+		if req.InstanceID != "" {
+			x.d.instanceCancel.Delete(req.InstanceID)
+		}
 		if err != nil && out.Error == nil {
 			out.Error = err
 		}

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -270,28 +270,43 @@ func (d *Dispatcher) StopInstance(ctx context.Context, instanceID string) error 
 		return nil
 	}
 	inst, err := d.db.GetWorkflowInstance(ctx, instanceID)
-	if err != nil || inst == nil {
+	if err != nil {
 		return err
+	}
+	if inst == nil {
+		// Reporting success for an id that names nothing let `--cancel` (and the
+		// dashboard) claim a run was stopped when nothing was even looked at.
+		return ErrInstanceNotFound
 	}
 	if d.dispatchQueue != nil {
 		if _, err := d.dispatchQueue.RequestCancelFor(ctx, inst.TaskID, inst.WorkflowID); err != nil {
 			aplog.Error("stop instance %s: cancel queued work: %v", instanceID, err)
 		}
 	}
-	// Cancel the in-flight run for this cell.
-	if val, ok := d.runCancel.LoadAndDelete(inst.CellID); ok {
-		cancel := val.(context.CancelFunc)
-		cancel()
+	// Cancel this instance's own step, when it registered one. Cancelling by cell
+	// instead would be ambiguous the moment a cell carries two live instances —
+	// exactly the state this command exists to clean up (issue #422) — because the
+	// cell-keyed map holds only whichever run started last.
+	if val, ok := d.instanceCancel.LoadAndDelete(instanceID); ok {
+		val.(context.CancelFunc)()
+	} else if val, ok := d.runCancel.LoadAndDelete(inst.CellID); ok {
+		// No per-instance registration (no step in flight for it, or a run that
+		// predates the instance-keyed map): fall back to the cell.
+		val.(context.CancelFunc)()
+		// Sweep the cell's active runs only on this path: doing it while a sibling
+		// instance is still running would drop the survivor from the dashboard.
+		d.activeRuns.Range(func(key, val any) bool {
+			run := val.(model.ActiveRun)
+			if run.Cell.ID == inst.CellID {
+				d.activeRuns.Delete(key)
+			}
+			return true
+		})
 	}
-	// Remove from in-flight and active tracking so the slot is freed.
+	// The marker only guards the routing→hand-off window, so releasing it is safe
+	// either way: a sibling instance that is still running keeps the cell shadowed
+	// by the in-flight instance guard.
 	d.inFlight.Delete(inst.CellID)
-	d.activeRuns.Range(func(key, val any) bool {
-		run := val.(model.ActiveRun)
-		if run.Cell.ID == inst.CellID {
-			d.activeRuns.Delete(key)
-		}
-		return true
-	})
 
 	// Mark the running task_execution interrupted.
 	if lastExec, err := d.db.GetLastExecution(ctx, inst.CellID); err == nil && lastExec != nil && lastExec.Status == "running" {


### PR DESCRIPTION
## What broke

On restart, a cell could end up with **two live instances**: the one startup continued under `resume: auto`, and a fresh step-1 run — two agents on the same worktree and branch (#422).

## Root cause

Not the rescan. The poll path was already guarded (`dropAutoResumingMatches` → `dropActiveMatches`, covered by `TestPollDoesNotRestartWhileAutoResuming`). The duplicate came from the **durable queue**:

1. The daemon dies mid-run. Its dispatch job stays `leased`; its instance is later marked `interrupted`.
2. `Start()` launched the embedded worker as its *first* action — before the reconciles, the rehydration passes and `resumeAutoInterrupted`. The worker reclaims the expired lease immediately and re-delivers the job.
3. The only check on a redelivery was `HasCompletedInstanceForRoute`. An interrupted run (or one being resumed right now) is not *completed*, so the payload ran again from step 1 — next to the run auto-resume was continuing.

That matches the report exactly: fresh instance at `plan`, resumed instance at `review`, seconds apart, no dispatch line in the log.

## Fix

- **Startup order**: the embedded worker starts last, after every startup pass, so no job is claimed before the guards exist.
- **Redelivery guard**: on attempt > 1, the job is skipped when the same (task, workflow) is being auto-resumed or already has a running/parked instance. It finishes with a `dispatch.dropped` event and an INFO line naming the reason. A redelivery with nothing live behind it still runs — that is the recovery path a reclaimed lease exists for.

## Recovery, in-tool

The issue also asked for a per-instance cancel:

```sh
apiary instances <instance-id> --cancel
```

Stops one instance and marks it `interrupted`, leaving the source item's labels and state alone (unlike `apiary restart`, which acts on the whole cell and re-dispatches). Cancel funcs are now keyed by instance as well as by cell, so stopping one of two runs on a cell leaves the survivor alone; an unknown id returns 404 instead of reporting success.

## Tests

New in `queue_redelivery_test.go` (both skip tests fail on `main`):

- redelivery while the pair is auto-resuming → no instance created
- redelivery while a live instance exists → no second instance
- redelivery with only an interrupted instance → runs (recovery preserved)

New in `stop_instance_test.go`: cancel targets only the named instance, falls back to the cell when no per-instance cancel is registered, and reports `ErrInstanceNotFound` for an unknown id.

Full suite green (`go test ./...`).

## Docs

`docs/resilience.md` (queue redelivery on restart), `docs/distributed-workers.md` (what a redelivery is checked against), `docs/cli.md` (`--cancel`).

Closes #422