### PR TITLE
feat(validate): check sources[].config keys against each adapter's declared schema

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,47 @@ Adapter details, API operations, and token permissions:
 - [GitHub source](github-source.md)
 - [Plane source](plane-source.md)
 
+### Accepted `config` keys
+
+`apiary validate` checks every `sources[].config` map against the keys the
+source type's adapter actually reads, and **fails** on an unknown key or a
+missing required one. A key the adapter never reads is a silent
+misconfiguration: the daemon starts, the source polls, and the setting simply
+never applies — writing `token:` instead of `api_key:` on a private GitHub repo
+polls anonymously, and GitHub answers `404`, so the symptom reads as a missing
+repository rather than as a credential that was never sent.
+
+| Type | Required | Optional |
+|---|---|---|
+| `github` | `repo` | `api_key`, `base_url` |
+| `plane` | `api_key`, `project`, `workspace` | `base_url` |
+| `jira` | `api_token`, `base_url`, `email` | `project`, `started_state` |
+| `prometheus` | `alertmanager_url` | `ack_via_silence`, `basic_auth_password`, `basic_auth_user`, `bearer_token`, `dispatch_by`, `max_new_per_poll`, `min_age`, `silence_duration` |
+| `dynatrace` | `api_token`, `base_url` | `lookback`, `max_new_per_poll`, `min_age` |
+| `plugin` | `plugin` | — |
+
+Near-misses get a suggestion, including the well-known synonyms that no edit
+distance would catch:
+
+```text
+✗ sources[0] "gh": config: unknown key "token" — did you mean "api_key"?
+  accepted keys for type "github": api_key, base_url, repo
+```
+
+Notes:
+
+- **A required key only has to be written**, not filled in.
+  `api_key: ${GITHUB_TOKEN}` on an unset variable still passes validation, so
+  `apiary validate` runs in a shell or CI job that does not hold the hive's
+  secrets. The missing credential surfaces when the daemon connects.
+- **`type: plugin` is not open-ended.** The only key it accepts is `plugin`,
+  the id of the bridged instance; a plugin's own settings live under
+  `plugins[].config` and are checked against the plugin manifest's JSON schema.
+  A setting placed on the source entry would be dropped, so it is rejected.
+- Upgrading can turn a previously accepted config into a validation error if it
+  carries stray or legacy keys. That is deliberate: those keys were doing
+  nothing.
+
 !!! tip "Use a label as the opt-in switch"
     Filtering on a label like `ai-ready` means nothing reaches the agents
     unless a human deliberately marked it. It's the simplest safety gate.

--- a/docs/dynatrace-source.md
+++ b/docs/dynatrace-source.md
@@ -47,6 +47,9 @@ workflows:
 | `min_age` | no | Flap dampener: a problem must have been open at least this long before it is ingested. Default `1m` |
 | `lookback` | no | How far back the poll's `from=` window reaches. The problems API defaults to the last 2 hours, which would hide older still-open problems, so the adapter always sends an explicit window. Default `720h` (30 days) |
 
+These are the only keys accepted; `apiary validate` rejects anything else (see
+[Accepted `config` keys](configuration.md#accepted-config-keys)).
+
 ### `filters`
 
 | Field | Description |

--- a/docs/github-source.md
+++ b/docs/github-source.md
@@ -28,6 +28,11 @@ sources:
 | `api_key` | no | — | GitHub personal access token (see permissions below) |
 | `base_url` | no | `https://api.github.com` | API base URL for GHES |
 
+These three are the only keys accepted; `apiary validate` rejects anything else
+(see [Accepted `config` keys](configuration.md#accepted-config-keys)). The token
+key is `api_key`, **not** `token`: a private repo polled without a token gets a
+`404` from GitHub, not a `401`, so the mistake reads as a missing repository.
+
 ### `filters`
 
 | Field | Description |

--- a/docs/jira-source.md
+++ b/docs/jira-source.md
@@ -33,6 +33,9 @@ sources:
 | `project` | no | Project key (e.g. `ERP`) or list of keys (`[ERP, OPS]`) to scope polling; recommended |
 | `started_state` | no | Status name Acknowledge transitions issues to on dispatch |
 
+These are the only keys accepted; `apiary validate` rejects anything else (see
+[Accepted `config` keys](configuration.md#accepted-config-keys)).
+
 If neither `project` nor `filters.jql` is set, the adapter polls every issue
 visible to the API user and logs a warning.
 

--- a/docs/plane-source.md
+++ b/docs/plane-source.md
@@ -29,6 +29,9 @@ sources:
 | `api_key` | yes | Plane API key |
 | `base_url` | no | Instance URL for self-hosted Plane (defaults to Plane cloud) |
 
+These are the only keys accepted; `apiary validate` rejects anything else (see
+[Accepted `config` keys](configuration.md#accepted-config-keys)).
+
 ### `filters`
 
 | Field | Description |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -362,6 +362,12 @@ sources:
       labels: ["severity=critical"]
 ```
 
+`plugin` is the **only** key the source entry accepts, and `apiary validate`
+rejects any other: the bridge forwards nothing from here to the plugin process.
+The plugin's own settings belong under `plugins[].config`, where they are
+checked against the manifest's JSON schema — a setting written on the source
+entry would be silently dropped.
+
 Methods (wire types in `sdk/plugin/source.go`):
 
 | Method | Payload → result |

--- a/docs/prometheus-source.md
+++ b/docs/prometheus-source.md
@@ -51,6 +51,9 @@ workflows:
 | `ack_via_silence` | no | When `true`, acknowledging a dispatched alert creates an Alertmanager silence for it, so it stops paging while an agent investigates. Default `false` (acknowledge is a no-op) |
 | `silence_duration` | no | How long an `ack_via_silence` silence lasts. Default `2h` |
 
+These are the only keys accepted; `apiary validate` rejects anything else (see
+[Accepted `config` keys](configuration.md#accepted-config-keys)).
+
 ### `filters`
 
 | Field | Description |

--- a/src/internal/cli/adapters.go
+++ b/src/internal/cli/adapters.go
@@ -32,6 +32,30 @@ func init() {
 		_, ok = a.(source.PREventPoller)
 		return ok
 	}
+	// Same pattern for the config-key lint: ask a fresh instance for the
+	// config schema it declares, so `apiary validate` rejects a key the
+	// adapter would never read instead of letting the source poll
+	// misconfigured.
+	config.SourceConfigSchema = func(sourceType string) (config.SourceSchema, bool) {
+		schema, ok := source.ConfigSchemaFor(sourceType)
+		if !ok {
+			return config.SourceSchema{}, false
+		}
+		out := config.SourceSchema{
+			Aliases:   schema.Aliases,
+			OpenEnded: schema.OpenEnded,
+			Keys:      make([]config.SourceSchemaKey, 0, len(schema.Keys)),
+		}
+		for _, k := range schema.Keys {
+			out.Keys = append(out.Keys, config.SourceSchemaKey{
+				Name:     k.Name,
+				Required: k.Required,
+				Secret:   k.Secret,
+				Desc:     k.Desc,
+			})
+		}
+		return out, true
+	}
 	// Same pattern for the write-capability lint: probe a fresh instance for
 	// the optional interfaces, so read-only sources (prometheus alerts) reject
 	// set_state/add_labels/approvals/wait_for-ci workflows at validation time.

--- a/src/internal/cli/source_config_schema_wiring_test.go
+++ b/src/internal/cli/source_config_schema_wiring_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+
+	// Register the real source adapters, as cmd/apiary does, so the schema
+	// probe in init() reads actual adapter declarations.
+	_ "github.com/orlandoburli/apiary/internal/source/dynatrace"
+	_ "github.com/orlandoburli/apiary/internal/source/github"
+	_ "github.com/orlandoburli/apiary/internal/source/jira"
+	_ "github.com/orlandoburli/apiary/internal/source/plane"
+	_ "github.com/orlandoburli/apiary/internal/source/pluginsource"
+	_ "github.com/orlandoburli/apiary/internal/source/prometheus"
+)
+
+// TestSourceConfigSchemaWiring_RealAdapters pins the key set every built-in
+// source declares. The lists are derived from each adapter's Connect; if a new
+// key is read there without being declared here, `apiary validate` would reject
+// a config that actually works, so this test is the place that breaks first.
+func TestSourceConfigSchemaWiring_RealAdapters(t *testing.T) {
+	if config.SourceConfigSchema == nil {
+		t.Fatal("config.SourceConfigSchema not wired by cli init()")
+	}
+
+	want := map[string]struct {
+		keys     []string
+		required []string
+	}{
+		"github": {
+			keys:     []string{"api_key", "base_url", "repo"},
+			required: []string{"repo"},
+		},
+		"plane": {
+			keys:     []string{"api_key", "base_url", "project", "workspace"},
+			required: []string{"api_key", "project", "workspace"},
+		},
+		"jira": {
+			keys:     []string{"api_token", "base_url", "email", "project", "started_state"},
+			required: []string{"api_token", "base_url", "email"},
+		},
+		"prometheus": {
+			keys: []string{"ack_via_silence", "alertmanager_url", "basic_auth_password", "basic_auth_user",
+				"bearer_token", "dispatch_by", "max_new_per_poll", "min_age", "silence_duration"},
+			required: []string{"alertmanager_url"},
+		},
+		"dynatrace": {
+			keys:     []string{"api_token", "base_url", "lookback", "max_new_per_poll", "min_age"},
+			required: []string{"api_token", "base_url"},
+		},
+		"plugin": {
+			keys:     []string{"plugin"},
+			required: []string{"plugin"},
+		},
+	}
+
+	for sourceType, exp := range want {
+		schema, ok := config.SourceConfigSchema(sourceType)
+		if !ok {
+			t.Errorf("%s: no config schema declared", sourceType)
+			continue
+		}
+		if schema.OpenEnded {
+			t.Errorf("%s: OpenEnded = true, want a closed key set", sourceType)
+		}
+		var keys, required []string
+		for _, k := range schema.Keys {
+			keys = append(keys, k.Name)
+			if k.Required {
+				required = append(required, k.Name)
+			}
+		}
+		if !sameSet(keys, exp.keys) {
+			t.Errorf("%s: keys = %v, want %v", sourceType, keys, exp.keys)
+		}
+		if !sameSet(required, exp.required) {
+			t.Errorf("%s: required keys = %v, want %v", sourceType, required, exp.required)
+		}
+	}
+
+	if _, ok := config.SourceConfigSchema("no-such-adapter"); ok {
+		t.Error("unknown source type reported a schema, want none (check skipped)")
+	}
+}
+
+// TestSourceConfigSchemaWiring_ValidateRejectsTokenTypo is the end-to-end
+// acceptance check for issue #441: `apiary validate` (cli wiring + real
+// adapters) must reject `token:` on a github source and point at `api_key`,
+// instead of letting every poll run unauthenticated.
+func TestSourceConfigSchemaWiring_ValidateRejectsTokenTypo(t *testing.T) {
+	cfg := &config.Config{
+		Version: "1",
+		Sources: []config.SourceConfig{{
+			ID:     "gh",
+			Type:   "github",
+			Config: map[string]any{"repo": "my-org/my-repo", "token": "ghp_secret"},
+		}},
+	}
+
+	var found string
+	for _, e := range cfg.Validate() {
+		if strings.Contains(e.Error(), `unknown key "token"`) {
+			found = e.Error()
+		}
+	}
+	if found == "" {
+		t.Fatalf("Validate() accepted config.token on a github source: %v", cfg.Validate())
+	}
+	for _, want := range []string{`sources[0] "gh"`, `did you mean "api_key"`, `accepted keys for type "github"`} {
+		if !strings.Contains(found, want) {
+			t.Errorf("error %q missing %q", found, want)
+		}
+	}
+	if strings.Contains(found, "ghp_secret") {
+		t.Errorf("error %q echoes the secret value", found)
+	}
+}
+
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, g := range got {
+		seen[g] = true
+	}
+	for _, w := range want {
+		if !seen[w] {
+			return false
+		}
+	}
+	return true
+}

--- a/src/internal/config/source_config_validate.go
+++ b/src/internal/config/source_config_validate.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SourceSchemaKey mirrors source.ConfigKey. The config package cannot import
+// the source package without inverting the dependency direction, so the cli
+// package translates the adapters' declarations into these types.
+type SourceSchemaKey struct {
+	Name     string
+	Required bool
+	Secret   bool
+	Desc     string
+}
+
+// SourceSchema mirrors source.ConfigSchema: the `sources[].config` keys one
+// source type's adapter actually reads.
+type SourceSchema struct {
+	Keys      []SourceSchemaKey
+	Aliases   map[string]string
+	OpenEnded bool
+}
+
+// SourceConfigSchema reports the declared config schema of a source type's
+// adapter. The cli package injects it (config cannot import the source package
+// without inverting the dependency direction). When nil — configs built in
+// code, isolated tests — the config-key check is skipped, mirroring
+// KnownAdapters. The second result is false for an unregistered source type or
+// an adapter that declares no schema; the check is then skipped for that source.
+var SourceConfigSchema func(sourceType string) (SourceSchema, bool)
+
+// keyNames returns the schema's key names, sorted, for error messages.
+func (s SourceSchema) keyNames() []string {
+	names := make([]string, 0, len(s.Keys))
+	for _, k := range s.Keys {
+		names = append(names, k.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// suggest returns the key the operator most likely meant, or "".
+//
+// The alias table is consulted first: `token` and `api_key` mean the same thing
+// to a human but are five edits apart, and that pair is the reason this check
+// exists. Edit distance then catches ordinary typos (`base_ul`, `repos`).
+func (s SourceSchema) suggest(key string) string {
+	norm := strings.ToLower(strings.TrimSpace(key))
+	if alias, ok := s.Aliases[norm]; ok {
+		return alias
+	}
+	best, bestDist := "", 0
+	for _, name := range s.keyNames() {
+		d := levenshtein(norm, name)
+		if d > editBudget(name) {
+			continue
+		}
+		if best == "" || d < bestDist {
+			best, bestDist = name, d
+		}
+	}
+	return best
+}
+
+// editBudget is how far a mistyped key may stray from a known one before the
+// suggestion becomes noise: one edit for short keys, two for longer ones.
+func editBudget(name string) int {
+	if len(name) <= 4 {
+		return 1
+	}
+	return 2
+}
+
+// levenshtein returns the edit distance between a and b.
+func levenshtein(a, b string) int {
+	ar, br := []rune(a), []rune(b)
+	prev := make([]int, len(br)+1)
+	cur := make([]int, len(br)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		cur[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(cur[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(br)]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// A required key is satisfied by being written at all: the check is that the
+// key exists, never that its value is non-empty. `api_key: ${GITHUB_TOKEN}`
+// expands to nothing whenever the variable is not exported, which YAML then
+// reads as a null value, and `apiary validate` must stay runnable in a shell
+// (or a CI job) that does not hold the hive's secrets. An unset variable is
+// still caught at daemon start, where the credential is actually used.
+
+// validateSourceConfig checks one source's `config` map against its adapter's
+// declared schema: unknown keys and missing required keys both fail, because a
+// source that polls with a key the adapter never reads runs misconfigured while
+// looking healthy.
+//
+// requiredHandledElsewhere names required keys whose absence Validate already
+// reports with a more specific message, so the operator does not see the same
+// problem twice.
+func validateSourceConfig(scope, sourceType string, cfg map[string]any, requiredHandledElsewhere map[string]bool) []error {
+	if SourceConfigSchema == nil || sourceType == "" {
+		return nil
+	}
+	schema, ok := SourceConfigSchema(sourceType)
+	if !ok {
+		return nil
+	}
+
+	accepted := fmt.Sprintf("accepted keys for type %q: %s", sourceType, strings.Join(schema.keyNames(), ", "))
+	known := map[string]bool{}
+	for _, k := range schema.Keys {
+		known[k.Name] = true
+	}
+
+	var errs []error
+
+	if !schema.OpenEnded {
+		unknown := make([]string, 0, len(cfg))
+		for key := range cfg {
+			if !known[key] {
+				unknown = append(unknown, key)
+			}
+		}
+		sort.Strings(unknown)
+		for _, key := range unknown {
+			if s := schema.suggest(key); s != "" {
+				errs = append(errs, fmt.Errorf("%s: config: unknown key %q — did you mean %q? %s", scope, key, s, accepted))
+				continue
+			}
+			errs = append(errs, fmt.Errorf("%s: config: unknown key %q; %s", scope, key, accepted))
+		}
+	}
+
+	for _, k := range schema.Keys {
+		if !k.Required || requiredHandledElsewhere[k.Name] {
+			continue
+		}
+		if _, present := cfg[k.Name]; present {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s: config: missing required key %q (%s); %s", scope, k.Name, k.Desc, accepted))
+	}
+
+	return errs
+}

--- a/src/internal/config/source_config_validate_test.go
+++ b/src/internal/config/source_config_validate_test.go
@@ -1,0 +1,178 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// githubSchema mirrors the real github adapter's declaration. The config
+// package cannot import the adapters (dependency direction), so the tests
+// inject a schema through the same hook the cli package uses; the adapters'
+// own declarations are covered by TestConfigSchemas_MatchConnect in the source
+// packages' test files.
+func githubSchema() SourceSchema {
+	return SourceSchema{
+		Keys: []SourceSchemaKey{
+			{Name: "repo", Required: true, Desc: `repository in "owner/repo" format`},
+			{Name: "api_key", Secret: true, Desc: "GitHub personal access token"},
+			{Name: "base_url", Desc: "API base URL, for GitHub Enterprise Server"},
+		},
+		Aliases: map[string]string{"token": "api_key"},
+	}
+}
+
+func withSourceSchemas(t *testing.T, schemas map[string]SourceSchema) {
+	t.Helper()
+	prev := SourceConfigSchema
+	SourceConfigSchema = func(sourceType string) (SourceSchema, bool) {
+		s, ok := schemas[sourceType]
+		return s, ok
+	}
+	t.Cleanup(func() { SourceConfigSchema = prev })
+}
+
+func sourceCfg(sourceType string, cfg map[string]any) *Config {
+	return &Config{
+		Version: "1",
+		Sources: []SourceConfig{{ID: "src", Type: sourceType, Config: cfg}},
+	}
+}
+
+func TestValidateSourceConfig(t *testing.T) {
+	schemas := map[string]SourceSchema{
+		"github": githubSchema(),
+		"passthrough": {
+			Keys:      []SourceSchemaKey{{Name: "endpoint", Required: true, Desc: "backend URL"}},
+			OpenEnded: true,
+		},
+	}
+
+	cases := []struct {
+		name     string
+		cfg      *Config
+		wantErr  string   // substring that must appear
+		wantNone []string // substrings that must NOT appear
+	}{
+		{
+			name:    "unknown key",
+			cfg:     sourceCfg("github", map[string]any{"repo": "o/r", "nonsense_key": "x"}),
+			wantErr: `unknown key "nonsense_key"`,
+		},
+		{
+			name:    "unknown key lists accepted keys",
+			cfg:     sourceCfg("github", map[string]any{"repo": "o/r", "nonsense_key": "x"}),
+			wantErr: `accepted keys for type "github": api_key, base_url, repo`,
+		},
+		{
+			name:    "alias suggestion token to api_key",
+			cfg:     sourceCfg("github", map[string]any{"repo": "o/r", "token": "ghp_x"}),
+			wantErr: `unknown key "token" — did you mean "api_key"?`,
+		},
+		{
+			name:    "edit-distance suggestion",
+			cfg:     sourceCfg("github", map[string]any{"repo": "o/r", "base_ul": "https://ghe"}),
+			wantErr: `unknown key "base_ul" — did you mean "base_url"?`,
+		},
+		{
+			name:    "missing required key",
+			cfg:     sourceCfg("github", map[string]any{"api_key": "ghp_x"}),
+			wantErr: `missing required key "repo"`,
+		},
+		{
+			// `repo: ${GH_REPO}` on an unset variable reads back as a null
+			// value; validate must stay runnable without the hive's secrets,
+			// so a written-but-empty key is not "missing".
+			name:     "empty value from an unset env var is not missing",
+			cfg:      sourceCfg("github", map[string]any{"repo": nil, "api_key": ""}),
+			wantNone: []string{"missing required key"},
+		},
+		{
+			name:     "valid config",
+			cfg:      sourceCfg("github", map[string]any{"repo": "o/r", "api_key": "ghp_x", "base_url": "https://ghe/api/v3"}),
+			wantNone: []string{"config:"},
+		},
+		{
+			name:     "open-ended type accepts unknown keys",
+			cfg:      sourceCfg("passthrough", map[string]any{"endpoint": "https://x", "whatever": 1}),
+			wantNone: []string{"unknown key"},
+		},
+		{
+			name:    "open-ended type still requires required keys",
+			cfg:     sourceCfg("passthrough", map[string]any{"whatever": 1}),
+			wantErr: `missing required key "endpoint"`,
+		},
+		{
+			name:     "unregistered source type is not checked",
+			cfg:      sourceCfg("mystery", map[string]any{"anything": 1}),
+			wantNone: []string{"unknown key", "missing required key"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withSourceSchemas(t, schemas)
+			errs := tc.cfg.Validate()
+			if tc.wantErr != "" && !hasErrContaining(errs, tc.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", errs, tc.wantErr)
+			}
+			for _, unwanted := range tc.wantNone {
+				if hasErrContaining(errs, unwanted) {
+					t.Errorf("Validate() = %v, want no error containing %q", errs, unwanted)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateSourceConfig_SkippedWhenHookNil mirrors the KnownAdapters
+// contract: a config built in code (no adapters registered) must not trip the
+// key check.
+func TestValidateSourceConfig_SkippedWhenHookNil(t *testing.T) {
+	prev := SourceConfigSchema
+	SourceConfigSchema = nil
+	t.Cleanup(func() { SourceConfigSchema = prev })
+
+	errs := sourceCfg("github", map[string]any{"token": "x"}).Validate()
+	if hasErrContaining(errs, "unknown key") {
+		t.Errorf("Validate() = %v, want no config-key errors when the hook is nil", errs)
+	}
+}
+
+// TestValidateSourceConfig_PluginRequiredNotDuplicated: the plugin bridge has a
+// dedicated "config.plugin is required" message; the generic required-key check
+// must not report the same problem a second time.
+func TestValidateSourceConfig_PluginRequiredNotDuplicated(t *testing.T) {
+	withSourceSchemas(t, map[string]SourceSchema{
+		"plugin": {Keys: []SourceSchemaKey{{Name: "plugin", Required: true, Desc: "plugin instance id"}}},
+	})
+
+	errs := sourceCfg("plugin", map[string]any{}).Validate()
+	var missing int
+	for _, err := range errs {
+		if strings.Contains(err.Error(), `missing required key "plugin"`) {
+			missing++
+		}
+	}
+	if missing != 0 {
+		t.Errorf("Validate() = %v, want the dedicated config.plugin message only", errs)
+	}
+	if !hasErrContaining(errs, "config.plugin is required") {
+		t.Errorf("Validate() = %v, want the dedicated config.plugin message", errs)
+	}
+}
+
+func TestSuggest(t *testing.T) {
+	schema := githubSchema()
+	cases := []struct{ key, want string }{
+		{"token", "api_key"},    // alias table: too far for edit distance
+		{"base_ul", "base_url"}, // one deletion
+		{"repos", "repo"},       // one insertion
+		{"REPO", "repo"},        // case-insensitive
+		{"completely_unrelated", ""},
+	}
+	for _, tc := range cases {
+		if got := schema.suggest(tc.key); got != tc.want {
+			t.Errorf("suggest(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -177,6 +177,18 @@ func (c *Config) Validate() []error {
 		}
 		sourceIDs[s.ID] = true
 
+		// A key the adapter never reads is a silent misconfiguration: the
+		// daemon starts, the source polls, and the setting simply does not
+		// apply (`token:` instead of `api_key:` polls GitHub anonymously).
+		// Reject it here, where it is still cheap to fix.
+		handledElsewhere := map[string]bool{}
+		if s.Type == "plugin" {
+			// The dedicated check below reports a missing config.plugin with a
+			// message that also explains what to point it at.
+			handledElsewhere["plugin"] = true
+		}
+		errs = append(errs, validateSourceConfig(fmt.Sprintf("sources[%d] %q", i, s.ID), s.Type, s.Config, handledElsewhere)...)
+
 		// A plugin-bridged source must name a declared, enabled plugin
 		// instance — the daemon resolves it at startup, but a broken
 		// reference should fail `apiary validate`, not the daemon.

--- a/src/internal/source/dynatrace/schema.go
+++ b/src/internal/source/dynatrace/schema.go
@@ -1,0 +1,26 @@
+package dynatrace
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "base_url", Required: true, Desc: "Dynatrace environment URL"},
+			{Name: "api_token", Required: true, Secret: true, Desc: "API token with the problems.read scope"},
+			{Name: "max_new_per_poll", Desc: "storm cap: max new problems dispatched per poll"},
+			{Name: "min_age", Desc: "flap dampener: minimum problem age before dispatch"},
+			{Name: "lookback", Desc: "how far back the problem query window reaches"},
+		},
+		Aliases: map[string]string{
+			"token":        "api_token",
+			"api_key":      "api_token",
+			"access_token": "api_token",
+			"url":          "base_url",
+			"api_url":      "base_url",
+			"environment":  "base_url",
+		},
+	}
+}

--- a/src/internal/source/github/schema.go
+++ b/src/internal/source/github/schema.go
@@ -1,0 +1,31 @@
+package github
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+//
+// api_key is optional on purpose: a public repository polls fine unauthenticated
+// (at 60 req/h). It is the alias table below that catches the motivating typo —
+// `token:` on a private repo, which GitHub answers with 404, not 401, so the
+// symptom reads as a missing repository rather than a credential never applied.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "repo", Required: true, Desc: `repository in "owner/repo" format`},
+			{Name: "api_key", Secret: true, Desc: "GitHub personal access token"},
+			{Name: "base_url", Desc: "API base URL, for GitHub Enterprise Server"},
+		},
+		Aliases: map[string]string{
+			"token":        "api_key",
+			"github_token": "api_key",
+			"api_token":    "api_key",
+			"access_token": "api_key",
+			"pat":          "api_key",
+			"repository":   "repo",
+			"url":          "base_url",
+			"api_url":      "base_url",
+		},
+	}
+}

--- a/src/internal/source/jira/schema.go
+++ b/src/internal/source/jira/schema.go
@@ -1,0 +1,30 @@
+package jira
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "base_url", Required: true, Desc: "Jira Cloud site URL"},
+			{Name: "email", Required: true, Desc: "Atlassian account email (Basic auth user)"},
+			{Name: "api_token", Required: true, Secret: true, Desc: "Atlassian API token"},
+			{Name: "project", Desc: "project key, or list of project keys, to scope polling"},
+			{Name: "started_state", Desc: "status the adapter moves an item to when work starts"},
+		},
+		Aliases: map[string]string{
+			"token":        "api_token",
+			"api_key":      "api_token",
+			"access_token": "api_token",
+			"username":     "email",
+			"user":         "email",
+			"projects":     "project",
+			"project_key":  "project",
+			"url":          "base_url",
+			"site":         "base_url",
+			"api_url":      "base_url",
+		},
+	}
+}

--- a/src/internal/source/plane/schema.go
+++ b/src/internal/source/plane/schema.go
@@ -1,0 +1,26 @@
+package plane
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "api_key", Required: true, Secret: true, Desc: "Plane API key"},
+			{Name: "workspace", Required: true, Desc: "workspace slug"},
+			{Name: "project", Required: true, Desc: "project id"},
+			{Name: "base_url", Desc: "API base URL, for self-hosted Plane"},
+		},
+		Aliases: map[string]string{
+			"token":          "api_key",
+			"api_token":      "api_key",
+			"access_token":   "api_key",
+			"workspace_slug": "workspace",
+			"project_id":     "project",
+			"url":            "base_url",
+			"api_url":        "base_url",
+		},
+	}
+}

--- a/src/internal/source/pluginsource/schema.go
+++ b/src/internal/source/pluginsource/schema.go
@@ -1,0 +1,24 @@
+package pluginsource
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+//
+// The bridge is deliberately NOT open-ended: nothing here is forwarded to the
+// plugin process. A plugin's own settings live under `plugins[].config` and are
+// checked against the plugin manifest's JSON schema, so a key placed here would
+// be silently dropped — exactly the failure this validation exists to prevent.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "plugin", Required: true, Desc: "id of an enabled plugins[] instance with the \"source\" capability"},
+		},
+		Aliases: map[string]string{
+			"plugin_id": "plugin",
+			"id":        "plugin",
+			"instance":  "plugin",
+		},
+	}
+}

--- a/src/internal/source/prometheus/schema.go
+++ b/src/internal/source/prometheus/schema.go
@@ -1,0 +1,34 @@
+package prometheus
+
+import "github.com/orlandoburli/apiary/internal/source"
+
+var _ source.ConfigSchemaProvider = (*Adapter)(nil)
+
+// ConfigSchema declares the `sources[].config` keys Connect reads.
+func (a *Adapter) ConfigSchema() source.ConfigSchema {
+	return source.ConfigSchema{
+		Keys: []source.ConfigKey{
+			{Name: "alertmanager_url", Required: true, Desc: "Alertmanager base URL"},
+			{Name: "bearer_token", Secret: true, Desc: "bearer token for Alertmanager"},
+			{Name: "basic_auth_user", Desc: "basic auth user for Alertmanager"},
+			{Name: "basic_auth_password", Secret: true, Desc: "basic auth password for Alertmanager"},
+			{Name: "max_new_per_poll", Desc: "storm cap: max new items dispatched per poll"},
+			{Name: "min_age", Desc: "flap dampener: minimum alert age before dispatch"},
+			{Name: "dispatch_by", Desc: `"alert" (default) or "group"`},
+			{Name: "ack_via_silence", Desc: "silence the alert while it is being investigated"},
+			{Name: "silence_duration", Desc: "how long an ack silence lasts"},
+		},
+		Aliases: map[string]string{
+			"url":                 "alertmanager_url",
+			"base_url":            "alertmanager_url",
+			"alertmanager":        "alertmanager_url",
+			"api_url":             "alertmanager_url",
+			"token":               "bearer_token",
+			"api_key":             "bearer_token",
+			"api_token":           "bearer_token",
+			"access_token":        "bearer_token",
+			"basic_auth_username": "basic_auth_user",
+			"basic_auth_pass":     "basic_auth_password",
+		},
+	}
+}

--- a/src/internal/source/schema.go
+++ b/src/internal/source/schema.go
@@ -1,0 +1,64 @@
+package source
+
+import "sort"
+
+// ConfigKey describes one key an adapter reads from a `sources[].config` map.
+//
+// The list is derived from the adapter's own Connect: a key the adapter never
+// reads must not be declared, because the whole point of the schema is that a
+// key accepted by validation is a key that actually takes effect.
+type ConfigKey struct {
+	Name     string // the YAML key, e.g. "api_key"
+	Required bool   // Connect fails without it
+	Secret   bool   // a credential; documented as such, never echoed in errors
+	Desc     string // short human description, used by docs/tests
+}
+
+// ConfigSchema is an adapter's declaration of the `sources[].config` keys it
+// understands. `apiary validate` rejects an unknown key (silent misconfiguration
+// — the daemon runs and does the wrong thing) and a missing required one.
+type ConfigSchema struct {
+	// Keys are every key the adapter reads.
+	Keys []ConfigKey
+
+	// Aliases maps a wrong-but-plausible key to the correct one, so validation
+	// can say "did you mean" where plain edit distance cannot: `token` and
+	// `api_key` are five edits apart but mean the same thing to a human.
+	Aliases map[string]string
+
+	// OpenEnded marks a source type that legitimately forwards arbitrary keys
+	// to something else. Unknown keys are then accepted; required keys are
+	// still enforced. No built-in source is open-ended today.
+	OpenEnded bool
+}
+
+// KeyNames returns the declared key names, sorted, for error messages and docs.
+func (s ConfigSchema) KeyNames() []string {
+	names := make([]string, 0, len(s.Keys))
+	for _, k := range s.Keys {
+		names = append(names, k.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ConfigSchemaProvider is an optional interface an adapter implements to declare
+// its config schema. Adapters that do not implement it are not config-validated.
+type ConfigSchemaProvider interface {
+	ConfigSchema() ConfigSchema
+}
+
+// ConfigSchemaFor returns the declared config schema for a source type. The
+// second result is false when the type is unregistered or its adapter declares
+// no schema.
+func ConfigSchemaFor(sourceType string) (ConfigSchema, bool) {
+	a, ok := New(sourceType)
+	if !ok {
+		return ConfigSchema{}, false
+	}
+	p, ok := a.(ConfigSchemaProvider)
+	if !ok {
+		return ConfigSchema{}, false
+	}
+	return p.ConfigSchema(), true
+}


### PR DESCRIPTION
## ⚠️ Breaking change — read first

`apiary validate` now **fails** on a `sources[].config` key that the source
type's adapter does not read, and on a missing required key. A hive carrying
stray or legacy keys under `sources[].config` will stop validating after
upgrading. That is deliberate — those keys were doing nothing — but it needs
the same release-note call-out #443 got.

The fix is always the same: delete the stray key, or rename it to the one the
error names.

## Problem

`sources[].config` was a free-form map, so a mistyped key was accepted
silently and the source ran misconfigured while looking healthy.

The reporter of #429 hit exactly this: `token:` instead of `api_key:` on a
`github` source meant every poll ran unauthenticated. Because GitHub answers
`404` (not `401`) for a private repo, the symptom read as a missing repository
rather than as a credential that was never applied — real debugging time spent
on the wrong hypothesis.

## What this does

Each source adapter now **declares the config keys it reads**, derived from its
own `Connect`:

```go
// internal/source/schema.go
type ConfigKey struct{ Name string; Required, Secret bool; Desc string }
type ConfigSchema struct{ Keys []ConfigKey; Aliases map[string]string; OpenEnded bool }
type ConfigSchemaProvider interface{ ConfigSchema() ConfigSchema }
```

The schema reaches the `config` package through a `cli`-injected hook
(`config.SourceConfigSchema`) — the same dependency inversion
`config.KnownAdapters` and `config.SourceCapabilities` already use, so there is
one mechanism, not two. When the hook is nil (configs built in code, isolated
tests) or the source type declares no schema, the check is skipped.

`apiary validate` then rejects:

```text
✗ sources[0] "gh": config: unknown key "token" — did you mean "api_key"?
  accepted keys for type "github": api_key, base_url, repo

✗ sources[1] "board": config: missing required key "workspace" (workspace slug);
  accepted keys for type "plane": api_key, base_url, project, workspace
```

Suggestions come from an **alias table first**, then edit distance: `token` and
`api_key` are five edits apart, so no distance metric would ever pair them, and
that pair is the motivating case. Edit distance still catches ordinary typos
(`base_ul` → `base_url`, `repos` → `repo`).

### Keys per source type

Derived from each adapter's `Connect` (not guessed), and pinned by a test:

| Type | Required | Optional | Source of truth |
|---|---|---|---|
| `github` | `repo` | `api_key`, `base_url` | `source/github/adapter.go:54-70` |
| `plane` | `api_key`, `project`, `workspace` | `base_url` | `source/plane/adapter.go:60-74` |
| `jira` | `api_token`, `base_url`, `email` | `project`, `started_state` | `source/jira/adapter.go:61-85` |
| `prometheus` | `alertmanager_url` | `ack_via_silence`, `basic_auth_password`, `basic_auth_user`, `bearer_token`, `dispatch_by`, `max_new_per_poll`, `min_age`, `silence_duration` | `source/prometheus/adapter.go:130-185` |
| `dynatrace` | `api_token`, `base_url` | `lookback`, `max_new_per_poll`, `min_age` | `source/dynatrace/adapter.go:82-120` |
| `plugin` | `plugin` | — | `source/pluginsource/adapter.go:84-100` |

These match the tables already in `docs/*-source.md`, which is a good sign the
docs were right and only the enforcement was missing.

### `type: plugin` is **not** open-ended (verified)

`pluginsource.Connect` reads `cfg["plugin"]` and nothing else, and the
dispatcher hands the adapter only `sc.Config` — nothing from the source entry
is forwarded to the plugin process. A plugin's own settings live under
`plugins[].config`, checked against the manifest's JSON schema. So a setting
written on the source entry would be silently dropped, which is precisely the
failure this PR exists to prevent: the key set is closed and documented as
such. The `OpenEnded` flag exists in the schema type for a future adapter that
genuinely proxies arbitrary keys; no built-in source uses it today.

### A required key only has to be *written*, not filled in

`api_key: ${GITHUB_TOKEN}` on an unset variable expands to nothing and YAML
reads it back as `null`. Failing on that would make `apiary validate`
unrunnable in any shell or CI job that does not hold the hive's secrets, so the
check is key-presence only. The missing credential still surfaces at daemon
start, where it is actually used.

## Examples

All four shipped configs (`.apiary/example-*.yaml` plus `.apiary/apiary.yaml`)
validate unchanged — no example needed fixing. `TestExampleConfigsValidate`
covers this.

## Tests

New:

- `internal/config/source_config_validate_test.go` — unknown key, accepted-key
  list in the message, `token` → `api_key` alias suggestion, edit-distance
  suggestion, missing required key, valid config, open-ended type (accepts
  unknown keys but still enforces required ones), unregistered type skipped,
  hook-nil skipped, no duplicate message for the plugin bridge, `suggest()`
  unit cases.
- `internal/cli/source_config_schema_wiring_test.go` — pins the real per-adapter
  key sets through the wired hook (breaks first if an adapter starts reading a
  key it does not declare), plus the end-to-end acceptance check: `Validate()`
  rejects `token:` on a github source, names the source and `api_key`, and does
  not echo the secret value.

```
$ cd src && go build ./... && go test ./...
ok  	github.com/orlandoburli/apiary/internal/cli	0.599s
ok  	github.com/orlandoburli/apiary/internal/config	0.276s
ok  	github.com/orlandoburli/apiary/internal/source	...
ok  	github.com/orlandoburli/apiary/internal/source/{dynatrace,github,jira,plane,pluginsource,prometheus}
... all packages ok, no failures
```

## Docs

- `docs/configuration.md` — new **Accepted `config` keys** section: the full
  per-type table, the error format, the env-var/required-key rule, the
  `type: plugin` exemption note, and the breaking-change warning.
- `docs/github-source.md` — calls out `api_key` vs `token` and the 404-not-401
  trap.
- `docs/plane-source.md`, `docs/jira-source.md`, `docs/prometheus-source.md`,
  `docs/dynatrace-source.md` — "these are the only keys accepted" pointer.
- `docs/plugins.md` — `plugin` is the only accepted key on the source entry;
  plugin settings belong under `plugins[].config`.

Closes #441
