### PR TITLE
feat(plugins): plugin registry with verified command-line installs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
       - DEVELOPMENT.md
       - docs/**
       - mkdocs.yml
+      - registry/**
   release:
     types: [published]
   workflow_dispatch:
@@ -64,6 +65,42 @@ jobs:
           else
             echo "could not resolve latest release — keeping versions as committed"
           fi
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - name: Compile the plugin registry index
+        # Published at /apiary/registry/v1/index.json — what `apiary plugins
+        # search|info` resolve names against. Metadata only; artifacts stay with
+        # their publishers.
+        run: |
+          cd src && go run ./cmd/apiary-registry build \
+            --dir ../registry --out ../docs/registry/v1/index.json
+
+      - name: Sign the plugin registry index
+        # Signing covers the index, which carries the digests, which cover the
+        # artifacts. Without a key configured the index publishes unsigned, and
+        # every CLI reports it as unverified — the honest state, and one that
+        # turns into verification the day the secret exists.
+        env:
+          MINISIGN_KEY: ${{ secrets.APIARY_REGISTRY_MINISIGN_KEY }}
+        run: |
+          if [ -z "$MINISIGN_KEY" ]; then
+            echo "::notice::APIARY_REGISTRY_MINISIGN_KEY is not set — publishing the registry index unsigned"
+            exit 0
+          fi
+          sudo apt-get update -qq && sudo apt-get install -y minisign
+          umask 077
+          printf '%s\n' "$MINISIGN_KEY" > "$RUNNER_TEMP/minisign.key"
+          # The key must be passwordless (minisign -G -W); CI cannot answer a prompt.
+          minisign -S -s "$RUNNER_TEMP/minisign.key" \
+            -m docs/registry/v1/index.json \
+            -t "apiary plugin registry index, commit $GITHUB_SHA"
+          shred -u "$RUNNER_TEMP/minisign.key" 2>/dev/null || rm -f "$RUNNER_TEMP/minisign.key"
+          echo "signed: $(ls docs/registry/v1/)"
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/plugin-registry.yml
+++ b/.github/workflows/plugin-registry.yml
@@ -1,0 +1,52 @@
+name: Plugin registry
+
+# The registry's gate. A listing may not claim a digest, a compatibility range,
+# or a conformance verdict that this job could not reproduce from the published
+# artifact.
+on:
+  pull_request:
+    paths:
+      - registry/**
+      - src/internal/plugin/registry*.go
+      - src/cmd/apiary-registry/**
+      - .github/workflows/plugin-registry.yml
+  push:
+    branches: [main]
+    paths:
+      - registry/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Verify entries against their published artifacts
+        run: |
+          cd src && go run ./cmd/apiary-registry check \
+            --dir ../registry \
+            --conformance-runner ../sdk/conformance/run.py \
+            --results "$RUNNER_TEMP/conformance.json"
+
+      - name: Compile the index
+        run: |
+          cd src && go run ./cmd/apiary-registry build \
+            --dir ../registry \
+            --results "$RUNNER_TEMP/conformance.json" \
+            --out "$RUNNER_TEMP/index.json"
+
+      - name: Show the compiled index
+        run: cat "$RUNNER_TEMP/index.json"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ apiary.yaml.local
 *.swp
 .gitnexus
 site/
+
+# Built by `make registry-build` / the docs deploy from registry/plugins/*.yaml
+docs/registry/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,11 @@ builds:
       # keep in sync with the Makefile's version injection
       - -s -w
       - -X github.com/orlandoburli/apiary/internal/version.Version={{ .Version }}
+      # The plugin registry's minisign public key. Released binaries verify the
+      # official index against it; an empty value (no APIARY_REGISTRY_PUBLIC_KEY
+      # in the release environment) means registry commands report the index as
+      # unverified rather than silently trusting it.
+      - -X github.com/orlandoburli/apiary/internal/plugin.OfficialRegistryPublicKey={{ if index .Env "APIARY_REGISTRY_PUBLIC_KEY" }}{{ .Env.APIARY_REGISTRY_PUBLIC_KEY }}{{ end }}
 
 archives:
   - id: apiary

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,14 @@ SDK     := sdk
 BINARY  := apiary
 BIN_DIR := bin
 PKG     := github.com/orlandoburli/apiary/internal/version
+PLUGINPKG := github.com/orlandoburli/apiary/internal/plugin
 
-VERSION  := $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.1.0-dev")
-LDFLAGS  := -ldflags "-X $(PKG).Version=$(VERSION)"
+# The minisign public key the official plugin registry index is signed with.
+# Empty means the index is used unverified, and every registry command says so.
+REGISTRY_KEY ?= $(APIARY_REGISTRY_PUBLIC_KEY)
+
+VERSION  := $(shell git describe --tags --match "v*" --always --dirty 2>/dev/null || echo "0.1.0-dev")
+LDFLAGS  := -ldflags "-X $(PKG).Version=$(VERSION) -X $(PLUGINPKG).OfficialRegistryPublicKey=$(REGISTRY_KEY)"
 
 .DEFAULT_GOAL := help
 
@@ -38,6 +43,23 @@ test-python: ## Run the Python SDK's unit tests (stdlib only)
 .PHONY: conformance
 conformance: ## Run the plugin protocol conformance kit against every example we ship
 	$(SDK)/conformance/check-examples.sh
+
+.PHONY: registry-check
+registry-check: ## Verify every plugin registry entry against its published artifacts
+	cd $(SRC) && go run ./cmd/apiary-registry check --dir ../registry \
+		--conformance-runner ../sdk/conformance/run.py --results ../$(BIN_DIR)/conformance.json
+
+.PHONY: registry-build
+registry-build: ## Compile the registry entries into docs/registry/v1/index.json
+	cd $(SRC) && go run ./cmd/apiary-registry build --dir ../registry \
+		--results ../$(BIN_DIR)/conformance.json --out ../docs/registry/v1/index.json
+
+.PHONY: registry-sign
+registry-sign: ## Sign docs/registry/v1/index.json with minisign (needs MINISIGN_KEY_FILE)
+	@test -n "$(MINISIGN_KEY_FILE)" || { echo "set MINISIGN_KEY_FILE=<path to the minisign secret key>"; exit 1; }
+	minisign -S -s "$(MINISIGN_KEY_FILE)" -m docs/registry/v1/index.json \
+		-t "apiary registry index $(shell git rev-parse --short HEAD)"
+	@echo "→ docs/registry/v1/index.json.minisig"
 
 .PHONY: test-verbose
 test-verbose: ## Run all tests with per-test output

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -381,6 +381,40 @@ Reset the project's SQLite database (asks for confirmation; `--yes` skips).
 
 Scaffold a starter `apiary.yaml` in the current directory.
 
+### `apiary plugins`
+
+Find, install and inspect [out-of-process plugins](plugins.md). The registry
+half (`search`, `info`, `install`, `upgrade`, `uninstall`) talks to a plugin
+index; the rest reports on what is already on disk.
+
+```sh
+apiary plugins search [query] [--capability source]
+apiary plugins info <id>[@version]
+apiary plugins install <id>[@version] [--dir path] [--yes] [--sha256 digest]
+apiary plugins upgrade <id> [--rollback]
+apiary plugins uninstall <id> [--force]
+apiary plugins list
+apiary plugins inspect <id>
+apiary plugins validate
+```
+
+| Command | Description |
+|---|---|
+| `search` | List registry entries matching a query, optionally filtered by capability |
+| `info` | One listing in full: capabilities, repository, releases, what CI's conformance run found, and whether it can be installed on this host |
+| `install` | Resolve, verify digests, validate the manifest, print what it will place and what access it declares, then commit it atomically. Prints the `plugins:` snippet — it never edits `apiary.yaml`, and never enables anything |
+| `upgrade` | The same checks, then swap; keeps one generation as `<id>.bak`, restores it if the new copy fails to validate. `--rollback` restores it on demand |
+| `uninstall` | Remove an installed plugin directory. Refuses while it is enabled in `apiary.yaml` unless `--force` |
+| `list` | What is installed, with each plugin's configured state |
+| `inspect` | Print one installed manifest as JSON |
+| `validate` | Re-check installed manifests, enabled instances' config, and pinned executables |
+
+Registry commands accept `--registry <url>` for a one-off index and `--offline`
+to use the cached one. A plugin runs with the daemon's OS permissions; a listing
+is reviewed, not endorsed. See
+[Registries and mirrors](plugins.md#registries-and-mirrors) for pinning a
+signing key or turning the registry off.
+
 ### `apiary service`
 
 Manage Apiary as a system service — systemd (Linux), launchd (macOS), or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,9 +36,24 @@ version: "1"        # currently the only accepted value
 
 Out-of-process extensions are discovered through `plugin_dirs` and enabled in
 the top-level `plugins` list. `apiary validate` checks installed manifests,
-Apiary/protocol compatibility, and each enabled instance's configuration schema.
-See [Out-of-process plugins](plugins.md) for the manifest, protocol, CLI, and
+Apiary/protocol compatibility, each enabled instance's configuration schema, and
+the integrity of any pinned executable. See
+[Out-of-process plugins](plugins.md) for the manifest, protocol, CLI, and
 security model.
+
+`plugin_registries` lists the indexes `apiary plugins search|info|install`
+resolve names against — the CLI only; the daemon never contacts a registry.
+Omit it for the official index, set `[]` to disable the registry and install by
+hand, or point it at a mirror and pin that mirror's signing key:
+
+```yaml
+plugin_registries:
+  - https://orlandoburli.com.br/apiary/registry/v1/index.json
+  - url: file:///opt/apiary/registry/index.json
+    public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+```
+
+Details in [Registries and mirrors](plugins.md#registries-and-mirrors).
 
 ## `runners`
 

--- a/docs/plugin-directory.md
+++ b/docs/plugin-directory.md
@@ -1,14 +1,42 @@
 # Plugin directory
 
 Plugins extend Apiary without a fork, as separate executables speaking
-[protocol 1](plugins.md#protocol-version-1). This page lists the ones we know
-about.
+[protocol 1](plugins.md#protocol-version-1). The **registry** is how you find
+and install them from the command line:
 
-Apiary has **no plugin registry**. Nothing here is downloaded, verified, or
-endorsed by the daemon — a listing is a pointer to someone else's repository,
-and installing a plugin means placing files you obtained and checked yourself.
-Read [Installing a plugin](plugins.md#installing-a-plugin) before you add any of
-them, and prefer a release whose checksum you can pin in the manifest.
+```bash
+apiary plugins search cron
+apiary plugins info dev.apiary.routines
+apiary plugins install dev.apiary.routines
+```
+
+A listing is a pointer to someone else's repository. It is reviewed; it is not
+endorsed, and Apiary has not read the code. The registry holds **metadata and
+digests only** — artifacts stay on their publisher's release infrastructure, and
+the daemon never contacts a registry at all. A plugin you install runs
+unsandboxed, with the daemon's OS permissions, as its user: read it before you
+enable it.
+
+## What the registry does for you
+
+Installing by hand is still supported and still documented
+([Installing a plugin](plugins.md#installing-a-plugin)). What the registry adds
+is the two steps a human does badly:
+
+- **Picking the right artifact.** The host-version constraint, the protocol
+  version, the platform and any withdrawal are resolved *before* a byte is
+  downloaded — so "0.3.0 requires apiary >= 0.20.0, you are on 0.19.1" is an
+  answer you get up front rather than an error after unpacking.
+- **Checking it is the one the publisher shipped.** The archive's digest is
+  verified before it is unpacked, the manifest inside is checked against the
+  listing, and the executable's digest is written into the installed manifest as
+  a `checksum` pin. That pin comes from the registry repository rather than from
+  beside the binary, which is what turns it from drift detection into a
+  supply-chain check — see [Trust and secrets](plugins.md#trust-and-secrets).
+
+Everything else stays as it was. Installation makes a plugin *available*; only a
+`plugins:` entry in `apiary.yaml` makes it *run*, and the daemon has to be
+restarted. `apiary plugins install` never edits your config.
 
 ## Available plugins
 
@@ -16,12 +44,18 @@ them, and prefer a release whose checksum you can pin in the manifest.
 |---|---|---|---|
 | `dev.apiary.routines` | `source` | **Scheduled routines.** Turns each due cron occurrence into a work item, so a nightly audit or an hourly sweep routes through triggers and workflows like any other task. | [apiary-routines](https://github.com/orlandoburli/apiary-routines) · [docs](https://orlandoburli.com.br/apiary-routines/) |
 
+`apiary plugins search` is the live version of this table, and
+`apiary plugins info <id>` adds what CI observed: whether the release passed the
+[conformance kit](plugin-sdk.md#the-conformance-kit), which platforms it builds
+for, and whether it can be installed on *this* host.
+
 ## Reference plugins
 
 These ship inside this repository under `src/examples/plugins/`, as working
-starting points rather than things to run in production. The three source
-plugins are behaviourally identical on purpose — diff them to see one contract
-expressed in three ecosystems.
+starting points rather than things to run in production. They publish no
+release artifacts, so they are not in the registry — build them from source. The
+three source plugins are behaviourally identical on purpose — diff them to see
+one contract expressed in three ecosystems.
 
 | Plugin | Language | Demonstrates |
 |---|---|---|
@@ -37,23 +71,37 @@ closest to your language. A plugin is one executable plus one
 `apiary-plugin.json` manifest; the daemon spawns it per call, writes one JSON
 request to stdin and reads one response from stdout.
 
-Two things worth knowing before you start, both learned from building
-`dev.apiary.routines`:
+One thing worth knowing before you start, learned from building
+`dev.apiary.routines`: **`config_schema` supports a subset of JSON Schema** and
+fails closed on anything outside it — see the keyword list in
+[Overview & Architecture](plugins.md#manifest-version-1). An unsupported keyword
+such as `pattern` invalidates the whole manifest, and the plugin is then
+reported as *not installed* rather than as having a bad schema.
 
-- **The Go SDK is not currently importable from outside this repository** —
-  `go get github.com/orlandoburli/apiary/sdk/plugin` does not resolve
-  ([#434](https://github.com/orlandoburli/apiary/issues/434)). Until that is
-  fixed, a third-party Go plugin implements the (small) wire protocol directly.
-  Every other language was always going to do that anyway.
-- **`config_schema` supports a subset of JSON Schema** and fails closed on
-  anything outside it — see the keyword list in
-  [Overview & Architecture](plugins.md#manifest-version-1). An unsupported keyword such as
-  `pattern` invalidates the whole manifest, and the plugin is then reported as
-  *not installed* rather than as having a bad schema.
+Go authors can `go get github.com/orlandoburli/apiary/sdk` — the SDK is its own
+module, tagged independently of the daemon.
 
 ## Getting listed
 
-Open a PR adding a row to the table above. Include the plugin id, its
-capabilities, one sentence on what it does, and a link to its repository. The
-plugin must be publicly readable so operators can inspect what they are about to
-run as the daemon's user.
+Open a pull request adding `registry/plugins/<your-plugin-id>.yaml`, described
+in full in [Publishing to the registry](plugin-sdk.md#publishing-to-the-registry).
+The plugin must be publicly readable so operators can inspect what they are
+about to run as the daemon's user, and every release must declare both digests —
+there is no unpinned listing.
+
+CI does not take any of it on trust: it downloads each artifact, re-derives both
+digests, cross-checks the manifest inside the archive against your entry, and
+runs the conformance kit. A listing cannot claim a digest, a compatibility
+range, or a conformance verdict that CI could not reproduce.
+
+## Turning the registry off
+
+The registry is a CLI convenience, not a dependency. To disable it — and keep
+manual installation only:
+
+```yaml
+plugin_registries: []
+```
+
+To resolve against an internal mirror instead, or to pin a registry to a signing
+key, see [Registries and mirrors](plugins.md#registries-and-mirrors).

--- a/docs/plugin-sdk.md
+++ b/docs/plugin-sdk.md
@@ -440,3 +440,96 @@ For the full case list and how to add one, see
    [Versioning and the protocol](#versioning-and-the-protocol).
 5. Add it to `sdk/conformance/check-examples.sh` so it is checked on every
    change to the protocol, the docs or the SDKs.
+
+## Publishing to the registry
+
+The [registry](plugin-directory.md) is how operators find and install your
+plugin from the command line. It stores metadata and digests only: your
+artifacts stay on your own release infrastructure, and nothing about the listing
+gives Apiary a copy of your code.
+
+### 1. Publish release artifacts
+
+One archive (`.tar.gz` or `.zip`) per platform, containing the executable and
+its `apiary-plugin.json`. The manifest may sit at the archive root or inside a
+single top-level directory. Anything that is not a plain file or directory —
+symlinks, hardlinks, devices — is refused at install time, so do not ship them.
+
+Releases are immutable: publish `1.0.1`, never a re-cut `1.0.0`.
+
+### 2. Compute both digests
+
+Every artifact declares two: the archive as you publish it, and the executable
+*inside* it, after unpacking.
+
+```bash
+shasum -a 256 myplugin_1.0.0_linux_amd64.tar.gz              # archive_sha256
+tar -xzf myplugin_1.0.0_linux_amd64.tar.gz -C /tmp/unpacked
+shasum -a 256 /tmp/unpacked/myplugin                          # executable_sha256
+```
+
+The second one becomes the `checksum` pin in the installed manifest when your
+own manifest carries none — which is why it comes from the registry rather than
+from your archive. If you do pin a `checksum` yourself, it must be the
+executable you ship, or the install aborts.
+
+### 3. Open a pull request
+
+Add `registry/plugins/<your-plugin-id>.yaml` to the
+[apiary repository](https://github.com/orlandoburli/apiary). The filename must
+be the plugin id.
+
+```yaml
+schema_version: 1
+id: com.example.nagios
+summary: One sentence on what it does.
+capabilities: [source]
+repository: https://github.com/example/apiary-nagios   # must be publicly readable
+license: MIT
+
+# Optional: the config registry CI runs the conformance kit with. Without it the
+# release publishes as "conformance not run" — an honest absence rather than an
+# unearned pass.
+conformance_config:
+  api_url: https://example.invalid/api
+
+releases:
+  - version: 1.0.0
+    apiary: ">= 0.13.0-0"    # the same constraint as your manifest's
+    protocol: 1
+    artifacts:
+      - os: linux            # GOOS/GOARCH spelling
+        arch: amd64
+        url: https://github.com/example/apiary-nagios/releases/download/v1.0.0/…tar.gz
+        archive_sha256: "…"
+        executable_sha256: "…"
+```
+
+### What CI checks
+
+Nothing in the listing is taken on trust. For every artifact, on every pull
+request: the entry is validated, the artifact is downloaded and its
+`archive_sha256` re-derived, it is unpacked and the `apiary-plugin.json` inside
+is cross-checked against your entry (id, version, protocol, `apiary` constraint,
+capabilities), `executable_sha256` is re-derived from the executable the
+manifest names, and — if you declared a `conformance_config` — the
+[conformance kit](#the-conformance-kit) runs against your published binary.
+
+A conformance failure does **not** block the listing. The verdict is published
+instead, and `apiary plugins info` shows it: the registry describes plugins, it
+does not certify them. You can run the same check locally with
+`make registry-check`.
+
+### Withdrawing a release
+
+Mark it, never delete it — the index has to stay honest about what was once
+resolvable:
+
+```yaml
+  - version: 1.0.0
+    yanked: true
+    yanked_reason: corrupt linux/amd64 archive; use 1.0.1
+```
+
+Resolution skips yanked releases and says why when nothing else qualifies.
+Operators who already installed one are unaffected until they upgrade.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -122,9 +122,74 @@ permissions.
 
 ## Installing a plugin
 
-Apiary has no plugin registry and never downloads plugins — installation is
-placing files, deliberately. Using the bundled `source-file` reference plugin
-as the example:
+Installation is placing files, deliberately — `apiary plugins install` does that
+for you and verifies what it places, or you do it by hand. Either way the daemon
+never downloads anything, nothing is enabled without an edit you make, and the
+files land in the same place.
+
+### From the registry
+
+```bash
+apiary plugins search cron                       # find one
+apiary plugins info dev.apiary.routines          # read what it declares
+apiary plugins install dev.apiary.routines       # verify, confirm, place the files
+```
+
+`install` resolves the release for this host — version constraint, protocol,
+platform, withdrawals — **before** downloading, then verifies the archive's
+digest against the registry's, unpacks it into a staging directory outside every
+searched path, validates the manifest, confirms the archive holds the plugin you
+asked for, and verifies the executable's digest. Only then does it print what it
+is about to install and ask:
+
+```text
+dev.apiary.routines 0.1.0  (source)
+  from     https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/…tar.gz
+  sha256   efb15a92…405f64d7 (verified)
+  registry https://orlandoburli.com.br/apiary/registry/v1/index.json (signature verified)
+  conformance  FAILED the protocol kit in registry CI — expect protocol bugs
+  pinned   f4d0c199…52b709f6 (from the registry, not from the archive)
+
+  Declared access (a declaration, not a sandbox):
+    network      no
+    read paths   configured state_file
+    write paths  configured state_file
+    secret env   (none)
+
+  This executable will run with the daemon's OS permissions, as its user.
+  A registry listing is a pointer to someone else's repository — it is not an
+  endorsement, and Apiary has not reviewed this code.
+
+Install into .apiary/plugins? [y/N]
+```
+
+That conformance line is real, and worth reading rather than skimming: registry
+CI ran the [conformance kit](plugin-sdk.md#the-conformance-kit) against this
+published binary and it failed three cases. A failure does not block a listing or
+an install — the registry describes plugins, it does not certify them — but it
+does tell you to expect protocol-level rough edges.
+
+`--yes` skips the prompt, not the summary. Other flags: `--dir` to choose which
+searched directory to install into (default: the first `plugin_dirs` entry),
+`--sha256` to cross-check the archive digest you were told to expect against the
+registry's (a disagreement stops the install before anything is downloaded),
+`--registry` for a one-off index, `--offline` to use the cached index.
+
+The commit is a single atomic rename: until you answer the prompt, nothing
+exists in any directory the daemon searches.
+
+**Pinning.** If the publisher's manifest carries no `checksum`, the installer
+writes the registry's executable digest into it. This is the point of installing
+from a registry rather than by hand: the pin now originates in a repository the
+publisher does not control, so the per-invocation integrity check compares
+against a value they cannot quietly rewrite. `apiary plugins validate` re-derives
+it too, so a swapped binary is caught by a command rather than at 3am. A
+publisher pin that disagrees with the registry aborts the install.
+
+### By hand
+
+The manual procedure needs no network and no registry, and stays fully
+supported. Using the bundled `source-file` reference plugin as the example:
 
 **1. Obtain the executable.** Build it from source or download a release from
 the plugin's publisher, then verify the artifact out of band (checksum,
@@ -152,8 +217,12 @@ apiary plugins inspect dev.apiary.source-file
 apiary plugins validate
 ```
 
+### Enabling it (either way)
+
 **4. Enable it in `apiary.yaml`.** Installation makes a plugin *available*;
-only a `plugins:` entry makes it *run*:
+only a `plugins:` entry makes it *run*. `apiary plugins install` prints this
+snippet, seeded with the config keys the manifest requires — it never edits your
+config itself:
 
 ```yaml
 plugins:
@@ -172,11 +241,65 @@ configured but inert.
 installed or reconfigured while the daemon runs is picked up on the next
 start.
 
-To **upgrade**, verify the new artifact in a staging directory, stop Apiary,
-replace the whole plugin directory atomically, run `apiary plugins validate`,
-and restart (details under [Trust and secrets](#trust-and-secrets)). To
-**uninstall**, remove the `plugins:` entry (or set `enabled: false`) and
-delete the plugin's directory.
+### Upgrading and uninstalling
+
+```bash
+apiary plugins upgrade dev.apiary.routines             # same checks, then swap
+apiary plugins upgrade dev.apiary.routines --rollback  # restore the kept version
+apiary plugins uninstall dev.apiary.routines
+```
+
+`upgrade` runs the full verification, sets the current version aside as
+`<id>.bak` (one generation), and commits the new one; if the result does not
+validate, the previous version is restored automatically. A running daemon keeps
+the version it started with until you restart it.
+
+`uninstall` removes the directory and refuses while the plugin is still enabled
+in `apiary.yaml` (`--force` overrides). It never edits your config — a `plugins:`
+entry pointing at an uninstalled id is already a clear `apiary validate` error.
+
+By hand, the equivalent is: verify the new artifact in a staging directory, stop
+Apiary, replace the whole plugin directory atomically, run
+`apiary plugins validate`, and restart (details under
+[Trust and secrets](#trust-and-secrets)). To uninstall, remove the `plugins:`
+entry (or set `enabled: false`) and delete the plugin's directory.
+
+### Registries and mirrors
+
+`plugin_registries` lists the indexes `search`, `info` and `install` resolve
+names against. Unset means the official index; each entry is a URL, or a mapping
+that pins that registry to a signing key:
+
+```yaml
+plugin_registries:
+  # The official index, verified against the key built into the binary.
+  - https://orlandoburli.com.br/apiary/registry/v1/index.json
+  # An internal mirror, verified against a key this organisation controls.
+  - url: file:///opt/apiary/registry/index.json
+    public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+```
+
+Registries are consulted in order and the first hit wins, so a mirror listed
+first deliberately shadows the official index. Only `https://` and `file://` are
+accepted: digests protect the payload, but nothing protects a plaintext
+resolution. `plugin_registries: []` disables the registry entirely, leaving
+manual installation. The daemon never reads any of this — registry access is a
+CLI concern.
+
+The index is signed with [minisign](https://jedisct1.github.io/minisign/) and
+verified before it is parsed; the local cache is verified on read too, so a cache
+poisoned on disk is caught rather than served. **Once a key is pinned there is no
+way to skip verification** — no flag, no environment variable. When no key is
+available for a registry, commands print
+`! … is not signature-verified (no public key pinned for it)` rather than letting
+an unverified index read as a checked one.
+
+Signing covers the index, which carries the digests, which cover the artifacts.
+It does not authenticate plugin publishers; artifact signing is a separate
+problem and is not solved here.
+
+For air-gapped installs, use a `file://` mirror or `--offline`, which uses the
+cached index and never touches the network.
 
 ## Manifest version 1
 
@@ -213,10 +336,16 @@ delete the plugin's directory.
   bare hex. When present it is verified when the plugin client is created and
   again before each invocation, so a binary replaced after installation is rejected.
   A malformed value is an error rather than being treated as unpinned, so
-  `apiary validate` catches a bad pin. This is **tamper-evidence, not
-  authenticity**: the digest lives beside the binary, so anyone able to rewrite
-  the executable can rewrite the pin too. It detects accidental drift and
-  unsophisticated swaps, not a determined attacker with write access.
+  `apiary validate` catches a bad pin, and both `apiary validate` and
+  `apiary plugins validate` re-derive the digest to catch a binary that changed
+  after installation. When the publisher ships no pin, `apiary plugins install`
+  writes the registry's digest here. A publisher-written pin is
+  **tamper-evidence, not authenticity**: the digest lives beside the binary, so
+  anyone able to rewrite the executable can rewrite the pin too — it detects
+  accidental drift and unsophisticated swaps, not a determined attacker with
+  write access. An installer-injected pin originates outside the publisher's own
+  release, which is what makes it a supply-chain check rather than a drift
+  check.
 - `capabilities` accepts `source`, `runner`, `workflow_action`,
   `approval_provider`, `secret_provider`, and `event_exporter`.
 - `config_schema` supports `type`, `properties`, `required`,
@@ -402,14 +531,30 @@ Python, Rust, and Bash examples.
 
 Plugins execute with the Apiary service account's OS permissions. Before install:
 
-1. Obtain the binary from a trusted publisher.
-2. Verify its checksum and signature out of band.
-3. Inspect the manifest's network, path, and secret requirements.
+1. Obtain the binary from a trusted publisher — read the code you are about to
+   run as that account. A registry listing is a pointer to someone else's
+   repository, reviewed but not endorsed, and never a substitute for this.
+2. Verify its provenance. `apiary plugins install` does the mechanical part:
+   digests checked before unpacking, manifest cross-checked against the listing,
+   executable pinned. Installing by hand means doing it out of band yourself.
+3. Inspect the manifest's network, path, and secret requirements — `install`
+   prints them and waits for you; `apiary plugins inspect` shows them any time.
 4. Install into a directory writable only by the Apiary operator/service account.
 
-Apiary does not download or auto-upgrade plugins. Upgrade atomically by verifying
-the new artifact in a staging directory, stopping Apiary, replacing the complete
-plugin directory, running `apiary plugins validate`, and restarting. Keep the old
+**How far the checks reach.** Signature verification covers the registry index,
+which carries the digests, which cover the artifacts. It does not authenticate
+plugin publishers, and it says nothing about what a plugin does with the access
+it declares. A `checksum` the publisher wrote is tamper-evidence only — the pin
+lives beside the binary, so anyone who can rewrite one can rewrite the other. A
+pin *injected at install* comes from the registry repository instead, which is a
+meaningfully stronger claim, but still one about bytes, not about intent.
+
+The daemon never contacts a registry, never downloads, and never auto-upgrades:
+every one of those is a command you run. Upgrade with
+`apiary plugins upgrade`, which stages, verifies, keeps one generation as
+`<id>.bak`, and restores it if the new copy fails to validate — or, by hand,
+verify the new artifact in a staging directory, stop Apiary, replace the complete
+plugin directory, run `apiary plugins validate`, and restart. Keep the old
 directory for rollback, but never leave two versions with the same ID in searched
 directories.
 

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -82,7 +82,7 @@ items flow through normal workflow trigger matching.
 
 - **Requirements:** Plugin installed in `plugin_dirs` and enabled under `plugins:`
 - **Write-back:** None (read-only source) — `apiary validate` rejects incompatible workflow features
-- **Setup:** See [Source plugins](plugins.md#source-plugins) and the `source-file` reference plugin
+- **Setup:** `apiary plugins search --capability source` for published ones, or see [Source plugins](plugins.md#source-plugins) and the `source-file` reference plugin
 
 ### Linear
 

--- a/openspec/CHANGELOG.md
+++ b/openspec/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Ativas
 
+- **plugin-registry** — Plugin registry and command-line installs: a static, PR-reviewed index (`registry/plugins/*.yaml` compiled to signed `index.json`, artifacts stay with their publishers) plus `apiary plugins search|info|install|upgrade|uninstall`. Pre-download resolution (host semver, protocol, os/arch, yanks), staged installs with digest verification and safe unpacking, checksum pin injection from the index — turning the manifest pin from drift detection into a supply-chain check — an explicit `security:` trust summary before commit, registry CI that re-derives every digest and runs the conformance kit, and mirrors/`--offline` for air-gapped installs. Installed still never means enabled; the daemon never contacts the registry. Four phases.
 - **step-wallclock-attribution** — Atribuição de wall-clock por step (thinking / writing / esperas de tool / tarefas em background) gravada em `task_executions` e `step_runs` ao lado das colunas de token, lista das chamadas mais lentas, payload do evento `system:task_started` no log, e comando `apiary profile <instance-id> [--json]`. GitHub issue #399.
 
 ## Arquivadas

--- a/openspec/changes/plugin-registry/design.md
+++ b/openspec/changes/plugin-registry/design.md
@@ -1,0 +1,261 @@
+# Design: plugin registry and command-line installs
+
+## Registry shape
+
+The registry is a **static, PR-reviewed index**, not a service. It lives in this
+repository and is compiled by CI into JSON published beside the docs site.
+
+```
+registry/
+├── plugins/
+│   ├── dev.apiary.routines.yaml     ← one file per plugin id
+│   └── dev.apiary.source-file.yaml
+└── schema/
+    └── index-v1.json                ← JSON Schema for the compiled index
+```
+
+There are no accounts, no uploads and no runtime API. Adding or updating a
+plugin is a pull request; the review is the trust boundary and the CI job is
+the gate.
+
+### Entry format
+
+```yaml
+schema_version: 1
+id: dev.apiary.routines
+summary: Turns each due cron occurrence into a work item.
+capabilities: [source]
+homepage: https://orlandoburli.com.br/apiary-routines/
+repository: https://github.com/orlandoburli/apiary-routines
+license: MIT
+releases:
+  - version: 0.1.0
+    apiary: ">= 0.18.0-0"     # semver constraint, matches the manifest's field
+    protocol: 1
+    published_at: 2026-08-27
+    artifacts:
+      - os: darwin
+        arch: arm64
+        url: https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/apiary-routines_0.1.0_darwin_arm64.tar.gz
+        archive_sha256: "…"        # of the downloaded file
+        executable_sha256: "…"     # of the executable inside, after unpacking
+```
+
+Rules the schema enforces:
+
+- `id` is reverse-DNS and matches `validPluginID` in
+  `src/internal/plugin/manifest.go`, and must equal the file's basename.
+- `version` is semver; versions are unique per entry and never rewritten. A bad
+  release is marked `yanked: true` with a `yanked_reason`, never deleted — the
+  index has to stay honest about what was once resolvable.
+- `capabilities` uses the same vocabulary as the manifest.
+- `protocol` must be a protocol the CLI supports (currently `1`).
+- `archive_sha256` and `executable_sha256` are required; there is no unpinned
+  release. An artifact whose digest cannot be reproduced by CI is not listed.
+- `os`/`arch` use Go's `GOOS`/`GOARCH` spelling. A release with no artifact for
+  the running platform is resolvable but not installable, and says so.
+
+### Compiled index
+
+CI concatenates the entries into a single document, so the CLI makes one
+request:
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-27T00:00:00Z",
+  "plugins": [ { "id": "…", "releases": [ … ], "conformance": { … } } ]
+}
+```
+
+`conformance` is written by CI, not by the submitter: the kit's verdict, the kit
+version and the commit it ran at. It is displayed by `plugins info` and is
+never presented as an endorsement.
+
+### Registry CI
+
+For every changed entry:
+
+1. Validate against `schema/index-v1.json`; check id/basename agreement,
+   semver, capability names, protocol.
+2. Download each artifact; assert `archive_sha256` matches.
+3. Unpack into a temp dir; assert the embedded `apiary-plugin.json` parses and
+   its `id`, `version`, `protocol` and `capabilities` match the entry, and that
+   `executable_sha256` matches the executable it names.
+4. Run the conformance kit (the harness behind
+   `.github/workflows/plugin-conformance.yml`) against the artifact for the CI
+   platform; record the verdict.
+5. On merge to `main`, rebuild `index.json`, sign it (phase 3) and deploy with
+   the docs site.
+
+Steps 2–4 mean a listing cannot claim a digest, a compatibility range or a
+conformance result that CI could not reproduce.
+
+## Resolution
+
+`resolve(id, constraint)` runs entirely against the cached index:
+
+1. Look up the plugin id; unknown ids fail with the closest matches by edit
+   distance.
+2. Filter releases: not `yanked`, `protocol` supported by this CLI, `apiary`
+   constraint satisfied by the running version (the same semver evaluation
+   `Installed.Validate` uses today, so the pre-flight answer and the
+   post-install answer cannot disagree), and an artifact for `runtime.GOOS` /
+   `runtime.GOARCH`.
+3. Pick the highest remaining semver, or the exact version when `id@version`
+   was given.
+4. If the filter empties, report *which* predicate eliminated the newest
+   candidate — "0.3.0 requires apiary >= 0.20.0, you are on 0.19.1" is the
+   whole point of resolving before downloading.
+
+### Index cache
+
+Cached under `${XDG_CACHE_HOME:-~/.cache}/apiary/registry/<host>/index.json`
+with its ETag. Refresh is a conditional GET, at most once per command, with a
+30s timeout. `--offline` uses the cache and never touches the network; a cold
+cache under `--offline` is a clear error, not an empty result.
+
+## Install state machine
+
+`apiary plugins install <id>[@version]` — every step is reversible until the
+last one, which is atomic:
+
+| # | Step | Failure behaviour |
+|---|---|---|
+| 1 | Resolve from the index | Abort; nothing on disk |
+| 2 | Refuse if the id is already installed in any `plugin_dirs` entry | Abort, pointing at `upgrade` |
+| 3 | Download to `TMPDIR/apiary-install-*/archive` with a size cap and a deadline | Abort; temp dir removed |
+| 4 | Verify `archive_sha256` (`fileSHA256`) | Abort loudly — a digest mismatch is reported as a supply-chain failure, not a network hiccup |
+| 5 | Unpack into the staging dir, rejecting absolute paths, `..`, symlinks, devices and hardlinks | Abort |
+| 6 | `plugin.Load(stagingDir, version)` + `Installed.Validate` — manifest schema, id agreement with the requested id, protocol, executable safety | Abort with the validator's own message |
+| 7 | Verify `executable_sha256` against the named executable | Abort loudly |
+| 8 | Inject `checksum: sha256:<executable_sha256>` if the manifest has none; verify agreement if it has one | A publisher pin that disagrees with the index aborts the install and is a registry bug |
+| 9 | Print the trust summary; prompt unless `--yes` | Abort; temp dir removed |
+| 10 | `rename(stagingDir, <plugin_dir>/<id>)` | Cross-device fallback: copy into `<plugin_dir>/.<id>.incoming`, then rename within the target filesystem |
+| 11 | Re-run discovery over the target directory and print the `plugins:` snippet | Reports a broken install rather than claiming success |
+
+Nothing in this sequence executes plugin code. The first execution is still the
+daemon's first invocation, after the operator has written a `plugins:` entry and
+restarted.
+
+### Trust summary
+
+Printed at step 9, always — `--yes` suppresses the prompt, not the output:
+
+```
+dev.apiary.routines 0.1.0  (source)
+  from   https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/…tar.gz
+  sha256 3f9a…c21e (verified)
+  conformance  passed (kit 1.0.0, 2026-08-27)
+
+  Declared access (a declaration, not a sandbox):
+    network      yes
+    read paths   ~/.apiary/routines.yaml
+    write paths  (none)
+    secret env   (none)
+
+  This executable will run with the daemon's OS permissions, as its user.
+  A registry listing is a pointer to someone else's repository — it is not an
+  endorsement, and Apiary has not reviewed this code.
+
+Install into .apiary/plugins? [y/N]
+```
+
+### Pin injection
+
+Step 8 is the security argument for the whole change. Today `docs/plugins.md`
+correctly describes the manifest `checksum` as tamper-evidence only: the pin
+sits in the same directory as the binary it protects. After a registry install
+the digest originates in the registry repository — a different host, a
+different access-control domain, reviewed in a pull request and re-derived by
+CI — so `integrityGuard.check` on every invocation is now comparing the file
+against a value the plugin's publisher cannot silently rewrite.
+
+The manifest rewrite is minimal: decode, set `checksum` when absent, re-encode
+with stable key order, write inside the staging dir before step 10. When the
+publisher already pinned, the installer verifies agreement and leaves the file
+byte-identical.
+
+## Upgrade and uninstall
+
+`upgrade <id>` runs steps 1–9 into a staging dir, then swaps:
+
+1. `rename(<plugin_dir>/<id>, <plugin_dir>/<id>.bak)` (one generation only; a
+   previous `.bak` is removed first).
+2. `rename(staging, <plugin_dir>/<id>)`.
+3. Re-run discovery; on failure, restore from `.bak` and exit non-zero.
+
+The daemon is not touched, and the command says so: a running daemon keeps the
+old plugin until it is restarted. `--rollback` restores `.bak`.
+
+`uninstall <id>` removes the directory, and refuses while the id appears as an
+enabled entry in `apiary.yaml` (`--force` overrides). It never edits config,
+because a `plugins:` entry pointing at an uninstalled id is already a clear
+validation error rather than a silent one.
+
+## Configuration
+
+```yaml
+plugin_registries:
+  - https://orlandoburli.com.br/apiary/registry/v1/index.json
+  # - file:///opt/apiary/registry/index.json     # internal mirror
+```
+
+Unset means the official index. `[]` disables every registry subcommand with an
+explicit message. Entries are consulted in order and the first hit wins;
+`--registry` overrides the list for one command. Only `https://` and `file://`
+are accepted — `http://` is rejected outright, since digests protect the payload
+but not the resolution.
+
+The daemon ignores this field entirely; it is CLI-only configuration that lives
+in `apiary.yaml` for the same reason `plugin_dirs` does.
+
+## Signing (phase 3)
+
+CI signs `index.json` with minisign; the public key is compiled into the
+binary. The CLI verifies before parsing and fails closed — no
+`--insecure-skip-signature`. Mirrors either carry the upstream signature
+verbatim (a `file://` copy of the signed document verifies exactly like the
+original) or are configured with their own key via
+`plugin_registries[].public_key`.
+
+Signature verification covers the index, which covers the digests, which cover
+the artifacts. It does not authenticate plugin *publishers*: signing the
+artifacts themselves is a separate change, and its absence is stated on the
+docs page rather than papered over.
+
+## Code layout
+
+| File | Contents |
+|---|---|
+| `src/internal/plugin/registry.go` | Index model, fetch, ETag cache, resolution |
+| `src/internal/plugin/registry_signature.go` | Minisign verification (phase 3) |
+| `src/internal/plugin/install.go` | Staging, download, unpack, pin injection, atomic commit |
+| `src/internal/cli/plugins.go` | `search`, `info`, `install`, `upgrade`, `uninstall` on the existing command group |
+| `src/internal/config/validate.go` | `plugin_registries` validation |
+| `registry/` | Entries, schema, and the CI workflow that gates them |
+
+Reuse is deliberate: `fileSHA256`, `normalizeChecksum` and `verifyChecksum`
+from `integrity.go`, `Load` / `Validate` from `manifest.go`, `Discover` from
+`discovery.go`. The installer adds no second implementation of any check the
+daemon already performs — a divergence between "what install accepts" and "what
+the daemon accepts" would be the worst failure mode this change could have.
+
+## Testing
+
+- **Index**: schema round-trip, unknown `schema_version` fails closed, yanked
+  releases skipped, resolution picks the right release, each rejection reports
+  the predicate that eliminated the newest candidate.
+- **Cache**: cold / warm / conditional-GET, `--offline` with and without a
+  cache, corrupt cache re-fetched rather than fatal.
+- **Install**: happy path end to end against a `file://` registry and a local
+  archive; digest mismatch at both stages; archive traversal (`../`, absolute,
+  symlink) rejected; manifest id ≠ requested id rejected; incompatible host
+  version rejected before download (asserted by a fetch-counting transport);
+  pin injected when absent, verified when present, install aborted on
+  disagreement; interrupted install leaves nothing in `plugin_dirs`.
+- **Upgrade**: swap, failed-validation rollback, `.bak` retention of exactly one
+  generation.
+- **Uninstall**: refusal while enabled, `--force`, idempotence.
+- **CLI**: golden output for `search` / `info` / the trust summary, and a test
+  that asserts `install` never writes to `apiary.yaml`.

--- a/openspec/changes/plugin-registry/proposal.md
+++ b/openspec/changes/plugin-registry/proposal.md
@@ -1,0 +1,203 @@
+# Proposal: Plugin Registry and Command-Line Installs
+
+## Why
+
+Protocol 1 made third-party plugins possible; nothing made them *findable* or
+*installable*. Today the whole distribution story is a markdown table
+(`docs/plugin-directory.md`) plus a five-step manual procedure: build or
+download an artifact, verify it out of band, `mkdir` a directory named after
+the plugin id, copy two files in, `chmod +x`, run `apiary plugins validate`,
+paste a `plugins:` block, restart. Every step is a place to get it subtly
+wrong, and the two that matter most for safety — *which* artifact and *whether
+it is the one the publisher shipped* — are the two Apiary offers no help with
+at all.
+
+The consequences are concrete:
+
+- **Discovery is a doc page.** A new plugin reaches operators only if they
+  re-read a table between releases. There is no `search`, no capability
+  filter, no "is this compatible with my Apiary version" answer short of
+  installing it and reading the validation error.
+- **Compatibility is discovered after installation.** `Installed.Validate`
+  checks the manifest's `apiary` semver constraint against the host — but only
+  once the files are already on disk, already extracted, already executable.
+- **The checksum pin is weak by construction, and we say so.** `docs/plugins.md`
+  admits it: the digest lives beside the binary, so "anyone able to rewrite the
+  executable can rewrite the pin too". It detects drift, not tampering.
+- **Nothing is ever verified end to end.** The repository has a conformance kit
+  and a CI workflow for it, and no published plugin is required to pass either.
+  An operator has no signal beyond the publisher's own README.
+
+The gap is that **Apiary has no name-to-artifact resolution layer**, so the
+integrity, compatibility and provenance checks it already knows how to perform
+all happen too late to prevent anything.
+
+This change adds that layer — deliberately, and without becoming a package
+manager. The current doctrine ("installation is placing files, deliberately";
+plugins run unsandboxed as the daemon's user) is not softened. It is
+mechanised, with the trust decision made *explicit and informed* instead of
+implicit and undocumented.
+
+---
+
+## What Changes
+
+| Area | Before | After |
+|---|---|---|
+| **Discovery** | A markdown table in the docs | A reviewed, CI-validated index compiled to static JSON, queryable with `apiary plugins search` |
+| **Compatibility check** | After installation, from the on-disk manifest | Before download, from the index: host semver + protocol + os/arch |
+| **Artifact integrity** | Operator verifies out of band, if they remember | Digest declared in the registry repository, verified by the CLI before anything is unpacked |
+| **Checksum pin** | Optional, publisher-supplied, lives beside the binary | Injected at install time from the registry digest when the publisher did not pin one |
+| **Install** | 5 manual steps, 2 of them security-relevant | `apiary plugins install <id>` — staged, verified, confirmed, atomically committed |
+| **Upgrade / uninstall** | Prose in the docs | `apiary plugins upgrade` / `uninstall`, with one generation of rollback kept |
+| **Conformance** | A kit nobody is required to run | Run in registry CI against the published artifact; the result is part of the entry |
+| **Enablement** | Manual `plugins:` block | Still manual — `install` prints the snippet and never edits `apiary.yaml` |
+| **Trust decision** | Undocumented, implicit in the copy commands | An explicit pre-install summary of the manifest's `security:` block, requiring confirmation |
+
+---
+
+## New Concepts
+
+| Concept | Description |
+|---|---|
+| **Registry index** | A static JSON document (schema v1) listing plugins and their releases. Compiled by CI from PR-reviewed YAML entries under `registry/plugins/`, published beside the docs site. No server, no accounts, no uploads. |
+| **Registry entry** | One YAML file per plugin id: identity, capabilities, links, license, and a list of releases. Adding or updating one is a pull request against this repository. |
+| **Release artifact** | A per-`os`/`arch` archive URL hosted **by the publisher**, with the archive digest and the digest of the executable inside it. Apiary hosts metadata only; it never mirrors or re-hosts binaries. |
+| **Staged install** | Download → verify digest → unpack → load and validate the manifest → present the trust summary → confirm → atomic `rename` into the plugin directory. Nothing is executed, and nothing lands in a searched directory, until every check has passed. |
+| **Pin injection** | When the publisher's manifest carries no `checksum`, the installer writes `sha256:<executable_sha256>` from the index. The pin now originates in a repository the publisher does not control, which is what turns `integrityGuard` from drift detection into a supply-chain check. |
+| **Registry mirror** | `plugin_registries:` accepts `file://` and internal HTTPS URLs, so air-gapped and enterprise installs resolve names against a copy they curate. An empty list disables the registry entirely. |
+
+---
+
+## Design
+
+The mechanics — index schema, resolution rules, the install state machine,
+failure and rollback semantics, and the signing plan — are in `design.md`. The
+proposal-level commitments are:
+
+1. **The index carries metadata, never code.** Artifacts stay on the
+   publisher's release infrastructure. Apiary's registry is a directory with
+   digests attached, and the docs' existing "a listing is a pointer to someone
+   else's repository" wording is carried into the CLI output verbatim.
+2. **Every check that can happen before download, happens before download.**
+   Host-version constraint, protocol version, capability set, platform
+   availability, and yanked-release status are all resolved from the index.
+3. **Installation never enables anything.** The `plugins:` entry stays a
+   deliberate edit by the operator, the daemon still has to be restarted, and
+   `install` exits after printing the snippet. Installed ≠ running is preserved
+   exactly as documented today.
+4. **The trust summary is not optional.** Before the first byte is committed to
+   a searched directory, the CLI prints the plugin id and version, the artifact
+   URL, the verified digest, the manifest's `security:` declaration (network,
+   read paths, write paths, `secret_env`) and the plain statement that the
+   executable will run with the daemon's OS permissions. `--yes` skips the
+   prompt, not the print.
+5. **Registry CI is the gate, review is the trust.** Entries are validated,
+   their digests re-computed from the real download, their embedded manifest
+   cross-checked against the declared metadata, and the conformance kit run
+   against the artifact. Listing remains *reviewed*, never *endorsed*.
+
+---
+
+## What Stays
+
+- **Protocol 1 and the manifest format** — unchanged. A registry-installed
+  plugin is byte-identical to a hand-installed one; the registry has no
+  runtime presence at all.
+- **Discovery, validation, and the invocation path** — `plugin.Discover`,
+  `Installed.Validate`, `integrityGuard`, and the client are untouched. The
+  installer *calls* them; it does not fork them.
+- **`plugin_dirs` layering** — one directory per plugin id, duplicate ids across
+  directories still an error. `install` writes into one searched directory and
+  refuses to create a duplicate.
+- **The daemon** — never contacts the registry, never downloads, never
+  self-updates a plugin. Registry access lives entirely in the CLI.
+- **`apiary plugins list | inspect | validate`** — unchanged semantics: what is
+  on disk, not what is published.
+- **The no-sandbox reality** — this change improves provenance, not isolation.
+  Nothing here makes it safer to run a plugin you have not read.
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Index format and read-only CLI
+
+1. Define the index schema (v1) and the per-plugin entry YAML under `registry/`.
+2. Add `internal/plugin/registry.go`: index model, fetch, ETag-aware cache under
+   `~/.cache/apiary/registry`, `--offline`.
+3. Add `plugin_registries` config (default: the official index URL) plus
+   config validation.
+4. Add `apiary plugins search [query] [--capability]` and
+   `apiary plugins info <id>[@version]`.
+5. Add the registry CI workflow: schema validation, digest re-computation from
+   the real artifact, manifest cross-check, conformance kit run.
+6. Publish `index.json` from the existing docs deploy; seed it with
+   `dev.apiary.routines` and the four reference plugins.
+
+### Phase 2 — Install, upgrade, uninstall
+
+7. Add `internal/plugin/install.go`: resolve → download → verify → unpack →
+   validate → summarise → commit, with a staging directory under `TMPDIR` and a
+   single atomic `rename`.
+8. Implement pin injection and the manifest rewrite (only when unpinned).
+9. Add `apiary plugins install <id>[@version]` with `--dir`, `--yes`,
+   `--sha256` (pin-to-expected override), `--registry`, `--offline`.
+10. Add `apiary plugins upgrade <id>` (keeps `<id>.bak` for one generation) and
+    `apiary plugins uninstall <id>` (refuses while the id is enabled in
+    `apiary.yaml`, unless `--force`).
+11. Print the `plugins:` snippet and the restart reminder; never touch
+    `apiary.yaml`.
+
+### Phase 3 — Signing and mirrors
+
+12. Sign `index.json` in CI (minisign); embed the public key in the binary.
+13. Verify the signature before use; fail closed, with no bypass flag.
+14. Document mirroring (`file://`, internal HTTPS) and the air-gapped workflow.
+
+### Phase 4 — Documentation
+
+15. Rewrite `docs/plugin-directory.md` around the registry; keep the
+    "pointer, not endorsement" framing and the getting-listed instructions,
+    retargeted at `registry/plugins/`.
+16. Update the installation and upgrade sections of `docs/plugins.md` to lead
+    with the CLI and keep the manual procedure as the offline path.
+17. Add a "Publishing to the registry" section to `docs/plugin-sdk.md`.
+
+---
+
+## Out of Scope
+
+- **Hosting artifacts.** Apiary stores metadata and digests; publishers host
+  their own releases. No mirroring, no CDN, no upload endpoint.
+- **Accounts, ownership, namespaces, or takedown flows.** A pull request is the
+  publishing mechanism; repository access control is the ownership model.
+- **Automatic or background upgrades.** No update checks in the daemon, no
+  notifications, no `--auto-upgrade`. Upgrades are an operator action.
+- **Dependency resolution between plugins.** Entries declare a host-version
+  constraint, nothing more. Plugins do not depend on plugins.
+- **Sandboxing.** The `security:` block stays an inspectable declaration, not an
+  enforcement mechanism. Improving that is a separate change.
+- **Enabling plugins from the CLI.** Writing `plugins:` entries into
+  `apiary.yaml` programmatically is deliberately excluded from v1.
+- **Telemetry.** No download counts, no install pings, no phone-home.
+- **Registry access from the daemon.** The daemon's plugin path stays offline.
+
+---
+
+## Migration
+
+Nothing existing breaks: the registry is an additional way to obtain files that
+the rest of the system already knows how to handle.
+
+| Existing state | Behavior after change |
+|---|---|
+| Hand-installed plugin directories | Unchanged — discovered, validated, and run exactly as before |
+| Manifest with a publisher `checksum` | Unchanged; the installer never overwrites an existing pin |
+| Manifest without a `checksum` | Unchanged when hand-installed; pinned from the index when installed via the CLI |
+| No `plugin_registries` in config | The official index is used for `search`/`info`/`install`; the daemon is unaffected |
+| `plugin_registries: []` | Registry subcommands report that the registry is disabled and exit non-zero; manual installation still works |
+| Air-gapped install | `--offline` against a warm cache, or a `file://` mirror |
+
+Operators who prefer the manual procedure keep it: it remains documented, it
+remains supported, and it remains the only path that needs no network at all.

--- a/openspec/changes/plugin-registry/tasks.md
+++ b/openspec/changes/plugin-registry/tasks.md
@@ -1,0 +1,65 @@
+# Tasks
+
+## Phase 1 — Index format and read-only CLI
+
+- [x] Define the registry entry format and `registry/schema/index-v1.json`.
+- [x] Implement the index model, fetch, ETag cache and `--offline` (`registry_index.go`, `registry_source.go`).
+- [x] Implement release resolution (yank, protocol, host semver, platform) with predicate-level error messages.
+- [x] Add `plugin_registries` config plus validation (`https://` and `file://` only, empty list disables).
+- [x] Add `apiary plugins search` and `apiary plugins info`.
+- [x] Add the registry CI workflow: schema, digest re-computation, manifest cross-check, conformance kit run.
+- [x] Compile and publish `index.json` from the docs deploy; seeded with `dev.apiary.routines` (the in-tree reference plugins publish no artifacts, so they cannot be listed).
+
+Phase 1 also added `src/cmd/apiary-registry` (repository tooling: `check` verifies
+every declared artifact end to end, `build` compiles the index) and the safe
+archive extractor the checker needs, which Phase 2's installer reuses.
+
+## Phase 2 — Install, upgrade, uninstall
+
+- [x] Implement the staged install pipeline in `internal/plugin/install.go` (download, digest, safe unpack, validate, atomic commit).
+- [x] Implement checksum pin injection and publisher-pin agreement checks.
+- [x] Add `apiary plugins install` with `--dir`, `--yes`, `--sha256`, `--registry`, `--offline`.
+- [x] Implement the trust summary output and confirmation prompt.
+- [x] Add `apiary plugins upgrade` with one-generation `.bak` rollback and `--rollback`.
+- [x] Add `apiary plugins uninstall` with the enabled-in-config refusal and `--force`.
+- [x] Print the `plugins:` snippet and restart reminder; assert `apiary.yaml` is never written.
+
+Phase 2 also added `Installed.VerifyPin()`, wired into `apiary plugins validate`
+and `apiary validate`: discovery only checked that a pin was well-formed, so an
+injected pin was verified per invocation by the daemon but never by the command
+whose job is checking. Archive format detection now reads magic bytes rather
+than the URL's filename.
+
+## Phase 3 — Signing and mirrors
+
+- [x] Sign `index.json` in CI with minisign; embed the public key in the binary.
+- [x] Verify the signature before parsing, failing closed with no bypass flag.
+- [x] Support per-registry `public_key` for internal mirrors.
+
+Phase 3 verifies minisign signatures in-process (`crypto/ed25519` plus
+BLAKE2b for minisign's prehashed mode), so no external tool is needed to check
+one and `minisign -Vm` agrees with what the CLI does. Signing is wired but not
+switched on: the docs deploy signs only when `APIARY_REGISTRY_MINISIGN_KEY`
+exists, and released binaries verify only when `APIARY_REGISTRY_PUBLIC_KEY` was
+stamped in at build time. Until both exist the index is reported as
+`(unverified)` on every command — generating the signing identity is the
+maintainer's call, not something this change invents. `registry/README.md`
+documents the three one-time steps.
+
+## Phase 4 — Documentation
+
+- [x] Rewrite `docs/plugin-directory.md` around the registry, keeping the "pointer, not endorsement" framing.
+- [x] Update `docs/plugins.md` installation/upgrade sections to lead with the CLI, keeping the manual path.
+- [x] Add a "Publishing to the registry" section to `docs/plugin-sdk.md`.
+
+Phase 4 also covered the pages the plan did not name but that had gone stale:
+`docs/cli.md` gains an `apiary plugins` section, `docs/configuration.md` and
+`schema/apiary.json` document `plugin_registries` (so the VS Code extension
+validates it), and `docs/supported-integrations.md` points at
+`plugins search --capability source`.
+
+## Gates
+
+- [x] Unit and integration tests per the testing section of `design.md`.
+- [x] Run repository gates and GitNexus change detection.
+- [ ] Update `openspec/CHANGELOG.md` and archive the change.

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,162 @@
+# Apiary plugin registry
+
+This directory is the registry: one reviewed YAML file per plugin, compiled by
+CI into the JSON index that `apiary plugins search` and `apiary plugins info`
+read.
+
+It holds **metadata only**. Artifacts stay on their publisher's release
+infrastructure — Apiary never mirrors, re-hosts, or serves a binary, and the
+daemon never contacts a registry at all. A listing is a pointer to someone
+else's repository. It is reviewed; it is not endorsed.
+
+```
+registry/
+├── plugins/<plugin-id>.yaml   ← add yours here, via pull request
+└── schema/index-v1.json       ← the schema of the compiled index
+```
+
+## Getting listed
+
+Open a pull request adding `plugins/<your-plugin-id>.yaml`. The filename must be
+the plugin id. Requirements:
+
+- The repository must be **publicly readable** — an operator has to be able to
+  read the code before running it as their daemon's user.
+- Every artifact needs both digests: `archive_sha256` (the file you publish) and
+  `executable_sha256` (the executable inside it, after unpacking). There is no
+  unpinned release.
+- Releases are **immutable**. A bad release is marked `yanked: true` with a
+  `yanked_reason`; it is never rewritten or deleted, because the index has to
+  stay honest about what was once resolvable.
+
+```yaml
+schema_version: 1
+id: com.example.nagios
+summary: One sentence on what it does.
+capabilities: [source]
+repository: https://github.com/example/apiary-nagios
+license: MIT
+
+# Optional: the config CI runs the protocol conformance kit with. Without it the
+# release is published as "conformance not run" — an honest absence rather than
+# an unearned pass.
+conformance_config:
+  api_url: https://example.invalid/api
+
+releases:
+  - version: 1.0.0
+    apiary: ">= 0.13.0-0"
+    protocol: 1
+    artifacts:
+      - os: linux
+        arch: amd64
+        url: https://github.com/example/apiary-nagios/releases/download/v1.0.0/nagios_1.0.0_linux_amd64.tar.gz
+        archive_sha256: "…"
+        executable_sha256: "…"
+```
+
+## What CI checks
+
+Nothing in a listing is taken on trust. For every artifact, on every pull
+request:
+
+1. The entry is validated — id, semver, capability vocabulary, protocol, digests.
+2. The artifact is downloaded and its `archive_sha256` re-derived.
+3. It is unpacked, and the `apiary-plugin.json` inside is cross-checked against
+   the entry: id, version, protocol, `apiary` constraint, capabilities.
+4. `executable_sha256` is re-derived from the executable the manifest names.
+5. If the entry declares `conformance_config`, the protocol conformance kit runs
+   against the published executable, and its verdict is recorded in the index.
+
+A conformance failure does **not** block a listing — the verdict is published
+instead, and `apiary plugins info` shows it. The registry describes plugins; it
+does not certify them.
+
+```bash
+make registry-check
+```
+
+## Signing
+
+The published index is signed with [minisign](https://jedisct1.github.io/minisign/),
+so a client can tell that the digests it is about to trust are the ones this
+repository reviewed. Signature verification covers the index, which carries the
+digests, which cover the artifacts. It does **not** authenticate plugin
+publishers — signing the artifacts themselves is a separate problem.
+
+Signing is not yet switched on. Turning it on is three steps, all one-time:
+
+1. **Generate a passwordless key** (CI cannot answer a password prompt):
+
+   ```bash
+   minisign -G -W -p apiary-registry.pub -s apiary-registry.key
+   ```
+
+2. **Store the secret key** as the repository secret
+   `APIARY_REGISTRY_MINISIGN_KEY` (the whole file, comment line included). The
+   docs deploy signs `index.json` with it and publishes `index.json.minisig`
+   beside it; while the secret is unset, the index publishes unsigned.
+
+3. **Stamp the public key into released binaries.** Set
+   `APIARY_REGISTRY_PUBLIC_KEY` to the base64 line of `apiary-registry.pub` in
+   the release environment — the Makefile and GoReleaser both pass it to
+   `-X …/internal/plugin.OfficialRegistryPublicKey`.
+
+Until step 3 lands in a released binary, `apiary plugins …` reports the official
+index as `(unverified)` on every command. That is deliberate: an unverified
+index is a real state, and saying nothing would let it read as verified.
+
+Once a key is pinned there is **no way to skip verification** — no flag, no
+environment variable. A missing, malformed, or mismatched signature fails the
+command.
+
+Anyone can check the published index by hand:
+
+```bash
+curl -sO https://orlandoburli.com.br/apiary/registry/v1/index.json
+curl -sO https://orlandoburli.com.br/apiary/registry/v1/index.json.minisig
+minisign -Vm index.json -P "<the base64 public key line>"
+```
+
+## Mirroring
+
+An internal or air-gapped install points `plugin_registries` at its own copy.
+Both forms are accepted — a bare URL, or a mapping that pins the mirror to its
+own signing key:
+
+```yaml
+plugin_registries:
+  # The official index, verified against the key built into the binary.
+  - https://orlandoburli.com.br/apiary/registry/v1/index.json
+  # An internal mirror, verified against a key this organisation controls.
+  - url: file:///opt/apiary/registry/index.json
+    public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+```
+
+Registries are consulted in order and the first hit wins, so a mirror listed
+first deliberately shadows the official index. Only `https://` and `file://` are
+accepted: digests protect the payload, but nothing protects a plaintext
+resolution.
+
+A mirror can either carry the upstream signature verbatim — copy
+`index.json.minisig` next to `index.json` and pin the upstream public key — or
+re-sign the index with its own key and pin that. Both verify identically.
+
+Air-gapped installs have two options: a `file://` mirror as above, or
+`--offline`, which uses the cached index and never touches the network. The
+cache is verified on the way out as well as on the way in, so a cache poisoned
+on disk is caught rather than served.
+
+## Building the index locally
+
+```bash
+make registry-build
+```
+
+Writes `docs/registry/v1/index.json`, which the docs deploy publishes at
+`https://orlandoburli.com.br/apiary/registry/v1/index.json`. To point a CLI at a
+local build:
+
+```bash
+apiary plugins search --registry file://$PWD/docs/registry/v1/index.json
+```

--- a/registry/plugins/dev.apiary.routines.yaml
+++ b/registry/plugins/dev.apiary.routines.yaml
@@ -1,0 +1,48 @@
+schema_version: 1
+id: dev.apiary.routines
+summary: >-
+  Scheduled routines: turns each due cron occurrence into a work item, so a
+  nightly audit or an hourly sweep routes through triggers and workflows like
+  any other task.
+capabilities: [source]
+homepage: https://orlandoburli.com.br/apiary-routines/
+repository: https://github.com/orlandoburli/apiary-routines
+license: MIT
+
+# The configuration registry CI runs the protocol conformance kit with. It is
+# never used by the CLI and never installed — the kit needs a plugin that can
+# answer poll/acknowledge/write_result, and only the plugin's own author knows
+# what a harmless configuration looks like.
+conformance_config:
+  state_file: /tmp/apiary-routines-conformance.json
+  routines:
+    - id: conformance
+      schedule: "0 3 * * *"
+      title: Conformance probe
+
+releases:
+  - version: 0.1.0
+    apiary: ">= 0.13.0-0"
+    protocol: 1
+    published_at: 2026-08-27
+    artifacts:
+      - os: darwin
+        arch: amd64
+        url: https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/apiary-routines_0.1.0_darwin_amd64.tar.gz
+        archive_sha256: a9273c4398787d7a204359f1c043de8033d0a00237a32f4b1e1f19bf67e07f96
+        executable_sha256: efdd5b96c1894b91d52994ac64d8ef035913e3e8bf910dad38d85daaa3b087d0
+      - os: darwin
+        arch: arm64
+        url: https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/apiary-routines_0.1.0_darwin_arm64.tar.gz
+        archive_sha256: efb15a92c9a4c3f9b1b2d586524f5b310ada850ea82f86c8610d3f78405f64d7
+        executable_sha256: f4d0c199278a776aa0927860be6c5487733c3d3543b7b17daf6e102252b709f6
+      - os: linux
+        arch: amd64
+        url: https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/apiary-routines_0.1.0_linux_amd64.tar.gz
+        archive_sha256: 611317a087587d85b664d937bb54d44f8ac029ed68c58a324c71d490769235a5
+        executable_sha256: 7883c2f09980069626a44b58a020c55d8b0633480a00315d1ac1ba18edd7ee3a
+      - os: linux
+        arch: arm64
+        url: https://github.com/orlandoburli/apiary-routines/releases/download/v0.1.0/apiary-routines_0.1.0_linux_arm64.tar.gz
+        archive_sha256: 00fc21d3387de2d191a23a71c3904761f47e617f898cf8a1a94591d539ab5735
+        executable_sha256: 6e9e7aecc3e01183b3aac14618dbad604a3e6c3c84f9b87ae5bb3e7643d0e435

--- a/registry/schema/index-v1.json
+++ b/registry/schema/index-v1.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orlandoburli.com.br/apiary/registry/v1/index.schema.json",
+  "title": "Apiary plugin registry index, version 1",
+  "description": "The compiled document Apiary CLIs fetch. Metadata and digests only: artifacts are hosted by their publishers, and a listing is a pointer to someone else's repository, never an endorsement.",
+  "type": "object",
+  "required": ["schema_version", "plugins"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": 1,
+      "description": "Clients fail closed on any other value rather than partially interpreting the document."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When registry CI compiled this index."
+    },
+    "plugins": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/plugin" }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^(sha256:)?[0-9a-f]{64}$"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["id", "summary", "capabilities", "repository", "releases"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){2,}$",
+          "description": "Lowercase reverse-DNS identifier, stable across releases."
+        },
+        "summary": { "type": "string", "minLength": 1 },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "source",
+              "runner",
+              "workflow_action",
+              "approval_provider",
+              "secret_provider",
+              "event_exporter"
+            ]
+          }
+        },
+        "homepage": { "type": "string", "format": "uri" },
+        "repository": {
+          "type": "string",
+          "format": "uri",
+          "description": "Publicly readable, so an operator can inspect what they are about to run as the daemon's user."
+        },
+        "license": { "type": "string" },
+        "releases": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/release" }
+        }
+      }
+    },
+    "release": {
+      "type": "object",
+      "required": ["version", "apiary", "protocol", "artifacts"],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Semantic version. Releases are immutable: a bad one is yanked, never rewritten."
+        },
+        "apiary": {
+          "type": "string",
+          "description": "Semantic-version constraint on the host, checked before anything is downloaded."
+        },
+        "protocol": { "type": "integer", "minimum": 1 },
+        "published_at": { "type": "string" },
+        "yanked": { "type": "boolean" },
+        "yanked_reason": { "type": "string", "minLength": 1 },
+        "conformance": { "$ref": "#/$defs/conformance" },
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/artifact" }
+        }
+      },
+      "if": { "properties": { "yanked": { "const": true } }, "required": ["yanked"] },
+      "then": { "required": ["yanked_reason"] }
+    },
+    "conformance": {
+      "type": "object",
+      "description": "Written by registry CI, never by the submitter. A test result, not a certification.",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": { "enum": ["passed", "failed", "not_run"] },
+        "kit": { "type": "string" },
+        "checked_at": { "type": "string" },
+        "commit": { "type": "string" }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["os", "arch", "url", "archive_sha256", "executable_sha256"],
+      "additionalProperties": false,
+      "properties": {
+        "os": { "type": "string", "description": "GOOS spelling (darwin, linux, windows)." },
+        "arch": { "type": "string", "description": "GOARCH spelling (amd64, arm64)." },
+        "url": {
+          "type": "string",
+          "pattern": "^https://",
+          "description": "Hosted by the plugin's publisher. Apiary never mirrors or re-hosts binaries."
+        },
+        "archive_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "Verified before the download is unpacked."
+        },
+        "executable_sha256": {
+          "$ref": "#/$defs/sha256",
+          "description": "Becomes the installed manifest's checksum pin, so the digest originates outside the publisher's own release."
+        }
+      }
+    }
+  }
+}

--- a/schema/apiary.json
+++ b/schema/apiary.json
@@ -200,6 +200,24 @@
       "description": "Directories searched for installed plugin folders. Relative paths resolve beside apiary.yaml; defaults to .apiary/plugins",
       "items": {"type": "string"}
     },
+    "plugin_registries": {
+      "type": "array",
+      "description": "Plugin registry indexes that `apiary plugins search|info|install` resolve names against. Each entry is an https:// or file:// URL, or a mapping with url and public_key. Omit for the official index; an empty list disables the registry. The daemon never reads it",
+      "items": {
+        "oneOf": [
+          {"type": "string", "description": "Registry index URL (https:// or file://)"},
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["url"],
+            "properties": {
+              "url": {"type": "string", "description": "Registry index URL (https:// or file://)"},
+              "public_key": {"type": "string", "description": "minisign public key (the bare base64 line) this registry's index must be signed by; once set, verification cannot be skipped"}
+            }
+          }
+        ]
+      }
+    },
     "plugins": {
       "type": "array",
       "description": "Installed out-of-process plugin instances. Omitted enabled defaults to true; disabled plugins remain discoverable but are not started or schema-validated",

--- a/src/cmd/apiary-registry/main.go
+++ b/src/cmd/apiary-registry/main.go
@@ -1,0 +1,337 @@
+// Command apiary-registry validates plugin registry entries and compiles them
+// into the index clients fetch. It is repository tooling, run by CI and by
+// `make registry-check` / `make registry-build` — it is not shipped in the
+// apiary binary and never runs on an operator's machine.
+//
+// The checker is what makes a listing worth anything: it downloads each declared
+// artifact, re-derives both digests, cross-checks the manifest inside the
+// archive against the metadata the entry claims, and optionally runs the
+// protocol conformance kit. An entry cannot assert a digest, a compatibility
+// range, or a conformance verdict that CI could not reproduce.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+const (
+	maxArtifactBytes = 256 << 20
+	downloadTimeout  = 5 * time.Minute
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	var err error
+	switch os.Args[1] {
+	case "check":
+		err = runCheck(os.Args[2:])
+	case "build":
+		err = runBuild(os.Args[2:])
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apiary-registry: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage:
+  apiary-registry check [--dir registry] [--offline] [--conformance-runner path] [--results file]
+  apiary-registry build [--dir registry] [--results file] --out path
+`)
+}
+
+// runCheck validates every entry and, unless --offline, every artifact it
+// declares.
+func runCheck(args []string) error {
+	flags := flag.NewFlagSet("check", flag.ExitOnError)
+	dir := flags.String("dir", "registry", "registry directory")
+	offline := flags.Bool("offline", false, "validate entry metadata only; do not download artifacts")
+	runner := flags.String("conformance-runner", "", "path to sdk/conformance/run.py; enables the conformance kit")
+	results := flags.String("results", "", "write conformance verdicts to this JSON file")
+	strictConformance := flags.Bool("strict-conformance", false, "treat a conformance failure as a check failure")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	entries, err := plugin.LoadEntries(filepath.Join(*dir, "plugins"))
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		fmt.Println("no entries to check")
+		return nil
+	}
+	verdicts := plugin.ConformanceResults{}
+	var failures []string
+	for _, entry := range entries {
+		fmt.Printf("== %s (%d release(s))\n", entry.ID, len(entry.Releases))
+		if *offline {
+			fmt.Printf("   metadata ok (offline: artifacts not verified)\n")
+			continue
+		}
+		for i := range entry.Releases {
+			release := &entry.Releases[i]
+			verdict, errs := checkRelease(entry, release, *runner, *strictConformance)
+			if verdict != nil {
+				verdicts[plugin.ConformanceKey(entry.ID, release.Version)] = *verdict
+			}
+			for _, err := range errs {
+				failures = append(failures, fmt.Sprintf("%s %s: %v", entry.ID, release.Version, err))
+				fmt.Printf("   ✗ %s: %v\n", release.Version, err)
+			}
+		}
+	}
+	if *results != "" {
+		if err := writeJSON(*results, verdicts); err != nil {
+			return err
+		}
+		fmt.Printf("→ conformance verdicts written to %s\n", *results)
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("%d check(s) failed:\n  - %s", len(failures), strings.Join(failures, "\n  - "))
+	}
+	fmt.Println("✓ registry entries verified")
+	return nil
+}
+
+// checkRelease verifies every artifact of one release and returns the
+// conformance verdict for the platform this checker runs on (the only artifact
+// it can actually execute).
+func checkRelease(entry *plugin.Entry, release *plugin.Release, conformanceRunner string, strict bool) (*plugin.Conformance, []error) {
+	var errs []error
+	var verdict *plugin.Conformance
+	for i := range release.Artifacts {
+		artifact := &release.Artifacts[i]
+		work, err := os.MkdirTemp("", "apiary-registry-*")
+		if err != nil {
+			return verdict, append(errs, err)
+		}
+		installed, err := verifyArtifact(entry, release, artifact, work)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", artifact.Platform(), err))
+			_ = os.RemoveAll(work)
+			continue
+		}
+		fmt.Printf("   ✓ %s %s verified (digests, manifest)\n", release.Version, artifact.Platform())
+
+		if conformanceRunner != "" && artifact.OS == runtime.GOOS && artifact.Arch == runtime.GOARCH && len(entry.ConformanceConfig) > 0 {
+			status := "passed"
+			if err := runConformance(conformanceRunner, entry, installed); err != nil {
+				status = "failed"
+				// A failing kit run is recorded and published, not suppressed:
+				// the registry describes plugins, it does not certify them, and
+				// an operator is better served by "conformance FAILED" in
+				// `plugins info` than by a listing that quietly never appears.
+				if strict {
+					errs = append(errs, fmt.Errorf("conformance: %w", err))
+				}
+			}
+			verdict = &plugin.Conformance{
+				Status:    status,
+				Kit:       "sdk/conformance",
+				CheckedAt: time.Now().UTC().Format(time.RFC3339),
+				Commit:    os.Getenv("GITHUB_SHA"),
+			}
+			fmt.Printf("   %s %s conformance %s\n", tick(status == "passed"), release.Version, status)
+		}
+		_ = os.RemoveAll(work)
+	}
+	return verdict, errs
+}
+
+// verifyArtifact is the checker's core: download, digest, unpack, and confirm
+// that the manifest inside the archive says what the entry says it says.
+func verifyArtifact(entry *plugin.Entry, release *plugin.Release, artifact *plugin.Artifact, work string) (*plugin.Installed, error) {
+	archive := filepath.Join(work, filepath.Base(artifact.URL))
+	if err := download(artifact.URL, archive); err != nil {
+		return nil, err
+	}
+	digest, err := plugin.FileSHA256(archive)
+	if err != nil {
+		return nil, err
+	}
+	if !plugin.DigestsMatch(digest, artifact.ArchiveSHA256) {
+		return nil, fmt.Errorf("archive_sha256 mismatch: entry declares %s, download is %s", artifact.ArchiveSHA256, digest)
+	}
+	unpacked := filepath.Join(work, "unpacked")
+	if err := os.MkdirAll(unpacked, 0o755); err != nil {
+		return nil, err
+	}
+	root, err := plugin.ExtractArchive(archive, unpacked)
+	if err != nil {
+		return nil, err
+	}
+	// An empty host version skips the compatibility check: CI validates the
+	// manifest's shape, not whether the runner happens to be a matching Apiary.
+	installed, err := plugin.Load(root, "")
+	if err != nil {
+		return nil, err
+	}
+	manifest := installed.Manifest
+	if manifest.ID != entry.ID {
+		return nil, fmt.Errorf("manifest id %q does not match the entry id %q", manifest.ID, entry.ID)
+	}
+	if manifest.Version != release.Version {
+		return nil, fmt.Errorf("manifest version %q does not match release %q", manifest.Version, release.Version)
+	}
+	if manifest.Protocol != release.Protocol {
+		return nil, fmt.Errorf("manifest protocol %d does not match release protocol %d", manifest.Protocol, release.Protocol)
+	}
+	if manifest.Apiary != release.Apiary {
+		return nil, fmt.Errorf("manifest apiary constraint %q does not match release %q", manifest.Apiary, release.Apiary)
+	}
+	if err := sameCapabilities(entry.Capabilities, manifest.Capabilities); err != nil {
+		return nil, err
+	}
+	executable := filepath.Join(root, manifest.Executable)
+	executableDigest, err := plugin.FileSHA256(executable)
+	if err != nil {
+		return nil, err
+	}
+	if !plugin.DigestsMatch(executableDigest, artifact.ExecutableSHA256) {
+		return nil, fmt.Errorf("executable_sha256 mismatch: entry declares %s, archive contains %s", artifact.ExecutableSHA256, executableDigest)
+	}
+	if manifest.Checksum != "" && !plugin.DigestsMatch(manifest.Checksum, executableDigest) {
+		return nil, fmt.Errorf("the manifest pins checksum %s, which is not the executable it ships", manifest.Checksum)
+	}
+	return installed, nil
+}
+
+func sameCapabilities(declared, manifest []plugin.Capability) error {
+	want := map[plugin.Capability]bool{}
+	for _, capability := range declared {
+		want[capability] = true
+	}
+	for _, capability := range manifest {
+		if !want[capability] {
+			return fmt.Errorf("manifest declares capability %q, which the entry does not list", capability)
+		}
+		delete(want, capability)
+	}
+	for capability := range want {
+		return fmt.Errorf("entry lists capability %q, which the manifest does not declare", capability)
+	}
+	return nil
+}
+
+// runConformance runs the protocol conformance kit against the published
+// executable. The verdict goes into the index as a test result — never as an
+// endorsement of what the plugin does with the access it declares.
+func runConformance(runnerPath string, entry *plugin.Entry, installed *plugin.Installed) error {
+	config, err := entry.ConformanceConfigJSON()
+	if err != nil {
+		return err
+	}
+	executable := filepath.Join(installed.Root, installed.Manifest.Executable)
+	command := exec.Command("python3", runnerPath, "--name", entry.ID, "--config", config, "--", executable)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+func download(url, target string) error {
+	client := &http.Client{Timeout: downloadTimeout}
+	response, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected status %s", url, response.Status)
+	}
+	file, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	written, err := io.Copy(file, io.LimitReader(response.Body, maxArtifactBytes+1))
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	if written > maxArtifactBytes {
+		return fmt.Errorf("download %s: larger than %d bytes; refusing it", url, int64(maxArtifactBytes))
+	}
+	return nil
+}
+
+// runBuild compiles the reviewed entries into the published index.
+func runBuild(args []string) error {
+	flags := flag.NewFlagSet("build", flag.ExitOnError)
+	dir := flags.String("dir", "registry", "registry directory")
+	results := flags.String("results", "", "conformance verdicts produced by `check --results`")
+	out := flags.String("out", "", "path to write the compiled index to")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *out == "" {
+		return fmt.Errorf("--out is required")
+	}
+	entries, err := plugin.LoadEntries(filepath.Join(*dir, "plugins"))
+	if err != nil {
+		return err
+	}
+	verdicts := plugin.ConformanceResults{}
+	if *results != "" {
+		raw, err := os.ReadFile(*results)
+		if os.IsNotExist(err) {
+			// Building without a checker run is legitimate (a docs deploy that
+			// only needs the metadata). Every release is then published as
+			// "conformance not run", which is exactly what happened.
+			fmt.Fprintf(os.Stderr, "no conformance results at %s; publishing every release as not_run\n", *results)
+			raw, err = []byte("{}"), nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(raw, &verdicts); err != nil {
+			return fmt.Errorf("read %s: %w", *results, err)
+		}
+	}
+	index, err := plugin.CompileIndex(entries, verdicts, time.Now())
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		return err
+	}
+	if err := writeJSON(*out, index); err != nil {
+		return err
+	}
+	fmt.Printf("→ %s (%d plugin(s))\n", *out, len(index.Plugins))
+	return nil
+}
+
+func writeJSON(path string, value any) error {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(encoded, '\n'), 0o644)
+}
+
+func tick(ok bool) string {
+	if ok {
+		return "✓"
+	}
+	return "✗"
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/orlandoburli/apiary/sdk v0.0.0
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.7.13
+	golang.org/x/crypto v0.46.0
 	golang.org/x/term v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
@@ -63,7 +64,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect
-	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/src/internal/cli/plugins.go
+++ b/src/internal/cli/plugins.go
@@ -15,6 +15,15 @@ import (
 func configuredPlugins(cfg *config.Config) (*plugin.Registry, []error) {
 	registry, errs := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
 	errs = append(errs, plugin.ValidateConfigured(registry, cfg.Plugins)...)
+	// Discovery checks that a pin is well-formed; only re-hashing the executable
+	// checks that it is still true. The daemon does this at client creation and
+	// before every invocation — doing it here means an operator finds out from
+	// `validate`, rather than from a plugin that stops working at 3am.
+	for _, installed := range registry.List() {
+		if err := installed.VerifyPin(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	return registry, errs
 }
 
@@ -53,6 +62,11 @@ func newPluginsCmd() *cobra.Command {
 			return encoder.Encode(installed)
 		},
 	})
+	cmd.AddCommand(newPluginsSearchCmd())
+	cmd.AddCommand(newPluginsInfoCmd())
+	cmd.AddCommand(newPluginsInstallCmd())
+	cmd.AddCommand(newPluginsUpgradeCmd())
+	cmd.AddCommand(newPluginsUninstallCmd())
 	cmd.AddCommand(&cobra.Command{
 		Use:   "validate",
 		Short: "Validate discovered manifests and enabled plugin configuration",

--- a/src/internal/cli/plugins_install.go
+++ b/src/internal/cli/plugins_install.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/plugin"
+	"github.com/orlandoburli/apiary/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// installFlags are the knobs shared by install and upgrade.
+type installFlags struct {
+	registry registryFlags
+	dir      string
+	yes      bool
+	sha256   string
+}
+
+func (f *installFlags) bind(cmd *cobra.Command) {
+	f.registry.bind(cmd)
+	cmd.Flags().StringVar(&f.dir, "dir", "", "plugin directory to install into (default: the first plugin_dirs entry)")
+	cmd.Flags().BoolVar(&f.yes, "yes", false, "skip the confirmation prompt (the trust summary is still printed)")
+	cmd.Flags().StringVar(&f.sha256, "sha256", "", "expected archive digest; cross-checked against the registry's before anything is downloaded")
+}
+
+// targetDir resolves where a plugin should be installed: --dir, else the first
+// configured plugin directory — the same paths discovery reads, so an install
+// can never land somewhere the daemon does not look.
+func (f *installFlags) targetDir(cfg *config.Config) (string, error) {
+	if f.dir != "" {
+		return filepath.Abs(f.dir)
+	}
+	dirs := plugin.ConfiguredDirs(cfg.PluginDirs, configFile)
+	if len(dirs) == 0 {
+		return "", errors.New("no plugin directory configured; pass --dir or set plugin_dirs")
+	}
+	return dirs[0], nil
+}
+
+func newPluginsInstallCmd() *cobra.Command {
+	flags := &installFlags{}
+	cmd := &cobra.Command{
+		Use:   "install <id>[@version]",
+		Short: "Install a plugin from the registry",
+		Long: "Install a plugin from the registry.\n\n" +
+			"The artifact is verified against the digest the registry publishes before it is\n" +
+			"unpacked, its manifest is validated, and its executable is pinned. Nothing is\n" +
+			"executed, and nothing is enabled: a plugin runs only once you add it to\n" +
+			"apiary.yaml and restart the daemon.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInstall(cmd, args[0], flags, false)
+		},
+	}
+	flags.bind(cmd)
+	return cmd
+}
+
+func newPluginsUpgradeCmd() *cobra.Command {
+	flags := &installFlags{}
+	var rollback bool
+	cmd := &cobra.Command{
+		Use:   "upgrade <id>[@version]",
+		Short: "Upgrade an installed plugin to a newer registry release",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if rollback {
+				return runRollback(cmd, args[0], flags)
+			}
+			return runInstall(cmd, args[0], flags, true)
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().BoolVar(&rollback, "rollback", false, "restore the previous version kept by the last upgrade")
+	return cmd
+}
+
+func runInstall(cmd *cobra.Command, argument string, flags *installFlags, upgrade bool) error {
+	id, requested := splitVersionSuffix(argument)
+	out := cmd.OutOrStdout()
+
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		// Installing needs to know where plugins live, and that is a config
+		// question. An empty config still answers it (the default directory).
+		cfg = &config.Config{}
+	}
+	target, err := flags.targetDir(cfg)
+	if err != nil {
+		return err
+	}
+	existing, err := installedPlugin(cfg, id)
+	if err != nil {
+		return err
+	}
+	switch {
+	case existing != nil && !upgrade:
+		return fmt.Errorf("%s %s is already installed in %s; use `apiary plugins upgrade %s` to replace it",
+			id, existing.Manifest.Version, existing.Root, id)
+	case existing == nil && upgrade:
+		return fmt.Errorf("%s is not installed; use `apiary plugins install %s`", id, id)
+	case existing != nil:
+		// Upgrading replaces the directory it is already installed in, wherever
+		// that is — not wherever this invocation would have chosen.
+		target = filepath.Dir(existing.Root)
+	}
+
+	entry, loaded, err := flags.registry.find(cmd.Context(), out, id)
+	if err != nil {
+		return err
+	}
+	resolved, err := entry.Resolve(plugin.ResolveOptions{Version: requested, ApiaryVersion: version.Version})
+	if err != nil {
+		return err
+	}
+	if existing != nil && existing.Manifest.Version == resolved.Release.Version {
+		fmt.Fprintf(out, "%s %s is already the newest release the registry offers for this host.\n", id, existing.Manifest.Version)
+		return nil
+	}
+
+	staged, err := plugin.Stage(cmd.Context(), resolved, version.Version, plugin.StageOptions{ExpectedArchiveSHA256: flags.sha256})
+	if err != nil {
+		return err
+	}
+	defer staged.Discard()
+
+	printTrustSummary(out, staged, loaded, target, existing)
+	if !flags.yes {
+		confirmed, err := confirmTrust(cmd, fmt.Sprintf("Install into %s?", target))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(out, "aborted; nothing was installed")
+			return nil
+		}
+	}
+
+	destination := filepath.Join(target, id)
+	backup := destination + ".bak"
+	if existing != nil {
+		_ = os.RemoveAll(backup)
+		if err := os.Rename(existing.Root, backup); err != nil {
+			return fmt.Errorf("set the current version aside: %w", err)
+		}
+	}
+	if err := staged.Commit(destination); err != nil {
+		if existing != nil {
+			_ = os.Rename(backup, existing.Root)
+		}
+		return err
+	}
+	// Prove the installed copy is what the daemon will accept, from the same
+	// discovery path the daemon uses — and put the old version back if not.
+	if _, err := plugin.Load(destination, version.Version); err != nil {
+		_ = os.RemoveAll(destination)
+		if existing != nil {
+			_ = os.Rename(backup, existing.Root)
+			return fmt.Errorf("the installed plugin does not validate (%w); the previous version was restored", err)
+		}
+		return fmt.Errorf("the installed plugin does not validate: %w", err)
+	}
+
+	printInstallOutcome(out, staged, destination, existing, backup)
+	return nil
+}
+
+func runRollback(cmd *cobra.Command, argument string, flags *installFlags) error {
+	id, _ := splitVersionSuffix(argument)
+	out := cmd.OutOrStdout()
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		cfg = &config.Config{}
+	}
+	target, err := flags.targetDir(cfg)
+	if err != nil {
+		return err
+	}
+	if existing, err := installedPlugin(cfg, id); err == nil && existing != nil {
+		target = filepath.Dir(existing.Root)
+	}
+	destination, backup := filepath.Join(target, id), filepath.Join(target, id+".bak")
+	if _, err := os.Stat(backup); err != nil {
+		return fmt.Errorf("no previous version kept for %s (looked for %s)", id, backup)
+	}
+	previous, err := plugin.Load(backup, version.Version)
+	if err != nil {
+		return fmt.Errorf("the kept version does not validate: %w", err)
+	}
+	swap := destination + ".rolling"
+	_ = os.RemoveAll(swap)
+	if err := os.Rename(destination, swap); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Rename(backup, destination); err != nil {
+		_ = os.Rename(swap, destination)
+		return err
+	}
+	_ = os.RemoveAll(swap)
+	fmt.Fprintf(out, "✓ restored %s %s in %s\n", id, previous.Manifest.Version, destination)
+	fmt.Fprintln(out, "  A running daemon keeps the version it started with until you restart it.")
+	return nil
+}
+
+func newPluginsUninstallCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "uninstall <id>",
+		Short: "Remove an installed plugin directory",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			out := cmd.OutOrStdout()
+			cfg, err := config.Load(configFile)
+			if err != nil {
+				cfg = &config.Config{}
+			}
+			installed, err := installedPlugin(cfg, id)
+			if err != nil {
+				return err
+			}
+			if installed == nil {
+				return fmt.Errorf("%s is not installed in plugin_dirs", id)
+			}
+			for _, instance := range cfg.Plugins {
+				if instance.ID == id && instance.IsEnabled() && !force {
+					return fmt.Errorf("%s is enabled in %s; remove its plugins: entry (or set enabled: false) first, or pass --force", id, configFile)
+				}
+			}
+			if err := os.RemoveAll(installed.Root); err != nil {
+				return err
+			}
+			_ = os.RemoveAll(installed.Root + ".bak")
+			fmt.Fprintf(out, "✓ removed %s %s from %s\n", id, installed.Manifest.Version, installed.Root)
+			fmt.Fprintf(out, "  Its plugins: entry in %s, if any, is left alone — apiary validate will point at it.\n", configFile)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "remove it even while it is enabled in apiary.yaml")
+	return cmd
+}
+
+// installedPlugin finds one plugin across the configured directories. Discovery
+// errors elsewhere (an unrelated broken plugin) must not block installing this
+// one, so only this plugin's own state is reported.
+func installedPlugin(cfg *config.Config, id string) (*plugin.Installed, error) {
+	registry, _ := plugin.DiscoverConfigured(cfg.PluginDirs, configFile, version.Version)
+	if installed, ok := registry.Get(id); ok {
+		return installed, nil
+	}
+	return nil, nil
+}
+
+// printTrustSummary states, before anything is committed, exactly what is about
+// to be placed on disk and what it will be able to do. --yes skips the prompt,
+// never this.
+func printTrustSummary(out io.Writer, staged *plugin.Staged, loaded *plugin.LoadedIndex, target string, existing *plugin.Installed) {
+	manifest := staged.Installed.Manifest
+	fmt.Fprintf(out, "\n%s %s  (%s)\n", manifest.ID, manifest.Version, capabilityList(manifest.Capabilities))
+	if existing != nil {
+		fmt.Fprintf(out, "  replaces %s, kept as %s until the next upgrade\n", existing.Manifest.Version, filepath.Base(existing.Root)+".bak")
+	}
+	fmt.Fprintf(out, "  from     %s\n", staged.Resolved.Artifact.URL)
+	fmt.Fprintf(out, "  sha256   %s (verified)\n", shortDigest(staged.Resolved.Artifact.ArchiveSHA256))
+	fmt.Fprintf(out, "  registry %s%s%s\n", loaded.URL, cacheNote(loaded), signatureNote(loaded))
+	fmt.Fprintf(out, "  %s\n", conformanceLine(staged.Resolved.Release))
+	if staged.PinInjected {
+		fmt.Fprintf(out, "  pinned   %s (from the registry, not from the archive)\n", shortDigest(staged.Resolved.Artifact.ExecutableSHA256))
+	} else {
+		fmt.Fprintf(out, "  pinned   %s (by its publisher; matches the registry)\n", shortDigest(manifest.Checksum))
+	}
+
+	fmt.Fprintln(out, "\n  Declared access (a declaration, not a sandbox):")
+	fmt.Fprintf(out, "    network      %s\n", yesNo(manifest.Security.Network))
+	fmt.Fprintf(out, "    read paths   %s\n", pathList(manifest.Security.ReadPaths))
+	fmt.Fprintf(out, "    write paths  %s\n", pathList(manifest.Security.WritePaths))
+	fmt.Fprintf(out, "    secret env   %s\n", pathList(manifest.Security.SecretEnv))
+	fmt.Fprintln(out, "\n  This executable will run with the daemon's OS permissions, as its user.")
+	fmt.Fprintln(out, "  A registry listing is a pointer to someone else's repository — it is not an")
+	fmt.Fprintln(out, "  endorsement, and Apiary has not reviewed this code.")
+	fmt.Fprintln(out)
+}
+
+func printInstallOutcome(out io.Writer, staged *plugin.Staged, destination string, existing *plugin.Installed, backup string) {
+	manifest := staged.Installed.Manifest
+	verb := "installed"
+	if existing != nil {
+		verb = fmt.Sprintf("upgraded %s →", existing.Manifest.Version)
+	}
+	fmt.Fprintf(out, "✓ %s %s %s in %s\n", verb, manifest.ID, manifest.Version, destination)
+	if existing != nil {
+		fmt.Fprintf(out, "  previous version kept at %s (`--rollback` restores it)\n", backup)
+		fmt.Fprintln(out, "\n  A running daemon keeps the version it started with until you restart it.")
+		return
+	}
+	fmt.Fprintln(out, "\n  Nothing runs yet. Installing makes a plugin available; only a plugins: entry")
+	fmt.Fprintf(out, "  in %s makes it run:\n\n", configFile)
+	fmt.Fprint(out, instanceSnippet(manifest))
+	fmt.Fprintln(out, "\n  Then run `apiary validate` and restart the daemon — plugin clients are created")
+	fmt.Fprintln(out, "  at startup.")
+}
+
+// instanceSnippet renders a plugins: entry seeded with the config keys the
+// manifest declares as required, so the operator edits values rather than
+// guessing key names out of a JSON schema.
+func instanceSnippet(manifest plugin.Manifest) string {
+	var builder strings.Builder
+	builder.WriteString("    plugins:\n")
+	builder.WriteString(fmt.Sprintf("      - id: %s\n", manifest.ID))
+	required := requiredConfigKeys(manifest.ConfigSchema)
+	if len(required) == 0 {
+		builder.WriteString("        config: {}\n")
+		return builder.String()
+	}
+	builder.WriteString("        config:\n")
+	for _, key := range required {
+		builder.WriteString(fmt.Sprintf("          %s: %s\n", key.name, key.placeholder()))
+	}
+	return builder.String()
+}
+
+type schemaKey struct {
+	name string
+	kind string
+}
+
+func (k schemaKey) placeholder() string {
+	switch k.kind {
+	case "integer", "number":
+		return "0"
+	case "boolean":
+		return "false"
+	case "array":
+		return "[]"
+	case "object":
+		return "{}"
+	default:
+		return "\"\""
+	}
+}
+
+func requiredConfigKeys(raw json.RawMessage) []schemaKey {
+	if len(raw) == 0 {
+		return nil
+	}
+	var schema struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil
+	}
+	keys := make([]schemaKey, 0, len(schema.Required))
+	for _, name := range schema.Required {
+		keys = append(keys, schemaKey{name: name, kind: schema.Properties[name].Type})
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].name < keys[j].name })
+	return keys
+}
+
+func conformanceLine(release *plugin.Release) string {
+	if release.Conformance == nil || release.Conformance.Status == "not_run" {
+		return "conformance  not run against this release"
+	}
+	switch release.Conformance.Status {
+	case "passed":
+		return "conformance  passed the protocol kit in registry CI"
+	default:
+		return "conformance  FAILED the protocol kit in registry CI — expect protocol bugs"
+	}
+}
+
+// confirmTrust asks once, on the command's own stdin. It exists alongside the
+// package's simpler confirm() because a trust decision needs two things that one
+// does not offer: a stream the tests can drive, and an explicit refusal when
+// there is no terminal to answer — an unattended pipe must not be read as "no
+// objection", it must be told to pass --yes.
+func confirmTrust(cmd *cobra.Command, question string) (bool, error) {
+	in := cmd.InOrStdin()
+	if file, ok := in.(*os.File); ok {
+		info, err := file.Stat()
+		if err == nil && info.Mode()&os.ModeCharDevice == 0 {
+			return false, errors.New("nothing to read a confirmation from; re-run with --yes if you have read the summary above")
+		}
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s [y/N] ", question)
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && answer == "" {
+		return false, nil
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes", nil
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+	return "no"
+}
+
+func pathList(values []string) string {
+	if len(values) == 0 {
+		return "(none)"
+	}
+	return strings.Join(values, ", ")
+}

--- a/src/internal/cli/plugins_install_test.go
+++ b/src/internal/cli/plugins_install_test.go
@@ -1,0 +1,389 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+// installFixture publishes a real archive over TLS and a file:// index that
+// describes it, so the tests exercise the same path an operator does.
+type installFixture struct {
+	registryURL string
+	projectDir  string
+	pluginDir   string
+	client      *http.Client
+}
+
+func newInstallFixture(t *testing.T, versions ...string) *installFixture {
+	t.Helper()
+	if len(versions) == 0 {
+		versions = []string{"1.0.0"}
+	}
+	project := t.TempDir()
+	pluginDir := filepath.Join(project, ".apiary", "plugins")
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(project, "apiary.yaml")
+	if err := os.WriteFile(configPath, []byte("version: \"1.0\"\nplugin_dirs: [.apiary/plugins]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previous := configFile
+	configFile = configPath
+	t.Cleanup(func() { configFile = previous })
+
+	archives := map[string][]byte{}
+	var releases []plugin.Release
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+
+	for _, version := range versions {
+		body := buildArchive(t, version)
+		archives["/"+version] = body
+		releases = append(releases, plugin.Release{
+			Version: version, Apiary: ">= 0.0.1-0", Protocol: plugin.ProtocolVersion,
+			Conformance: &plugin.Conformance{Status: "passed"},
+			Artifacts: []plugin.Artifact{{
+				OS: runtime.GOOS, Arch: runtime.GOARCH, URL: server.URL + "/" + version,
+				ArchiveSHA256:    digestOf(body),
+				ExecutableSHA256: digestOf([]byte(executableBody(version))),
+			}},
+		})
+	}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := archives[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(body)
+	})
+
+	index := plugin.Index{SchemaVersion: 1, Plugins: []plugin.RegistryPlugin{{
+		ID: "dev.apiary.example", Summary: "an example plugin",
+		Capabilities: []plugin.Capability{plugin.CapabilitySource},
+		Repository:   "https://example.invalid/repo", Releases: releases,
+	}}}
+	encoded, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexPath := filepath.Join(t.TempDir(), "index.json")
+	if err := os.WriteFile(indexPath, encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The installer builds its own client for artifact downloads, so the test
+	// server's certificate has to be acceptable to the default transport.
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = server.Client().Transport
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+	return &installFixture{registryURL: "file://" + indexPath, projectDir: project, pluginDir: pluginDir, client: server.Client()}
+}
+
+func executableBody(version string) string {
+	return "#!/bin/sh\n# version " + version + "\nexit 0\n"
+}
+
+func buildArchive(t *testing.T, version string) []byte {
+	t.Helper()
+	manifest := fmt.Sprintf(`{"schema_version":1,"id":"dev.apiary.example","version":%q,"apiary":">= 0.0.1-0","protocol":1,"executable":"plugin.sh","capabilities":["source"],"config_schema":{"type":"object","properties":{"path":{"type":"string"},"depth":{"type":"integer"}},"required":["path","depth"],"additionalProperties":false},"security":{"network":true,"read_paths":["/etc/hosts"],"secret_env":["EXAMPLE_TOKEN"]}}`, version)
+
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	writer := tar.NewWriter(gzipWriter)
+	for _, entry := range []struct {
+		name string
+		body string
+		mode int64
+	}{
+		{plugin.ManifestFilename, manifest, 0o644},
+		{"plugin.sh", executableBody(version), 0o755},
+	} {
+		if err := writer.WriteHeader(&tar.Header{Name: entry.name, Mode: entry.mode, Size: int64(len(entry.body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write([]byte(entry.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, closer := range []func() error{writer.Close, gzipWriter.Close} {
+		if err := closer(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return buffer.Bytes()
+}
+
+func digestOf(body []byte) string {
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func runInstallCmd(t *testing.T, fixture *installFixture, args ...string) (string, error) {
+	t.Helper()
+	cmd := newPluginsInstallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(append(args, "--registry", fixture.registryURL))
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestInstallVerifiesPinsAndDoesNotEnable(t *testing.T) {
+	fixture := newInstallFixture(t)
+	out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes")
+	if err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	root := filepath.Join(fixture.pluginDir, "dev.apiary.example")
+	installed, err := plugin.Load(root, "")
+	if err != nil {
+		t.Fatalf("the installed plugin must validate: %v", err)
+	}
+	if installed.Manifest.Checksum == "" {
+		t.Fatal("the installer must pin the executable it verified")
+	}
+
+	// The trust summary is not optional, and --yes suppresses the prompt only.
+	for _, want := range []string{
+		"Declared access", "network      yes", "secret env   EXAMPLE_TOKEN",
+		"daemon's OS permissions", "not an", "endorsement",
+		"(verified)", "from the registry, not from the archive",
+		"Nothing runs yet", "plugins:", "id: dev.apiary.example",
+		"path: \"\"", "depth: 0", // seeded from the manifest's required config keys
+		"restart the daemon",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("install output is missing %q:\n%s", want, out)
+		}
+	}
+
+	// Installing must never enable anything: apiary.yaml is left untouched.
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(config), "plugins:") {
+		t.Fatalf("install wrote to apiary.yaml:\n%s", config)
+	}
+}
+
+func TestInstallRefusesToReplaceAnInstalledPlugin(t *testing.T) {
+	fixture := newInstallFixture(t)
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes")
+	if err == nil || !strings.Contains(err.Error(), "already installed") {
+		t.Fatalf("want a refusal pointing at upgrade, got %v\n%s", err, out)
+	}
+}
+
+// Declining at the prompt must leave the plugin directory exactly as it was.
+func TestInstallAbortsOnDecline(t *testing.T) {
+	fixture := newInstallFixture(t)
+	cmd := newPluginsInstallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader("n\n"))
+	cmd.SetArgs([]string{"dev.apiary.example", "--registry", fixture.registryURL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("%v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "nothing was installed") {
+		t.Fatalf("want an explicit abort:\n%s", out.String())
+	}
+	entries, err := os.ReadDir(fixture.pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("a declined install left files behind: %v", entries)
+	}
+}
+
+func TestInstallRejectsAMismatchedExpectedDigest(t *testing.T) {
+	fixture := newInstallFixture(t)
+	out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes", "--sha256",
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	if err == nil || !strings.Contains(err.Error(), "nothing was downloaded") {
+		t.Fatalf("want a pre-download refusal, got %v\n%s", err, out)
+	}
+}
+
+func TestUpgradeSwapsAndKeepsOneGeneration(t *testing.T) {
+	fixture := newInstallFixture(t, "1.0.0", "1.1.0")
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example@1.0.0", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	cmd := newPluginsUpgradeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"dev.apiary.example", "--yes", "--registry", fixture.registryURL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("%v\n%s", err, out.String())
+	}
+
+	installed, err := plugin.Load(filepath.Join(fixture.pluginDir, "dev.apiary.example"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed.Manifest.Version != "1.1.0" {
+		t.Fatalf("want 1.1.0 installed, got %s", installed.Manifest.Version)
+	}
+	kept, err := plugin.Load(filepath.Join(fixture.pluginDir, "dev.apiary.example.bak"), "")
+	if err != nil {
+		t.Fatalf("the previous version must be kept: %v", err)
+	}
+	if kept.Manifest.Version != "1.0.0" {
+		t.Fatalf("want 1.0.0 kept, got %s", kept.Manifest.Version)
+	}
+	if !strings.Contains(out.String(), "daemon keeps the version it started with") {
+		t.Fatalf("an upgrade must say the running daemon is unaffected:\n%s", out.String())
+	}
+}
+
+func TestUpgradeRollbackRestoresTheKeptVersion(t *testing.T) {
+	fixture := newInstallFixture(t, "1.0.0", "1.1.0")
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example@1.0.0", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	upgrade := newPluginsUpgradeCmd()
+	upgrade.SetOut(&bytes.Buffer{})
+	upgrade.SetArgs([]string{"dev.apiary.example", "--yes", "--registry", fixture.registryURL})
+	if err := upgrade.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	rollback := newPluginsUpgradeCmd()
+	var out bytes.Buffer
+	rollback.SetOut(&out)
+	rollback.SetErr(&out)
+	rollback.SetArgs([]string{"dev.apiary.example", "--rollback"})
+	if err := rollback.Execute(); err != nil {
+		t.Fatalf("%v\n%s", err, out.String())
+	}
+	installed, err := plugin.Load(filepath.Join(fixture.pluginDir, "dev.apiary.example"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed.Manifest.Version != "1.0.0" {
+		t.Fatalf("rollback did not restore 1.0.0, got %s", installed.Manifest.Version)
+	}
+}
+
+func TestUpgradeIsANoopWhenAlreadyNewest(t *testing.T) {
+	fixture := newInstallFixture(t)
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	cmd := newPluginsUpgradeCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"dev.apiary.example", "--yes", "--registry", fixture.registryURL})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "already the newest") {
+		t.Fatalf("want a no-op message:\n%s", out.String())
+	}
+}
+
+func TestUninstallRefusesWhileEnabled(t *testing.T) {
+	fixture := newInstallFixture(t)
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	enabled := "version: \"1.0\"\nplugin_dirs: [.apiary/plugins]\nplugins:\n  - id: dev.apiary.example\n    config: {path: /tmp/x, depth: 1}\n"
+	if err := os.WriteFile(configFile, []byte(enabled), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newPluginsUninstallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"dev.apiary.example"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "is enabled") {
+		t.Fatalf("want a refusal while enabled, got %v\n%s", err, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(fixture.pluginDir, "dev.apiary.example")); err != nil {
+		t.Fatal("the refused uninstall must not have removed anything")
+	}
+
+	forced := newPluginsUninstallCmd()
+	out.Reset()
+	forced.SetOut(&out)
+	forced.SetErr(&out)
+	forced.SetArgs([]string{"dev.apiary.example", "--force"})
+	if err := forced.Execute(); err != nil {
+		t.Fatalf("%v\n%s", err, out.String())
+	}
+	if _, err := os.Stat(filepath.Join(fixture.pluginDir, "dev.apiary.example")); !os.IsNotExist(err) {
+		t.Fatal("--force must remove the plugin directory")
+	}
+	// Uninstall never edits config: the stale entry stays, for validate to flag.
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(config), "dev.apiary.example") {
+		t.Fatal("uninstall must not edit apiary.yaml")
+	}
+}
+
+func TestUninstallUnknownPlugin(t *testing.T) {
+	newInstallFixture(t)
+	cmd := newPluginsUninstallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"dev.apiary.example"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("want a not-installed error, got %v", err)
+	}
+}
+
+// The injected pin is only worth something if something checks it. The daemon
+// does, per invocation; validate answers the same question up front.
+func TestValidateCatchesATamperedExecutable(t *testing.T) {
+	fixture := newInstallFixture(t)
+	if out, err := runInstallCmd(t, fixture, "dev.apiary.example", "--yes"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	executable := filepath.Join(fixture.pluginDir, "dev.apiary.example", "plugin.sh")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nrm -rf /\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newPluginsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"validate"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "failed integrity check") {
+		t.Fatalf("a swapped executable must be caught, got %v\n%s", err, out.String())
+	}
+}

--- a/src/internal/cli/plugins_registry.go
+++ b/src/internal/cli/plugins_registry.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/plugin"
+	"github.com/orlandoburli/apiary/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// registryFlags are shared by every registry-backed subcommand.
+type registryFlags struct {
+	registry string
+	offline  bool
+}
+
+func (f *registryFlags) bind(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.registry, "registry", "", "registry index URL to use for this command (https:// or file://)")
+	cmd.Flags().BoolVar(&f.offline, "offline", false, "use the cached index and never touch the network")
+}
+
+// sources resolves which registries to consult: the flag wins, then
+// apiary.yaml, then the official index. A missing or unreadable config is not
+// fatal — search and info are useful outside a project directory, where there is
+// no config to read.
+//
+// A URL passed with --registry still picks up the signing key configured for
+// that same URL, so pointing at a mirror explicitly cannot quietly drop the
+// verification the config asked for.
+func (f *registryFlags) sources() ([]plugin.RegistrySource, error) {
+	cfg, cfgErr := config.Load(configFile)
+	if f.registry != "" {
+		source := plugin.RegistrySource{URL: f.registry}
+		if cfgErr == nil {
+			for _, configured := range cfg.Registries() {
+				if configured.URL == f.registry {
+					source = configured
+					break
+				}
+			}
+		}
+		if err := source.Validate(); err != nil {
+			return nil, err
+		}
+		return []plugin.RegistrySource{source}, nil
+	}
+	if cfgErr != nil {
+		return plugin.DefaultRegistrySources(), nil
+	}
+	sources := cfg.Registries()
+	if len(sources) == 0 {
+		return nil, errors.New("plugin_registries is empty: the registry is disabled for this project; install plugins manually or list a registry URL")
+	}
+	for i, source := range sources {
+		if err := source.Validate(); err != nil {
+			return nil, fmt.Errorf("plugin_registries[%d]: %w", i, err)
+		}
+	}
+	return sources, nil
+}
+
+// load fetches every configured registry. Registries are consulted in order and
+// the first hit wins, so a mirror can shadow the official index deliberately.
+func (f *registryFlags) load(ctx context.Context, out io.Writer) ([]*plugin.LoadedIndex, error) {
+	sources, err := f.sources()
+	if err != nil {
+		return nil, err
+	}
+	indexes := make([]*plugin.LoadedIndex, 0, len(sources))
+	var failures []error
+	for _, source := range sources {
+		loaded, err := plugin.LoadIndex(ctx, source.URL, plugin.FetchOptions{Offline: f.offline, PublicKey: source.Key()})
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		if loaded.Warning != nil {
+			fmt.Fprintf(out, "! %s is unreachable (%v); using the cached copy\n", source.URL, loaded.Warning)
+		}
+		if loaded.Unsigned {
+			// Said once, plainly: an unverified index is a real state, and the
+			// alternative — silence — would let it read as verified.
+			fmt.Fprintf(out, "! %s is not signature-verified (no public key pinned for it)\n", source.URL)
+		}
+		indexes = append(indexes, loaded)
+	}
+	if len(indexes) == 0 {
+		return nil, errors.Join(failures...)
+	}
+	for _, err := range failures {
+		fmt.Fprintf(out, "! %v\n", err)
+	}
+	return indexes, nil
+}
+
+// find returns the first registry entry for an id, with the index it came from.
+func (f *registryFlags) find(ctx context.Context, out io.Writer, id string) (*plugin.RegistryPlugin, *plugin.LoadedIndex, error) {
+	indexes, err := f.load(ctx, out)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, loaded := range indexes {
+		if entry, ok := loaded.Find(id); ok {
+			return entry, loaded, nil
+		}
+	}
+	var suggestions []string
+	for _, loaded := range indexes {
+		suggestions = append(suggestions, loaded.Suggest(id)...)
+	}
+	if len(suggestions) > 0 {
+		return nil, nil, fmt.Errorf("no plugin %q in the registry; did you mean: %s", id, strings.Join(suggestions, ", "))
+	}
+	return nil, nil, fmt.Errorf("no plugin %q in the registry", id)
+}
+
+func newPluginsSearchCmd() *cobra.Command {
+	flags := &registryFlags{}
+	var capability string
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search the plugin registry",
+		Long: "Search the plugin registry.\n\n" +
+			"A registry listing is a pointer to someone else's repository. Nothing here is\n" +
+			"downloaded, verified, or endorsed by the daemon — read the plugin's code before\n" +
+			"you run it.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) == 1 {
+				query = args[0]
+			}
+			if capability != "" && !isKnownCapability(capability) {
+				return fmt.Errorf("unknown capability %q; supported: %s", capability, strings.Join(plugin.SupportedCapabilityNames(), ", "))
+			}
+			out := cmd.OutOrStdout()
+			indexes, err := flags.load(cmd.Context(), out)
+			if err != nil {
+				return err
+			}
+			writer := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+			seen := map[string]bool{}
+			matches := 0
+			for _, loaded := range indexes {
+				for _, entry := range loaded.Search(query, plugin.Capability(capability)) {
+					if seen[entry.ID] {
+						continue
+					}
+					seen[entry.ID] = true
+					matches++
+					latest := latestVersionFor(entry)
+					fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", entry.ID, latest, capabilityList(entry.Capabilities), entry.Summary)
+				}
+			}
+			if err := writer.Flush(); err != nil {
+				return err
+			}
+			if matches == 0 {
+				fmt.Fprintln(out, "no plugins matched")
+				return nil
+			}
+			fmt.Fprintf(out, "\n%d plugin(s). `apiary plugins info <id>` for details; listings are pointers, not endorsements.\n", matches)
+			return nil
+		},
+	}
+	flags.bind(cmd)
+	cmd.Flags().StringVar(&capability, "capability", "", "only show plugins declaring this capability")
+	return cmd
+}
+
+func newPluginsInfoCmd() *cobra.Command {
+	flags := &registryFlags{}
+	cmd := &cobra.Command{
+		Use:   "info <id>[@version]",
+		Short: "Show a registry listing and whether it can be installed here",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, requested := splitVersionSuffix(args[0])
+			out := cmd.OutOrStdout()
+			entry, loaded, err := flags.find(cmd.Context(), out, id)
+			if err != nil {
+				return err
+			}
+			printRegistryEntry(out, entry, loaded, requested)
+			return nil
+		},
+	}
+	flags.bind(cmd)
+	return cmd
+}
+
+func printRegistryEntry(out io.Writer, entry *plugin.RegistryPlugin, loaded *plugin.LoadedIndex, requested string) {
+	fmt.Fprintf(out, "%s\n", entry.ID)
+	fmt.Fprintf(out, "  %s\n\n", entry.Summary)
+	writer := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(writer, "  capabilities\t%s\n", capabilityList(entry.Capabilities))
+	fmt.Fprintf(writer, "  repository\t%s\n", entry.Repository)
+	if entry.Homepage != "" {
+		fmt.Fprintf(writer, "  homepage\t%s\n", entry.Homepage)
+	}
+	if entry.License != "" {
+		fmt.Fprintf(writer, "  license\t%s\n", entry.License)
+	}
+	fmt.Fprintf(writer, "  registry\t%s%s%s\n", loaded.URL, cacheNote(loaded), signatureNote(loaded))
+	_ = writer.Flush()
+
+	// Resolution answers the only question that matters before a download: can
+	// this host actually run any of these releases?
+	resolved, resolveErr := entry.Resolve(plugin.ResolveOptions{Version: requested, ApiaryVersion: version.Version})
+	fmt.Fprintf(out, "\n  releases\n")
+	releases := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for i := range entry.Releases {
+		release := &entry.Releases[i]
+		marker := "  "
+		if resolved != nil && resolved.Release == release {
+			marker = "→ "
+		}
+		state := releaseState(release)
+		fmt.Fprintf(releases, "    %s%s\t%s\t%s\t%s\t%s\n", marker, release.Version, "apiary "+release.Apiary,
+			"protocol "+fmt.Sprint(release.Protocol), state, strings.Join(release.Platforms(), " "))
+	}
+	_ = releases.Flush()
+
+	fmt.Fprintln(out)
+	defer func() {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "  A listing is a pointer to someone else's repository — it is not an endorsement,")
+		fmt.Fprintln(out, "  and a plugin runs with the daemon's OS permissions, as its user. Read the code.")
+	}()
+	if resolveErr != nil {
+		fmt.Fprintf(out, "  Not installable on this host (%s/%s, apiary %s):\n    %v\n", runtime.GOOS, runtime.GOARCH, version.Version, resolveErr)
+		return
+	}
+	if resolved.CompatibilityUnchecked != "" {
+		fmt.Fprintf(out, "  ! this build reports version %q, which is not semantic versioning — the release's\n", resolved.CompatibilityUnchecked)
+		fmt.Fprintf(out, "    apiary constraint (%s) could not be checked against it\n\n", resolved.Release.Apiary)
+	}
+	fmt.Fprintf(out, "  Installable here: %s %s for %s\n", entry.ID, resolved.Release.Version, resolved.Artifact.Platform())
+	fmt.Fprintf(out, "    from    %s\n", resolved.Artifact.URL)
+	fmt.Fprintf(out, "    sha256  %s\n", shortDigest(resolved.Artifact.ArchiveSHA256))
+}
+
+// releaseState describes a release the way an operator reads the list: what CI
+// observed, and whether the publisher has withdrawn it.
+func releaseState(release *plugin.Release) string {
+	if release.Yanked {
+		return "yanked: " + release.YankedReason
+	}
+	if release.Conformance == nil {
+		return "conformance not run"
+	}
+	switch release.Conformance.Status {
+	case "passed":
+		return "conformance passed"
+	case "failed":
+		return "conformance FAILED"
+	default:
+		return "conformance not run"
+	}
+}
+
+// signatureNote states what the index's provenance actually is, wherever the
+// registry is named.
+func signatureNote(loaded *plugin.LoadedIndex) string {
+	if loaded.Unsigned {
+		return " (unverified)"
+	}
+	return " (signature verified)"
+}
+
+func cacheNote(loaded *plugin.LoadedIndex) string {
+	if loaded.FromCache {
+		return " (cached)"
+	}
+	return ""
+}
+
+func capabilityList(capabilities []plugin.Capability) string {
+	names := make([]string, len(capabilities))
+	for i, capability := range capabilities {
+		names[i] = string(capability)
+	}
+	return strings.Join(names, ",")
+}
+
+func latestVersionFor(entry *plugin.RegistryPlugin) string {
+	resolved, err := entry.Resolve(plugin.ResolveOptions{ApiaryVersion: version.Version})
+	if err != nil {
+		return "-"
+	}
+	return resolved.Release.Version
+}
+
+func isKnownCapability(name string) bool {
+	for _, known := range plugin.SupportedCapabilityNames() {
+		if known == name {
+			return true
+		}
+	}
+	return false
+}
+
+// splitVersionSuffix accepts "id" and "id@version". Plugin ids never contain
+// "@", so the split is unambiguous.
+func splitVersionSuffix(argument string) (id, requestedVersion string) {
+	if at := strings.LastIndex(argument, "@"); at > 0 {
+		return argument[:at], argument[at+1:]
+	}
+	return argument, ""
+}
+
+func shortDigest(digest string) string {
+	digest = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(digest)), "sha256:")
+	if len(digest) <= 16 {
+		return digest
+	}
+	return digest[:8] + "…" + digest[len(digest)-8:]
+}

--- a/src/internal/cli/plugins_registry_test.go
+++ b/src/internal/cli/plugins_registry_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+)
+
+// writeTestIndex publishes a two-plugin index to a file:// registry.
+func writeTestIndex(t *testing.T) string {
+	t.Helper()
+	artifact := plugin.Artifact{
+		OS: runtime.GOOS, Arch: runtime.GOARCH, URL: "https://example.invalid/p.tar.gz",
+		ArchiveSHA256:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		ExecutableSHA256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+	index := plugin.Index{SchemaVersion: 1, Plugins: []plugin.RegistryPlugin{
+		{
+			ID: "dev.apiary.routines", Summary: "scheduled routines",
+			Capabilities: []plugin.Capability{plugin.CapabilitySource},
+			Repository:   "https://example.invalid/routines",
+			Releases: []plugin.Release{{Version: "1.0.0", Apiary: ">= 0.1.0-0", Protocol: plugin.ProtocolVersion,
+				Conformance: &plugin.Conformance{Status: "passed", Kit: "sdk/conformance"},
+				Artifacts:   []plugin.Artifact{artifact}}},
+		},
+		{
+			ID: "dev.apiary.exporter", Summary: "event exporter",
+			Capabilities: []plugin.Capability{plugin.CapabilityEventExporter},
+			Repository:   "https://example.invalid/exporter",
+			Releases: []plugin.Release{{Version: "2.0.0", Apiary: ">= 0.1.0-0", Protocol: plugin.ProtocolVersion,
+				Artifacts: []plugin.Artifact{artifact}}},
+		},
+	}}
+	encoded, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "index.json")
+	if err := os.WriteFile(path, encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return "file://" + path
+}
+
+func TestPluginsSearchListsAndFilters(t *testing.T) {
+	registry := writeTestIndex(t)
+
+	cmd := newPluginsSearchCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--registry", registry})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "dev.apiary.routines") || !strings.Contains(out.String(), "dev.apiary.exporter") {
+		t.Fatalf("both plugins should be listed:\n%s", out.String())
+	}
+
+	cmd = newPluginsSearchCmd()
+	out.Reset()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--registry", registry, "--capability", "event_exporter"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "dev.apiary.routines") || !strings.Contains(out.String(), "dev.apiary.exporter") {
+		t.Fatalf("capability filter failed:\n%s", out.String())
+	}
+}
+
+func TestPluginsSearchRejectsUnknownCapability(t *testing.T) {
+	cmd := newPluginsSearchCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--registry", writeTestIndex(t), "--capability", "nonsense"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "unknown capability") {
+		t.Fatalf("want an unknown-capability error, got %v", err)
+	}
+}
+
+func TestPluginsInfoShowsProvenanceAndTheTrustCaveat(t *testing.T) {
+	cmd := newPluginsInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"dev.apiary.routines", "--registry", writeTestIndex(t)})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	rendered := out.String()
+	for _, want := range []string{
+		"dev.apiary.routines",
+		"https://example.invalid/routines", // where to read the code
+		"conformance passed",               // CI's verdict, not the publisher's claim
+		"not an endorsement",               // the caveat is never omitted
+		"daemon's OS permissions",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("info output is missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestPluginsInfoSuggestsOnTypo(t *testing.T) {
+	cmd := newPluginsInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"dev.apiary.routine", "--registry", writeTestIndex(t)})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "did you mean: dev.apiary.routines") {
+		t.Fatalf("want a suggestion, got %v", err)
+	}
+}
+
+func TestPluginsInfoRejectsPlaintextRegistry(t *testing.T) {
+	cmd := newPluginsInfoCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"dev.apiary.routines", "--registry", "http://example.invalid/index.json"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "https") {
+		t.Fatalf("a plaintext registry must be refused, got %v", err)
+	}
+}
+
+// An explicitly empty plugin_registries turns the registry off; commands must
+// say so rather than quietly falling back to the official index.
+func TestRegistryDisabledByEmptyConfigList(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "apiary.yaml")
+	if err := os.WriteFile(configPath, []byte("version: \"1.0\"\nplugin_registries: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previous := configFile
+	configFile = configPath
+	t.Cleanup(func() { configFile = previous })
+
+	cmd := newPluginsSearchCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "registry is disabled") {
+		t.Fatalf("want a disabled-registry error, got %v", err)
+	}
+}
+
+func TestSplitVersionSuffix(t *testing.T) {
+	if id, version := splitVersionSuffix("dev.apiary.routines@1.2.3"); id != "dev.apiary.routines" || version != "1.2.3" {
+		t.Fatalf("got %q %q", id, version)
+	}
+	if id, version := splitVersionSuffix("dev.apiary.routines"); id != "dev.apiary.routines" || version != "" {
+		t.Fatalf("got %q %q", id, version)
+	}
+}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -27,7 +27,13 @@ type Config struct {
 	Tasks         *TasksConfig                        `yaml:"tasks"`
 	Notifications *NotificationsConfig                `yaml:"notifications"`
 	PluginDirs    []string                            `yaml:"plugin_dirs,omitempty"`
-	Plugins       []plugin.InstanceConfig             `yaml:"plugins,omitempty"`
+	// PluginRegistries lists the indexes `apiary plugins search|info|install`
+	// resolve names against. Each entry is a URL, or a mapping carrying that
+	// registry's own signing key. Unset means the official index; an explicit
+	// empty list disables the registry entirely. The daemon never reads it —
+	// registry access is a CLI concern only.
+	PluginRegistries []plugin.RegistrySource `yaml:"plugin_registries,omitempty"`
+	Plugins          []plugin.InstanceConfig `yaml:"plugins,omitempty"`
 
 	rawContent string // original YAML text before env expansion; used by Save()
 	configDir  string // absolute directory holding apiary.yaml; base for relative paths
@@ -42,6 +48,17 @@ func (c *Config) Dir() string {
 		return ""
 	}
 	return c.configDir
+}
+
+// Registries returns the plugin registries to consult. A nil list means the
+// operator expressed no preference and gets the official index; an explicitly
+// empty list means they turned the registry off, and is returned as-is so
+// commands can say so instead of silently reaching out.
+func (c *Config) Registries() []plugin.RegistrySource {
+	if c == nil || c.PluginRegistries == nil {
+		return plugin.DefaultRegistrySources()
+	}
+	return c.PluginRegistries
 }
 
 // ProfileConfig is an overlay that overrides runner, model, fallbacks, and

--- a/src/internal/config/plugin_registry_validate_test.go
+++ b/src/internal/config/plugin_registry_validate_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/plugin"
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateRejectsUnusableRegistries(t *testing.T) {
+	cfg := &Config{Version: "1.0", PluginRegistries: []plugin.RegistrySource{
+		{URL: "http://example.invalid/index.json"},
+		{URL: ""},
+		{URL: "https://example.invalid/index.json", PublicKey: "not-a-key"},
+	}}
+	var joined []string
+	for _, err := range cfg.Validate() {
+		joined = append(joined, err.Error())
+	}
+	rendered := strings.Join(joined, "\n")
+	for _, want := range []string{"plugin_registries[0]", "must use https", "plugin_registries[1]", "plugin_registries[2]", "public_key"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("want %q in:\n%s", want, rendered)
+		}
+	}
+}
+
+// Unset means "no preference" and gets the official index; an explicitly empty
+// list means the operator turned the registry off, and must stay empty.
+func TestRegistriesDistinguishesUnsetFromDisabled(t *testing.T) {
+	if got := (&Config{}).Registries(); len(got) != 1 || got[0].URL != plugin.DefaultRegistryURL {
+		t.Fatalf("unset should default to the official index, got %v", got)
+	}
+	if got := (&Config{PluginRegistries: []plugin.RegistrySource{}}).Registries(); len(got) != 0 {
+		t.Fatalf("an empty list disables the registry, got %v", got)
+	}
+}
+
+// The scalar form predates per-registry keys and must keep working untouched.
+func TestPluginRegistriesAcceptsBothYAMLForms(t *testing.T) {
+	const document = `
+version: "1.0"
+plugin_registries:
+  - https://example.invalid/index.json
+  - url: file:///opt/apiary/registry/index.json
+    public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(document), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.PluginRegistries) != 2 {
+		t.Fatalf("want two registries, got %d", len(cfg.PluginRegistries))
+	}
+	if cfg.PluginRegistries[0].URL != "https://example.invalid/index.json" || cfg.PluginRegistries[0].PublicKey != "" {
+		t.Fatalf("scalar form decoded wrong: %+v", cfg.PluginRegistries[0])
+	}
+	mirror := cfg.PluginRegistries[1]
+	if mirror.URL != "file:///opt/apiary/registry/index.json" || mirror.PublicKey == "" {
+		t.Fatalf("mapping form decoded wrong: %+v", mirror)
+	}
+	if mirror.Key() != mirror.PublicKey {
+		t.Fatal("a mirror's own key must be the key it is verified against")
+	}
+}
+
+// The official index is verified against the key stamped into the binary; a
+// third-party registry never inherits it.
+func TestKeySelection(t *testing.T) {
+	previous := plugin.OfficialRegistryPublicKey
+	plugin.OfficialRegistryPublicKey = "RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3"
+	t.Cleanup(func() { plugin.OfficialRegistryPublicKey = previous })
+
+	if got := (plugin.RegistrySource{URL: plugin.DefaultRegistryURL}).Key(); got != plugin.OfficialRegistryPublicKey {
+		t.Fatalf("the official index must use the embedded key, got %q", got)
+	}
+	if got := (plugin.RegistrySource{URL: "https://mirror.invalid/index.json"}).Key(); got != "" {
+		t.Fatalf("a third-party registry must not inherit the official key, got %q", got)
+	}
+}

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -115,6 +115,11 @@ func (c *Config) Validate() []error {
 			errs = append(errs, fmt.Errorf("plugin_dirs[%d]: path must not be empty", i))
 		}
 	}
+	for i, source := range c.PluginRegistries {
+		if err := source.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("plugin_registries[%d]: %w", i, err))
+		}
+	}
 
 	if c.Version == "" {
 		errs = append(errs, fmt.Errorf("version is required"))

--- a/src/internal/plugin/discovery.go
+++ b/src/internal/plugin/discovery.go
@@ -24,6 +24,26 @@ func DiscoverConfigured(paths []string, configFile, apiaryVersion string) (*Regi
 	return Discover(paths, baseDir, apiaryVersion)
 }
 
+// ConfiguredDirs resolves the plugin directories a config declares to absolute
+// paths, applying the same defaulting and base directory as discovery. Commands
+// that write into a plugin directory need the same answer discovery reads from,
+// or an install could land somewhere the daemon never looks.
+func ConfiguredDirs(paths []string, configFile string) []string {
+	absoluteConfig, err := filepath.Abs(configFile)
+	if err != nil {
+		absoluteConfig = configFile
+	}
+	baseDir := filepath.Dir(absoluteConfig)
+	if len(paths) == 0 {
+		paths = []string{filepath.Join(".apiary", "plugins")}
+	}
+	resolved := make([]string, 0, len(paths))
+	for _, path := range paths {
+		resolved = append(resolved, expandPath(path, baseDir))
+	}
+	return resolved
+}
+
 func Discover(paths []string, baseDir, apiaryVersion string) (*Registry, []error) {
 	registry := &Registry{plugins: map[string]*Installed{}}
 	var errs []error

--- a/src/internal/plugin/install.go
+++ b/src/internal/plugin/install.go
@@ -1,0 +1,326 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Installing is still placing files, deliberately — the registry only removes
+// the parts a human does badly: picking the right artifact, and checking it is
+// the one the publisher shipped. Nothing here executes plugin code, nothing
+// lands in a searched directory until every check has passed, and nothing is
+// ever enabled: that stays an edit the operator makes to apiary.yaml.
+const (
+	maxArtifactBytes   = 256 << 20
+	artifactTimeout    = 10 * time.Minute
+	incomingDirPattern = ".incoming-*"
+)
+
+// StageOptions controls a staged install.
+type StageOptions struct {
+	// ExpectedArchiveSHA256 is an operator-supplied digest (--sha256). It is a
+	// cross-check against the registry's, never a replacement for it: if the two
+	// disagree, one of them is wrong and the install stops.
+	ExpectedArchiveSHA256 string
+	Client                *http.Client
+	Timeout               time.Duration
+}
+
+// Staged is a verified plugin sitting outside every searched directory, ready
+// to be committed or discarded.
+type Staged struct {
+	Resolved  *Resolved
+	Installed *Installed
+	// Root is the directory that will become <plugin_dir>/<id>.
+	Root string
+	// PinInjected records that the manifest had no checksum and was pinned to
+	// the registry's digest.
+	PinInjected bool
+	tempRoot    string
+}
+
+// Stage runs every step of an install except the last: download, verify the
+// archive digest, unpack safely, load and validate the manifest, confirm it is
+// the plugin that was asked for, verify the executable digest, and pin it.
+func Stage(ctx context.Context, resolved *Resolved, apiaryVersion string, opts StageOptions) (*Staged, error) {
+	if resolved == nil || resolved.Artifact == nil {
+		return nil, fmt.Errorf("nothing resolved to install")
+	}
+	if expected := opts.ExpectedArchiveSHA256; expected != "" && !DigestsMatch(expected, resolved.Artifact.ArchiveSHA256) {
+		return nil, fmt.Errorf("--sha256 %s does not match the registry's digest %s for %s; one of them is wrong, so nothing was downloaded",
+			expected, resolved.Artifact.ArchiveSHA256, resolved.Artifact.URL)
+	}
+	tempRoot, err := os.MkdirTemp("", "apiary-install-*")
+	if err != nil {
+		return nil, err
+	}
+	staged := &Staged{Resolved: resolved, tempRoot: tempRoot}
+	if err := staged.fill(ctx, apiaryVersion, opts); err != nil {
+		staged.Discard()
+		return nil, err
+	}
+	return staged, nil
+}
+
+func (s *Staged) fill(ctx context.Context, apiaryVersion string, opts StageOptions) error {
+	artifact := s.Resolved.Artifact
+	archive := filepath.Join(s.tempRoot, safeArchiveName(artifact.URL))
+	if err := downloadArtifact(ctx, artifact.URL, archive, opts); err != nil {
+		return err
+	}
+	digest, err := FileSHA256(archive)
+	if err != nil {
+		return err
+	}
+	if !DigestsMatch(digest, artifact.ArchiveSHA256) {
+		// Not a network hiccup: the bytes are not the bytes the registry
+		// reviewed, and the only safe move is to stop.
+		return fmt.Errorf("checksum mismatch for %s\n  registry declares %s\n  download is       %s\nnothing was installed",
+			artifact.URL, normalizedDigest(artifact.ArchiveSHA256), normalizedDigest(digest))
+	}
+
+	unpacked := filepath.Join(s.tempRoot, "unpacked")
+	if err := os.MkdirAll(unpacked, 0o755); err != nil {
+		return err
+	}
+	root, err := ExtractArchive(archive, unpacked)
+	if err != nil {
+		return err
+	}
+	installed, err := Load(root, apiaryVersion)
+	if err != nil {
+		return err
+	}
+	// The registry is not authoritative about what is inside the archive; the
+	// manifest is. They have to agree, or the listing describes something other
+	// than what was downloaded.
+	if installed.Manifest.ID != s.Resolved.Plugin.ID {
+		return fmt.Errorf("the archive contains plugin %q, but %q was requested; nothing was installed",
+			installed.Manifest.ID, s.Resolved.Plugin.ID)
+	}
+	if installed.Manifest.Version != s.Resolved.Release.Version {
+		return fmt.Errorf("the archive contains version %q, but the registry lists %q; nothing was installed",
+			installed.Manifest.Version, s.Resolved.Release.Version)
+	}
+	executable := filepath.Join(root, installed.Manifest.Executable)
+	executableDigest, err := FileSHA256(executable)
+	if err != nil {
+		return err
+	}
+	if !DigestsMatch(executableDigest, artifact.ExecutableSHA256) {
+		return fmt.Errorf("checksum mismatch for the executable inside %s\n  registry declares %s\n  archive contains  %s\nnothing was installed",
+			filepath.Base(artifact.URL), normalizedDigest(artifact.ExecutableSHA256), normalizedDigest(executableDigest))
+	}
+
+	pinned, err := pinChecksum(installed, executableDigest, apiaryVersion)
+	if err != nil {
+		return err
+	}
+	s.Installed, s.PinInjected, s.Root = pinned.installed, pinned.injected, root
+	return nil
+}
+
+type pinResult struct {
+	installed *Installed
+	injected  bool
+}
+
+// pinChecksum writes the registry's executable digest into the manifest when the
+// publisher shipped no pin. This is the point of the whole exercise: an
+// unpinned manifest gains a digest that originates in the registry repository
+// rather than beside the binary, so the daemon's per-invocation integrity check
+// is comparing against a value the publisher cannot quietly rewrite.
+func pinChecksum(installed *Installed, executableDigest, apiaryVersion string) (pinResult, error) {
+	if existing := installed.Manifest.Checksum; existing != "" {
+		if !DigestsMatch(existing, executableDigest) {
+			return pinResult{}, fmt.Errorf("the manifest pins checksum %s, which is not the executable it ships (%s); nothing was installed",
+				existing, normalizedDigest(executableDigest))
+		}
+		return pinResult{installed: installed}, nil
+	}
+	manifest := installed.Manifest
+	manifest.Checksum = executableDigest
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return pinResult{}, err
+	}
+	if err := os.WriteFile(installed.Path, append(encoded, '\n'), 0o644); err != nil {
+		return pinResult{}, err
+	}
+	// Re-load rather than trusting the rewrite: what lands on disk has to be a
+	// manifest the daemon itself accepts.
+	reloaded, err := Load(installed.Root, apiaryVersion)
+	if err != nil {
+		return pinResult{}, fmt.Errorf("pinning the checksum produced a manifest Apiary rejects: %w", err)
+	}
+	return pinResult{installed: reloaded, injected: true}, nil
+}
+
+// Commit moves the staged plugin into its final location in one atomic rename.
+// Until this call, nothing exists in any searched directory.
+func (s *Staged) Commit(target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(s.Root, target); err == nil {
+		s.tempRoot = ""
+		return nil
+	}
+	// A staging directory on another filesystem cannot be renamed into place, so
+	// the payload is copied next to the target and renamed within it. The
+	// manifest is written last: a directory without one is invisible to
+	// discovery, so a concurrent `apiary validate` never sees a half-copy.
+	incoming, err := os.MkdirTemp(filepath.Dir(target), incomingDirPattern)
+	if err != nil {
+		return err
+	}
+	if err := copyPluginDir(s.Root, incoming); err != nil {
+		_ = os.RemoveAll(incoming)
+		return err
+	}
+	if err := os.Rename(incoming, target); err != nil {
+		_ = os.RemoveAll(incoming)
+		return err
+	}
+	return nil
+}
+
+// Discard removes everything the staging step created.
+func (s *Staged) Discard() {
+	if s == nil || s.tempRoot == "" {
+		return
+	}
+	_ = os.RemoveAll(s.tempRoot)
+	s.tempRoot = ""
+}
+
+// copyPluginDir copies a plugin directory, writing the manifest last so the
+// destination is never discoverable while it is incomplete.
+func copyPluginDir(source, target string) error {
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	var manifest os.DirEntry
+	for _, entry := range entries {
+		if entry.Name() == ManifestFilename {
+			manifest = entry
+			continue
+		}
+		if err := copyEntry(source, target, entry); err != nil {
+			return err
+		}
+	}
+	if manifest == nil {
+		return fmt.Errorf("staged plugin has no %s", ManifestFilename)
+	}
+	return copyEntry(source, target, manifest)
+}
+
+func copyEntry(source, target string, entry os.DirEntry) error {
+	from, to := filepath.Join(source, entry.Name()), filepath.Join(target, entry.Name())
+	info, err := entry.Info()
+	if err != nil {
+		return err
+	}
+	if entry.IsDir() {
+		if err := os.MkdirAll(to, info.Mode().Perm()); err != nil {
+			return err
+		}
+		nested, err := os.ReadDir(from)
+		if err != nil {
+			return err
+		}
+		for _, child := range nested {
+			if err := copyEntry(from, to, child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("staged plugin contains %q, which is not a regular file", entry.Name())
+	}
+	reader, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+	writer, err := os.OpenFile(to, os.O_CREATE|os.O_EXCL|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(writer, reader)
+	if closeErr := writer.Close(); err == nil {
+		err = closeErr
+	}
+	return err
+}
+
+func downloadArtifact(ctx context.Context, url, target string, opts StageOptions) error {
+	if !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("artifact URL %q must be https", url)
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = artifactTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: unexpected status %s", url, response.Status)
+	}
+	file, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	written, err := io.Copy(file, io.LimitReader(response.Body, maxArtifactBytes+1))
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	if written > maxArtifactBytes {
+		return fmt.Errorf("download %s: larger than %d bytes; refusing it", url, int64(maxArtifactBytes))
+	}
+	return nil
+}
+
+// safeArchiveName keeps the download's basename for readable errors without
+// letting a registry URL choose a path.
+func safeArchiveName(url string) string {
+	name := filepath.Base(filepath.FromSlash(strings.TrimSuffix(url, "/")))
+	if name == "." || name == string(filepath.Separator) || strings.Contains(name, "..") {
+		return "artifact"
+	}
+	return name
+}
+
+func normalizedDigest(digest string) string {
+	normalized, ok, err := normalizeChecksum(digest)
+	if err != nil || !ok {
+		return digest
+	}
+	return "sha256:" + normalized
+}

--- a/src/internal/plugin/install_test.go
+++ b/src/internal/plugin/install_test.go
@@ -1,0 +1,271 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fixture builds a real archive, serves it over TLS, and returns a Resolved
+// pointing at it — the same shape resolution produces from a published index.
+type fixture struct {
+	resolved *Resolved
+	server   *httptest.Server
+	client   *http.Client
+	archive  string
+}
+
+func newFixture(t *testing.T, options ...func(*fixtureOptions)) *fixture {
+	t.Helper()
+	settings := fixtureOptions{
+		manifest:   `{"schema_version":1,"id":"dev.apiary.example","version":"1.0.0","apiary":">= 0.1.0-0","protocol":1,"executable":"plugin.sh","capabilities":["source"],"security":{"network":true,"read_paths":["/etc/hosts"],"secret_env":["EXAMPLE_TOKEN"]}}`,
+		executable: "#!/bin/sh\nexit 0\n",
+	}
+	for _, option := range options {
+		option(&settings)
+	}
+	archive := writeTarGz(t, []tarEntry{
+		{name: ManifestFilename, body: settings.manifest},
+		{name: "plugin.sh", body: settings.executable, mode: 0o755},
+	})
+	body, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(body) }))
+	t.Cleanup(server.Close)
+
+	archiveDigest, err := FileSHA256(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unpacked := t.TempDir()
+	root, err := ExtractArchive(archive, unpacked)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executableDigest, err := FileSHA256(filepath.Join(root, "plugin.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.wrongArchiveDigest {
+		archiveDigest = "sha256:" + testDigest
+	}
+	if settings.wrongExecutableDigest {
+		executableDigest = "sha256:" + testDigest
+	}
+
+	artifact := Artifact{OS: "linux", Arch: "amd64", URL: server.URL + "/plugin.tar.gz",
+		ArchiveSHA256: archiveDigest, ExecutableSHA256: executableDigest}
+	release := Release{Version: settings.releaseVersion(), Apiary: ">= 0.1.0-0", Protocol: ProtocolVersion, Artifacts: []Artifact{artifact}}
+	entry := &RegistryPlugin{ID: settings.entryID(), Summary: "example", Capabilities: []Capability{CapabilitySource},
+		Repository: "https://example.invalid/repo", Releases: []Release{release}}
+
+	return &fixture{
+		resolved: &Resolved{Plugin: entry, Release: &entry.Releases[0], Artifact: &entry.Releases[0].Artifacts[0]},
+		server:   server, client: server.Client(), archive: archive,
+	}
+}
+
+type fixtureOptions struct {
+	manifest              string
+	executable            string
+	entryIDOverride       string
+	versionOverride       string
+	wrongArchiveDigest    bool
+	wrongExecutableDigest bool
+}
+
+func (o fixtureOptions) entryID() string {
+	if o.entryIDOverride != "" {
+		return o.entryIDOverride
+	}
+	return "dev.apiary.example"
+}
+
+func (o fixtureOptions) releaseVersion() string {
+	if o.versionOverride != "" {
+		return o.versionOverride
+	}
+	return "1.0.0"
+}
+
+func (f *fixture) stage(t *testing.T, opts StageOptions) (*Staged, error) {
+	t.Helper()
+	if opts.Client == nil {
+		opts.Client = f.client
+	}
+	return Stage(context.Background(), f.resolved, "", opts)
+}
+
+func TestStageVerifiesAndPins(t *testing.T) {
+	fixture := newFixture(t)
+	staged, err := fixture.stage(t, StageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer staged.Discard()
+
+	if !staged.PinInjected {
+		t.Fatal("an unpinned manifest must be pinned from the registry's digest")
+	}
+	if !DigestsMatch(staged.Installed.Manifest.Checksum, fixture.resolved.Artifact.ExecutableSHA256) {
+		t.Fatalf("the injected pin must be the registry's digest, got %q", staged.Installed.Manifest.Checksum)
+	}
+	// The rewritten manifest has to be one the daemon accepts, from disk.
+	reloaded, err := Load(staged.Root, "")
+	if err != nil {
+		t.Fatalf("the pinned manifest must still validate: %v", err)
+	}
+	if reloaded.Manifest.Checksum == "" {
+		t.Fatal("the pin was not persisted")
+	}
+}
+
+func TestStageKeepsAPublisherPin(t *testing.T) {
+	// Build once to learn the digest, then republish with it pinned.
+	probe := newFixture(t)
+	staged, err := probe.stage(t, StageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := staged.Installed.Manifest.Checksum
+	staged.Discard()
+
+	pinned := newFixture(t, func(o *fixtureOptions) {
+		o.manifest = strings.Replace(o.manifest, `"protocol":1,`, `"protocol":1,"checksum":"`+digest+`",`, 1)
+	})
+	staged, err = pinned.stage(t, StageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer staged.Discard()
+	if staged.PinInjected {
+		t.Fatal("a publisher's pin must be left alone")
+	}
+}
+
+func TestStageRejectsAPublisherPinThatIsNotTheShippedExecutable(t *testing.T) {
+	fixture := newFixture(t, func(o *fixtureOptions) {
+		o.manifest = strings.Replace(o.manifest, `"protocol":1,`, `"protocol":1,"checksum":"sha256:`+testDigest+`",`, 1)
+	})
+	_, err := fixture.stage(t, StageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not the executable it ships") {
+		t.Fatalf("want a pin/executable disagreement, got %v", err)
+	}
+}
+
+func TestStageRejectsDigestMismatches(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		option func(*fixtureOptions)
+		want   string
+	}{
+		{"archive", func(o *fixtureOptions) { o.wrongArchiveDigest = true }, "checksum mismatch for"},
+		{"executable", func(o *fixtureOptions) { o.wrongExecutableDigest = true }, "checksum mismatch for the executable"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newFixture(t, testCase.option)
+			_, err := fixture.stage(t, StageOptions{})
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("want %q, got %v", testCase.want, err)
+			}
+			if err != nil && !strings.Contains(err.Error(), "nothing was installed") {
+				t.Fatalf("a mismatch must say nothing was installed, got %v", err)
+			}
+		})
+	}
+}
+
+// The operator's --sha256 is a cross-check, not an override: a disagreement
+// stops the install before a byte is fetched.
+func TestStageRejectsExpectedDigestDisagreement(t *testing.T) {
+	fixture := newFixture(t)
+	_, err := fixture.stage(t, StageOptions{ExpectedArchiveSHA256: "sha256:" + testDigest})
+	if err == nil || !strings.Contains(err.Error(), "nothing was downloaded") {
+		t.Fatalf("want a pre-download refusal, got %v", err)
+	}
+}
+
+func TestStageRejectsAnArchiveHoldingADifferentPlugin(t *testing.T) {
+	fixture := newFixture(t, func(o *fixtureOptions) { o.entryIDOverride = "dev.apiary.other" })
+	_, err := fixture.stage(t, StageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "was requested") {
+		t.Fatalf("want an id disagreement, got %v", err)
+	}
+}
+
+func TestStageRejectsAVersionTheRegistryDoesNotList(t *testing.T) {
+	fixture := newFixture(t, func(o *fixtureOptions) { o.versionOverride = "2.0.0" })
+	_, err := fixture.stage(t, StageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "the registry lists") {
+		t.Fatalf("want a version disagreement, got %v", err)
+	}
+}
+
+func TestStageLeavesNothingBehindOnFailure(t *testing.T) {
+	fixture := newFixture(t, func(o *fixtureOptions) { o.wrongArchiveDigest = true })
+	before, _ := filepath.Glob(filepath.Join(os.TempDir(), "apiary-install-*"))
+	if _, err := fixture.stage(t, StageOptions{}); err == nil {
+		t.Fatal("expected a failure")
+	}
+	after, _ := filepath.Glob(filepath.Join(os.TempDir(), "apiary-install-*"))
+	if len(after) > len(before) {
+		t.Fatalf("a failed stage left staging directories behind: %v", after)
+	}
+}
+
+func TestCommitIsAtomicAndDiscoverable(t *testing.T) {
+	fixture := newFixture(t)
+	staged, err := fixture.stage(t, StageOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	destination := filepath.Join(pluginDir, "dev.apiary.example")
+	if err := staged.Commit(destination); err != nil {
+		t.Fatal(err)
+	}
+	registry, errs := Discover([]string{pluginDir}, pluginDir, "")
+	if len(errs) > 0 {
+		t.Fatalf("the committed plugin must discover cleanly: %v", errs)
+	}
+	if _, ok := registry.Get("dev.apiary.example"); !ok {
+		t.Fatal("the committed plugin was not discovered")
+	}
+}
+
+// The cross-device path copies rather than renames; the manifest is written
+// last so a half-copy is never discoverable.
+func TestCopyPluginDirWritesTheManifestLast(t *testing.T) {
+	source, target := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "plugin.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, ManifestFilename), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A copy that fails on the payload must not have written a manifest, since
+	// a directory carrying one is visible to discovery.
+	if err := os.WriteFile(filepath.Join(target, "plugin.sh"), []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyPluginDir(source, target); err == nil {
+		t.Fatal("expected the payload copy to fail")
+	}
+	if _, err := os.Stat(filepath.Join(target, ManifestFilename)); err == nil {
+		t.Fatal("a failed copy must not leave a discoverable manifest behind")
+	}
+}
+
+func TestSafeArchiveNameIgnoresPathsInURLs(t *testing.T) {
+	for _, url := range []string{"https://example.invalid/../../etc/passwd", "https://example.invalid/"} {
+		if name := safeArchiveName(url); strings.Contains(name, "..") || strings.ContainsRune(name, filepath.Separator) {
+			t.Fatalf("unsafe archive name %q from %q", name, url)
+		}
+	}
+}

--- a/src/internal/plugin/integrity.go
+++ b/src/internal/plugin/integrity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -74,6 +75,18 @@ func verifyChecksum(execPath, want string) error {
 		return fmt.Errorf("executable %q failed integrity check: manifest pins sha256:%s but file is sha256:%s (the plugin binary changed after installation)", execPath, digest, got)
 	}
 	return nil
+}
+
+// VerifyPin re-derives the executable's digest and compares it to the manifest's
+// pin. The daemon does this when it creates a client and before every
+// invocation; exposing it lets `apiary plugins validate` answer the same
+// question ahead of time, which matters most for a registry install, where the
+// pin came from the registry rather than from beside the binary.
+func (p *Installed) VerifyPin() error {
+	if p.Manifest.Checksum == "" {
+		return nil
+	}
+	return verifyChecksum(filepath.Join(p.Root, p.Manifest.Executable), p.Manifest.Checksum)
 }
 
 // integrityGuard re-verifies a pinned executable before each invocation, so a

--- a/src/internal/plugin/registry_archive.go
+++ b/src/internal/plugin/registry_archive.go
@@ -1,0 +1,256 @@
+package plugin
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A plugin archive is untrusted input handled by a process that is about to be
+// asked to trust its contents, so extraction refuses everything that could
+// write outside the destination or smuggle in something that is not a plain
+// file: absolute paths, traversal, symlinks, hardlinks, devices, sockets.
+const (
+	maxArchiveBytes   = 512 << 20 // uncompressed total; a plugin is one executable
+	maxArchiveEntries = 4096
+)
+
+// ExtractArchive unpacks a .tar.gz or .zip into destDir, which must already
+// exist and should be empty. It returns the directory holding the manifest:
+// archives that wrap their payload in a single top-level directory are as
+// common as those that do not, and either is fine.
+func ExtractArchive(archivePath, destDir string) (string, error) {
+	destDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", err
+	}
+	// The format comes from the bytes, not from the name: a download URL is
+	// whatever the publisher's release host makes it, and an archive that is
+	// really a gzip must not be refused for arriving without an extension.
+	format, err := sniffArchiveFormat(archivePath)
+	if err != nil {
+		return "", err
+	}
+	switch format {
+	case "tar.gz":
+		err = extractTarGz(archivePath, destDir)
+	case "zip":
+		err = extractZip(archivePath, destDir)
+	}
+	if err != nil {
+		return "", err
+	}
+	return manifestRoot(destDir)
+}
+
+// sniffArchiveFormat identifies the archive by its magic bytes.
+func sniffArchiveFormat(archivePath string) (string, error) {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+	header := make([]byte, 4)
+	n, err := io.ReadFull(file, header)
+	if err != nil && n < 4 {
+		return "", fmt.Errorf("read %q: %w", filepath.Base(archivePath), err)
+	}
+	switch {
+	case header[0] == 0x1f && header[1] == 0x8b:
+		return "tar.gz", nil
+	case string(header) == "PK\x03\x04":
+		return "zip", nil
+	default:
+		return "", fmt.Errorf("unsupported archive format for %q; expected a gzipped tarball or a zip", filepath.Base(archivePath))
+	}
+}
+
+// manifestRoot locates the directory holding apiary-plugin.json — the archive
+// root, or a single top-level directory inside it.
+func manifestRoot(destDir string) (string, error) {
+	if _, err := os.Stat(filepath.Join(destDir, ManifestFilename)); err == nil {
+		return destDir, nil
+	}
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		return "", err
+	}
+	var directories []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			directories = append(directories, entry.Name())
+		}
+	}
+	if len(directories) == 1 {
+		candidate := filepath.Join(destDir, directories[0])
+		if _, err := os.Stat(filepath.Join(candidate, ManifestFilename)); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("archive contains no %s at its root or in a single top-level directory", ManifestFilename)
+}
+
+// safeJoin resolves one archive entry's path against the destination, rejecting
+// anything that would land outside it.
+func safeJoin(destDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("archive entry has an empty name")
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(name))
+	if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || cleaned == ".." {
+		return "", fmt.Errorf("archive entry %q escapes the destination directory", name)
+	}
+	target := filepath.Join(destDir, cleaned)
+	relative, err := filepath.Rel(destDir, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("archive entry %q escapes the destination directory", name)
+	}
+	return target, nil
+}
+
+func extractTarGz(archivePath, destDir string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("read %q: %w", filepath.Base(archivePath), err)
+	}
+	defer func() { _ = gzipReader.Close() }()
+
+	reader := tar.NewReader(gzipReader)
+	var written, count int64
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read %q: %w", filepath.Base(archivePath), err)
+		}
+		count++
+		if count > maxArchiveEntries {
+			return fmt.Errorf("archive has more than %d entries; refusing it", maxArchiveEntries)
+		}
+		target, err := safeJoin(destDir, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			n, err := writeFile(target, reader, os.FileMode(header.Mode).Perm(), maxArchiveBytes-written)
+			if err != nil {
+				return err
+			}
+			written += n
+		default:
+			// Symlinks, hardlinks, devices and the rest have no legitimate place
+			// in a plugin archive, and every one of them is a way to reach
+			// outside the directory we are about to validate.
+			return fmt.Errorf("archive entry %q is not a regular file or directory; refusing it", header.Name)
+		}
+	}
+}
+
+func extractZip(archivePath, destDir string) error {
+	reader, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return fmt.Errorf("read %q: %w", filepath.Base(archivePath), err)
+	}
+	defer func() { _ = reader.Close() }()
+	if len(reader.File) > maxArchiveEntries {
+		return fmt.Errorf("archive has more than %d entries; refusing it", maxArchiveEntries)
+	}
+	var written int64
+	for _, entry := range reader.File {
+		target, err := safeJoin(destDir, entry.Name)
+		if err != nil {
+			return err
+		}
+		info := entry.FileInfo()
+		switch {
+		case info.IsDir():
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case info.Mode().IsRegular():
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			source, err := entry.Open()
+			if err != nil {
+				return err
+			}
+			n, err := writeFile(target, source, info.Mode().Perm(), maxArchiveBytes-written)
+			_ = source.Close()
+			if err != nil {
+				return err
+			}
+			written += n
+		default:
+			return fmt.Errorf("archive entry %q is not a regular file or directory; refusing it", entry.Name)
+		}
+	}
+	return nil
+}
+
+// writeFile copies one entry, refusing to exceed the archive's total budget —
+// a decompression bomb should cost a bounded amount of disk, not all of it.
+func writeFile(target string, source io.Reader, mode os.FileMode, budget int64) (int64, error) {
+	if budget <= 0 {
+		return 0, fmt.Errorf("archive expands beyond %d bytes; refusing it", int64(maxArchiveBytes))
+	}
+	if mode == 0 {
+		mode = 0o644
+	}
+	file, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+	if err != nil {
+		return 0, err
+	}
+	written, err := io.Copy(file, io.LimitReader(source, budget+1))
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return written, err
+	}
+	if written > budget {
+		return written, fmt.Errorf("archive expands beyond %d bytes; refusing it", int64(maxArchiveBytes))
+	}
+	return written, nil
+}
+
+// FileSHA256 returns a file's digest as "sha256:<hex>", the form the manifest's
+// checksum pin uses.
+func FileSHA256(path string) (string, error) {
+	sum, err := fileSHA256(path)
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + sum, nil
+}
+
+// DigestsMatch compares two SHA-256 digests written in either accepted form
+// ("sha256:<hex>" or bare hex).
+func DigestsMatch(left, right string) bool {
+	normalizedLeft, okLeft, errLeft := normalizeChecksum(left)
+	normalizedRight, okRight, errRight := normalizeChecksum(right)
+	if errLeft != nil || errRight != nil || !okLeft || !okRight {
+		return false
+	}
+	return normalizedLeft == normalizedRight
+}

--- a/src/internal/plugin/registry_archive_test.go
+++ b/src/internal/plugin/registry_archive_test.go
@@ -1,0 +1,181 @@
+package plugin
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// tarEntry is one member of a synthetic archive, including the shapes a plugin
+// archive must never contain.
+type tarEntry struct {
+	name     string
+	body     string
+	mode     int64
+	typeflag byte
+	linkname string
+}
+
+func writeTarGz(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "plugin.tar.gz")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	writer := tar.NewWriter(gzipWriter)
+	for _, entry := range entries {
+		flag := entry.typeflag
+		if flag == 0 {
+			flag = tar.TypeReg
+		}
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		header := &tar.Header{Name: entry.name, Mode: mode, Size: int64(len(entry.body)), Typeflag: flag, Linkname: entry.linkname}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write([]byte(entry.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, closer := range []func() error{writer.Close, gzipWriter.Close, file.Close} {
+		if err := closer(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+const testManifestJSON = `{"schema_version":1,"id":"dev.apiary.example","version":"1.0.0","apiary":">= 0.1.0-0","protocol":1,"executable":"plugin.sh","capabilities":["source"]}`
+
+func TestExtractArchiveHappyPath(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: ManifestFilename, body: testManifestJSON},
+		{name: "plugin.sh", body: "#!/bin/sh\nexit 0\n", mode: 0o755},
+	})
+	dest := t.TempDir()
+	root, err := ExtractArchive(archive, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != dest {
+		t.Fatalf("want the manifest at the archive root, got %s", root)
+	}
+	if _, err := Load(root, ""); err != nil {
+		t.Fatalf("the unpacked plugin should load: %v", err)
+	}
+}
+
+func TestExtractArchiveFindsSingleTopLevelDirectory(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: "plugin-1.0.0/", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "plugin-1.0.0/" + ManifestFilename, body: testManifestJSON},
+		{name: "plugin-1.0.0/plugin.sh", body: "#!/bin/sh\nexit 0\n", mode: 0o755},
+	})
+	root, err := ExtractArchive(archive, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(root) != "plugin-1.0.0" {
+		t.Fatalf("want the wrapped directory, got %s", root)
+	}
+}
+
+// An archive is untrusted input handled just before we are asked to trust its
+// contents. Everything that could write outside the destination, or smuggle in
+// something that is not a plain file, is refused.
+func TestExtractArchiveRefusesUnsafeEntries(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry tarEntry
+	}{
+		{"traversal", tarEntry{name: "../escaped", body: "x"}},
+		{"nested traversal", tarEntry{name: "a/../../escaped", body: "x"}},
+		{"absolute path", tarEntry{name: "/etc/passwd", body: "x"}},
+		{"symlink", tarEntry{name: "link", typeflag: tar.TypeSymlink, linkname: "/etc/passwd"}},
+		{"hardlink", tarEntry{name: "link", typeflag: tar.TypeLink, linkname: "plugin.sh"}},
+		{"fifo", tarEntry{name: "pipe", typeflag: tar.TypeFifo}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			archive := writeTarGz(t, []tarEntry{{name: ManifestFilename, body: testManifestJSON}, testCase.entry})
+			dest := t.TempDir()
+			if _, err := ExtractArchive(archive, dest); err == nil {
+				t.Fatalf("%s must be refused", testCase.name)
+			}
+			if _, err := os.Stat(filepath.Join(filepath.Dir(dest), "escaped")); err == nil {
+				t.Fatal("an entry escaped the destination directory")
+			}
+		})
+	}
+}
+
+func TestExtractArchiveRejectsUnknownFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugin.rar")
+	if err := os.WriteFile(path, []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExtractArchive(path, t.TempDir()); err == nil || !strings.Contains(err.Error(), "unsupported archive format") {
+		t.Fatalf("want an unsupported-format error, got %v", err)
+	}
+}
+
+// Format detection reads the bytes, not the filename: release URLs routinely
+// carry no usable extension.
+func TestExtractArchiveIgnoresTheFilename(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: ManifestFilename, body: testManifestJSON},
+		{name: "plugin.sh", body: "#!/bin/sh\nexit 0\n", mode: 0o755},
+	})
+	extensionless := filepath.Join(t.TempDir(), "download")
+	body, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(extensionless, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExtractArchive(extensionless, t.TempDir()); err != nil {
+		t.Fatalf("a gzipped tarball must extract regardless of its name: %v", err)
+	}
+}
+
+func TestExtractArchiveRequiresAManifest(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{{name: "README.md", body: "hello"}})
+	if _, err := ExtractArchive(archive, t.TempDir()); err == nil || !strings.Contains(err.Error(), ManifestFilename) {
+		t.Fatalf("want a missing-manifest error, got %v", err)
+	}
+}
+
+func TestDigestsMatchAcceptsBothForms(t *testing.T) {
+	if !DigestsMatch("sha256:"+testDigest, strings.ToUpper(testDigest)) {
+		t.Fatal("prefixed and bare digests must compare equal")
+	}
+	if DigestsMatch(testDigest, "") || DigestsMatch("garbage", testDigest) {
+		t.Fatal("an unusable digest must never compare equal")
+	}
+}
+
+func TestFileSHA256IsManifestPinShaped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("apiary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := FileSHA256(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(digest, "sha256:") {
+		t.Fatalf("want a manifest-shaped pin, got %s", digest)
+	}
+	if _, _, err := normalizeChecksum(digest); err != nil {
+		t.Fatalf("the pin must be one the manifest validator accepts: %v", err)
+	}
+}

--- a/src/internal/plugin/registry_config.go
+++ b/src/internal/plugin/registry_config.go
@@ -1,0 +1,88 @@
+package plugin
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OfficialRegistryPublicKey is the minisign public key the official index is
+// signed with. It is stamped in at build time:
+//
+//	-X github.com/orlandoburli/apiary/internal/plugin.OfficialRegistryPublicKey=<base64 line>
+//
+// While it is empty, the official index is fetched unsigned and every command
+// says so. That is the honest state for a registry whose signing key does not
+// exist yet — quieter than refusing to work, and louder than pretending the
+// index was verified.
+var OfficialRegistryPublicKey string
+
+// RegistrySource is one entry of plugin_registries. It accepts either a bare
+// URL or a mapping carrying that registry's own signing key, so an internal
+// mirror can be pinned to a key its operators control:
+//
+//	plugin_registries:
+//	  - https://orlandoburli.com.br/apiary/registry/v1/index.json
+//	  - url: file:///opt/apiary/registry/index.json
+//	    public_key: RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3
+type RegistrySource struct {
+	URL string `yaml:"url" json:"url"`
+	// PublicKey is a minisign public key (the bare base64 line). When set, this
+	// registry's index MUST be signed by it — there is no flag to skip that.
+	PublicKey string `yaml:"public_key,omitempty" json:"public_key,omitempty"`
+}
+
+// UnmarshalYAML accepts the scalar form as well as the mapping form, so
+// existing `plugin_registries: [https://…]` configs keep working unchanged.
+func (s *RegistrySource) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.ScalarNode {
+		return node.Decode(&s.URL)
+	}
+	type plain RegistrySource // avoid recursing into this method
+	var decoded plain
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*s = RegistrySource(decoded)
+	return nil
+}
+
+// MarshalYAML writes the scalar form back when there is nothing else to say.
+func (s RegistrySource) MarshalYAML() (any, error) {
+	if s.PublicKey == "" {
+		return s.URL, nil
+	}
+	type plain RegistrySource
+	return plain(s), nil
+}
+
+// Key returns the public key this source must be verified against: its own if
+// it declares one, the embedded official key for the official index, and
+// otherwise none — in which case the index is used unverified and said to be.
+func (s RegistrySource) Key() string {
+	if s.PublicKey != "" {
+		return s.PublicKey
+	}
+	if s.URL == DefaultRegistryURL {
+		return OfficialRegistryPublicKey
+	}
+	return ""
+}
+
+// Validate checks one configured registry.
+func (s RegistrySource) Validate() error {
+	if err := ValidateRegistryURL(s.URL); err != nil {
+		return err
+	}
+	if s.PublicKey != "" {
+		if _, err := ParsePublicKey(s.PublicKey); err != nil {
+			return fmt.Errorf("public_key: %w", err)
+		}
+	}
+	return nil
+}
+
+// DefaultRegistrySources is what an operator who expressed no preference gets.
+func DefaultRegistrySources() []RegistrySource {
+	return []RegistrySource{{URL: DefaultRegistryURL}}
+}

--- a/src/internal/plugin/registry_entry.go
+++ b/src/internal/plugin/registry_entry.go
@@ -1,0 +1,143 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Publishing is a pull request: one YAML file per plugin under
+// registry/plugins/, reviewed by a human and verified by CI, compiled into the
+// JSON index clients read. There is no upload endpoint and no account — the
+// repository's access control is the ownership model.
+const EntrySchemaVersion = 1
+
+// Entry is the on-disk form of a registry listing.
+type Entry struct {
+	SchemaVersion  int `yaml:"schema_version"`
+	RegistryPlugin `yaml:",inline"`
+}
+
+// LoadEntry reads and validates one entry file. The filename must be the plugin
+// id, so a listing cannot be reviewed under one name and published under
+// another.
+func LoadEntry(path string) (*Entry, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var entry Entry
+	decoder := yaml.NewDecoder(strings.NewReader(string(raw)))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&entry); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if entry.SchemaVersion != EntrySchemaVersion {
+		return nil, fmt.Errorf("%s: unsupported schema_version %d; expected %d", path, entry.SchemaVersion, EntrySchemaVersion)
+	}
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if base != entry.ID {
+		return nil, fmt.Errorf("%s: filename must be %q.yaml to match the plugin id", path, entry.ID)
+	}
+	if errs := entry.Validate(); len(errs) > 0 {
+		messages := make([]string, len(errs))
+		for i, err := range errs {
+			messages[i] = err.Error()
+		}
+		return nil, fmt.Errorf("%s:\n  - %s", path, strings.Join(messages, "\n  - "))
+	}
+	if _, err := entry.ConformanceConfigJSON(); err != nil {
+		return nil, fmt.Errorf("%s: conformance_config: %w", path, err)
+	}
+	return &entry, nil
+}
+
+// ConformanceConfigJSON renders the entry's conformance configuration as the
+// JSON the kit expects on the wire. Empty when the entry declares none, in
+// which case CI records the release as "conformance not run" rather than
+// inventing a configuration the plugin never agreed to.
+func (p *RegistryPlugin) ConformanceConfigJSON() (string, error) {
+	if len(p.ConformanceConfig) == 0 {
+		return "", nil
+	}
+	encoded, err := json.Marshal(p.ConformanceConfig)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// LoadEntries reads every entry in a directory, failing on the first invalid
+// one. A registry that partially parses would publish exactly the listings
+// nobody checked.
+func LoadEntries(dir string) ([]*Entry, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	entries := make([]*Entry, 0, len(matches))
+	seen := map[string]string{}
+	for _, path := range matches {
+		entry, err := LoadEntry(path)
+		if err != nil {
+			return nil, err
+		}
+		if previous, exists := seen[entry.ID]; exists {
+			return nil, fmt.Errorf("%s: plugin id %q is already listed by %s", path, entry.ID, previous)
+		}
+		seen[entry.ID] = path
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// ConformanceResults maps "<id>@<version>" to the verdict CI observed. It is
+// produced by the checker and merged at build time, so a submitter cannot
+// declare their own plugin conformant.
+type ConformanceResults map[string]Conformance
+
+// ConformanceKey is the results key for one release.
+func ConformanceKey(id, version string) string { return id + "@" + version }
+
+// CompileIndex turns reviewed entries into the document clients fetch, stamping
+// CI's conformance verdicts onto the releases they were observed against.
+func CompileIndex(entries []*Entry, results ConformanceResults, generatedAt time.Time) (*Index, error) {
+	index := &Index{SchemaVersion: IndexSchemaVersion, GeneratedAt: generatedAt.UTC().Format(time.RFC3339)}
+	for _, entry := range entries {
+		published := entry.RegistryPlugin
+		// CI's business, not the client's: it is excluded from the JSON anyway,
+		// and dropping it here keeps the published value and the serialized one
+		// telling the same story.
+		published.ConformanceConfig = nil
+		published.Releases = make([]Release, len(entry.Releases))
+		copy(published.Releases, entry.Releases)
+		for i := range published.Releases {
+			release := &published.Releases[i]
+			verdict, ok := results[ConformanceKey(entry.ID, release.Version)]
+			if !ok {
+				verdict = Conformance{Status: "not_run"}
+			}
+			release.Conformance = &verdict
+		}
+		index.Plugins = append(index.Plugins, published)
+	}
+	sort.Slice(index.Plugins, func(i, j int) bool { return index.Plugins[i].ID < index.Plugins[j].ID })
+	// Round-trip through the client's own parser: whatever CI publishes must be
+	// something a client would accept, or the failure surfaces on operators'
+	// machines instead of in CI.
+	encoded, err := json.Marshal(index)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := ParseIndex(encoded); err != nil {
+		return nil, fmt.Errorf("compiled index would be rejected by clients: %w", err)
+	}
+	return index, nil
+}

--- a/src/internal/plugin/registry_entry_test.go
+++ b/src/internal/plugin/registry_entry_test.go
@@ -1,0 +1,155 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const validEntryYAML = `schema_version: 1
+id: dev.apiary.example
+summary: an example
+capabilities: [source]
+repository: https://example.invalid/repo
+releases:
+  - version: 1.0.0
+    apiary: ">= 0.1.0-0"
+    protocol: 1
+    artifacts:
+      - os: linux
+        arch: amd64
+        url: https://example.invalid/p.tar.gz
+        archive_sha256: ` + testDigest + `
+        executable_sha256: ` + testDigest + `
+`
+
+func writeEntry(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadEntryAcceptsAValidListing(t *testing.T) {
+	path := writeEntry(t, t.TempDir(), "dev.apiary.example.yaml", validEntryYAML)
+	entry, err := LoadEntry(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ID != "dev.apiary.example" || len(entry.Releases) != 1 {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+}
+
+// A listing reviewed under one name must not publish under another.
+func TestLoadEntryRequiresFilenameToMatchID(t *testing.T) {
+	path := writeEntry(t, t.TempDir(), "something-else.yaml", validEntryYAML)
+	if _, err := LoadEntry(path); err == nil || !strings.Contains(err.Error(), "filename") {
+		t.Fatalf("want a filename/id mismatch error, got %v", err)
+	}
+}
+
+func TestLoadEntryRejectsUnknownFields(t *testing.T) {
+	path := writeEntry(t, t.TempDir(), "dev.apiary.example.yaml", validEntryYAML+"surprise: true\n")
+	if _, err := LoadEntry(path); err == nil {
+		t.Fatal("an entry with unknown fields must be rejected")
+	}
+}
+
+func TestLoadEntryRejectsUnknownSchemaVersion(t *testing.T) {
+	body := strings.Replace(validEntryYAML, "schema_version: 1", "schema_version: 7", 1)
+	path := writeEntry(t, t.TempDir(), "dev.apiary.example.yaml", body)
+	if _, err := LoadEntry(path); err == nil || !strings.Contains(err.Error(), "schema_version") {
+		t.Fatalf("want a fail-closed schema version error, got %v", err)
+	}
+}
+
+// A registry that partially parses would publish exactly the listings nobody
+// checked.
+func TestLoadEntriesFailsOnAnyInvalidEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "dev.apiary.example.yaml", validEntryYAML)
+	writeEntry(t, dir, "dev.apiary.broken.yaml", "schema_version: 1\nid: dev.apiary.broken\n")
+	if _, err := LoadEntries(dir); err == nil {
+		t.Fatal("one invalid entry must fail the whole load")
+	}
+}
+
+func TestCompileIndexStampsConformanceVerdicts(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "dev.apiary.example.yaml", validEntryYAML)
+	entries, err := LoadEntries(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := ConformanceResults{ConformanceKey("dev.apiary.example", "1.0.0"): {Status: "failed", Kit: "sdk/conformance"}}
+	index, err := CompileIndex(entries, results, time.Unix(0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verdict := index.Plugins[0].Releases[0].Conformance
+	if verdict == nil || verdict.Status != "failed" {
+		t.Fatalf("CI's verdict must reach the index, got %+v", verdict)
+	}
+}
+
+// Absent evidence is published as absent — never as a pass.
+func TestCompileIndexMarksUnrunConformance(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "dev.apiary.example.yaml", validEntryYAML)
+	entries, err := LoadEntries(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index, err := CompileIndex(entries, nil, time.Unix(0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := index.Plugins[0].Releases[0].Conformance.Status; got != "not_run" {
+		t.Fatalf("want not_run, got %q", got)
+	}
+}
+
+// The conformance config is CI's business: it must not reach the published
+// index, where a client would have no use for it.
+func TestCompileIndexOmitsConformanceConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "dev.apiary.example.yaml", validEntryYAML+"conformance_config:\n  path: /tmp/x\n")
+	entries, err := LoadEntries(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := entries[0].ConformanceConfigJSON()
+	if err != nil || !strings.Contains(config, "/tmp/x") {
+		t.Fatalf("CI needs the config as JSON, got %q (%v)", config, err)
+	}
+	index, err := CompileIndex(entries, nil, time.Unix(0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if index.Plugins[0].ConformanceConfig != nil {
+		t.Fatal("conformance_config must not be published")
+	}
+	encoded, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "conformance_config") || strings.Contains(string(encoded), "/tmp/x") {
+		t.Fatalf("conformance_config leaked into the published index: %s", encoded)
+	}
+}
+
+// Whatever CI publishes has to be something a client would accept, or the
+// failure surfaces on operators' machines instead of in CI.
+func TestCompileIndexRoundTripsThroughTheClientParser(t *testing.T) {
+	entry := &Entry{SchemaVersion: 1, RegistryPlugin: *testEntry(testRelease("1.0.0", ">= 0.1.0-0"))}
+	entry.Capabilities = []Capability{"not-a-capability"}
+	if _, err := CompileIndex([]*Entry{entry}, nil, time.Unix(0, 0)); err == nil {
+		t.Fatal("an index clients would reject must not compile")
+	}
+}

--- a/src/internal/plugin/registry_index.go
+++ b/src/internal/plugin/registry_index.go
@@ -1,0 +1,379 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// The registry is a static, reviewed index: metadata and digests only. It never
+// carries plugin code, and the daemon never reads it — resolution happens in the
+// CLI, before anything is downloaded, so an incompatible or unavailable release
+// is reported instead of installed.
+const (
+	// IndexSchemaVersion is the compiled index format this Apiary understands.
+	// An unknown version fails closed rather than being partially interpreted.
+	IndexSchemaVersion = 1
+
+	// DefaultRegistryURL is used when apiary.yaml declares no plugin_registries.
+	DefaultRegistryURL = "https://orlandoburli.com.br/apiary/registry/v1/index.json"
+)
+
+// Index is the compiled registry document: every reviewed entry, in one file, so
+// a CLI command needs exactly one request.
+type Index struct {
+	SchemaVersion int              `json:"schema_version"`
+	GeneratedAt   string           `json:"generated_at,omitempty"`
+	Plugins       []RegistryPlugin `json:"plugins"`
+}
+
+// RegistryPlugin is one plugin's entry: stable identity plus its releases.
+type RegistryPlugin struct {
+	ID           string       `json:"id" yaml:"id"`
+	Summary      string       `json:"summary" yaml:"summary"`
+	Capabilities []Capability `json:"capabilities" yaml:"capabilities"`
+	Homepage     string       `json:"homepage,omitempty" yaml:"homepage,omitempty"`
+	Repository   string       `json:"repository" yaml:"repository"`
+	License      string       `json:"license,omitempty" yaml:"license,omitempty"`
+	// ConformanceConfig is the plugin config the conformance kit should run
+	// with. Registry CI uses it; the CLI never does, and it is not published in
+	// the index. Absent means "the kit was not run", which `info` reports as
+	// such rather than glossing over.
+	ConformanceConfig map[string]any `json:"-" yaml:"conformance_config,omitempty"`
+	Releases          []Release      `json:"releases" yaml:"releases"`
+}
+
+// Release is one published version of a plugin.
+type Release struct {
+	Version      string       `json:"version" yaml:"version"`
+	Apiary       string       `json:"apiary" yaml:"apiary"`
+	Protocol     int          `json:"protocol" yaml:"protocol"`
+	PublishedAt  string       `json:"published_at,omitempty" yaml:"published_at,omitempty"`
+	Yanked       bool         `json:"yanked,omitempty" yaml:"yanked,omitempty"`
+	YankedReason string       `json:"yanked_reason,omitempty" yaml:"yanked_reason,omitempty"`
+	Conformance  *Conformance `json:"conformance,omitempty" yaml:"-"`
+	Artifacts    []Artifact   `json:"artifacts" yaml:"artifacts"`
+}
+
+// Conformance records what registry CI observed when it ran the protocol
+// conformance kit against the published artifact. It is written by CI, never by
+// the submitter, and is a test result — not an endorsement.
+type Conformance struct {
+	Status    string `json:"status"` // passed | failed | not_run
+	Kit       string `json:"kit,omitempty"`
+	CheckedAt string `json:"checked_at,omitempty"`
+	Commit    string `json:"commit,omitempty"`
+}
+
+// Artifact is one platform's download. Both digests are mandatory: the archive's,
+// so the download can be verified before it is unpacked, and the executable's,
+// so the installed manifest can be pinned to a value that originates outside the
+// publisher's own release.
+type Artifact struct {
+	OS               string `json:"os" yaml:"os"`
+	Arch             string `json:"arch" yaml:"arch"`
+	URL              string `json:"url" yaml:"url"`
+	ArchiveSHA256    string `json:"archive_sha256" yaml:"archive_sha256"`
+	ExecutableSHA256 string `json:"executable_sha256" yaml:"executable_sha256"`
+}
+
+// ParseIndex decodes and fully validates a compiled index. A malformed or
+// unknown-version document is rejected outright: a half-understood registry is
+// worse than no registry.
+func ParseIndex(data []byte) (*Index, error) {
+	var index Index
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&index); err != nil {
+		return nil, fmt.Errorf("decode registry index: %w", err)
+	}
+	if index.SchemaVersion != IndexSchemaVersion {
+		return nil, fmt.Errorf("unsupported registry index schema_version %d; this Apiary supports %d — upgrade Apiary or point plugin_registries at a v%d index",
+			index.SchemaVersion, IndexSchemaVersion, IndexSchemaVersion)
+	}
+	seen := map[string]bool{}
+	for i := range index.Plugins {
+		entry := &index.Plugins[i]
+		if errs := entry.Validate(); len(errs) > 0 {
+			return nil, fmt.Errorf("registry index entry %q: %w", entry.ID, errs[0])
+		}
+		if seen[entry.ID] {
+			return nil, fmt.Errorf("registry index lists %q twice", entry.ID)
+		}
+		seen[entry.ID] = true
+	}
+	sort.Slice(index.Plugins, func(i, j int) bool { return index.Plugins[i].ID < index.Plugins[j].ID })
+	return &index, nil
+}
+
+// Validate checks one entry against the rules registry CI enforces at review
+// time. The CLI re-runs it on every fetch so a mis-published index cannot make
+// a client behave in ways review never approved.
+func (p *RegistryPlugin) Validate() []error {
+	var errs []error
+	if !validPluginID(p.ID) {
+		errs = append(errs, fmt.Errorf("id %q must be a lowercase reverse-DNS identifier", p.ID))
+	}
+	if strings.TrimSpace(p.Summary) == "" {
+		errs = append(errs, fmt.Errorf("summary is required"))
+	}
+	if strings.TrimSpace(p.Repository) == "" {
+		errs = append(errs, fmt.Errorf("repository is required: an operator must be able to read the code before running it"))
+	}
+	if len(p.Capabilities) == 0 {
+		errs = append(errs, fmt.Errorf("at least one capability is required"))
+	}
+	for _, capability := range p.Capabilities {
+		if _, ok := supportedCapabilities[capability]; !ok {
+			errs = append(errs, fmt.Errorf("unsupported capability %q; supported: %s", capability, strings.Join(SupportedCapabilityNames(), ", ")))
+		}
+	}
+	if len(p.Releases) == 0 {
+		errs = append(errs, fmt.Errorf("at least one release is required"))
+	}
+	versions := map[string]bool{}
+	for i := range p.Releases {
+		release := &p.Releases[i]
+		prefix := fmt.Sprintf("releases[%d]", i)
+		if _, err := semver.StrictNewVersion(release.Version); err != nil {
+			errs = append(errs, fmt.Errorf("%s: version %q is not semantic versioning", prefix, release.Version))
+		} else if versions[release.Version] {
+			errs = append(errs, fmt.Errorf("%s: duplicate version %q; releases are immutable, publish a new version instead", prefix, release.Version))
+		}
+		versions[release.Version] = true
+		if strings.TrimSpace(release.Apiary) == "" {
+			errs = append(errs, fmt.Errorf("%s: apiary compatibility constraint is required", prefix))
+		} else if _, err := semver.NewConstraint(release.Apiary); err != nil {
+			errs = append(errs, fmt.Errorf("%s: apiary compatibility %q is invalid: %w", prefix, release.Apiary, err))
+		}
+		if release.Protocol <= 0 {
+			errs = append(errs, fmt.Errorf("%s: protocol is required", prefix))
+		}
+		if release.Yanked && strings.TrimSpace(release.YankedReason) == "" {
+			errs = append(errs, fmt.Errorf("%s: yanked releases must state a yanked_reason", prefix))
+		}
+		if len(release.Artifacts) == 0 {
+			errs = append(errs, fmt.Errorf("%s: at least one artifact is required", prefix))
+		}
+		platforms := map[string]bool{}
+		for j := range release.Artifacts {
+			artifact := &release.Artifacts[j]
+			where := fmt.Sprintf("%s.artifacts[%d]", prefix, j)
+			if artifact.OS == "" || artifact.Arch == "" {
+				errs = append(errs, fmt.Errorf("%s: os and arch are required (GOOS/GOARCH spelling)", where))
+			}
+			platform := artifact.Platform()
+			if platforms[platform] {
+				errs = append(errs, fmt.Errorf("%s: duplicate platform %q", where, platform))
+			}
+			platforms[platform] = true
+			if !strings.HasPrefix(artifact.URL, "https://") {
+				errs = append(errs, fmt.Errorf("%s: url must be https", where))
+			}
+			for label, digest := range map[string]string{"archive_sha256": artifact.ArchiveSHA256, "executable_sha256": artifact.ExecutableSHA256} {
+				if _, _, err := normalizeChecksum(digest); err != nil || strings.TrimSpace(digest) == "" {
+					errs = append(errs, fmt.Errorf("%s: %s is required and must be a SHA-256 digest", where, label))
+				}
+			}
+		}
+	}
+	return errs
+}
+
+// Platform is the artifact's GOOS/GOARCH pair as one comparable string.
+func (a Artifact) Platform() string { return a.OS + "/" + a.Arch }
+
+// Find returns the entry for an id.
+func (idx *Index) Find(id string) (*RegistryPlugin, bool) {
+	if idx == nil {
+		return nil, false
+	}
+	for i := range idx.Plugins {
+		if idx.Plugins[i].ID == id {
+			return &idx.Plugins[i], true
+		}
+	}
+	return nil, false
+}
+
+// Search matches a free-text query against ids and summaries, optionally
+// filtered by capability. An empty query lists everything.
+func (idx *Index) Search(query string, capability Capability) []*RegistryPlugin {
+	if idx == nil {
+		return nil
+	}
+	needle := strings.ToLower(strings.TrimSpace(query))
+	var matches []*RegistryPlugin
+	for i := range idx.Plugins {
+		entry := &idx.Plugins[i]
+		if capability != "" && !entry.HasCapability(capability) {
+			continue
+		}
+		haystack := strings.ToLower(entry.ID + " " + entry.Summary)
+		if needle == "" || strings.Contains(haystack, needle) {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+// HasCapability reports whether the entry declares a capability.
+func (p *RegistryPlugin) HasCapability(capability Capability) bool {
+	for _, current := range p.Capabilities {
+		if current == capability {
+			return true
+		}
+	}
+	return false
+}
+
+// Suggest returns ids close to a miss, so a typo does not read as "no such
+// plugin". Comparison is a cheap prefix/substring match on the last label.
+func (idx *Index) Suggest(id string) []string {
+	if idx == nil {
+		return nil
+	}
+	needle := strings.ToLower(id)
+	if at := strings.LastIndex(needle, "."); at >= 0 {
+		needle = needle[at+1:]
+	}
+	var out []string
+	for i := range idx.Plugins {
+		candidate := idx.Plugins[i].ID
+		if needle != "" && strings.Contains(strings.ToLower(candidate), needle) {
+			out = append(out, candidate)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ResolveOptions selects one artifact for one host.
+type ResolveOptions struct {
+	Version       string // exact version; empty means "newest usable"
+	ApiaryVersion string // host version; "" or "dev" skips the constraint check
+	GOOS          string // defaults to the running platform
+	GOARCH        string
+}
+
+// Resolved is the outcome of resolution: which release, and which download.
+type Resolved struct {
+	Plugin   *RegistryPlugin
+	Release  *Release
+	Artifact *Artifact
+	// CompatibilityUnchecked is set when the host's own version string is not
+	// semantic versioning — a development build, typically. The constraint is
+	// skipped rather than failing every resolution, and commands say so instead
+	// of implying a check that did not happen.
+	CompatibilityUnchecked string
+}
+
+// Resolve picks the release to install, running every check that can be made
+// before a byte is downloaded. When nothing qualifies it explains which
+// predicate eliminated the newest candidate — "0.3.0 requires apiary >= 0.20.0,
+// you are on 0.19.1" is the answer worth having before a download, not after.
+func (p *RegistryPlugin) Resolve(opts ResolveOptions) (*Resolved, error) {
+	if opts.GOOS == "" {
+		opts.GOOS = runtime.GOOS
+	}
+	if opts.GOARCH == "" {
+		opts.GOARCH = runtime.GOARCH
+	}
+	candidates := make([]*Release, 0, len(p.Releases))
+	for i := range p.Releases {
+		if opts.Version != "" && p.Releases[i].Version != opts.Version {
+			continue
+		}
+		candidates = append(candidates, &p.Releases[i])
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("%s has no release %s; published versions: %s", p.ID, opts.Version, strings.Join(p.versions(), ", "))
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		left, errLeft := semver.NewVersion(candidates[i].Version)
+		right, errRight := semver.NewVersion(candidates[j].Version)
+		if errLeft != nil || errRight != nil {
+			return candidates[i].Version > candidates[j].Version
+		}
+		return left.GreaterThan(right)
+	})
+
+	var firstRejection error
+	for _, release := range candidates {
+		artifact, unchecked, err := release.usableOn(opts)
+		if err != nil {
+			if firstRejection == nil {
+				firstRejection = fmt.Errorf("%s %s: %w", p.ID, release.Version, err)
+			}
+			continue
+		}
+		return &Resolved{Plugin: p, Release: release, Artifact: artifact, CompatibilityUnchecked: unchecked}, nil
+	}
+	return nil, fmt.Errorf("no usable release of %s: %w", p.ID, firstRejection)
+}
+
+// usableOn evaluates the pre-download predicates in the order an operator would
+// ask them: is it withdrawn, can this Apiary speak to it, is it built for this
+// machine.
+func (r *Release) usableOn(opts ResolveOptions) (artifact *Artifact, unchecked string, err error) {
+	if r.Yanked {
+		return nil, "", fmt.Errorf("withdrawn by its publisher (%s)", r.YankedReason)
+	}
+	if r.Protocol != ProtocolVersion {
+		return nil, "", fmt.Errorf("speaks plugin protocol %d; this Apiary speaks protocol %d", r.Protocol, ProtocolVersion)
+	}
+	if opts.ApiaryVersion != "" && opts.ApiaryVersion != "dev" {
+		constraint, err := semver.NewConstraint(r.Apiary)
+		if err != nil {
+			return nil, "", fmt.Errorf("declares an invalid apiary constraint %q", r.Apiary)
+		}
+		host, hostErr := semver.NewVersion(opts.ApiaryVersion)
+		switch {
+		case hostErr != nil:
+			// Development builds carry version strings git describe invented.
+			// Refusing every plugin on that basis would be a worse answer than
+			// installing one and letting the daemon's own manifest check —
+			// which runs against the same constraint — have the final word.
+			unchecked = opts.ApiaryVersion
+		case !constraint.Check(host):
+			return nil, "", fmt.Errorf("requires apiary %s, this host is %s", r.Apiary, host)
+		}
+	}
+	artifact = r.ArtifactFor(opts.GOOS, opts.GOARCH)
+	if artifact == nil {
+		return nil, "", fmt.Errorf("has no build for %s/%s (available: %s)", opts.GOOS, opts.GOARCH, strings.Join(r.Platforms(), ", "))
+	}
+	return artifact, unchecked, nil
+}
+
+// ArtifactFor returns the download for one platform, or nil.
+func (r *Release) ArtifactFor(goos, goarch string) *Artifact {
+	for i := range r.Artifacts {
+		if r.Artifacts[i].OS == goos && r.Artifacts[i].Arch == goarch {
+			return &r.Artifacts[i]
+		}
+	}
+	return nil
+}
+
+// Platforms lists the release's platforms, for error messages and `info`.
+func (r *Release) Platforms() []string {
+	out := make([]string, 0, len(r.Artifacts))
+	for _, artifact := range r.Artifacts {
+		out = append(out, artifact.Platform())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (p *RegistryPlugin) versions() []string {
+	out := make([]string, 0, len(p.Releases))
+	for _, release := range p.Releases {
+		out = append(out, release.Version)
+	}
+	return out
+}

--- a/src/internal/plugin/registry_index_test.go
+++ b/src/internal/plugin/registry_index_test.go
@@ -1,0 +1,192 @@
+package plugin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+const testDigest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func testArtifact(goos, goarch string) Artifact {
+	return Artifact{OS: goos, Arch: goarch, URL: "https://example.invalid/p.tar.gz", ArchiveSHA256: testDigest, ExecutableSHA256: testDigest}
+}
+
+func testEntry(releases ...Release) *RegistryPlugin {
+	return &RegistryPlugin{
+		ID: "dev.apiary.example", Summary: "example", Capabilities: []Capability{CapabilitySource},
+		Repository: "https://example.invalid/repo", Releases: releases,
+	}
+}
+
+func testRelease(version, constraint string) Release {
+	return Release{Version: version, Apiary: constraint, Protocol: ProtocolVersion, Artifacts: []Artifact{testArtifact("linux", "amd64")}}
+}
+
+func TestParseIndexRejectsUnknownSchemaVersion(t *testing.T) {
+	_, err := ParseIndex([]byte(`{"schema_version": 99, "plugins": []}`))
+	if err == nil || !strings.Contains(err.Error(), "schema_version 99") {
+		t.Fatalf("want a fail-closed schema version error, got %v", err)
+	}
+}
+
+func TestParseIndexRejectsUnknownFields(t *testing.T) {
+	_, err := ParseIndex([]byte(`{"schema_version": 1, "plugins": [], "surprise": true}`))
+	if err == nil {
+		t.Fatal("an index with unknown fields must be rejected, not partially interpreted")
+	}
+}
+
+func TestParseIndexRejectsDuplicateIDs(t *testing.T) {
+	index := Index{SchemaVersion: 1, Plugins: []RegistryPlugin{*testEntry(testRelease("1.0.0", ">= 0.1.0-0")), *testEntry(testRelease("1.0.0", ">= 0.1.0-0"))}}
+	encoded, _ := json.Marshal(index)
+	if _, err := ParseIndex(encoded); err == nil || !strings.Contains(err.Error(), "twice") {
+		t.Fatalf("want a duplicate-id rejection, got %v", err)
+	}
+}
+
+func TestParseIndexRejectsUnpinnedArtifact(t *testing.T) {
+	release := testRelease("1.0.0", ">= 0.1.0-0")
+	release.Artifacts[0].ExecutableSHA256 = ""
+	index := Index{SchemaVersion: 1, Plugins: []RegistryPlugin{*testEntry(release)}}
+	encoded, _ := json.Marshal(index)
+	if _, err := ParseIndex(encoded); err == nil || !strings.Contains(err.Error(), "executable_sha256") {
+		t.Fatalf("an artifact without both digests must be rejected, got %v", err)
+	}
+}
+
+func TestValidateRequiresYankReason(t *testing.T) {
+	release := testRelease("1.0.0", ">= 0.1.0-0")
+	release.Yanked = true
+	errs := testEntry(release).Validate()
+	if len(errs) == 0 || !strings.Contains(errs[0].Error(), "yanked_reason") {
+		t.Fatalf("a yank must state why, got %v", errs)
+	}
+}
+
+func TestResolvePicksNewestUsableRelease(t *testing.T) {
+	entry := testEntry(
+		testRelease("1.0.0", ">= 0.1.0-0"),
+		testRelease("1.2.0", ">= 0.1.0-0"),
+		testRelease("1.1.0", ">= 0.1.0-0"),
+	)
+	resolved, err := entry.Resolve(ResolveOptions{ApiaryVersion: "0.19.0", GOOS: "linux", GOARCH: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Release.Version != "1.2.0" {
+		t.Fatalf("want 1.2.0, got %s", resolved.Release.Version)
+	}
+}
+
+func TestResolveSkipsYankedAndReportsWhy(t *testing.T) {
+	newest := testRelease("2.0.0", ">= 0.1.0-0")
+	newest.Yanked = true
+	newest.YankedReason = "corrupt archive"
+	entry := testEntry(testRelease("1.0.0", ">= 0.1.0-0"), newest)
+
+	resolved, err := entry.Resolve(ResolveOptions{ApiaryVersion: "0.19.0", GOOS: "linux", GOARCH: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Release.Version != "1.0.0" {
+		t.Fatalf("a yanked release must not be selected, got %s", resolved.Release.Version)
+	}
+}
+
+// Each rejection has to name the predicate that eliminated the newest
+// candidate — that answer is the reason resolution happens before a download.
+func TestResolveExplainsEachRejection(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   *RegistryPlugin
+		options ResolveOptions
+		want    string
+	}{
+		{
+			name:    "host version too old",
+			entry:   testEntry(testRelease("1.0.0", ">= 0.20.0-0")),
+			options: ResolveOptions{ApiaryVersion: "0.19.1", GOOS: "linux", GOARCH: "amd64"},
+			want:    "requires apiary >= 0.20.0-0, this host is 0.19.1",
+		},
+		{
+			name: "no build for this platform",
+			entry: testEntry(Release{Version: "1.0.0", Apiary: ">= 0.1.0-0", Protocol: ProtocolVersion,
+				Artifacts: []Artifact{testArtifact("linux", "amd64")}}),
+			options: ResolveOptions{ApiaryVersion: "0.19.1", GOOS: "windows", GOARCH: "arm64"},
+			want:    "has no build for windows/arm64",
+		},
+		{
+			name: "future protocol",
+			entry: testEntry(Release{Version: "1.0.0", Apiary: ">= 0.1.0-0", Protocol: ProtocolVersion + 1,
+				Artifacts: []Artifact{testArtifact("linux", "amd64")}}),
+			options: ResolveOptions{ApiaryVersion: "0.19.1", GOOS: "linux", GOARCH: "amd64"},
+			want:    "speaks plugin protocol",
+		},
+		{
+			name: "only a yanked release",
+			entry: func() *RegistryPlugin {
+				release := testRelease("1.0.0", ">= 0.1.0-0")
+				release.Yanked, release.YankedReason = true, "corrupt archive"
+				return testEntry(release)
+			}(),
+			options: ResolveOptions{ApiaryVersion: "0.19.1", GOOS: "linux", GOARCH: "amd64"},
+			want:    "withdrawn by its publisher (corrupt archive)",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := testCase.entry.Resolve(testCase.options)
+			if err == nil || !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("want an error mentioning %q, got %v", testCase.want, err)
+			}
+		})
+	}
+}
+
+// A development build's version string is whatever git describe invented.
+// Refusing every plugin on that basis would be a worse answer than resolving and
+// letting the daemon's own manifest check decide.
+func TestResolveToleratesNonSemverHostVersion(t *testing.T) {
+	entry := testEntry(testRelease("1.0.0", ">= 0.20.0-0"))
+	resolved, err := entry.Resolve(ResolveOptions{ApiaryVersion: "sdk/v1.0.1-1-gabcdef-dirty", GOOS: "linux", GOARCH: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.CompatibilityUnchecked == "" {
+		t.Fatal("skipping the constraint must be reported, not silent")
+	}
+}
+
+func TestResolveExactVersion(t *testing.T) {
+	entry := testEntry(testRelease("1.0.0", ">= 0.1.0-0"), testRelease("2.0.0", ">= 0.1.0-0"))
+	resolved, err := entry.Resolve(ResolveOptions{Version: "1.0.0", ApiaryVersion: "0.19.0", GOOS: "linux", GOARCH: "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Release.Version != "1.0.0" {
+		t.Fatalf("want the requested 1.0.0, got %s", resolved.Release.Version)
+	}
+	if _, err := entry.Resolve(ResolveOptions{Version: "9.9.9", ApiaryVersion: "0.19.0"}); err == nil {
+		t.Fatal("an unknown version must be an error")
+	}
+}
+
+func TestSearchAndSuggest(t *testing.T) {
+	index := &Index{SchemaVersion: 1, Plugins: []RegistryPlugin{
+		{ID: "dev.apiary.routines", Summary: "scheduled routines", Capabilities: []Capability{CapabilitySource}},
+		{ID: "dev.apiary.exporter", Summary: "event exporter", Capabilities: []Capability{CapabilityEventExporter}},
+	}}
+	if got := index.Search("routine", ""); len(got) != 1 || got[0].ID != "dev.apiary.routines" {
+		t.Fatalf("query match failed: %v", got)
+	}
+	if got := index.Search("", CapabilityEventExporter); len(got) != 1 || got[0].ID != "dev.apiary.exporter" {
+		t.Fatalf("capability filter failed: %v", got)
+	}
+	if got := index.Search("", ""); len(got) != 2 {
+		t.Fatalf("an empty query lists everything, got %v", got)
+	}
+	if got := index.Suggest("dev.apiary.routine"); len(got) != 1 || got[0] != "dev.apiary.routines" {
+		t.Fatalf("a typo should suggest the real id, got %v", got)
+	}
+}

--- a/src/internal/plugin/registry_signature.go
+++ b/src/internal/plugin/registry_signature.go
@@ -1,0 +1,168 @@
+package plugin
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Signature verification covers the index, which carries the digests, which
+// cover the artifacts. It does not authenticate plugin publishers: signing the
+// artifacts themselves is a separate problem, and this is deliberately not
+// presented as solving it.
+//
+// The format is minisign's, so an operator can check the same file with the
+// standard tool and get the same answer:
+//
+//	minisign -Vm index.json -P <public key>
+//
+// Public key line:  base64( "Ed" ‖ key_id[8] ‖ ed25519_public_key[32] )
+// Signature file:   untrusted comment / base64( algorithm[2] ‖ key_id[8] ‖ signature[64] )
+//
+//	trusted comment   / base64( global_signature[64] )
+//
+// The global signature covers signature ‖ trusted_comment, which is what stops
+// the trusted comment from being rewritten independently of the payload.
+const (
+	minisignAlgorithmLegacy    = "Ed" // signature over the file content
+	minisignAlgorithmPrehashed = "ED" // signature over BLAKE2b-512 of the content
+
+	publicKeyBytes = 2 + 8 + ed25519.PublicKeySize
+	signatureBytes = 2 + 8 + ed25519.SignatureSize
+)
+
+// PublicKey is a parsed minisign public key.
+type PublicKey struct {
+	KeyID [8]byte
+	Key   ed25519.PublicKey
+}
+
+// ID renders the key id the way minisign prints it.
+func (k *PublicKey) ID() string {
+	return strings.ToUpper(hex.EncodeToString(k.KeyID[:]))
+}
+
+// ParsePublicKey accepts either a full minisign public key file (with its
+// comment line) or the bare base64 line, which is what fits in a config file.
+func ParsePublicKey(raw string) (*PublicKey, error) {
+	line := ""
+	for _, candidate := range strings.Split(strings.TrimSpace(raw), "\n") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || strings.HasPrefix(candidate, "untrusted comment:") {
+			continue
+		}
+		line = candidate
+		break
+	}
+	if line == "" {
+		return nil, fmt.Errorf("public key is empty")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(line)
+	if err != nil {
+		return nil, fmt.Errorf("public key is not valid base64: %w", err)
+	}
+	if len(decoded) != publicKeyBytes {
+		return nil, fmt.Errorf("public key is %d bytes, expected %d (a minisign public key)", len(decoded), publicKeyBytes)
+	}
+	if algorithm := string(decoded[:2]); algorithm != minisignAlgorithmLegacy {
+		return nil, fmt.Errorf("unsupported public key algorithm %q; expected %q (ed25519)", algorithm, minisignAlgorithmLegacy)
+	}
+	key := &PublicKey{Key: ed25519.PublicKey(decoded[10:])}
+	copy(key.KeyID[:], decoded[2:10])
+	return key, nil
+}
+
+// signature is a parsed .minisig file.
+type signature struct {
+	algorithm      string
+	keyID          [8]byte
+	value          []byte
+	trustedComment string
+	globalValue    []byte
+}
+
+func parseSignature(raw []byte) (*signature, error) {
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
+	var payload, trustedComment, globalLine string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == "" || strings.HasPrefix(trimmed, "untrusted comment:"):
+			continue
+		case strings.HasPrefix(trimmed, "trusted comment:"):
+			trustedComment = strings.TrimSpace(strings.TrimPrefix(trimmed, "trusted comment:"))
+		case payload == "":
+			payload = trimmed
+		case globalLine == "":
+			globalLine = trimmed
+		}
+	}
+	if payload == "" {
+		return nil, fmt.Errorf("signature file carries no signature line")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, fmt.Errorf("signature is not valid base64: %w", err)
+	}
+	if len(decoded) != signatureBytes {
+		return nil, fmt.Errorf("signature is %d bytes, expected %d", len(decoded), signatureBytes)
+	}
+	parsed := &signature{
+		algorithm:      string(decoded[:2]),
+		value:          decoded[10:],
+		trustedComment: trustedComment,
+	}
+	copy(parsed.keyID[:], decoded[2:10])
+	if globalLine != "" {
+		if parsed.globalValue, err = base64.StdEncoding.DecodeString(globalLine); err != nil {
+			return nil, fmt.Errorf("global signature is not valid base64: %w", err)
+		}
+	}
+	return parsed, nil
+}
+
+// VerifySignature checks a payload against a minisign signature. Every failure
+// is fatal to the caller: an index whose signature does not verify is not a
+// degraded index, it is an index of unknown origin.
+func VerifySignature(key *PublicKey, payload, rawSignature []byte) error {
+	if key == nil {
+		return fmt.Errorf("no public key to verify against")
+	}
+	parsed, err := parseSignature(rawSignature)
+	if err != nil {
+		return err
+	}
+	if parsed.keyID != key.KeyID {
+		return fmt.Errorf("signature was made with key %s, but this registry is pinned to key %s",
+			strings.ToUpper(hex.EncodeToString(parsed.keyID[:])), key.ID())
+	}
+	var signed []byte
+	switch parsed.algorithm {
+	case minisignAlgorithmLegacy:
+		signed = payload
+	case minisignAlgorithmPrehashed:
+		digest := blake2b.Sum512(payload)
+		signed = digest[:]
+	default:
+		return fmt.Errorf("unsupported signature algorithm %q", parsed.algorithm)
+	}
+	if !ed25519.Verify(key.Key, signed, parsed.value) {
+		return fmt.Errorf("signature does not match the content it accompanies")
+	}
+	if len(parsed.globalValue) > 0 {
+		// The trusted comment is only trustworthy because of this second
+		// signature; skipping it would let anyone rewrite what it claims.
+		var global bytes.Buffer
+		global.Write(parsed.value)
+		global.WriteString(parsed.trustedComment)
+		if !ed25519.Verify(key.Key, global.Bytes(), parsed.globalValue) {
+			return fmt.Errorf("the signature's trusted comment does not verify")
+		}
+	}
+	return nil
+}

--- a/src/internal/plugin/registry_signature_test.go
+++ b/src/internal/plugin/registry_signature_test.go
@@ -1,0 +1,175 @@
+package plugin
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// signingKey assembles minisign-format keys and signatures byte for byte, so the
+// verifier is exercised against the real layout rather than against a shape this
+// package invented for itself.
+type signingKey struct {
+	public  ed25519.PublicKey
+	private ed25519.PrivateKey
+	keyID   [8]byte
+}
+
+func newSigningKey(t *testing.T) *signingKey {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := &signingKey{public: public, private: private}
+	if _, err := rand.Read(key.keyID[:]); err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func (k *signingKey) publicKeyLine() string {
+	raw := append([]byte(minisignAlgorithmLegacy), k.keyID[:]...)
+	raw = append(raw, k.public...)
+	return base64.StdEncoding.EncodeToString(raw)
+}
+
+func (k *signingKey) publicKeyFile() string {
+	return "untrusted comment: minisign public key " + k.ID() + "\n" + k.publicKeyLine() + "\n"
+}
+
+func (k *signingKey) ID() string {
+	return (&PublicKey{KeyID: k.keyID}).ID()
+}
+
+// sign produces a .minisig, in either the legacy or the prehashed mode minisign
+// itself chooses between.
+func (k *signingKey) sign(payload []byte, algorithm, trustedComment string) []byte {
+	signed := payload
+	if algorithm == minisignAlgorithmPrehashed {
+		digest := blake2b.Sum512(payload)
+		signed = digest[:]
+	}
+	value := ed25519.Sign(k.private, signed)
+	raw := append([]byte(algorithm), k.keyID[:]...)
+	raw = append(raw, value...)
+	global := ed25519.Sign(k.private, append(append([]byte{}, value...), []byte(trustedComment)...))
+	return []byte(fmt.Sprintf("untrusted comment: signature from apiary registry\n%s\ntrusted comment: %s\n%s\n",
+		base64.StdEncoding.EncodeToString(raw), trustedComment, base64.StdEncoding.EncodeToString(global)))
+}
+
+func TestVerifySignatureAcceptsBothMinisignModes(t *testing.T) {
+	key := newSigningKey(t)
+	parsed, err := ParsePublicKey(key.publicKeyFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"schema_version":1,"plugins":[]}`)
+	for _, algorithm := range []string{minisignAlgorithmLegacy, minisignAlgorithmPrehashed} {
+		t.Run(algorithm, func(t *testing.T) {
+			if err := VerifySignature(parsed, payload, key.sign(payload, algorithm, "timestamp:1")); err != nil {
+				t.Fatalf("a valid %s signature must verify: %v", algorithm, err)
+			}
+		})
+	}
+}
+
+func TestParsePublicKeyAcceptsTheBareLine(t *testing.T) {
+	key := newSigningKey(t)
+	fromFile, err := ParsePublicKey(key.publicKeyFile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromLine, err := ParsePublicKey(key.publicKeyLine())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromFile.ID() != fromLine.ID() || !fromFile.Key.Equal(fromLine.Key) {
+		t.Fatal("a bare key line and a key file must parse to the same key")
+	}
+}
+
+func TestParsePublicKeyRejectsGarbage(t *testing.T) {
+	for _, testCase := range []struct{ name, raw string }{
+		{"empty", ""},
+		{"not base64", "untrusted comment: x\nnot base64!!"},
+		{"wrong length", "AAAA"},
+		{"comment only", "untrusted comment: minisign public key"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if _, err := ParsePublicKey(testCase.raw); err == nil {
+				t.Fatal("expected a rejection")
+			}
+		})
+	}
+}
+
+func TestVerifySignatureRejectsTamperedContent(t *testing.T) {
+	key := newSigningKey(t)
+	parsed, _ := ParsePublicKey(key.publicKeyFile())
+	payload := []byte(`{"schema_version":1,"plugins":[]}`)
+	raw := key.sign(payload, minisignAlgorithmPrehashed, "timestamp:1")
+	if err := VerifySignature(parsed, []byte(`{"schema_version":1,"plugins":["evil"]}`), raw); err == nil {
+		t.Fatal("a modified index must not verify")
+	}
+}
+
+// A signature from some other key is not "unsigned", it is wrong.
+func TestVerifySignatureRejectsAnotherKey(t *testing.T) {
+	signer, pinned := newSigningKey(t), newSigningKey(t)
+	parsed, _ := ParsePublicKey(pinned.publicKeyFile())
+	payload := []byte("index")
+	err := VerifySignature(parsed, payload, signer.sign(payload, minisignAlgorithmLegacy, "t"))
+	if err == nil || !strings.Contains(err.Error(), "pinned to key") {
+		t.Fatalf("want a key-id mismatch, got %v", err)
+	}
+}
+
+// The trusted comment is only trustworthy because of the global signature.
+func TestVerifySignatureRejectsARewrittenTrustedComment(t *testing.T) {
+	key := newSigningKey(t)
+	parsed, _ := ParsePublicKey(key.publicKeyFile())
+	payload := []byte("index")
+	raw := string(key.sign(payload, minisignAlgorithmLegacy, "timestamp:1 file:index.json"))
+	tampered := strings.Replace(raw, "trusted comment: timestamp:1 file:index.json", "trusted comment: timestamp:9999 file:other.json", 1)
+	err := VerifySignature(parsed, payload, []byte(tampered))
+	if err == nil || !strings.Contains(err.Error(), "trusted comment") {
+		t.Fatalf("want a trusted-comment rejection, got %v", err)
+	}
+}
+
+func TestVerifySignatureRejectsMalformedAndMissingSignatures(t *testing.T) {
+	key := newSigningKey(t)
+	parsed, _ := ParsePublicKey(key.publicKeyFile())
+	for _, testCase := range []struct{ name, raw string }{
+		{"empty", ""},
+		{"comment only", "untrusted comment: nothing here\n"},
+		{"not base64", "untrusted comment: x\n!!!not base64!!!\n"},
+		{"truncated", "untrusted comment: x\n" + base64.StdEncoding.EncodeToString([]byte("short")) + "\n"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := VerifySignature(parsed, []byte("index"), []byte(testCase.raw)); err == nil {
+				t.Fatal("expected a rejection")
+			}
+		})
+	}
+	if err := VerifySignature(nil, []byte("index"), []byte("whatever")); err == nil {
+		t.Fatal("verifying without a key must be an error, never a pass")
+	}
+}
+
+// An unknown algorithm must fail closed rather than fall through to a default.
+func TestVerifySignatureRejectsUnknownAlgorithm(t *testing.T) {
+	key := newSigningKey(t)
+	parsed, _ := ParsePublicKey(key.publicKeyFile())
+	payload := []byte("index")
+	raw := key.sign(payload, "XX", "t")
+	if err := VerifySignature(parsed, payload, raw); err == nil || !strings.Contains(err.Error(), "unsupported signature algorithm") {
+		t.Fatalf("want an unsupported-algorithm rejection, got %v", err)
+	}
+}

--- a/src/internal/plugin/registry_source.go
+++ b/src/internal/plugin/registry_source.go
@@ -1,0 +1,337 @@
+package plugin
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Registry access is CLI-only: the daemon never reaches out to a registry, so
+// nothing here runs in the dispatch path. Only https:// and file:// are
+// accepted — digests protect the payload, but nothing protects a plaintext
+// resolution, and pointing a client at an attacker-chosen index is the whole
+// game.
+const (
+	registryFetchTimeout = 30 * time.Second
+	// A registry index is metadata. Anything this size is a bug or an attack.
+	maxIndexBytes = 8 << 20
+	// Signatures live beside the index they cover, minisign's own convention.
+	signatureSuffix = ".minisig"
+)
+
+// FetchOptions controls how an index is obtained.
+type FetchOptions struct {
+	// PublicKey is the minisign key this registry is pinned to. When set, the
+	// index MUST carry a signature that verifies against it: a missing,
+	// malformed, or mismatched signature is an error, and there is no flag to
+	// proceed anyway. When empty, the index is used unverified and LoadedIndex
+	// says so.
+	PublicKey string
+	// Offline uses the cache and never touches the network. A cold cache is an
+	// error, not an empty result.
+	Offline bool
+	// CacheDir overrides the per-user cache location (tests, air-gapped setups).
+	CacheDir string
+	Client   *http.Client
+	Timeout  time.Duration
+}
+
+// LoadedIndex is an index plus how it was obtained, so commands can be honest
+// about serving cached data.
+type LoadedIndex struct {
+	*Index
+	URL       string
+	FromCache bool
+	// Warning is set when the network failed but a usable cache existed. The
+	// command succeeds; the operator is told the data may be stale.
+	Warning error
+	// Unsigned records that no key was available to verify this index against.
+	// It is not a failure — it is the state of a registry whose signing key the
+	// operator has not pinned — but commands surface it rather than implying a
+	// check that did not happen.
+	Unsigned bool
+}
+
+// ValidateRegistryURL accepts the two schemes a registry may be served over.
+func ValidateRegistryURL(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("registry URL must not be empty")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("registry URL %q is not a URL: %w", raw, err)
+	}
+	switch parsed.Scheme {
+	case "https", "file":
+		return nil
+	case "http":
+		return fmt.Errorf("registry URL %q must use https: digests protect the download, nothing protects a plaintext index", raw)
+	default:
+		return fmt.Errorf("registry URL %q must use https:// or file://", raw)
+	}
+}
+
+// LoadIndex fetches and parses one registry index, using a conditional GET
+// against the local cache. A file:// index is read directly and never cached —
+// it is already local, and caching it would only add a way to serve stale data.
+func LoadIndex(ctx context.Context, rawURL string, opts FetchOptions) (*LoadedIndex, error) {
+	if err := ValidateRegistryURL(rawURL); err != nil {
+		return nil, err
+	}
+	parsed, _ := url.Parse(rawURL)
+	key, err := fetchKey(opts.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if parsed.Scheme == "file" {
+		path := filepath.FromSlash(parsed.Path)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read registry index %q: %w", rawURL, err)
+		}
+		if key != nil {
+			rawSignature, err := os.ReadFile(path + signatureSuffix)
+			if err != nil {
+				return nil, unsignedError(rawURL, key, err)
+			}
+			if err := VerifySignature(key, data, rawSignature); err != nil {
+				return nil, fmt.Errorf("registry %q failed signature verification: %w", rawURL, err)
+			}
+		}
+		index, err := ParseIndex(data)
+		if err != nil {
+			return nil, fmt.Errorf("registry %q: %w", rawURL, err)
+		}
+		return &LoadedIndex{Index: index, URL: rawURL, Unsigned: key == nil}, nil
+	}
+
+	cache := newIndexCache(opts.CacheDir, rawURL)
+	if opts.Offline {
+		data, _, err := cache.read()
+		if err != nil {
+			return nil, fmt.Errorf("--offline: no cached copy of %q; run once without --offline first", rawURL)
+		}
+		index, err := verifiedIndex(rawURL, data, cache.readSignature(), key)
+		if err != nil {
+			return nil, err
+		}
+		return &LoadedIndex{Index: index, URL: rawURL, FromCache: true, Unsigned: key == nil}, nil
+	}
+
+	cached, etag, cacheErr := cache.read()
+	fetched, fetchErr := fetchIndex(ctx, rawURL, etag, opts)
+	switch {
+	case fetchErr != nil && cacheErr == nil:
+		// The network is not the authority on whether we can work: a warm cache
+		// still answers, as long as the operator is told it is a cache. It is
+		// re-verified here, so a cache poisoned on disk is caught too.
+		index, err := verifiedIndex(rawURL, cached, cache.readSignature(), key)
+		if err != nil {
+			return nil, fmt.Errorf("registry %q unreachable (%v) and %w", rawURL, fetchErr, err)
+		}
+		return &LoadedIndex{Index: index, URL: rawURL, FromCache: true, Warning: fetchErr, Unsigned: key == nil}, nil
+	case fetchErr != nil:
+		return nil, fetchErr
+	case fetched.notModified:
+		index, err := verifiedIndex(rawURL, cached, cache.readSignature(), key)
+		if err != nil {
+			return nil, err
+		}
+		return &LoadedIndex{Index: index, URL: rawURL, FromCache: true, Unsigned: key == nil}, nil
+	}
+
+	var rawSignature []byte
+	if key != nil {
+		signature, signatureErr := fetchIndex(ctx, rawURL+signatureSuffix, "", opts)
+		if signatureErr != nil {
+			return nil, unsignedError(rawURL, key, signatureErr)
+		}
+		rawSignature = signature.data
+	}
+	index, err := verifiedIndex(rawURL, fetched.data, rawSignature, key)
+	if err != nil {
+		// A response that does not verify or does not parse must not poison the
+		// cache: the next run should get a clean fetch rather than inherit this.
+		return nil, err
+	}
+	cache.write(fetched.data, fetched.etag)
+	cache.writeSignature(rawSignature)
+	return &LoadedIndex{Index: index, URL: rawURL, Unsigned: key == nil}, nil
+}
+
+// verifiedIndex checks the signature (when a key is pinned) before the bytes are
+// interpreted at all, then parses.
+func verifiedIndex(rawURL string, data, rawSignature []byte, key *PublicKey) (*Index, error) {
+	if key != nil {
+		if len(rawSignature) == 0 {
+			return nil, unsignedError(rawURL, key, errors.New("no signature alongside the index"))
+		}
+		if err := VerifySignature(key, data, rawSignature); err != nil {
+			return nil, fmt.Errorf("registry %q failed signature verification: %w", rawURL, err)
+		}
+	}
+	index, err := ParseIndex(data)
+	if err != nil {
+		return nil, fmt.Errorf("registry %q: %w", rawURL, err)
+	}
+	return index, nil
+}
+
+// fetchKey parses the pinned key once, up front: a malformed key in config is a
+// configuration error, not a verification failure to be discovered later.
+func fetchKey(raw string) (*PublicKey, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	key, err := ParsePublicKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("pinned registry public key: %w", err)
+	}
+	return key, nil
+}
+
+func unsignedError(rawURL string, key *PublicKey, cause error) error {
+	return fmt.Errorf("registry %q is pinned to signing key %s but no valid signature could be read from %s%s (%v); refusing to use an unverified index",
+		rawURL, key.ID(), rawURL, signatureSuffix, cause)
+}
+
+// fetchResult keeps the ETag with the body it belongs to, so caching stays an
+// implementation detail of this file rather than shared state.
+type fetchResult struct {
+	data        []byte
+	etag        string
+	notModified bool
+}
+
+func fetchIndex(ctx context.Context, rawURL, etag string, opts FetchOptions) (fetchResult, error) {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = registryFetchTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fetchResult{}, fmt.Errorf("registry %q: %w", rawURL, err)
+	}
+	request.Header.Set("Accept", "application/json")
+	if etag != "" {
+		request.Header.Set("If-None-Match", etag)
+	}
+	client := opts.Client
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fetchResult{}, fmt.Errorf("fetch registry %q: %w", rawURL, err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	switch response.StatusCode {
+	case http.StatusNotModified:
+		return fetchResult{notModified: true}, nil
+	case http.StatusOK:
+	default:
+		return fetchResult{}, fmt.Errorf("fetch registry %q: unexpected status %s", rawURL, response.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxIndexBytes+1))
+	if err != nil {
+		return fetchResult{}, fmt.Errorf("read registry %q: %w", rawURL, err)
+	}
+	if len(body) > maxIndexBytes {
+		return fetchResult{}, fmt.Errorf("registry %q is larger than %d bytes; refusing it", rawURL, maxIndexBytes)
+	}
+	return fetchResult{data: body, etag: response.Header.Get("ETag")}, nil
+}
+
+// indexCache stores one index per registry URL, keyed by a digest of the URL so
+// two registries never collide and no path component is attacker-controlled.
+type indexCache struct{ dir string }
+
+func newIndexCache(override, rawURL string) *indexCache {
+	base := override
+	if base == "" {
+		userCache, err := os.UserCacheDir()
+		if err != nil {
+			return &indexCache{}
+		}
+		base = filepath.Join(userCache, "apiary", "registry")
+	}
+	sum := sha256.Sum256([]byte(rawURL))
+	return &indexCache{dir: filepath.Join(base, hex.EncodeToString(sum[:])[:16])}
+}
+
+// readSignature returns the cached signature, or nil. A missing one is not an
+// error here: whether that is fatal depends on whether a key is pinned, and
+// that decision belongs to the caller.
+func (c *indexCache) readSignature() []byte {
+	if c.dir == "" {
+		return nil
+	}
+	data, err := os.ReadFile(filepath.Join(c.dir, "index.json"+signatureSuffix))
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func (c *indexCache) writeSignature(data []byte) {
+	if c.dir == "" || len(data) == 0 {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(c.dir, "index.json"+signatureSuffix), data, 0o644)
+}
+
+func (c *indexCache) read() ([]byte, string, error) {
+	if c.dir == "" {
+		return nil, "", errors.New("no cache directory")
+	}
+	data, err := os.ReadFile(filepath.Join(c.dir, "index.json"))
+	if err != nil {
+		return nil, "", err
+	}
+	etag, _ := os.ReadFile(filepath.Join(c.dir, "etag"))
+	return data, strings.TrimSpace(string(etag)), nil
+}
+
+// write is best-effort: a registry command must not fail because a cache could
+// not be written.
+func (c *indexCache) write(data []byte, etag string) {
+	if c.dir == "" {
+		return
+	}
+	if err := os.MkdirAll(c.dir, 0o755); err != nil {
+		return
+	}
+	temp, err := os.CreateTemp(c.dir, ".index-*")
+	if err != nil {
+		return
+	}
+	name := temp.Name()
+	if _, err := temp.Write(data); err != nil {
+		_ = temp.Close()
+		_ = os.Remove(name)
+		return
+	}
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(name)
+		return
+	}
+	if err := os.Rename(name, filepath.Join(c.dir, "index.json")); err != nil {
+		_ = os.Remove(name)
+		return
+	}
+	_ = os.WriteFile(filepath.Join(c.dir, "etag"), []byte(etag), 0o644)
+}

--- a/src/internal/plugin/registry_source_test.go
+++ b/src/internal/plugin/registry_source_test.go
@@ -1,0 +1,316 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func indexJSON(t *testing.T) []byte {
+	t.Helper()
+	index := Index{SchemaVersion: 1, Plugins: []RegistryPlugin{*testEntry(testRelease("1.0.0", ">= 0.1.0-0"))}}
+	encoded, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return encoded
+}
+
+func TestValidateRegistryURLRejectsPlaintextAndUnknownSchemes(t *testing.T) {
+	if err := ValidateRegistryURL("http://example.invalid/index.json"); err == nil || !strings.Contains(err.Error(), "https") {
+		t.Fatalf("plaintext resolution must be refused, got %v", err)
+	}
+	if err := ValidateRegistryURL("ftp://example.invalid/index.json"); err == nil {
+		t.Fatal("unknown schemes must be refused")
+	}
+	if err := ValidateRegistryURL("https://example.invalid/index.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRegistryURL("file:///tmp/index.json"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadIndexFromFileURL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "index.json")
+	if err := os.WriteFile(path, indexJSON(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadIndex(context.Background(), "file://"+path, FetchOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Plugins) != 1 || loaded.FromCache {
+		t.Fatalf("want one plugin read directly, got %d plugins fromCache=%v", len(loaded.Plugins), loaded.FromCache)
+	}
+}
+
+// The second run must revalidate rather than re-download, and a 304 must serve
+// the cached body.
+func TestLoadIndexUsesConditionalGet(t *testing.T) {
+	body := indexJSON(t)
+	var requests, conditional atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("ETag", `"v1"`)
+		if r.Header.Get("If-None-Match") == `"v1"` {
+			conditional.Add(1)
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	cache := t.TempDir()
+	client := server.Client()
+	first, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: client})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.FromCache {
+		t.Fatal("the first fetch cannot come from a cold cache")
+	}
+	second, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: client})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.FromCache || conditional.Load() != 1 || requests.Load() != 2 {
+		t.Fatalf("want a conditional revalidation: fromCache=%v conditional=%d requests=%d", second.FromCache, conditional.Load(), requests.Load())
+	}
+}
+
+func TestLoadIndexOfflineNeedsAWarmCache(t *testing.T) {
+	body := indexJSON(t)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(body) }))
+	defer server.Close()
+	cache := t.TempDir()
+
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Offline: true, Client: server.Client()}); err == nil {
+		t.Fatal("--offline with a cold cache must be an error, not an empty result")
+	}
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: server.Client()}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Offline: true, Client: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.FromCache {
+		t.Fatal("--offline must serve the cache")
+	}
+}
+
+// An unreachable registry with a warm cache still answers — but says so.
+func TestLoadIndexFallsBackToCacheWithAWarning(t *testing.T) {
+	body := indexJSON(t)
+	var fail atomic.Bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+	cache := t.TempDir()
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: server.Client()}); err != nil {
+		t.Fatal(err)
+	}
+	fail.Store(true)
+	loaded, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: server.Client()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.FromCache || loaded.Warning == nil {
+		t.Fatalf("a cached answer during an outage must carry a warning: fromCache=%v warning=%v", loaded.FromCache, loaded.Warning)
+	}
+}
+
+// A corrupt response must not be cached: the next run should get a clean fetch
+// rather than inherit the failure.
+func TestLoadIndexDoesNotCacheCorruptResponses(t *testing.T) {
+	var serveGarbage atomic.Bool
+	serveGarbage.Store(true)
+	body := indexJSON(t)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if serveGarbage.Load() {
+			_, _ = w.Write([]byte("{not json"))
+			return
+		}
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+	cache := t.TempDir()
+
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: server.Client()}); err == nil {
+		t.Fatal("a corrupt index must be an error")
+	}
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Offline: true, Client: server.Client()}); err == nil {
+		t.Fatal("the corrupt response must not have been cached")
+	}
+	serveGarbage.Store(false)
+	if _, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: cache, Client: server.Client()}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadIndexRejectsUnexpectedStatus(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer server.Close()
+	_, err := LoadIndex(context.Background(), server.URL, FetchOptions{CacheDir: t.TempDir(), Client: server.Client()})
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprint(http.StatusNotFound)) {
+		t.Fatalf("want the status in the error, got %v", err)
+	}
+}
+
+// signedRegistry serves an index and its .minisig from the same TLS server, the
+// way a docs deploy publishes them.
+func signedRegistry(t *testing.T, key *signingKey, tamper bool, withSignature bool) (string, *http.Client) {
+	t.Helper()
+	body := indexJSON(t)
+	signature := key.sign(body, minisignAlgorithmPrehashed, "timestamp:1 file:index.json")
+	if tamper {
+		body = append(body[:len(body)-1], []byte(` `)...)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(body) })
+	if withSignature {
+		mux.HandleFunc("/index.json.minisig", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(signature) })
+	}
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL + "/index.json", server.Client()
+}
+
+func TestLoadIndexVerifiesASignedRegistry(t *testing.T) {
+	key := newSigningKey(t)
+	url, client := signedRegistry(t, key, false, true)
+	loaded, err := LoadIndex(context.Background(), url, FetchOptions{
+		CacheDir: t.TempDir(), Client: client, PublicKey: key.publicKeyLine(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Unsigned {
+		t.Fatal("a verified index must not be reported as unsigned")
+	}
+}
+
+// Pinning a key means the index must be signed. There is no flag to proceed.
+func TestLoadIndexFailsClosedWithoutASignature(t *testing.T) {
+	key := newSigningKey(t)
+	url, client := signedRegistry(t, key, false, false)
+	_, err := LoadIndex(context.Background(), url, FetchOptions{
+		CacheDir: t.TempDir(), Client: client, PublicKey: key.publicKeyLine(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "refusing to use an unverified index") {
+		t.Fatalf("want a fail-closed refusal, got %v", err)
+	}
+}
+
+func TestLoadIndexRejectsAModifiedSignedIndex(t *testing.T) {
+	key := newSigningKey(t)
+	url, client := signedRegistry(t, key, true, true)
+	_, err := LoadIndex(context.Background(), url, FetchOptions{
+		CacheDir: t.TempDir(), Client: client, PublicKey: key.publicKeyLine(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed signature verification") {
+		t.Fatalf("want a verification failure, got %v", err)
+	}
+}
+
+func TestLoadIndexRejectsAnIndexSignedByAnotherKey(t *testing.T) {
+	url, client := signedRegistry(t, newSigningKey(t), false, true)
+	_, err := LoadIndex(context.Background(), url, FetchOptions{
+		CacheDir: t.TempDir(), Client: client, PublicKey: newSigningKey(t).publicKeyLine(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed signature verification") {
+		t.Fatalf("want a key mismatch, got %v", err)
+	}
+}
+
+// The cache is on disk, where anything with write access can reach it, so a
+// cached index is verified on the way out as well as on the way in.
+func TestLoadIndexVerifiesTheCacheToo(t *testing.T) {
+	key := newSigningKey(t)
+	url, client := signedRegistry(t, key, false, true)
+	cache := t.TempDir()
+	options := FetchOptions{CacheDir: cache, Client: client, PublicKey: key.publicKeyLine()}
+	if _, err := LoadIndex(context.Background(), url, options); err != nil {
+		t.Fatal(err)
+	}
+	// Rewrite the cached index in place, leaving its signature untouched.
+	cached, err := filepath.Glob(filepath.Join(cache, "*", "index.json"))
+	if err != nil || len(cached) != 1 {
+		t.Fatalf("expected one cached index, got %v (%v)", cached, err)
+	}
+	poisoned := Index{SchemaVersion: 1, Plugins: []RegistryPlugin{*testEntry(testRelease("9.9.9", ">= 0.1.0-0"))}}
+	encoded, err := json.Marshal(poisoned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cached[0], encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	options.Offline = true
+	if _, err := LoadIndex(context.Background(), url, options); err == nil || !strings.Contains(err.Error(), "failed signature verification") {
+		t.Fatalf("a poisoned cache must be caught, got %v", err)
+	}
+}
+
+func TestLoadIndexReportsAnUnsignedRegistry(t *testing.T) {
+	url, client := signedRegistry(t, newSigningKey(t), false, false)
+	loaded, err := LoadIndex(context.Background(), url, FetchOptions{CacheDir: t.TempDir(), Client: client})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.Unsigned {
+		t.Fatal("without a pinned key the index is unverified and must say so")
+	}
+}
+
+func TestLoadIndexRejectsAMalformedPinnedKey(t *testing.T) {
+	url, client := signedRegistry(t, newSigningKey(t), false, true)
+	_, err := LoadIndex(context.Background(), url, FetchOptions{CacheDir: t.TempDir(), Client: client, PublicKey: "nonsense"})
+	if err == nil || !strings.Contains(err.Error(), "pinned registry public key") {
+		t.Fatalf("a bad key is a configuration error, got %v", err)
+	}
+}
+
+// A file:// mirror carries the upstream signature verbatim and verifies exactly
+// like the original.
+func TestLoadIndexVerifiesAFileMirror(t *testing.T) {
+	key := newSigningKey(t)
+	dir := t.TempDir()
+	body := indexJSON(t)
+	path := filepath.Join(dir, "index.json")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+signatureSuffix, key.sign(body, minisignAlgorithmLegacy, "mirror"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadIndex(context.Background(), "file://"+path, FetchOptions{PublicKey: key.publicKeyLine()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Unsigned {
+		t.Fatal("a verified mirror must not be reported as unsigned")
+	}
+	if err := os.Remove(path + signatureSuffix); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadIndex(context.Background(), "file://"+path, FetchOptions{PublicKey: key.publicKeyLine()}); err == nil {
+		t.Fatal("a pinned mirror without a signature must be refused")
+	}
+}


### PR DESCRIPTION
Adds a plugin registry so plugins can be found and installed from the command line, without turning Apiary into a package manager or softening the trust posture the plugin docs commit to.

OpenSpec change: `openspec/changes/plugin-registry/` (proposal, design, tasks — all four phases implemented).

## What this is

A **static, PR-reviewed index**: one YAML entry per plugin under `registry/plugins/`, compiled by CI into the JSON clients fetch and published beside the docs site. No accounts, no uploads, no server. Metadata and digests only — artifacts stay on their publisher's release infrastructure, and **the daemon never contacts a registry**; resolution, download and verification are CLI concerns.

```bash
apiary plugins search cron
apiary plugins info dev.apiary.routines
apiary plugins install dev.apiary.routines
apiary plugins upgrade dev.apiary.routines [--rollback]
apiary plugins uninstall dev.apiary.routines
```

`list`, `inspect` and `validate` keep their current meaning (what is on disk).

## Why it is worth having

Installing by hand stays fully supported and needs no network. What the registry adds is the two steps a human does badly:

- **Picking the right artifact.** Host-version constraint, protocol, platform and yanks resolve from the index *before* anything is downloaded — `Installed.Validate` already knew how to check compatibility, it just ran after the files were on disk.
- **Checking it is what the publisher shipped.** Archive digest verified before unpacking, manifest cross-checked against the listing, executable digest verified, then pinned.

**The pin is the security argument.** `docs/plugins.md` concedes a publisher's `checksum` is tamper-evidence only — the digest lives beside the binary, so anyone who can rewrite one can rewrite the other. When the publisher ships no pin, the installer writes the registry's digest, which originates in a repository the publisher does not control.

That only means something if something checks it. It didn't: discovery only checked that a pin was *well-formed*. I appended a byte to an installed plugin and `apiary plugins validate` said `✓ plugins are valid`. `Installed.VerifyPin` now re-derives the digest in `apiary validate` and `apiary plugins validate` — additive, CLI-only, fires only when a pin exists and is violated.

## Install flow

Staging happens outside every searched directory; a single atomic rename commits it. Before that: verify archive digest → unpack (refusing traversal, symlinks, hardlinks, devices) → load and validate the manifest → confirm the archive holds the plugin that was asked for → verify the executable digest → pin → print the trust summary → confirm.

Nothing executes. **Nothing is enabled** — `install` prints a `plugins:` snippet seeded with the manifest's required config keys and never touches `apiary.yaml`. `--yes` skips the prompt, not the summary.

## Signing

The index is verified in-process (ed25519 + BLAKE2b for minisign's prehashed mode), including the global signature over the trusted comment; the on-disk cache is verified on read, so a locally poisoned cache is caught. `minisign -Vm` agrees with what the CLI does. **Once a key is pinned there is no way to skip verification** — no flag, no env var.

**Signing is wired but dormant, deliberately.** CI signs only when `APIARY_REGISTRY_MINISIGN_KEY` exists; binaries verify only when `APIARY_REGISTRY_PUBLIC_KEY` was stamped at build time. Generating the signing identity is the maintainer's call, not something a PR should invent. Until both exist, every command prints `! … is not signature-verified (no public key pinned for it)` — a visible third state, because failing closed with no key in existence would refuse every command on day one, and silence would let an unsigned index read as a checked one. Three one-time steps are in `registry/README.md`.

## Registry CI found a real bug

`.github/workflows/plugin-registry.yml` downloads each declared artifact, re-derives both digests, cross-checks the embedded manifest against the entry, and runs the conformance kit. Against the seeded entry it reports that **`dev.apiary.routines` 0.1.0 fails 3 of 10 conformance cases**: it answers protocol mismatches with `protocol_mismatch` where the protocol specifies `unsupported_protocol` (two cases), and returns a success result on trailing stdin data.

A conformance failure **records a verdict rather than blocking the listing** (`--strict-conformance` opts into blocking): the registry describes plugins, it does not certify them, and hiding the listing would hide the finding. `plugins info` shows `conformance FAILED`. The fix belongs in that plugin's own repo, filed as orlandoburli/apiary-routines#5 with each failure reproduced against the published binary — one of them silently advances routine state for a request the plugin never validated.

## Two changes outside the stated scope

- **`Discover` was left alone.** Impact analysis returned **CRITICAL** (daemon startup, `validate`, `run`, `worker`, dashboard). It would have let me ignore dot-directories during a cross-device staging copy; the same guarantee comes free by writing the manifest last, since a directory without one is already invisible to discovery.
- **Makefile version fix.** `git describe --tags` picked up `sdk/*` tags, so locally built binaries reported `sdk/v1.0.1-…` and *every* plugin compatibility check failed as "not semantic versioning". Added `--match "v*"`, the same exclusion `.goreleaser.yaml` already documents. Resolution now also tolerates a non-semver host version by skipping the constraint and saying so, rather than refusing every plugin on a dev build.

Also: archive format detection reads magic bytes instead of the URL's filename (release URLs routinely carry no usable extension).

## Compatibility

Nothing existing breaks. Hand-installed plugins are discovered and run exactly as before; a publisher's `checksum` is never overwritten; `plugin_registries` is optional, accepts the old scalar form, and `[]` disables the registry entirely. The daemon's plugin path is unchanged.

## Verification

- `make test` and `go vet ./...` clean; ~75 new tests (resolution predicates, ETag/offline/cache, archive traversal and safety, digest mismatches at both stages, pin injected/kept/contradicted, declined install leaves nothing, upgrade swap + rollback, uninstall refusal, signature tamper/wrong-key/rewritten-comment/poisoned-cache, `apiary.yaml` asserted untouched).
- End to end against the **real published** `dev.apiary.routines` release: install, re-install refusal, upgrade no-op, `--sha256` mismatch, uninstall, tamper detection, and all four signing states with a throwaway key.
- Docs: every documented command and flag run against the built binary; mkdocs site builds; schema validated both ways.

