### PR TITLE
feat(workflow): adicionar result_comment on_fail e always

### DIFF
--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -35,6 +35,8 @@ const (
 	ResultCommentOnComplete = "on_complete"
 	ResultCommentPerStep    = "per_step"
 	ResultCommentOff        = "off"
+	ResultCommentOnFail     = "on_fail" // post only when the workflow fails
+	ResultCommentAlways     = "always"  // post on both success and failure
 )
 
 // Publish modes for an agent step: whether the engine writes an APIARY_PUBLISH

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -73,9 +73,10 @@ func (c *Config) validateWorkflow(
 
 	// Result comment mode.
 	switch wf.ResultComment {
-	case "", ResultCommentOnComplete, ResultCommentPerStep, ResultCommentOff:
+	case "", ResultCommentOnComplete, ResultCommentPerStep, ResultCommentOff,
+		ResultCommentOnFail, ResultCommentAlways:
 	default:
-		errs = append(errs, fmt.Errorf("%s: invalid result_comment %q (want on_complete|per_step|off)", ctx, wf.ResultComment))
+		errs = append(errs, fmt.Errorf("%s: invalid result_comment %q (want on_complete|per_step|off|on_fail|always)", ctx, wf.ResultComment))
 	}
 
 	// Trigger source reference.

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -134,7 +134,7 @@ func TestWorkflow_InvalidResume(t *testing.T) {
 func TestWorkflow_InvalidResultComment(t *testing.T) {
 	cfg := baseWorkflowConfig()
 	cfg.Workflows = []config.WorkflowConfig{
-		{ID: "wf", ResultComment: "always", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
+		{ID: "wf", ResultComment: "bogus", Steps: []config.StepConfig{{ID: "s1", Agent: "architect"}}},
 	}
 	assertError(t, cfg, "invalid result_comment")
 }

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -955,17 +955,22 @@ func (e *Engine) linkPullRequest(ctx context.Context, task model.InternalTask, b
 	aplog.Info("step %q: linked pull request %s to task %s", step.ID, pr.URL, task.ID)
 }
 
-// applyCompletion applies the on_complete/on_fail hook and posts the on_complete
-// result comment (the final memory document) to the task's source bindings.
+// applyCompletion applies the on_complete/on_fail hook and posts the result
+// comment (the final memory document) to the task's source bindings.
 func (e *Engine) applyCompletion(ctx context.Context, r *dagRun, failed bool) {
 	if e.side == nil {
 		return
 	}
 	wf := r.wf
+	mode := e.resultCommentMode(wf)
 
-	if !failed && e.resultCommentMode(wf) == config.ResultCommentOnComplete {
+	if !failed && (mode == config.ResultCommentOnComplete || mode == config.ResultCommentAlways) {
 		doc := e.mem.Build(r.cell, r.memSteps())
 		_ = e.side.PostComment(ctx, r.task, r.bindings, finalComment(wf, false, doc))
+	}
+	if failed && (mode == config.ResultCommentOnFail || mode == config.ResultCommentAlways) {
+		doc := e.mem.Build(r.cell, r.memSteps())
+		_ = e.side.PostComment(ctx, r.task, r.bindings, finalComment(wf, true, doc))
 	}
 
 	var hook *config.OnComplete

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -777,6 +777,85 @@ func TestEngine_ResultCommentOff(t *testing.T) {
 	}
 }
 
+func TestEngine_ResultCommentOnFail(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false
+
+	t.Run("posts on failure", func(t *testing.T) {
+		store := newFakeStore()
+		exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: false, Output: "boom"}}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		wf.ResultComment = config.ResultCommentOnFail
+		_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
+
+		if len(side.comments) != 1 {
+			t.Fatalf("expected 1 on_fail comment, got %d", len(side.comments))
+		}
+		if !strings.Contains(side.comments[0], "✗ Failed") {
+			t.Errorf("unexpected comment: %q", side.comments[0])
+		}
+	})
+
+	t.Run("silent on success", func(t *testing.T) {
+		store := newFakeStore()
+		exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true, Output: "ok"}}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		wf.ResultComment = config.ResultCommentOnFail
+		_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
+
+		if len(side.comments) != 0 {
+			t.Errorf("expected no comments on success with on_fail mode, got: %v", side.comments)
+		}
+	})
+}
+
+func TestEngine_ResultCommentAlways(t *testing.T) {
+	cfg := baseCfg()
+	cfg.Settings.ResultComment = false
+
+	t.Run("posts on success", func(t *testing.T) {
+		store := newFakeStore()
+		exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true, Output: "ok"}}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		wf.ResultComment = config.ResultCommentAlways
+		_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
+
+		if len(side.comments) != 1 {
+			t.Fatalf("expected 1 comment on success with always mode, got %d", len(side.comments))
+		}
+		if !strings.Contains(side.comments[0], "✓ Done") {
+			t.Errorf("unexpected comment: %q", side.comments[0])
+		}
+	})
+
+	t.Run("posts on failure", func(t *testing.T) {
+		store := newFakeStore()
+		exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: false, Output: "boom"}}}
+		side := &fakeSide{}
+		eng := testEngine(cfg, store, exec, side)
+
+		wf := synthWF(config.RouteConfig{ID: "r", Agent: "backend-dev"})
+		wf.ResultComment = config.ResultCommentAlways
+		_, _, _ = eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1", Title: "t"})
+
+		if len(side.comments) != 1 {
+			t.Fatalf("expected 1 comment on failure with always mode, got %d", len(side.comments))
+		}
+		if !strings.Contains(side.comments[0], "✗ Failed") {
+			t.Errorf("unexpected comment: %q", side.comments[0])
+		}
+	})
+}
+
 func TestEngine_StructuredOutputPersisted(t *testing.T) {
 	cfg := baseCfg()
 	store := newFakeStore()


### PR DESCRIPTION
## Summary

- Adiciona constante `ResultCommentOnFail = "on_fail"` em `config/workflow.go` — posta o documento de memória apenas quando o workflow falha
- Adiciona constante `ResultCommentAlways = "always"` — posta tanto em sucesso quanto em falha
- Atualiza `applyCompletion()` em `engine.go` para avaliar os novos modos com lógica `failed && (on_fail || always)` / `!failed && (on_complete || always)`
- Atualiza validação YAML em `workflow_validate.go` para aceitar os novos valores
- Corrige teste existente `TestWorkflow_InvalidResultComment` (usava `"always"` como valor inválido; substitui por `"bogus"`)
- Adiciona `TestEngine_ResultCommentOnFail` e `TestEngine_ResultCommentAlways` cobrindo todos os cenários

## Test plan

- [x] `TestEngine_ResultCommentOnFail/posts_on_failure` — posta comentário com "✗ Failed" ao falhar
- [x] `TestEngine_ResultCommentOnFail/silent_on_success` — sem comentário em sucesso
- [x] `TestEngine_ResultCommentAlways/posts_on_success` — posta comentário com "✓ Done" em sucesso
- [x] `TestEngine_ResultCommentAlways/posts_on_failure` — posta comentário com "✗ Failed" ao falhar
- [x] Testes existentes (`on_complete`, `per_step`, `off`) continuam verdes
- [x] Validação YAML rejeita valores desconhecidos como `"bogus"`

Ref orlandoburli/project-erp#4715