### PR TITLE
fix(ci): pin the release-check snapshot to the newest daemon tag

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -38,6 +38,18 @@ jobs:
           version: "~> v2"
           args: check
 
+      # The SDK module is tagged `sdk/vX.Y.Z`, independently of the daemon's
+      # `vX.Y.Z`. GoReleaser derives the snapshot version from `git describe`,
+      # which picks whichever tag is nearest — so an SDK tag yields
+      # `sdk/v1.0.1-SNAPSHOT-<sha>`, and Docker rejects the slash as an image
+      # tag ("invalid reference format"). `git.ignore_tags` does NOT cover this:
+      # it is accepted by `goreleaser check` but does not affect current-tag
+      # selection. Pinning the current tag to the newest daemon tag does.
+      - name: Pin GoReleaser to the newest daemon tag
+        run: |
+          tag="$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)"
+          echo "GORELEASER_CURRENT_TAG=${tag:-v0.0.0}" >> "$GITHUB_ENV"
+
       - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,11 +8,11 @@ version: 2
 project_name: apiary
 
 git:
-  # The SDK module is tagged `sdk/vX.Y.Z`, independently of the daemon's
-  # `vX.Y.Z`. Left alone, `git describe` picks whichever is nearest, and an
-  # SDK tag makes the derived version `sdk/v1.0.0-…` — a slash Docker rejects
-  # as an image tag ("invalid reference format"). Daemon releases are the only
-  # thing this config builds, so it only ever looks at `v*` tags.
+  # Kept for changelog/previous-tag selection only. NOTE: this does NOT stop
+  # `git describe` from picking an `sdk/vX.Y.Z` tag as the *current* tag —
+  # verified against goreleaser 2.16.0, where every pattern form was a no-op.
+  # The snapshot build pins GORELEASER_CURRENT_TAG instead; see
+  # .github/workflows/release-check.yml.
   ignore_tags:
     - "sdk/*"
 


### PR DESCRIPTION
## Why

`sdk/v1.0.0` and `sdk/v1.0.1` are now pushed, and they sit nearer to `main` than the newest daemon tag. GoReleaser derives the snapshot version from `git describe`, so it picks the SDK tag and produces `sdk/v1.0.1-SNAPSHOT-<sha>` — Docker rejects the slash with `invalid reference format`, failing the `snapshot` job for every PR that touches this workflow's trigger paths.

PR #448 tried to fix this with `git.ignore_tags: ["sdk/*"]`. **That does not work.** The key is accepted by `goreleaser check`, which is why it looked right, but it does not affect current-tag selection. Verified against goreleaser 2.16.0 — every pattern form is a no-op:

| pattern | result |
|---|---|
| `sdk/*` | `current=sdk/v1.0.1` |
| `sdk/v*` | `current=sdk/v1.0.1` |
| `sdk/**` | `current=sdk/v1.0.1` |
| `^sdk/` | `current=sdk/v1.0.1` |
| `sdk/v[0-9]*` | `current=sdk/v1.0.1` |

#448's `snapshot` check passed only because `sdk/v1.0.1` did not exist yet when it ran, and `v0.19.0` was then the nearest tag.

## What

Pin `GORELEASER_CURRENT_TAG` to the newest `v[0-9]*` tag in the `release-check` workflow. Verified locally:

```
before: building snapshot... version=sdk/v1.0.1-SNAPSHOT-aec41b9
after:  using tags previous=v0.18.2 current=v0.19.0
        building snapshot... version=0.19.0-SNAPSHOT-aec41b9
```

The `git.ignore_tags` block is kept for changelog/previous-tag selection, with a comment recording that it does not cover the current tag, so nobody re-derives the same wrong conclusion.

**Real releases were never affected**: `release.yml` is triggered by the `v*` tag push and checks out that exact ref, so `describe` matches it exactly.