### PR TITLE
docs: list apiary-pgsink as a companion tool

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -283,3 +283,30 @@ poll with its `status` (passed/failed/pending/timeout/error/unknown), the PR
 `pr_url`, the per-check `detail` (JSON), and `checked_at`. This makes a parked CI
 wait auditable — how many times it polled, when, and what each poll returned —
 which the dashboard surfaces in the task detail and history views.
+
+## Getting this data out
+
+The tables above are Apiary's own working store, not a reporting warehouse. Two
+ways out, depending on what you want:
+
+- **`apiary improve --dump-evidence`** computes step, workflow, agent and wait
+  metrics in Go and prints them as JSON, with no model involved. Good for a
+  one-off question. See [Self-Improvement](improve.md).
+- **[apiary-pgsink](https://github.com/orlandoburli/apiary-pgsink)** replicates
+  this schema into PostgreSQL — backfill the history, then follow it — so the
+  data is queryable from BI tools and survives Apiary's own log retention. It is
+  a separate service, not a plugin: it runs beside the daemon and reads its
+  database. See [Companion tools](supported-integrations.md#companion-tools).
+
+Two things about this schema make a naive exporter get it wrong, and are worth
+knowing whichever route you take:
+
+- **`task_executions` and `step_runs` are written twice.** A row is inserted at
+  dispatch with `status = 'running'` and zero cost, and updated at completion
+  with the tokens, cost and timings. Neither table carries an `updated_at`, so a
+  copy driven by an insert cursor alone replicates the empty row and never sees
+  the rest — every cost figure downstream stays zero.
+- **Timestamps carry a local UTC offset**, so comparing them as text sorts them
+  wrongly across offsets. Rows written before the `_time_format` fix also carry
+  a Go monotonic-clock suffix that SQLite's own `datetime()` cannot parse, which
+  is why they are absent from some windowed dashboard queries.

--- a/docs/supported-integrations.md
+++ b/docs/supported-integrations.md
@@ -223,6 +223,32 @@ Workflows can route to different agents, which run on different runners. Tasks f
 
 ---
 
+## Companion tools
+
+Separate projects that work with Apiary without extending it. Unlike
+[plugins](plugin-directory.md), these are not invoked by the daemon and do not
+speak protocol 1 — they are their own services, with their own releases.
+
+### apiary-pgsink
+
+**Status:** ✅ Stable | **Runs:** beside the daemon, as its user
+
+Replicates Apiary's SQLite database into PostgreSQL: `backfill` loads the
+history, `sync` follows it. Per-table filters and injected columns, so a shared
+target can hold several Apiary installations and carry your own tenant or
+environment labels.
+
+- **Why:** reporting and BI. The sink also keeps rows past Apiary's own log
+  retention, which makes it an archive as well as a mirror.
+- **Requirements:** the same host as the daemon, running as its user — SQLite in
+  WAL mode has no true read-only reader
+- **Install:** [releases](https://github.com/orlandoburli/apiary-pgsink/releases),
+  or `ghcr.io/orlandoburli/apiary-pgsink`
+- **Home:** [apiary-pgsink](https://github.com/orlandoburli/apiary-pgsink) ·
+  [docs](https://orlandoburli.com.br/apiary-pgsink/)
+
+---
+
 ## Planned integrations
 
 | System | Type | Status |


### PR DESCRIPTION
## What

Lists [apiary-pgsink](https://github.com/orlandoburli/apiary-pgsink) — which replicates Apiary's database into PostgreSQL for reporting — on the docs site, and answers "how do I get this data out?" on the Data Model page.

## Why not the plugin registry

pgsink is **not a plugin**. It has no `apiary-plugin.json`, does not speak protocol 1, and the daemon never invokes it — it is a separate service that reads the daemon's database and runs beside it.

A `registry/plugins/` listing would fail on its own terms: `capabilities` requires at least one value from a closed enum (`source`, `runner`, `workflow_action`, `approval_provider`, `secret_provider`, `event_exporter`) and pgsink has none of them, and registry CI runs the conformance kit against every listed release. Listing it would tell operators `apiary plugins install` produces something the daemon can invoke, which it does not.

So: a **Companion tools** section in Supported Integrations, explicitly distinguished from plugins.

## Changes

- `docs/supported-integrations.md` — new Companion tools section
- `docs/data-model.md` — a "Getting this data out" section pointing at both `apiary improve --dump-evidence` and pgsink, and naming the two schema properties that make a naive exporter produce wrong data:
  - `task_executions` and `step_runs` are written twice (dispatch, then completion) and carry no `updated_at`, so an insert-cursor copy replicates the zero-cost row and never sees the rest
  - timestamps carry a local UTC offset, so text comparison mis-sorts across offsets; pre-`_time_format` rows carry a Go monotonic-clock suffix `datetime()` cannot parse, which is why they are absent from some windowed dashboard queries

## Verification

`mkdocs build --strict` reports the same 8 warnings as `main` — all pre-existing, all in the `index.md`/`development.md` build-time copies. No new ones.

Docs only. No code, no schema, no behaviour change.