### PR TITLE
fix(approvals): mint a fresh request each time a gate is re-entered

### DIFF
--- a/docs/human-approvals.md
+++ b/docs/human-approvals.md
@@ -205,6 +205,30 @@ the caller immediately rather than holding the connection open — and a respons
 persisted immediately before a crash is applied once the parked workflow is
 rehydrated.
 
+## A gate inside a rework loop
+
+A gate can sit inside a loop — `on_fail.goto` or `on_reject.restart_from` pointing
+at a step *before* the gate — and the workflow will re-enter it on every lap. Each
+visit opens its own request, so every lap is answerable on its own; answering lap 1
+never closes lap 2.
+
+The request id carries the lap. The first visit is `<instance>:<step>`, and each
+later one appends its attempt:
+
+```bash
+$ apiary approvals
+  REQUEST                            WORKFLOW         STEP           PARKED    EXPIRES
+  wf-8a31:pre-review@3               jira-implement   pre-review     4m        in 23h
+```
+
+Answer the id `apiary approvals` prints, not one remembered from an earlier lap —
+an id whose lap is already resolved is refused with `already approved`. The
+earlier laps' decisions stay in the store as their own rows, so the audit trail
+shows every answer the gate collected rather than only the last one.
+
+A timeout, `remind_after`, and `escalate_after` are all measured from the current
+lap's park, not from the first one.
+
 The execution timeline records `approval.requested`, `approval.reminder`,
 `approval.escalated`, `approval.granted`, `approval.rejected`, and
 `approval.timed_out`. Actor, channel, feedback, form values, request identity, and

--- a/src/internal/db/approval_rework_loop_test.go
+++ b/src/internal/db/approval_rework_loop_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// A rework loop re-enters the same approval step on the same workflow instance.
+// Each visit must mint its own answerable request instead of resurfacing the
+// previous lap's resolved one, which used to leave the human's decision bouncing
+// off with "already approved" forever (#462).
+func TestCreateApprovalRequestMintsFreshAttemptPerLap(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	lap1 := &ApprovalRequest{ID: "inst:pre-review", WorkflowInstanceID: "inst", StepID: "pre-review", Message: "review?"}
+	if err := c.CreateApprovalRequest(ctx, lap1); err != nil {
+		t.Fatal(err)
+	}
+	if lap1.ID != "inst:pre-review" || lap1.Attempt != 1 {
+		t.Fatalf("lap 1: id=%q attempt=%d, want inst:pre-review/1", lap1.ID, lap1.Attempt)
+	}
+
+	// Still open: re-creating hands back the same gate, never a second one.
+	again := &ApprovalRequest{ID: "inst:pre-review", WorkflowInstanceID: "inst", StepID: "pre-review", Message: "review?"}
+	if err := c.CreateApprovalRequest(ctx, again); err != nil {
+		t.Fatal(err)
+	}
+	if again.ID != lap1.ID || again.Attempt != 1 {
+		t.Fatalf("re-entry while open: id=%q attempt=%d, want the open request back", again.ID, again.Attempt)
+	}
+
+	if _, won, err := c.ResolveApprovalRequest(ctx, lap1.ID, ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "cli", IdempotencyKey: "k1", Values: map[string]any{"decision": "rework"}}); err != nil || !won {
+		t.Fatalf("resolve lap 1: won=%v err=%v", won, err)
+	}
+
+	lap2 := &ApprovalRequest{ID: "inst:pre-review", WorkflowInstanceID: "inst", StepID: "pre-review", Message: "review?"}
+	if err := c.CreateApprovalRequest(ctx, lap2); err != nil {
+		t.Fatal(err)
+	}
+	if lap2.Attempt != 2 || lap2.ID != "inst:pre-review@2" {
+		t.Fatalf("lap 2: id=%q attempt=%d, want inst:pre-review@2/2", lap2.ID, lap2.Attempt)
+	}
+	if lap2.Status != ApprovalPending {
+		t.Fatalf("lap 2 status=%q, want pending", lap2.Status)
+	}
+
+	// The instance is parked on the newest lap, so that is what the pollers see.
+	current, err := c.GetApprovalByInstance(ctx, "inst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current == nil || current.ID != lap2.ID {
+		t.Fatalf("GetApprovalByInstance=%+v, want %s", current, lap2.ID)
+	}
+
+	// And it is answerable: lap 1's decision does not block it.
+	if _, won, err := c.ResolveApprovalRequest(ctx, lap2.ID, ApprovalResponse{Decision: "reject", Actor: "alice", Channel: "cli", IdempotencyKey: "k2"}); err != nil || !won {
+		t.Fatalf("resolve lap 2: won=%v err=%v", won, err)
+	}
+	if stored, _ := c.GetApprovalRequest(ctx, lap1.ID); stored.Status != ApprovalApproved {
+		t.Fatalf("lap 1 status=%q, want the earlier decision preserved", stored.Status)
+	}
+}
+
+// A database created before the attempt column carries the narrow
+// UNIQUE(workflow_instance_id, step_id) constraint, which no ALTER can widen.
+// InitSchema must rebuild the table, keeping the existing rows and the responses
+// that reference them by id.
+func TestInitSchemaWidensLegacyApprovalUniqueness(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+
+	// Recreate the pre-#462 shape underneath the migrated one.
+	legacy := []string{
+		`DROP TABLE approval_requests`,
+		`CREATE TABLE approval_requests (
+		  id TEXT PRIMARY KEY,
+		  workflow_instance_id TEXT NOT NULL,
+		  task_id TEXT, workflow_id TEXT, step_id TEXT NOT NULL, message TEXT,
+		  approvers TEXT NOT NULL DEFAULT '[]', delegates TEXT NOT NULL DEFAULT '{}', required_approvals INTEGER NOT NULL DEFAULT 1, fields TEXT NOT NULL DEFAULT '[]',
+		  status TEXT NOT NULL DEFAULT 'pending', response_values TEXT NOT NULL DEFAULT '{}',
+		  feedback TEXT, responded_by TEXT, response_channel TEXT,
+		  idempotency_key TEXT UNIQUE, created_at DATETIME NOT NULL, expires_at DATETIME,
+		  reminded_at DATETIME, escalated_at DATETIME, responded_at DATETIME,
+		  UNIQUE(workflow_instance_id, step_id)
+		)`,
+		`INSERT INTO approval_requests (id, workflow_instance_id, step_id, status, created_at)
+		 VALUES ('inst:gate', 'inst', 'gate', 'approved', '2026-08-01 10:00:00')`,
+	}
+	for _, stmt := range legacy {
+		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if legacyKey, err := hasLegacyApprovalUnique(ctx, c.db); err != nil || !legacyKey {
+		t.Fatalf("setup: legacy=%v err=%v", legacyKey, err)
+	}
+
+	if err := InitSchema(ctx, c.db); err != nil {
+		t.Fatal(err)
+	}
+	if legacyKey, err := hasLegacyApprovalUnique(ctx, c.db); err != nil || legacyKey {
+		t.Fatalf("after migrate: legacy=%v err=%v", legacyKey, err)
+	}
+	stored, err := c.GetApprovalRequest(ctx, "inst:gate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored == nil || stored.Attempt != 1 || stored.Status != ApprovalApproved {
+		t.Fatalf("carried row=%+v, want the approved lap 1 with attempt 1", stored)
+	}
+
+	// The whole point: a second lap now fits.
+	lap2 := &ApprovalRequest{ID: "inst:gate", WorkflowInstanceID: "inst", StepID: "gate"}
+	if err := c.CreateApprovalRequest(ctx, lap2); err != nil {
+		t.Fatal(err)
+	}
+	if lap2.ID != "inst:gate@2" {
+		t.Fatalf("lap 2 id=%q, want inst:gate@2", lap2.ID)
+	}
+}

--- a/src/internal/db/approval_store.go
+++ b/src/internal/db/approval_store.go
@@ -35,11 +35,15 @@ type ApprovalRequest struct {
 	RespondedBy        string              `json:"responded_by,omitempty"`
 	ResponseChannel    string              `json:"response_channel,omitempty"`
 	IdempotencyKey     string              `json:"idempotency_key,omitempty"`
-	CreatedAt          time.Time           `json:"created_at"`
-	ExpiresAt          *time.Time          `json:"expires_at,omitempty"`
-	RemindedAt         *time.Time          `json:"reminded_at,omitempty"`
-	EscalatedAt        *time.Time          `json:"escalated_at,omitempty"`
-	RespondedAt        *time.Time          `json:"responded_at,omitempty"`
+	// Attempt counts this step's visits within the instance, starting at 1. A
+	// rework loop re-enters the same approval step on the same instance and each
+	// lap gets its own answerable request (#462).
+	Attempt     int        `json:"attempt,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	RemindedAt  *time.Time `json:"reminded_at,omitempty"`
+	EscalatedAt *time.Time `json:"escalated_at,omitempty"`
+	RespondedAt *time.Time `json:"responded_at,omitempty"`
 }
 
 type ApprovalResponse struct {
@@ -52,6 +56,19 @@ type ApprovalResponse struct {
 	Values         map[string]any `json:"values,omitempty"`
 }
 
+// CreateApprovalRequest persists a request for one visit to an approval step.
+//
+// The caller supplies a base id (instance:step). When the step is re-entered by
+// a rework loop the previous lap's request is already terminally resolved, so a
+// fresh attempt is minted and the id is suffixed "@<attempt>" to keep it unique
+// — req.ID is rewritten in place, and callers must use it (not the id they
+// passed) for notifications and audit events. Reusing lap 1's resolved row
+// instead is what wedged looping workflows: every later lap dead-ended at an
+// approval that answered "already approved" (#462).
+//
+// It is still idempotent within a lap: while a request for the pair is
+// unresolved (pending or escalated), re-creating returns that row verbatim —
+// req is overwritten with the stored one — rather than opening a second gate.
 func (c *Client) CreateApprovalRequest(ctx context.Context, req *ApprovalRequest) error {
 	if req.ID == "" || req.WorkflowInstanceID == "" || req.StepID == "" {
 		return fmt.Errorf("approval id, instance, and step are required")
@@ -65,21 +82,58 @@ func (c *Client) CreateApprovalRequest(ctx context.Context, req *ApprovalRequest
 	if req.CreatedAt.IsZero() {
 		req.CreatedAt = time.Now().UTC()
 	}
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// An unresolved request for this step is the gate that is already open:
+	// hand it back instead of opening a second one.
+	open, err := c.scanApproval(tx.QueryRowContext(ctx, approvalSelect+
+		` WHERE workflow_instance_id=? AND step_id=? AND status IN (?,?) ORDER BY attempt DESC LIMIT 1`,
+		req.WorkflowInstanceID, req.StepID, ApprovalPending, ApprovalEscalated))
+	if err != nil {
+		return err
+	}
+	if open != nil {
+		*req = *open
+		return nil
+	}
+
+	if req.Attempt <= 0 {
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COALESCE(MAX(attempt), 0) + 1 FROM approval_requests WHERE workflow_instance_id=? AND step_id=?`,
+			req.WorkflowInstanceID, req.StepID).Scan(&req.Attempt); err != nil {
+			return err
+		}
+	}
+	if req.Attempt > 1 {
+		req.ID = fmt.Sprintf("%s@%d", req.ID, req.Attempt)
+	}
+
 	approvers, _ := json.Marshal(req.Approvers)
 	delegates, _ := json.Marshal(req.Delegates)
 	fields, _ := json.Marshal(req.Fields)
-	_, err := c.db.ExecContext(ctx, `INSERT INTO approval_requests
-		(id, workflow_instance_id, task_id, workflow_id, step_id, message, approvers, delegates, required_approvals, fields, status, created_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(workflow_instance_id, step_id) DO NOTHING`,
-		req.ID, req.WorkflowInstanceID, nullStr(req.TaskID), nullStr(req.WorkflowID), req.StepID, nullStr(req.Message), string(approvers), string(delegates), req.RequiredApprovals, string(fields), req.Status, req.CreatedAt, req.ExpiresAt)
-	return err
+	if _, err := tx.ExecContext(ctx, `INSERT INTO approval_requests
+		(id, workflow_instance_id, task_id, workflow_id, step_id, message, approvers, delegates, required_approvals, fields, status, created_at, expires_at, attempt)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(workflow_instance_id, step_id, attempt) DO NOTHING`,
+		req.ID, req.WorkflowInstanceID, nullStr(req.TaskID), nullStr(req.WorkflowID), req.StepID, nullStr(req.Message), string(approvers), string(delegates), req.RequiredApprovals, string(fields), req.Status, req.CreatedAt, req.ExpiresAt, req.Attempt); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (c *Client) GetApprovalRequest(ctx context.Context, id string) (*ApprovalRequest, error) {
 	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE id=?`, id))
 }
+
+// GetApprovalByInstance returns the instance's most recently minted request —
+// the one it is parked on. rowid breaks a created_at tie so a loop that re-enters
+// the same step twice inside one clock tick still returns the newer lap's row and
+// not the resolved one it supersedes (#462).
 func (c *Client) GetApprovalByInstance(ctx context.Context, id string) (*ApprovalRequest, error) {
-	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE workflow_instance_id=? ORDER BY created_at DESC LIMIT 1`, id))
+	return c.scanApproval(c.db.QueryRowContext(ctx, approvalSelect+` WHERE workflow_instance_id=? ORDER BY created_at DESC, rowid DESC LIMIT 1`, id))
 }
 func (c *Client) ListApprovalRequests(ctx context.Context, status string, limit int) ([]ApprovalRequest, error) {
 	if limit <= 0 || limit > 500 {
@@ -227,7 +281,7 @@ func (c *Client) updateApprovalStatus(ctx context.Context, id, status string, fr
 	return n == 1, nil
 }
 
-const approvalSelect = `SELECT id, workflow_instance_id, COALESCE(task_id,''), COALESCE(workflow_id,''), step_id, COALESCE(message,''), approvers, delegates, required_approvals, fields, status, response_values, COALESCE(feedback,''), COALESCE(responded_by,''), COALESCE(response_channel,''), COALESCE(idempotency_key,''), created_at, expires_at, reminded_at, escalated_at, responded_at FROM approval_requests`
+const approvalSelect = `SELECT id, workflow_instance_id, COALESCE(task_id,''), COALESCE(workflow_id,''), step_id, COALESCE(message,''), approvers, delegates, required_approvals, fields, status, response_values, COALESCE(feedback,''), COALESCE(responded_by,''), COALESCE(response_channel,''), COALESCE(idempotency_key,''), attempt, created_at, expires_at, reminded_at, escalated_at, responded_at FROM approval_requests`
 
 type approvalScanner interface{ Scan(...any) error }
 
@@ -241,7 +295,7 @@ func (c *Client) scanApproval(row approvalScanner) (*ApprovalRequest, error) {
 func scanApprovalRow(row approvalScanner) (*ApprovalRequest, error) {
 	var req ApprovalRequest
 	var approvers, delegates, fields, values string
-	err := row.Scan(&req.ID, &req.WorkflowInstanceID, &req.TaskID, &req.WorkflowID, &req.StepID, &req.Message, &approvers, &delegates, &req.RequiredApprovals, &fields, &req.Status, &values, &req.Feedback, &req.RespondedBy, &req.ResponseChannel, &req.IdempotencyKey, &req.CreatedAt, &req.ExpiresAt, &req.RemindedAt, &req.EscalatedAt, &req.RespondedAt)
+	err := row.Scan(&req.ID, &req.WorkflowInstanceID, &req.TaskID, &req.WorkflowID, &req.StepID, &req.Message, &approvers, &delegates, &req.RequiredApprovals, &fields, &req.Status, &values, &req.Feedback, &req.RespondedBy, &req.ResponseChannel, &req.IdempotencyKey, &req.Attempt, &req.CreatedAt, &req.ExpiresAt, &req.RemindedAt, &req.EscalatedAt, &req.RespondedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -330,7 +330,12 @@ CREATE TABLE IF NOT EXISTS approval_requests (
   feedback TEXT, responded_by TEXT, response_channel TEXT,
   idempotency_key TEXT UNIQUE, created_at DATETIME NOT NULL, expires_at DATETIME,
   reminded_at DATETIME, escalated_at DATETIME, responded_at DATETIME,
-  UNIQUE(workflow_instance_id, step_id)
+  -- attempt counts this step's visits within the instance. A rework loop
+  -- legitimately re-enters the same approval step on the same instance, and each
+  -- visit needs its own answerable request; keying uniqueness on the pair alone
+  -- resurfaced lap 1's already-resolved row forever (#462).
+  attempt INTEGER NOT NULL DEFAULT 1,
+  UNIQUE(workflow_instance_id, step_id, attempt)
 );
 CREATE TABLE IF NOT EXISTS approval_responses (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -501,6 +506,10 @@ var migrations = []string{
 	`CREATE INDEX IF NOT EXISTS idx_improvement_findings_run ON improvement_findings(run_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_improvement_findings_scope ON improvement_findings(scope, state)`,
 	`CREATE INDEX IF NOT EXISTS idx_improvement_runs_created ON improvement_runs(created_at DESC)`,
+	// Per-lap approval requests (#462). The column is additive; the UNIQUE
+	// constraint it belongs to is widened by rebuildApprovalRequestsAttempt,
+	// since SQLite cannot alter a table-level constraint in place.
+	`ALTER TABLE approval_requests ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1`,
 }
 
 // InitSchema creates all tables and indices. Safe to call multiple times (uses IF NOT EXISTS).
@@ -522,7 +531,126 @@ func InitSchema(ctx context.Context, db *sql.DB) error {
 	if err := repairSupersededFailedTasks(ctx, db); err != nil {
 		return fmt.Errorf("repair superseded failed tasks: %w", err)
 	}
+	if err := rebuildApprovalRequestsAttempt(ctx, db); err != nil {
+		return fmt.Errorf("widen approval_requests uniqueness: %w", err)
+	}
 	return nil
+}
+
+// rebuildApprovalRequestsAttempt widens the approval_requests uniqueness from
+// (workflow_instance_id, step_id) to (workflow_instance_id, step_id, attempt).
+//
+// A workflow that loops back past an approval step re-enters the same step id on
+// the same instance. Under the two-column key the engine could not mint a second
+// request for lap 2, so it kept resurfacing lap 1's already-resolved row and the
+// human's answer bounced off with "already approved" — wedging the instance
+// permanently (#462).
+//
+// SQLite cannot drop or alter a table-level UNIQUE constraint, so the table has
+// to be rebuilt. Foreign keys are off on our connections, and approval_responses
+// references approval_requests(id) — ids are preserved verbatim by the copy, so
+// the responses keep pointing at the right rows. Idempotent: once the widened
+// constraint is in place the detection below stops matching.
+func rebuildApprovalRequestsAttempt(ctx context.Context, db *sql.DB) error {
+	needs, err := hasLegacyApprovalUnique(ctx, db)
+	if err != nil || !needs {
+		return err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	stmts := []string{
+		`CREATE TABLE approval_requests_new (
+		  id TEXT PRIMARY KEY,
+		  workflow_instance_id TEXT NOT NULL,
+		  task_id TEXT, workflow_id TEXT, step_id TEXT NOT NULL, message TEXT,
+		  approvers TEXT NOT NULL DEFAULT '[]', delegates TEXT NOT NULL DEFAULT '{}', required_approvals INTEGER NOT NULL DEFAULT 1, fields TEXT NOT NULL DEFAULT '[]',
+		  status TEXT NOT NULL DEFAULT 'pending', response_values TEXT NOT NULL DEFAULT '{}',
+		  feedback TEXT, responded_by TEXT, response_channel TEXT,
+		  idempotency_key TEXT UNIQUE, created_at DATETIME NOT NULL, expires_at DATETIME,
+		  reminded_at DATETIME, escalated_at DATETIME, responded_at DATETIME,
+		  attempt INTEGER NOT NULL DEFAULT 1,
+		  UNIQUE(workflow_instance_id, step_id, attempt)
+		)`,
+		`INSERT INTO approval_requests_new
+		  (id, workflow_instance_id, task_id, workflow_id, step_id, message, approvers, delegates, required_approvals, fields,
+		   status, response_values, feedback, responded_by, response_channel, idempotency_key, created_at, expires_at,
+		   reminded_at, escalated_at, responded_at, attempt)
+		 SELECT id, workflow_instance_id, task_id, workflow_id, step_id, message, approvers, delegates, required_approvals, fields,
+		   status, response_values, feedback, responded_by, response_channel, idempotency_key, created_at, expires_at,
+		   reminded_at, escalated_at, responded_at, COALESCE(attempt, 1)
+		 FROM approval_requests`,
+		`DROP TABLE approval_requests`,
+		`ALTER TABLE approval_requests_new RENAME TO approval_requests`,
+		`CREATE INDEX IF NOT EXISTS idx_approval_requests_status ON approval_requests(status, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_approval_requests_instance ON approval_requests(workflow_instance_id)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("%s: %w", strings.SplitN(stmt, "\n", 2)[0], err)
+		}
+	}
+	return tx.Commit()
+}
+
+// hasLegacyApprovalUnique reports whether approval_requests still carries the
+// narrow two-column UNIQUE(workflow_instance_id, step_id) constraint. A brand-new
+// database is created from the schema const, which already carries the wide key,
+// so this reports false there.
+func hasLegacyApprovalUnique(ctx context.Context, db *sql.DB) (bool, error) {
+	rows, err := db.QueryContext(ctx, `PRAGMA index_list(approval_requests)`)
+	if err != nil {
+		return false, err
+	}
+	var uniques []string
+	for rows.Next() {
+		// seq, name, unique, origin, partial
+		var seq int
+		var name, origin string
+		var unique, partial int
+		if err := rows.Scan(&seq, &name, &unique, &origin, &partial); err != nil {
+			rows.Close()
+			return false, err
+		}
+		if unique == 1 && origin == "u" {
+			uniques = append(uniques, name)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	for _, name := range uniques {
+		cols, err := indexColumns(ctx, db, name)
+		if err != nil {
+			return false, err
+		}
+		if len(cols) == 2 && cols[0] == "workflow_instance_id" && cols[1] == "step_id" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// indexColumns returns the column names an index covers, in index order.
+func indexColumns(ctx context.Context, db *sql.DB, index string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`PRAGMA index_info(%q)`, index))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var cols []string
+	for rows.Next() {
+		var seqno, cid int
+		var name sql.NullString
+		if err := rows.Scan(&seqno, &cid, &name); err != nil {
+			return nil, err
+		}
+		cols = append(cols, name.String)
+	}
+	return cols, rows.Err()
 }
 
 // repairSupersededFailedTasks corrects tasks stranded in 'failed' by builds

--- a/src/internal/workflow/approval_rework_loop_test.go
+++ b/src/internal/workflow/approval_rework_loop_test.go
@@ -1,0 +1,99 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
+)
+
+// An approval step sitting inside a rework loop is re-entered on every lap of the
+// same workflow instance. Each re-entry must mint a fresh, answerable request:
+// under the old (instance, step) uniqueness the engine resurfaced lap 1's already
+// resolved row, so the human's lap-2 answer bounced off with "already approved"
+// and the instance wedged for good (#462).
+func TestApprovalInsideReworkLoopIsAnswerableOnEveryLap(t *testing.T) {
+	ctx := context.Background()
+	client := realDB(t)
+
+	exec := newSeqExecutor()
+	exec.scripts["verify"] = []StepResult{
+		{Success: false, Output: "needs rework"}, // lap 1 → loop back past the gate
+		{Success: true, Output: "LGTM"},          // lap 2 → done
+	}
+	eng := realEngine(t, client, exec)
+
+	wf := config.WorkflowConfig{
+		ID: "rework-gate",
+		Steps: []config.StepConfig{
+			{ID: "implement", Agent: "agent-a"},
+			// Explicit approvers keep the gate waiting for a persisted response
+			// rather than a source comment, which is the path the CLI and the
+			// dashboard both take.
+			{ID: "pre-review", Type: config.StepTypeApproval, DependsOn: []string{"implement"},
+				Message: "Ready for review?", Approvers: []string{"alice"}, RequiredApprovals: 1},
+			{ID: "verify", Agent: "agent-b", DependsOn: []string{"pre-review"},
+				OnFail: &config.StepOutcome{Goto: "implement", MaxRetries: 2}},
+		},
+	}
+
+	instID, success, err := eng.RunInstance(ctx, wf, model.InternalTask{ID: "T-462"})
+	if err != nil {
+		t.Fatalf("RunInstance: %v", err)
+	}
+	if success {
+		t.Fatal("instance parked at the gate should not report success")
+	}
+
+	answer := func(lap int, key string) *db.ApprovalRequest {
+		t.Helper()
+		req, err := client.GetApprovalByInstance(ctx, instID)
+		if err != nil || req == nil {
+			t.Fatalf("lap %d: request=%+v err=%v", lap, req, err)
+		}
+		if req.Status != db.ApprovalPending {
+			t.Fatalf("lap %d: request %s is %q, want pending — the human cannot answer it", lap, req.ID, req.Status)
+		}
+		response := db.ApprovalResponse{Decision: "approve", Actor: "alice", Channel: "cli", IdempotencyKey: key}
+		if _, won, err := client.ResolveApprovalRequest(ctx, req.ID, response); err != nil || !won {
+			t.Fatalf("lap %d: resolving %s: won=%v err=%v", lap, req.ID, won, err)
+		}
+		if _, err := eng.ResolveApprovalResponse(ctx, instID, response); err != nil {
+			t.Fatalf("lap %d: advance: %v", lap, err)
+		}
+		return req
+	}
+
+	lap1 := answer(1, "cli-lap-1")
+	if lap1.Attempt != 1 || lap1.ID != instID+":pre-review" {
+		t.Fatalf("lap 1 request=%s attempt=%d", lap1.ID, lap1.Attempt)
+	}
+
+	// verify failed and looped back past the gate: the instance is parked again,
+	// this time on a request of its own.
+	if parked := eng.ParkedApprovals(); len(parked) != 1 || parked[0].Step.ID != "pre-review" {
+		t.Fatalf("after lap 1: parked=%+v, want one park at pre-review", parked)
+	}
+	lap2 := answer(2, "cli-lap-2")
+	if lap2.Attempt != 2 || lap2.ID == lap1.ID {
+		t.Fatalf("lap 2 request=%s attempt=%d, want a fresh request distinct from %s", lap2.ID, lap2.Attempt, lap1.ID)
+	}
+
+	inst, err := client.GetWorkflowInstance(ctx, instID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inst.State != db.InstanceStateDone {
+		t.Fatalf("instance state=%q, want done — the second lap should have run to completion", inst.State)
+	}
+
+	// Both decisions survive as separate audit rows.
+	for _, want := range []string{lap1.ID, lap2.ID} {
+		stored, err := client.GetApprovalRequest(ctx, want)
+		if err != nil || stored == nil || stored.Status != db.ApprovalApproved {
+			t.Fatalf("request %s=%+v err=%v, want an approved row per lap", want, stored, err)
+		}
+	}
+}

--- a/src/internal/workflow/dag.go
+++ b/src/internal/workflow/dag.go
@@ -533,7 +533,16 @@ func (e *Engine) enterApproval(ctx context.Context, r *dagRun, step config.StepC
 	}
 	request := &db.ApprovalRequest{ID: requestID, WorkflowInstanceID: r.instID, TaskID: r.task.ID, WorkflowID: r.wf.ID, StepID: step.ID, Message: step.Message, Approvers: step.Approvers, Delegates: step.Delegates, RequiredApprovals: step.RequiredApprovals, Fields: fields, CreatedAt: r.parkedAt, ExpiresAt: expires}
 	if store, ok := e.store.(approvalRequestStore); ok {
-		_ = store.CreateApprovalRequest(ctx, request)
+		// The store owns the lap number: a rework loop re-enters this same step id
+		// on this same instance, and each visit needs its own answerable request.
+		// It rewrites request.ID for lap 2 and beyond, so everything below must use
+		// request.ID rather than the base id built above (#462). A failure here is
+		// worth saying out loud — it used to be swallowed, which is how a gate
+		// nobody could answer looked like a healthy park.
+		if err := store.CreateApprovalRequest(ctx, request); err != nil {
+			aplog.Error("workflow %s: persisting approval request for step %q on instance %s: %v", r.wf.ID, step.ID, r.instID, err)
+		}
+		requestID = request.ID
 	}
 	for _, provider := range e.approvalProviders {
 		if err := provider.RequestApproval(ctx, request); err != nil {


### PR DESCRIPTION
Closes #462.

## The bug

`approval_requests` was keyed `UNIQUE(workflow_instance_id, step_id)`. A workflow shaped like `pre-review (approval) → [rework] → plan → implement → review → pre-review (again, same instance)` legitimately re-enters the same `step_id` on the same `workflow_instance_id` on every lap, and there was no room for a second row.

So the engine resurfaced lap 1's already-`approved` request. Two things then went wrong at once:

- `apiary approve <id>` / a dashboard click on lap 2 hit `approval request … is already approved` — the human could no longer answer the gate at all.
- `Dispatcher.checkApprovals` read the same stale row, saw `approved`, and re-applied lap 1's decision to lap 2's park.

The instance wedged until someone forced a brand-new one, discarding the old instance's context.

## The fix

Uniqueness is now `(workflow_instance_id, step_id, attempt)`.

The store owns the lap number. `CreateApprovalRequest` is still idempotent *within* a lap — while a request for the step is `pending` or `escalated`, re-creating hands that same gate back rather than opening a second one — but once the previous lap is terminally resolved the next visit mints attempt N and suffixes the id `@N`:

```
wf-8a31:pre-review      lap 1
wf-8a31:pre-review@2    lap 2
```

`@` rather than `#` because these ids travel through `/approvals/<id>/respond`. Every lap keeps its own row, so the audit trail shows every answer the gate collected instead of only the first.

`enterApproval` now reads `request.ID` back from the store for the provider notifications and the `approval.requested` event, and logs a failed create instead of swallowing it — the silent `_ =` is a large part of why a gate nobody could answer looked like a healthy park.

`GetApprovalByInstance` breaks a `created_at` tie by `rowid`, so a loop that re-enters a gate inside one clock tick still returns the new lap rather than the resolved one it supersedes.

## Migration

SQLite cannot drop or alter a table-level `UNIQUE`, so existing databases are migrated by rebuilding the table (`rebuildApprovalRequestsAttempt`, run from `InitSchema`). It detects the narrow two-column key via `PRAGMA index_list`/`index_info` and is a no-op afterwards. Foreign keys are off on our connections and ids are copied verbatim, so `approval_responses` keeps pointing at the right rows.

## Tests

- `TestCreateApprovalRequestMintsFreshAttemptPerLap` — reuse while open, fresh attempt once resolved, both rows answerable and preserved.
- `TestInitSchemaWidensLegacyApprovalUniqueness` — builds the pre-fix table, migrates it, and confirms a second lap now fits.
- `TestApprovalInsideReworkLoopIsAnswerableOnEveryLap` — end-to-end through the engine on a real SQLite store: gate → verify fails → loop back past the gate → gate is answerable again → instance reaches `done`.

`go build ./... && go vet ./... && go test ./...` all pass.

Docs: a new "A gate inside a rework loop" section in `docs/human-approvals.md` explains the per-lap ids and that timeout/remind/escalate are measured from the current lap's park.