### PR TITLE
fix(registry): publish the conformance verdicts the index promises

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -72,13 +72,33 @@ jobs:
           go-version-file: src/go.mod
           cache-dependency-path: src/go.sum
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Re-derive the registry's conformance verdicts
+        # Best effort on purpose. This downloads every listed artifact to run the
+        # protocol kit against it, so a publisher's dead link or a slow release
+        # host must not be able to take the documentation site down with it —
+        # without verdicts the index publishes them as "not run", which is
+        # exactly what happened.
+        continue-on-error: true
+        run: |
+          cd src && go run ./cmd/apiary-registry check \
+            --dir ../registry \
+            --conformance-runner ../sdk/conformance/run.py \
+            --results "$RUNNER_TEMP/conformance.json"
+
       - name: Compile the plugin registry index
         # Published at /apiary/registry/v1/index.json — what `apiary plugins
         # search|info` resolve names against. Metadata only; artifacts stay with
-        # their publishers.
+        # their publishers. A missing results file is tolerated: every release
+        # then publishes as "conformance not run".
         run: |
           cd src && go run ./cmd/apiary-registry build \
-            --dir ../registry --out ../docs/registry/v1/index.json
+            --dir ../registry --results "$RUNNER_TEMP/conformance.json" \
+            --out ../docs/registry/v1/index.json
 
       - name: Sign the plugin registry index
         # Signing covers the index, which carries the digests, which cover the
@@ -101,11 +121,6 @@ jobs:
             -t "apiary plugin registry index, commit $GITHUB_SHA"
           shred -u "$RUNNER_TEMP/minisign.key" 2>/dev/null || rm -f "$RUNNER_TEMP/minisign.key"
           echo "signed: $(ls docs/registry/v1/)"
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
 
       - name: Install mkdocs
         run: pip install mkdocs-material


### PR DESCRIPTION
Follow-up to #450, found by watching the first live deploy.

## The bug

The docs deploy runs `apiary-registry build` but never `check`. Only the checker produces conformance verdicts, and it only ran in the pull-request workflow, where its results went nowhere. So the published index carries this for every release, permanently:

```json
"conformance": { "status": "not_run" }
```

The [first live index](https://orlandoburli.com.br/apiary/registry/v1/index.json) shipped `not_run` for `dev.apiary.routines` — minutes after CI, on the same commit, found its three protocol failures (orlandoburli/apiary-routines#5).

That contradicts what the docs, the registry README and `apiary plugins info` all promise: the reason for running the kit against a *published artifact* is that an operator sees the verdict before installing. As shipped, nobody would ever see one.

## The fix

Re-derive the verdicts in the deploy, before compiling the index.

Deliberately `continue-on-error`: the checker downloads every listed artifact, so as the registry grows, a publisher's dead link or a slow release host could otherwise take the whole documentation site down with it. When the check fails, `build` tolerates the missing results file and every release publishes as `not_run` — the honest fallback, never a stale or invented verdict.

Also moves `Setup Python` ahead of the checker, which shells out to `python3` for the conformance runner. It worked on the runner image, but by luck rather than by declaration.

## Verified

Ran the deploy's exact two commands locally:

```
published verdict: {'status': 'failed', 'kit': 'sdk/conformance', 'checked_at': '...'}
```

The real check is this workflow running on merge; the published index should then show `failed` for 0.1.0, and `apiary plugins info dev.apiary.routines` should show `conformance FAILED` instead of `conformance not run`.
