### PR TITLE
fix(workflow): give the agent working directory a real source

### DIFF
--- a/.apiary/example-apiary-full.yaml
+++ b/.apiary/example-apiary-full.yaml
@@ -27,6 +27,13 @@ runners:
   - id: claude-cli
     type: cli
     provider: claude
+    # config:
+    #   # Fleet-wide default working directory for agents on this runner. It is
+    #   # the lowest-precedence layer of the chain
+    #   #   step.working_dir > workflow.working_dir > agents[].working_dir >
+    #   #   runners[].config.working_dir > the directory holding apiary.yaml
+    #   # Relative paths resolve against the apiary.yaml directory; "~" expands.
+    #   working_dir: ~/Projects/project-erp
     # Model Context Protocol servers exposed to every agent on this runner.
     # Each provider writes them into its own native MCP config: claude uses a
     # temp file + `--mcp-config`, cursor merges ~/.cursor/mcp.json + `--approve-mcps`,
@@ -245,6 +252,9 @@ agents:
     soul_file: .apiary/souls/engineer.md
     runner: claude-cli
     model: claude-sonnet-4-6
+    # Agent-scope working directory: every step running this agent starts here,
+    # unless the workflow or the step says otherwise. Relative to this file.
+    working_dir: ..
     skills: [git-workflow, e2e-before-pr, gitnexus-codebase, handler-error-logging, changelog-contexto]
     # Rate-limit failover chain: if claude-cli is rejected by the 5h session
     # limit, retry on these runners (in order) until one isn't rate-limited.
@@ -356,6 +366,11 @@ workflows:
       match:
         source: project-erp
         labels: [agent:reviewer]
+    # Workflow-scope working directory: every step of this workflow runs here.
+    # Overrides agents[].working_dir and runners[].config.working_dir; a step's
+    # own working_dir still wins. Relative paths resolve against this file's
+    # directory, so ".." is the repository root.
+    working_dir: ..
     # Workflow-scope env: applied to every step of this workflow. Overrides
     # agent.env; overridden by step.env. Precedence: STEP > WORKFLOW > AGENT.
     env:
@@ -364,6 +379,9 @@ workflows:
     steps:
       - id: run
         agent: reviewer
+        # Step-scope working directory: highest precedence of all. Same shape as
+        # env — the narrowest scope that declares one wins.
+        working_dir: ../src
         # Step-scope env: highest-precedence explicit scope. CI_TARGET here wins
         # over the workflow value; REVIEW_PROFILE falls back to the workflow's.
         env:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,6 +189,7 @@ agents:
 | `fallback_strategy` | no | Ordering policy for the failover chain: `ordered` (default), `random`, `least_cost`, `fastest` |
 | `mcps` | no | Agent-scope [MCP servers](runners.md#mcp-servers), layered over the runner's |
 | `env` | no | Agent-scope environment variables — see [Environment variables](#environment-variables) |
+| `working_dir` | no | Directory this agent's steps run in — see [Working directory](runners.md#working-directory). Defaults to the directory holding `apiary.yaml` |
 
 Which tasks reach an agent is decided by a
 [workflow `trigger`](workflows.md#triggers), never by the agent itself.

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -197,6 +197,59 @@ runners:
     with [sandboxing](#sandboxing-agent-execution) so a successful prompt
     injection is contained, or narrow the runner with `allowed_tools`.
 
+## Working directory
+
+Every agent subprocess starts in a working directory, and that directory is the
+agent's whole frame of reference: it is what `pwd` reports, what a bare `git
+status` inspects, and the root a relative path in a prompt resolves against. An
+agent that starts nowhere in particular has to *find* the repository first —
+burning turns on it, and searching the operator's home directory on the way.
+
+Apiary resolves the directory per step, taking the first of these that is set:
+
+| # | Source | Scope |
+|---|---|---|
+| 1 | `steps[].working_dir` | One step |
+| 2 | `workflows[].working_dir` | Every step of one workflow |
+| 3 | `agents[].working_dir` | Every step that runs one agent |
+| 4 | `runners[].config.working_dir` | Every agent on one runner |
+| 5 | the directory holding `apiary.yaml` | Fleet-wide default |
+
+The last row is the default, so an agent always starts somewhere the operator
+chose — usually the very repository the hive is about.
+
+Relative paths resolve against the directory holding `apiary.yaml`, and a
+leading `~` expands to the user's home. With the config at
+`~/Projects/app/.apiary/apiary.yaml`, `working_dir: ..` is the repository root.
+
+```yaml
+runners:
+  - id: claude-cli
+    type: cli
+    provider: claude
+    config:
+      working_dir: ~/Projects/app        # fleet-wide default
+
+agents:
+  - id: docs-writer
+    runner: claude-cli
+    model: sonnet
+    working_dir: ~/Projects/app/docs     # this agent writes docs only
+
+workflows:
+  - id: release
+    working_dir: ~/Projects/app          # every step of this workflow
+    steps:
+      - id: build
+        agent: builder
+        working_dir: ~/Projects/app/src  # this step only
+```
+
+!!! tip "Checkout per workflow"
+    `workflows[].working_dir` is the knob for pointing one hive at several
+    checkouts — a workflow per repository, each with its own directory, all
+    sharing the same agents.
+
 ## API runners
 
 API runners skip the subprocess and POST to a chat-completions endpoint

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -31,6 +31,7 @@ loops. This page covers the whole surface.
 | `steps` | The pipeline — see [Steps](#steps) |
 | `on_complete` / `on_fail` | [Hooks](#completion-hooks) applied when the instance finishes |
 | `env` | Workflow-scope [environment variables](configuration.md#environment-variables) |
+| `working_dir` | [Working directory](runners.md#working-directory) for every step of this workflow |
 | `resume` | [Resume policy](#resuming-instances): `allowed` (default), `forbidden`, `auto` |
 
 ## Triggers
@@ -236,6 +237,7 @@ steps:
 | `publish` / `spawn` | Control agent-emitted write-backs and child tasks — see [Tasks & fan-out](tasks-and-fanout.md) |
 | `pull_request_from` | Name of an output field holding the URL of a PR this step opened; links that PR to the task — see [Linking a PR](#linking-a-pr-pull_request_from) |
 | `env` | Step-scope environment variables (highest precedence) |
+| `working_dir` | [Working directory](runners.md#working-directory) for this step (highest precedence) |
 | `idempotent` | Mark the step safe to re-run on [resume](#resuming-instances) |
 
 **Structured output.** When a step declares an `output` schema, the agent is

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -255,6 +255,10 @@
             "type": "string",
             "description": "Path to agent persona/instructions file"
           },
+          "working_dir": {
+            "type": "string",
+            "description": "Process working directory for every step that runs this agent. Overrides runners[].config.working_dir; overridden by workflow.working_dir and step.working_dir. Relative paths resolve against the directory holding apiary.yaml; '~' is expanded. Default: the apiary.yaml directory"
+          },
           "skills": {
             "type": "array",
             "description": "Skill names injected into the agent's prompt",
@@ -502,6 +506,10 @@
           },
           "on_fail": {
             "$ref": "#/definitions/OnComplete"
+          },
+          "working_dir": {
+            "type": "string",
+            "description": "Process working directory for every step of this workflow. Overrides agents[].working_dir; overridden by step.working_dir. Relative paths resolve against the directory holding apiary.yaml; '~' is expanded"
           },
           "env": {
             "type": "object",
@@ -1009,6 +1017,10 @@
         "pull_request_from": {
           "type": "string",
           "description": "Name of a field in this step's structured output holding the URL of a pull request the step opened (e.g. pr_url). The engine parses it and links the PR to the task, which is what the dashboard's 'open PR' shortcut reads — so PR-linked features work even when the task's source (Jira, Plane) cannot enumerate pull requests itself. Only valid on type=agent; must name a field the step's output schema declares"
+        },
+        "working_dir": {
+          "type": "string",
+          "description": "Process working directory for this step. Highest-precedence scope: overrides workflow.working_dir, agents[].working_dir and runners[].config.working_dir. Relative paths resolve against the directory holding apiary.yaml; '~' is expanded"
         },
         "env": {
           "type": "object",

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -30,6 +30,18 @@ type Config struct {
 	Plugins       []plugin.InstanceConfig             `yaml:"plugins,omitempty"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
+	configDir  string // absolute directory holding apiary.yaml; base for relative paths
+}
+
+// Dir returns the absolute directory the config was loaded from. It is the base
+// for resolving relative paths declared in the config (e.g. working_dir) and the
+// last-resort working directory for agent steps. Empty when the Config was not
+// produced by Load (defaults, tests).
+func (c *Config) Dir() string {
+	if c == nil {
+		return ""
+	}
+	return c.configDir
 }
 
 // ProfileConfig is an overlay that overrides runner, model, fallbacks, and
@@ -135,7 +147,12 @@ type AgentConfig struct {
 	// MaxTurns caps the number of agent turns per step run. 0 (the default)
 	// means unlimited: CLI runners omit the provider's turns flag entirely, so
 	// long-running coding tasks are never cut short unless explicitly capped.
-	MaxTurns    int    `yaml:"max_turns,omitempty"`
+	MaxTurns int `yaml:"max_turns,omitempty"`
+	// WorkingDir is the process working directory for every step that runs this
+	// agent. It sits between workflow.working_dir and runners[].config.working_dir
+	// in the precedence chain (see Config.ResolveWorkingDir). Relative paths are
+	// resolved against the directory holding apiary.yaml; "~" is expanded.
+	WorkingDir  string `yaml:"working_dir,omitempty"`
 	SourceToken string `yaml:"source_token,omitempty"`
 	SourceEmail string `yaml:"source_email,omitempty"`
 	SourceName  string `yaml:"source_name,omitempty"`
@@ -335,8 +352,8 @@ type Settings struct {
 	// support per-agent permissions. Default false preserves the historical
 	// permissive behaviour; individual agents can always restrict themselves via
 	// agents[].permissions regardless of this setting.
-	LeastPrivilegeAgents bool   `yaml:"least_privilege_agents,omitempty"`
-	ResultComment        bool   `yaml:"result_comment"`
+	LeastPrivilegeAgents bool `yaml:"least_privilege_agents,omitempty"`
+	ResultComment        bool `yaml:"result_comment"`
 	// TaskTimeout bounds a single runner invocation end to end. Default 2h.
 	// It is a runaway backstop, not a service-level target: an implementation
 	// step legitimately runs for an hour or more, so a short total bound kills
@@ -881,6 +898,11 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 	cfg.rawContent = raw
+	if abs, err := filepath.Abs(path); err == nil {
+		cfg.configDir = filepath.Dir(abs)
+	} else {
+		cfg.configDir = filepath.Dir(path)
+	}
 	if err := resolveLocalWorkflows(path, &cfg); err != nil {
 		return nil, err
 	}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -97,6 +97,10 @@ type WorkflowConfig struct {
 	// Env is the workflow-scope environment overlay applied to every step of this
 	// workflow. It overrides agent.env and is overridden by step.env.
 	Env map[string]string `yaml:"env,omitempty"`
+	// WorkingDir is the process working directory for every step of this
+	// workflow, unless a step overrides it. Relative paths are resolved against
+	// the directory holding apiary.yaml; "~" is expanded.
+	WorkingDir string `yaml:"working_dir,omitempty"`
 }
 
 // ResumePolicy returns the effective resume policy, defaulting to ResumeAllowed.
@@ -224,7 +228,12 @@ type StepConfig struct {
 	FailWhen string `yaml:"fail_when,omitempty"`
 
 	// ── agent step ────────────────────────────────────────────────
-	Agent           string        `yaml:"agent,omitempty"`
+	Agent string `yaml:"agent,omitempty"`
+	// WorkingDir is the process working directory for this step's agent
+	// subprocess. Highest precedence in the working-directory chain (see
+	// Config.ResolveWorkingDir). Relative paths are resolved against the
+	// directory holding apiary.yaml; "~" is expanded.
+	WorkingDir      string        `yaml:"working_dir,omitempty"`
 	Model           string        `yaml:"model,omitempty"` // overrides agent's model for this step
 	Prompt          string        `yaml:"prompt,omitempty"`
 	SummaryPrompt   string        `yaml:"summary_prompt,omitempty"`

--- a/src/internal/config/workingdir.go
+++ b/src/internal/config/workingdir.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveWorkingDir picks the process working directory for one agent step.
+//
+// Precedence, first non-empty wins:
+//
+//	step.working_dir
+//	workflow.working_dir
+//	agents[].working_dir
+//	runners[].config.working_dir   (the agent's runner, or default_runner)
+//	the directory holding apiary.yaml
+//
+// The chain never yields "/" by default: an agent with no cwd of its own has to
+// go looking for the repository, which wastes turns, wanders into the operator's
+// home directory, and can settle on the wrong checkout (#436). The config's own
+// directory is a bounded, operator-chosen starting point.
+//
+// Relative values are resolved against the config directory, and a leading "~"
+// is expanded to the user's home. When the Config carries no directory of its
+// own (built in memory rather than loaded from disk), the process working
+// directory is used as the base and as the final fallback.
+func (c *Config) ResolveWorkingDir(agent AgentConfig, workflowDir, stepDir string) string {
+	base := c.Dir()
+	if base == "" {
+		if wd, err := os.Getwd(); err == nil {
+			base = wd
+		}
+	}
+
+	for _, candidate := range []string{stepDir, workflowDir, agent.WorkingDir, c.runnerWorkingDir(agent)} {
+		if dir := expandDir(candidate, base); dir != "" {
+			return dir
+		}
+	}
+	return base
+}
+
+// runnerWorkingDir returns the working_dir declared in the config block of the
+// runner this agent uses (its own, or the global default_runner).
+func (c *Config) runnerWorkingDir(agent AgentConfig) string {
+	if c == nil {
+		return ""
+	}
+	id := agent.Runner
+	if id == "" {
+		id = c.DefaultRunner
+	}
+	if id == "" {
+		return ""
+	}
+	for i := range c.Runners {
+		if c.Runners[i].ID != id {
+			continue
+		}
+		dir, _ := c.Runners[i].Config["working_dir"].(string)
+		return dir
+	}
+	return ""
+}
+
+// expandDir expands "~" and makes a relative path absolute against base.
+// It returns "" for an empty input so callers can walk a precedence chain.
+func expandDir(dir, base string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	if dir == "~" || strings.HasPrefix(dir, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			dir = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(dir, "~"), "/"))
+		}
+	}
+	if !filepath.IsAbs(dir) && base != "" {
+		dir = filepath.Join(base, dir)
+	}
+	return filepath.Clean(dir)
+}

--- a/src/internal/config/workingdir_test.go
+++ b/src/internal/config/workingdir_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// wdConfig builds a config whose every layer declares a distinct working_dir, so
+// a precedence test can drop layers and see which one wins.
+func wdConfig(configDir string) *Config {
+	return &Config{
+		DefaultRunner: "claude",
+		Runners: []RunnerConfig{
+			{ID: "claude", Config: map[string]any{"working_dir": "/runner/dir"}},
+			{ID: "other", Config: map[string]any{"working_dir": "/other/dir"}},
+		},
+		configDir: configDir,
+	}
+}
+
+func TestResolveWorkingDir_Precedence(t *testing.T) {
+	cfg := wdConfig("/cfg")
+	agent := AgentConfig{ID: "dev", Runner: "claude", WorkingDir: "/agent/dir"}
+
+	tests := []struct {
+		name     string
+		agent    AgentConfig
+		wfDir    string
+		stepDir  string
+		expected string
+	}{
+		{"step wins over everything", agent, "/wf/dir", "/step/dir", "/step/dir"},
+		{"workflow wins over agent and runner", agent, "/wf/dir", "", "/wf/dir"},
+		{"agent wins over runner", agent, "", "", "/agent/dir"},
+		{
+			"runner is used when agent and above are silent",
+			AgentConfig{ID: "dev", Runner: "claude"},
+			"", "", "/runner/dir",
+		},
+		{
+			"default_runner supplies the runner when the agent names none",
+			AgentConfig{ID: "dev"},
+			"", "", "/runner/dir",
+		},
+		{
+			"the agent's own runner is preferred over default_runner",
+			AgentConfig{ID: "dev", Runner: "other"},
+			"", "", "/other/dir",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cfg.ResolveWorkingDir(tc.agent, tc.wfDir, tc.stepDir); got != tc.expected {
+				t.Errorf("ResolveWorkingDir = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestResolveWorkingDir_ConfigDirDefault is the #436 regression: with nothing
+// configured the step must land in the config's own directory, never in "/".
+func TestResolveWorkingDir_ConfigDirDefault(t *testing.T) {
+	cfg := &Config{configDir: "/home/dev/project/.apiary"}
+
+	got := cfg.ResolveWorkingDir(AgentConfig{ID: "dev"}, "", "")
+	if got != "/home/dev/project/.apiary" {
+		t.Errorf("ResolveWorkingDir = %q, want the config directory", got)
+	}
+	if got == "/" {
+		t.Error("ResolveWorkingDir must never fall back to the filesystem root")
+	}
+}
+
+// TestResolveWorkingDir_NoConfigDirFallsBackToCwd covers a Config built in
+// memory (no file on disk): the process working directory stands in, and "/" is
+// still never returned.
+func TestResolveWorkingDir_NoConfigDirFallsBackToCwd(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	cfg := &Config{}
+
+	if got := cfg.ResolveWorkingDir(AgentConfig{ID: "dev"}, "", ""); got != wd {
+		t.Errorf("ResolveWorkingDir = %q, want %q", got, wd)
+	}
+}
+
+func TestResolveWorkingDir_RelativeResolvedAgainstConfigDir(t *testing.T) {
+	cfg := wdConfig("/home/dev/project/.apiary")
+	agent := AgentConfig{ID: "dev"}
+
+	if got := cfg.ResolveWorkingDir(agent, "", "../src"); got != "/home/dev/project/src" {
+		t.Errorf("step relative dir = %q, want /home/dev/project/src", got)
+	}
+	if got := cfg.ResolveWorkingDir(agent, "worktrees/main", ""); got != "/home/dev/project/.apiary/worktrees/main" {
+		t.Errorf("workflow relative dir = %q, want the config dir joined", got)
+	}
+}
+
+func TestResolveWorkingDir_ExpandsTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory in this environment")
+	}
+	cfg := wdConfig("/cfg")
+
+	want := filepath.Join(home, "code", "apiary")
+	if got := cfg.ResolveWorkingDir(AgentConfig{ID: "dev"}, "", "~/code/apiary"); got != want {
+		t.Errorf("ResolveWorkingDir = %q, want %q", got, want)
+	}
+	if got := cfg.ResolveWorkingDir(AgentConfig{ID: "dev"}, "~", ""); got != filepath.Clean(home) {
+		t.Errorf("bare ~ = %q, want %q", got, home)
+	}
+}
+
+// TestLoad_RecordsConfigDir verifies Load() remembers where the config came
+// from, which is what makes the config-dir default work at runtime.
+func TestLoad_RecordsConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "apiary.yaml")
+	body := "version: \"1\"\nagents:\n  - id: dev\n    model: sonnet\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	wantDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		wantDir = dir
+	}
+	gotDir, err := filepath.EvalSymlinks(cfg.Dir())
+	if err != nil {
+		gotDir = cfg.Dir()
+	}
+	if gotDir != wantDir {
+		t.Fatalf("cfg.Dir() = %q, want %q", gotDir, wantDir)
+	}
+
+	got := cfg.ResolveWorkingDir(AgentConfig{ID: "dev"}, "", "")
+	if gotResolved, err := filepath.EvalSymlinks(got); err == nil {
+		got = gotResolved
+	}
+	if got != wantDir {
+		t.Errorf("ResolveWorkingDir = %q, want the config directory %q", got, wantDir)
+	}
+}
+
+// TestResolveWorkingDir_YAMLPrecedenceEndToEnd parses a real config and checks
+// the chain the way an operator would experience it.
+func TestResolveWorkingDir_YAMLPrecedenceEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "apiary.yaml")
+	body := `version: "1"
+default_runner: claude
+runners:
+  - id: claude
+    type: cli
+    config:
+      working_dir: /runner/dir
+agents:
+  - id: dev
+    model: sonnet
+    working_dir: /agent/dir
+workflows:
+  - id: wf
+    working_dir: /wf/dir
+    steps:
+      - id: a
+        agent: dev
+      - id: b
+        agent: dev
+        working_dir: /step/dir
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	wf := cfg.Workflows[0]
+	agent := cfg.Agents[0]
+
+	if agent.WorkingDir != "/agent/dir" {
+		t.Errorf("agent working_dir not parsed: %q", agent.WorkingDir)
+	}
+	if wf.WorkingDir != "/wf/dir" {
+		t.Errorf("workflow working_dir not parsed: %q", wf.WorkingDir)
+	}
+	if got := cfg.ResolveWorkingDir(agent, wf.WorkingDir, wf.Steps[0].WorkingDir); got != "/wf/dir" {
+		t.Errorf("step a = %q, want /wf/dir", got)
+	}
+	if got := cfg.ResolveWorkingDir(agent, wf.WorkingDir, wf.Steps[1].WorkingDir); got != "/step/dir" {
+		t.Errorf("step b = %q, want /step/dir", got)
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -403,7 +403,7 @@ func (x *wfStepExecutor) ExecuteStep(ctx context.Context, req workflow.StepReque
 		SummaryPrompt:      req.Step.SummaryPrompt,
 		StepID:             req.Step.ID,
 		WorkflowInstanceID: req.InstanceID,
-		WorkingDir:         "/",
+		WorkingDir:         x.d.cfg.ResolveWorkingDir(req.Agent, req.WorkflowWorkingDir, req.Step.WorkingDir),
 		Env:                env,
 		Timeout:            x.d.cfg.Settings.TaskTimeoutDuration(),
 		StallTimeout:       x.d.cfg.Settings.StallTimeoutDuration(),

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -256,17 +256,17 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				var foreachExitCode int
 				switch step.StepType() {
 				case config.StepTypeParallel:
-					res, parallelContribs, parallel = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.ID, r.wf.Env, parallelCache, waitDeadline)
+					res, parallelContribs, parallel = e.runParallelStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.ID, scopeOf(r.wf), parallelCache, waitDeadline)
 				case config.StepTypeForeach:
 					var fr foreachResult
 					if step.Concurrency > 1 {
 						// Release our global slot so item goroutines can use all
 						// available slots. Re-acquire before the deferred release fires.
 						<-sem
-						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, sem, r.wf.Env)
+						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, sem, scopeOf(r.wf))
 						sem <- struct{}{}
 					} else {
-						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, nil, r.wf.Env)
+						res, fr = e.executeForeachStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, contribSnap, r.wf.ID, nil, scopeOf(r.wf))
 					}
 					foreachExitCode = fr.failed
 				case config.StepTypeWorkflow:
@@ -274,7 +274,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				case config.StepTypeWaitFor:
 					res, _ = e.RunWaitStep(ctx, r.instID, step, r.cell.SourceID, r.cell.ID, waitDeadline)
 				default: // StepTypeAgent
-					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
+					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, scopeOf(r.wf))
 				}
 				resultCh <- workerResult{
 					stepID:           step.ID,

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -55,7 +55,7 @@ func (e *Engine) runParallelStep(
 	ctx context.Context, instID string,
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
-	memSnap []MemoryStep, wfID string, wfEnv map[string]string,
+	memSnap []MemoryStep, wfID string, scope wfScope,
 	cached map[string]StepResult, waitDeadline time.Time,
 ) (StepResult, []MemoryStep, parallelState) {
 	children := step.SubSteps
@@ -76,7 +76,7 @@ func (e *Engine) runParallelStep(
 		}
 		pending++
 		go func(i int, child config.StepConfig) {
-			res := e.runParallelChild(ctx, instID, child, cell, task, bindings, memSnap, wfEnv, waitDeadline)
+			res := e.runParallelChild(ctx, instID, child, cell, task, bindings, memSnap, scope, waitDeadline)
 			// Children never pass through the scheduler loop, so the
 			// on_missing_output guard has to be applied here (#421). A pending
 			// wait_for child is not successful yet, so the guard skips it.
@@ -152,11 +152,11 @@ func (e *Engine) runParallelChild(
 	ctx context.Context, instID string,
 	child config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
-	memSnap []MemoryStep, wfEnv map[string]string, waitDeadline time.Time,
+	memSnap []MemoryStep, scope wfScope, waitDeadline time.Time,
 ) StepResult {
 	switch child.StepType() {
 	case config.StepTypeAgent:
-		return e.runStep(ctx, instID, child, cell, task, bindings, memSnap, wfEnv)
+		return e.runStep(ctx, instID, child, cell, task, bindings, memSnap, scope)
 	case config.StepTypeWaitFor:
 		res, err := e.RunWaitStep(ctx, instID, child, cell.SourceID, cell.ID, waitDeadline)
 		if err != nil {

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -131,6 +131,24 @@ type StepRequest struct {
 	// instance this step belongs to. The executor merges it between agent.env and
 	// step.env when building the subprocess environment.
 	WorkflowEnv map[string]string
+	// WorkflowWorkingDir is the workflow-scope working directory (wf.working_dir)
+	// for the instance this step belongs to. The executor folds it into the
+	// working-directory precedence chain, below step.working_dir (#436).
+	WorkflowWorkingDir string
+}
+
+// wfScope carries the workflow-level settings a step inherits while it runs:
+// the environment overlay and the authored working directory. It is threaded
+// through the scheduler so nested steps (parallel children, foreach items)
+// inherit them too.
+type wfScope struct {
+	Env        map[string]string
+	WorkingDir string
+}
+
+// scopeOf builds the inherited scope for one workflow.
+func scopeOf(wf config.WorkflowConfig) wfScope {
+	return wfScope{Env: wf.Env, WorkingDir: wf.WorkingDir}
 }
 
 // StepResult is the outcome of executing one agent step.
@@ -582,7 +600,7 @@ func (e *Engine) completeTask(ctx context.Context, r *dagRun, failed bool) {
 // publish write-back can reach the task's source bindings; they are passed by
 // value (not via dagRun) so the function stays safe to call from the parallel
 // and foreach worker goroutines.
-func (e *Engine) runStep(ctx context.Context, instID string, step config.StepConfig, cell model.SourceItem, task model.InternalTask, bindings []model.SourceBinding, memSteps []MemoryStep, wfEnv map[string]string) StepResult {
+func (e *Engine) runStep(ctx context.Context, instID string, step config.StepConfig, cell model.SourceItem, task model.InternalTask, bindings []model.SourceBinding, memSteps []MemoryStep, scope wfScope) StepResult {
 	started := e.now()
 	sr := &db.StepRun{
 		ID:                 e.newID("sr"),
@@ -616,14 +634,15 @@ func (e *Engine) runStep(ctx context.Context, instID string, step config.StepCon
 		ag = *agent
 	}
 	res := e.exec.ExecuteStep(ctx, StepRequest{
-		InstanceID:  instID,
-		Cell:        cell,
-		Step:        step,
-		Agent:       ag,
-		Model:       resolvedModel,
-		MemoryDoc:   memDoc,
-		Prompt:      step.Prompt,
-		WorkflowEnv: wfEnv,
+		InstanceID:         instID,
+		Cell:               cell,
+		Step:               step,
+		Agent:              ag,
+		Model:              resolvedModel,
+		MemoryDoc:          memDoc,
+		Prompt:             step.Prompt,
+		WorkflowEnv:        scope.Env,
+		WorkflowWorkingDir: scope.WorkingDir,
 	})
 
 	finished := e.now()

--- a/src/internal/workflow/foreach.go
+++ b/src/internal/workflow/foreach.go
@@ -35,7 +35,7 @@ func (e *Engine) executeForeachStep(
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, contribSnap map[string]MemoryStep,
-	wfID string, sem chan struct{}, wfEnv map[string]string,
+	wfID string, sem chan struct{}, scope wfScope,
 ) (StepResult, foreachResult) {
 	items, err := resolveItemsFromContrib(step.Items, contribSnap)
 	if err != nil {
@@ -67,9 +67,9 @@ func (e *Engine) executeForeachStep(
 	}
 
 	if sem != nil && step.Concurrency > 1 {
-		return e.executeForeachConcurrent(ctx, instID, step, cell, task, bindings, memSnap, wfID, sem, items, as, wfEnv)
+		return e.executeForeachConcurrent(ctx, instID, step, cell, task, bindings, memSnap, wfID, sem, items, as, scope)
 	}
-	return e.executeForeachSequential(ctx, instID, step, cell, task, bindings, memSnap, wfID, items, as, wfEnv)
+	return e.executeForeachSequential(ctx, instID, step, cell, task, bindings, memSnap, wfID, items, as, scope)
 }
 
 // executeForeachSequential runs foreach items one at a time (original behaviour).
@@ -78,7 +78,7 @@ func (e *Engine) executeForeachSequential(
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, wfID string,
-	items []any, as string, wfEnv map[string]string,
+	items []any, as string, scope wfScope,
 ) (StepResult, foreachResult) {
 	var fr foreachResult
 	for i, item := range items {
@@ -88,7 +88,7 @@ func (e *Engine) executeForeachSequential(
 		sub.DependsOn = nil
 		sub.Prompt = renderItemTemplate(step.Step.Prompt, as, item)
 
-		res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, wfEnv)
+		res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, scope)
 		// Items never pass through the scheduler loop, so the on_missing_output
 		// guard has to be applied here (#421).
 		res = e.applyMissingOutput(ctx, runIDs{taskID: task.ID, wfID: wfID, instID: instID}, sub, res)
@@ -113,7 +113,7 @@ func (e *Engine) executeForeachConcurrent(
 	step config.StepConfig, cell model.SourceItem,
 	task model.InternalTask, bindings []model.SourceBinding,
 	memSnap []MemoryStep, wfID string,
-	sem chan struct{}, items []any, as string, wfEnv map[string]string,
+	sem chan struct{}, items []any, as string, scope wfScope,
 ) (StepResult, foreachResult) {
 	var (
 		mu      sync.Mutex
@@ -152,7 +152,7 @@ func (e *Engine) executeForeachConcurrent(
 			sem <- struct{}{} // acquire global slot
 			defer func() { <-sem }()
 
-			res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, wfEnv)
+			res := e.runStep(ctx, instID, sub, cell, task, bindings, memSnap, scope)
 			res = e.applyMissingOutput(ctx, runIDs{taskID: task.ID, wfID: wfID, instID: instID}, sub, res)
 
 			mu.Lock()

--- a/src/internal/workflow/wait_park_parallel_test.go
+++ b/src/internal/workflow/wait_park_parallel_test.go
@@ -203,7 +203,7 @@ func TestParallelChild_UnsupportedKindFailsWithDiagnostic(t *testing.T) {
 
 	res := eng.runParallelChild(context.Background(), "inst-1",
 		config.StepConfig{ID: "nested", Type: config.StepTypeForeach},
-		model.SourceItem{}, model.InternalTask{}, nil, nil, nil, time.Time{})
+		model.SourceItem{}, model.InternalTask{}, nil, nil, wfScope{}, time.Time{})
 
 	if res.Success {
 		t.Fatal("an unsupported parallel child must not report success")

--- a/src/internal/workflow/workingdir_threading_test.go
+++ b/src/internal/workflow/workingdir_threading_test.go
@@ -1,0 +1,42 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// TestEngine_WorkflowWorkingDirThreadedToStep verifies the engine hands the
+// workflow's working_dir to the executor via StepRequest.WorkflowWorkingDir, and
+// that the step's own working_dir rides along on the StepConfig. Resolving the
+// two against the agent/runner/config layers is the daemon executor's job
+// (config.ResolveWorkingDir); here we assert both reach it unchanged (#436).
+func TestEngine_WorkflowWorkingDirThreadedToStep(t *testing.T) {
+	cfg := baseCfg()
+	store := newFakeStore()
+	exec := &fakeExecutor{results: map[string]StepResult{"run": {Success: true}}}
+	eng := testEngine(cfg, store, exec, &fakeSide{})
+
+	wf := config.WorkflowConfig{
+		ID:         "release",
+		WorkingDir: "/wf/dir",
+		Steps:      []config.StepConfig{{ID: "run", Agent: "backend-dev", WorkingDir: "/step/dir"}},
+	}
+
+	if _, _, err := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "C1"}); err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+
+	if len(exec.seen) != 1 {
+		t.Fatalf("expected 1 step request, got %d", len(exec.seen))
+	}
+	req := exec.seen[0]
+	if req.WorkflowWorkingDir != "/wf/dir" {
+		t.Errorf("WorkflowWorkingDir = %q, want /wf/dir", req.WorkflowWorkingDir)
+	}
+	if req.Step.WorkingDir != "/step/dir" {
+		t.Errorf("Step.WorkingDir = %q, want /step/dir", req.Step.WorkingDir)
+	}
+}


### PR DESCRIPTION
## Problem

Every agent step was dispatched with `WorkingDir: "/"` (hardcoded in `internal/daemon/workflow.go`), so `claude`, `codex`, `cursor` and `opencode` all started at the filesystem root. `WorkerRunConfig.working_dir` was parsed but never consumed by the workflow engine — it belonged to the removed `workers:` dispatch path.

An agent that starts nowhere in particular has to *find* the repository first. It wastes turns orienting, searches the operator's `$HOME` on the way (one run listed `~/Documents` into the daemon log), and can settle on the wrong checkout when several match — silently, because the output still looks right.

## Fix

The working directory is now resolved per step, first non-empty wins:

| # | Source | Scope |
|---|---|---|
| 1 | `steps[].working_dir` | One step |
| 2 | `workflows[].working_dir` | Every step of one workflow |
| 3 | `agents[].working_dir` | Every step that runs one agent |
| 4 | `runners[].config.working_dir` | Every agent on one runner |
| 5 | the directory holding `apiary.yaml` | Fleet-wide default |

The last row is the default, so the chain never yields `/` — an agent always starts somewhere the operator chose. Relative paths resolve against the config directory, and a leading `~` is expanded.

## Changes

- **config** — new `working_dir` on `StepConfig`, `WorkflowConfig` and `AgentConfig`; `Config` remembers the directory it was loaded from (`Config.Dir`) and walks the chain (`Config.ResolveWorkingDir`, new `internal/config/workingdir.go`).
- **workflow engine** — the workflow-scope `env` parameter threaded through the scheduler (`runStep`, `runParallelStep`, `runParallelChild`, the two foreach paths) becomes a `wfScope` carrying env *and* working dir; surfaced to executors as `StepRequest.WorkflowWorkingDir`. No arity changes, no behaviour change for env.
- **daemon** — `wfStepExecutor.ExecuteStep` builds `RunRequest.WorkingDir` from the chain instead of `"/"`.
- **schema/docs** — `schema/apiary.json` (agents, workflows, `StepConfig`), `.apiary/example-apiary-full.yaml`, and `docs/runners.md` (new "Working directory" section) with cross-references from `docs/configuration.md` and `docs/workflows.md`.

## Tests

New `internal/config/workingdir_test.go` covers the full precedence chain (including `default_runner` vs the agent's own runner), the config-dir default, the cwd fallback for an in-memory config, relative resolution, `~` expansion, and end-to-end YAML parsing. New `internal/workflow/workingdir_threading_test.go` asserts the engine threads both workflow- and step-level values to the executor.

`cd src && go build ./... && go test ./...` — all packages pass.

Closes #436