### PR TITLE
feat(dashboard): auto-refresh the workflow monitor and name its task

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -421,6 +421,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case workflowMonitorMsg:
 		if a.model.tasksTab != nil && len(msg.instances) > 0 {
+			a.model.tasksTab.WorkflowTaskID = msg.taskID
+			a.model.tasksTab.WorkflowTaskLabel = a.taskLabel(msg.taskID)
+			a.model.tasksTab.WorkflowAwaitTicks = 0
 			a.model.tasksTab.WorkflowInstances = msg.instances
 			a.model.tasksTab.WorkflowInstanceIdx = 0
 			a.model.tasksTab.WorkflowInstance = msg.instances[0]
@@ -461,6 +464,35 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			t.WorkflowInstance = msg.instance
 			if t.WorkflowInstanceIdx >= 0 && t.WorkflowInstanceIdx < len(t.WorkflowInstances) {
 				t.WorkflowInstances[t.WorkflowInstanceIdx] = msg.instance
+			}
+		}
+		a.model.loading = false
+
+	case workflowInstancesRefreshMsg:
+		// Re-listed instances for the open monitor (a manual run was started and
+		// its instance is being waited for). Keep showing the same instance unless
+		// a newer one has appeared, which is exactly what the user asked to see.
+		if t := a.model.tasksTab; t != nil && t.View == TaskViewWorkflow &&
+			t.WorkflowTaskID == msg.taskID && len(msg.instances) > 0 {
+			appeared := len(t.WorkflowInstances) == 0 || t.WorkflowInstances[0].ID != msg.instances[0].ID
+			current := ""
+			if t.WorkflowInstance != nil {
+				current = t.WorkflowInstance.ID
+			}
+			t.WorkflowInstances = msg.instances
+			if appeared {
+				t.WorkflowAwaitTicks = 0
+				a.selectWorkflowInstance(t, 0)
+			} else {
+				// Same set — re-point the cursor at the instance still on screen,
+				// since a new row could have shifted its index.
+				for i, inst := range msg.instances {
+					if inst.ID == current {
+						t.WorkflowInstanceIdx = i
+						t.WorkflowInstance = inst
+						break
+					}
+				}
 			}
 		}
 		a.model.loading = false
@@ -1378,10 +1410,15 @@ func (a *App) handleWorkflowMonitorKey(key string) (tea.Model, tea.Cmd) {
 		}
 
 	case "r":
-		// Refresh the monitor.
+		// Refresh the monitor: the shown instance, plus the task's instance list
+		// so a workflow started since the view opened shows up.
 		if inst != nil {
 			a.model.loading = true
-			return a, a.refreshWorkflowMonitor(inst.ID, inst.CellID)
+			cmds := []tea.Cmd{a.refreshWorkflowMonitor(inst.ID, inst.CellID)}
+			if t.WorkflowTaskID != "" {
+				cmds = append(cmds, a.refreshWorkflowInstances(t.WorkflowTaskID))
+			}
+			return a, tea.Batch(cmds...)
 		}
 
 	case "X":
@@ -1612,6 +1649,11 @@ func (a *App) focusedTaskID() (string, bool) {
 		}
 		if t.View == TaskViewDetail && t.Detail != nil {
 			return t.Detail.TaskID, true
+		}
+		// The monitor's own task, not whatever the list cursor happens to sit on:
+		// a re-sorted list underneath would otherwise retarget the action.
+		if t.View == TaskViewWorkflow && t.WorkflowTaskID != "" {
+			return t.WorkflowTaskID, true
 		}
 		if rows := a.filteredTasks(t); t.SelectedIdx >= 0 && t.SelectedIdx < len(rows) {
 			return rows[t.SelectedIdx].TaskID, true
@@ -1845,22 +1887,52 @@ func (a *App) openWorkflowMonitorOrLogs(taskID string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
-		if dbConn != nil {
-			// A task can fan out to several workflow instances over its life
-			// (e.g. triage → implementation); load all of them, newest first, so
-			// the monitor can switch between them with [ and ].
-			insts, err := dbConn.ListWorkflowInstancesByCell(ctx, taskID)
-			if err == nil && len(insts) > 0 {
-				items := make([]*WorkflowInstanceItem, 0, len(insts))
-				for i := range insts {
-					items = append(items, buildWorkflowInstanceItem(ctx, dbConn, &insts[i]))
-				}
-				return workflowMonitorMsg{taskID: taskID, instances: items}
-			}
+		if items := listWorkflowInstanceItems(ctx, dbConn, taskID); len(items) > 0 {
+			return workflowMonitorMsg{taskID: taskID, instances: items}
 		}
 		// No workflow instance — fall back to logs view.
 		return taskLogsMsg{taskID: taskID, logs: nil, detail: nil}
 	}
+}
+
+// listWorkflowInstanceItems loads every workflow instance bound to a task,
+// newest first. A task can fan out to several instances over its life (e.g.
+// triage → implementation), and the monitor switches between them with [ and ].
+func listWorkflowInstanceItems(ctx context.Context, dbConn *db.Client, taskID string) []*WorkflowInstanceItem {
+	if dbConn == nil {
+		return nil
+	}
+	insts, err := dbConn.ListWorkflowInstancesByCell(ctx, taskID)
+	if err != nil || len(insts) == 0 {
+		return nil
+	}
+	items := make([]*WorkflowInstanceItem, 0, len(insts))
+	for i := range insts {
+		items = append(items, buildWorkflowInstanceItem(ctx, dbConn, &insts[i]))
+	}
+	return items
+}
+
+// refreshWorkflowInstances re-lists the open monitor's instances so a workflow
+// started manually (Shift+W) shows up on its own, without leaving the view and
+// re-entering it.
+func (a *App) refreshWorkflowInstances(taskID string) tea.Cmd {
+	dbConn := a.dbConn
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		items := listWorkflowInstanceItems(ctx, dbConn, taskID)
+		if len(items) == 0 {
+			return nil
+		}
+		return workflowInstancesRefreshMsg{taskID: taskID, instances: items}
+	}
+}
+
+// workflowInstancesRefreshMsg carries a re-listed instance set for the open monitor.
+type workflowInstancesRefreshMsg struct {
+	taskID    string
+	instances []*WorkflowInstanceItem
 }
 
 // applyApprovalPrompt loads the pending approval request for an instance parked
@@ -2216,8 +2288,16 @@ func (a *App) fetchActiveTab() tea.Cmd {
 		if t := a.model.tasksTab; t != nil {
 			switch t.View {
 			case TaskViewWorkflow:
+				var cmds []tea.Cmd
+				// A manual run was started from this screen: re-list the task's
+				// instances until the new one appears (or the wait times out, so a
+				// run the daemon never dispatched does not poll forever).
+				if t.WorkflowAwaitTicks > 0 && t.WorkflowTaskID != "" {
+					t.WorkflowAwaitTicks--
+					cmds = append(cmds, a.refreshWorkflowInstances(t.WorkflowTaskID))
+				}
 				if inst := t.WorkflowInstance; inst != nil {
-					cmds := []tea.Cmd{a.refreshWorkflowMonitor(inst.ID, inst.CellID)}
+					cmds = append(cmds, a.refreshWorkflowMonitor(inst.ID, inst.CellID))
 					// Live-tail the open step-log panel (throttled like the logs view).
 					if t.WorkflowShowLogs && t.WorkflowLogStepID != "" &&
 						t.WorkflowStepIdx < len(inst.Steps) && a.model.tickCount%2 == 0 {
@@ -4075,6 +4155,35 @@ func wfStateStyle(state string) lipgloss.Style {
 	}
 }
 
+// taskLabel resolves a short human label for a task id ("ERP-42 — Fix the thing"),
+// from the rows already loaded in the Tasks tab. It falls back to the id itself,
+// which is still better than showing nothing.
+func (a *App) taskLabel(taskID string) string {
+	if taskID == "" {
+		return ""
+	}
+	t := a.model.tasksTab
+	if t == nil {
+		return taskID
+	}
+	for _, it := range t.History {
+		if it.TaskID != taskID && it.DrillKey != taskID {
+			continue
+		}
+		title := strings.TrimSpace(it.Title)
+		switch {
+		case it.Number != "" && title != "":
+			return it.Number + " — " + title
+		case title != "":
+			return title
+		case it.Number != "":
+			return it.Number
+		}
+		break
+	}
+	return taskID
+}
+
 func taskDetailLabel(d *TaskItem) string {
 	prefix := ""
 	if d.Number != "" {
@@ -5446,6 +5555,15 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 	// position (oldest = 1) and a hint that [ / ] switch between them.
 	if n := len(t.WorkflowInstances); n > 1 {
 		label += "   " + StyleMuted.Render(fmt.Sprintf("workflow %d/%d · [ ] switch", n-t.WorkflowInstanceIdx, n))
+	}
+	// Which task this run belongs to. Without it the monitor shows a workflow id
+	// and a step list with nothing saying what they are working on. It comes last
+	// in the title and is truncated to whatever the box border leaves free, so a
+	// narrow terminal loses characters of the title instead of its top border.
+	if task := strings.TrimSpace(t.WorkflowTaskLabel); task != "" {
+		if avail := a.model.width - lipgloss.Width(label) - 12; avail >= 12 {
+			label += "   " + StyleMuted.Render("· "+truncate(task, avail))
+		}
 	}
 
 	// ── left panel: step list ───────────────────────────────────────────────

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -120,6 +120,14 @@ type TasksTab struct {
 	LogDrillKey       string // legacy cell id used to hydrate the detail header
 
 	// Workflow monitor sub-view (View == TaskViewWorkflow).
+	WorkflowTaskID    string // task the monitor is showing (scopes list refreshes)
+	WorkflowTaskLabel string // human label for that task ("#42 — Fix the thing")
+	// WorkflowAwaitTicks counts down the refresh ticks that still re-list the
+	// task's instances while a manually started workflow (Shift+W) has not
+	// appeared yet. Dispatch is asynchronous, so the instance shows up a moment
+	// after the run is accepted; the monitor jumps to it as soon as it exists.
+	WorkflowAwaitTicks int
+
 	WorkflowInstances   []*WorkflowInstanceItem // all instances for the task, newest-first
 	WorkflowInstanceIdx int                     // index into WorkflowInstances of the one being shown
 	WorkflowInstance    *WorkflowInstanceItem   // instance being monitored (== WorkflowInstances[WorkflowInstanceIdx])

--- a/src/internal/dashboard/workflow_monitor_manual_run_test.go
+++ b/src/internal/dashboard/workflow_monitor_manual_run_test.go
@@ -1,0 +1,146 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// monitorTab builds a Tasks tab sitting in the workflow monitor on ISSUE-9.
+func monitorTab() *TasksTab {
+	insts := []*WorkflowInstanceItem{
+		{ID: "i1", Workflow: "triage", State: "done", CellID: "ISSUE-9", Steps: []WorkflowStepItem{{StepID: "x"}}},
+	}
+	return &TasksTab{
+		View:              TaskViewWorkflow,
+		WorkflowTaskID:    "ISSUE-9",
+		WorkflowTaskLabel: "ERP-9 — Ship the thing",
+		WorkflowInstances: insts,
+		WorkflowInstance:  insts[0],
+		WorkflowStepIdx:   0,
+	}
+}
+
+// TestManualRunArmsMonitorRefresh verifies that starting a workflow with the
+// picker while the monitor is open arms the instance-list refresh, so the new
+// run appears without leaving the screen and coming back.
+func TestManualRunArmsMonitorRefresh(t *testing.T) {
+	a := &App{model: NewModel()}
+	a.model.tasksTab = monitorTab()
+
+	a.awaitManualRunInMonitor("ISSUE-9")
+	if a.model.tasksTab.WorkflowAwaitTicks != wfMonitorAwaitTicks {
+		t.Fatalf("monitor should await the new instance, got %d ticks", a.model.tasksTab.WorkflowAwaitTicks)
+	}
+
+	// A run started against a different task must not arm this monitor.
+	a.model.tasksTab = monitorTab()
+	a.awaitManualRunInMonitor("ISSUE-42")
+	if a.model.tasksTab.WorkflowAwaitTicks != 0 {
+		t.Errorf("a run on another task should not arm the monitor, got %d ticks", a.model.tasksTab.WorkflowAwaitTicks)
+	}
+}
+
+// TestWorkflowInstancesRefreshSwitchesToNewInstance verifies the monitor jumps to
+// a newly created instance when one appears, and otherwise keeps the instance the
+// user is looking at (with its step cursor).
+func TestWorkflowInstancesRefreshSwitchesToNewInstance(t *testing.T) {
+	a := &App{model: NewModel()}
+	tab := monitorTab()
+	tab.WorkflowAwaitTicks = wfMonitorAwaitTicks
+	a.model.tasksTab = tab
+
+	newer := &WorkflowInstanceItem{ID: "i2", Workflow: "implementation", State: "running", CellID: "ISSUE-9"}
+	a.Update(workflowInstancesRefreshMsg{
+		taskID:    "ISSUE-9",
+		instances: []*WorkflowInstanceItem{newer, tab.WorkflowInstances[0]},
+	})
+
+	if tab.WorkflowInstance == nil || tab.WorkflowInstance.ID != "i2" || tab.WorkflowInstanceIdx != 0 {
+		t.Fatalf("monitor should show the new instance i2, got %+v idx=%d", tab.WorkflowInstance, tab.WorkflowInstanceIdx)
+	}
+	if tab.WorkflowAwaitTicks != 0 {
+		t.Errorf("await should be cleared once the instance appeared, got %d", tab.WorkflowAwaitTicks)
+	}
+
+	// A refresh with the same set keeps the shown instance and its step cursor.
+	tab.WorkflowStepIdx = 3
+	a.Update(workflowInstancesRefreshMsg{
+		taskID:    "ISSUE-9",
+		instances: []*WorkflowInstanceItem{newer, tab.WorkflowInstances[1]},
+	})
+	if tab.WorkflowInstance.ID != "i2" || tab.WorkflowStepIdx != 3 {
+		t.Errorf("unchanged set should keep instance and cursor, got %s idx=%d", tab.WorkflowInstance.ID, tab.WorkflowStepIdx)
+	}
+
+	// A refresh for another task is dropped.
+	a.Update(workflowInstancesRefreshMsg{taskID: "ISSUE-42", instances: []*WorkflowInstanceItem{{ID: "zz"}}})
+	if tab.WorkflowInstance.ID != "i2" {
+		t.Errorf("refresh for another task should be ignored, got %s", tab.WorkflowInstance.ID)
+	}
+}
+
+// TestFetchActiveTabRefreshesInstancesWhileAwaiting verifies the refresh tick
+// re-lists instances only while a manual run is pending, and gives up eventually.
+func TestFetchActiveTabRefreshesInstancesWhileAwaiting(t *testing.T) {
+	a := &App{model: NewModel()}
+	tab := monitorTab()
+	a.model.tasksTab = tab
+	a.model.activeTab = tabIndex(a.model, "Tasks")
+
+	tab.WorkflowAwaitTicks = 2
+	for i := 0; i < 2; i++ {
+		if cmd := a.fetchActiveTab(); cmd == nil {
+			t.Fatalf("tick %d should have produced refresh commands", i)
+		}
+	}
+	if tab.WorkflowAwaitTicks != 0 {
+		t.Fatalf("await budget should be spent, got %d", tab.WorkflowAwaitTicks)
+	}
+}
+
+// TestWorkflowMonitorShowsTaskLabel verifies the monitor's title names the task
+// being watched — without it the screen shows a workflow id and nothing else.
+func TestWorkflowMonitorShowsTaskLabel(t *testing.T) {
+	a := &App{model: NewModel()}
+	a.model.width = 160
+	a.model.height = 40
+	tab := monitorTab()
+	a.model.tasksTab = tab
+
+	out := ansi.Strip(a.renderWorkflowMonitor(tab, 20))
+	if !strings.Contains(out, "ERP-9 — Ship the thing") {
+		t.Errorf("monitor title should name the task, got:\n%s", strings.SplitN(out, "\n", 2)[0])
+	}
+}
+
+// TestTaskLabelFromHistory verifies the label used by the monitor header is
+// resolved from the loaded task rows, by task id or legacy drill key.
+func TestTaskLabelFromHistory(t *testing.T) {
+	a := &App{model: NewModel()}
+	a.model.tasksTab = &TasksTab{History: []TaskItem{
+		{TaskID: "t-1", DrillKey: "ISSUE-9", Number: "ERP-9", Title: "Ship the thing"},
+		{TaskID: "t-2", Title: "Untitled number-less"},
+	}}
+
+	if got := a.taskLabel("ISSUE-9"); got != "ERP-9 — Ship the thing" {
+		t.Errorf("drill-key lookup: got %q", got)
+	}
+	if got := a.taskLabel("t-2"); got != "Untitled number-less" {
+		t.Errorf("title-only lookup: got %q", got)
+	}
+	if got := a.taskLabel("nope"); got != "nope" {
+		t.Errorf("unknown task should fall back to its id, got %q", got)
+	}
+}
+
+// tabIndex finds the index of a tab by name so the test can activate it.
+func tabIndex(m *Model, name string) int {
+	for i, tb := range m.tabs {
+		if tb == name {
+			return i
+		}
+	}
+	return 0
+}

--- a/src/internal/dashboard/workflow_picker.go
+++ b/src/internal/dashboard/workflow_picker.go
@@ -105,11 +105,30 @@ func (a *App) handleWorkflowPickerKey(key string) (tea.Model, tea.Cmd) {
 		workflowID := ids[a.model.pickerIdx]
 		ref, _ := a.pickerTarget()
 		a.closeWorkflowPicker()
+		a.awaitManualRunInMonitor(ref)
 		return a, a.runWorkflowCmd(workflowID, ref)
 	case "esc":
 		a.closeWorkflowPicker()
 	}
 	return a, nil
+}
+
+// wfMonitorAwaitTicks bounds how long the monitor keeps re-listing instances
+// after a manual run (refreshInterval each), so a run the daemon accepted but
+// never dispatched stops the polling instead of continuing for the whole session.
+const wfMonitorAwaitTicks = 30
+
+// awaitManualRunInMonitor arms the open workflow monitor to pick up the instance
+// a manual run is about to create. Dispatch is asynchronous, so the instance does
+// not exist yet; the monitor's refresh tick watches for it and switches to it.
+// Without this the operator had to leave the screen and come back to see the run
+// they just started.
+func (a *App) awaitManualRunInMonitor(itemRef string) {
+	t := a.model.tasksTab
+	if t == nil || t.View != TaskViewWorkflow || itemRef == "" || t.WorkflowTaskID != itemRef {
+		return
+	}
+	t.WorkflowAwaitTicks = wfMonitorAwaitTicks
 }
 
 // runWorkflowCmd asks the daemon to start a workflow manually and reports the


### PR DESCRIPTION
Two small UX fixes in the task workflow monitor (the screen you get with `enter` on a task).

## Manually started workflows now show up on their own

Pressing `W` on the workflow screen started the run, but the view kept showing the previous instance — you had to go back to the list and press enter again to see it. The monitor only ever re-fetched the instance it was already pointing at; it never re-listed the task's instances.

- `TasksTab` records the task the monitor is showing (`WorkflowTaskID` / `WorkflowTaskLabel`).
- Picking a workflow arms a bounded instance-list refresh (`awaitManualRunInMonitor`). Dispatch is asynchronous, so the instance does not exist when the run is accepted; the refresh tick re-lists instances and switches to the new one as soon as it appears. The wait is capped at 30 ticks (~60s) so a run the daemon never dispatched stops polling.
- `r` in the monitor re-lists instances as well, not just the shown one.
- Side effect worth calling out: `W` inside the monitor now targets the task on screen instead of whatever the list cursor happens to sit on — a list that re-sorted underneath used to retarget the action.

## The monitor says which task it is

The title was `WORKFLOW <id> <badge>` with no indication of what the run was working on. It now ends with the task label (`· ERP-9 — Ship the thing`), resolved from the loaded task rows by task id or legacy drill key, and truncated to whatever the box border leaves free so a narrow terminal loses title characters rather than its top border.

## Tests

`internal/dashboard/workflow_monitor_manual_run_test.go` covers arming, jump-to-new-instance vs. keep-the-current-cursor, the await budget being spent, the rendered title, and label resolution.

```
go test ./internal/dashboard/
```