### PR TITLE
docs(openspec): document apiary plugins in the CLI spec

### DIFF
--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -69,6 +69,69 @@ apiary validate [--config path] [--connectivity]
 
 ---
 
+### `apiary plugins`
+
+Find, install and inspect out-of-process plugins (see the plugin-api spec's
+External Plugin Protocol). The registry-backed subcommands resolve names against
+a plugin index; the rest report on what is installed on disk.
+
+```
+apiary plugins search [query] [--capability id] [--registry url] [--offline]
+apiary plugins info <id>[@version] [--registry url] [--offline]
+apiary plugins install <id>[@version] [--dir path] [--yes] [--sha256 digest] [--registry url] [--offline]
+apiary plugins upgrade <id>[@version] [--rollback] [--dir path] [--yes] [--sha256 digest] [--registry url] [--offline]
+apiary plugins uninstall <id> [--force]
+apiary plugins list
+apiary plugins inspect <id>
+apiary plugins validate
+```
+
+| Subcommand | Description |
+|---|---|
+| `search` | Registry entries matching a query, optionally filtered by capability |
+| `info` | One listing: capabilities, repository, releases, the conformance verdict registry CI recorded, and whether any release is installable on this host |
+| `install` | Resolve, verify, present, and install one plugin (see below) |
+| `upgrade` | The same, replacing an installed plugin; keeps one generation as `<id>.bak` and restores it if the new copy fails to validate |
+| `uninstall` | Remove an installed plugin directory |
+| `list` | Installed plugins with each one's configured state |
+| `inspect` | Print one installed manifest as JSON |
+| `validate` | Re-check installed manifests, enabled instances' `config`, and pinned executables |
+
+| Flag | Description |
+|---|---|
+| `--capability` | Only entries declaring this capability (`search`) |
+| `--registry` | Registry index URL for this invocation (`https://` or `file://`), overriding `plugin_registries` |
+| `--offline` | Resolve from the cached index; never touch the network |
+| `--dir` | Plugin directory to install into (default: the first `plugin_dirs` entry) |
+| `--yes` | Skip the confirmation prompt — not the summary it prints |
+| `--sha256` | Expected archive digest, cross-checked against the registry's before anything is downloaded |
+| `--rollback` | Restore the version kept by the last upgrade (`upgrade`) |
+| `--force` | Uninstall even while the plugin is enabled in `apiary.yaml` (`uninstall`) |
+
+`install` and `upgrade` run in one order, and abort at the first failure without
+leaving anything in a searched directory: resolve the release for this host
+(version constraint, protocol, platform, withdrawals) before downloading; verify
+the archive digest; unpack into a staging directory, rejecting entries that are
+not plain files or directories; load and validate the manifest; confirm it is the
+plugin and version that were requested; verify the executable digest; pin it;
+print the plugin's declared access and ask for confirmation; commit with one
+atomic rename.
+
+Invariants:
+
+- **Installing never enables.** A plugin runs only once the operator adds a
+  `plugins:` entry and restarts the daemon. `install` prints the snippet and
+  never writes to `apiary.yaml`; `uninstall` never removes an entry.
+- **The daemon never contacts a registry.** Resolution, download and signature
+  verification happen only in these commands.
+- **Verification cannot be skipped.** Where a registry has a pinned signing key,
+  an unsigned, malformed or mismatched index fails the command; there is no flag
+  to proceed. Where no key is available, commands report the index as unverified
+  rather than implying a check that did not happen.
+- **No plugin code executes** in any of these commands, including `validate`.
+
+---
+
 ### `apiary cells`
 
 List tasks currently visible to Apiary, before routing.


### PR DESCRIPTION
Closes the gap I flagged in #459.

`openspec/specs/cli/spec.md` documented nine commands and had never mentioned `apiary plugins` — not since the plugin SDK shipped `list`, `inspect` and `validate`, and not after the registry added `search`, `info`, `install`, `upgrade` and `uninstall`. A spec that omits a whole command group is worse than one that is merely out of date: nothing in it says it is incomplete.

## What's in

All **eight** subcommands, not just the five new ones — the older three were the original gap. Written in the file's existing shape: description, usage block, tables, `---`. Placed after `apiary validate`, whose sibling `plugins validate` it is.

Beyond the surface, it records the invariants — the part worth holding the system to when someone later proposes a convenience:

- **Installing never enables.** `install` prints the `plugins:` snippet and never writes `apiary.yaml`; `uninstall` never removes an entry.
- **The daemon never contacts a registry.** Resolution, download and verification live only in these commands.
- **Verification cannot be skipped** where a key is pinned, and is reported as *absent* where none is available.
- **No plugin code executes** in any of them, `validate` included.

The install/upgrade ordering is written out as a sequence, because "which check happens before the download" is the property the design turns on, and it is not recoverable from a flag table.

## Verification

Not transcribed from memory — a script extracts every subcommand and flag from the new section and checks each against `--help` on the built binary:

```
all 8 subcommands and their documented flags exist
```
