### PR TITLE
fix(workflow): sequence flat workflows, so an approval step actually gates

### DIFF
--- a/src/internal/config/lower_v2.go
+++ b/src/internal/config/lower_v2.go
@@ -17,9 +17,21 @@ import (
 // than re-dissolved into a sequential group — so re-validating an in-place-lowered
 // Config (Config.Validate mutates) preserves concurrency and the join policy.
 func LowerV2Workflow(wf WorkflowConfig) (WorkflowConfig, error) {
-	// Quick exit: no step uses v2 fields → nothing to do.
+	// No step uses a v2 field, so there is nothing to lower — but the steps still
+	// need the implicit sequential edges the engine promises. Without them a flat
+	// workflow reaches the DAG with no dependencies at all, every step is
+	// immediately runnable, and they run concurrently: an approval step gated
+	// nothing, and the step after it could finish before the instance even parked.
+	//
+	// The early exit stays because it is also the idempotence guard: a workflow
+	// that has already been lowered reports no v2 steps (Condition replaces If,
+	// and a lowered parallel node is explicitly excluded), so re-entering the full
+	// pass would rewrite already-rewritten expressions. sequenceSteps is safe to
+	// re-run — it only fills in edges that are missing.
 	if !anyV2Steps(wf.Steps) {
-		return wf, nil
+		out := wf
+		out.Steps = sequenceSteps(wf.Steps)
+		return out, nil
 	}
 
 	lc := &lowerCtx{
@@ -69,6 +81,31 @@ func buildStepIndex(steps []StepConfig) map[string]StepConfig {
 	}
 	walk(steps)
 	return m
+}
+
+// sequenceSteps threads the implicit sequential ordering through a step list the
+// lowering pass leaves alone: each step depends on the one declared before it.
+//
+// This is what makes "steps run in the order they are declared" true — the
+// promise the docs make and that the removal of `depends_on` points authors at.
+// It uses SeqDependsOn rather than DependsOn for the same reason lowerLeafStep
+// does: a condition-skipped step must not block its successor.
+//
+// It is idempotent, and it never overrides an edge a step already carries, so it
+// is safe on an already-lowered workflow.
+func sequenceSteps(steps []StepConfig) []StepConfig {
+	out := make([]StepConfig, len(steps))
+	prevID := ""
+	for i, s := range steps {
+		out[i] = s
+		if prevID != "" && len(s.DependsOn) == 0 && len(s.SeqDependsOn) == 0 {
+			out[i].SeqDependsOn = []string{prevID}
+		}
+		if s.ID != "" {
+			prevID = s.ID
+		}
+	}
+	return out
 }
 
 // anyV2Steps reports whether any step in the list (or its children) uses a v2

--- a/src/internal/config/sequencing_test.go
+++ b/src/internal/config/sequencing_test.go
@@ -1,0 +1,78 @@
+package config
+
+import "testing"
+
+// A workflow using no v2 field is still sequenced. Before this, the lowering
+// pass exited early and such a workflow reached the engine with no dependency
+// edges at all — every step immediately runnable, so they ran concurrently. An
+// approval step gated nothing: the step after it could finish before the
+// instance had even parked.
+func TestFlatWorkflowIsSequenced(t *testing.T) {
+	wf := WorkflowConfig{ID: "flat", Steps: []StepConfig{
+		{ID: "gate", Type: StepTypeApproval, Message: "Deploy?"},
+		{ID: "deploy", Agent: "engineer"},
+		{ID: "notify", Agent: "engineer"},
+	}}
+
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Steps[0].SeqDependsOn) != 0 {
+		t.Errorf("the first step should depend on nothing, got %v", out.Steps[0].SeqDependsOn)
+	}
+	for i, want := range map[int]string{1: "gate", 2: "deploy"} {
+		got := out.Steps[i].SeqDependsOn
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("step %q should follow %q, got %v", out.Steps[i].ID, want, got)
+		}
+	}
+}
+
+// Sequencing must not override an edge the step already carries, and running it
+// twice must not change the result — LowerV2Workflow is documented idempotent.
+func TestSequencingIsIdempotentAndPreservesExplicitEdges(t *testing.T) {
+	wf := WorkflowConfig{ID: "flat", Steps: []StepConfig{
+		{ID: "a", Agent: "engineer"},
+		{ID: "b", Agent: "engineer", DependsOn: []string{"a"}},
+		{ID: "c", Agent: "engineer", SeqDependsOn: []string{"a"}},
+	}}
+
+	once, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(once.Steps[1].SeqDependsOn) != 0 {
+		t.Errorf("an explicit depends_on must not gain a seq edge, got %v", once.Steps[1].SeqDependsOn)
+	}
+	if got := once.Steps[2].SeqDependsOn; len(got) != 1 || got[0] != "a" {
+		t.Errorf("an existing seq edge must be preserved, got %v", got)
+	}
+
+	twice, err := LowerV2Workflow(once)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range twice.Steps {
+		a, b := once.Steps[i].SeqDependsOn, twice.Steps[i].SeqDependsOn
+		if len(a) != len(b) || (len(a) == 1 && a[0] != b[0]) {
+			t.Errorf("step %q changed on re-lowering: %v → %v", twice.Steps[i].ID, a, b)
+		}
+	}
+}
+
+// A v2 workflow keeps going through the full pass, which does its own chaining;
+// sequencing must not double up or disturb it.
+func TestV2WorkflowStillLowersNormally(t *testing.T) {
+	wf := WorkflowConfig{ID: "v2", Steps: []StepConfig{
+		{ID: "classify", Agent: "engineer"},
+		{ID: "build", Agent: "engineer", If: "true"},
+	}}
+	out, err := LowerV2Workflow(wf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := out.Steps[1].SeqDependsOn; len(got) != 1 || got[0] != "classify" {
+		t.Fatalf("v2 chaining broke: %v", got)
+	}
+}

--- a/src/internal/config/workflow_validate_test.go
+++ b/src/internal/config/workflow_validate_test.go
@@ -260,12 +260,27 @@ func TestWorkflow_OnFailGotoNotAncestor(t *testing.T) {
 	cfg.Workflows = []config.WorkflowConfig{
 		{ID: "wf", Steps: []config.StepConfig{
 			{ID: "a", Agent: "architect"},
-			{ID: "b", Agent: "backend-dev"},
-			// b does not depend on a, so goto a is not an ancestor back-edge.
-			{ID: "c", Agent: "architect", DependsOn: []string{"b"}, OnFail: &config.StepOutcome{Goto: "a", MaxRetries: 1}},
+			// Jumping forward to a step declared later is not a back-edge.
+			{ID: "b", Agent: "backend-dev", OnFail: &config.StepOutcome{Goto: "c", MaxRetries: 1}},
+			{ID: "c", Agent: "architect"},
 		}},
 	}
 	assertError(t, cfg, "must target an ancestor")
+}
+
+// Declaration order makes an earlier step a valid back-edge target, because
+// steps are sequenced implicitly — `a` precedes `b` precedes `c`, so `goto a`
+// from `c` is a genuine loop-back even with no depends_on anywhere.
+func TestWorkflow_OnFailGotoEarlierStepIsAnAncestor(t *testing.T) {
+	cfg := baseWorkflowConfig()
+	cfg.Workflows = []config.WorkflowConfig{
+		{ID: "wf", Steps: []config.StepConfig{
+			{ID: "a", Agent: "architect"},
+			{ID: "b", Agent: "backend-dev"},
+			{ID: "c", Agent: "architect", OnFail: &config.StepOutcome{Goto: "a", MaxRetries: 1}},
+		}},
+	}
+	assertNoError(t, cfg)
 }
 
 // Regression: a v2 workflow mixes plain sequential steps (chained only via the


### PR DESCRIPTION
## The bug

`docs/workflows.md` says *"Steps run **sequentially in the order written**."* That was only true for workflows that happened to use a v2 field.

`LowerV2Workflow` exits early when `anyV2Steps` is false, and `SeqDependsOn` is assigned **exclusively inside the lowering pass**. So a workflow of plain `agent` and `approval` steps reached the engine with no dependency edges at all — every step immediately runnable, running concurrently.

The sharpest consequence: **an approval step gated nothing.**

Verified against a live daemon on the minimal config:

```yaml
steps:
  - id: gate
    type: approval
    message: Should we deploy?
  - id: deploy
    agent: engineer
```

```
instance : approval_waiting
step_runs: [('deploy', 'passed')]     ← ran and finished while parked
approval : [('gate', 'pending')]      ← nobody had answered
```

`deploy` was already running *before* the instance parked. The human was asked for permission to do something already done.

And the trap closes on the author — `depends_on` is rejected at load:

> `depends_on` was removed from step config: the v2 workflow engine uses implicit sequential ordering (steps run in the order they are declared). Remove the `depends_on` field — ordering is automatic.

Ordering is promised, the manual workaround is refused, and ordering does not happen.

## The fix

Thread the implicit edges in the early-exit path too, via `sequenceSteps`.

The early exit itself **stays**, because it is also the idempotence guard: an already-lowered workflow reports no v2 steps (`Condition` replaces `If`, and a lowered `parallel` node is explicitly excluded), so re-entering the full pass would rewrite already-rewritten expressions. `sequenceSteps` is safe to re-run — it fills in missing edges and never overrides one a step already carries.

After, live:

```
instance : approval_waiting
step_runs: []                          ← deploy did not run
```

then on `apiary approve`:

```
instance : running
step_runs: [('deploy', 'running')]     ← starts only now
```

## Blast radius

Small in practice: a single `if:`, `reject_when:` or `parallel:` anywhere in a workflow already triggered lowering, so most real configs were accidentally correct. This fixes the ones that use none — which is exactly the shape a first workflow takes.

## A test that encoded the bug

`TestWorkflow_OnFailGotoNotAncestor` asserted that in a flat list `a` was *not* an ancestor of `c`. With declaration order restored it legitimately is, so the case is re-pointed at a genuine forward `goto`, and the back-edge that is now valid gets its own test.

Three new cases cover the fix: a flat workflow is chained; sequencing is idempotent and preserves explicit edges; a v2 workflow still lowers normally.