### PR TITLE
fix(config): narrow the result_comment deprecation to per_step

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -858,8 +858,27 @@ triggered the workflow, so a label-driven trigger fires once and the item
 stops matching on the next poll. Removals run after `add_labels`, and sources
 that don't support label removal skip the directive.
 
-A workflow can also override the global result-comment behavior:
-`result_comment: on_complete | per_step | off`.
+A workflow can also override the global result-comment behavior with
+`result_comment`:
+
+| Mode | Posts |
+|---|---|
+| `on_complete` | the workflow's memory document, when it succeeds |
+| `on_fail` | the memory document, when it fails |
+| `always` | both |
+| `off` | nothing |
+| `per_step` | each step's raw output, as its own comment — **deprecated** |
+
+The completion modes post the **memory document**: the aggregate the engine
+builds from every step's `memory.write` fields. No single agent produces it, and
+`on_fail` covers exactly the runs where a step crashed, timed out, or was rate
+limited and emitted nothing at all — so these are the right tool when you want a
+guaranteed write-back.
+
+`per_step` is deprecated because it dumps a step's stdout verbatim. An agent that
+wants to report should say so deliberately with an
+[`APIARY_PUBLISH`](tasks-and-fanout.md#apiary_publish-write-back) block, choosing its own
+wording. It still works, but `apiary validate` advises against it.
 
 ## Resuming instances
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -914,17 +914,29 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// warnDeprecatedResultComment logs a deprecation warning when result_comment is
-// set to any non-default value, at the global settings level or on any workflow.
-// The feature still works (see Engine.resultCommentMode); the APIARY_PUBLISH
-// marker in agent output is the supported replacement.
+// warnDeprecatedResultComment logs a deprecation warning for result_comment
+// per_step, the one mode APIARY_PUBLISH actually replaces.
+//
+// The original deprecation (#74) covered every mode, on the premise that an
+// agent-emitted marker supersedes an engine-posted comment. That holds for
+// per_step, which dumps a step's raw stdout: an agent that wants to report can
+// say so deliberately, and better, with APIARY_PUBLISH.
+//
+// It does not hold for the completion modes. on_complete, on_fail and always
+// post the workflow's *memory document* — an aggregate the engine builds across
+// every step (Engine.applyCompletion), which no single agent's output contains.
+// on_fail is the sharper case: it exists precisely for runs where a step failed,
+// timed out, or hit a rate limit and produced no usable output at all, so there
+// may be no agent left to emit a marker. Warning there told operators to replace
+// a working feature with one that structurally cannot cover it — and #431 then
+// extended those very modes, leaving the config both deprecated and growing.
+//
+// The per_step path stays functional; this is advice, not removal.
 func warnDeprecatedResultComment(cfg *Config) {
-	const msg = "result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead"
-	if cfg.Settings.ResultComment {
-		aplog.Warn("settings.result_comment: %s", msg)
-	}
+	const msg = "result_comment: per_step is deprecated; have the agent emit an APIARY_PUBLISH block instead " +
+		"(the on_complete/on_fail/always modes are not deprecated — they post the workflow memory document)"
 	for _, wf := range cfg.Workflows {
-		if wf.ResultComment != "" {
+		if wf.ResultComment == ResultCommentPerStep {
 			aplog.Warn("workflow %q: %s", wf.ID, msg)
 		}
 	}

--- a/src/internal/config/result_comment_deprecation_test.go
+++ b/src/internal/config/result_comment_deprecation_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	aplog "github.com/orlandoburli/apiary/internal/log"
+)
+
+// captureWarnings collects the warnings emitted while loading a config, via the
+// log package's sink.
+func captureWarnings(t *testing.T, cfg *Config) []string {
+	t.Helper()
+	var got []string
+	aplog.SetSink(func(level, msg string) {
+		if level == "WARN" {
+			got = append(got, msg)
+		}
+	})
+	t.Cleanup(func() { aplog.SetSink(nil) })
+	warnDeprecatedResultComment(cfg)
+	return got
+}
+
+// The completion modes post the workflow memory document — an aggregate no
+// single agent's output contains, and on_fail covers runs where the agent
+// produced nothing at all. Warning there would point operators at a replacement
+// that structurally cannot cover the case.
+func TestResultCommentCompletionModesAreNotDeprecated(t *testing.T) {
+	for _, mode := range []string{ResultCommentOnComplete, ResultCommentOnFail, ResultCommentAlways, ResultCommentOff} {
+		cfg := &Config{Workflows: []WorkflowConfig{{ID: "wf", ResultComment: mode}}}
+		if w := captureWarnings(t, cfg); len(w) != 0 {
+			t.Errorf("result_comment: %s should not warn, got %v", mode, w)
+		}
+	}
+}
+
+// per_step dumps a step's raw stdout; an agent that wants to report can choose
+// what to say with APIARY_PUBLISH instead. That one stays deprecated.
+func TestResultCommentPerStepWarns(t *testing.T) {
+	cfg := &Config{Workflows: []WorkflowConfig{{ID: "release", ResultComment: ResultCommentPerStep}}}
+	warnings := captureWarnings(t, cfg)
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning, got %v", warnings)
+	}
+	w := warnings[0]
+	for _, want := range []string{"release", "per_step", "APIARY_PUBLISH", "not deprecated"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning should mention %q: %s", want, w)
+		}
+	}
+}
+
+// settings.result_comment is the global on_complete switch, so it must not warn
+// either — it selects a completion mode, not per_step.
+func TestGlobalResultCommentSettingDoesNotWarn(t *testing.T) {
+	cfg := &Config{Settings: Settings{ResultComment: true}}
+	if w := captureWarnings(t, cfg); len(w) != 0 {
+		t.Errorf("settings.result_comment should not warn, got %v", w)
+	}
+}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -30,13 +30,19 @@ const (
 	ResumeAuto      = "auto"
 )
 
-// Result comment modes for a workflow.
+// Result comment modes for a workflow. The completion modes post the workflow's
+// memory document — the aggregate the engine builds across every step — which is
+// why they are not superseded by an agent's APIARY_PUBLISH block.
 const (
-	ResultCommentOnComplete = "on_complete"
-	ResultCommentPerStep    = "per_step"
-	ResultCommentOff        = "off"
-	ResultCommentOnFail     = "on_fail" // post only when the workflow fails
-	ResultCommentAlways     = "always"  // post on both success and failure
+	ResultCommentOnComplete = "on_complete" // post the memory document when the workflow succeeds
+	ResultCommentOnFail     = "on_fail"     // post it only when the workflow fails
+	ResultCommentAlways     = "always"      // post it on both success and failure
+	ResultCommentOff        = "off"         // post nothing
+	// ResultCommentPerStep posts each step's raw output as its own comment.
+	// DEPRECATED: an agent that wants to report should emit an APIARY_PUBLISH
+	// block, which lets it choose what to say instead of dumping stdout. Still
+	// functional; warnDeprecatedResultComment advises against it at load.
+	ResultCommentPerStep = "per_step"
 )
 
 // Publish modes for an agent step: whether the engine writes an APIARY_PUBLISH
@@ -81,7 +87,8 @@ type WorkflowConfig struct {
 	// allowed (default), forbidden, or auto. Empty means allowed.
 	Resume string `yaml:"resume,omitempty"`
 	// ResultComment overrides settings.result_comment for this workflow:
-	// on_complete (default), per_step, or off. Empty inherits the global default.
+	// on_complete, on_fail, always, per_step (deprecated), or off. Empty inherits
+	// the global default.
 	ResultComment string         `yaml:"result_comment,omitempty"`
 	Trigger       *TriggerConfig `yaml:"trigger,omitempty"`
 	Steps         []StepConfig   `yaml:"steps"`


### PR DESCRIPTION
## The contradiction

v0.18.0 told operators two things at once:

```
workflow "x": result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead
```

…while the same release ([#431](https://github.com/orlandoburli/apiary/pull/431)) **added** `on_fail` and `always` modes to `result_comment`. The config was simultaneously deprecated and growing.

## Which half was wrong

The original deprecation ([#74](https://github.com/orlandoburli/apiary/pull/74)) was written on the premise that *"an agent-emitted marker supersedes an engine-posted comment."*

That holds for **`per_step`**, which dumps a step's raw stdout after every step. An agent that wants to report can say so deliberately — and better — with an `APIARY_PUBLISH` block. Deprecation is right here.

It does **not** hold for the completion modes. `on_complete`, `on_fail` and `always` post the workflow's **memory document** — the aggregate `applyCompletion` builds across every step's `memory.write` fields:

```go
doc := e.mem.Build(r.cell, r.memSteps())
_ = e.side.PostComment(ctx, r.task, r.bindings, finalComment(wf, failed, doc))
```

No single agent's output contains that. And `on_fail` is the sharper case: it exists precisely for runs where a step failed, timed out, or hit a rate limit and produced nothing usable — so there may be **no agent left to emit a marker at all**. Warning there told operators to replace a working feature with one that structurally cannot cover the case.

## The change

- The warning fires only for `per_step`, and names the alternative without implying the other modes are going away.
- `settings.result_comment` (the global `on_complete` switch) stops warning entirely — it selects a completion mode, not `per_step`.
- `per_step` stays fully functional. This is advice, not removal.

Before / after on a config using `on_fail`:

```
- WARN  result_comment is deprecated; use APIARY_PUBLISH marker in agent output instead
+ (silent)
```

and on one using `per_step`:

```
WARN  result_comment: per_step is deprecated; have the agent emit an APIARY_PUBLISH block
      instead (the on_complete/on_fail/always modes are not deprecated — they post the
      workflow memory document)
```

## Docs

`docs/workflows.md` still listed `on_complete | per_step | off` — missing both modes #431 added — and never explained that the completion modes post the memory document. It now documents all five with that distinction.

## Tests

Three new cases pin the boundary: completion modes and `settings.result_comment` must stay silent; `per_step` must warn and name both the workflow and the alternative. Verified with the built binary across all four modes.