### PR TITLE
docs: warn that gitnexus analyze reverts our committed skill files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,26 @@ This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relations
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->
+
+## After running `gitnexus analyze`
+
+A **full** index build — a fresh clone, a **new git worktree**, or `--force` —
+rewrites all six `.claude/skills/gitnexus/*/SKILL.md` files from the tool's
+bundled copies, discarding what this repo commits there (measured on 1.6.3: 76
+insertions, 165 deletions). `--skip-agents-md` does **not** prevent it: it covers
+only the generated block above. An incremental analyze over an existing
+`.gitnexus/` leaves them alone, which is why this mostly bites in worktrees —
+every new one is a first analyze.
+
+Always restore them afterwards, and check the tree is clean:
+
+```bash
+gitnexus analyze --skip-agents-md && git checkout -- .claude/skills/gitnexus/
+git status --short
+```
+
+What the regenerated copies drop matters: the `node .gitnexus/run.cjs` runner
+instructions and the npm 11 `npx` crash workaround (#1939) — the very failure the
+line above tells you to route around.
+
+Tracked in #457; upstream at abhigyanpatwari/GitNexus#3080.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,26 @@ This project is indexed by GitNexus as **apiary** (6306 symbols, 22913 relations
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->
+
+## After running `gitnexus analyze`
+
+A **full** index build — a fresh clone, a **new git worktree**, or `--force` —
+rewrites all six `.claude/skills/gitnexus/*/SKILL.md` files from the tool's
+bundled copies, discarding what this repo commits there (measured on 1.6.3: 76
+insertions, 165 deletions). `--skip-agents-md` does **not** prevent it: it covers
+only the generated block above. An incremental analyze over an existing
+`.gitnexus/` leaves them alone, which is why this mostly bites in worktrees —
+every new one is a first analyze.
+
+Always restore them afterwards, and check the tree is clean:
+
+```bash
+gitnexus analyze --skip-agents-md && git checkout -- .claude/skills/gitnexus/
+git status --short
+```
+
+What the regenerated copies drop matters: the `node .gitnexus/run.cjs` runner
+instructions and the npm 11 `npx` crash workaround (#1939) — the very failure the
+line above tells you to route around.
+
+Tracked in #457; upstream at abhigyanpatwari/GitNexus#3080.


### PR DESCRIPTION
Closes the first checkbox of #457.

A full `gitnexus analyze` rewrites all six `.claude/skills/gitnexus/*/SKILL.md` files from the tool's bundled copies, discarding what this repo commits there — 76 insertions, 165 deletions on gitnexus 1.6.3. `--skip-agents-md`, which `CLAUDE.md` tells everyone to pass, does **not** prevent it: that flag covers only the generated block in `CLAUDE.md` / `AGENTS.md`.

Nothing in the repo warned about this, and the shape of the bug hides it:

| Run | Clobbers? |
|---|---|
| First analyze in a fresh clone/checkout/**worktree** | **yes** |
| `analyze --force` | **yes** |
| Incremental analyze with an existing `.gitnexus/` | no |

So it looks harmless until someone works in a worktree, where every first analyze is a full build and six tracked files quietly revert into whatever commit comes next.

## Placement

The note goes **after** `<!-- gitnexus:end -->`. Both files are entirely inside that block, so anything added within it would be erased by the next analyze that omits `--skip-agents-md`.

Verified rather than assumed: I copied the tree, ran `gitnexus analyze --force` with no `--skip-agents-md`, and confirmed only the delimited section changed while the appended paragraph survived intact.

That same run demonstrated the wider problem — it rewrote the block's own stale-index line from `node .gitnexus/run.cjs analyze` to `npx gitnexus analyze`, dropping the #1939 workaround exactly as the skills do.

## AGENTS.md too

The two files are byte-identical mirrors and stay that way here. Warning Claude but not the agents reading `AGENTS.md` would leave the ones most likely to run analyze unattended unwarned.

Upstream: abhigyanpatwari/GitNexus#3080.
