### PR TITLE
fix(dashboard): unfreeze the approval form and render its banner as markdown

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -15,12 +15,15 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/term"
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/daemon"
@@ -575,6 +578,19 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	// The workflow picker owns every key while it is open, like the confirm modal.
+	if a.model.pickerActive {
+		return a.handleWorkflowPickerKey(key)
+	}
+
+	// So does the approval form — its text fields consume printable keys, so no
+	// global shortcut may fire underneath it. Both guards sit above the global
+	// single-letter bindings: below them, typing a note into a field ran q (quit
+	// the dashboard), o (open the task in a browser), t, or p instead of typing.
+	if a.model.approvalActive {
+		return a.handleApprovalFormKey(key)
+	}
+
 	if key == "q" {
 		return a, tea.Quit
 	}
@@ -626,17 +642,6 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.model.confirmTaskID = ""
 		}
 		return a, nil
-	}
-
-	// The workflow picker owns every key while it is open, like the confirm modal.
-	if a.model.pickerActive {
-		return a.handleWorkflowPickerKey(key)
-	}
-
-	// So does the approval form — its text fields consume printable keys, so no
-	// global shortcut may fire underneath it.
-	if a.model.approvalActive {
-		return a.handleApprovalFormKey(key)
 	}
 
 	// Start a workflow manually (Shift+W): pick one, run it now regardless of
@@ -3773,7 +3778,7 @@ func (a *App) taskDetailLines(t *TasksTab) []string {
 		b.WriteString("  " + StyleError.Render(truncate(d.Error, a.model.width-4)) + "\n")
 	}
 	if t.DetailInstance != nil {
-		b.WriteString(renderWorkflowSteps(t.DetailInstance))
+		b.WriteString(renderWorkflowSteps(t.DetailInstance, a.model.width-6))
 	}
 	b.WriteString(renderSourceBindings(d))
 	b.WriteString(renderTaskLineage(d))
@@ -3905,10 +3910,52 @@ func renderTaskTimeline(d *TaskItem) string {
 	return b.String()
 }
 
+// approvalBanner renders the parked gate's message for the detail panel.
+//
+// The message is the step's own question, written in the config and routinely
+// carrying markdown. It used to be printed raw and unwrapped in one yellow
+// string, which both showed the markup as text and spilled past the panel's
+// border on any long line. It is rendered like the approval form's copy of the
+// same message, and memoized because View runs on every keystroke while glamour
+// is far too slow for that (#175).
+func approvalBanner(msg string, width int) string {
+	lines := approvalBannerLines(msg, width-2)
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("  " + StyleWarning.Render("⏸") + strings.TrimRight(lines[0], " ") + "\n")
+	for _, ln := range lines[1:] {
+		b.WriteString("  " + strings.TrimRight(ln, " ") + "\n")
+	}
+	return b.String()
+}
+
+// approvalBannerMemo caches the last banner render. One gate is on screen at a
+// time, so a single entry keyed by (message, width) is all the panel needs; the
+// lock guards against a future caller rendering off the UI goroutine.
+var approvalBannerMemo struct {
+	sync.Mutex
+	msg   string
+	width int
+	lines []string
+}
+
+func approvalBannerLines(msg string, width int) []string {
+	approvalBannerMemo.Lock()
+	defer approvalBannerMemo.Unlock()
+	if approvalBannerMemo.msg == msg && approvalBannerMemo.width == width {
+		return approvalBannerMemo.lines
+	}
+	lines := markdownLines(msg, width)
+	approvalBannerMemo.msg, approvalBannerMemo.width, approvalBannerMemo.lines = msg, width, lines
+	return lines
+}
+
 // renderWorkflowSteps renders the step-progress panel for a task that ran
 // through the workflow engine: the workflow id + instance state, an
 // approval-waiting banner when parked, and one row per step.
-func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
+func renderWorkflowSteps(inst *WorkflowInstanceItem, width int) string {
 	var b strings.Builder
 	b.WriteString("\n  " + StyleLabel.Render("Workflow") + "      " +
 		StyleValueStrong.Render(valueOr(inst.Workflow, "—")) + "  " +
@@ -3919,7 +3966,7 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem) string {
 	}
 
 	if inst.State == db.InstanceStateApprovalWaiting && inst.Message != "" {
-		b.WriteString("  " + StyleWarning.Render("⏸ "+inst.Message) + "\n")
+		b.WriteString(approvalBanner(inst.Message, width))
 		if inst.Approval != nil {
 			if len(inst.Approval.Approvers) > 0 {
 				b.WriteString("  " + StyleMuted.Render("Approvers: "+strings.Join(inst.Approval.Approvers, ", ")) + "\n")
@@ -4867,11 +4914,39 @@ func (a *App) agentFileLines() []string {
 	return lines
 }
 
-// renderMarkdown renders markdown to ANSI-styled terminal text wrapped to width.
-// It uses glamour's auto style so it adapts to the terminal background.
+// markdownStyle is the glamour style every markdown render uses, resolved once
+// by resolveMarkdownStyle before the program starts. See that function for why
+// it is not glamour.WithAutoStyle(). It defaults to the unstyled variant so a
+// caller that never resolves it renders plain text rather than blocking.
+var markdownStyle = styles.NoTTYStyle
+
+// resolveMarkdownStyle picks the glamour style from the terminal background,
+// once, while stdin still belongs to us.
+//
+// glamour.WithAutoStyle() asks the terminal for its background colour and then
+// blocks up to five seconds reading the reply. Once bubbletea is running its own
+// input loop owns stdin and swallows that reply, so the query always waits out
+// its full timeout — on the UI thread that freezes the entire dashboard, and on
+// a warm-up goroutine it stalls the render it was computing. Asking before
+// tea.Program starts costs one fast round trip and every render after it is
+// pure computation.
+func resolveMarkdownStyle() {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		markdownStyle = styles.NoTTYStyle
+		return
+	}
+	if lipgloss.HasDarkBackground() {
+		markdownStyle = styles.DarkStyle
+		return
+	}
+	markdownStyle = styles.LightStyle
+}
+
+// renderMarkdown renders markdown to ANSI-styled terminal text wrapped to width,
+// in the style resolved for this terminal at startup.
 func renderMarkdown(src string, width int) (string, error) {
 	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
+		glamour.WithStandardStyle(markdownStyle),
 		glamour.WithWordWrap(width),
 	)
 	if err != nil {
@@ -5925,6 +6000,10 @@ func styleStepType(t string) string {
 
 // Run starts the dashboard.
 func (a *App) Run() error {
+	// Before bubbletea takes over stdin: any terminal query made after this
+	// point never gets its answer back. See resolveMarkdownStyle.
+	resolveMarkdownStyle()
+
 	p := tea.NewProgram(a, tea.WithAltScreen())
 	_, err := p.Run()
 	return err

--- a/src/internal/dashboard/approval_form.go
+++ b/src/internal/dashboard/approval_form.go
@@ -430,16 +430,24 @@ const approvalMessageWidth = 52
 // render path, which runs on every keystroke), and falls back to a plain wrap
 // when glamour fails so a message is never dropped.
 func renderApprovalMessage(msg string) []string {
-	msg = strings.TrimSpace(msg)
-	if msg == "" {
+	return markdownLines(msg, approvalMessageWidth)
+}
+
+// markdownLines renders markdown to display lines wrapped to width, falling back
+// to a plain wrap when glamour fails so text is never dropped.
+func markdownLines(src string, width int) []string {
+	src = strings.TrimSpace(src)
+	if src == "" {
 		return nil
 	}
-	rendered, err := renderMarkdown(msg, approvalMessageWidth)
-	if err != nil {
-		return clampToWidth(wrapPlain(msg, approvalMessageWidth), approvalMessageWidth)
+	if width < 8 {
+		width = 8
 	}
-	lines := strings.Split(strings.Trim(rendered, "\n"), "\n")
-	return clampToWidth(lines, approvalMessageWidth)
+	rendered, err := renderMarkdown(src, width)
+	if err != nil {
+		return clampToWidth(wrapPlain(src, width), width)
+	}
+	return clampToWidth(strings.Split(strings.Trim(rendered, "\n"), "\n"), width)
 }
 
 // approvalMessageLines returns the rendered message trimmed to what the terminal

--- a/src/internal/dashboard/approval_form_test.go
+++ b/src/internal/dashboard/approval_form_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/orlandoburli/apiary/internal/db"
@@ -269,5 +270,26 @@ func TestApprovalFormTruncatesLongMessage(t *testing.T) {
 	}
 	if got := lipgloss.Height(a.renderApprovalForm("")); got > a.model.height {
 		t.Fatalf("dialog is %d lines tall, taller than the %d-line terminal", got, a.model.height)
+	}
+}
+
+// The form's text fields must win over the global single-letter bindings. They
+// used to be checked after them, so typing a note ran q (quit the dashboard),
+// o (open the task in a browser), t or p instead of typing the character.
+func TestApprovalFormOwnsGlobalLetterKeys(t *testing.T) {
+	a := &App{model: &Model{width: 100, height: 40, tabs: []string{"Overview", "Tasks"}, activeTab: 1}}
+	a.openApprovalForm(fieldRequest())
+	a.model.approvalIdx = 1 // the string field
+
+	for _, key := range []string{"o", "k", "q", "t", "p"} {
+		if _, cmd := a.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}); cmd != nil {
+			t.Fatalf("%q fired a global binding while the form was open", key)
+		}
+		if !a.model.approvalActive {
+			t.Fatalf("%q closed the form", key)
+		}
+	}
+	if got := a.model.approvalDraft["change_ticket"]; got != "okqtp" {
+		t.Fatalf("field got %q, want %q", got, "okqtp")
 	}
 }

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/orlandoburli/apiary/internal/db"
 )
 
@@ -23,7 +25,7 @@ func TestRenderWorkflowSteps_CIPolls(t *testing.T) {
 			{StepID: "check-ci", Status: "failed", Detail: `{"build":"failure"}`, CheckedAt: base.Add(2 * time.Minute)},
 		},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "CI Polls (3)") {
 		t.Errorf("expected CI poll count header; got:\n%s", out)
 	}
@@ -42,7 +44,7 @@ func TestRenderWorkflowSteps_NoCIPolls(t *testing.T) {
 		State:    "done",
 		Steps:    []WorkflowStepItem{{StepID: "implement", Agent: "engineer", State: "passed"}},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if strings.Contains(out, "CI Polls") {
 		t.Errorf("instance with no polls should not render a CI Polls section:\n%s", out)
 	}
@@ -61,7 +63,7 @@ func TestRenderWorkflowSteps(t *testing.T) {
 		},
 	}
 
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 
 	for _, want := range []string{"feature-development", "running", "Steps", "plan", "implement", "review", "(cached)"} {
 		if !strings.Contains(out, want) {
@@ -81,7 +83,7 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 		},
 	}
 
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "approval_waiting") {
 		t.Errorf("expected approval_waiting badge:\n%s", out)
 	}
@@ -92,7 +94,7 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 
 func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
 	inst := &WorkflowInstanceItem{ID: "wf-1", Workflow: "release", State: db.InstanceStateApprovalWaiting, Message: "Awaiting approval", Approval: &db.ApprovalRequest{ID: "wf-1:gate", Approvers: []string{"alice", "carol"}, RequiredApprovals: 2}}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	for _, want := range []string{"alice, carol", "Press y to approve or n to reject"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q:\n%s", want, out)
@@ -101,7 +103,7 @@ func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
 	// With declared fields the answer is a form, not a keystroke — the detail
 	// panel points at it rather than sending the operator to the webhook.
 	inst.Approval.Fields = []map[string]any{{"name": "ticket", "required": true}}
-	out = stripANSI(renderWorkflowSteps(inst))
+	out = stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "Press a to answer (1 fields)") {
 		t.Fatalf("structured-field guidance missing:\n%s", out)
 	}
@@ -112,7 +114,7 @@ func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
 func TestRenderWorkflowSteps_OperatorGateOmitsApprovers(t *testing.T) {
 	inst := &WorkflowInstanceItem{ID: "wf-2", Workflow: "release", State: db.InstanceStateApprovalWaiting,
 		Message: "Ship it?", Approval: &db.ApprovalRequest{ID: "wf-2:gate"}}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if strings.Contains(out, "Approvers:") {
 		t.Fatalf("unexpected approvers line for an operator gate:\n%s", out)
 	}
@@ -123,7 +125,7 @@ func TestRenderWorkflowSteps_OperatorGateOmitsApprovers(t *testing.T) {
 
 func TestRenderWorkflowSteps_NoSteps(t *testing.T) {
 	inst := &WorkflowInstanceItem{ID: "wf_3", Workflow: "single", State: "done"}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "single") || !strings.Contains(out, "done") {
 		t.Errorf("expected workflow id and state even with no steps:\n%s", out)
 	}
@@ -144,7 +146,7 @@ func TestRenderWorkflowSteps_FailedAfterPassedSteps(t *testing.T) {
 			{StepID: "implement", Agent: "engineer", State: "passed", Duration: "30s"},
 		},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "no further steps recorded") {
 		t.Errorf("expected a failure marker for an all-passed failed instance:\n%s", out)
 	}
@@ -165,7 +167,7 @@ func TestRenderWorkflowSteps_FailedStepVisible(t *testing.T) {
 			{StepID: "review", Agent: "reviewer", State: "failed", Duration: "12s"},
 		},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if strings.Contains(out, "no further steps recorded") {
 		t.Errorf("should not add a marker when a failed step is already visible:\n%s", out)
 	}
@@ -174,7 +176,7 @@ func TestRenderWorkflowSteps_FailedStepVisible(t *testing.T) {
 // A failed instance with zero recorded steps still gets a marker.
 func TestRenderWorkflowSteps_FailedNoSteps(t *testing.T) {
 	inst := &WorkflowInstanceItem{ID: "wf_f3", Workflow: "implementation", State: "failed"}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "before any step completed") {
 		t.Errorf("expected a failure marker for a failed instance with no steps:\n%s", out)
 	}
@@ -239,7 +241,7 @@ func TestRenderWorkflowSteps_StepSpanAndTokens(t *testing.T) {
 				StartedAt: at("2026-06-08 13:42:01"), FinishedAt: at("2026-06-08 13:50:16"), TotalTokens: 42100},
 		},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	for _, want := range []string{
 		"STARTED", "ENDED", "DURATION", "TOKENS", "STATE", // column header
 		"06-08 13:42:01", "06-08 13:50:16", "42k", // step row cells (compact: no decimal above 10 units)
@@ -267,7 +269,7 @@ func TestRenderWorkflowSteps_WaitBetweenSteps(t *testing.T) {
 				StartedAt: at("2026-06-08 15:46:53")},
 		},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if !strings.Contains(out, "↓ 1h54m42s waiting") {
 		t.Errorf("expected the long inter-step wait to be shown:\n%s", out)
 	}
@@ -284,8 +286,35 @@ func TestRenderWorkflowSteps_NoMarkerWhenDone(t *testing.T) {
 		State:    "done",
 		Steps:    []WorkflowStepItem{{StepID: "implement", Agent: "engineer", State: "passed"}},
 	}
-	out := stripANSI(renderWorkflowSteps(inst))
+	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if strings.Contains(out, "workflow failed") {
 		t.Errorf("done instance should not show a failure marker:\n%s", out)
+	}
+}
+
+// The parked-gate banner carries the step's own question, which is markdown. It
+// used to be printed raw and unwrapped, so the markup showed as text and long
+// lines spilled past the panel border.
+func TestApprovalBannerRendersMarkdownWithinWidth(t *testing.T) {
+	inst := &WorkflowInstanceItem{
+		ID: "wf-1", Workflow: "release", State: db.InstanceStateApprovalWaiting,
+		Message: "Release 2.4 is staged.\n\n- migrations applied\n- " +
+			strings.Repeat("a very long line that must be wrapped rather than spilling past the border ", 3),
+		Approval: &db.ApprovalRequest{ID: "wf-1:gate"},
+	}
+	const width = 60
+
+	out := renderWorkflowSteps(inst, width)
+	for _, ln := range strings.Split(stripANSI(out), "\n") {
+		if lipgloss.Width(ln) > width {
+			t.Fatalf("line is %d wide, wider than the %d-column panel: %q", lipgloss.Width(ln), width, ln)
+		}
+	}
+	plain := stripANSI(out)
+	if !strings.Contains(plain, "migrations applied") {
+		t.Fatalf("banner lost the message:\n%s", plain)
+	}
+	if strings.Contains(plain, "- migrations applied") {
+		t.Fatalf("banner shows raw markdown instead of rendering it:\n%s", plain)
 	}
 }


### PR DESCRIPTION
Follow-up to #452, found by driving the real TUI in a pty against a seeded parked approval.

## 1. Answering a gate froze the dashboard for five seconds

`renderMarkdown` built its renderer with `glamour.WithAutoStyle()`, which asks the terminal for its background colour and then blocks up to five seconds reading the reply. Once bubbletea is running, its own input loop owns stdin and swallows that reply, so the query always waits out the full timeout. A SIGQUIT stack caught it on the UI thread:

```
termenv.(*Output).waitForData
termenv.(*Output).backgroundColor
glamour.getDefaultStyle
dashboard.renderMarkdown
dashboard.openApprovalForm
```

The style is now resolved **once in `Run()`, before `tea.NewProgram`**, and renders use `WithStandardStyle`. This also removes the same stall from the log and transcript warm-up goroutines, which paid it on every render.

## 2. The task-detail banner showed the message raw

The detail panel printed `StyleWarning.Render("⏸ "+inst.Message)` — no markdown, no wrapping — so the markup showed as text and long lines spilled past the panel border. It now renders like the form's copy of the same message, memoized by `(message, width)` since `View` runs on every keystroke. `renderWorkflowSteps` takes a width for this.

## 3. Typing in the form ran global shortcuts

The `approvalActive` guard sat below the global single-letter bindings, so typing a note fired `q` (quit the dashboard), `o` (open the task in a browser), `t` or `p` instead of typing the character. Both modal guards moved above them.

## Verification

Driven live in a pty with a seeded `approval_waiting` instance: the form now opens instantly, headings/bullets/inline code/code blocks/blockquotes all render, the banner stays inside the panel border, a 40-line message on a 24-row terminal trims to `… N more lines — apiary approvals <id>`, and typing `okay` into a field yields `okay` (was `kay`).

Tests added for the banner width/markdown and for the key precedence. `go test ./...` passes across the module.