### PR TITLE
feat(sdk): conformance kit for the plugin protocol, plus a Python SDK

### DIFF
--- a/.github/workflows/plugin-conformance.yml
+++ b/.github/workflows/plugin-conformance.yml
@@ -1,0 +1,62 @@
+name: plugin-conformance
+
+# Runs the language-agnostic plugin protocol conformance kit against every
+# plugin implementation the repository ships — the Go and Python SDKs, the
+# in-tree Bash and Node example plugins, and the hand-rolled Python/Rust/Bash
+# examples extracted from the docs. A documented snippet that drifts out of
+# conformance fails here instead of quietly misleading a reader.
+on:
+  pull_request:
+    paths:
+      - "sdk/**"
+      - "src/examples/plugins/**"
+      - "docs/plugins.md"
+      - "docs/plugin-sdk.md"
+      - ".github/workflows/plugin-conformance.yml"
+  push:
+    branches: [main]
+    paths:
+      - "sdk/**"
+      - "src/examples/plugins/**"
+      - "docs/plugins.md"
+      - "docs/plugin-sdk.md"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # ubuntu-latest ships jq and a Rust toolchain; the kit skips anything
+      # that turns out to be missing rather than failing the run.
+      - name: Build the Node example plugin
+        working-directory: src/examples/plugins/source-node
+        run: npm install && npm run build
+
+      - name: Go SDK unit tests
+        working-directory: sdk
+        run: go test ./...
+
+      - name: Python SDK unit tests
+        working-directory: sdk/python
+        run: python3 -m unittest discover -s tests
+
+      - name: Conformance kit
+        run: sdk/conformance/check-examples.sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,15 @@ version: 2
 
 project_name: apiary
 
+git:
+  # The SDK module is tagged `sdk/vX.Y.Z`, independently of the daemon's
+  # `vX.Y.Z`. Left alone, `git describe` picks whichever is nearest, and an
+  # SDK tag makes the derived version `sdk/v1.0.0-…` — a slash Docker rejects
+  # as an image tag ("invalid reference format"). Daemon releases are the only
+  # thing this config builds, so it only ever looks at `v*` tags.
+  ignore_tags:
+    - "sdk/*"
+
 before:
   hooks:
     - sh -c "cd src && go mod tidy"

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,18 @@ install: ## Install apiary to $$GOPATH/bin (makes it available on PATH)
 # ── test ───────────────────────────────────────────────────────────────────────
 
 .PHONY: test
-test: ## Run all tests (daemon module + SDK module)
+test: ## Run all tests (daemon module + Go SDK module + Python SDK)
 	cd $(SDK) && go test ./...
 	cd $(SRC) && go test ./...
+	cd $(SDK)/python && python3 -m unittest discover -s tests
+
+.PHONY: test-python
+test-python: ## Run the Python SDK's unit tests (stdlib only)
+	cd $(SDK)/python && python3 -m unittest discover -s tests
+
+.PHONY: conformance
+conformance: ## Run the plugin protocol conformance kit against every example we ship
+	$(SDK)/conformance/check-examples.sh
 
 .PHONY: test-verbose
 test-verbose: ## Run all tests with per-test output

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -2,9 +2,31 @@
 
 Plugins talk to Apiary over a deliberately small JSON protocol (see
 [Protocol version 1](plugins.md#protocol-version-1)), so a plugin can be
-written in **any language**. For Go there is an official SDK that handles the
-protocol envelope for you; for everything else this page specifies exactly
-what your code — or an SDK you build for your language — must do.
+written in **any language**. Official SDKs handle the protocol envelope for you
+in **Go** and **Python**; for everything else this page specifies exactly what
+your code — or an SDK you build for your language — must do, and the
+[conformance kit](#the-conformance-kit) checks that it does.
+
+## Versioning and the protocol
+
+**Every SDK version tracks the protocol, not the Apiary release.** The daemon
+and the SDKs move on separate schedules and are versioned separately; what
+binds them is the wire protocol a given SDK speaks. Any SDK whose protocol
+version matches the daemon's is compatible — so pin whichever versions you
+like.
+
+| Artifact | Version scheme | Current |
+|---|---|---|
+| Go SDK (`github.com/orlandoburli/apiary/sdk`) | tag `sdk/vX.Y.Z` | `sdk/v1.x` → protocol 1 |
+| Python SDK (`apiary-plugin`, in `sdk/python`) | `X.Y.Z` | `1.x` → protocol 1 |
+| Apiary daemon | tag `vX.Y.Z` | see [releases](https://github.com/orlandoburli/apiary/releases) |
+
+An SDK stays on major version 1 for as long as protocol 1 is what it speaks;
+a future protocol bump gets its own SDK major version (for Go, `sdk/v2.x` with
+import path `github.com/orlandoburli/apiary/sdk/v2`; for Python,
+`apiary-plugin` 2.x). Within a protocol, SDK patch and minor releases are
+additive and safe to upgrade. Any SDK you write for another language should
+follow the same rule.
 
 ## Go SDK
 
@@ -25,23 +47,10 @@ in `sdk/` at the repository root), separate from the daemon module. Depending
 on it pulls in **nothing but the standard library** — none of the daemon's
 dependency graph.
 
-### Versioning and the protocol
-
-The SDK is tagged independently of the daemon:
-
-| Tag | Module | Example |
-|---|---|---|
-| `sdk/vX.Y.Z` | the SDK (`github.com/orlandoburli/apiary/sdk`) | `sdk/v1.0.0` → `go get github.com/orlandoburli/apiary/sdk@v1.0.0` |
-| `vX.Y.Z` | the Apiary daemon release | `v0.18.2` |
-
-So an SDK version does **not** track the daemon version — pin whichever you
-like, they move on separate schedules. What binds them is
-`pluginsdk.ProtocolVersion`, the wire protocol the SDK speaks: any SDK
-version whose `ProtocolVersion` matches the daemon's is compatible. Protocol 1
-is current, and the SDK stays on `sdk/v1.x` for as long as protocol 1 is what
-it speaks; a future protocol bump gets its own SDK major version
-(`sdk/v2.x`, import path `github.com/orlandoburli/apiary/sdk/v2`). Within a
-protocol, SDK patch and minor releases are additive and safe to upgrade.
+The tag `sdk/vX.Y.Z` releases it, independently of the daemon's `vX.Y.Z` —
+`sdk/v1.0.0` is fetched as `go get github.com/orlandoburli/apiary/sdk@v1.0.0`.
+The constant `pluginsdk.ProtocolVersion` is the protocol it speaks; see
+[Versioning and the protocol](#versioning-and-the-protocol).
 
 ### Entry points
 
@@ -154,9 +163,89 @@ echo '{"protocol":1,"request_id":"t1","capability":"source","method":"poll","con
 In Go tests, drive `ServeOne` with a `strings.Reader` and a `bytes.Buffer` —
 no subprocess needed.
 
+## Python SDK
+
+Import path:
+
+```python
+from apiary_plugin import CAPABILITY_SOURCE, PluginError, Request, main
+from apiary_plugin.source import SOURCE_METHOD_POLL, SourceItem, SourceOKResult, SourcePollResult
+```
+
+Install it from a checkout — the package lives in `sdk/python` and is **not
+published to PyPI**:
+
+```bash
+pip install ./sdk/python
+```
+
+Like the Go SDK it depends on **nothing but the standard library**, and its
+version tracks the protocol (`apiary-plugin` 1.x speaks protocol 1) — see
+[Versioning and the protocol](#versioning-and-the-protocol).
+
+### Entry points
+
+| Symbol | Purpose |
+|---|---|
+| `main(handler)` | Call from `__main__`: serves one request on stdin/stdout, reports transport failures on stderr, exits 2 on them |
+| `serve_one(handler, stdin=…, stdout=…)` | The engine behind `main`, with injectable streams — use it in tests |
+| `Request` | The decoded envelope: `protocol`, `request_id`, `capability`, `method`, `config`, `payload` |
+| `PluginError(code, message)` | **Raise** it to return an error response; both fields must be non-empty (the constructor enforces it) |
+| `TransportError` | The stream itself was unusable, so no response can be delivered — distinct from a *delivered* error |
+| `apiary_plugin.source` | Typed mirrors of `sdk/plugin/source.go`: `SourceItem`, `SourcePollRequest`/`SourcePollResult`, `SourceAckRequest`, `SourceWriteResultRequest`, `SourceOKResult`, and the method-name constants |
+
+Where the Go SDK returns `(result, *ResponseError)`, the Python SDK returns the
+result and raises `PluginError` — the same dichotomy in idiomatic Python.
+Anything with a `to_dict()` (every typed mirror) encodes itself, and empty
+optional fields are dropped exactly as the Go structs' `omitempty` drops them,
+so both SDKs put the same bytes on the wire.
+
+### A complete source plugin in Python
+
+This is the bundled example (`sdk/python/examples/source_file.py`), trimmed to
+its essence — the same behaviour as the Go `source-file` plugin:
+
+```python
+#!/usr/bin/env python3
+import json
+
+from apiary_plugin import CAPABILITY_SOURCE, PluginError, Request, main
+from apiary_plugin.source import (
+    SOURCE_METHOD_ACKNOWLEDGE, SOURCE_METHOD_POLL, SOURCE_METHOD_WRITE_RESULT,
+    SourceItem, SourceOKResult, SourcePollResult,
+)
+
+
+def handle(request: Request):
+    if request.capability != CAPABILITY_SOURCE:
+        raise PluginError("unsupported_capability", "expected capability source")
+    if request.method == SOURCE_METHOD_POLL:
+        path = request.config.get("path")
+        if not isinstance(path, str) or path == "":
+            raise PluginError("invalid_config", "config.path is required")
+        try:
+            with open(path, encoding="utf-8") as handle_:
+                items = json.load(handle_)
+        except FileNotFoundError:
+            return SourcePollResult(items=[])          # no file yet means no work yet
+        except (OSError, ValueError) as err:
+            raise PluginError("read_failed", str(err)) from err
+        return SourcePollResult(items=[SourceItem.from_dict(item) for item in items])
+    if request.method in (SOURCE_METHOD_ACKNOWLEDGE, SOURCE_METHOD_WRITE_RESULT):
+        return SourceOKResult()
+    raise PluginError("unsupported_method", f"unknown method {request.method}")
+
+
+main(handle)
+```
+
+Make it executable, pair it with a manifest declaring
+`"capabilities": ["source"]`, and [install it](plugins.md#installing-a-plugin)
+like any other plugin.
+
 ## Other languages
 
-There is no official SDK outside Go yet (tracked in
+TypeScript/Node and Rust SDKs are still open (tracked in
 [#367](https://github.com/orlandoburli/apiary/issues/367)) — but none is
 required. Complete installable examples ship in `src/examples/plugins/`:
 `source-bash` (shell script, no build step) and `source-node`
@@ -178,9 +267,15 @@ set -euo pipefail
 
 req=$(cat)                                       # the single request, stdin → EOF
 request_id=$(jq -r '.request_id' <<<"$req")
+protocol=$(jq -r '.protocol' <<<"$req")
 method=$(jq -r '.method' <<<"$req")
 
 respond() { jq -nc --arg id "$request_id" "{protocol: 1, request_id: \$id} + $1"; }
+
+if [[ "$protocol" != "1" ]]; then                # refuse, don't serve, on mismatch
+  respond '{error: {code: "unsupported_protocol", message: "expected protocol 1"}}'
+  exit 0
+fi
 
 case "$method" in
   poll)
@@ -203,9 +298,11 @@ esac
 
 Real-world versions swap the hard-coded item for `curl`/`jq` against whatever
 API you monitor. Mind stdout purity: every `echo` that isn't the response must
-go to stderr (`>&2`). A complete, installable Bash plugin (config handling,
-error responses, file-backed items) ships as
-`src/examples/plugins/source-bash`.
+go to stderr (`>&2`). Trimmed for the page, this one skips the `capability`
+check; a plugin that may be asked for more than one capability should switch on
+it too, the way `src/examples/plugins/source-bash` does — a complete,
+installable Bash plugin with config handling, error responses and file-backed
+items.
 
 ### Rust example
 
@@ -283,3 +380,63 @@ minimal SDK must:
 
 Keep it stateless — the process serves one request and exits, so an SDK needs
 no connection handling, retries, or lifecycle management.
+
+## The conformance kit
+
+You do not have to take those seven rules on trust, and you should not have to
+discover a violation from a daemon log. `sdk/conformance/` is a
+**language-agnostic golden corpus**: JSON request fixtures plus the
+expectations each response must meet, one case per rule, driven against any
+plugin executable as a subprocess over stdin/stdout. The Go SDK, the Python
+SDK, a Bash script and a Rust binary are all validated by the same corpus.
+
+Point it at your plugin:
+
+```bash
+python3 sdk/conformance/run.py -- ./my-plugin
+```
+
+If your plugin needs configuration, pass the `config:` block the host would
+have supplied from `apiary.yaml`:
+
+```bash
+python3 sdk/conformance/run.py \
+  --config '{"path":"sdk/conformance/fixtures/items.json"}' \
+  -- ./my-plugin
+```
+
+```text
+  PASS  poll-result-shape        rules 1,3,4,5,6,7
+  PASS  protocol-mismatch        rules 2
+  …
+  10/10 cases passed
+```
+
+The runner needs nothing but `python3` — no pip install, no virtualenv — and
+your plugin needs nothing but the ability to be executed, so the kit is the
+same amount of work in every ecosystem. Each case names the rules it enforces,
+so a failure points at the paragraph above that it violates; cases marked
+`[should]` are advisory and warn instead of failing. `make conformance` runs
+the whole corpus against every plugin this repository ships, **including the
+Python, Rust and Bash examples extracted from these docs** — a documented
+snippet that drifts out of conformance fails CI rather than quietly misleading
+a reader.
+
+For the full case list and how to add one, see
+[`sdk/conformance/README.md`](https://github.com/orlandoburli/apiary/blob/main/sdk/conformance/README.md).
+
+### If you are writing a new-language SDK
+
+1. Write the thinnest possible envelope wrapper and one example plugin that
+   answers `poll`, `acknowledge` and `write_result` — the Python SDK's
+   `sdk/python/examples/source_file.py` is the shape to copy.
+2. Run the kit against that example until it is 10/10. Every rule has at least
+   one case, so a green run is a real statement about the implementation, not
+   a smoke test.
+3. Mirror the typed source structs (rule 7). The corpus checks the wire shape
+   your mirrors produce: stable non-empty `id`, RFC3339 timestamps, string
+   `key:value` labels, no duplicate ids in one poll.
+4. Version it against the **protocol**, per
+   [Versioning and the protocol](#versioning-and-the-protocol).
+5. Add it to `sdk/conformance/check-examples.sh` so it is checked on every
+   change to the protocol, the docs or the SDKs.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -319,8 +319,10 @@ else:
 ```
 
 Make it executable, name it in a manifest with `"capabilities": ["source"]`,
-and it installs like any other plugin. Go authors get all of the envelope
-handling for free from the SDK — see below.
+and it installs like any other plugin. Go and Python authors get all of the
+envelope handling for free from the [official SDKs](plugin-sdk.md), and any
+plugin — hand-rolled or not — can be checked against the
+[conformance kit](plugin-sdk.md#the-conformance-kit).
 
 Capability method vocabulary:
 

--- a/sdk/conformance/README.md
+++ b/sdk/conformance/README.md
@@ -1,0 +1,112 @@
+# Plugin protocol conformance kit
+
+A language-agnostic test corpus for Apiary's plugin protocol (version 1).
+
+Protocol 1 is small enough to implement by hand in any language, which is the
+point — but "small" is not "obvious", and every implementation gets the same
+handful of details wrong. This kit turns the seven contract rules from
+[Writing an SDK for your language](../../docs/plugin-sdk.md#writing-an-sdk-for-your-language)
+into golden request fixtures plus the expectations each response must meet,
+and runs them against **any plugin executable** as a subprocess over
+stdin/stdout. Go SDK, Python SDK, a Bash script, a Rust binary — same corpus,
+same verdict.
+
+## Run it
+
+```bash
+python3 sdk/conformance/run.py -- ./my-plugin
+```
+
+Against a plugin that needs configuration, pass the `config:` block that the
+host would have supplied from `apiary.yaml`:
+
+```bash
+python3 sdk/conformance/run.py \
+  --config '{"path":"sdk/conformance/fixtures/items.json"}' \
+  -- ./my-plugin
+```
+
+| Option | Effect |
+|---|---|
+| `--config JSON` | merged into every request's `config` block |
+| `--case NAME` | run one case (repeatable) |
+| `--name LABEL` | label for the report header |
+| `--cwd DIR` | working directory for the plugin subprocess |
+| `--verbose` | dump each case's stdout/stderr/exit code |
+| `--json` | machine-readable report |
+
+Exit status is 0 when every `must` case passes. `should` cases are advisory:
+they surface as warnings and never fail the run.
+
+The runner needs nothing but `python3` — no pip install, no virtualenv. The
+plugin under test needs nothing but the ability to be executed.
+
+## Check everything this repo ships
+
+```bash
+make conformance
+```
+
+`check-examples.sh` runs the corpus against the Go SDK's example plugin, the
+Python SDK's example plugin, the in-tree Bash and Node plugins, and the
+hand-rolled Python/Rust/Bash examples **extracted from the docs** — so a
+documented snippet that drifts out of conformance fails the build instead of
+quietly misleading a reader. Missing toolchains (no Node, no Rust) are skipped
+with a notice rather than failing.
+
+## What the corpus covers
+
+| Case | Rules | Checks |
+|---|---|---|
+| `poll-result-shape` | 1,3,4,5,6,7 | a well-formed `source.poll` returns exactly one JSON object, protocol 1, id echoed, one of result/error, exit 0; a result mirrors `SourcePollResult` (items array, non-empty stable `id`, RFC3339 timestamps, string labels, no duplicate ids) |
+| `protocol-mismatch` | 2 | protocol 99 is refused with error code exactly `unsupported_protocol` — not a crash, not a result |
+| `protocol-zero` | 2 | protocol 0 (the zero value of a dropped field) is refused the same way |
+| `request-id-verbatim` | 3 | an id with spaces, punctuation and non-ASCII comes back byte for byte |
+| `acknowledge-ok` | 4,5,6 | `source.acknowledge` answers with a result, conventionally `{"ok": true}` |
+| `write-result-ok` | 4,5,6 | same for `source.write_result` |
+| `unknown-method` | 5,6 | an unknown method is a reported error with non-empty `code`+`message`, still exit 0 |
+| `unknown-capability` *(should)* | 5,6 | a capability the plugin does not implement should be refused, not served by whichever method handler happens to match |
+| `trailing-data` | 1 | a second object glued onto the stream must never produce a success result |
+| `empty-stdin` | 1,4 | an empty stream carries no request, so no result may be invented |
+
+Stdout purity (rule 4) is enforced on **every** case, not just its own: each
+response is parsed strictly, and anything besides exactly one JSON object —
+a stray `print`, a banner, a second line — fails the case.
+
+## Add a case
+
+Drop a JSON file in `cases/`. The runner reads them in filename order.
+
+```json
+{
+  "name": "my-case",
+  "rules": [5],
+  "level": "must",
+  "description": "Why this rule matters, in a sentence.",
+  "request": { "protocol": 1, "request_id": "conf-my-case", "capability": "source", "method": "poll" },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "either",
+    "result_shape": "source_poll"
+  }
+}
+```
+
+| Field | Values |
+|---|---|
+| `level` | `must` (failures fail the run) or `should` (failures warn) |
+| `stdin_raw` | send this exact string instead of an encoded `request` |
+| `stdin_suffix` | appended after the encoded request — for framing cases |
+| `expect.exit_code` | a number, or `"any"` |
+| `expect.stdout` | `single_json_object` or `at_most_one_json_object` |
+| `expect.outcome` | `result`, `error`, `either`, `no_result` |
+| `expect.error_code` | required exact code |
+| `expect.error_code_preferred` | conventional code — a mismatch only warns |
+| `expect.result_shape` | `source_poll` or `source_ok` |
+
+Keep new cases anchored to a numbered rule. The corpus tests the **protocol**,
+never a plugin's business logic: any case that only one implementation could
+pass does not belong here.

--- a/sdk/conformance/cases/01-poll-result-shape.json
+++ b/sdk/conformance/cases/01-poll-result-shape.json
@@ -1,0 +1,21 @@
+{
+  "name": "poll-result-shape",
+  "rules": [1, 3, 4, 5, 6, 7],
+  "level": "must",
+  "description": "A well-formed source.poll request yields exactly one JSON response on stdout, protocol 1, the request id echoed verbatim, exactly one of result/error, and exit 0. When a result is returned it must mirror SourcePollResult (items array of SourceItem).",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-poll-1",
+    "capability": "source",
+    "method": "poll",
+    "payload": {"since": "2026-01-01T00:00:00Z", "states": ["open"], "labels": ["origin:conformance"]}
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "either",
+    "result_shape": "source_poll"
+  }
+}

--- a/sdk/conformance/cases/02-protocol-mismatch.json
+++ b/sdk/conformance/cases/02-protocol-mismatch.json
@@ -1,0 +1,20 @@
+{
+  "name": "protocol-mismatch",
+  "rules": [2],
+  "level": "must",
+  "description": "A request carrying an unsupported protocol version must be refused with a well-formed error response whose code is exactly `unsupported_protocol` — not a crash, not a result.",
+  "request": {
+    "protocol": 99,
+    "request_id": "conf-protocol-99",
+    "capability": "source",
+    "method": "poll"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "error",
+    "error_code": "unsupported_protocol"
+  }
+}

--- a/sdk/conformance/cases/03-protocol-zero.json
+++ b/sdk/conformance/cases/03-protocol-zero.json
@@ -1,0 +1,20 @@
+{
+  "name": "protocol-zero",
+  "rules": [2],
+  "level": "must",
+  "description": "Protocol 0 (the zero value a sloppy encoder produces when the field is dropped) is just as unsupported as any other mismatch, and must be reported the same way.",
+  "request": {
+    "protocol": 0,
+    "request_id": "conf-protocol-0",
+    "capability": "source",
+    "method": "acknowledge"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "error",
+    "error_code": "unsupported_protocol"
+  }
+}

--- a/sdk/conformance/cases/04-request-id-verbatim.json
+++ b/sdk/conformance/cases/04-request-id-verbatim.json
@@ -1,0 +1,20 @@
+{
+  "name": "request-id-verbatim",
+  "rules": [3],
+  "level": "must",
+  "description": "The request id is opaque to the plugin: whatever string the host sends comes back byte for byte, including spaces, punctuation and non-ASCII characters. Plugins that re-derive or normalise the id fail here.",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf/id with spaces & ünïcode-42",
+    "capability": "source",
+    "method": "acknowledge",
+    "payload": {"item": {"id": "conf-1"}, "action": "dispatched"}
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "either"
+  }
+}

--- a/sdk/conformance/cases/05-acknowledge-ok.json
+++ b/sdk/conformance/cases/05-acknowledge-ok.json
@@ -1,0 +1,21 @@
+{
+  "name": "acknowledge-ok",
+  "rules": [4, 5, 6],
+  "level": "must",
+  "description": "source.acknowledge is a write-back method a source plugin must answer. Plugins with nothing to mark answer with a result (conventionally {\"ok\": true}) rather than an error.",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-ack-1",
+    "capability": "source",
+    "method": "acknowledge",
+    "payload": {"item": {"id": "conf-1", "title": "Conformance fixture item"}, "action": "dispatched"}
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "result",
+    "result_shape": "source_ok"
+  }
+}

--- a/sdk/conformance/cases/06-write-result-ok.json
+++ b/sdk/conformance/cases/06-write-result-ok.json
@@ -1,0 +1,25 @@
+{
+  "name": "write-result-ok",
+  "rules": [4, 5, 6],
+  "level": "must",
+  "description": "source.write_result carries the run outcome back to the plugin. Like acknowledge, a plugin with no result surface answers with a result rather than an error.",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-write-result-1",
+    "capability": "source",
+    "method": "write_result",
+    "payload": {
+      "item": {"id": "conf-1", "title": "Conformance fixture item"},
+      "success": true,
+      "output": "conformance runner"
+    }
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "result",
+    "result_shape": "source_ok"
+  }
+}

--- a/sdk/conformance/cases/07-unknown-method.json
+++ b/sdk/conformance/cases/07-unknown-method.json
@@ -1,0 +1,20 @@
+{
+  "name": "unknown-method",
+  "rules": [5, 6],
+  "level": "must",
+  "description": "An unknown method is a failure the plugin reports, not one it crashes on: a well-formed error response with a non-empty machine-readable code and a non-empty message, still exiting 0 because a response was delivered. `unsupported_method` is the conventional code (a different one is only a warning).",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-unknown-method",
+    "capability": "source",
+    "method": "definitely_not_a_method"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "error",
+    "error_code_preferred": "unsupported_method"
+  }
+}

--- a/sdk/conformance/cases/08-unknown-capability.json
+++ b/sdk/conformance/cases/08-unknown-capability.json
@@ -1,0 +1,19 @@
+{
+  "name": "unknown-capability",
+  "rules": [5, 6],
+  "level": "should",
+  "description": "A capability the plugin does not implement should be refused rather than silently served by whatever method handler happens to match. Advisory: the seven contract rules do not mandate a capability check, so returning a result here is a warning, not a failure — but a plugin that answers `poll` for capability `runner` is answering a question it was not asked.",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-unknown-capability",
+    "capability": "definitely_not_a_capability",
+    "method": "poll"
+  },
+  "expect": {
+    "exit_code": 0,
+    "stdout": "single_json_object",
+    "protocol": 1,
+    "request_id": "echo",
+    "outcome": "error"
+  }
+}

--- a/sdk/conformance/cases/09-trailing-data.json
+++ b/sdk/conformance/cases/09-trailing-data.json
@@ -1,0 +1,18 @@
+{
+  "name": "trailing-data",
+  "rules": [1],
+  "level": "must",
+  "description": "Exactly one request object is delivered per process. A second object glued onto the stream is a framing error: the plugin must not answer it as if it were a valid single request. Either refuse it with an error response (exit 0) or fail the transport (no response on stdout, non-zero exit) — what it must never do is emit a success result.",
+  "request": {
+    "protocol": 1,
+    "request_id": "conf-trailing-1",
+    "capability": "source",
+    "method": "poll"
+  },
+  "stdin_suffix": "\n{\"protocol\":1,\"request_id\":\"conf-trailing-2\",\"capability\":\"source\",\"method\":\"poll\"}\n",
+  "expect": {
+    "exit_code": "any",
+    "stdout": "at_most_one_json_object",
+    "outcome": "no_result"
+  }
+}

--- a/sdk/conformance/cases/10-empty-stdin.json
+++ b/sdk/conformance/cases/10-empty-stdin.json
@@ -1,0 +1,12 @@
+{
+  "name": "empty-stdin",
+  "rules": [1, 4],
+  "level": "must",
+  "description": "An empty stream carries no request, so there is nothing to answer. The plugin must not invent a success result; a non-zero exit with a diagnostic on stderr is the expected shape, and a well-formed error response is also acceptable.",
+  "stdin_raw": "",
+  "expect": {
+    "exit_code": "any",
+    "stdout": "at_most_one_json_object",
+    "outcome": "no_result"
+  }
+}

--- a/sdk/conformance/check-examples.sh
+++ b/sdk/conformance/check-examples.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Run the conformance corpus against every plugin implementation this
+# repository ships: the Go SDK's example plugins, the Python SDK's example, the
+# in-tree Bash and Node plugins, and the hand-rolled examples embedded in the
+# docs. One command, one verdict — `make conformance` calls this.
+#
+# Toolchains that are missing are skipped with a notice rather than failing the
+# run, so a contributor without Node or Rust still gets a useful result; CI has
+# all of them.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$REPO/sdk/conformance/run.py"
+FIXTURE="$REPO/sdk/conformance/fixtures/items.json"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PYTHON="${PYTHON:-python3}"
+FILE_CONFIG="{\"path\":\"$FIXTURE\"}"
+failures=()
+skipped=()
+
+check() { # check <label> <config> <command...>
+  local label="$1" config="$2"
+  shift 2
+  if ! "$PYTHON" "$RUNNER" --name "$label" --config "$config" -- "$@"; then
+    failures+=("$label")
+  fi
+}
+
+skip() {
+  skipped+=("$1")
+  echo ""
+  echo "  SKIP  $1 ($2)"
+}
+
+# ── Go SDK: the reference implementation and its example plugin ───────────────
+if command -v go >/dev/null 2>&1; then
+  if (cd "$REPO/src" && go build -o "$WORK/source-file" ./examples/plugins/source-file); then
+    check "go source-file (Go SDK)" "$FILE_CONFIG" "$WORK/source-file"
+  else
+    failures+=("go source-file (build)")
+  fi
+else
+  skip "go source-file (Go SDK)" "go not installed"
+fi
+
+# ── Python SDK ───────────────────────────────────────────────────────────────
+check "python source_file (Python SDK)" "$FILE_CONFIG" "$PYTHON" "$REPO/sdk/python/examples/source_file.py"
+
+# ── In-tree hand-rolled example plugins ──────────────────────────────────────
+if command -v jq >/dev/null 2>&1; then
+  check "in-tree source-bash" "$FILE_CONFIG" "$REPO/src/examples/plugins/source-bash/apiary-plugin-source-bash"
+else
+  skip "in-tree source-bash" "jq not installed"
+fi
+
+NODE_PLUGIN="$REPO/src/examples/plugins/source-node/apiary-plugin-source-node"
+if [[ -x "$NODE_PLUGIN" ]]; then
+  check "in-tree source-node" "$FILE_CONFIG" "$NODE_PLUGIN"
+else
+  skip "in-tree source-node" "not built — run 'npm install && npm run build' in src/examples/plugins/source-node"
+fi
+
+# ── The examples embedded in the docs ────────────────────────────────────────
+if ! "$PYTHON" "$REPO/sdk/conformance/extract_doc_examples.py" "$WORK/docs" >/dev/null; then
+  failures+=("docs example extraction")
+else
+  check "docs Python (plugins.md)" "{}" "$PYTHON" "$WORK/docs/py-doc.py"
+  if command -v jq >/dev/null 2>&1; then
+    check "docs Bash (plugin-sdk.md)" "{}" "bash" "$WORK/docs/bash-doc.sh"
+  else
+    skip "docs Bash (plugin-sdk.md)" "jq not installed"
+  fi
+  if command -v cargo >/dev/null 2>&1; then
+    if (cd "$WORK/docs/rust" && cargo build --release --quiet 2>&1 | tail -3); then
+      check "docs Rust (plugin-sdk.md)" "{}" "$WORK/docs/rust/target/release/apiary-plugin-rust-source"
+    else
+      failures+=("docs Rust (build)")
+    fi
+  else
+    skip "docs Rust (plugin-sdk.md)" "cargo not installed"
+  fi
+fi
+
+echo ""
+if ((${#skipped[@]})); then
+  echo "skipped: ${skipped[*]}"
+fi
+if ((${#failures[@]})); then
+  echo "CONFORMANCE FAILED: ${failures[*]}"
+  exit 1
+fi
+echo "CONFORMANCE OK — every checked plugin conforms to protocol 1"

--- a/sdk/conformance/extract_doc_examples.py
+++ b/sdk/conformance/extract_doc_examples.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Extract the hand-rolled plugin examples embedded in the docs.
+
+The docs claim their Python, Rust and Bash plugins are verified against the
+protocol. This script lifts them out of the Markdown verbatim so the
+conformance runner can keep that claim honest — a snippet that drifts out of
+conformance fails CI instead of quietly misleading a reader.
+
+Extraction is anchored on the section heading plus the fenced block's language,
+and it fails loudly when a section moves: a silently skipped example is worse
+than a broken build.
+
+Usage: extract_doc_examples.py <output-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# (label, markdown file, section heading, fence language, output path)
+EXAMPLES = [
+    ("python", "docs/plugins.md", "### A complete plugin in 20 lines", "python", "py-doc.py"),
+    ("bash", "docs/plugin-sdk.md", "### Bash example", "bash", "bash-doc.sh"),
+    ("rust-cargo", "docs/plugin-sdk.md", "### Rust example", "toml", "rust/Cargo.toml"),
+    ("rust", "docs/plugin-sdk.md", "### Rust example", "rust", "rust/src/main.rs"),
+]
+
+EXECUTABLE = {"py-doc.py", "bash-doc.sh"}
+
+
+def extract(markdown: str, heading: str, language: str) -> str:
+    section = re.search(re.escape(heading) + r"(.*?)(?=\n## |\Z)", markdown, re.S)
+    if not section:
+        raise SystemExit(f"section not found: {heading!r}")
+    block = re.search(r"```" + language + r"\n(.*?)```", section.group(1), re.S)
+    if not block:
+        raise SystemExit(f"no ```{language} block under {heading!r}")
+    return block.group(1)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: extract_doc_examples.py <output-dir>")
+    out_dir = Path(sys.argv[1])
+    for label, doc, heading, language, relative in EXAMPLES:
+        code = extract((REPO / doc).read_text(encoding="utf-8"), heading, language)
+        target = out_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(code, encoding="utf-8")
+        if target.name in EXECUTABLE:
+            target.chmod(os.stat(target).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        print(f"{label}: {doc} → {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/conformance/fixtures/items.json
+++ b/sdk/conformance/fixtures/items.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "conf-1",
+    "number": "CONF-1",
+    "title": "Conformance fixture item",
+    "description": "An item served by the plugin under test so the runner can check the SourceItem mirror.",
+    "labels": ["origin:conformance", "severity:low"],
+    "type": "task",
+    "priority": "low",
+    "state": "open",
+    "url": "https://example.invalid/conf-1",
+    "metadata": {"fixture": true},
+    "created_at": "2026-01-02T03:04:05Z",
+    "updated_at": "2026-01-02T03:04:05Z"
+  },
+  {
+    "id": "conf-2",
+    "title": "Second conformance fixture item",
+    "labels": ["origin:conformance"],
+    "state": "open"
+  }
+]

--- a/sdk/conformance/run.py
+++ b/sdk/conformance/run.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Apiary plugin protocol conformance runner.
+
+Drives any plugin executable — in any language — as a subprocess over
+stdin/stdout and checks it against the golden case corpus in ``cases/``. The
+corpus encodes the seven rules from the "Writing an SDK for your language"
+section of ``docs/plugin-sdk.md``:
+
+  1. Read stdin to EOF, decode exactly one request; trailing data is an error
+  2. Verify ``protocol == 1``; respond ``unsupported_protocol`` on mismatch
+  3. Echo ``request_id`` verbatim
+  4. Stdout purity: exactly one JSON object, all logging to stderr
+  5. Result/error dichotomy, ``error`` carrying non-empty ``code``+``message``
+  6. Exit 0 on a delivered response
+  7. Typed SourceItem mirrors: stable ``id``, RFC3339 timestamps,
+     ``key:value`` labels
+
+Usage:
+    run.py [options] -- <plugin command> [args...]
+
+Options:
+    --config JSON   merged into every request's `config` block, so a plugin
+                    that needs e.g. {"path": "items.json"} can be exercised
+                    with real items instead of an empty poll
+    --case NAME     run only the named case (repeatable)
+    --name LABEL    label for the report header
+    --verbose       print the request/response of every case
+    --json          emit a machine-readable report on stdout
+
+Exit status is 0 when every `must` case passes. `should` cases that fail are
+reported as warnings and do not affect the exit status.
+
+Standard library only, on purpose: the kit must run wherever a plugin author
+can run their plugin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CASES_DIR = Path(__file__).resolve().parent / "cases"
+
+# RFC3339: date-time with a mandatory offset (Z or ±HH:MM).
+RFC3339 = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$"
+)
+
+RESET, RED, GREEN, YELLOW, DIM = "\033[0m", "\033[31m", "\033[32m", "\033[33m", "\033[2m"
+
+
+def colorize(text: str, color: str) -> str:
+    if not sys.stdout.isatty() or os.environ.get("NO_COLOR"):
+        return text
+    return f"{color}{text}{RESET}"
+
+
+class Outcome:
+    """The verdict on one case."""
+
+    def __init__(self, case: dict):
+        self.case = case
+        self.name = case["name"]
+        self.level = case.get("level", "must")
+        self.rules = case.get("rules", [])
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+        self.stdout = ""
+        self.stderr = ""
+        self.exit_code: int | None = None
+
+    def fail(self, message: str) -> None:
+        # A `should` case can only ever warn.
+        (self.failures if self.level == "must" else self.warnings).append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+
+def load_cases(only: list[str]) -> list[dict]:
+    cases = []
+    for path in sorted(CASES_DIR.glob("*.json")):
+        case = json.loads(path.read_text(encoding="utf-8"))
+        case["_file"] = path.name
+        if only and case["name"] not in only:
+            continue
+        cases.append(case)
+    if only:
+        found = {case["name"] for case in cases}
+        for name in only:
+            if name not in found:
+                raise SystemExit(f"no such case: {name}")
+    return cases
+
+
+def build_stdin(case: dict, config: dict) -> str:
+    if "stdin_raw" in case:
+        return case["stdin_raw"]
+    request = dict(case["request"])
+    if config:
+        merged = dict(request.get("config") or {})
+        merged.update(config)
+        request["config"] = merged
+    return json.dumps(request) + case.get("stdin_suffix", "\n")
+
+
+def parse_stdout(raw: str) -> tuple[list, str | None]:
+    """Decode the JSON values on stdout.
+
+    Returns (values, error). Stdout purity means exactly one value and no
+    trailing bytes other than whitespace, so anything else surfaces here.
+    """
+    decoder = json.JSONDecoder()
+    values, index = [], 0
+    while index < len(raw):
+        while index < len(raw) and raw[index] in " \t\r\n":
+            index += 1
+        if index >= len(raw):
+            break
+        try:
+            value, index = decoder.raw_decode(raw, index)
+        except ValueError as err:
+            return values, f"stdout is not pure JSON at byte {index}: {err}"
+        values.append(value)
+    return values, None
+
+
+def check_source_item(item, where: str, outcome: Outcome) -> None:
+    if not isinstance(item, dict):
+        outcome.fail(f"{where} is {type(item).__name__}, want a SourceItem object")
+        return
+    item_id = item.get("id")
+    if not isinstance(item_id, str) or item_id == "":
+        outcome.fail(f"{where}.id must be a non-empty string (the host drops items without one), got {item_id!r}")
+    for field in ("created_at", "updated_at"):
+        value = item.get(field)
+        if value in (None, ""):
+            continue  # empty means "now"
+        if not isinstance(value, str) or not RFC3339.match(value):
+            outcome.fail(f"{where}.{field} must be an RFC3339 timestamp, got {value!r}")
+    labels = item.get("labels")
+    if labels is not None:
+        if not isinstance(labels, list):
+            outcome.fail(f"{where}.labels must be an array, got {type(labels).__name__}")
+        else:
+            for i, label in enumerate(labels):
+                if not isinstance(label, str):
+                    outcome.fail(f"{where}.labels[{i}] must be a string, got {label!r}")
+                elif ":" not in label:
+                    outcome.warn(f"{where}.labels[{i}]={label!r} is not in `key:value` form")
+    for field, want in (("number", str), ("title", str), ("description", str), ("type", str),
+                        ("priority", str), ("state", str), ("url", str), ("metadata", dict)):
+        value = item.get(field)
+        if value is not None and not isinstance(value, want):
+            outcome.fail(f"{where}.{field} must be {want.__name__}, got {type(value).__name__}")
+
+
+def check_result_shape(shape: str, result, outcome: Outcome) -> None:
+    if shape == "source_poll":
+        if not isinstance(result, dict):
+            outcome.fail(f"result must be a SourcePollResult object, got {type(result).__name__}")
+            return
+        items = result.get("items")
+        if items is None:
+            outcome.fail("result.items is missing (SourcePollResult always carries an items array)")
+            return
+        if not isinstance(items, list):
+            outcome.fail(f"result.items must be an array, got {type(items).__name__}")
+            return
+        seen = set()
+        for i, item in enumerate(items):
+            check_source_item(item, f"result.items[{i}]", outcome)
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                if item["id"] in seen:
+                    outcome.fail(f"result.items[{i}].id={item['id']!r} is duplicated; ids are the host's dedup key")
+                seen.add(item["id"])
+    elif shape == "source_ok":
+        if not isinstance(result, dict):
+            outcome.fail(f"result must be an object, got {type(result).__name__}")
+        elif result.get("ok") is not True:
+            outcome.warn('result is not the conventional {"ok": true} for a write-back method')
+
+
+def run_case(command: list[str], case: dict, config: dict, cwd: str | None) -> Outcome:
+    outcome = Outcome(case)
+    stdin = build_stdin(case, config)
+    try:
+        proc = subprocess.run(
+            command,
+            input=stdin.encode("utf-8"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        outcome.fail(f"plugin executable not found: {command[0]}")
+        return outcome
+    except subprocess.TimeoutExpired:
+        outcome.fail("plugin did not exit within 30s (the protocol is single-shot; serve one request and exit)")
+        return outcome
+
+    outcome.stdout = proc.stdout.decode("utf-8", "replace")
+    outcome.stderr = proc.stderr.decode("utf-8", "replace")
+    outcome.exit_code = proc.returncode
+    expect = case["expect"]
+
+    values, parse_error = parse_stdout(outcome.stdout)
+    want_stdout = expect.get("stdout", "single_json_object")
+    if parse_error:
+        outcome.fail(parse_error)
+    if want_stdout == "single_json_object" and len(values) != 1:
+        outcome.fail(f"stdout must carry exactly one JSON object, found {len(values)}")
+    if want_stdout == "at_most_one_json_object" and len(values) > 1:
+        outcome.fail(f"stdout must carry at most one JSON object, found {len(values)}")
+
+    response = values[0] if values else None
+    if response is not None and not isinstance(response, dict):
+        outcome.fail(f"the response must be a JSON object, got {type(response).__name__}")
+        response = None
+
+    want_exit = expect.get("exit_code", 0)
+    if want_exit != "any" and proc.returncode != want_exit:
+        # Rule 6 is about *delivered* responses: a plugin that emitted nothing
+        # is failing the transport, which the outcome checks below catch.
+        if response is not None or want_stdout == "single_json_object":
+            outcome.fail(f"exit code {proc.returncode}, want {want_exit} (a delivered response exits 0)")
+
+    if response is not None:
+        if "protocol" in expect and response.get("protocol") != expect["protocol"]:
+            outcome.fail(f"response.protocol is {response.get('protocol')!r}, want {expect['protocol']}")
+        if expect.get("request_id") == "echo" and "request" in case:
+            want_id = case["request"]["request_id"]
+            if response.get("request_id") != want_id:
+                outcome.fail(f"response.request_id is {response.get('request_id')!r}, want {want_id!r} echoed verbatim")
+
+        has_result = "result" in response and response["result"] is not None
+        has_error = "error" in response and response["error"] is not None
+        if has_result and has_error:
+            outcome.fail("response carries both result and error; exactly one is allowed")
+        if has_error:
+            error = response["error"]
+            if not isinstance(error, dict):
+                outcome.fail(f"response.error must be an object, got {type(error).__name__}")
+            else:
+                for field in ("code", "message"):
+                    value = error.get(field)
+                    if not isinstance(value, str) or value == "":
+                        outcome.fail(f"response.error.{field} must be a non-empty string, got {value!r}")
+                want_code = expect.get("error_code")
+                if want_code and error.get("code") != want_code:
+                    outcome.fail(f"response.error.code is {error.get('code')!r}, want {want_code!r}")
+                preferred = expect.get("error_code_preferred")
+                if preferred and error.get("code") != preferred:
+                    outcome.warn(f"response.error.code is {error.get('code')!r}; {preferred!r} is the conventional code")
+
+        want_outcome = expect.get("outcome", "either")
+        if want_outcome == "result" and not has_result:
+            outcome.fail("response must carry a result" + (f" (got error {response['error']!r})" if has_error else ""))
+        if want_outcome == "error" and not has_error:
+            outcome.fail("response must carry an error")
+        if want_outcome == "no_result" and has_result:
+            outcome.fail(f"response must not carry a success result, got {json.dumps(response.get('result'))[:200]}")
+        if want_outcome == "either" and not has_result and not has_error:
+            outcome.fail("response carries neither result nor error; exactly one is required")
+
+        shape = expect.get("result_shape")
+        if shape and has_result:
+            check_result_shape(shape, response["result"], outcome)
+    elif expect.get("outcome") in ("result", "error", "either"):
+        outcome.fail("no JSON response on stdout")
+
+    return outcome
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(add_help=True, description="Apiary plugin protocol conformance runner")
+    parser.add_argument("--config", default="", help="JSON object merged into every request's config block")
+    parser.add_argument("--case", action="append", default=[], help="run only this case (repeatable)")
+    parser.add_argument("--name", default="", help="label for the report header")
+    parser.add_argument("--cwd", default=None, help="working directory for the plugin subprocess")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--json", dest="as_json", action="store_true", help="emit a machine-readable report")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="-- <plugin command> [args...]")
+    args = parser.parse_args()
+
+    command = args.command[1:] if args.command and args.command[0] == "--" else args.command
+    if not command:
+        parser.error("a plugin command is required: run.py [options] -- ./my-plugin")
+
+    config = json.loads(args.config) if args.config else {}
+    if not isinstance(config, dict):
+        parser.error("--config must be a JSON object")
+
+    cases = load_cases(args.case)
+    label = args.name or command[0]
+    outcomes = [run_case(command, case, config, args.cwd) for case in cases]
+
+    if args.as_json:
+        print(json.dumps({
+            "plugin": label,
+            "command": command,
+            "cases": [
+                {
+                    "name": o.name,
+                    "level": o.level,
+                    "rules": o.rules,
+                    "passed": o.passed,
+                    "failures": o.failures,
+                    "warnings": o.warnings,
+                    "exit_code": o.exit_code,
+                }
+                for o in outcomes
+            ],
+        }, indent=2))
+        return 0 if all(o.passed for o in outcomes) else 1
+
+    stream = sys.stdout
+    print(f"\nconformance: {label}", file=stream)
+    print(f"  command: {' '.join(command)}", file=stream)
+    if config:
+        print(f"  config:  {json.dumps(config)}", file=stream)
+    print("", file=stream)
+
+    for outcome in outcomes:
+        rules = ",".join(str(rule) for rule in outcome.rules)
+        if outcome.passed and not outcome.warnings:
+            mark = colorize("PASS", GREEN)
+        elif outcome.passed:
+            mark = colorize("WARN", YELLOW)
+        else:
+            mark = colorize("FAIL", RED)
+        suffix = "" if outcome.level == "must" else colorize("  [should]", DIM)
+        print(f"  {mark}  {outcome.name:<24} {colorize('rules ' + rules, DIM)}{suffix}", file=stream)
+        for failure in outcome.failures:
+            print(f"          {colorize('× ' + failure, RED)}", file=stream)
+        for warning in outcome.warnings:
+            print(f"          {colorize('! ' + warning, YELLOW)}", file=stream)
+        if args.verbose:
+            print(f"          stdout: {outcome.stdout.strip()!r}", file=stream)
+            print(f"          stderr: {outcome.stderr.strip()!r}", file=stream)
+            print(f"          exit:   {outcome.exit_code}", file=stream)
+
+    failed = [o for o in outcomes if not o.passed]
+    warned = sum(len(o.warnings) for o in outcomes)
+    print("", file=stream)
+    if failed:
+        print(colorize(f"  {len(outcomes) - len(failed)}/{len(outcomes)} cases passed, {len(failed)} failed", RED), file=stream)
+        return 1
+    print(colorize(f"  {len(outcomes)}/{len(outcomes)} cases passed", GREEN)
+          + (colorize(f" ({warned} warning(s))", YELLOW) if warned else ""), file=stream)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/plugin/protocol.go
+++ b/sdk/plugin/protocol.go
@@ -58,6 +58,12 @@ func ServeOne(ctx context.Context, input io.Reader, output io.Writer, handler Ha
 	if err := decoder.Decode(&request); err != nil {
 		return fmt.Errorf("decode request: %w", err)
 	}
+	// Exactly one request per process: a second value on the stream is a
+	// framing error, not a second turn to serve. Answering the first one
+	// anyway would let a malformed stream look like a healthy exchange.
+	if decoder.More() {
+		return fmt.Errorf("decode request: unexpected trailing data after the request; the protocol is single-shot")
+	}
 	response := Response{Protocol: ProtocolVersion, RequestID: request.RequestID}
 	if request.Protocol != ProtocolVersion {
 		response.Error = &ResponseError{Code: "unsupported_protocol", Message: fmt.Sprintf("protocol %d is unsupported; expected %d", request.Protocol, ProtocolVersion)}

--- a/sdk/plugin/protocol_test.go
+++ b/sdk/plugin/protocol_test.go
@@ -51,3 +51,45 @@ func TestServeOneRejectsProtocolMismatchWithoutCallingHandler(t *testing.T) {
 		t.Fatalf("response=%+v", response)
 	}
 }
+
+func TestServeOneRejectsTrailingDataWithoutAnswering(t *testing.T) {
+	// The host starts one process per request, so a second object glued onto
+	// the stream means the framing is broken — the first request must not be
+	// answered as if the exchange were healthy.
+	input := strings.NewReader(`{"protocol":1,"request_id":"req-1","capability":"source","method":"poll"}` + "\n" +
+		`{"protocol":1,"request_id":"req-2","capability":"source","method":"poll"}`)
+	var output bytes.Buffer
+	called := false
+	err := ServeOne(context.Background(), input, &output, func(context.Context, Request) (any, *ResponseError) {
+		called = true
+		return SourceOKResult{OK: true}, nil
+	})
+	if err == nil {
+		t.Fatal("trailing data must be a transport error")
+	}
+	if called {
+		t.Fatal("handler must not run for a malformed stream")
+	}
+	if output.Len() != 0 {
+		t.Fatalf("stdout must stay empty, got %q", output.String())
+	}
+}
+
+func TestServeOneAcceptsTrailingWhitespace(t *testing.T) {
+	// Encoders that terminate the request with a newline (or several) are
+	// fine: only another *value* counts as trailing data.
+	input := strings.NewReader(`{"protocol":1,"request_id":"req-1","capability":"source","method":"poll"}` + "\n\n  \t\n")
+	var output bytes.Buffer
+	if err := ServeOne(context.Background(), input, &output, func(context.Context, Request) (any, *ResponseError) {
+		return SourceOKResult{OK: true}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var response Response
+	if err := json.Unmarshal(output.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.RequestID != "req-1" || response.Error != nil {
+		t.Fatalf("response=%+v", response)
+	}
+}

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.egg-info/
+build/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,80 @@
+# apiary-plugin (Python)
+
+The official Python SDK for [Apiary](https://github.com/orlandoburli/apiary)
+plugins. It handles the protocol envelope — the single-shot JSON exchange on
+stdin/stdout — and mirrors the typed `source` structs, so a plugin is one
+handler function.
+
+Standard library only, on purpose: a plugin is a short-lived subprocess the
+daemon spawns, and it should not drag a dependency tree into that path.
+
+## Install
+
+```bash
+pip install ./sdk/python          # from a checkout
+```
+
+The package is **not published to PyPI**; install it from the repository (or
+vendor the `apiary_plugin/` directory, which is two files).
+
+## Use
+
+```python
+#!/usr/bin/env python3
+from apiary_plugin import CAPABILITY_SOURCE, PluginError, Request, main
+from apiary_plugin.source import (
+    SOURCE_METHOD_ACKNOWLEDGE,
+    SOURCE_METHOD_POLL,
+    SOURCE_METHOD_WRITE_RESULT,
+    SourceItem,
+    SourceOKResult,
+    SourcePollResult,
+)
+
+
+def handle(request: Request):
+    if request.capability != CAPABILITY_SOURCE:
+        raise PluginError("unsupported_capability", "expected capability source")
+    if request.method == SOURCE_METHOD_POLL:
+        return SourcePollResult(items=[
+            SourceItem(id="py-1", title="Hello from Python", labels=["origin:python"], state="open"),
+        ])
+    if request.method in (SOURCE_METHOD_ACKNOWLEDGE, SOURCE_METHOD_WRITE_RESULT):
+        return SourceOKResult()
+    raise PluginError("unsupported_method", f"unknown method {request.method}")
+
+
+main(handle)
+```
+
+Make the script executable, pair it with a manifest declaring
+`"capabilities": ["source"]`, and install it like any other plugin.
+
+| Symbol | Purpose |
+|---|---|
+| `main(handler)` | Serve one request on stdin/stdout and exit — all a plugin's `__main__` needs |
+| `serve_one(handler, stdin=…, stdout=…)` | The engine behind `main`, with injectable streams — use it in tests |
+| `Request` | The decoded envelope: `protocol`, `request_id`, `capability`, `method`, `config`, `payload` |
+| `PluginError(code, message)` | Raise it to return an error response; both fields must be non-empty |
+| `TransportError` | The stream itself was unusable — no response can be delivered, `main` exits 2 |
+| `apiary_plugin.source` | Typed mirrors of `sdk/plugin/source.go`: `SourceItem`, `SourcePollRequest/Result`, `SourceAckRequest`, `SourceWriteResultRequest`, `SourceOKResult` |
+
+Your handler returns the result value; anything with a `to_dict()` (every typed
+mirror here) encodes itself. Diagnostics go to **stderr** — stdout carries the
+one response object and nothing else.
+
+## Versioning
+
+The version tracks the **protocol**, not the Apiary release: `apiary-plugin`
+1.x speaks protocol 1, and a future protocol bump gets a new major version.
+See [Versioning and the protocol](../../docs/plugin-sdk.md#versioning-and-the-protocol).
+
+## Tests and conformance
+
+```bash
+python3 -m unittest discover -s sdk/python/tests          # unit tests
+make conformance                                          # the shared protocol corpus
+```
+
+The [conformance kit](../conformance/README.md) runs this SDK's example plugin
+(`examples/source_file.py`) against the same golden corpus as every other SDK.

--- a/sdk/python/apiary_plugin/__init__.py
+++ b/sdk/python/apiary_plugin/__init__.py
@@ -1,0 +1,55 @@
+"""Apiary plugin SDK for Python.
+
+Wraps Apiary's single-shot JSON plugin protocol (version 1) so a plugin is one
+handler function::
+
+    from apiary_plugin import PluginError, Request, main
+    from apiary_plugin.source import SOURCE_METHOD_POLL, SourceItem, SourcePollResult
+
+    def handle(request: Request):
+        if request.method == SOURCE_METHOD_POLL:
+            return SourcePollResult(items=[SourceItem(id="1", title="Hello")])
+        raise PluginError("unsupported_method", f"unknown method {request.method}")
+
+    main(handle)
+
+The version tracks the **protocol**, not the Apiary release: 1.x speaks
+protocol 1.
+"""
+
+from .protocol import (
+    CAPABILITY_APPROVAL_PROVIDER,
+    CAPABILITY_EVENT_EXPORTER,
+    CAPABILITY_RUNNER,
+    CAPABILITY_SECRET_PROVIDER,
+    CAPABILITY_SOURCE,
+    CAPABILITY_WORKFLOW_ACTION,
+    PROTOCOL_VERSION,
+    Handler,
+    PluginError,
+    Request,
+    TransportError,
+    decode_request,
+    main,
+    serve_one,
+)
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "CAPABILITY_APPROVAL_PROVIDER",
+    "CAPABILITY_EVENT_EXPORTER",
+    "CAPABILITY_RUNNER",
+    "CAPABILITY_SECRET_PROVIDER",
+    "CAPABILITY_SOURCE",
+    "CAPABILITY_WORKFLOW_ACTION",
+    "PROTOCOL_VERSION",
+    "Handler",
+    "PluginError",
+    "Request",
+    "TransportError",
+    "decode_request",
+    "main",
+    "serve_one",
+    "__version__",
+]

--- a/sdk/python/apiary_plugin/protocol.py
+++ b/sdk/python/apiary_plugin/protocol.py
@@ -1,0 +1,166 @@
+"""Protocol envelope handling for Apiary plugins.
+
+Mirrors ``sdk/plugin/protocol.go``: one request in on stdin, one response out
+on stdout, then the process exits. Standard library only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Optional
+
+PROTOCOL_VERSION = 1
+
+# Capability names. `source` and `event_exporter` are live; the rest reserve
+# the vocabulary for capabilities the host does not bridge yet.
+CAPABILITY_SOURCE = "source"
+CAPABILITY_RUNNER = "runner"
+CAPABILITY_WORKFLOW_ACTION = "workflow_action"
+CAPABILITY_APPROVAL_PROVIDER = "approval_provider"
+CAPABILITY_SECRET_PROVIDER = "secret_provider"
+CAPABILITY_EVENT_EXPORTER = "event_exporter"
+
+_ENVELOPE_FIELDS = frozenset({"protocol", "request_id", "capability", "method", "config", "payload"})
+
+
+class TransportError(Exception):
+    """The stream itself was unusable, so no response can be delivered.
+
+    Raised for a malformed, absent or over-long request. ``main`` reports it on
+    stderr and exits non-zero — deliberately distinct from ``PluginError``,
+    which is a *delivered* answer.
+    """
+
+
+class PluginError(Exception):
+    """A failure the plugin reports to the host as a well-formed error response.
+
+    ``code`` is machine-readable (``"read_failed"``, ``"unsupported_method"``),
+    ``message`` is for humans. Both must be non-empty — the host logs them, and
+    an empty code is indistinguishable from success in an alert.
+    """
+
+    def __init__(self, code: str, message: str):
+        if not code:
+            raise ValueError("PluginError code must be non-empty")
+        if not message:
+            raise ValueError("PluginError message must be non-empty")
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+    def to_dict(self) -> dict:
+        return {"code": self.code, "message": self.message}
+
+
+@dataclass
+class Request:
+    """One decoded request. ``protocol`` is always 1 by the time a handler runs."""
+
+    protocol: int = 0
+    request_id: str = ""
+    capability: str = ""
+    method: str = ""
+    config: Mapping[str, Any] = field(default_factory=dict)
+    payload: Any = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "Request":
+        unknown = set(raw) - _ENVELOPE_FIELDS
+        if unknown:
+            # The Go SDK decodes with DisallowUnknownFields; matching that here
+            # keeps a typo in a hand-written request from being silently eaten.
+            raise TransportError(f"unknown envelope field(s): {', '.join(sorted(unknown))}")
+        return cls(
+            protocol=raw.get("protocol", 0),
+            request_id=raw.get("request_id", ""),
+            capability=raw.get("capability", ""),
+            method=raw.get("method", ""),
+            config=raw.get("config") or {},
+            payload=raw.get("payload"),
+        )
+
+
+# A handler returns the result value for a successful response, or raises
+# PluginError to return an error response. Anything the JSON encoder accepts
+# works as a result; the typed classes in `apiary_plugin.source` encode
+# themselves via `to_dict`.
+Handler = Callable[[Request], Any]
+
+
+def encode_result(value: Any) -> Any:
+    """Encode a handler's return value, honouring `to_dict` on typed mirrors."""
+    if value is None:
+        return None
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+    if isinstance(value, (list, tuple)):
+        return [encode_result(item) for item in value]
+    return value
+
+
+def decode_request(raw: str) -> Request:
+    """Decode exactly one request object; trailing data is a transport error."""
+    decoder = json.JSONDecoder()
+    stripped = raw.strip()
+    if not stripped:
+        raise TransportError("no request on stdin")
+    try:
+        value, end = decoder.raw_decode(stripped)
+    except ValueError as err:
+        raise TransportError(f"decode request: {err}") from err
+    if stripped[end:].strip():
+        raise TransportError("unexpected trailing data after the request; the protocol is single-shot")
+    if not isinstance(value, dict):
+        raise TransportError(f"request must be a JSON object, got {type(value).__name__}")
+    return Request.from_dict(value)
+
+
+def serve_one(handler: Handler, stdin=None, stdout=None) -> None:
+    """Read one request, invoke ``handler``, write one response.
+
+    Single-shot on purpose: the host starts a fresh process per invocation, so
+    there is no loop, no state and no lifecycle to manage.
+    """
+    if handler is None:
+        raise TransportError("plugin handler is required")
+    source = sys.stdin if stdin is None else stdin
+    sink = sys.stdout if stdout is None else stdout
+
+    request = decode_request(source.read())
+    response: dict = {"protocol": PROTOCOL_VERSION, "request_id": request.request_id}
+    if request.protocol != PROTOCOL_VERSION:
+        response["error"] = {
+            "code": "unsupported_protocol",
+            "message": f"protocol {request.protocol} is unsupported; expected {PROTOCOL_VERSION}",
+        }
+    else:
+        try:
+            result = encode_result(handler(request))
+            if result is not None:
+                # Mirrors the Go SDK's `omitempty`: a nil result is left out of
+                # the envelope rather than serialised as a null "answer".
+                response["result"] = result
+        except PluginError as err:
+            response["error"] = err.to_dict()
+    # Exactly one JSON object, nothing before or after it. Everything a plugin
+    # wants to say to a human belongs on stderr.
+    sink.write(json.dumps(response) + "\n")
+    sink.flush()
+
+
+def main(handler: Handler) -> None:
+    """Entry point for a plugin executable: serve one request and exit.
+
+    Exits 0 once a response is on stdout — including an error response, which
+    is a delivered answer — and 2 when the transport failed and there is
+    nothing to deliver.
+    """
+    try:
+        serve_one(handler)
+    except TransportError as err:
+        print(err, file=sys.stderr)
+        raise SystemExit(2)

--- a/sdk/python/apiary_plugin/source.py
+++ b/sdk/python/apiary_plugin/source.py
@@ -1,0 +1,164 @@
+"""Typed mirrors of the ``source`` capability wire contract.
+
+A line-for-line counterpart of ``sdk/plugin/source.go``. Optional fields are
+omitted from the encoded JSON, matching the Go structs' ``omitempty`` tags, so
+a plugin written against either SDK puts the same bytes on the wire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Optional
+
+# Method names a source plugin switches on.
+SOURCE_METHOD_POLL = "poll"
+SOURCE_METHOD_ACKNOWLEDGE = "acknowledge"
+SOURCE_METHOD_WRITE_RESULT = "write_result"
+
+
+def _compact(values: dict) -> dict:
+    """Drop empty optional fields — the `omitempty` of the Go structs."""
+    return {key: value for key, value in values.items() if value not in (None, "", [], {})}
+
+
+@dataclass
+class SourceItem:
+    """One unit of work surfaced by a source plugin.
+
+    ``id`` is the source-native identifier **and the host's dedup key**: it must
+    be stable for the lifetime of the item and unique per dispatch-worthy
+    occurrence. Items without one are dropped by the host, so it is the only
+    required field. Returning the same item on every poll while it stays
+    relevant is the expected shape.
+
+    ``labels`` drive workflow trigger matching and use ``key:value`` form.
+    ``created_at`` / ``updated_at`` are RFC3339 strings; empty means "now".
+    """
+
+    id: str
+    number: str = ""
+    title: str = ""
+    description: str = ""
+    labels: List[str] = field(default_factory=list)
+    type: str = ""
+    priority: str = ""
+    state: str = ""
+    url: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+    updated_at: str = ""
+
+    def to_dict(self) -> dict:
+        encoded = _compact(
+            {
+                "number": self.number,
+                "title": self.title,
+                "description": self.description,
+                "labels": list(self.labels),
+                "type": self.type,
+                "priority": self.priority,
+                "state": self.state,
+                "url": self.url,
+                "metadata": dict(self.metadata),
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+            }
+        )
+        # id is never omitted: an item without one is not dispatchable.
+        return {"id": self.id, **encoded}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "SourceItem":
+        return cls(
+            id=raw.get("id", ""),
+            number=raw.get("number", ""),
+            title=raw.get("title", ""),
+            description=raw.get("description", ""),
+            labels=list(raw.get("labels") or []),
+            type=raw.get("type", ""),
+            priority=raw.get("priority", ""),
+            state=raw.get("state", ""),
+            url=raw.get("url", ""),
+            metadata=dict(raw.get("metadata") or {}),
+            created_at=raw.get("created_at", ""),
+            updated_at=raw.get("updated_at", ""),
+        )
+
+
+@dataclass
+class SourcePollRequest:
+    """Payload of ``poll``.
+
+    ``since`` is the previous poll time (RFC3339, empty on the first poll) and
+    is informational: plugins that re-return ongoing items may ignore it.
+    ``states`` / ``labels`` are the source's ``filters:`` from apiary.yaml,
+    forwarded so the plugin can filter at the backend where possible.
+    """
+
+    since: str = ""
+    states: List[str] = field(default_factory=list)
+    labels: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "SourcePollRequest":
+        raw = raw or {}
+        return cls(
+            since=raw.get("since", ""),
+            states=list(raw.get("states") or []),
+            labels=list(raw.get("labels") or []),
+        )
+
+
+@dataclass
+class SourcePollResult:
+    """Result of ``poll``: the plugin's current work items."""
+
+    items: List[SourceItem] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        # `items` is always present, empty array included — "no work right now"
+        # is an answer, and dropping the key would look like a malformed result.
+        return {"items": [item.to_dict() for item in self.items]}
+
+
+@dataclass
+class SourceAckRequest:
+    """Payload of ``acknowledge``: the item and the host's ack action."""
+
+    item: SourceItem
+    action: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "SourceAckRequest":
+        raw = raw or {}
+        return cls(item=SourceItem.from_dict(raw.get("item") or {}), action=raw.get("action", ""))
+
+
+@dataclass
+class SourceWriteResultRequest:
+    """Payload of ``write_result``: the run outcome for an item."""
+
+    item: SourceItem
+    success: bool = False
+    output: str = ""
+    error: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "SourceWriteResultRequest":
+        raw = raw or {}
+        return cls(
+            item=SourceItem.from_dict(raw.get("item") or {}),
+            success=bool(raw.get("success", False)),
+            output=raw.get("output", ""),
+            error=raw.get("error", ""),
+        )
+
+
+@dataclass
+class SourceOKResult:
+    """The conventional ``{"ok": true}`` answer to a write-back method."""
+
+    ok: bool = True
+
+    def to_dict(self) -> dict:
+        return {"ok": self.ok}

--- a/sdk/python/examples/source_file.py
+++ b/sdk/python/examples/source_file.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Reference protocol-1 source plugin in Python.
+
+Behaviourally identical to the Go `src/examples/plugins/source-file` plugin:
+it polls Apiary work items from the JSON file named by `config.path`, so any
+external process can drop items there and have Apiary dispatch workflows for
+them. It is also the plugin the conformance kit runs to validate this SDK.
+"""
+
+import json
+import os
+import sys
+
+# Importable in-tree without installing the package; `pip install apiary-plugin`
+# makes this line unnecessary.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from apiary_plugin import CAPABILITY_SOURCE, PluginError, Request, main  # noqa: E402
+from apiary_plugin.source import (  # noqa: E402
+    SOURCE_METHOD_ACKNOWLEDGE,
+    SOURCE_METHOD_POLL,
+    SOURCE_METHOD_WRITE_RESULT,
+    SourceItem,
+    SourceOKResult,
+    SourcePollResult,
+)
+
+
+def poll(request: Request) -> SourcePollResult:
+    path = request.config.get("path")
+    if not isinstance(path, str) or path == "":
+        raise PluginError("invalid_config", "config.path is required")
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = handle.read()
+    except FileNotFoundError:
+        return SourcePollResult(items=[])  # an absent file simply means no work yet
+    except OSError as err:
+        raise PluginError("read_failed", str(err)) from err
+    try:
+        items = json.loads(raw)
+    except ValueError as err:
+        raise PluginError("invalid_items", f"{path} must hold a JSON array of items: {err}") from err
+    if not isinstance(items, list):
+        raise PluginError("invalid_items", f"{path} must hold a JSON array of items")
+    print(f"poll: {len(items)} item(s) from {path}", file=sys.stderr)  # diagnostics → stderr
+    return SourcePollResult(items=[SourceItem.from_dict(item) for item in items])
+
+
+def handle(request: Request):
+    if request.capability != CAPABILITY_SOURCE:
+        raise PluginError("unsupported_capability", "expected capability source")
+    if request.method == SOURCE_METHOD_POLL:
+        return poll(request)
+    if request.method in (SOURCE_METHOD_ACKNOWLEDGE, SOURCE_METHOD_WRITE_RESULT):
+        # Nothing to mark in a plain file; report success so host logs stay clean.
+        return SourceOKResult(ok=True)
+    raise PluginError("unsupported_method", f"unknown method {request.method}")
+
+
+if __name__ == "__main__":
+    main(handle)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "apiary-plugin"
+version = "1.0.0"
+description = "Official Python SDK for Apiary plugins (protocol 1)"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "BSD-3-Clause" }
+authors = [{ name = "Orlando Burli" }]
+keywords = ["apiary", "plugin", "sdk", "agents", "orchestration"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries",
+]
+# Standard library only, on purpose: a plugin is a short-lived subprocess the
+# daemon spawns, and it should not drag a dependency tree into that path.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/orlandoburli/apiary"
+Documentation = "https://orlandoburli.com.br/apiary/plugin-sdk/"
+Source = "https://github.com/orlandoburli/apiary/tree/main/sdk/python"
+
+[tool.setuptools]
+packages = ["apiary_plugin"]
+
+[tool.setuptools.package-data]
+apiary_plugin = ["py.typed"]

--- a/sdk/python/tests/test_protocol.py
+++ b/sdk/python/tests/test_protocol.py
@@ -1,0 +1,156 @@
+"""Unit tests for the Python plugin SDK. Run with: python3 -m unittest discover sdk/python/tests"""
+
+import io
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+from apiary_plugin import PluginError, Request, TransportError, decode_request, serve_one  # noqa: E402
+from apiary_plugin.source import (  # noqa: E402
+    SourceAckRequest,
+    SourceItem,
+    SourceOKResult,
+    SourcePollRequest,
+    SourcePollResult,
+    SourceWriteResultRequest,
+)
+
+
+def serve(raw: str, handler):
+    out = io.StringIO()
+    serve_one(handler, stdin=io.StringIO(raw), stdout=out)
+    return json.loads(out.getvalue())
+
+
+class TestEnvelope(unittest.TestCase):
+    def test_echoes_request_and_encodes_result(self):
+        response = serve(
+            '{"protocol":1,"request_id":"req-1","capability":"source","method":"poll"}',
+            lambda request: SourcePollResult(items=[SourceItem(id="a")]),
+        )
+        self.assertEqual(response["protocol"], 1)
+        self.assertEqual(response["request_id"], "req-1")
+        self.assertEqual(response["result"], {"items": [{"id": "a"}]})
+        self.assertNotIn("error", response)
+
+    def test_request_id_is_echoed_verbatim(self):
+        weird = "id with spaces & ünïcode/42"
+        response = serve(
+            json.dumps({"protocol": 1, "request_id": weird, "capability": "source", "method": "acknowledge"}),
+            lambda request: SourceOKResult(),
+        )
+        self.assertEqual(response["request_id"], weird)
+
+    def test_protocol_mismatch_short_circuits_the_handler(self):
+        called = []
+        response = serve(
+            '{"protocol":99,"request_id":"req-2","capability":"source","method":"poll"}',
+            lambda request: called.append(request) or SourceOKResult(),
+        )
+        self.assertEqual(called, [])
+        self.assertEqual(response["error"]["code"], "unsupported_protocol")
+        self.assertNotIn("result", response)
+
+    def test_plugin_error_becomes_an_error_response(self):
+        def handler(request):
+            raise PluginError("read_failed", "boom")
+
+        response = serve('{"protocol":1,"request_id":"req-3","capability":"source","method":"poll"}', handler)
+        self.assertEqual(response["error"], {"code": "read_failed", "message": "boom"})
+        self.assertNotIn("result", response)
+
+    def test_plugin_error_rejects_empty_code_or_message(self):
+        with self.assertRaises(ValueError):
+            PluginError("", "message")
+        with self.assertRaises(ValueError):
+            PluginError("code", "")
+
+    def test_stdout_carries_exactly_one_json_object(self):
+        out = io.StringIO()
+        serve_one(
+            lambda request: SourceOKResult(),
+            stdin=io.StringIO('{"protocol":1,"request_id":"r","capability":"source","method":"acknowledge"}'),
+            stdout=out,
+        )
+        raw = out.getvalue()
+        self.assertTrue(raw.endswith("\n"))
+        self.assertEqual(len(raw.strip().splitlines()), 1)
+
+
+class TestDecodeRequest(unittest.TestCase):
+    def test_trailing_data_is_a_transport_error(self):
+        one = '{"protocol":1,"request_id":"a","capability":"source","method":"poll"}'
+        with self.assertRaises(TransportError):
+            decode_request(one + "\n" + one)
+
+    def test_trailing_whitespace_is_fine(self):
+        request = decode_request('{"protocol":1,"request_id":"a","capability":"source","method":"poll"}\n\n  \n')
+        self.assertEqual(request.request_id, "a")
+
+    def test_empty_stdin_is_a_transport_error(self):
+        with self.assertRaises(TransportError):
+            decode_request("   \n")
+
+    def test_unknown_envelope_field_is_rejected(self):
+        with self.assertRaises(TransportError):
+            decode_request('{"protocol":1,"request_id":"a","capability":"source","method":"poll","nope":1}')
+
+    def test_non_object_request_is_rejected(self):
+        with self.assertRaises(TransportError):
+            decode_request("[1,2,3]")
+
+
+class TestSourceMirrors(unittest.TestCase):
+    def test_item_omits_empty_optionals_but_never_the_id(self):
+        self.assertEqual(SourceItem(id="x").to_dict(), {"id": "x"})
+
+    def test_item_round_trips(self):
+        raw = {
+            "id": "conf-1",
+            "number": "CONF-1",
+            "title": "t",
+            "description": "d",
+            "labels": ["origin:test"],
+            "type": "task",
+            "priority": "low",
+            "state": "open",
+            "url": "https://example.invalid/1",
+            "metadata": {"a": 1},
+            "created_at": "2026-01-02T03:04:05Z",
+            "updated_at": "2026-01-02T03:04:05Z",
+        }
+        self.assertEqual(SourceItem.from_dict(raw).to_dict(), raw)
+
+    def test_empty_poll_result_still_carries_the_items_key(self):
+        self.assertEqual(SourcePollResult().to_dict(), {"items": []})
+
+    def test_poll_request_payload(self):
+        payload = SourcePollRequest.from_dict({"since": "2026-01-01T00:00:00Z", "states": ["open"]})
+        self.assertEqual(payload.since, "2026-01-01T00:00:00Z")
+        self.assertEqual(payload.states, ["open"])
+        self.assertEqual(payload.labels, [])
+        self.assertEqual(SourcePollRequest.from_dict(None).since, "")
+
+    def test_write_back_payloads(self):
+        ack = SourceAckRequest.from_dict({"item": {"id": "a"}, "action": "dispatched"})
+        self.assertEqual((ack.item.id, ack.action), ("a", "dispatched"))
+        write = SourceWriteResultRequest.from_dict({"item": {"id": "a"}, "success": True, "output": "ok"})
+        self.assertEqual((write.item.id, write.success, write.output, write.error), ("a", True, "ok", ""))
+
+    def test_ok_result(self):
+        self.assertEqual(SourceOKResult().to_dict(), {"ok": True})
+
+
+class TestRequest(unittest.TestCase):
+    def test_defaults(self):
+        request = Request.from_dict({"protocol": 1, "request_id": "a"})
+        self.assertEqual(request.config, {})
+        self.assertIsNone(request.payload)
+        self.assertEqual(request.capability, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #367 — the conformance kit and the Python SDK. TypeScript/Node and Rust remain open, so this does not close the issue.

## The conformance kit (`sdk/conformance/`)

Protocol 1 is small enough to hand-roll in any language, which is the point — but "small" is not "obvious", and until now nothing checked that an implementation actually honoured the seven contract rules `docs/plugin-sdk.md` specifies. The kit is a **language-agnostic golden corpus**: JSON request fixtures plus the expectations each response must meet, driven against any plugin executable as a subprocess over stdin/stdout. The runner is `python3` stdlib only — no pip install, no virtualenv — so it costs the same in every ecosystem as it does here.

```bash
python3 sdk/conformance/run.py --config '{"path":"items.json"}' -- ./my-plugin
```

Ten cases, at least one per rule:

| Case | Rules | Checks |
|---|---|---|
| `poll-result-shape` | 1,3,4,5,6,7 | one JSON object, protocol 1, id echoed, one of result/error, exit 0; a result mirrors `SourcePollResult` — non-empty stable `id`, RFC3339 timestamps, string labels, no duplicate ids |
| `protocol-mismatch` | 2 | protocol 99 refused with error code exactly `unsupported_protocol` |
| `protocol-zero` | 2 | protocol 0 (a dropped field's zero value) refused the same way |
| `request-id-verbatim` | 3 | an id with spaces, punctuation and non-ASCII comes back byte for byte |
| `acknowledge-ok` / `write-result-ok` | 4,5,6 | write-back methods answer with a result, not an error |
| `unknown-method` | 5,6 | reported as an error with non-empty `code`+`message`, still exit 0 |
| `unknown-capability` *(should)* | 5,6 | advisory: a capability the plugin does not implement should be refused |
| `trailing-data` | 1 | a second object glued onto the stream must never yield a success result |
| `empty-stdin` | 1,4 | an empty stream carries no request, so no result may be invented |

Stdout purity (rule 4) is enforced on **every** case: each response is parsed strictly, and a stray `print`, banner or second line fails the case.

## Two real failures found

The issue calls the docs' hand-rolled examples "verified". The kit was the first chance to check that, and it found two violations — both fixed here:

- **The Go SDK broke rule 1.** `json.Decoder.Decode` stops at the first value and ignores the rest, so `ServeOne` answered a request with a second object glued onto the stream as if the exchange were healthy. It now treats trailing data as a transport error: nothing on stdout, handler never runs, exit 2. (`impact({target:"ServeOne", direction:"upstream"})` → LOW risk: one direct caller, `Main`.)
- **The Bash example in `docs/plugin-sdk.md` broke rule 2** — the one rule the docs spell out with a specific error code. It never read `protocol`, so it served a protocol-99 poll with real items. Fixed in the snippet.

Verbatim results after the fixes (`make conformance`):

```
conformance: go source-file (Go SDK)          10/10 cases passed
conformance: python source_file (Python SDK)  10/10 cases passed
conformance: in-tree source-bash              10/10 cases passed
conformance: in-tree source-node              10/10 cases passed
conformance: docs Python (plugins.md)         10/10 cases passed
conformance: docs Bash (plugin-sdk.md)        10/10 cases passed (1 warning)
conformance: docs Rust (plugin-sdk.md)        10/10 cases passed
CONFORMANCE OK — every checked plugin conforms to protocol 1
```

The docs' Bash snippet keeps one advisory warning: trimmed for the page, it does not switch on `capability`. That is a `should`, not one of the seven rules, and the prose now says so and points at `src/examples/plugins/source-bash` for the complete version.

`check-examples.sh` extracts the Python/Rust/Bash examples **verbatim from the Markdown** rather than duplicating them, so a documented snippet that drifts out of conformance fails CI instead of quietly misleading a reader. Extraction fails loudly when a section moves — a silently skipped example is worse than a broken build. Missing toolchains (no Node, no Rust) are skipped with a notice.

## The Python SDK (`sdk/python`)

Per the decision on distribution, non-Go SDKs are **monorepo folders** alongside the Go module, not separate repos.

- `apiary_plugin.protocol` — envelope handling: `main`, `serve_one`, `Request`, `PluginError`, `TransportError`, capability constants.
- `apiary_plugin.source` — typed mirrors of `sdk/plugin/source.go`, with `omitempty` semantics preserved, so a plugin written against either SDK puts the same bytes on the wire.
- Where Go returns `(result, *ResponseError)`, Python returns the result and raises `PluginError` — the same dichotomy, idiomatic in each language. `PluginError` rejects an empty `code` or `message` at construction, so rule 5 cannot be violated by accident.
- `pyproject.toml` makes it pip-installable from a checkout (`pip install ./sdk/python`, verified). **Not published to PyPI.**
- Stdlib only, `py.typed`, 18 unit tests on `python3 -m unittest`, and an example plugin that passes the corpus 10/10.

## Docs

- **Versioning and the protocol** is now a top-level section governing all SDKs — Go `sdk/v1.x`, Python `apiary-plugin` 1.x, both speaking protocol 1, both moving on a schedule independent of the daemon's `vX.Y.Z`. Consistent with the Go-specific section from #440, which now links to it.
- A **Python SDK** section with entry points and a complete example.
- **The conformance kit** section: how to run it, what a green run means, and a five-step recipe for a new-language SDK author (write the wrapper → 10/10 → mirror the typed structs → version against the protocol → add yourself to `check-examples.sh`).

## Wiring

- `make conformance`; `make test` also runs the Python unit tests.
- New `plugin-conformance` workflow on `sdk/**`, `src/examples/plugins/**`, `docs/plugins.md`, `docs/plugin-sdk.md` — Go tests, Python tests, then the kit.

## Verification

`cd src && go build ./... && go vet ./... && go test ./...`, the same for `sdk/`, `python3 -m unittest discover` in `sdk/python`, and `make conformance`. All clean.

## What remains open on #367

- **TypeScript/Node SDK** (npm) — deliberately not in this PR.
- **Rust SDK** (crate) — likewise.
- Publishing decisions: the Python package is in-tree only; nothing is on PyPI, and no npm/crates.io publication is set up.

Both remaining SDKs now have the corpus to validate against, which was the point of doing this first.
