### PR TITLE
fix(ci): trigger the docs deploy on everything it publishes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,12 +3,20 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [main]
+    # Everything whose content or logic ends up in the published site. A file
+    # that changes what this workflow publishes but is missing here stays
+    # unpublished until an unrelated change happens to trigger a deploy — which
+    # is how a broken deploy step went unnoticed until the next docs edit.
     paths:
-      - README.md
-      - DEVELOPMENT.md
+      - README.md          # copied to docs/index.md
+      - DEVELOPMENT.md     # copied to docs/development.md
+      - LICENSE            # served at /LICENSE
       - docs/**
       - mkdocs.yml
-      - registry/**
+      - registry/**                  # the entries the index is compiled from
+      - src/cmd/apiary-registry/**   # the compiler that produces the index
+      - sdk/conformance/**           # the kit whose verdicts the index carries
+      - .github/workflows/pages.yml  # this workflow itself
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
Follow-up to #453, which could not deploy itself.

## The bug

`pages.yml` was not in its own `paths` filter, so editing the deploy never re-ran the deploy. #453 fixed the published index carrying `conformance: not_run`, merged, and then did nothing — I had to dispatch the workflow by hand for it to take effect. Left alone it would have waited for an unrelated `docs/**` edit, and until then the site would have quietly lagged the repository.

## The fix

List everything whose content or logic ends up in the published site:

| Added | Why |
|---|---|
| `.github/workflows/pages.yml` | the workflow itself — the bug above |
| `LICENSE` | copied into `docs/` and served at `/LICENSE` |
| `src/cmd/apiary-registry/**` | the compiler that produces the published index |
| `sdk/conformance/**` | the kit whose verdicts the index carries — a new case can flip a listing from passed to failed with no docs or registry file changing |

The cost is a ~4-minute docs deploy on changes to those paths. The alternative is a published site that silently lags `main`, which is the failure mode that produced #453 and this PR.

Trimming any row is reasonable if you'd rather not redeploy on Go or kit changes — the first row is the one that actually bit.
