### PR TITLE
fix(skills): fail loud when a declared agent skill is not on disk

### DIFF
--- a/.apiary/example-with-recovery.yaml
+++ b/.apiary/example-with-recovery.yaml
@@ -24,14 +24,18 @@ agents:
     description: Senior software engineer — backend and API design
     soul_file: .apiary/souls/engineer.md
     model: claude-sonnet-4-6
-    skills: [backend-api, error-handling, database]
+    # Each name must exist on disk as <root>/.apiary/skills/<name>/SKILL.md
+    # (.claude/skills and .opencode/skills are searched too, plus the same
+    # directories under $HOME). `apiary validate` fails on a name it cannot
+    # find, so this example ships the declaration commented out:
+    # skills: [backend-api, error-handling, database]
     runner: claude-cli
 
   - id: reviewer
     description: Code reviewer — quality assurance and best practices
     soul_file: .apiary/souls/reviewer.md
     model: claude-sonnet-4-6
-    skills: [code-review, testing]
+    # skills: [code-review, testing]   # see the note on the engineer agent above
     runner: claude-cli
 
 workflows:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ agents:
 | `model` | yes | Model name passed to the runner |
 | `runner` | no | Runner ID (falls back to `default_runner`) |
 | `soul_file` | no | Path to the agent's system prompt / persona file |
-| `skills` | no | Skill names injected into the agent's context |
+| `skills` | no | Skill names injected into the agent's context — each must exist as `<name>/SKILL.md`, see [Skills](#skills) |
 | `max_workers` | no | Per-agent concurrency cap (default 1) — see [concurrency](#concurrency) |
 | `max_turns` | no | Max agent turns per step run (default 0 = unlimited). CLI runners pass it as the provider's turns flag (e.g. claude's `--max-turns`); 0 omits the flag |
 | `permissions` | no | Per-agent tool permissions for runners that support them (OpenCode). Keys: `read`, `glob`, `grep`, `task`, `edit`, `bash`, `webfetch`; values `allow`/`deny`. An explicit entry always wins over `settings.least_privilege_agents`. Note: with the permissive default, `webfetch` is omitted from the generated `opencode.json` (preserving the historical key set) unless you set it explicitly |
@@ -192,6 +192,47 @@ agents:
 
 Which tasks reach an agent is decided by a
 [workflow `trigger`](workflows.md#triggers), never by the agent itself.
+
+### Skills
+
+`skills` lists **names**, not paths. Each name must exist on disk as a
+directory holding a `SKILL.md` — never as a flat `<name>.md` file:
+
+```
+.apiary/skills/
+└── git-workflow/
+    └── SKILL.md        ✅  resolves as skills: [git-workflow]
+
+.apiary/skills/
+└── git-workflow.md     ❌  never loaded
+```
+
+The search order, first match wins:
+
+| # | Path |
+|---|---|
+| 1 | `.claude/skills/<name>/SKILL.md` |
+| 2 | `.opencode/skills/<name>/SKILL.md` |
+| 3 | `.apiary/skills/<name>/SKILL.md` |
+| 4–6 | the same three directories under `$HOME` (globally installed skills) |
+
+The first three are relative to the directory the daemon runs in, the same
+root `soul_file` paths are resolved against.
+
+A skill that resolves to nothing is an error, not a warning:
+
+- `apiary validate` **fails**, listing every candidate path it tried, and — if
+  a flat `<name>.md` is sitting where the directory was expected — telling you
+  the path you probably meant;
+- the daemon logs one warning per unresolved skill at startup, naming the
+  agent, the skill and the candidates;
+- the dashboard's agent panel flags the file as `(missing)`.
+
+!!! warning "Upgrading"
+    Before this check existed, a skill that could not be located was silently
+    dropped and the agent ran without it. If your hive carries a dangling skill
+    name, `apiary validate` now fails on it: fix the layout, or remove the name
+    from `skills`.
 
 ### Agent identity
 

--- a/src/internal/cli/skills_validate_test.go
+++ b/src/internal/cli/skills_validate_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSkillsConfig writes a minimal config declaring one agent with one skill
+// into a fresh directory, chdirs into it (skills resolve relative to the
+// working directory, like soul_file) and points the cli at it.
+func writeSkillsConfig(t *testing.T, skill string) string {
+	t.Helper()
+	root := t.TempDir()
+	yaml := "version: \"1.0\"\n" +
+		"agents:\n" +
+		"  - id: engineer\n" +
+		"    model: claude-sonnet-5\n" +
+		"    skills: [" + skill + "]\n"
+	configPath := filepath.Join(root, "apiary.yaml")
+	if err := os.WriteFile(configPath, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	previous := configFile
+	configFile = configPath
+	t.Cleanup(func() { configFile = previous })
+	return root
+}
+
+// runValidate runs the validate command as `apiary validate` does and returns
+// its error plus what it printed to stderr.
+func runValidate(t *testing.T) (error, string) {
+	t.Helper()
+	cmd := newValidateCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	return cmd.RunE(cmd, nil), stderr.String()
+}
+
+// TestValidateFailsOnUnresolvableSkill is the headline behaviour of issue #429:
+// a declared skill that is nowhere on disk must fail validation, and the message
+// must list the candidate paths so the user can see the expected shape.
+func TestValidateFailsOnUnresolvableSkill(t *testing.T) {
+	writeSkillsConfig(t, "no-such-skill-429")
+
+	err, stderr := runValidate(t)
+	if err == nil {
+		t.Fatalf("validate exited 0 on an unresolvable skill; stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, `skill "no-such-skill-429" not found`) {
+		t.Errorf("stderr = %q, want the missing-skill error", stderr)
+	}
+	if !strings.Contains(stderr, filepath.Join(".apiary", "skills", "no-such-skill-429", "SKILL.md")) {
+		t.Errorf("stderr = %q, want the candidate paths tried", stderr)
+	}
+}
+
+// TestValidateHintsFlatSkillFile covers the mistake users actually make: the
+// skill written as `<name>.md` instead of `<name>/SKILL.md`.
+func TestValidateHintsFlatSkillFile(t *testing.T) {
+	root := writeSkillsConfig(t, "flat-skill-429")
+	flat := filepath.Join(root, ".apiary", "skills", "flat-skill-429.md")
+	if err := os.MkdirAll(filepath.Dir(flat), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flat, []byte("# flat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err, stderr := runValidate(t)
+	if err == nil {
+		t.Fatalf("validate exited 0 on a flat skill file; stderr=%q", stderr)
+	}
+	want := filepath.Join(".apiary", "skills", "flat-skill-429", "SKILL.md")
+	if !strings.Contains(stderr, "did you mean") || !strings.Contains(stderr, want) {
+		t.Errorf("stderr = %q, want a hint pointing at %q", stderr, want)
+	}
+}
+
+// TestValidatePassesOnResolvableSkill guards the other side: a skill laid out
+// correctly must not trip the new check.
+func TestValidatePassesOnResolvableSkill(t *testing.T) {
+	root := writeSkillsConfig(t, "good-skill-429")
+	path := filepath.Join(root, ".apiary", "skills", "good-skill-429", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# good\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err, stderr := runValidate(t); err != nil {
+		t.Fatalf("validate failed on a resolvable skill: %v; stderr=%q", err, stderr)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/plugin"
+	"github.com/orlandoburli/apiary/internal/skills"
 )
 
 // KnownAdapters reports the registered runner adapter names. The cli package
@@ -209,6 +210,18 @@ func (c *Config) Validate() []error {
 		if a.SoulFile != "" {
 			if _, err := os.Stat(a.SoulFile); err != nil {
 				errs = append(errs, fmt.Errorf("agents[%d] %q: soul_file %q not found or not readable: %w", i, a.ID, a.SoulFile, err))
+			}
+		}
+		// A declared skill that resolves to nothing is the same class of error
+		// as a missing soul_file: the agent runs without instructions it was
+		// configured to have, and nothing else in a run says so.
+		for _, name := range a.Skills {
+			if strings.TrimSpace(name) == "" {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: skills: skill name must not be empty", i, a.ID))
+				continue
+			}
+			if res := skills.Resolve("", name); !res.Found() {
+				errs = append(errs, fmt.Errorf("agents[%d] %q: %s", i, a.ID, res.Reason()))
 			}
 		}
 		if a.Runner != "" && !runnerIDs[a.Runner] {

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -507,6 +507,11 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 	// agent pushes from the very first run.
 	installGitHooks(d.cfg.Settings.GitHooks)
 
+	// Say so, once, before the first dispatch when an agent declares a skill
+	// that is not on disk: the run would otherwise proceed with the agent
+	// quietly missing instructions it was configured to have.
+	d.warnUnresolvedSkills()
+
 	// A fresh process owns no in-flight runs: clear any executions left in the
 	// 'running' state by a previously-killed dispatcher so the dashboard's
 	// agent status reflects real, live claude processes rather than orphans.

--- a/src/internal/daemon/skills_check.go
+++ b/src/internal/daemon/skills_check.go
@@ -1,0 +1,29 @@
+package daemon
+
+import (
+	aplog "github.com/orlandoburli/apiary/internal/log"
+	"github.com/orlandoburli/apiary/internal/skills"
+)
+
+// warnUnresolvedSkills logs one warning per declared skill that resolves to no
+// file on disk, naming the agent, the skill and every candidate path tried.
+//
+// `apiary validate` already rejects such a config, but a daemon can be started
+// on a hive whose skills were renamed or deleted after the config was written.
+// Without this the run proceeds with the skill simply absent from the agent's
+// context and nothing anywhere says so (issue #429).
+func (d *Dispatcher) warnUnresolvedSkills() {
+	if d.cfg == nil {
+		return
+	}
+	for _, ac := range d.cfg.Agents {
+		for _, name := range ac.Skills {
+			if name == "" {
+				continue
+			}
+			if res := skills.Resolve("", name); !res.Found() {
+				aplog.Warn("agent %s: %s", ac.ID, res.Reason())
+			}
+		}
+	}
+}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/format"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/skills"
 )
 
 // refreshInterval controls how often the active tab re-queries the database.
@@ -4655,12 +4656,18 @@ func (a *App) buildAgentFiles(d *AgentStatus) []AgentFileItem {
 		})
 	}
 	for _, skill := range d.Skills {
-		path := filepath.Join(".claude", "skills", skill, "SKILL.md")
+		// Shared resolver: this panel, `apiary validate` and the daemon's
+		// startup warning must agree on where a skill is looked for.
+		res := skills.Resolve("", skill)
+		path := res.Path
+		if path == "" {
+			path = skills.PrimaryPath("", skill)
+		}
 		files = append(files, AgentFileItem{
 			Kind:    "skill",
 			Name:    skill,
 			Path:    path,
-			Missing: !fileExists(path),
+			Missing: !res.Found(),
 		})
 	}
 	return files

--- a/src/internal/improve/workspace.go
+++ b/src/internal/improve/workspace.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/skills"
 )
 
 // FileKind classifies a workspace file by what changing it would affect.
@@ -39,20 +40,6 @@ type Workspace struct {
 	// an agent whose instructions it never saw is worse than one that knows a
 	// piece is missing.
 	UnresolvedSkills []string `json:"unresolved_skills,omitempty"`
-}
-
-// skillSearchDirs lists where a declared skill name may live, relative to the
-// workspace root plus the user's home.
-//
-// Apiary itself never resolves skills: agents[].skills is passed through to the
-// runner as bare names (the opencode agent file carries them verbatim), and the
-// runner applies its own conventions. So this mirrors those conventions rather
-// than reusing an apiary resolver — there is none. A name that matches nothing
-// is reported in UnresolvedSkills.
-var skillSearchDirs = []string{
-	".claude/skills",
-	".opencode/skills",
-	".apiary/skills",
 }
 
 // Discover walks the configuration to find every file that shapes agent
@@ -133,28 +120,10 @@ func Discover(cfg *config.Config, configFile string) (*Workspace, error) {
 }
 
 // resolveSkill looks for a declared skill name in the conventional locations.
+// It delegates to the shared resolver so the advisor, `apiary validate`, the
+// daemon's startup warning and the dashboard all search the same paths.
 func resolveSkill(root, name string) string {
-	if name == "" {
-		return ""
-	}
-	home, _ := os.UserHomeDir()
-	roots := []string{root}
-	if home != "" {
-		roots = append(roots, home)
-	}
-	for _, r := range roots {
-		for _, dir := range skillSearchDirs {
-			for _, candidate := range []string{
-				filepath.Join(r, dir, name, "SKILL.md"),
-				filepath.Join(r, dir, name+".md"),
-			} {
-				if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
-					return candidate
-				}
-			}
-		}
-	}
-	return ""
+	return skills.Resolve(root, name).Path
 }
 
 // excludedNames matches files that must never reach a prompt or a patch,

--- a/src/internal/skills/skills.go
+++ b/src/internal/skills/skills.go
@@ -1,0 +1,150 @@
+// Package skills resolves the skill names declared in agents[].skills to files
+// on disk.
+//
+// Apiary does not load skills itself — the names are passed through to the
+// runner, which applies its own conventions. This package mirrors those
+// conventions so that every surface that reports on skills (config validation,
+// the daemon's startup check, the dashboard's agent panel and the improve
+// advisor) agrees on where a skill is looked for and what it means when it is
+// not there.
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SearchDirs lists the directories a declared skill name may live in, relative
+// to the workspace root and to the user's home directory. Order is significant:
+// it is the order the candidate paths are tried and reported in.
+var SearchDirs = []string{
+	".claude/skills",
+	".opencode/skills",
+	".apiary/skills",
+}
+
+// Resolution is the outcome of resolving one declared skill name.
+type Resolution struct {
+	// Name is the skill name as declared in the config.
+	Name string
+	// Path is the SKILL.md that was found, or "" when nothing resolved.
+	Path string
+	// Candidates are every path tried, in order. Reported on failure so the
+	// user can see the expected `<name>/SKILL.md` shape.
+	Candidates []string
+	// FlatFile is an existing `<name>.md` sitting where `<name>/SKILL.md` was
+	// expected. That is the mistake users actually make — souls are configured
+	// as plain `.md` paths and skills are not — so it earns its own hint.
+	FlatFile string
+}
+
+// Found reports whether the skill resolved to a file on disk.
+func (r Resolution) Found() bool { return r.Path != "" }
+
+// Reason renders the failure as a single human-readable clause, listing every
+// candidate path tried and, when a flat `<name>.md` exists, the directory form
+// the user probably meant. It returns "" for a resolved skill.
+func (r Resolution) Reason() string {
+	if r.Found() {
+		return ""
+	}
+	tried := make([]string, 0, len(r.Candidates))
+	for _, c := range r.Candidates {
+		tried = append(tried, display(c))
+	}
+	msg := fmt.Sprintf("skill %q not found (tried %s)", r.Name, strings.Join(tried, ", "))
+	if r.FlatFile != "" {
+		msg += fmt.Sprintf("; found %s — did you mean %s?",
+			display(r.FlatFile), display(expectedFor(r.FlatFile, r.Name)))
+	}
+	return msg
+}
+
+// expectedFor maps a flat `<dir>/<name>.md` to the `<dir>/<name>/SKILL.md` it
+// should have been.
+func expectedFor(flat, name string) string {
+	return filepath.Join(filepath.Dir(flat), name, "SKILL.md")
+}
+
+// display shortens a path under the user's home to `~/…` so the candidate list
+// stays readable.
+func display(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if rel, err := filepath.Rel(home, path); err == nil &&
+		rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.Join("~", rel)
+	}
+	return path
+}
+
+// roots returns the directories the search dirs are joined onto: the workspace
+// root first (an empty root means the current working directory), then the
+// user's home, where globally installed skills live.
+func roots(root string) []string {
+	out := []string{root}
+	if home, err := os.UserHomeDir(); err == nil && home != "" && home != root {
+		out = append(out, home)
+	}
+	return out
+}
+
+// Candidates returns every path a skill named `name` is looked for, in order.
+// Only the `<name>/SKILL.md` form is a candidate: a flat `<name>.md` is not
+// loaded by any runner, so treating it as a resolution would reproduce exactly
+// the silent failure this list exists to expose.
+func Candidates(root, name string) []string {
+	if name == "" {
+		return nil
+	}
+	var out []string
+	for _, r := range roots(root) {
+		for _, dir := range SearchDirs {
+			out = append(out, filepath.Join(r, filepath.FromSlash(dir), name, "SKILL.md"))
+		}
+	}
+	return out
+}
+
+// Resolve looks for a declared skill name under root and the user's home.
+func Resolve(root, name string) Resolution {
+	res := Resolution{Name: name, Candidates: Candidates(root, name)}
+	if name == "" {
+		return res
+	}
+	for _, candidate := range res.Candidates {
+		if isFile(candidate) {
+			res.Path = candidate
+			return res
+		}
+	}
+	for _, r := range roots(root) {
+		for _, dir := range SearchDirs {
+			flat := filepath.Join(r, filepath.FromSlash(dir), name+".md")
+			if isFile(flat) {
+				res.FlatFile = flat
+				return res
+			}
+		}
+	}
+	return res
+}
+
+// PrimaryPath is the path a skill is expected at when nothing resolved: the
+// first candidate. Surfaces that must show a path even for a missing skill (the
+// dashboard's agent files list) use it.
+func PrimaryPath(root, name string) string {
+	if c := Candidates(root, name); len(c) > 0 {
+		return c[0]
+	}
+	return ""
+}
+
+func isFile(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}

--- a/src/internal/skills/skills_test.go
+++ b/src/internal/skills/skills_test.go
@@ -1,0 +1,106 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile creates path (with parents) holding body.
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestResolveFindsSkillDirectory is the happy path: `<dir>/<name>/SKILL.md`
+// under any of the search directories resolves.
+func TestResolveFindsSkillDirectory(t *testing.T) {
+	for _, dir := range SearchDirs {
+		t.Run(dir, func(t *testing.T) {
+			root := t.TempDir()
+			want := filepath.Join(root, filepath.FromSlash(dir), "skill-429-fixture", "SKILL.md")
+			writeFile(t, want, "# fixture skill\n")
+
+			res := Resolve(root, "skill-429-fixture")
+			if !res.Found() {
+				t.Fatalf("expected skill-429-fixture to resolve, got %+v", res)
+			}
+			if res.Path != want {
+				t.Errorf("path = %q, want %q", res.Path, want)
+			}
+			if res.Reason() != "" {
+				t.Errorf("Reason() on a resolved skill = %q, want empty", res.Reason())
+			}
+		})
+	}
+}
+
+// TestResolveMissingSkillListsCandidates covers the silent-failure case from
+// issue #429: nothing on disk, and the failure names every path tried.
+func TestResolveMissingSkillListsCandidates(t *testing.T) {
+	root := t.TempDir()
+
+	res := Resolve(root, "no-such-skill-429")
+	if res.Found() {
+		t.Fatalf("expected no resolution, got %q", res.Path)
+	}
+	if len(res.Candidates) < len(SearchDirs) {
+		t.Fatalf("candidates = %v, want at least one per search dir", res.Candidates)
+	}
+	reason := res.Reason()
+	for _, dir := range SearchDirs {
+		want := filepath.Join(root, filepath.FromSlash(dir), "no-such-skill-429", "SKILL.md")
+		if !strings.Contains(reason, want) {
+			t.Errorf("reason %q does not mention candidate %q", reason, want)
+		}
+	}
+	if strings.Contains(reason, "did you mean") {
+		t.Errorf("reason %q offers a flat-file hint with no flat file on disk", reason)
+	}
+}
+
+// TestResolveFlatFileHint is the mistake users actually make: the skill written
+// as `<name>.md` next to where `<name>/SKILL.md` was expected. It must not
+// resolve (no runner loads it) and it must produce the "did you mean" hint.
+func TestResolveFlatFileHint(t *testing.T) {
+	root := t.TempDir()
+	flat := filepath.Join(root, ".apiary", "skills", "skill-429-fixture.md")
+	writeFile(t, flat, "# fixture skill\n")
+
+	res := Resolve(root, "skill-429-fixture")
+	if res.Found() {
+		t.Fatalf("a flat <name>.md must not resolve, got %q", res.Path)
+	}
+	if res.FlatFile != flat {
+		t.Errorf("FlatFile = %q, want %q", res.FlatFile, flat)
+	}
+	want := filepath.Join(root, ".apiary", "skills", "skill-429-fixture", "SKILL.md")
+	reason := res.Reason()
+	if !strings.Contains(reason, "did you mean") || !strings.Contains(reason, want) {
+		t.Errorf("reason = %q, want a hint pointing at %q", reason, want)
+	}
+}
+
+// TestResolveEmptyName keeps a blank entry in skills: from producing a bogus
+// candidate list.
+func TestResolveEmptyName(t *testing.T) {
+	res := Resolve(t.TempDir(), "")
+	if res.Found() || len(res.Candidates) != 0 {
+		t.Fatalf("empty name should resolve to nothing with no candidates, got %+v", res)
+	}
+}
+
+// TestPrimaryPath pins the path surfaces show for a skill that is not there.
+func TestPrimaryPath(t *testing.T) {
+	root := t.TempDir()
+	want := filepath.Join(root, ".claude", "skills", "deploying-429", "SKILL.md")
+	if got := PrimaryPath(root, "deploying-429"); got != want {
+		t.Errorf("PrimaryPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #429

## Problem

A skill named in `agents[].skills` that cannot be located on disk fails **silently**: `apiary validate` prints `✓ config is valid`, the daemon logs nothing, and the run proceeds with the skill simply absent from the agent's context. Only the dashboard hinted at it, rendering the file as `(missing)`.

The reporter lost weeks to this: six skills laid out as flat `.apiary/skills/<name>.md` files instead of `<name>/SKILL.md`, so none of them ever resolved, while souls that referenced those skills loaded fine — agents were told to follow sections of documents they had never been given.

## What changed

**New `internal/skills` package — the single resolver.** The search order lived in two divergent copies (`internal/improve` searched three dirs under root and `$HOME`; the dashboard only looked at `.claude/skills/<name>/SKILL.md`). Now one package owns it, and validate, the daemon, the dashboard and the improve advisor all call it:

| # | Candidate |
|---|---|
| 1–3 | `.claude/skills/<name>/SKILL.md`, `.opencode/skills/<name>/SKILL.md`, `.apiary/skills/<name>/SKILL.md` |
| 4–6 | the same three under `$HOME` |

1. **`apiary validate` fails** on an unresolvable skill, mirroring the missing-`soul_file` error style and listing every candidate tried:

   ```
   ✗ agents[0] "engineer": skill "git-workflow" not found (tried .claude/skills/git-workflow/SKILL.md, .opencode/skills/git-workflow/SKILL.md, .apiary/skills/git-workflow/SKILL.md, ~/.claude/skills/git-workflow/SKILL.md, ~/.opencode/skills/git-workflow/SKILL.md, ~/.apiary/skills/git-workflow/SKILL.md)
   ```

2. **The daemon warns at startup**, once per unresolved skill, naming agent, skill and candidates (`Dispatcher.warnUnresolvedSkills`, called from `Start` before the first dispatch). Validation rejects such a config, but a running hive can have skills renamed or deleted after the config was written.

3. **Flat-file hint.** A `<name>.md` sitting where `<name>/SKILL.md` was expected appends `; found .apiary/skills/git-workflow.md — did you mean .apiary/skills/git-workflow/SKILL.md?`.

Docs: `docs/configuration.md` gains an `agents` → **Skills** section making the `<name>/SKILL.md` layout, the search order and the new failure modes explicit, with the good/bad layout side by side.

## ⚠️ Breaking change

**Failing validate is breaking for hives carrying a dangling skill name.** A config that validated yesterday can fail today — that is the point (the skill was never loaded), but it will bite on upgrade: `apiary validate` exits non-zero, and any tooling gating on it stops. The fix is to lay the skill out as `<name>/SKILL.md` or drop the name from `skills`. The docs carry an "Upgrading" warning saying exactly this; it belongs in the release notes too.

Two smaller behaviour changes fall out of sharing one resolver:

- A flat `<name>.md` no longer counts as a resolution **anywhere**. `internal/improve` used to accept it, which meant the advisor reported a file the runner never loads as a resolved skill.
- `.apiary/example-with-recovery.yaml` declared five skills that do not ship with the repo, so it no longer validated. The declarations are commented out with a note stating the required layout — the example teaches the shape without shipping stub skills.

## Tests

New `internal/skills/skills_test.go` (resolvable skill in each search dir, missing skill listing candidates, flat-file hint, empty name, primary path) and `internal/cli/skills_validate_test.go` (validate exits non-zero on a missing skill, hints on the flat file, stays clean on a correctly laid out one).

```
$ cd src && go build ./... && go test ./...
ok  github.com/orlandoburli/apiary/internal/cli        0.480s
ok  github.com/orlandoburli/apiary/internal/config     (cached)
ok  github.com/orlandoburli/apiary/internal/daemon     (cached)
ok  github.com/orlandoburli/apiary/internal/dashboard  (cached)
ok  github.com/orlandoburli/apiary/internal/improve    (cached)
ok  github.com/orlandoburli/apiary/internal/skills     0.609s
… every package ok
```

## Out of scope

The issue's final note — validating known `config` keys per source type (`token:` vs `api_key:` on a `github` source) — is tracked separately as #441.
