### PR TITLE
fix(dashboard): show the approval's own question, and count waiting gates

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1862,6 +1862,33 @@ func (a *App) openWorkflowMonitorOrLogs(taskID string) tea.Cmd {
 	}
 }
 
+// applyApprovalPrompt loads the pending approval request for an instance parked
+// at an approval step and shows the operator what it is actually asking.
+//
+// Both call sites used to overwrite Message with a fixed string — "Awaiting human
+// approval — reply on the task to resume or abort." — which threw away the step's
+// own question and, worse, gave advice that only ever applied to a resume_on gate.
+// A gate with no source trigger cannot be answered by replying on the task at all,
+// so the banner was telling operators to do the one thing that does nothing.
+//
+// The message the step declared is the prompt; the keys to answer it come from
+// renderWorkflowSteps. The fixed line survives only as a fallback for an instance
+// whose request row is missing or carries no message, since an empty Message
+// hides the banner (and its key hints) entirely.
+func applyApprovalPrompt(ctx context.Context, dbConn *db.Client, item *WorkflowInstanceItem) {
+	if item == nil || item.State != db.InstanceStateApprovalWaiting {
+		return
+	}
+	if dbConn != nil {
+		item.Approval, _ = dbConn.GetApprovalByInstance(ctx, item.ID)
+	}
+	if item.Approval != nil && strings.TrimSpace(item.Approval.Message) != "" {
+		item.Message = item.Approval.Message
+		return
+	}
+	item.Message = "Awaiting human approval."
+}
+
 // buildWorkflowInstanceItem hydrates a WorkflowInstanceItem (steps + per-step
 // usage) from a stored workflow instance, for the live monitor views.
 func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.WorkflowInstance) *WorkflowInstanceItem {
@@ -1872,10 +1899,7 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 		CellID:    inst.CellID,
 		CreatedAt: inst.CreatedAt,
 	}
-	if inst.State == "approval_waiting" {
-		item.Message = "Awaiting human approval — reply on the task to resume or abort."
-		item.Approval, _ = dbConn.GetApprovalByInstance(ctx, inst.ID)
-	}
+	applyApprovalPrompt(ctx, dbConn, item)
 	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
 	if err == nil {
 		usage := loadStepUsageFallback(ctx, dbConn, inst.ID, steps)
@@ -2270,6 +2294,10 @@ func (a *App) fetchOverview() tea.Cmd {
 		}
 
 		if dbConn != nil {
+			// Independent of the stats rollup: a waiting approval must still be
+			// reported when the 24h aggregate query fails.
+			data.PendingApprovals, _ = dbConn.CountPendingApprovals(ctx)
+
 			if stats, err := dbConn.GetDashboardStats(ctx, time.Now().AddDate(0, 0, -1)); err == nil && stats != nil {
 				data.Status = stats.DispatcherStatus
 				data.ActiveAgents = stats.ActiveAgents
@@ -2802,9 +2830,7 @@ func (a *App) buildTaskHistory(ctx context.Context, dbConn *db.Client, internalT
 				if polls, err := dbConn.ListCIPollChecks(ctx, seg.Instance.ID); err == nil {
 					item.CIPolls = mapCIPolls(polls)
 				}
-				if item.State == db.InstanceStateApprovalWaiting {
-					item.Message = "Awaiting human approval — reply on the task to resume or abort."
-				}
+				applyApprovalPrompt(ctx, dbConn, &item)
 				segments = append(segments, TaskHistorySegmentItem{
 					Instance: item,
 					Logs:     mapLogLines(seg.Logs),
@@ -3228,10 +3254,19 @@ func (a *App) renderOverviewTab(height int) string {
 	if o.TodayTokens > 0 {
 		tokensStr = fmt.Sprintf("%s in / %s out / %s total", format.Tokens(o.TodayInputTokens), format.Tokens(o.TodayOutputTokens), format.Tokens(o.TodayTokens))
 	}
+	// A waiting approval is a to-do, not a measurement: it is the one line here
+	// that stays until a human acts, so it is rendered as an alert when non-zero
+	// and dimmed to a plain zero otherwise.
+	approvals := StyleMuted.Render("0")
+	if o.PendingApprovals > 0 {
+		approvals = StyleWarning.Render(fmt.Sprintf("%d ⏸ — press a on the task to answer", o.PendingApprovals))
+	}
+
 	fmt.Fprintf(&b,
 		"\nTasks (24h):\n"+
 			"  Running:    %d\n"+
 			"  Queued:     %d\n"+
+			"  Approvals:  %s\n"+
 			"  Completed:  %s\n"+
 			"  Failed:     %s\n"+
 			"\n"+
@@ -3245,6 +3280,7 @@ func (a *App) renderOverviewTab(height int) string {
 			"  Success Rate: %s\n",
 		o.ActiveRuns,
 		o.QueuedTasks,
+		approvals,
 		StyleSuccess.Render(fmt.Sprintf("%d ✓", o.CompletedToday)),
 		StyleError.Render(fmt.Sprintf("%d ✗", o.FailedToday)),
 		costStr,

--- a/src/internal/dashboard/approval_form_test.go
+++ b/src/internal/dashboard/approval_form_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -154,5 +155,74 @@ func TestApprovalFormRendersOptions(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("form is missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// The banner must show the step's own question. Both call sites used to
+// overwrite it with a fixed "reply on the task to resume or abort" line, which
+// discarded the prompt and pointed operators at the source-comment flow — a
+// no-op for a gate that declares no resume_on.
+func TestApprovalPromptShowsTheStepsQuestion(t *testing.T) {
+	item := &WorkflowInstanceItem{
+		ID:    "wf-1",
+		State: db.InstanceStateApprovalWaiting,
+		Approval: &db.ApprovalRequest{
+			ID:      "wf-1:gate",
+			Message: "Release 2.4 is staged. How should it go out?",
+		},
+	}
+	// A nil db keeps the already-loaded request; the message must win.
+	applyApprovalPrompt(context.Background(), nil, item)
+	if item.Message != "Release 2.4 is staged. How should it go out?" {
+		t.Fatalf("banner = %q, want the approval's own message", item.Message)
+	}
+	if strings.Contains(item.Message, "reply on the task") {
+		t.Fatal("the stale source-comment advice is back")
+	}
+}
+
+// An empty Message hides the banner and its key hints, so a request without one
+// still needs a non-empty fallback — but not the misleading old text.
+func TestApprovalPromptFallsBackWithoutAMessage(t *testing.T) {
+	item := &WorkflowInstanceItem{ID: "wf-1", State: db.InstanceStateApprovalWaiting}
+	applyApprovalPrompt(context.Background(), nil, item)
+	if item.Message == "" {
+		t.Fatal("an empty message would hide the approval banner entirely")
+	}
+	if strings.Contains(item.Message, "reply on the task") {
+		t.Fatalf("fallback should not advise replying on the task: %q", item.Message)
+	}
+}
+
+// Instances that are not parked at an approval must be left alone.
+func TestApprovalPromptIgnoresOtherStates(t *testing.T) {
+	item := &WorkflowInstanceItem{ID: "wf-1", State: db.InstanceStateRunning, Message: "step 2 of 4"}
+	applyApprovalPrompt(context.Background(), nil, item)
+	if item.Message != "step 2 of 4" {
+		t.Fatalf("message was rewritten for a running instance: %q", item.Message)
+	}
+}
+
+// Overview must surface a waiting approval, since a gate with no timeout waits
+// forever and nothing outside the Tasks tab used to mention one.
+func TestOverviewShowsPendingApprovals(t *testing.T) {
+	a := newFormApp()
+	a.model.overviewTab = &OverviewTab{PendingApprovals: 2}
+	out := stripANSI(a.renderOverviewTab(40))
+	if !strings.Contains(out, "Approvals:") {
+		t.Fatalf("overview is missing the approvals row:\n%s", out)
+	}
+	if !strings.Contains(out, "2 ⏸") {
+		t.Fatalf("overview should show the pending count:\n%s", out)
+	}
+
+	// Zero stays quiet — it is a to-do counter, not an alert to cry wolf with.
+	a.model.overviewTab = &OverviewTab{}
+	out = stripANSI(a.renderOverviewTab(40))
+	if !strings.Contains(out, "Approvals:") {
+		t.Fatalf("the row should still render at zero:\n%s", out)
+	}
+	if strings.Contains(out, "⏸") {
+		t.Fatalf("zero approvals should not render an alert:\n%s", out)
 	}
 }

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -58,12 +58,17 @@ type AgentCount struct {
 }
 
 type OverviewTab struct {
-	Status            string
-	Uptime            string
-	Concurrency       int
-	ActiveAgents      int
-	ActiveRuns        int
-	QueuedTasks       int
+	Status       string
+	Uptime       string
+	Concurrency  int
+	ActiveAgents int
+	ActiveRuns   int
+	QueuedTasks  int
+	// PendingApprovals counts approval requests nobody has answered yet. It is
+	// the only Overview number that is a to-do rather than a measurement: a gate
+	// with no timeout waits forever, and until now nothing outside the Tasks tab
+	// said one was waiting.
+	PendingApprovals  int
 	CompletedToday    int
 	FailedToday       int
 	ThroughputRatio   string

--- a/src/internal/db/approval_store.go
+++ b/src/internal/db/approval_store.go
@@ -171,6 +171,17 @@ func (c *Client) ResolveApprovalRequest(ctx context.Context, id string, response
 	return req, resolved, getErr
 }
 
+// CountPendingApprovals returns how many approval requests are still unanswered.
+// Escalated counts as unanswered: escalation re-targets a request, it does not
+// resolve it — an operator still has to respond.
+func (c *Client) CountPendingApprovals(ctx context.Context) (int, error) {
+	var n int
+	err := c.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM approval_requests WHERE status IN (?,?)`,
+		ApprovalPending, ApprovalEscalated).Scan(&n)
+	return n, err
+}
+
 // CountApprovals returns how many approve responses a request has recorded so
 // far, for progress display against RequiredApprovals. A request with no
 // approvers resolves on the first response, so this is only interesting for a


### PR DESCRIPTION
## The banner showed the wrong thing

Both places that build a `WorkflowInstanceItem` overwrote `Message` with a fixed string:

```go
item.Message = "Awaiting human approval — reply on the task to resume or abort."
item.Approval, _ = dbConn.GetApprovalByInstance(ctx, inst.ID)   // ← the real one, right here
```

Two problems, compounding:

1. **It discarded the step's question.** An operator saw that *something* was waiting, but not what it was asking. "Release 2.4 is staged. How should it go out?" became generic text.
2. **The advice is wrong now.** "Reply on the task" is the source-comment flow. A gate that declares no `resume_on` cannot be answered that way at all — the banner recommended the one action that does nothing.

The line directly below already loaded the real request into `item.Approval`, which the form and the key hints read. The message was one field away, unused.

## The fix

Both sites now share `applyApprovalPrompt`, which renders the request's own message. The generic line survives only as a fallback for a request with no message, because an empty `Message` hides the banner — and its key hints — entirely.

Before / after, against a live daemon:

```
- ⏸ Awaiting human approval — reply on the task to resume or abort.
+ ⏸ Release 2.4 is staged. How should it go out?
    Press a to answer (1 fields) or n to reject
```

## Overview: pending approvals

Nothing outside the Tasks tab said a gate was waiting, which matters more now that an operator gate with no `timeout` waits indefinitely by design.

```
Tasks (24h):
  Running:    0
  Queued:     0
  Approvals:  2 ⏸ — press a on the task to answer
  Completed:  0 ✓
```

It is the one number on Overview that is a to-do rather than a measurement, so it renders as an alert when non-zero and a dim `0` otherwise. Two details:

- Read **independently of the 24h stats rollup**, so a failure there cannot hide a waiting gate.
- Counts `escalated` alongside `pending` — escalation re-targets a request, it does not answer it.

## Tests

Four new cases: the banner shows the step's message; a message-less request still gets a non-empty fallback that does *not* advise replying on the task; non-approval instances are untouched; Overview renders the count and stays quiet at zero.

The banner test was checked against the previous behaviour and fails on it.

Verified end to end by rendering the real views against a live daemon's database.