### PR TITLE
fix(dashboard): render the approval message as markdown

### DIFF
--- a/src/internal/dashboard/approval_form.go
+++ b/src/internal/dashboard/approval_form.go
@@ -99,6 +99,7 @@ func (a *App) openApprovalForm(req *db.ApprovalRequest) {
 	a.model.approvalErr = ""
 	a.model.approvalVals = map[string]any{}
 	a.model.approvalDraft = map[string]string{}
+	a.model.approvalMsg = renderApprovalMessage(req.Message)
 	for _, f := range approvalFields(req) {
 		switch f.Type {
 		case "boolean":
@@ -141,6 +142,7 @@ func (a *App) closeApprovalForm() {
 	a.model.approvalDraft = nil
 	a.model.approvalErr = ""
 	a.model.approvalIdx = 0
+	a.model.approvalMsg = nil
 }
 
 // handleApprovalFormKey owns every key while the form is open.
@@ -325,8 +327,8 @@ func (a *App) renderApprovalForm(view string) string {
 
 	rows := make([]string, 0, len(fields)+6)
 	rows = append(rows, StyleBoxTitle.Render(" Answer approval "))
-	if req.Message != "" {
-		rows = append(rows, StyleWarning.Render(wrapTo(req.Message, 52)))
+	if msg := a.approvalMessageLines(len(fields)); len(msg) > 0 {
+		rows = append(rows, msg...)
 	}
 	if len(req.Approvers) > 0 {
 		quorum := req.RequiredApprovals
@@ -413,22 +415,58 @@ func (a *App) renderApprovalValue(f approvalField, focused bool) string {
 	}
 }
 
-// wrapTo hard-wraps text at width on word boundaries, for the dialog's fixed
-// column. lipgloss wraps rendered blocks, but the message is styled per line.
-func wrapTo(s string, width int) string {
-	words := strings.Fields(s)
-	if len(words) == 0 {
-		return ""
+// approvalMessageWidth is the dialog's inner text column: the box is 58 wide
+// with 3 columns of padding on each side.
+const approvalMessageWidth = 52
+
+// renderApprovalMessage turns the request's message into display lines.
+//
+// The message is authored in the workflow config and routinely carries markdown
+// — lists of what is about to ship, links, inline code, fenced diffs. It used to
+// be squashed into a single yellow paragraph by a word-wrapper that split on
+// whitespace, which threw away every line break, list and code block: the
+// operator answering the gate saw less than the author wrote. It is rendered as
+// markdown instead, once when the form opens (glamour is far too slow for the
+// render path, which runs on every keystroke), and falls back to a plain wrap
+// when glamour fails so a message is never dropped.
+func renderApprovalMessage(msg string) []string {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return nil
 	}
-	var lines []string
-	line := words[0]
-	for _, w := range words[1:] {
-		if len(line)+1+len(w) > width {
-			lines = append(lines, line)
-			line = w
-			continue
-		}
-		line += " " + w
+	rendered, err := renderMarkdown(msg, approvalMessageWidth)
+	if err != nil {
+		return clampToWidth(wrapPlain(msg, approvalMessageWidth), approvalMessageWidth)
 	}
-	return strings.Join(append(lines, line), "\n")
+	lines := strings.Split(strings.Trim(rendered, "\n"), "\n")
+	return clampToWidth(lines, approvalMessageWidth)
+}
+
+// approvalMessageLines returns the rendered message trimmed to what the terminal
+// can show: a long message must not push the fields and the key hints off the
+// screen, since those are how the gate gets answered. What does not fit is
+// replaced by a count, and the full text stays available in
+// `apiary approvals <request-id>`.
+func (a *App) approvalMessageLines(fieldCount int) []string {
+	lines := a.model.approvalMsg
+	if len(lines) == 0 {
+		return nil
+	}
+	// The rest of the dialog: border + padding + title + approvers + spacers +
+	// error + key hints (7), two rows per field, and a line of breathing room.
+	budget := a.model.height - 9 - 2*fieldCount
+	if a.model.height <= 0 || len(lines) <= budget {
+		return lines
+	}
+	if budget < 2 {
+		budget = 2
+	}
+	kept := make([]string, 0, budget)
+	kept = append(kept, lines[:budget-1]...)
+	id := "<request-id>"
+	if a.model.approvalReq != nil {
+		id = a.model.approvalReq.ID
+	}
+	return append(kept, StyleFooterDim.Render(fmt.Sprintf(
+		"… %d more lines — apiary approvals %s", len(lines)-(budget-1), id)))
 }

--- a/src/internal/dashboard/approval_form_test.go
+++ b/src/internal/dashboard/approval_form_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/orlandoburli/apiary/internal/db"
 )
 
@@ -224,5 +226,48 @@ func TestOverviewShowsPendingApprovals(t *testing.T) {
 	}
 	if strings.Contains(out, "⏸") {
 		t.Fatalf("zero approvals should not render an alert:\n%s", out)
+	}
+}
+
+// The gate's message is markdown, and the form must keep its shape. It used to
+// be word-wrapped into one yellow paragraph, which collapsed every line break,
+// list item and code block into prose.
+func TestApprovalFormRendersMessageAsMarkdown(t *testing.T) {
+	a := newFormApp()
+	a.model.width, a.model.height = 100, 40
+	req := fieldRequest()
+	req.Message = "Release 2.4 is staged.\n\n- migrations applied\n- smoke tests green\n\nProceed?"
+	a.openApprovalForm(req)
+
+	out := stripANSI(a.renderApprovalForm(""))
+	for _, want := range []string{"migrations applied", "smoke tests green", "Proceed?"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("form is missing %q:\n%s", want, out)
+		}
+	}
+	// The two bullets are separate lines, not one run-together sentence.
+	if strings.Contains(out, "migrations applied smoke tests green") {
+		t.Fatalf("list items were collapsed into a paragraph:\n%s", out)
+	}
+}
+
+// A message longer than the terminal must not push the fields and key hints off
+// the screen — the operator would have no way left to answer the gate.
+func TestApprovalFormTruncatesLongMessage(t *testing.T) {
+	a := newFormApp()
+	a.model.width, a.model.height = 100, 20
+	req := fieldRequest()
+	req.Message = strings.Repeat("- a bullet\n", 40)
+	a.openApprovalForm(req)
+
+	out := stripANSI(a.renderApprovalForm(""))
+	if !strings.Contains(out, "more lines") {
+		t.Fatalf("long message should be trimmed with a hint:\n%s", out)
+	}
+	if !strings.Contains(out, "approve") || !strings.Contains(out, "Rollout strategy") {
+		t.Fatalf("fields and key hints must survive a long message:\n%s", out)
+	}
+	if got := lipgloss.Height(a.renderApprovalForm("")); got > a.model.height {
+		t.Fatalf("dialog is %d lines tall, taller than the %d-line terminal", got, a.model.height)
 	}
 }

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -44,6 +44,7 @@ type Model struct {
 	approvalVals   map[string]any    // committed values, by field name
 	approvalDraft  map[string]string // in-progress text for typed fields
 	approvalErr    string            // local validation message, cleared on edit
+	approvalMsg    []string          // the request's message, markdown-rendered once on open
 
 	notice      string    // one-line result banner for the last IPC action
 	noticeIsErr bool      // render the banner as an error


### PR DESCRIPTION
The answer-approval modal ran the gate's message through a word-wrapper that split on whitespace (`wrapTo`), so every line break, list item, blockquote and fenced block collapsed into one run-on yellow paragraph. Messages are authored in the workflow config and routinely carry markdown — the operator answering the gate saw less than the author wrote.

## What changed

- `wrapTo` is gone. The message goes through `renderMarkdown` (glamour), the same helper the log and transcript viewers use, at the dialog's 52-column inner width. The yellow `StyleWarning` treatment is dropped — glamour styles headings, lists and code itself. A plain wrap is the fallback if glamour errors, so a message is never dropped.
- Rendered **once when the form opens** and cached in `model.approvalMsg`; glamour is far too slow for the render path, which runs on every keystroke (same reasoning as #175).
- New `approvalMessageLines` trims a long message to what the terminal can show. Overflowing the dialog would push the field rows and the ⏎/^r/esc hints off screen, leaving no way to answer the gate; the trimmed tail shows `… N more lines — apiary approvals <request-id>`.

## Verification

- Two tests added: markdown structure survives (bullets stay on separate lines, not collapsed into a paragraph), and a 40-line message on a 20-line terminal keeps the fields and key hints while the dialog stays within the terminal height.
- `go build ./...`, `go vet ./internal/dashboard/`, and the dashboard package tests pass.