### PR TITLE
feat(wait_for): poll the linked PR's forge for kind: ci (ci_source)

### DIFF
--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -50,6 +50,17 @@ GitHub's `/issues` endpoint also returns pull requests, but the adapter filters
 them out during polling — only plain issues become cells (always
 `Type: "issue"`).
 
+### As a CI source for another tracker
+
+The adapter can answer for a pull request by number, not only for one it
+resolved from its own issues. That makes it usable as the `ci_source` of a
+workflow whose tasks come from somewhere else — a Jira- or Plane-sourced
+pipeline whose agents push here. Configure it as a second source pointing at
+the repository the PRs live in, and point the wait at it with
+[`ci_source`](workflows.md#waiting-on-ci-hosted-elsewhere-ci_source). A PR URL
+belonging to another repository is refused rather than answered with this
+repository's same-numbered PR.
+
 ## PR event polling (`trigger.on: pr_*`)
 
 When any workflow declares a [PR event trigger](workflows.md#pr-event-triggers-on),

--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -68,15 +68,19 @@ visible to the API user and logs a warning.
 - **Labels.** Adding/removing labels uses Jira's atomic update verbs; labels
   are created implicitly. Jira labels cannot contain spaces — names with
   whitespace are rewritten with `-` (e.g. `needs review` → `needs-review`).
-- **No CI polling.** `wait_for` steps with `kind: ci` need a source that can
-  see pull requests; Jira issues have no PR mapping, so host CI waits on a
-  GitHub source instead. `apiary validate` rejects such a step against a
-  Jira-only config, so this surfaces at config time rather than at runtime.
+- **CI waits need the forge, via `ci_source`.** Jira issues have no PR mapping,
+  so a plain `wait_for {kind: ci}` cannot resolve anything (and `apiary
+  validate` rejects it against a Jira-only config). Configure the GitHub
+  repository as a second source and point the step at it with
+  [`ci_source`](workflows.md#waiting-on-ci-hosted-elsewhere-ci_source): the wait
+  then polls the PR the workflow recorded with `pull_request_from`, on the forge
+  that hosts it.
 - **PRs link from the workflow.** Because the adapter cannot enumerate a task's
   pull requests, the dashboard's `p` shortcut has nothing to open unless the
   workflow reports the PR itself: point
   [`pull_request_from`](workflows.md#linking-a-pr-pull_request_from) at the
-  output field carrying the PR URL on the step that opens it.
+  output field carrying the PR URL on the step that opens it. The same link is
+  what a `ci_source` CI wait polls.
 - **Dependency waits work.** `wait_for` steps with
   [`kind: dependency`](workflows.md#wait_for-steps-waiting-on-blockers-kind-dependency)
   read the inward side of the issue's `Blocks` links (*"is blocked by"*;

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -282,9 +282,9 @@ output field carrying the PR URL, and the step registers its own PR.
 - `apiary validate` rejects a `pull_request_from` naming a field the step's
   `output` schema does not declare.
 
-This does **not** enable `wait_for {kind: ci}` on those sources: polling check
-runs needs a source adapter that can talk to the forge, which is a separate
-capability from knowing a PR's URL.
+A linked PR is also what `wait_for {kind: ci}` waits on when the forge is not
+the task's source — see [waiting on CI hosted
+elsewhere](#waiting-on-ci-hosted-elsewhere-ci_source).
 
 ### Workflow memory
 
@@ -695,8 +695,8 @@ How it works:
 - `kind: ci` needs a source that can poll check runs (GitHub today). Against a
   source that cannot — Jira, Plane, an alert source — `apiary validate` rejects
   the step at config time, wherever it sits, including inside a `parallel:`
-  group. See [linking a PR by hand](#linking-a-pr-pull_request_from) for what
-  still works on those sources.
+  group. When the PRs live on a forge that is not the task's source, add
+  [`ci_source`](#waiting-on-ci-hosted-elsewhere-ci_source) instead.
 - Each poll records a row of history — status, PR URL, per-check detail —
   which the dashboard shows in the task's detail view, so a long CI wait is
   fully auditable.
@@ -714,6 +714,65 @@ is present, it routes that failure exclusively — typically looping back to
 the implementation step so the agent rebases — with its own `max_retries`
 budget, separate from `on_fail`. Without `on_conflict`, a conflict falls
 through to `on_fail` like any other failure.
+
+#### Waiting on CI hosted elsewhere (`ci_source`)
+
+The default CI wait resolves the PR from the task's own source item, which only
+a source that hosts both the issue **and** the code can do. In the common split
+setup — issues in Jira, code on GitHub — nothing in the tracker knows what a
+pull request is, and the wait can never pass.
+
+`ci_source` names the configured source that hosts the PR, and the wait polls
+*that* forge for the PR the workflow itself reported:
+
+```yaml
+sources:
+  - id: jira
+    type: jira
+    config: {site: acme, email: ..., api_token: ...}
+  - id: github            # the forge: same repo the agents push to
+    type: github
+    config: {repo: acme/backend, api_key: ...}
+
+workflows:
+  - id: deliver
+    trigger: {match: {source: jira, labels: [ai-ready]}}
+    steps:
+      - id: implement
+        agent: engineer
+        prompt: "Implement the change and open a PR."
+        output:
+          type: object
+          properties:
+            pr_url: {type: string}
+          required: [pr_url]
+        pull_request_from: pr_url     # ← records the PR against the task
+
+      - id: check-ci
+        type: wait_for
+        wait_for:
+          kind: ci
+          ci_source: github           # ← poll THIS source, by PR number
+          check_interval: 60s
+          max_duration: 2h
+```
+
+- The PR comes from the task's linked pull requests, so a step earlier in the
+  workflow must record one with
+  [`pull_request_from`](#linking-a-pr-pull_request_from). The **most recently
+  linked** PR is the one polled — a rework lap after a red CI waits on the new
+  PR, not the old one.
+- Until a PR is linked, the wait simply stays **pending** (parked, restart-safe)
+  rather than failing — it is safe to start waiting before the PR exists.
+  `max_duration` still bounds it.
+- The task's own source needs no CI capability at all: with `ci_source` set,
+  `apiary validate` checks the *named* source instead, rejecting one that is not
+  configured or whose adapter cannot poll a PR's checks.
+- The named source must be configured for the repository the PRs live in. A PR
+  URL from a different repository is refused rather than answered with a
+  same-numbered PR of the configured one.
+- Everything else is unchanged: conflict detection, `fail_if_not_passed`,
+  `on_conflict`, poll history, restart-safe parking.
 
 ### `wait_for` steps — waiting on blockers (`kind: dependency`)
 

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -1159,6 +1159,10 @@
           "type": "string",
           "description": "Remove this label from the task before polling begins (resets stale labels from previous runs)"
         },
+        "ci_source": {
+          "type": "string",
+          "description": "Kind 'ci' only: id of the configured source hosting the pull request whose CI to wait on, for setups where the issue tracker and the git forge differ (a Jira task whose PRs live on GitHub). The PR itself comes from the task's linked pull requests, recorded by an earlier step's pull_request_from. Empty polls the task's own source by its item id"
+        },
         "satisfied_when": {
           "type": "array",
           "description": "Kind 'dependency' only: conditions under which a blocker counts as satisfied — 'merged' (a linked PR merged) and/or 'done' (status is Done-category). A blocker is satisfied when ANY listed condition holds. Defaults to [merged, done]",

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -46,6 +46,7 @@ func init() {
 		_, caps.RemoveLabels = a.(source.LabelRemover)
 		_, caps.Approvals = a.(source.TaskPoller)
 		_, caps.CIWait = a.(source.CIStatusPoller)
+		_, caps.PRCIWait = a.(source.PRCIStatusPoller)
 		_, caps.SubIssues = a.(source.SubIssueCreator)
 		_, caps.Resolvable = a.(source.ItemResolver)
 		return caps

--- a/src/internal/cli/source_caps_wiring_test.go
+++ b/src/internal/cli/source_caps_wiring_test.go
@@ -46,7 +46,7 @@ func TestSourceCapsWiring_RealAdapters(t *testing.T) {
 		t.Errorf("dynatrace caps = %+v, want all-false (read-only problem source)", caps)
 	}
 
-	want := config.SourceCaps{SetState: true, AddLabels: true, RemoveLabels: true, Approvals: true, CIWait: true, SubIssues: true}
+	want := config.SourceCaps{SetState: true, AddLabels: true, RemoveLabels: true, Approvals: true, CIWait: true, PRCIWait: true, SubIssues: true}
 	if caps := config.SourceCapabilities("github"); caps != want {
 		t.Errorf("github caps = %+v, want %+v", caps, want)
 	}

--- a/src/internal/config/source_caps_validate.go
+++ b/src/internal/config/source_caps_validate.go
@@ -106,7 +106,11 @@ func workflowCapNeeds(w WorkflowConfig) []capNeed {
 				needs = append(needs, capNeed{sctx + " (approval)", func(c SourceCaps) bool { return c.Approvals }})
 			}
 		case StepTypeWaitFor:
-			if s.WaitFor != nil && (s.WaitFor.Kind == "" || s.WaitFor.Kind == WaitKindCI) {
+			// ci_source delegates the CI check to another configured source (the
+			// forge hosting the PR), so the task's own source needs no CI
+			// capability at all — that separation is the point of the field.
+			// validateWaitForStep checks the named source instead (#444).
+			if s.WaitFor != nil && (s.WaitFor.Kind == "" || s.WaitFor.Kind == WaitKindCI) && s.WaitFor.CISource == "" {
 				needs = append(needs, capNeed{sctx + " (wait_for ci)", func(c SourceCaps) bool { return c.CIWait }})
 			}
 		}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -33,6 +33,7 @@ type SourceCaps struct {
 	RemoveLabels bool // source.LabelRemover — remove_labels
 	Approvals    bool // source.TaskPoller — approval steps
 	CIWait       bool // source.CIStatusPoller — wait_for kind "ci"
+	PRCIWait     bool // source.PRCIStatusPoller — wait_for kind "ci" with ci_source
 	SubIssues    bool // source.SubIssueCreator — materialize: sub_issue
 	Resolvable   bool // source.ItemResolver — interrupt_on_resolve
 }

--- a/src/internal/config/wait_ci_source_validate_test.go
+++ b/src/internal/config/wait_ci_source_validate_test.go
@@ -1,0 +1,79 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// withSplitSourceCaps models the setup #444 is about: "tracker" (Jira-like)
+// owns the work items but knows nothing about pull requests, while "forge"
+// (GitHub-like) hosts the PRs and can poll CI for one by number.
+func withSplitSourceCaps(t *testing.T) {
+	t.Helper()
+	prev := config.SourceCapabilities
+	config.SourceCapabilities = func(sourceType string) config.SourceCaps {
+		switch sourceType {
+		case "tracker":
+			return config.SourceCaps{SetState: true, AddLabels: true, Approvals: true}
+		case "forge":
+			return config.SourceCaps{SetState: true, AddLabels: true, Approvals: true, CIWait: true, PRCIWait: true}
+		}
+		return config.SourceCaps{}
+	}
+	t.Cleanup(func() { config.SourceCapabilities = prev })
+}
+
+func ciWaitConfig(wait config.WaitForConfig) *config.Config {
+	return &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{
+			{ID: "jira", Type: "tracker"},
+			{ID: "github", Type: "forge"},
+		},
+		Workflows: []config.WorkflowConfig{{
+			ID:      "deliver",
+			Trigger: &config.TriggerConfig{Match: config.RouteMatch{Source: "jira"}},
+			Steps: []config.StepConfig{
+				{ID: "implement", Agent: "eng", PullRequestFrom: "pr_url"},
+				{ID: "await-ci", Type: config.StepTypeWaitFor, WaitFor: &wait},
+			},
+		}},
+	}
+}
+
+// Without ci_source the wait is still linted against the task's own source, and
+// a tracker that cannot poll CI is still rejected — the #425 behaviour stands.
+func TestWaitCISource_UnsetStillRejectsIncapableSource(t *testing.T) {
+	withSplitSourceCaps(t)
+	errsContain(t, ciWaitConfig(config.WaitForConfig{Kind: config.WaitKindCI}).Validate(), "(wait_for ci)")
+}
+
+// With ci_source the CI check is delegated to the forge, so the tracker needs no
+// CI capability of its own — this config must lint clean.
+func TestWaitCISource_DelegatesCapabilityToNamedSource(t *testing.T) {
+	withSplitSourceCaps(t)
+	errs := ciWaitConfig(config.WaitForConfig{Kind: config.WaitKindCI, CISource: "github"}).Validate()
+	errsNotContain(t, errs, "(wait_for ci)")
+	errsNotContain(t, errs, "ci_source")
+}
+
+func TestWaitCISource_RejectsUnknownSource(t *testing.T) {
+	withSplitSourceCaps(t)
+	errsContain(t, ciWaitConfig(config.WaitForConfig{CISource: "gitlab"}).Validate(),
+		`ci_source "gitlab" is not a configured source`)
+}
+
+// Naming a source that cannot poll CI for a PR is caught at load time rather
+// than at runtime, when the wait would have failed with the same cause.
+func TestWaitCISource_RejectsSourceWithoutPRCIPolling(t *testing.T) {
+	withSplitSourceCaps(t)
+	errsContain(t, ciWaitConfig(config.WaitForConfig{CISource: "jira"}).Validate(),
+		`cannot poll CI for a pull request`)
+}
+
+func TestWaitCISource_RejectedOnDependencyKind(t *testing.T) {
+	withSplitSourceCaps(t)
+	errsContain(t, ciWaitConfig(config.WaitForConfig{Kind: config.WaitKindDependency, CISource: "github"}).Validate(),
+		`ci_source is only valid with kind "ci"`)
+}

--- a/src/internal/config/workflow.go
+++ b/src/internal/config/workflow.go
@@ -536,6 +536,18 @@ type WaitForConfig struct {
 	// Used to reset stale labels from previous runs.
 	RemoveLabel string `yaml:"remove_label,omitempty"`
 
+	// CISource names the configured source that hosts the pull request whose CI
+	// this step waits on, for setups where the issue tracker and the git forge
+	// are different systems (a Jira task whose PRs live on GitHub). Empty — the
+	// default — polls the task's own source by its item id, which is what a
+	// GitHub-sourced pipeline wants.
+	//
+	// The PR itself comes from the task's linked pull requests, which a step
+	// earlier in the workflow records with pull_request_from. Until one is
+	// linked the wait simply stays pending, exactly as it does while the source
+	// has not cross-referenced a PR yet (#444). kind: ci only.
+	CISource string `yaml:"ci_source,omitempty"`
+
 	// ── kind: dependency only ─────────────────────────────────────
 	// SatisfiedWhen lists the conditions under which a blocker counts as
 	// satisfied: "merged" (a linked PR merged) and/or "done" (status is

--- a/src/internal/config/workflow_validate.go
+++ b/src/internal/config/workflow_validate.go
@@ -744,6 +744,31 @@ func (c *Config) validateWaitForStep(sctx string, s StepConfig) []error {
 		errs = append(errs, fmt.Errorf("%s: wait_for step kind %q not supported (valid: ci, dependency)", sctx, cfg.Kind))
 	}
 
+	// ci_source names the source that hosts the PR whose CI this step waits on.
+	// It only makes sense for a CI wait, must name a source that exists, and
+	// that source's adapter must be able to poll CI for a pull request by
+	// number — otherwise the wait would fail at runtime for a reason the config
+	// already reveals (#444).
+	if cfg.CISource != "" {
+		switch {
+		case cfg.Kind != "" && cfg.Kind != WaitKindCI:
+			errs = append(errs, fmt.Errorf("%s: wait_for ci_source is only valid with kind \"ci\"", sctx))
+		case len(c.Sources) > 0:
+			var srcType string
+			for _, src := range c.Sources {
+				if src.ID == cfg.CISource {
+					srcType = src.Type
+					break
+				}
+			}
+			if srcType == "" {
+				errs = append(errs, fmt.Errorf("%s: wait_for ci_source %q is not a configured source", sctx, cfg.CISource))
+			} else if SourceCapabilities != nil && !SourceCapabilities(srcType).PRCIWait {
+				errs = append(errs, fmt.Errorf("%s: wait_for ci_source %q (type %q) cannot poll CI for a pull request", sctx, cfg.CISource, srcType))
+			}
+		}
+	}
+
 	// dependency-only fields are rejected on other kinds.
 	if cfg.Kind != WaitKindDependency {
 		if len(cfg.SatisfiedWhen) > 0 {

--- a/src/internal/daemon/wait_ci_source_test.go
+++ b/src/internal/daemon/wait_ci_source_test.go
@@ -1,0 +1,130 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/workflow"
+)
+
+// forgeAdapter is a git forge that can answer for a pull request by number but
+// knows nothing about the task's own source items — the GitHub side of a
+// Jira-sourced pipeline (#444).
+type forgeAdapter struct {
+	mu   sync.Mutex
+	seen []source.PullRequestRef
+}
+
+func (a *forgeAdapter) ID() string                                                  { return "github" }
+func (a *forgeAdapter) Connect(context.Context, map[string]any) error               { return nil }
+func (a *forgeAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) { return nil, nil }
+func (a *forgeAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (a *forgeAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+func (a *forgeAdapter) PollCIStatusForPR(_ context.Context, pr source.PullRequestRef) (source.CIStatus, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.seen = append(a.seen, pr)
+	return source.CIStatus{Status: "passed", URL: pr.URL}, nil
+}
+
+// trackerAdapter owns the work items and has no CI capability at all (Jira).
+type trackerAdapter struct{}
+
+func (trackerAdapter) ID() string                                                  { return "jira" }
+func (trackerAdapter) Connect(context.Context, map[string]any) error               { return nil }
+func (trackerAdapter) Poll(context.Context, time.Time) ([]model.SourceItem, error) { return nil, nil }
+func (trackerAdapter) Acknowledge(context.Context, model.SourceItem, model.AckAction) error {
+	return nil
+}
+func (trackerAdapter) WriteResult(context.Context, model.SourceItem, model.RunResult) error {
+	return nil
+}
+
+func ciSourceDispatcher(t *testing.T) (*Dispatcher, *db.Client, *forgeAdapter) {
+	t.Helper()
+	ctx := context.Background()
+	dbc, err := db.New(ctx, filepath.Join(t.TempDir(), "ci.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = dbc.Close() })
+
+	forge := &forgeAdapter{}
+	d := &Dispatcher{
+		db:      dbc,
+		sources: map[string]source.Adapter{"jira": trackerAdapter{}, "github": forge},
+	}
+	d.binder = source.NewSourceBinder(dbc)
+	return d, dbc, forge
+}
+
+// The happy path: the CI status of the PR linked to a Jira-sourced task comes
+// from the forge named by ci_source, addressed by PR number.
+func TestPollCIForLinkedPR_UsesNewestLinkedPR(t *testing.T) {
+	ctx := context.Background()
+	d, dbc, forge := ciSourceDispatcher(t)
+
+	task, err := d.binder.Bind(ctx, model.SourceItem{ID: "PSP-1", SourceID: "jira", Title: "PSP-1"})
+	if err != nil {
+		t.Fatalf("bind task: %v", err)
+	}
+	for _, pr := range []db.TaskPullRequest{
+		{SourceID: "jira", PRNumber: 10, PRURL: "https://github.com/o/r/pull/10", PRState: "closed"},
+		{SourceID: "jira", PRNumber: 11, PRURL: "https://github.com/o/r/pull/11", PRState: "open"},
+	} {
+		if err := dbc.UpsertTaskPullRequest(ctx, task.ID, pr); err != nil {
+			t.Fatalf("link PR: %v", err)
+		}
+	}
+
+	got, err := d.pollCIForLinkedPR(ctx, workflow.CIStatusRequest{
+		TaskID: task.ID, SourceID: "jira", SourceItemID: "PSP-1", CISourceID: "github",
+	})
+	if err != nil {
+		t.Fatalf("pollCIForLinkedPR: %v", err)
+	}
+	if got.Status != "passed" {
+		t.Errorf("status = %q, want passed", got.Status)
+	}
+	if len(forge.seen) != 1 || forge.seen[0].Number != 11 {
+		t.Errorf("forge polled %+v, want only the newest linked PR (#11) — a rework lap must not wait on the old PR", forge.seen)
+	}
+}
+
+// No PR reported yet is a "not yet", so the wait stays parked instead of failing.
+func TestPollCIForLinkedPR_NoLinkedPR(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := ciSourceDispatcher(t)
+
+	_, err := d.pollCIForLinkedPR(ctx, workflow.CIStatusRequest{TaskID: "t1", CISourceID: "github"})
+	if !errors.Is(err, workflow.ErrPRNotLinked) {
+		t.Errorf("error = %v, want ErrPRNotLinked so the wait keeps polling", err)
+	}
+}
+
+// A ci_source that is not configured, or cannot poll a PR, is permanent: the
+// error must wrap ErrUnsupported so the engine fails the step at once.
+func TestPollCIForLinkedPR_UnsupportedCISource(t *testing.T) {
+	ctx := context.Background()
+	d, _, _ := ciSourceDispatcher(t)
+
+	for name, req := range map[string]workflow.CIStatusRequest{
+		"unknown source":     {TaskID: "t1", CISourceID: "gitlab"},
+		"source without cap": {TaskID: "t1", CISourceID: "jira"},
+	} {
+		if _, err := d.pollCIForLinkedPR(ctx, req); !errors.Is(err, source.ErrUnsupported) {
+			t.Errorf("%s: error = %v, want it to wrap ErrUnsupported", name, err)
+		}
+	}
+}

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -32,18 +32,24 @@ func (d *Dispatcher) workflowEngine() *workflow.Engine {
 			opts = append(opts, workflow.WithMemoryStore(d.memStore))
 		}
 		// Wire up CI status polling for wait_for steps.
-		opts = append(opts, workflow.WithCIStatusChecker(func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error) {
-			adapter, ok := d.sources[sourceID]
+		opts = append(opts, workflow.WithCIStatusChecker(func(ctx context.Context, req workflow.CIStatusRequest) (source.CIStatus, error) {
+			// ci_source: the forge that hosts the PR is a different system from
+			// the source that owns the task (Jira issue, GitHub PR) — ask it
+			// about the task's linked PR instead of the task's own item (#444).
+			if req.CISourceID != "" {
+				return d.pollCIForLinkedPR(ctx, req)
+			}
+			adapter, ok := d.sources[req.SourceID]
 			if !ok {
-				return source.CIStatus{}, fmt.Errorf("source %q not found", sourceID)
+				return source.CIStatus{}, fmt.Errorf("source %q not found", req.SourceID)
 			}
 			poller, ok := adapter.(source.CIStatusPoller)
 			if !ok {
 				// Permanent, not transient: fail the wait at once instead of
 				// polling a capability that will never appear (#425).
-				return source.CIStatus{}, fmt.Errorf("source %q cannot poll CI status: %w", sourceID, source.ErrUnsupported)
+				return source.CIStatus{}, fmt.Errorf("source %q cannot poll CI status: %w", req.SourceID, source.ErrUnsupported)
 			}
-			return poller.PollCIStatus(ctx, sourceItemID)
+			return poller.PollCIStatus(ctx, req.SourceItemID)
 		}))
 		// Wire up blocker listing for wait_for steps with kind: dependency.
 		opts = append(opts, workflow.WithDependencyChecker(func(ctx context.Context, sourceID, sourceItemID, linkType string) ([]source.BlockerRef, error) {
@@ -758,6 +764,47 @@ func (s *wfSideEffects) PostComment(ctx context.Context, task model.InternalTask
 		}
 	}
 	return nil
+}
+
+// pollCIForLinkedPR answers a wait_for/ci check whose step named a ci_source:
+// the CI status comes from the task's most recently linked pull request, polled
+// on the forge that hosts it, rather than from the task's own source item.
+//
+// The PR set is the one pull_request_from writes as the workflow runs, so the
+// newest row (seq ASC → last) is the PR the current lap opened — a rework lap
+// after a red CI waits on its new PR, not the old one.
+//
+// Errors are split deliberately: a missing/incapable ci_source wraps
+// source.ErrUnsupported so the engine fails the step at once with the cause
+// named, while a database hiccup is returned bare and retried next cycle. No PR
+// linked yet is neither — it is workflow.ErrPRNotLinked, which keeps the wait
+// pending until a step reports one.
+func (d *Dispatcher) pollCIForLinkedPR(ctx context.Context, req workflow.CIStatusRequest) (source.CIStatus, error) {
+	adapter, ok := d.sources[req.CISourceID]
+	if !ok {
+		return source.CIStatus{}, fmt.Errorf("ci_source %q is not a configured source: %w", req.CISourceID, source.ErrUnsupported)
+	}
+	poller, ok := adapter.(source.PRCIStatusPoller)
+	if !ok {
+		return source.CIStatus{}, fmt.Errorf("ci_source %q cannot poll CI for a pull request: %w", req.CISourceID, source.ErrUnsupported)
+	}
+	if d.db == nil {
+		return source.CIStatus{}, fmt.Errorf("ci_source %q needs the task's linked pull requests, which require a database: %w", req.CISourceID, source.ErrUnsupported)
+	}
+
+	prs, err := d.db.ListTaskPullRequests(ctx, req.TaskID)
+	if err != nil {
+		return source.CIStatus{}, fmt.Errorf("listing pull requests linked to task %s: %w", req.TaskID, err)
+	}
+	if len(prs) == 0 {
+		return source.CIStatus{}, workflow.ErrPRNotLinked
+	}
+	pr := prs[len(prs)-1]
+	return poller.PollCIStatusForPR(ctx, source.PullRequestRef{
+		Number: pr.PRNumber,
+		URL:    pr.PRURL,
+		State:  pr.PRState,
+	})
 }
 
 // LinkPullRequest persists a PR a workflow step reported against the task. It

--- a/src/internal/source/github/adapter.go
+++ b/src/internal/source/github/adapter.go
@@ -21,14 +21,15 @@ func init() {
 // Compile-time checks: the GitHub adapter supports the optional source
 // capabilities used by the dispatcher and the workflow engine.
 var (
-	_ source.StateSetter     = (*Adapter)(nil)
-	_ source.LabelAdder      = (*Adapter)(nil)
-	_ source.LabelRemover    = (*Adapter)(nil)
-	_ source.TaskPoller      = (*Adapter)(nil)
-	_ source.CIStatusPoller  = (*Adapter)(nil)
-	_ source.SubIssueCreator = (*Adapter)(nil)
-	_ source.BlockerLister   = (*Adapter)(nil)
-	_ source.PREventPoller   = (*Adapter)(nil)
+	_ source.StateSetter      = (*Adapter)(nil)
+	_ source.LabelAdder       = (*Adapter)(nil)
+	_ source.LabelRemover     = (*Adapter)(nil)
+	_ source.TaskPoller       = (*Adapter)(nil)
+	_ source.CIStatusPoller   = (*Adapter)(nil)
+	_ source.PRCIStatusPoller = (*Adapter)(nil)
+	_ source.SubIssueCreator  = (*Adapter)(nil)
+	_ source.BlockerLister    = (*Adapter)(nil)
+	_ source.PREventPoller    = (*Adapter)(nil)
 )
 
 type Adapter struct {
@@ -407,9 +408,17 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 		}
 	}
 
+	return a.ciStatusFromPRBody(ctx, prBody, cellID)
+}
+
+// ciStatusFromPRBody synthesizes a CI status from an already-fetched pull
+// request payload. It is the half of the CI check that is the same whether the
+// PR was resolved from an issue (PollCIStatus) or addressed directly by number
+// (PollCIStatusForPR); ref only labels log lines and error messages.
+func (a *Adapter) ciStatusFromPRBody(ctx context.Context, prBody []byte, ref string) (source.CIStatus, error) {
 	var pr pullRequest
 	if err := json.Unmarshal(prBody, &pr); err != nil {
-		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: decoding PR %s: %w", cellID, err)
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: decoding PR %s: %w", ref, err)
 	}
 
 	// A PR with merge conflicts can never merge until someone rebases/resolves it,
@@ -420,13 +429,13 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	// definitive "has conflicts" signal; "unknown"/null means GitHub is still
 	// computing mergeability (lazy, async) so we fall through and keep waiting.
 	if pr.MergeableState == "dirty" {
-		aplog.Info("github: PR #%d for %s has merge conflicts (mergeable_state=dirty)", pr.Number, cellID)
+		aplog.Info("github: PR #%d for %s has merge conflicts (mergeable_state=dirty)", pr.Number, ref)
 		return source.CIStatus{Status: "conflict", URL: pr.HTMLURL}, nil
 	}
 
 	headSHA := pr.Head.SHA
 	if headSHA == "" {
-		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: PR %s has no head SHA", cellID)
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: PR %s has no head SHA", ref)
 	}
 
 	// Get the combined status for this commit.
@@ -517,6 +526,60 @@ func (a *Adapter) PollCIStatus(ctx context.Context, cellID string) (source.CISta
 	}
 
 	return source.CIStatus{Status: overall, URL: pr.HTMLURL, Checks: checks}, nil
+}
+
+// PollCIStatusForPR checks the CI status of one pull request in this adapter's
+// repository, for tasks whose own source cannot resolve a PR (a Jira-sourced
+// task whose agents push to GitHub). Implements source.PRCIStatusPoller.
+//
+// A ref whose URL points at a different repository is a configuration error, not
+// a transient one: reporting some same-numbered PR of the configured repo would
+// be worse than failing. A ref with no URL is trusted as-is — the number is all
+// the caller had.
+func (a *Adapter) PollCIStatusForPR(ctx context.Context, pr source.PullRequestRef) (source.CIStatus, error) {
+	if pr.Number <= 0 {
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: pull request ref has no number")
+	}
+	if err := a.checkPRRefRepo(pr); err != nil {
+		return source.CIStatus{Status: "unknown"}, err
+	}
+
+	prPath := fmt.Sprintf("/repos/%s/%s/pulls/%d", a.owner, a.repo, pr.Number)
+	body, err := a.client.get(ctx, prPath)
+	if err != nil {
+		if isAuthError(err) {
+			return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: cannot read PR #%d — the configured token likely lacks 'Pull requests: Read' (and 'Contents: Read'): %w", pr.Number, err)
+		}
+		return source.CIStatus{Status: "unknown"}, fmt.Errorf("github: fetching PR #%d: %w", pr.Number, err)
+	}
+	return a.ciStatusFromPRBody(ctx, body, fmt.Sprintf("#%d", pr.Number))
+}
+
+// checkPRRefRepo rejects a PR ref whose URL names a repository other than the
+// one this adapter is configured for. An unparseable or repo-less URL is
+// tolerated: the check only fires on a URL that clearly identifies a different
+// owner/repo.
+func (a *Adapter) checkPRRefRepo(pr source.PullRequestRef) error {
+	if strings.TrimSpace(pr.URL) == "" {
+		return nil
+	}
+	u, err := url.Parse(pr.URL)
+	if err != nil {
+		return nil
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segs) < 2 || segs[0] == "" || segs[1] == "" {
+		return nil
+	}
+	// An API URL (/repos/<owner>/<repo>/pulls/N) carries the pair one level in.
+	if segs[0] == "repos" && len(segs) >= 3 {
+		segs = segs[1:]
+	}
+	if !strings.EqualFold(segs[0], a.owner) || !strings.EqualFold(segs[1], a.repo) {
+		return fmt.Errorf("github: pull request %s belongs to %s/%s, but source %q is configured for %s/%s: %w",
+			pr.URL, segs[0], segs[1], a.id, a.owner, a.repo, source.ErrUnsupported)
+	}
+	return nil
 }
 
 // ListPullRequests returns every pull request cross-referenced from the issue,

--- a/src/internal/source/github/pollci_pr_test.go
+++ b/src/internal/source/github/pollci_pr_test.go
@@ -1,0 +1,113 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// prCIServer stands up a GitHub API stub for PR 1961 (head SHA "abc") addressed
+// DIRECTLY by number — no issue and no timeline, which is exactly the situation
+// of a Jira-sourced task: nothing in this repo cross-references the work item.
+func prCIServer(t *testing.T, combinedStatus, checkRuns string) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/timeline"), strings.Contains(r.URL.Path, "/issues/"):
+			t.Errorf("issue endpoint %q hit: a PR-addressed check must not need the issue", r.URL.Path)
+			http.NotFound(w, r)
+		case strings.HasSuffix(r.URL.Path, "/pulls/1961"):
+			_, _ = w.Write([]byte(`{"number":1961,"html_url":"https://gh/pr/1961","head":{"sha":"abc"}}`))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/status"):
+			_, _ = w.Write([]byte(combinedStatus))
+		case strings.HasSuffix(r.URL.Path, "/commits/abc/check-runs"):
+			_, _ = w.Write([]byte(checkRuns))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+}
+
+// The whole point of #444: CI for a PR the adapter's own source never saw.
+func TestPollCIStatusForPR_GreenChecks(t *testing.T) {
+	a := prCIServer(t, `{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[{"name":"test","status":"completed","conclusion":"success"}]}`)
+
+	got, err := a.PollCIStatusForPR(context.Background(),
+		source.PullRequestRef{Number: 1961, URL: "https://github.com/o/r/pull/1961"})
+	if err != nil {
+		t.Fatalf("PollCIStatusForPR: %v", err)
+	}
+	if got.Status != "passed" {
+		t.Errorf("status = %q, want passed", got.Status)
+	}
+	if got.URL != "https://gh/pr/1961" {
+		t.Errorf("url = %q, want the PR html_url", got.URL)
+	}
+}
+
+// The conflict short-circuit is shared with the issue-addressed path, so it must
+// hold here too — a conflicting PR never becomes "pending forever".
+func TestPollCIStatusForPR_MergeConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/pulls/1961") {
+			_, _ = w.Write([]byte(`{"number":1961,"html_url":"https://gh/pr/1961","head":{"sha":"abc"},"mergeable_state":"dirty"}`))
+			return
+		}
+		t.Errorf("unexpected request %q after a dirty PR", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	a := &Adapter{id: "gh", owner: "o", repo: "r", client: newClient(srv.URL, "")}
+
+	got, err := a.PollCIStatusForPR(context.Background(), source.PullRequestRef{Number: 1961})
+	if err != nil {
+		t.Fatalf("PollCIStatusForPR: %v", err)
+	}
+	if got.Status != "conflict" {
+		t.Errorf("status = %q, want conflict", got.Status)
+	}
+}
+
+// A PR from another repository must be refused, not answered with this repo's
+// same-numbered PR — a wrong green light is worse than an error.
+func TestPollCIStatusForPR_RejectsForeignRepo(t *testing.T) {
+	a := prCIServer(t, `{}`, `{}`)
+
+	_, err := a.PollCIStatusForPR(context.Background(),
+		source.PullRequestRef{Number: 1961, URL: "https://github.com/other/project/pull/1961"})
+	if err == nil {
+		t.Fatal("PollCIStatusForPR on a foreign PR: want error, got nil")
+	}
+	if !errors.Is(err, source.ErrUnsupported) {
+		t.Errorf("error %v does not wrap ErrUnsupported — the engine would retry a permanent misconfiguration", err)
+	}
+}
+
+// A ref carrying no URL is trusted: the number is all the caller had.
+func TestPollCIStatusForPR_NoURLIsAccepted(t *testing.T) {
+	a := prCIServer(t, `{"state":"pending","total_count":0,"statuses":[]}`,
+		`{"check_runs":[{"name":"test","status":"in_progress"}]}`)
+
+	got, err := a.PollCIStatusForPR(context.Background(), source.PullRequestRef{Number: 1961})
+	if err != nil {
+		t.Fatalf("PollCIStatusForPR: %v", err)
+	}
+	if got.Status != "pending" {
+		t.Errorf("status = %q, want pending", got.Status)
+	}
+}
+
+func TestPollCIStatusForPR_RejectsZeroNumber(t *testing.T) {
+	a := prCIServer(t, `{}`, `{}`)
+	if _, err := a.PollCIStatusForPR(context.Background(), source.PullRequestRef{}); err == nil {
+		t.Fatal("want error for a ref with no PR number")
+	}
+}

--- a/src/internal/source/source.go
+++ b/src/internal/source/source.go
@@ -89,6 +89,24 @@ type CIStatusPoller interface {
 	PollCIStatus(ctx context.Context, cellID string) (CIStatus, error)
 }
 
+// PRCIStatusPoller is an optional interface a source may implement to check the
+// CI status of a pull request it hosts, addressed by the PR itself rather than
+// by one of the source's own items.
+//
+// It exists for the split setup where the issue tracker and the git forge are
+// different systems — a Jira- or Plane-sourced task whose agents open PRs on
+// GitHub. CIStatusPoller cannot serve that case: it takes a source item id and
+// resolves the PR from it, which only a forge that hosts BOTH can do. Here the
+// engine supplies the PR (linked to the task by pull_request_from) and the forge
+// named by the step's ci_source answers for it (#444).
+//
+// The ref carries the PR URL as well as its number: an adapter is configured for
+// exactly one repository and MUST reject a ref that belongs to another one,
+// rather than silently reporting some unrelated PR's checks.
+type PRCIStatusPoller interface {
+	PollCIStatusForPR(ctx context.Context, pr PullRequestRef) (CIStatus, error)
+}
+
 // PullRequestRef is one pull request linked to a source item (e.g. a PR that
 // cross-references a GitHub issue). State is best-effort and may be empty when
 // the source does not fetch it.

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -83,6 +83,11 @@ type dagRun struct {
 	waitDeadline time.Time
 }
 
+// waitTarget is the run's work item as a wait_for step addresses it.
+func (r *dagRun) waitTarget() WaitTarget {
+	return WaitTarget{TaskID: r.task.ID, SourceID: r.cell.SourceID, SourceItemID: r.cell.ID}
+}
+
 // initDAG builds the in-memory state for a workflow instance's step graph. The
 // execution view (cell) is projected from the task + its primary binding. seed
 // is inherited memory for a sub-workflow child; depth tracks nesting.
@@ -272,7 +277,7 @@ func (e *Engine) driveDAG(ctx context.Context, r *dagRun) dagOutcome {
 				case config.StepTypeWorkflow:
 					res = e.executeSubWorkflowStep(ctx, r.instID, step, r.task, r.bindings, memSnap, contribSnap, r.depth, r.wf.ID)
 				case config.StepTypeWaitFor:
-					res, _ = e.RunWaitStep(ctx, r.instID, step, r.cell.SourceID, r.cell.ID, waitDeadline)
+					res, _ = e.RunWaitStep(ctx, r.instID, step, r.waitTarget(), waitDeadline)
 				default: // StepTypeAgent
 					res = e.runStep(ctx, r.instID, step, r.cell, r.task, r.bindings, memSnap, r.wf.Env)
 				}

--- a/src/internal/workflow/dag_parallel.go
+++ b/src/internal/workflow/dag_parallel.go
@@ -158,7 +158,7 @@ func (e *Engine) runParallelChild(
 	case config.StepTypeAgent:
 		return e.runStep(ctx, instID, child, cell, task, bindings, memSnap, wfEnv)
 	case config.StepTypeWaitFor:
-		res, err := e.RunWaitStep(ctx, instID, child, cell.SourceID, cell.ID, waitDeadline)
+		res, err := e.RunWaitStep(ctx, instID, child, WaitTarget{TaskID: task.ID, SourceID: cell.SourceID, SourceItemID: cell.ID}, waitDeadline)
 		if err != nil {
 			aplog.Error("workflow: parallel child %q: wait_for step failed: %v", child.ID, err)
 			return StepResult{Success: false, Output: err.Error(), Err: err}

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -262,9 +262,37 @@ type ApprovalLifecycleProvider interface {
 // runs, threads workflow memory between steps, and applies side effects. In
 // Phase 2 it executes agent steps sequentially in declaration order (single-step
 // and linear chains); the DAG executor with splits/foreach arrives in Phase 3.
+// WaitTarget identifies the work item a wait_for step polls against: the task
+// itself plus the primary source binding it executes as. Both halves matter —
+// the source item is what a source-native check (CI resolved from an issue,
+// blockers of an issue) addresses, while the task is what carries cross-system
+// links such as its pull requests (#444).
+type WaitTarget struct {
+	TaskID       string
+	SourceID     string
+	SourceItemID string
+}
+
+// CIStatusRequest is one CI status question from a wait_for step. When
+// CISourceID is empty the task's own source answers for its item id (the
+// GitHub-sourced case). When set, that source is asked about the task's most
+// recently linked pull request instead, which is how a Jira-sourced task gets
+// the CI status of a PR living on a git forge.
+type CIStatusRequest struct {
+	TaskID       string
+	SourceID     string
+	SourceItemID string
+	CISourceID   string
+}
+
+// ErrPRNotLinked reports that a ci_source wait found no pull request linked to
+// the task yet. It is a "not yet", not a failure: the step stays pending until
+// a step reports its PR via pull_request_from (or the deadline elapses).
+var ErrPRNotLinked = errors.New("no pull request linked to the task")
+
 // CIStatusChecker is called by wait_for steps to check the current CI status of a PR/branch.
 // It returns a CIStatus or an error if the check fails (transient or permanent).
-type CIStatusChecker func(ctx context.Context, sourceID, sourceItemID string) (source.CIStatus, error)
+type CIStatusChecker func(ctx context.Context, req CIStatusRequest) (source.CIStatus, error)
 
 // DependencyChecker is called by wait_for steps with kind "dependency" to list
 // the task's upstream blockers. linkType is the step's blocker_link_type

--- a/src/internal/workflow/wait_ci_source_test.go
+++ b/src/internal/workflow/wait_ci_source_test.go
@@ -1,0 +1,110 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/source"
+)
+
+// ciSourceWorkflow waits on CI hosted by a source OTHER than the task's own —
+// the Jira-issue/GitHub-PR split (#444).
+func ciSourceWorkflow() config.WorkflowConfig {
+	return config.WorkflowConfig{ID: "impl", Steps: []config.StepConfig{
+		{ID: "implement", Agent: "backend-dev", PullRequestFrom: "pr_url"},
+		{ID: "check-ci", Type: config.StepTypeWaitFor, DependsOn: []string{"implement"},
+			WaitFor: &config.WaitForConfig{Kind: "ci", CISource: "github", CheckInterval: "30s", MaxDuration: "2h"}},
+		{ID: "review", Agent: "backend-dev", DependsOn: []string{"check-ci"}},
+	}}
+}
+
+// ciSourceEngine is waitForEngine with a checker that sees the whole request, so
+// a test can assert on what the engine asked for, not just what it got back.
+func ciSourceEngine(store Store, exec StepExecutor, clock *time.Time,
+	ci func(CIStatusRequest) (source.CIStatus, error)) *Engine {
+	var seq atomic.Int64
+	return NewEngine(baseCfg(), store, exec,
+		WithSideEffects(&fakeSide{}),
+		WithClock(func() time.Time { return *clock }),
+		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
+		WithCIStatusChecker(func(_ context.Context, req CIStatusRequest) (source.CIStatus, error) {
+			return ci(req)
+		}),
+	)
+}
+
+// The step's ci_source and the task id both reach the checker: without them the
+// daemon cannot find which forge to ask, or about which PR.
+func TestWaitCISource_RequestCarriesCISourceAndTask(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	var got CIStatusRequest
+	eng := ciSourceEngine(newFakeStore(), &fakeExecutor{}, &clock,
+		func(req CIStatusRequest) (source.CIStatus, error) {
+			got = req
+			return source.CIStatus{Status: "pending"}, nil
+		})
+
+	eng.RunInstance(context.Background(), ciSourceWorkflow(), model.InternalTask{ID: "task-1"})
+
+	if got.CISourceID != "github" {
+		t.Errorf("CISourceID = %q, want github (the step's ci_source)", got.CISourceID)
+	}
+	if got.TaskID != "task-1" {
+		t.Errorf("TaskID = %q, want task-1 — the PR is linked to the task, not to the source item", got.TaskID)
+	}
+}
+
+// A task whose PR has not been reported yet is NOT a failure: the wait parks and
+// keeps checking, exactly as it does while CI itself is pending.
+func TestWaitCISource_NoLinkedPRStaysParked(t *testing.T) {
+	store := newFakeStore()
+	clock := time.Unix(1000, 0)
+	linked := false
+	eng := ciSourceEngine(store, &fakeExecutor{}, &clock,
+		func(CIStatusRequest) (source.CIStatus, error) {
+			if !linked {
+				return source.CIStatus{}, fmt.Errorf("task t1: %w", ErrPRNotLinked)
+			}
+			return source.CIStatus{Status: "passed"}, nil
+		})
+
+	instID, success, _ := eng.RunInstance(context.Background(), ciSourceWorkflow(), model.InternalTask{ID: "t1"})
+	if success {
+		t.Fatal("instance reported success while no PR was linked yet")
+	}
+	if state := store.instances[instID].State; state != db.InstanceStateWaiting {
+		t.Fatalf("instance state = %q, want waiting — an unlinked PR must not fail the wait", state)
+	}
+
+	// Once a step reports the PR, the very next check advances the workflow.
+	linked = true
+	eng.CheckParkedWaits(context.Background())
+	if state := store.instances[instID].State; state != db.InstanceStateDone {
+		t.Errorf("instance state = %q, want done once the PR is linked and CI is green", state)
+	}
+}
+
+// A ci_source that cannot poll (missing source, wrong adapter) is permanent, so
+// the wait fails at once instead of polling a capability that will never appear.
+func TestWaitCISource_UnsupportedFailsImmediately(t *testing.T) {
+	store := newFakeStore()
+	clock := time.Unix(1000, 0)
+	eng := ciSourceEngine(store, &fakeExecutor{}, &clock,
+		func(CIStatusRequest) (source.CIStatus, error) {
+			return source.CIStatus{}, fmt.Errorf("ci_source %q is not a configured source: %w", "github", source.ErrUnsupported)
+		})
+
+	instID, success, _ := eng.RunInstance(context.Background(), ciSourceWorkflow(), model.InternalTask{ID: "t1"})
+	if success {
+		t.Fatal("a wait against an unusable ci_source must not pass")
+	}
+	if state := store.instances[instID].State; state == db.InstanceStateWaiting {
+		t.Error("instance parked on a permanently unsupported ci_source; want a terminal failure")
+	}
+}

--- a/src/internal/workflow/wait_park.go
+++ b/src/internal/workflow/wait_park.go
@@ -113,14 +113,14 @@ func (e *Engine) RecheckWait(ctx context.Context, instanceID string) (terminal b
 		return false
 	}
 	step, isWait := r.waitStepConfig()
-	sourceID, itemID := r.cell.SourceID, r.cell.ID
+	target := r.waitTarget()
 	deadline := r.waitDeadline
 	e.mu.Unlock()
 
 	if !isWait {
 		return false
 	}
-	res, _ := e.RunWaitStep(ctx, instanceID, step, sourceID, itemID, deadline)
+	res, _ := e.RunWaitStep(ctx, instanceID, step, target, deadline)
 	return !res.Pending
 }
 

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -34,7 +34,7 @@ func waitForEngine(cfg *config.Config, store Store, exec StepExecutor, side Side
 		WithSideEffects(side),
 		WithClock(func() time.Time { return *clock }),
 		WithIDGen(func(prefix string) string { return prefix + "-" + itoa(int(seq.Add(1))) }),
-		WithCIStatusChecker(func(_ context.Context, _, _ string) (source.CIStatus, error) {
+		WithCIStatusChecker(func(_ context.Context, _ CIStatusRequest) (source.CIStatus, error) {
 			return ci()
 		}),
 	)

--- a/src/internal/workflow/wait_step.go
+++ b/src/internal/workflow/wait_step.go
@@ -24,7 +24,7 @@ func (e *Engine) RunWaitStep(
 	ctx context.Context,
 	instID string,
 	step config.StepConfig,
-	sourceID, sourceItemID string,
+	target WaitTarget,
 	deadline time.Time,
 ) (StepResult, error) {
 	if step.WaitFor == nil {
@@ -34,9 +34,9 @@ func (e *Engine) RunWaitStep(
 	cfg := step.WaitFor
 	switch cfg.Kind {
 	case "", config.WaitKindCI:
-		return e.checkCIWaitStep(ctx, instID, step, sourceID, sourceItemID, deadline)
+		return e.checkCIWaitStep(ctx, instID, step, target, deadline)
 	case config.WaitKindDependency:
-		return e.checkDependencyWaitStep(ctx, instID, step, sourceID, sourceItemID, deadline)
+		return e.checkDependencyWaitStep(ctx, instID, step, target, deadline)
 	default:
 		return StepResult{}, fmt.Errorf("wait_for step %q unsupported kind: %q", step.ID, cfg.Kind)
 	}
@@ -49,7 +49,7 @@ func (e *Engine) checkCIWaitStep(
 	ctx context.Context,
 	instID string,
 	step config.StepConfig,
-	sourceID, sourceItemID string,
+	target WaitTarget,
 	deadline time.Time,
 ) (StepResult, error) {
 	if e.ciChecker == nil {
@@ -80,7 +80,20 @@ func (e *Engine) checkCIWaitStep(
 		}, nil
 	}
 
-	status, err := e.ciChecker(ctx, sourceID, sourceItemID)
+	status, err := e.ciChecker(ctx, CIStatusRequest{
+		TaskID:       target.TaskID,
+		SourceID:     target.SourceID,
+		SourceItemID: target.SourceItemID,
+		CISourceID:   cfg.CISource,
+	})
+	if errors.Is(err, ErrPRNotLinked) {
+		// The workflow waits on a PR that no step has reported yet (the forge is
+		// a different system from the source, so nothing else can discover it).
+		// That is a "not yet", not a failure: the deadline still bounds it.
+		aplog.Debug("wait_for step %q: no pull request linked to the task yet", step.ID)
+		e.recordCIPoll(ctx, instID, step.ID, "pending", "", "no pull request linked to the task yet")
+		return StepResult{Pending: true}, nil
+	}
 	if errors.Is(err, source.ErrUnsupported) {
 		// The source will never gain the capability by waiting: fail now with the
 		// cause named, rather than polling until max_duration with a WARN a
@@ -187,7 +200,7 @@ func (e *Engine) checkDependencyWaitStep(
 	ctx context.Context,
 	instID string,
 	step config.StepConfig,
-	sourceID, sourceItemID string,
+	target WaitTarget,
 	deadline time.Time,
 ) (StepResult, error) {
 	if e.depChecker == nil {
@@ -217,7 +230,7 @@ func (e *Engine) checkDependencyWaitStep(
 		return StepResult{Pending: true}, nil
 	}
 
-	blockers, err := e.depChecker(ctx, sourceID, sourceItemID, cfg.BlockerLinkType)
+	blockers, err := e.depChecker(ctx, target.SourceID, target.SourceItemID, cfg.BlockerLinkType)
 	if errors.Is(err, source.ErrUnsupported) {
 		return e.unsupportedWait(ctx, instID, step, "dependency", err), nil
 	}


### PR DESCRIPTION
Closes #444.

## The gap

`wait_for {kind: ci}` resolved its poller from the **task's own source binding**, so with Jira as the source and PRs on GitHub the step could never pass: Jira implements no `CIStatusPoller`, and GitHub's `PollCIStatus` starts from an *issue number in its own repo*. #425 made this fail loudly (terminal `ErrUnsupported` + a validate-time lint); it did not make it work.

## The fix

`wait_for.ci_source` names the configured source that hosts the PR:

```yaml
- id: implement
  agent: engineer
  output: {type: object, properties: {pr_url: {type: string}}, required: [pr_url]}
  pull_request_from: pr_url      # records the PR against the task

- id: check-ci
  type: wait_for
  wait_for:
    kind: ci
    ci_source: github            # poll THIS source, by PR number
    max_duration: 2h
```

The PR comes from `task_pull_requests` (populated by `pull_request_from` since #425) — newest row, so a rework lap waits on its new PR — and the named forge answers for it through a new optional adapter interface:

```go
type PRCIStatusPoller interface {
    PollCIStatusForPR(ctx context.Context, pr PullRequestRef) (CIStatus, error)
}
```

implemented by the GitHub adapter. Its PR→status half (conflict short-circuit, check-runs + combined-status aggregation) is extracted from `PollCIStatus` and shared, so both paths behave identically.

## Behaviour notes

- **No PR linked yet is pending, not a failure** (`workflow.ErrPRNotLinked`), so a wait may start before the PR exists; `max_duration` still bounds it.
- A missing or incapable `ci_source` wraps `source.ErrUnsupported` → the step fails at once with the cause recorded in the poll history, rather than polling a capability that will never appear.
- A PR URL from **another repository** is refused rather than answered with the configured repo's same-numbered PR (a wrong green light is worse than an error).
- `apiary validate`: with `ci_source` set the CI capability lint targets the *named* source instead of the task's own; it also rejects an unknown source id, a source whose adapter cannot poll a PR, and `ci_source` on `kind: dependency`.
- Unset `ci_source` keeps today's path byte for byte.

Internally `RunWaitStep` now takes a `WaitTarget{TaskID, SourceID, SourceItemID}` and the CI checker a `CIStatusRequest`, because the PR is linked to the *task*, not to the source item.

## Tests

- `internal/source/github`: PR-addressed green/pending/conflict, foreign-repo rejection (asserts it wraps `ErrUnsupported`), zero-number guard, and a stub that fails the test if the issue/timeline endpoints are touched.
- `internal/config`: delegation lints clean, unknown source, incapable source, `kind: dependency` rejection, plus the #425 behaviour without `ci_source` as a regression anchor.
- `internal/workflow`: the request carries `ci_source` + task id; an unlinked PR parks and then advances once linked; an unsupported `ci_source` fails terminally.
- `internal/daemon`: `pollCIForLinkedPR` picks the newest linked PR, returns `ErrPRNotLinked` with none, and wraps `ErrUnsupported` for unknown/incapable sources.

Full suite green (`go build ./... && go vet ./... && go test ./...`).

## Docs

New "Waiting on CI hosted elsewhere (`ci_source`)" section in `docs/workflows.md` (with the full Jira+GitHub config), updated Jira and GitHub source pages, and the JSON schema.
