### PR TITLE
feat(state): write the canonical vocabulary, split state from reason (release N+1)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -99,8 +99,12 @@ apiary instances <instance-id>
 apiary instances <instance-id> --cancel
 ```
 
-States: `pending`, `running`, `approval_waiting`, `interrupted`, `done`,
-`failed`.
+States: `queued`, `running`, `blocked`, `done`, `failed`, `canceled`.
+
+A `blocked` instance carries a reason saying what it is waiting on — `approval`,
+`ci`, `dependency` — or `interrupted` when a daemon died mid-run and left it
+orphaned. Only the last of those is resumable; the others are alive and will
+continue on their own.
 
 `--cancel` stops one running instance: its in-flight step is cancelled and the
 instance is marked `interrupted`, along with any queued or leased dispatch job

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -89,7 +89,8 @@ erDiagram
         TEXT workflow_id
         TEXT cell_id
         TEXT source_id
-        TEXT state "pending|running|approval_waiting|interrupted|done|failed"
+        TEXT state "queued|running|blocked|done|failed|canceled"
+        TEXT blocked_reason "approval|ci|dependency|interrupted"
         TEXT parent_instance_id "sub-workflow child"
         TEXT resumed_from
         TEXT task_id FK "-> internal_tasks.id"
@@ -102,7 +103,9 @@ erDiagram
         TEXT workflow_instance_id FK
         TEXT step_id "workflow step config id"
         TEXT agent_id
-        TEXT state "pending|running|passed|failed|skipped|skipped_cached"
+        TEXT state "queued|running|blocked|done|failed|skipped"
+        TEXT blocked_reason "approval|ci|dependency|interrupted"
+        TEXT skipped_reason "cached"
         TEXT output "agent output (output prompt)"
         TEXT structured_output "JSON (APIARY_OUTPUT)"
         TEXT summary
@@ -146,7 +149,8 @@ erDiagram
         TEXT description
         TEXT input "JSON from spawner"
         TEXT dedup_key "idempotent spawn: UNIQUE(parent_task_id, dedup_key)"
-        TEXT state "registered|running|approval_waiting|done|failed"
+        TEXT state "queued|running|blocked|done|failed|canceled"
+        TEXT blocked_reason "approval|ci|dependency|retry_backoff|interrupted"
         TEXT metadata "JSON: labels, priority, type"
         INTEGER outstanding_workflows
         TIMESTAMP created_at

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -569,7 +569,7 @@ if: ${{ not (memory.track == "docs" or memory.track == "chore") }}
 ### Approval steps
 
 An approval step parks the workflow until a human answers it. The instance
-enters the `approval_waiting` state and survives daemon restarts.
+enters the `blocked` state with a `blocked_reason` of `approval`, and survives daemon restarts.
 
 The simplest form waits for whoever is running apiary — no approver list, no
 source signals:

--- a/openspec/changes/unified-task-state-model/proposal.md
+++ b/openspec/changes/unified-task-state-model/proposal.md
@@ -372,7 +372,17 @@ understand the new vocabulary before any binary starts producing it.
 - **Recovering the true reason for historical `waiting` rows** — the data is not there (§3).
 - **Renaming `task_executions` legacy `success`/`failed` execution statuses** — that table is the
   agent-run log, a different axis from workflow lifecycle; folding it in would widen the diff
-  without clarifying anything.
+  without clarifying anything. (The dashboard normalizes it for display.)
+- **The DAG scheduler's in-memory vocabulary** (`internal/workflow/dag.go`: `stPending`,
+  `stRunning`, `stPassed`, `stFailed`, `stSkipped`, `stCondSkipped`, `stWaiting`) — a fifth
+  vocabulary found during implementation. It is deliberately left alone for two reasons: it never
+  reaches the database, and it *is* the user-facing expression API — `steps.lint.state ==
+  'passed'` in a workflow condition reads these values. Renaming them would break every deployed
+  config's conditions while changing nothing an operator sees.
+- **Vocabularies that merely share words.** GitHub CI statuses (`source.CIStatus`:
+  `passed|failed|pending|conflict`), approval-request statuses (`pending|approved|rejected|
+  timed_out`), and plugin conformance verdicts all use these words for unrelated domains. They are
+  untouched; a find-and-replace over the state strings would have corrupted every one.
 
 ---
 

--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -17,6 +17,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/daemon"
 	"github.com/orlandoburli/apiary/internal/format"
+	apstate "github.com/orlandoburli/apiary/internal/state"
 )
 
 var (
@@ -314,43 +315,45 @@ func stateCell(state string, width int) string {
 	return stateColor(state).Render(state) + strings.Repeat(" ", pad)
 }
 
-func stateColor(state string) lipgloss.Style {
-	switch state {
-	case "passed", "done":
+func stateColor(st string) lipgloss.Style {
+	switch apstate.Normalize(st) {
+	case apstate.Done:
 		return instOK
-	case "failed":
+	case apstate.Failed:
 		return instErr
-	case "running", "approval_waiting":
+	case apstate.Running, apstate.Blocked:
 		return instWarn
 	default:
 		return instMuted
 	}
 }
 
-func stateGlyph(state string) string {
-	switch state {
-	case "done":
+func stateGlyph(st string) string {
+	switch apstate.Normalize(st) {
+	case apstate.Done:
 		return instOK.Render("✓")
-	case "failed":
+	case apstate.Failed:
 		return instErr.Render("✗")
-	case "running":
+	case apstate.Running:
 		return instWarn.Render("●")
-	case "approval_waiting":
+	case apstate.Blocked:
 		return instWarn.Render("⏸")
 	default:
 		return instMuted.Render("○")
 	}
 }
 
-func stepGlyph(state string) string {
-	switch state {
-	case "passed":
+func stepGlyph(st string) string {
+	switch apstate.Normalize(st) {
+	case apstate.Done:
 		return instOK.Render("✓")
-	case "failed":
+	case apstate.Failed:
 		return instErr.Render("✗")
-	case "running":
+	case apstate.Running:
 		return instWarn.Render("●")
-	case "skipped", "skipped_cached":
+	case apstate.Blocked:
+		return instWarn.Render("⏸")
+	case apstate.Skipped:
 		return instMuted.Render("⊘")
 	default:
 		return instMuted.Render("○")

--- a/src/internal/config/timeout_test.go
+++ b/src/internal/config/timeout_test.go
@@ -56,8 +56,8 @@ func TestStallTimeoutParsing(t *testing.T) {
 		{"", 0},
 		{"0", 0},
 		{"20m", 20 * time.Minute},
-		{"-5m", 0},        // negative is meaningless; treat as disabled
-		{"nonsense", 0},   // unparseable must not silently enable a killer
+		{"-5m", 0},      // negative is meaningless; treat as disabled
+		{"nonsense", 0}, // unparseable must not silently enable a killer
 	}
 	for _, tc := range cases {
 		s := Settings{StallTimeout: tc.in}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -31,6 +31,7 @@ import (
 	runnerimpl "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
 	"github.com/orlandoburli/apiary/internal/source/pluginsource"
+	"github.com/orlandoburli/apiary/internal/state"
 	"github.com/orlandoburli/apiary/internal/version"
 	workerpkg "github.com/orlandoburli/apiary/internal/worker"
 	"github.com/orlandoburli/apiary/internal/workflow"
@@ -78,8 +79,8 @@ type Dispatcher struct {
 	// nil when no DB is configured (tests / dry-run without persistence).
 	binder source.SourceBinder
 
-	sem        chan struct{}            // poll concurrency (size 1)
-	agentSem   map[string]chan struct{} // per-agent dispatch concurrency
+	sem      chan struct{}            // poll concurrency (size 1)
+	agentSem map[string]chan struct{} // per-agent dispatch concurrency
 	// bg tracks every goroutine the dispatcher spawns to carry a dispatch
 	// forward off the poll loop (fan-out runs, PR-event runs, parked
 	// approval/wait advances, resumes). Waiting on it gives callers — chiefly
@@ -558,6 +559,17 @@ func (d *Dispatcher) Start(ctx context.Context, wg *sync.WaitGroup) {
 			aplog.Warn("reconcile orphan task counters: %v", err)
 		} else if recounted > 0 || settled > 0 {
 			aplog.Info("reconciled outstanding counter on %d task(s), settled %d stranded task(s)", recounted, settled)
+		}
+
+		// Carry interruption up to the task, so a task whose every instance was
+		// orphaned reads as blocked/interrupted instead of sitting in the queued
+		// state and looking like it had just arrived (#465). Runs after the
+		// recount above, which is what makes the outstanding counter trustworthy
+		// enough to test here.
+		if n, err := d.db.PropagateInterruptedToTasks(ctx); err != nil {
+			aplog.Warn("propagate interrupted instances to tasks: %v", err)
+		} else if n > 0 {
+			aplog.Info("marked %d task(s) blocked after their workflow instances were interrupted", n)
 		}
 	}
 	if d.db != nil {
@@ -1142,9 +1154,12 @@ func (d *Dispatcher) ForceRestart(ctx context.Context, ref string) (RestartResul
 			aplog.Error("force-restart %s: list workflow instances: %v", cellID, err)
 		} else {
 			for _, inst := range insts {
-				switch inst.State {
-				case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStateWaiting, db.InstanceStatePending:
-					if err := d.db.UpdateWorkflowInstanceState(ctx, inst.ID, db.InstanceStateInterrupted); err != nil {
+				// Anything not yet settled gets interrupted. A negative test
+				// rather than a list of live states: the canonical vocabulary
+				// collapses the three parked states onto one, and a positive
+				// list is what silently misses a state added later (#465).
+				if !state.State(inst.State).IsTerminal() {
+					if err := d.db.UpdateWorkflowInstanceState(ctx, inst.ID, db.InstanceStateBlocked, string(state.ReasonInterrupted)); err != nil {
 						aplog.Error("force-restart %s: interrupt instance %s: %v", cellID, inst.ID, err)
 					} else {
 						aplog.Info("force-restart %s: interrupted workflow instance %s (was %s)", cellID, inst.ID, inst.State)

--- a/src/internal/daemon/dropped_dispatch_test.go
+++ b/src/internal/daemon/dropped_dispatch_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/queue"
 	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // captureLogs redirects the global log sink for the duration of a test and
@@ -253,7 +254,7 @@ func TestDropActiveMatchesTreatsInterruptedAsTerminal(t *testing.T) {
 	ctx := context.Background()
 	dbc := openDropTestDB(t, "interrupted.db")
 
-	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-implement", CellID: "297869", TaskID: "T2", State: db.InstanceStateInterrupted})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "jira-implement", CellID: "297869", TaskID: "T2", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted)})
 
 	d := &Dispatcher{db: dbc}
 	kept, dropped := d.dropActiveMatches(ctx, "T2", []router.Match{{Route: config.RouteConfig{ID: "jira-implement"}}})

--- a/src/internal/daemon/forcerestart_workflow_test.go
+++ b/src/internal/daemon/forcerestart_workflow_test.go
@@ -37,8 +37,8 @@ func TestForceRestart_InterruptsWorkflowInstance(t *testing.T) {
 	if err != nil || inst == nil {
 		t.Fatalf("get instance: inst=%v err=%v", inst, err)
 	}
-	if inst.State != db.InstanceStateInterrupted {
-		t.Fatalf("instance state = %q, want %q", inst.State, db.InstanceStateInterrupted)
+	if inst.State != db.InstanceStateBlocked {
+		t.Fatalf("instance state = %q, want %q", inst.State, db.InstanceStateBlocked)
 	}
 
 	// dropActiveMatches no longer shadows the workflow, so the next poll re-dispatches.

--- a/src/internal/daemon/inflight_guard_test.go
+++ b/src/internal/daemon/inflight_guard_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // TestDropActiveMatches verifies the source-agnostic in-flight guard: a workflow
@@ -24,7 +25,7 @@ func TestDropActiveMatches(t *testing.T) {
 
 	// task T1: implementation parked at an approval step (the gap inFlight misses);
 	// triage already done.
-	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "implementation", CellID: "1948", TaskID: "T1", State: db.InstanceStateApprovalWaiting})
+	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i1", WorkflowID: "implementation", CellID: "1948", TaskID: "T1", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval)})
 	_ = dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: "i2", WorkflowID: "triage", CellID: "1948", TaskID: "T1", State: db.InstanceStateDone})
 
 	d := &Dispatcher{db: dbc}

--- a/src/internal/daemon/instance_detail_test.go
+++ b/src/internal/daemon/instance_detail_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // TestInstanceDetail_IncludesCIPolls verifies the wait_for CI poll history is
@@ -20,7 +21,7 @@ func TestInstanceDetail_IncludesCIPolls(t *testing.T) {
 	t.Cleanup(func() { _ = dbc.Close() })
 
 	mustCreateInstance(t, dbc, &db.WorkflowInstance{
-		ID: "wi_ci", WorkflowID: "implementation", CellID: "42", State: db.InstanceStateWaiting,
+		ID: "wi_ci", WorkflowID: "implementation", CellID: "42", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonCI),
 	})
 	if err := dbc.CreateStepRun(ctx, &db.StepRun{
 		ID: "wi_ci-implement", WorkflowInstanceID: "wi_ci", StepID: "implement", AgentID: "engineer", State: db.StepStatePassed,

--- a/src/internal/daemon/parked_approval_concurrency_test.go
+++ b/src/internal/daemon/parked_approval_concurrency_test.go
@@ -140,7 +140,7 @@ func TestCheckApprovals_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
 
 	for _, id := range []string{instA, instB} {
 		inst, _ := dbc.GetWorkflowInstance(ctx, id)
-		if inst == nil || inst.State != db.InstanceStateApprovalWaiting {
+		if inst == nil || inst.State != db.InstanceStateBlocked {
 			t.Fatalf("instance %s not parked at approval (state=%v)", id, inst)
 		}
 	}
@@ -183,7 +183,7 @@ func TestCheckApprovals_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
 		t.Errorf("wedged instance A was re-evaluated (polls %d→%d) over %d cycles; it should be skipped via approvalAdvancing",
 			aWedged, got, cycles)
 	}
-	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateApprovalWaiting {
+	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateBlocked {
 		t.Errorf("instance B should still be parked (un-approved), got %v", inst)
 	}
 

--- a/src/internal/daemon/parked_wait_concurrency_test.go
+++ b/src/internal/daemon/parked_wait_concurrency_test.go
@@ -166,7 +166,7 @@ func TestCheckWaits_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
 
 	for _, id := range []string{instA, instB} {
 		inst, _ := dbc.GetWorkflowInstance(ctx, id)
-		if inst == nil || inst.State != db.InstanceStateWaiting {
+		if inst == nil || inst.State != db.InstanceStateBlocked {
 			t.Fatalf("instance %s not parked at wait_for (state=%v)", id, inst)
 		}
 	}
@@ -208,7 +208,7 @@ func TestCheckWaits_SlowAdvanceDoesNotStarveRecheck(t *testing.T) {
 		t.Errorf("wedged instance A was re-checked (polls %d→%d) over %d cycles; it should be skipped via waitAdvancing",
 			aWedged, got, cycles)
 	}
-	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateWaiting {
+	if inst, _ := dbc.GetWorkflowInstance(ctx, instB); inst == nil || inst.State != db.InstanceStateBlocked {
 		t.Errorf("instance B should still be parked (pending CI), got %v", inst)
 	}
 

--- a/src/internal/daemon/queue_dispatch.go
+++ b/src/internal/daemon/queue_dispatch.go
@@ -285,7 +285,9 @@ func (d *Dispatcher) settleRemoteQueueJob(ctx context.Context, job queue.Job) er
 		state = db.InstanceStateDone
 	}
 	if job.State == queue.JobCanceled {
-		state = db.InstanceStateInterrupted
+		// Operator cancellation is its own terminal state now, rather than being
+		// recorded as an interruption it was never quite the same as (#465).
+		state = db.InstanceStateCanceled
 	}
 	if err := d.db.CreateWorkflowInstance(ctx, &db.WorkflowInstance{ID: instanceID, WorkflowID: job.WorkflowID, TaskID: job.TaskID, SourceID: job.SourceID, State: state}); err != nil {
 		return err

--- a/src/internal/daemon/queue_redelivery_test.go
+++ b/src/internal/daemon/queue_redelivery_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/queue"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // redeliveredJob runs one poll, takes the job it enqueued for workflowID and
@@ -78,7 +79,7 @@ func TestExecuteQueuedJob_RedeliveryRunsWhenNothingIsLive(t *testing.T) {
 	job, task := redeliveredJob(t, d, dbc, "triage")
 	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
 		ID: "i-orphan", WorkflowID: "triage", CellID: "c1", SourceID: "src",
-		TaskID: task.ID, State: db.InstanceStateInterrupted,
+		TaskID: task.ID, State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted),
 	}); err != nil {
 		t.Fatalf("create interrupted instance: %v", err)
 	}

--- a/src/internal/daemon/queue_settle_parked_test.go
+++ b/src/internal/daemon/queue_settle_parked_test.go
@@ -140,7 +140,7 @@ func TestReconcileTerminalQueueJobs_LeavesParkedInstanceAlone(t *testing.T) {
 	d1, dbc1 := newParkingWorkerDispatcher(t, dbPath, adapter)
 	stop1 := runWorker(t, d1)
 	d1.poll(ctx, d1.cfg.Sources[0], adapter, time.Time{})
-	if !waitForInstanceState(t, dbc1, "c1", "triage", db.InstanceStateApprovalWaiting, 15*time.Second) {
+	if !waitForInstanceState(t, dbc1, "c1", "triage", db.InstanceStateBlocked, 15*time.Second) {
 		t.Fatalf("workflow never parked at the approval gate:%s", queueDiagnostics(t, dbc1))
 	}
 	// The job that started the parked run goes terminal even though the run is
@@ -173,7 +173,7 @@ func TestReconcileTerminalQueueJobs_LeavesParkedInstanceAlone(t *testing.T) {
 			t.Errorf("startup reconcile wrote placeholder instance %s (workflow %s, state %s) for a run still parked at an approval",
 				instance.ID, instance.WorkflowID, instance.State)
 		}
-		if instance.State == db.InstanceStateApprovalWaiting {
+		if instance.State == db.InstanceStateBlocked {
 			parked++
 		}
 	}

--- a/src/internal/daemon/rehydrate_approval_test.go
+++ b/src/internal/daemon/rehydrate_approval_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // approvingPoller is a poll-only source whose PollTask always reports an approving
@@ -109,7 +110,7 @@ func TestRehydrateParkedApprovals_ResumesAndSettlesTask(t *testing.T) {
 	instID := "wf-parked-1"
 	if err := dbc.CreateWorkflowInstance(ctx, &db.WorkflowInstance{
 		ID: instID, WorkflowID: "feature", TaskID: task.ID, CellID: cell.ID, SourceID: "src",
-		State: db.InstanceStateApprovalWaiting,
+		State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval),
 	}); err != nil {
 		t.Fatalf("create instance: %v", err)
 	}

--- a/src/internal/daemon/resolved.go
+++ b/src/internal/daemon/resolved.go
@@ -7,6 +7,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/db"
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // liveInstanceStates are the states a workflow instance can be in while its
@@ -14,8 +15,19 @@ import (
 // that will never come once the item is gone.
 var liveInstanceStates = []string{
 	db.InstanceStateRunning,
-	db.InstanceStateWaiting,
-	db.InstanceStateApprovalWaiting,
+	// Legacy park states, for a database not yet migrated. Canonical parks are
+	// handled by the blocked-reason pass below (#465).
+	"waiting",
+	"approval_waiting",
+}
+
+// liveBlockedReasons are the reasons a 'blocked' instance is still alive: it is
+// waiting for something that can still arrive. Interruption is excluded — an
+// orphan is dead and stopping it again is meaningless.
+var liveBlockedReasons = []string{
+	string(state.ReasonApproval),
+	string(state.ReasonCI),
+	string(state.ReasonDependency),
 }
 
 // checkResolved stops workflow instances whose source item is no longer active

--- a/src/internal/daemon/resolved_test.go
+++ b/src/internal/daemon/resolved_test.go
@@ -80,8 +80,8 @@ func TestCheckResolved_StopsInstance(t *testing.T) {
 	if len(adapter.asked) != 1 || len(adapter.asked[0]) != 1 || adapter.asked[0][0] != itemID {
 		t.Fatalf("adapter asked %v, want [[%s]]", adapter.asked, itemID)
 	}
-	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateInterrupted {
-		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateInterrupted)
+	if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateBlocked {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateBlocked)
 	}
 }
 
@@ -137,13 +137,13 @@ func TestCheckResolved_IgnoresOtherSources(t *testing.T) {
 
 // A parked instance is as pointless to keep alive as a running one.
 func TestCheckResolved_StopsParkedInstance(t *testing.T) {
-	for _, state := range []string{db.InstanceStateWaiting, db.InstanceStateApprovalWaiting} {
+	for _, state := range []string{db.InstanceStateBlocked, db.InstanceStateBlocked} {
 		t.Run(state, func(t *testing.T) {
 			ctx := context.Background()
 			dbc := openTestDB(ctx, t)
 			itemID := "fp:2026-01-01T00:00:00Z"
 			_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
-			if err := dbc.UpdateWorkflowInstanceState(ctx, instID, state); err != nil {
+			if err := dbc.UpdateWorkflowInstanceState(ctx, instID, state, ""); err != nil {
 				t.Fatalf("park instance: %v", err)
 			}
 
@@ -151,8 +151,8 @@ func TestCheckResolved_StopsParkedInstance(t *testing.T) {
 			d := &Dispatcher{db: dbc, cfg: &config.Config{}}
 			d.checkResolved(ctx, srcCfg(true), adapter)
 
-			if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateInterrupted {
-				t.Fatalf("instance state = %q, want %q", got, db.InstanceStateInterrupted)
+			if got := instanceState(ctx, t, dbc, instID); got != db.InstanceStateBlocked {
+				t.Fatalf("instance state = %q, want %q", got, db.InstanceStateBlocked)
 			}
 		})
 	}
@@ -164,7 +164,7 @@ func TestCheckResolved_LeavesTerminalInstances(t *testing.T) {
 	dbc := openTestDB(ctx, t)
 	itemID := "fp:2026-01-01T00:00:00Z"
 	_, instID := seedBoundTask(ctx, t, dbc, "prod-alerts", itemID)
-	if err := dbc.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateDone); err != nil {
+	if err := dbc.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateDone, ""); err != nil {
 		t.Fatalf("finish instance: %v", err)
 	}
 

--- a/src/internal/daemon/restart_unknown_id_test.go
+++ b/src/internal/daemon/restart_unknown_id_test.go
@@ -142,8 +142,8 @@ func TestForceRestart_KnownCellStillRestarts(t *testing.T) {
 	if err != nil || inst == nil {
 		t.Fatalf("get instance: inst=%v err=%v", inst, err)
 	}
-	if inst.State != db.InstanceStateInterrupted {
-		t.Errorf("instance state = %q, want %q", inst.State, db.InstanceStateInterrupted)
+	if inst.State != db.InstanceStateBlocked {
+		t.Errorf("instance state = %q, want %q", inst.State, db.InstanceStateBlocked)
 	}
 	if len(fake.statesSet) != 1 || fake.statesSet[0] != "todo" {
 		t.Errorf("statesSet = %v, want [todo]", fake.statesSet)

--- a/src/internal/daemon/resume_auto.go
+++ b/src/internal/daemon/resume_auto.go
@@ -9,6 +9,7 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/router"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // autoResumeKey keys the in-memory guard that stops a poll from dispatching a
@@ -41,7 +42,7 @@ func (d *Dispatcher) resumeAutoInterrupted(ctx context.Context) {
 	if d.db == nil {
 		return
 	}
-	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateInterrupted)
+	instances, err := d.db.ListWorkflowInstancesBlockedBy(ctx, string(state.ReasonInterrupted))
 	if err != nil {
 		aplog.Warn("auto-resume interrupted instances: list: %v", err)
 		return

--- a/src/internal/daemon/resume_auto_test.go
+++ b/src/internal/daemon/resume_auto_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/router"
 	runnerpkg "github.com/orlandoburli/apiary/internal/runner"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // stepRecordingRunner records the step id of every run it is asked to perform,
@@ -71,7 +72,7 @@ func autoResumeFixture(t *testing.T, policy string) (*Dispatcher, *db.Client, *s
 
 	inst := &db.WorkflowInstance{
 		ID: "i-orphan", WorkflowID: "impl", CellID: "ISSUE-9", SourceID: "src",
-		TaskID: task.ID, State: db.InstanceStateInterrupted,
+		TaskID: task.ID, State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted),
 	}
 	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
 		t.Fatalf("create instance: %v", err)
@@ -79,7 +80,7 @@ func autoResumeFixture(t *testing.T, policy string) (*Dispatcher, *db.Client, *s
 	for _, sr := range []db.StepRun{
 		{ID: "sr1", WorkflowInstanceID: inst.ID, StepID: "plan", AgentID: "a", State: db.StepStatePassed},
 		{ID: "sr2", WorkflowInstanceID: inst.ID, StepID: "implement", AgentID: "a", State: db.StepStatePassed},
-		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateInterrupted},
+		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateBlocked},
 	} {
 		sr := sr
 		if err := dbc.CreateStepRun(ctx, &sr); err != nil {
@@ -318,7 +319,7 @@ func TestPollDoesNotRestartWhileAutoResuming(t *testing.T) {
 	}
 	inst := &db.WorkflowInstance{
 		ID: "i-orphan", WorkflowID: "impl", CellID: item.ID, SourceID: "src",
-		TaskID: task.ID, State: db.InstanceStateInterrupted,
+		TaskID: task.ID, State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted),
 	}
 	if err := dbc.CreateWorkflowInstance(ctx, inst); err != nil {
 		t.Fatalf("create instance: %v", err)
@@ -326,7 +327,7 @@ func TestPollDoesNotRestartWhileAutoResuming(t *testing.T) {
 	for _, sr := range []db.StepRun{
 		{ID: "sr1", WorkflowInstanceID: inst.ID, StepID: "plan", AgentID: "a", State: db.StepStatePassed},
 		{ID: "sr2", WorkflowInstanceID: inst.ID, StepID: "implement", AgentID: "a", State: db.StepStatePassed},
-		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateInterrupted},
+		{ID: "sr3", WorkflowInstanceID: inst.ID, StepID: "qa", AgentID: "a", State: db.StepStateBlocked},
 	} {
 		sr := sr
 		if err := dbc.CreateStepRun(ctx, &sr); err != nil {

--- a/src/internal/daemon/stop_instance_test.go
+++ b/src/internal/daemon/stop_instance_test.go
@@ -59,7 +59,7 @@ func TestStopInstance_CancelsOnlyTheNamedInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get instance: %v", err)
 	}
-	if inst.State != db.InstanceStateInterrupted {
+	if inst.State != db.InstanceStateBlocked {
 		t.Errorf("stopped instance state = %q, want interrupted", inst.State)
 	}
 	keep, err := d.db.GetWorkflowInstance(ctx, "i-keep")

--- a/src/internal/daemon/workflow.go
+++ b/src/internal/daemon/workflow.go
@@ -13,6 +13,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/router"
 	"github.com/orlandoburli/apiary/internal/runner/execution"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 	"github.com/orlandoburli/apiary/internal/workflow"
 )
 
@@ -90,7 +91,7 @@ func (d *Dispatcher) rehydrateParkedApprovals(ctx context.Context) {
 	if d.db == nil {
 		return
 	}
-	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateApprovalWaiting)
+	instances, err := d.db.ListWorkflowInstancesBlockedBy(ctx, string(state.ReasonApproval))
 	if err != nil {
 		aplog.Warn("rehydrate parked approvals: list instances: %v", err)
 		return
@@ -137,7 +138,7 @@ func (d *Dispatcher) rehydrateParkedWaits(ctx context.Context) {
 	if d.db == nil {
 		return
 	}
-	instances, err := d.db.ListWorkflowInstancesByState(ctx, db.InstanceStateWaiting)
+	instances, err := d.db.ListWorkflowInstancesBlockedBy(ctx, string(state.ReasonCI), string(state.ReasonDependency))
 	if err != nil {
 		aplog.Warn("rehydrate parked waits: list instances: %v", err)
 		return
@@ -207,6 +208,14 @@ func (t dbTaskTracker) HasFailedInstance(ctx context.Context, taskID string) (bo
 
 func (t dbTaskTracker) SetTaskState(ctx context.Context, taskID string, state model.TaskState) error {
 	return t.db.InternalTasks().UpdateTaskState(ctx, taskID, state)
+}
+
+func (t dbTaskTracker) SetTaskStateReason(ctx context.Context, taskID string, state model.TaskState, reason string) error {
+	return t.db.InternalTasks().UpdateTaskStateReason(ctx, taskID, state, reason)
+}
+
+func (t dbTaskTracker) CountConsecutiveFailedInstances(ctx context.Context, taskID, workflowID string) (int, error) {
+	return t.db.CountConsecutiveFailedInstances(ctx, taskID, workflowID)
 }
 
 // dispatchWorkflow runs a matched task through the workflow engine. The route is

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -12,6 +12,7 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // ErrTaskNotFound is returned by DeleteTask when no task, binding, or workflow
@@ -318,7 +319,7 @@ func (d *Dispatcher) StopInstance(ctx context.Context, instanceID string) error 
 	}
 
 	// Mark the instance itself interrupted.
-	if err := d.db.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateInterrupted); err != nil {
+	if err := d.db.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateBlocked, string(state.ReasonInterrupted)); err != nil {
 		aplog.Error("stop instance %s: update state: %v", instanceID, err)
 	}
 	aplog.Info("stopped instance %s (cell %s)", instanceID, inst.CellID)
@@ -592,7 +593,15 @@ func instanceSummary(v db.WorkflowInstanceView, now time.Time) InstanceSummary {
 // interrupted/pending where no meaningful span exists.
 func instanceDuration(inst db.WorkflowInstance, now time.Time) string {
 	switch inst.State {
-	case db.InstanceStateRunning, db.InstanceStateApprovalWaiting, db.InstanceStateWaiting:
+	case db.InstanceStateRunning:
+		return humanDuration(now.Sub(inst.CreatedAt))
+	case db.InstanceStateBlocked:
+		// A run parked on an approval or a CI wait is still accruing wall clock;
+		// an interrupted one stopped when the daemon died, and its elapsed time
+		// is not meaningful (#465).
+		if inst.BlockedReason == string(state.ReasonInterrupted) {
+			return "—"
+		}
 		return humanDuration(now.Sub(inst.CreatedAt))
 	case db.InstanceStateDone, db.InstanceStateFailed:
 		return humanDuration(inst.UpdatedAt.Sub(inst.CreatedAt))

--- a/src/internal/daemon/workflow_ipc_test.go
+++ b/src/internal/daemon/workflow_ipc_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 func TestInstanceDuration(t *testing.T) {
@@ -23,7 +24,7 @@ func TestInstanceDuration(t *testing.T) {
 		},
 		{
 			name:    "approval_waiting uses now-created",
-			inst:    db.WorkflowInstance{State: db.InstanceStateApprovalWaiting, CreatedAt: base},
+			inst:    db.WorkflowInstance{State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval), CreatedAt: base},
 			wantDur: "02:00",
 		},
 		{
@@ -38,7 +39,7 @@ func TestInstanceDuration(t *testing.T) {
 		},
 		{
 			name:    "interrupted has no span",
-			inst:    db.WorkflowInstance{State: db.InstanceStateInterrupted, CreatedAt: base},
+			inst:    db.WorkflowInstance{State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted), CreatedAt: base},
 			wantDur: "—",
 		},
 	}

--- a/src/internal/daemon/workflow_resume.go
+++ b/src/internal/daemon/workflow_resume.go
@@ -12,6 +12,7 @@ import (
 	aplog "github.com/orlandoburli/apiary/internal/log"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // Resume error sentinels. They map to CLI exit codes / HTTP statuses:
@@ -57,8 +58,17 @@ type ResumePreview struct {
 // resumableState reports whether an instance in this state can be resumed.
 // Only failed and interrupted instances qualify; done/running/approval_waiting/
 // pending are rejected (approval_waiting resumes via the polling loop, not here).
-func resumableState(state string) bool {
-	return state == db.InstanceStateFailed || state == db.InstanceStateInterrupted
+// resumableState reports whether an instance in this state can be resumed.
+//
+// It takes the blocked reason because the canonical vocabulary collapses
+// approval waits, CI waits and interruption onto "blocked" (#465), and only the
+// last of those is resumable: a run parked on an approval is alive and will
+// continue when someone answers, so resuming it would double-run the workflow.
+func resumableState(st, reason string) bool {
+	if st == db.InstanceStateFailed {
+		return true
+	}
+	return st == db.InstanceStateBlocked && reason == string(state.ReasonInterrupted)
 }
 
 // workflowByID resolves a workflow definition by id, covering both declared
@@ -84,7 +94,7 @@ func (d *Dispatcher) ResumePreview(ctx context.Context, id string, opts ResumeOp
 	if inst == nil {
 		return nil, ErrInstanceNotFound
 	}
-	if !resumableState(inst.State) {
+	if !resumableState(inst.State, inst.BlockedReason) {
 		return nil, ErrInstanceNotResumable
 	}
 	wf, err := d.resumeWorkflow(ctx, inst, opts.ConfigMode)
@@ -162,7 +172,7 @@ func (d *Dispatcher) startResume(ctx context.Context, id string, opts ResumeOpti
 	if inst == nil {
 		return "", ErrInstanceNotFound
 	}
-	if !resumableState(inst.State) {
+	if !resumableState(inst.State, inst.BlockedReason) {
 		return "", ErrInstanceNotResumable
 	}
 	wf, err := d.resumeWorkflow(ctx, inst, opts.ConfigMode)

--- a/src/internal/daemon/workflow_resume_test.go
+++ b/src/internal/daemon/workflow_resume_test.go
@@ -9,20 +9,30 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 func TestResumableState(t *testing.T) {
-	cases := map[string]bool{
-		db.InstanceStateFailed:          true,
-		db.InstanceStateInterrupted:     true,
-		db.InstanceStateDone:            false,
-		db.InstanceStateRunning:         false,
-		db.InstanceStateApprovalWaiting: false,
-		db.InstanceStatePending:         false,
+	// The canonical vocabulary files interruption, approval waits and CI waits
+	// all under "blocked", so the reason is what separates a resumable orphan
+	// from a live park (#465).
+	cases := []struct {
+		st     string
+		reason string
+		want   bool
+	}{
+		{db.InstanceStateFailed, "", true},
+		{db.InstanceStateBlocked, string(state.ReasonInterrupted), true},
+		{db.InstanceStateBlocked, string(state.ReasonApproval), false},
+		{db.InstanceStateBlocked, string(state.ReasonCI), false},
+		{db.InstanceStateBlocked, "", false},
+		{db.InstanceStateDone, "", false},
+		{db.InstanceStateRunning, "", false},
+		{db.InstanceStateQueued, "", false},
 	}
-	for state, want := range cases {
-		if got := resumableState(state); got != want {
-			t.Errorf("resumableState(%q) = %v, want %v", state, got, want)
+	for _, c := range cases {
+		if got := resumableState(c.st, c.reason); got != c.want {
+			t.Errorf("resumableState(%q, %q) = %v, want %v", c.st, c.reason, got, c.want)
 		}
 	}
 }

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -1955,7 +1955,7 @@ type workflowInstancesRefreshMsg struct {
 // whose request row is missing or carries no message, since an empty Message
 // hides the banner (and its key hints) entirely.
 func applyApprovalPrompt(ctx context.Context, dbConn *db.Client, item *WorkflowInstanceItem) {
-	if item == nil || item.State != db.InstanceStateApprovalWaiting {
+	if item == nil || !blockedOnApproval(item.State, item.BlockedReason) {
 		return
 	}
 	if dbConn != nil {
@@ -1972,11 +1972,12 @@ func applyApprovalPrompt(ctx context.Context, dbConn *db.Client, item *WorkflowI
 // usage) from a stored workflow instance, for the live monitor views.
 func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.WorkflowInstance) *WorkflowInstanceItem {
 	item := &WorkflowInstanceItem{
-		ID:        inst.ID,
-		Workflow:  inst.WorkflowID,
-		State:     inst.State,
-		CellID:    inst.CellID,
-		CreatedAt: inst.CreatedAt,
+		ID:            inst.ID,
+		Workflow:      inst.WorkflowID,
+		State:         inst.State,
+		BlockedReason: inst.BlockedReason,
+		CellID:        inst.CellID,
+		CreatedAt:     inst.CreatedAt,
 	}
 	applyApprovalPrompt(ctx, dbConn, item)
 	steps, err := dbConn.ListStepRuns(ctx, inst.ID)
@@ -1985,15 +1986,17 @@ func buildWorkflowInstanceItem(ctx context.Context, dbConn *db.Client, inst *db.
 		now := time.Now()
 		for _, s := range steps {
 			si := WorkflowStepItem{
-				StepID:     s.StepID,
-				Agent:      s.AgentID,
-				State:      s.State,
-				Duration:   wfStepDuration(s, now),
-				Cached:     s.SkippedCached,
-				Output:     s.Output,
-				Summary:    s.Summary,
-				StartedAt:  s.StartedAt,
-				FinishedAt: s.FinishedAt,
+				StepID:        s.StepID,
+				Agent:         s.AgentID,
+				State:         s.State,
+				BlockedReason: s.BlockedReason,
+				SkippedReason: s.SkippedReason,
+				Duration:      wfStepDuration(s, now),
+				Cached:        s.SkippedCached,
+				Output:        s.Output,
+				Summary:       s.Summary,
+				StartedAt:     s.StartedAt,
+				FinishedAt:    s.FinishedAt,
 			}
 			si.InputTokens, si.OutputTokens, si.TotalTokens, si.NumTurns, si.NumToolCalls, si.CostUSD =
 				stepUsageFromMap(s, usage)
@@ -2752,6 +2755,7 @@ func mapInstances(ctx context.Context, dbConn *db.Client, insts []db.WorkflowIns
 			ID:               in.ID,
 			Workflow:         in.WorkflowID,
 			State:            in.State,
+			BlockedReason:    in.BlockedReason,
 			CellID:           in.CellID,
 			ParentInstanceID: in.ParentInstanceID,
 			ResumedFrom:      in.ResumedFrom,
@@ -2987,6 +2991,8 @@ func mapStepRuns(steps []db.StepRun, now time.Time) []WorkflowStepItem {
 			StepID:              s.StepID,
 			Agent:               s.AgentID,
 			State:               s.State,
+			BlockedReason:       s.BlockedReason,
+			SkippedReason:       s.SkippedReason,
 			Duration:            wfStepDuration(s, now),
 			Cached:              s.SkippedCached,
 			Output:              s.Output,
@@ -3883,7 +3889,7 @@ func renderTaskInstances(d *TaskItem) string {
 			dur = in.FinishedAt.Sub(*in.StartedAt).Round(time.Second).String()
 		}
 		b.WriteString(fmt.Sprintf("    %s %s %s %s %s %s%s\n",
-			pad(wfInstanceBadge(in.State), colState),
+			pad(wfInstanceBadge(in.State, in.BlockedReason), colState),
 			pad(truncate(in.Workflow, colWf), colWf),
 			StyleMuted.Render(pad(tsCell(in.StartedAt), colTime)),
 			StyleMuted.Render(pad(tsCell(in.FinishedAt), colTime)),
@@ -3960,13 +3966,13 @@ func renderWorkflowSteps(inst *WorkflowInstanceItem, width int) string {
 	var b strings.Builder
 	b.WriteString("\n  " + StyleLabel.Render("Workflow") + "      " +
 		StyleValueStrong.Render(valueOr(inst.Workflow, "—")) + "  " +
-		wfInstanceBadge(inst.State) + "\n")
+		wfInstanceBadge(inst.State, inst.BlockedReason) + "\n")
 
 	if summary := wfInstanceSummary(inst); summary != "" {
 		b.WriteString("              " + summary + "\n")
 	}
 
-	if inst.State == db.InstanceStateApprovalWaiting && inst.Message != "" {
+	if blockedOnApproval(inst.State, inst.BlockedReason) && inst.Message != "" {
 		b.WriteString(approvalBanner(inst.Message, width))
 		if inst.Approval != nil {
 			if len(inst.Approval.Approvers) > 0 {
@@ -4138,64 +4144,114 @@ func wfStepHeader() string {
 // step id, agent, started, ended, duration, tokens, state) without indentation or
 // trailing newline, aligned under wfStepHeader. Callers add the indent.
 func wfStepRow(s WorkflowStepItem) string {
-	state := s.State
-	if s.Cached {
-		state += " (cached)"
+	stateLabel := stepStateLabel(s.State, s.BlockedReason)
+	if s.Cached || s.SkippedReason == string(state.ReasonCached) {
+		stateLabel += " (cached)"
 	}
 	return fmt.Sprintf("%s %s %s %s %s %s %s  %s",
-		wfStepGlyph(s.State),
+		wfStepGlyph(s.State, s.BlockedReason),
 		pad(truncate(s.StepID, colStep), colStep),
 		pad(truncate(s.Agent, colAgent), colAgent),
 		StyleMuted.Render(pad(tsCell(s.StartedAt), colTime)),
 		StyleMuted.Render(pad(tsCell(s.FinishedAt), colTime)),
 		StyleMuted.Render(padLeft(valueOr(s.Duration, "—"), colDur)),
 		StyleMuted.Render(padLeft(fmtTokensShort(s.TotalTokens), colTok)),
-		wfStateStyle(s.State).Render(state),
+		wfStateStyle(s.State, s.BlockedReason).Render(stateLabel),
 	)
 }
 
-func wfInstanceBadge(state string) string {
-	switch state {
-	case db.InstanceStateDone:
+// blockedOnApproval reports whether an instance is parked on a human approval
+// gate, as opposed to a CI wait or an orphaning interrupt — all three of which
+// share the 'blocked' state and are told apart only by the reason (#465). The
+// legacy state is recognised so an un-migrated database still shows its banner.
+func blockedOnApproval(st, reason string) bool {
+	return st == "approval_waiting" ||
+		(state.Normalize(st) == state.Blocked && reason == string(state.ReasonApproval))
+}
+
+// stepStateLabel is the word shown for a step's state, expanded with its reason
+// when the state alone is ambiguous. "blocked" says a step is parked; only
+// "blocked:approval" says what it is parked on (#465).
+func stepStateLabel(st, reason string) string {
+	canon, implied := state.NormalizeWithReason(st)
+	if reason == "" {
+		reason = string(implied)
+	}
+	if canon == state.Blocked && reason != "" {
+		return "blocked:" + reason
+	}
+	return string(canon)
+}
+
+// wfInstanceBadge renders an instance's state. It takes the blocked reason
+// because the canonical vocabulary collapses approval waits, CI waits and
+// interruption onto "blocked" (#465) — and those three want different words and
+// different colours: two are healthy parks, the third is an orphan.
+func wfInstanceBadge(st, reason string) string {
+	canon, implied := state.NormalizeWithReason(st)
+	// A legacy row carries its reason inside the state name
+	// ('approval_waiting', 'waiting', 'interrupted') and has no reason column
+	// value. Recover it rather than rendering a bare "blocked" that says less
+	// than the old vocabulary did.
+	if reason == "" {
+		reason = string(implied)
+	}
+	switch canon {
+	case state.Done:
 		return StyleSuccess.Render("done")
-	case db.InstanceStateFailed:
+	case state.Failed:
 		return StyleError.Render("failed")
-	case db.InstanceStateRunning:
+	case state.Canceled:
+		return StyleMuted.Render("canceled")
+	case state.Running:
 		return StyleWarning.Render("running")
-	case db.InstanceStateApprovalWaiting:
-		return StyleWarning.Render("approval_waiting")
-	case db.InstanceStateWaiting:
-		return StyleWarning.Render("waiting")
-	case db.InstanceStateInterrupted:
-		return StyleError.Render("interrupted")
+	case state.Queued:
+		return StyleMuted.Render("queued")
+	case state.Blocked:
+		switch reason {
+		case string(state.ReasonInterrupted):
+			return StyleError.Render("interrupted")
+		case "":
+			return StyleWarning.Render("blocked")
+		default:
+			return StyleWarning.Render("blocked:" + reason)
+		}
 	default:
-		return StyleMuted.Render(state)
+		return StyleMuted.Render(st)
 	}
 }
 
-func wfStepGlyph(state string) string {
-	switch state {
-	case db.StepStatePassed:
+func wfStepGlyph(st, reason string) string {
+	switch state.Normalize(st) {
+	case state.Done:
 		return StyleSuccess.Render("✓")
-	case db.StepStateFailed:
+	case state.Failed:
 		return StyleError.Render("✗")
-	case db.StepStateRunning:
+	case state.Running:
 		return StyleWarning.Render("●")
-	case db.StepStateInterrupted:
-		return StyleError.Render("⊗")
-	case db.StepStateSkipped, db.StepStateSkippedCached:
+	case state.Blocked:
+		if reason == string(state.ReasonInterrupted) {
+			return StyleError.Render("⊗")
+		}
+		return StyleWarning.Render("⏸")
+	case state.Skipped:
 		return StyleMuted.Render("⊘")
 	default:
 		return StyleMuted.Render("○")
 	}
 }
 
-func wfStateStyle(state string) lipgloss.Style {
-	switch state {
-	case db.StepStatePassed:
+func wfStateStyle(st, reason string) lipgloss.Style {
+	switch state.Normalize(st) {
+	case state.Done:
 		return StyleSuccess
-	case db.StepStateFailed, db.StepStateInterrupted:
+	case state.Failed:
 		return StyleError
+	case state.Blocked:
+		if reason == string(state.ReasonInterrupted) {
+			return StyleError
+		}
+		return StyleWarning
 	case db.StepStateRunning:
 		return StyleWarning
 	default:
@@ -4349,7 +4405,7 @@ func (a *App) taskHistoryLines() []string {
 			out = append(out, "") // blank separator between instances
 		}
 		out = append(out, historySegmentHeader(seg.Instance))
-		if seg.Instance.State == db.InstanceStateApprovalWaiting && seg.Instance.Message != "" {
+		if blockedOnApproval(seg.Instance.State, seg.Instance.BlockedReason) && seg.Instance.Message != "" {
 			out = append(out, "  "+StyleWarning.Render("⏸ "+seg.Instance.Message))
 		}
 		if len(seg.Instance.Steps) > 0 {
@@ -4384,7 +4440,7 @@ func historySegmentHeader(in WorkflowInstanceItem) string {
 	if !in.CreatedAt.IsZero() {
 		when = StyleMuted.Render(" · " + in.CreatedAt.Format("01-02 15:04"))
 	}
-	return StyleMuted.Render("── ") + wfInstanceBadge(in.State) + " " +
+	return StyleMuted.Render("── ") + wfInstanceBadge(in.State, in.BlockedReason) + " " +
 		StyleValueStrong.Render(valueOr(in.Workflow, "—")) + when + StyleMuted.Render(" ──")
 }
 
@@ -5553,13 +5609,9 @@ func taskStatusBadge(status string) string {
 // "why is this parked" is the question an operator is actually asking; the bare
 // word "blocked" is the fallback for a reason with no short form.
 func badgeLabel(raw string, s state.State, reason state.Reason) string {
-	// "success" is the legacy execution status shown on the Agents tab. It
-	// normalizes to Done, but is kept verbatim so that tab's vocabulary does not
-	// shift underneath operators in a release that changes nothing else.
-	if raw == "success" {
-		return raw
-	}
-
+	// Every state now renders as its canonical name — the render-time renaming
+	// table this function replaced is gone (#465). The Agents tab's legacy
+	// "success" normalizes to "done" along with everything else.
 	switch s {
 	case state.Blocked:
 		switch reason {
@@ -5671,7 +5723,7 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 
 	leftW, rightW := a.wfMonitorPanelWidths()
 
-	label := "WORKFLOW  " + StyleValueStrong.Render(inst.Workflow) + "  " + wfInstanceBadge(inst.State)
+	label := "WORKFLOW  " + StyleValueStrong.Render(inst.Workflow) + "  " + wfInstanceBadge(inst.State, inst.BlockedReason)
 	// When the task fanned out to several workflows, show this one's chronological
 	// position (oldest = 1) and a hint that [ / ] switch between them.
 	if n := len(t.WorkflowInstances); n > 1 {
@@ -5720,7 +5772,7 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 	for i := start; i < end; i++ {
 		s := inst.Steps[i]
 		selected := i == t.WorkflowStepIdx
-		glyph := wfStepGlyph(s.State)
+		glyph := wfStepGlyph(s.State, s.BlockedReason)
 		stepName := truncate(s.StepID, 17)
 		agent := truncate(valueOr(s.Agent, "—"), 13)
 		state := truncate(s.State, 10)
@@ -5787,7 +5839,7 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 			right.WriteString("  " + StyleLabel.Render(pad(k+":", 12)) + " " + v + "\n")
 		}
 		right.WriteString(StyleTableHeader.Render(fitLine(" "+s.StepID, rightW)) + "\n")
-		row2("State", wfStepGlyph(s.State)+" "+wfStateStyle(s.State).Render(s.State))
+		row2("State", wfStepGlyph(s.State, s.BlockedReason)+" "+wfStateStyle(s.State, s.BlockedReason).Render(stepStateLabel(s.State, s.BlockedReason)))
 		row2("Agent", valueOr(s.Agent, "—"))
 		row2("Duration", valueOr(s.Duration, "—"))
 		if s.Cached {
@@ -5829,7 +5881,7 @@ func (a *App) renderWorkflowMonitor(t *TasksTab, height int) string {
 			}
 		}
 
-		if s.State == db.StepStateRunning || s.State == db.StepStatePassed || s.State == db.StepStateFailed || s.State == db.StepStateInterrupted {
+		if s.State == db.StepStateRunning || s.State == db.StepStatePassed || s.State == db.StepStateFailed || s.State == db.StepStateBlocked {
 			right.WriteString("\n  " + StyleMuted.Render("enter/l: logs  X: stop workflow  R: restart workflow") + "\n")
 		}
 	} else {

--- a/src/internal/dashboard/approval_form_test.go
+++ b/src/internal/dashboard/approval_form_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 func newFormApp() *App {
@@ -168,7 +169,7 @@ func TestApprovalFormRendersOptions(t *testing.T) {
 func TestApprovalPromptShowsTheStepsQuestion(t *testing.T) {
 	item := &WorkflowInstanceItem{
 		ID:    "wf-1",
-		State: db.InstanceStateApprovalWaiting,
+		State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval),
 		Approval: &db.ApprovalRequest{
 			ID:      "wf-1:gate",
 			Message: "Release 2.4 is staged. How should it go out?",
@@ -187,7 +188,7 @@ func TestApprovalPromptShowsTheStepsQuestion(t *testing.T) {
 // An empty Message hides the banner and its key hints, so a request without one
 // still needs a non-empty fallback — but not the misleading old text.
 func TestApprovalPromptFallsBackWithoutAMessage(t *testing.T) {
-	item := &WorkflowInstanceItem{ID: "wf-1", State: db.InstanceStateApprovalWaiting}
+	item := &WorkflowInstanceItem{ID: "wf-1", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval)}
 	applyApprovalPrompt(context.Background(), nil, item)
 	if item.Message == "" {
 		t.Fatal("an empty message would hide the approval banner entirely")

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -173,8 +173,9 @@ type TasksTab struct {
 type WorkflowInstanceItem struct {
 	ID               string
 	Workflow         string
-	State            string // pending, running, approval_waiting, interrupted, done, failed
-	Message          string // approval message when State == approval_waiting
+	State            string // queued, running, blocked, done, failed, canceled
+	BlockedReason    string // approval, ci, dependency, interrupted — when State == blocked
+	Message          string // approval message when blocked on an approval gate
 	CellID           string // the task/cell this instance is bound to
 	ParentInstanceID string // set for sub-workflow instances
 	ResumedFrom      string // set when this instance resumed a prior one
@@ -243,7 +244,9 @@ type TaskLineageItem struct {
 type WorkflowStepItem struct {
 	StepID              string
 	Agent               string
-	State               string // pending, running, passed, failed, skipped, skipped_cached
+	State               string // queued, running, blocked, done, failed, skipped
+	BlockedReason       string // approval, ci, dependency, interrupted — when State == blocked
+	SkippedReason       string // cached — when State == skipped
 	Duration            string
 	Cached              bool
 	Output              string

--- a/src/internal/dashboard/task_lineage_render_test.go
+++ b/src/internal/dashboard/task_lineage_render_test.go
@@ -147,7 +147,7 @@ func TestTaskStatusBadge_InternalStates(t *testing.T) {
 		"done":             "done",
 		"running":          "running",
 		"failed":           "failed",
-		"success":          "success", // legacy, still supported
+		"success":          "done", // legacy execution status, now canonical
 	}
 	for state, want := range cases {
 		out := stripANSI(taskStatusBadge(state))

--- a/src/internal/dashboard/workflow_render_test.go
+++ b/src/internal/dashboard/workflow_render_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 func TestRenderWorkflowSteps_CIPolls(t *testing.T) {
@@ -76,7 +77,7 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 	inst := &WorkflowInstanceItem{
 		ID:       "wf_2",
 		Workflow: "feature-development",
-		State:    "approval_waiting",
+		State:    "approval_waiting", // legacy value: reason encoded in the state
 		Message:  "Awaiting human approval — reply on the task to resume or abort.",
 		Steps: []WorkflowStepItem{
 			{StepID: "gate", Agent: "", State: "running", Duration: "—"},
@@ -84,8 +85,10 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 	}
 
 	out := stripANSI(renderWorkflowSteps(inst, 80))
-	if !strings.Contains(out, "approval_waiting") {
-		t.Errorf("expected approval_waiting badge:\n%s", out)
+	// A legacy 'approval_waiting' row still reports what it is parked on, with
+	// the reason recovered from the state name (#465).
+	if !strings.Contains(out, "blocked:approval") {
+		t.Errorf("expected blocked:approval badge:\n%s", out)
 	}
 	if !strings.Contains(out, "Awaiting human approval") {
 		t.Errorf("expected approval message banner:\n%s", out)
@@ -93,7 +96,7 @@ func TestRenderWorkflowSteps_ApprovalBanner(t *testing.T) {
 }
 
 func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
-	inst := &WorkflowInstanceItem{ID: "wf-1", Workflow: "release", State: db.InstanceStateApprovalWaiting, Message: "Awaiting approval", Approval: &db.ApprovalRequest{ID: "wf-1:gate", Approvers: []string{"alice", "carol"}, RequiredApprovals: 2}}
+	inst := &WorkflowInstanceItem{ID: "wf-1", Workflow: "release", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval), Message: "Awaiting approval", Approval: &db.ApprovalRequest{ID: "wf-1:gate", Approvers: []string{"alice", "carol"}, RequiredApprovals: 2}}
 	out := stripANSI(renderWorkflowSteps(inst, 80))
 	for _, want := range []string{"alice, carol", "Press y to approve or n to reject"} {
 		if !strings.Contains(out, want) {
@@ -112,7 +115,7 @@ func TestRenderWorkflowSteps_ApprovalActions(t *testing.T) {
 // A gate with no approvers is answered by whoever is at the keyboard, so the
 // panel must not print an empty "Approvers:" line.
 func TestRenderWorkflowSteps_OperatorGateOmitsApprovers(t *testing.T) {
-	inst := &WorkflowInstanceItem{ID: "wf-2", Workflow: "release", State: db.InstanceStateApprovalWaiting,
+	inst := &WorkflowInstanceItem{ID: "wf-2", Workflow: "release", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval),
 		Message: "Ship it?", Approval: &db.ApprovalRequest{ID: "wf-2:gate"}}
 	out := stripANSI(renderWorkflowSteps(inst, 80))
 	if strings.Contains(out, "Approvers:") {
@@ -297,7 +300,7 @@ func TestRenderWorkflowSteps_NoMarkerWhenDone(t *testing.T) {
 // lines spilled past the panel border.
 func TestApprovalBannerRendersMarkdownWithinWidth(t *testing.T) {
 	inst := &WorkflowInstanceItem{
-		ID: "wf-1", Workflow: "release", State: db.InstanceStateApprovalWaiting,
+		ID: "wf-1", Workflow: "release", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval),
 		Message: "Release 2.4 is staged.\n\n- migrations applied\n- " +
 			strings.Repeat("a very long line that must be wrapped rather than spilling past the border ", 3),
 		Approval: &db.ApprovalRequest{ID: "wf-1:gate"},

--- a/src/internal/db/client.go
+++ b/src/internal/db/client.go
@@ -495,4 +495,3 @@ func (c *Client) UpdateAgentStatus(ctx context.Context, agentID, status, current
 	`, status, currentTaskID, time.Now(), agentID)
 	return err
 }
-

--- a/src/internal/db/execution_event_test.go
+++ b/src/internal/db/execution_event_test.go
@@ -78,7 +78,7 @@ func TestWorkflowAndStepLifecycleEvents(t *testing.T) {
 	if err := c.UpdateStepRun(ctx, step); err != nil {
 		t.Fatal(err)
 	}
-	if err := c.UpdateWorkflowInstanceState(ctx, inst.ID, InstanceStateDone); err != nil {
+	if err := c.UpdateWorkflowInstanceState(ctx, inst.ID, InstanceStateDone, ""); err != nil {
 		t.Fatal(err)
 	}
 	events, _ := c.ListExecutionEvents(ctx, ExecutionEventFilter{TaskID: "task"})

--- a/src/internal/db/schema.go
+++ b/src/internal/db/schema.go
@@ -116,7 +116,8 @@ CREATE TABLE IF NOT EXISTS workflow_instances (
   workflow_id TEXT NOT NULL,
   cell_id TEXT NOT NULL,
   source_id TEXT,
-  state TEXT NOT NULL,            -- pending|running|approval_waiting|interrupted|done|failed
+  state TEXT NOT NULL,            -- queued|running|blocked|done|failed|canceled (see internal/state)
+  blocked_reason TEXT,            -- approval|ci|dependency|retry_backoff|interrupted, when state='blocked'
   parent_instance_id TEXT,       -- set for sub-workflow child instances
   resumed_from TEXT,             -- instance id this was resumed from
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -138,7 +139,9 @@ CREATE TABLE IF NOT EXISTS step_runs (
   workflow_instance_id TEXT NOT NULL,
   step_id TEXT NOT NULL,
   agent_id TEXT,
-  state TEXT NOT NULL,           -- pending|running|passed|failed|skipped|skipped_cached
+  state TEXT NOT NULL,           -- queued|running|blocked|done|failed|skipped (see internal/state)
+  blocked_reason TEXT,           -- approval|ci|dependency|interrupted, when state='blocked'
+  skipped_reason TEXT,           -- cached, when state='skipped'
   output TEXT,
   structured_output TEXT,        -- JSON-encoded structured output
   summary TEXT,
@@ -171,7 +174,8 @@ CREATE TABLE IF NOT EXISTS internal_tasks (
   title TEXT NOT NULL,
   description TEXT,
   input TEXT,                                   -- JSON: structured input from spawner
-  state TEXT NOT NULL DEFAULT 'registered',     -- registered|running|approval_waiting|done|failed
+  state TEXT NOT NULL DEFAULT 'queued',         -- queued|running|blocked|done|failed|canceled (see internal/state)
+  blocked_reason TEXT,                          -- approval|ci|dependency|retry_backoff|interrupted
   metadata TEXT,                                -- JSON: labels, priority, type, etc.
   outstanding_workflows INTEGER DEFAULT 0,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -501,6 +505,14 @@ var migrations = []string{
 	// constraint it belongs to is widened by rebuildApprovalRequestsAttempt,
 	// since SQLite cannot alter a table-level constraint in place.
 	`ALTER TABLE approval_requests ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1`,
+	// Canonical state model (#465): the reason a row is parked or was skipped is
+	// stored beside the state rather than encoded into it. This is what lets
+	// 'approval_waiting'/'waiting'/'interrupted' collapse to 'blocked', and
+	// 'skipped_cached' to 'skipped', without losing why.
+	`ALTER TABLE internal_tasks ADD COLUMN blocked_reason TEXT`,
+	`ALTER TABLE workflow_instances ADD COLUMN blocked_reason TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN blocked_reason TEXT`,
+	`ALTER TABLE step_runs ADD COLUMN skipped_reason TEXT`,
 }
 
 // InitSchema creates all tables, indices, and additive columns. It is pure DDL:
@@ -552,6 +564,41 @@ func MigrateData(ctx context.Context, db *sql.DB) error {
 	}
 	if err := dropDispatcherState(ctx, db); err != nil {
 		return fmt.Errorf("drop dispatcher_state: %w", err)
+	}
+	if err := migrateStates(ctx, db); err != nil {
+		return fmt.Errorf("migrate states: %w", err)
+	}
+	return nil
+}
+
+// migrateStates converts stored states from the four legacy vocabularies to the
+// canonical one (#465) — but only for rows that are already terminal.
+//
+// This restriction is the whole safety argument. A task that is running, an
+// instance parked on a CI wait, and a job holding a lease are left exactly as
+// they are and convert on their next natural transition, so nothing is ever
+// rewritten underneath the engine. Normalize on the read path (internal/state)
+// means those un-migrated rows still display and compare correctly meanwhile.
+//
+// Deliberately not converted in bulk, because each is a live-row state:
+// registered, pending, approval_waiting, waiting, leased, interrupted.
+// 'interrupted' looks terminal but is the input to ReconcileOrphanWorkflowInstances
+// and to orphan propagation, so converting it here would race a daemon that is
+// mid-reconcile; reconcile rewrites those rows on every start anyway.
+//
+// Idempotent: converted rows stop matching.
+func migrateStates(ctx context.Context, db *sql.DB) error {
+	stmts := []string{
+		// Steps: 'passed' is 'done'; 'skipped_cached' is 'skipped' with a reason.
+		`UPDATE step_runs SET state = 'done' WHERE state = 'passed'`,
+		`UPDATE step_runs SET state = 'skipped', skipped_reason = 'cached' WHERE state = 'skipped_cached'`,
+		// Dispatch jobs: 'succeeded' is 'done'.
+		`UPDATE dispatch_jobs SET state = 'done' WHERE state = 'succeeded'`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
 	}
 	return nil
 }

--- a/src/internal/db/state_migration_test.go
+++ b/src/internal/db/state_migration_test.go
@@ -1,0 +1,185 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+// TestMigrateStates_OnlyTouchesTerminalRows is the safety property the whole
+// two-release rollout rests on (#465): a task that is running, an instance
+// parked on a CI wait, and a job holding a lease must come through the migration
+// untouched, so nothing is ever rewritten underneath a live engine.
+func TestMigrateStates_OnlyTouchesTerminalRows(t *testing.T) {
+	ctx := context.Background()
+	c := newStateTestClient(t)
+	now := time.Now().UTC()
+
+	seed := []string{
+		// Terminal rows in the legacy vocabulary — these SHOULD convert.
+		`INSERT INTO workflow_instances (id, workflow_id, cell_id, state, created_at, updated_at)
+		 VALUES ('i-term', 'w', 'c', 'done', '` + now.Format(time.DateTime) + `', '` + now.Format(time.DateTime) + `')`,
+		`INSERT INTO step_runs (id, workflow_instance_id, step_id, state) VALUES ('s-passed', 'i-term', 'a', 'passed')`,
+		`INSERT INTO step_runs (id, workflow_instance_id, step_id, state) VALUES ('s-cached', 'i-term', 'b', 'skipped_cached')`,
+
+		// Live rows in the legacy vocabulary — these MUST NOT convert.
+		`INSERT INTO internal_tasks (id, title, state, created_at, updated_at)
+		 VALUES ('t-live', 'running task', 'registered', '` + now.Format(time.DateTime) + `', '` + now.Format(time.DateTime) + `')`,
+		`INSERT INTO workflow_instances (id, workflow_id, cell_id, state, created_at, updated_at)
+		 VALUES ('i-wait', 'w', 'c', 'waiting', '` + now.Format(time.DateTime) + `', '` + now.Format(time.DateTime) + `')`,
+		`INSERT INTO workflow_instances (id, workflow_id, cell_id, state, created_at, updated_at)
+		 VALUES ('i-appr', 'w', 'c', 'approval_waiting', '` + now.Format(time.DateTime) + `', '` + now.Format(time.DateTime) + `')`,
+		`INSERT INTO step_runs (id, workflow_instance_id, step_id, state) VALUES ('s-run', 'i-wait', 'c', 'running')`,
+	}
+	for _, stmt := range seed {
+		if _, err := c.db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("seed %s: %v", stmt, err)
+		}
+	}
+
+	if err := c.MigrateData(ctx); err != nil {
+		t.Fatalf("MigrateData: %v", err)
+	}
+
+	get := func(table, id string) string {
+		var got string
+		if err := c.db.QueryRowContext(ctx, `SELECT state FROM `+table+` WHERE id = ?`, id).Scan(&got); err != nil {
+			t.Fatalf("read %s/%s: %v", table, id, err)
+		}
+		return got
+	}
+
+	// Converted.
+	if got := get("step_runs", "s-passed"); got != "done" {
+		t.Errorf("terminal step 'passed' = %q, want done", got)
+	}
+	if got := get("step_runs", "s-cached"); got != "skipped" {
+		t.Errorf("terminal step 'skipped_cached' = %q, want skipped", got)
+	}
+	var reason string
+	if err := c.db.QueryRowContext(ctx, `SELECT COALESCE(skipped_reason,'') FROM step_runs WHERE id='s-cached'`).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if reason != string(state.ReasonCached) {
+		t.Errorf("skipped_reason = %q, want cached", reason)
+	}
+
+	// Untouched — the whole point.
+	for _, c2 := range []struct{ table, id, want string }{
+		{"internal_tasks", "t-live", "registered"},
+		{"workflow_instances", "i-wait", "waiting"},
+		{"workflow_instances", "i-appr", "approval_waiting"},
+		{"step_runs", "s-run", "running"},
+	} {
+		if got := get(c2.table, c2.id); got != c2.want {
+			t.Errorf("live row %s/%s = %q, want it untouched (%q)", c2.table, c2.id, got, c2.want)
+		}
+	}
+}
+
+// TestPropagateInterruptedToTasks covers the first of the two defects the
+// canonical model exists to fix: a task whose every instance was orphaned used
+// to sit in the queued state, indistinguishable from one that had just arrived.
+func TestPropagateInterruptedToTasks(t *testing.T) {
+	ctx := context.Background()
+	c := newStateTestClient(t)
+	now := time.Now().UTC()
+	ts := now.Format(time.DateTime)
+
+	mkTask := func(id, st string) {
+		if _, err := c.db.ExecContext(ctx,
+			`INSERT INTO internal_tasks (id, title, state, outstanding_workflows, created_at, updated_at)
+			 VALUES (?, ?, ?, 0, ?, ?)`, id, id, st, ts, ts); err != nil {
+			t.Fatalf("seed task: %v", err)
+		}
+	}
+	mkInst := func(id, taskID, st, reason string) {
+		if _, err := c.db.ExecContext(ctx,
+			`INSERT INTO workflow_instances (id, workflow_id, cell_id, task_id, state, blocked_reason, created_at, updated_at)
+			 VALUES (?, 'w', 'c', ?, ?, ?, ?, ?)`, id, taskID, st, reason, ts, ts); err != nil {
+			t.Fatalf("seed instance: %v", err)
+		}
+	}
+
+	// Orphaned: only instance is interrupted → should propagate.
+	mkTask("t-orphan", "queued")
+	mkInst("i-orphan", "t-orphan", InstanceStateBlocked, string(state.ReasonInterrupted))
+
+	// Still alive: one interrupted, one parked on an approval → must not.
+	mkTask("t-mixed", "queued")
+	mkInst("i-dead", "t-mixed", InstanceStateBlocked, string(state.ReasonInterrupted))
+	mkInst("i-appr", "t-mixed", InstanceStateBlocked, string(state.ReasonApproval))
+
+	// Settled: terminal task → must not be reopened as blocked.
+	mkTask("t-done", "done")
+	mkInst("i-done", "t-done", InstanceStateBlocked, string(state.ReasonInterrupted))
+
+	if _, err := c.PropagateInterruptedToTasks(ctx); err != nil {
+		t.Fatalf("propagate: %v", err)
+	}
+
+	check := func(id, wantState, wantReason string) {
+		t.Helper()
+		var st, reason string
+		if err := c.db.QueryRowContext(ctx,
+			`SELECT state, COALESCE(blocked_reason,'') FROM internal_tasks WHERE id = ?`, id).Scan(&st, &reason); err != nil {
+			t.Fatalf("read %s: %v", id, err)
+		}
+		if st != wantState || reason != wantReason {
+			t.Errorf("task %s = (%q,%q), want (%q,%q)", id, st, reason, wantState, wantReason)
+		}
+	}
+	check("t-orphan", "blocked", string(state.ReasonInterrupted))
+	check("t-mixed", "queued", "")
+	check("t-done", "done", "")
+}
+
+// TestHasActiveInstanceForRoute_InterruptedDoesNotShadow pins that an orphaned
+// instance never blocks a re-dispatch. Interruption shares the 'blocked' state
+// with live parks now, so only the reason keeps these apart — and getting it
+// wrong would strand every workflow across a daemon restart.
+func TestHasActiveInstanceForRoute_InterruptedDoesNotShadow(t *testing.T) {
+	ctx := context.Background()
+	c := newStateTestClient(t)
+
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "i1", WorkflowID: "wf", CellID: "c", TaskID: "T1",
+		State: InstanceStateBlocked, BlockedReason: string(state.ReasonInterrupted),
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	active, err := c.HasActiveInstanceForRoute(ctx, "T1", "wf")
+	if err != nil {
+		t.Fatalf("has active: %v", err)
+	}
+	if active {
+		t.Error("an interrupted instance must not shadow a re-dispatch")
+	}
+
+	if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+		ID: "i2", WorkflowID: "wf", CellID: "c", TaskID: "T1",
+		State: InstanceStateBlocked, BlockedReason: string(state.ReasonApproval),
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	active, err = c.HasActiveInstanceForRoute(ctx, "T1", "wf")
+	if err != nil {
+		t.Fatalf("has active: %v", err)
+	}
+	if !active {
+		t.Error("an instance parked on an approval is alive and must shadow a re-dispatch")
+	}
+}
+
+func newStateTestClient(t *testing.T) *Client {
+	t.Helper()
+	c, err := New(context.Background(), filepath.Join(t.TempDir(), "apiary.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -130,10 +130,18 @@ func (s *InternalTaskStore) GetTask(ctx context.Context, id string) (*model.Inte
 }
 
 // UpdateTaskState transitions a task to a new state.
-func (s *InternalTaskStore) UpdateTaskState(ctx context.Context, id string, state model.TaskState) error {
+func (s *InternalTaskStore) UpdateTaskState(ctx context.Context, id string, st model.TaskState) error {
+	return s.UpdateTaskStateReason(ctx, id, st, "")
+}
+
+// UpdateTaskStateReason transitions a task, recording why when the state is
+// 'blocked'. A task blocked on an approval and one blocked because its last
+// attempt failed and another is due are the same state and differ only here
+// (#465).
+func (s *InternalTaskStore) UpdateTaskStateReason(ctx context.Context, id string, st model.TaskState, reason string) error {
 	_, err := s.db.ExecContext(ctx, `
-		UPDATE internal_tasks SET state = ?, updated_at = ? WHERE id = ?
-	`, string(state), time.Now(), id)
+		UPDATE internal_tasks SET state = ?, blocked_reason = ?, updated_at = ? WHERE id = ?
+	`, string(st), nullStr(reason), time.Now(), id)
 	return err
 }
 
@@ -173,15 +181,25 @@ func (s *InternalTaskStore) UpdateTaskMetadata(ctx context.Context, id, title, d
 // belong to a new round, so HasFailedInstance stops counting earlier rounds'
 // failures and a successful re-dispatch/escalation can settle the task as done.
 // Both CASEs read the pre-update state, so the bump and the flip agree.
+// taskReopenable matches a task that a new dispatch should reopen: one that has
+// settled, or one waiting out a retry backoff. A task blocked on an approval or
+// a CI wait must NOT match — it is alive, and reopening it would bump the
+// generation underneath a run that is still going (#465).
+const taskReopenable = `(
+	state IN ('done','failed','canceled')
+	OR (state = 'blocked' AND COALESCE(blocked_reason,'') = 'retry_backoff')
+)`
+
 func (s *InternalTaskStore) IncrementOutstanding(ctx context.Context, id string, delta int) (int, error) {
 	if _, err := s.db.ExecContext(ctx, `
 		UPDATE internal_tasks
 		SET outstanding_workflows = outstanding_workflows + ?,
-		    generation = CASE WHEN ? > 0 AND state IN ('done','failed') THEN generation + 1 ELSE generation END,
-		    state = CASE WHEN ? > 0 AND state IN ('done','failed') THEN 'running' ELSE state END,
+		    generation = CASE WHEN ? > 0 AND `+taskReopenable+` THEN generation + 1 ELSE generation END,
+		    state = CASE WHEN ? > 0 AND `+taskReopenable+` THEN 'running' ELSE state END,
+		    blocked_reason = CASE WHEN ? > 0 AND `+taskReopenable+` THEN NULL ELSE blocked_reason END,
 		    updated_at = ?
 		WHERE id = ?
-	`, delta, delta, delta, time.Now(), id); err != nil {
+	`, delta, delta, delta, delta, time.Now(), id); err != nil {
 		return 0, err
 	}
 	return s.outstanding(ctx, id)

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -4,31 +4,44 @@ import (
 	"context"
 	"database/sql"
 	"time"
+
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
-// Workflow instance states.
+// Workflow instance states — canonical values from internal/state (#465).
+//
+// The three parked states collapse onto 'blocked' and are told apart by
+// blocked_reason, so InstanceStateApprovalWaiting, InstanceStateWaiting and
+// InstanceStateInterrupted are all "blocked" and differ only in the reason
+// written alongside. Compare on the reason, never on these three names, when the
+// distinction matters — see ReconcileOrphanTaskCounters for the one place it does.
 const (
-	InstanceStatePending         = "pending"
-	InstanceStateRunning         = "running"
-	InstanceStateApprovalWaiting = "approval_waiting"
-	InstanceStateWaiting         = "waiting"
-	InstanceStateInterrupted     = "interrupted"
-	InstanceStateDone            = "done"
-	InstanceStateFailed          = "failed"
+	InstanceStateQueued   = "queued"
+	InstanceStateRunning  = "running"
+	InstanceStateBlocked  = "blocked"
+	InstanceStateDone     = "done"
+	InstanceStateFailed   = "failed"
+	InstanceStateCanceled = "canceled"
 )
+
+// InterruptedInstance reports whether an instance is an orphan: blocked because
+// execution stopped abnormally, rather than blocked awaiting something that will
+// arrive. The distinction used to be carried by a separate 'interrupted' state;
+// it is now the reason, and every caller that cared about it must say so
+// explicitly. The legacy value is still recognised for un-migrated rows.
+func InterruptedInstance(st, reason string) bool {
+	return st == "interrupted" ||
+		(st == InstanceStateBlocked && reason == string(state.ReasonInterrupted))
+}
 
 // Step run states.
 const (
-	StepStatePending       = "pending"
-	StepStateRunning       = "running"
-	StepStatePassed        = "passed"
-	StepStateFailed        = "failed"
-	StepStateSkipped       = "skipped"
-	StepStateSkippedCached = "skipped_cached"
-	// StepStateInterrupted marks a step left non-terminal (running/pending) by a
-	// previously-killed daemon. It is the step-level companion to
-	// InstanceStateInterrupted and is set by ReconcileOrphanStepRuns at startup.
-	StepStateInterrupted = "interrupted"
+	StepStateQueued  = "queued"
+	StepStateRunning = "running"
+	StepStateBlocked = "blocked"
+	StepStatePassed  = "done"
+	StepStateFailed  = "failed"
+	StepStateSkipped = "skipped"
 )
 
 // Publish states for a step run's APIARY_PUBLISH write-back.
@@ -42,12 +55,15 @@ const (
 // TaskID is the canonical link; CellID/SourceID are retained (and still populated
 // from the task's primary source binding) for the dashboard until a future change.
 type WorkflowInstance struct {
-	ID               string
-	WorkflowID       string
-	TaskID           string
-	CellID           string
-	SourceID         string
-	State            string
+	ID         string
+	WorkflowID string
+	TaskID     string
+	CellID     string
+	SourceID   string
+	State      string
+	// BlockedReason explains a State of "blocked": approval | ci | dependency |
+	// retry_backoff | interrupted. Empty for every other state.
+	BlockedReason    string
 	ParentInstanceID string
 	ResumedFrom      string
 	CreatedAt        time.Time
@@ -61,11 +77,15 @@ type StepRun struct {
 	StepID             string
 	AgentID            string
 	State              string
-	Output             string
-	StructuredOutput   string // JSON-encoded
-	Summary            string
-	ExitCode           int
-	SkippedCached      bool
+	// BlockedReason explains a State of "blocked"; SkippedReason explains
+	// "skipped" (currently only "cached"). Both empty otherwise.
+	BlockedReason    string
+	SkippedReason    string
+	Output           string
+	StructuredOutput string // JSON-encoded
+	Summary          string
+	ExitCode         int
+	SkippedCached    bool
 	// PublishPayload is the APIARY_PUBLISH text the step's agent emitted, if any.
 	PublishPayload string
 	// PublishState records the write-back outcome: sent | failed | skipped.
@@ -106,11 +126,12 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 	inst.UpdatedAt = now
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO workflow_instances
-		  (id, workflow_id, task_id, cell_id, source_id, state, parent_instance_id, resumed_from,
+		  (id, workflow_id, task_id, cell_id, source_id, state, blocked_reason, parent_instance_id, resumed_from,
 		   task_generation, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
 		        COALESCE((SELECT generation FROM internal_tasks WHERE id = ?), 0), ?, ?)
 	`, inst.ID, inst.WorkflowID, nullStr(inst.TaskID), inst.CellID, nullStr(inst.SourceID), inst.State,
+		nullStr(inst.BlockedReason),
 		nullStr(inst.ParentInstanceID), nullStr(inst.ResumedFrom), inst.TaskID, inst.CreatedAt, inst.UpdatedAt)
 	if err == nil {
 		c.recordWorkflowEvent(ctx, inst, "workflow.started", map[string]any{"state": inst.State})
@@ -121,19 +142,30 @@ func (c *Client) CreateWorkflowInstance(ctx context.Context, inst *WorkflowInsta
 	return err
 }
 
-// UpdateWorkflowInstanceState transitions an instance to a new state.
-func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state string) error {
+// UpdateWorkflowInstanceState transitions an instance to a new state, together
+// with the reason when that state is "blocked".
+//
+// The reason is a parameter rather than something the store infers because
+// "blocked" alone does not say whether the run is waiting on a human, on CI, or
+// was interrupted — and those three had distinct states before the vocabulary
+// was unified (#465). Pass "" for any state other than blocked.
+func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, newState, reason string) error {
 	inst, _ := c.GetWorkflowInstance(ctx, id)
-	if inst != nil && inst.State == state {
+	if inst != nil && inst.State == newState && inst.BlockedReason == reason {
 		return nil
 	}
 	_, err := c.db.ExecContext(ctx, `
-		UPDATE workflow_instances SET state = ?, updated_at = ? WHERE id = ?
-	`, state, time.Now(), id)
+		UPDATE workflow_instances SET state = ?, blocked_reason = ?, updated_at = ? WHERE id = ?
+	`, newState, nullStr(reason), time.Now(), id)
 	if err == nil && inst != nil {
-		inst.State = state
-		if eventType := workflowStateEventType(state); eventType != "" {
-			c.recordWorkflowEvent(ctx, inst, eventType, map[string]any{"state": state})
+		inst.State = newState
+		inst.BlockedReason = reason
+		if eventType := workflowStateEventType(newState, reason); eventType != "" {
+			meta := map[string]any{"state": newState}
+			if reason != "" {
+				meta["reason"] = reason
+			}
+			c.recordWorkflowEvent(ctx, inst, eventType, meta)
 		}
 	}
 	return err
@@ -142,7 +174,7 @@ func (c *Client) UpdateWorkflowInstanceState(ctx context.Context, id, state stri
 // GetWorkflowInstance fetches an instance by ID, or (nil, nil) if not found.
 func (c *Client) GetWorkflowInstance(ctx context.Context, id string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE id = ?
 	`, id)
@@ -205,10 +237,19 @@ func (c *Client) CountConsecutiveFailedInstances(ctx context.Context, taskID, wo
 // states do not block — they remain eligible for retry or manual resume.
 func (c *Client) HasActiveInstanceForRoute(ctx context.Context, taskID, workflowID string) (bool, error) {
 	var n int
+	// Active means running or parked-and-alive. An interrupted instance is
+	// blocked but dead: it must NOT shadow a re-dispatch, or a daemon restart
+	// would strand the workflow forever. The legacy 'running'/'approval_waiting'
+	// /'waiting' values are still matched so an un-migrated database behaves the
+	// same (#465).
 	err := c.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM workflow_instances
-		WHERE task_id = ? AND workflow_id = ? AND state IN (?, ?, ?)
-	`, taskID, workflowID, InstanceStateRunning, InstanceStateApprovalWaiting, InstanceStateWaiting).Scan(&n)
+		WHERE task_id = ? AND workflow_id = ?
+		  AND (
+		        state IN ('running','approval_waiting','waiting')
+		     OR (state = 'blocked' AND COALESCE(blocked_reason,'') <> ?)
+		      )
+	`, taskID, workflowID, string(state.ReasonInterrupted)).Scan(&n)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -252,10 +293,67 @@ func (c *Client) HasResumeDescendant(ctx context.Context, instanceID string) (bo
 // ListWorkflowInstancesByState returns all instances in the given state, oldest first.
 func (c *Client) ListWorkflowInstancesByState(ctx context.Context, state string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE state = ? ORDER BY created_at ASC
 	`, state)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
+// ListWorkflowInstancesBlockedBy returns instances parked for any of the given
+// reasons, oldest first.
+//
+// Rehydration needs this rather than a state lookup: every park is 'blocked'
+// now, and an approval rehydrator that matched the state alone would also pick
+// up CI waits and orphans (#465). The legacy per-reason states are matched too,
+// so an un-migrated database rehydrates identically.
+func (c *Client) ListWorkflowInstancesBlockedBy(ctx context.Context, reasons ...string) ([]WorkflowInstance, error) {
+	if len(reasons) == 0 {
+		return nil, nil
+	}
+	args := []any{}
+	placeholders := ""
+	for i, r := range reasons {
+		if i > 0 {
+			placeholders += ","
+		}
+		placeholders += "?"
+		args = append(args, r)
+	}
+	// Legacy state names carrying the same meaning as each reason.
+	legacy := map[string]string{
+		"approval":    "approval_waiting",
+		"ci":          "waiting",
+		"dependency":  "waiting",
+		"interrupted": "interrupted",
+	}
+	legacyPlaceholders := ""
+	seen := map[string]bool{}
+	for _, r := range reasons {
+		if l, ok := legacy[r]; ok && !seen[l] {
+			seen[l] = true
+			if legacyPlaceholders != "" {
+				legacyPlaceholders += ","
+			}
+			legacyPlaceholders += "?"
+			args = append(args, l)
+		}
+	}
+	if legacyPlaceholders == "" {
+		legacyPlaceholders = "NULL"
+	}
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
+		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
+		FROM workflow_instances
+		WHERE (state = 'blocked' AND COALESCE(blocked_reason,'') IN (`+placeholders+`))
+		   OR state IN (`+legacyPlaceholders+`)
+		ORDER BY created_at ASC
+	`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +367,7 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 		limit = 20
 	}
 	rows, err := c.db.QueryContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances ORDER BY created_at DESC LIMIT ?
 	`, limit)
@@ -284,7 +382,7 @@ func (c *Client) ListWorkflowInstances(ctx context.Context, limit int) ([]Workfl
 // cell, or (nil, nil) when the cell has no workflow instance.
 func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC LIMIT 1
 	`, cellID)
@@ -300,7 +398,7 @@ func (c *Client) GetLatestInstanceByCell(ctx context.Context, cellID string) (*W
 // written before task_id existed, which ListWorkflowInstancesByTask would miss.
 func (c *Client) ListWorkflowInstancesByCell(ctx context.Context, cellID string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE cell_id = ? ORDER BY created_at DESC
 	`, cellID)
@@ -316,7 +414,7 @@ func (c *Client) ListWorkflowInstancesByCell(ctx context.Context, cellID string)
 // so the dashboard lists all of them per task. Backed by idx_wf_instances_task.
 func (c *Client) ListWorkflowInstancesByTask(ctx context.Context, taskID string) ([]WorkflowInstance, error) {
 	rows, err := c.db.QueryContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances WHERE task_id = ? ORDER BY created_at DESC
 	`, taskID)
@@ -331,7 +429,7 @@ func (c *Client) ListWorkflowInstancesByTask(ctx context.Context, taskID string)
 // instance of a workflow, or (nil, nil) when none exists.
 func (c *Client) LatestResumableInstance(ctx context.Context, workflowID string) (*WorkflowInstance, error) {
 	row := c.db.QueryRowContext(ctx, `
-		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state,
+		SELECT id, workflow_id, cell_id, COALESCE(source_id,''), state, COALESCE(blocked_reason,''),
 		       COALESCE(parent_instance_id,''), COALESCE(resumed_from,''), created_at, updated_at, COALESCE(task_id,'')
 		FROM workflow_instances
 		WHERE workflow_id = ? AND state IN ('failed','interrupted')
@@ -414,9 +512,9 @@ func (c *Client) GetTaskTitle(ctx context.Context, id string) (string, error) {
 func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, error) {
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE workflow_instances
-		SET state = ?, updated_at = ?
+		SET state = ?, blocked_reason = ?, updated_at = ?
 		WHERE state = ?
-	`, InstanceStateInterrupted, time.Now(), InstanceStateRunning)
+	`, InstanceStateBlocked, string(state.ReasonInterrupted), time.Now(), InstanceStateRunning)
 	if err != nil {
 		return 0, err
 	}
@@ -436,12 +534,54 @@ func (c *Client) ReconcileOrphanWorkflowInstances(ctx context.Context) (int64, e
 func (c *Client) ReconcileOrphanStepRuns(ctx context.Context) (int64, error) {
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE step_runs
-		SET state = ?, finished_at = COALESCE(finished_at, ?)
+		SET state = ?, blocked_reason = ?, finished_at = COALESCE(finished_at, ?)
 		WHERE state IN (?, ?)
 		  AND workflow_instance_id IN (
-		    SELECT id FROM workflow_instances WHERE state = ?
+		    SELECT id FROM workflow_instances
+		    WHERE state = ? AND blocked_reason = ?
 		  )
-	`, StepStateInterrupted, time.Now(), StepStateRunning, StepStatePending, InstanceStateInterrupted)
+	`, StepStateBlocked, string(state.ReasonInterrupted), time.Now(),
+		StepStateRunning, StepStateQueued,
+		InstanceStateBlocked, string(state.ReasonInterrupted))
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// PropagateInterruptedToTasks marks a task blocked/interrupted when it has no
+// live workflow instance left and at least one interrupted one.
+//
+// This is the fix for the oldest complaint about the Tasks view: a task whose
+// every instance was orphaned by a restart stayed in 'registered' and rendered
+// as "queued", indistinguishable from a task that arrived three seconds ago.
+// The information was always there in workflow_instances; nothing carried it up
+// to the task (#465).
+//
+// Scoped to non-terminal, non-running tasks with a zero outstanding counter, so
+// it runs after ReconcileOrphanTaskCounters has recounted and cannot disturb a
+// task that is genuinely working. Idempotent: flipped rows stop matching.
+func (c *Client) PropagateInterruptedToTasks(ctx context.Context) (int64, error) {
+	res, err := c.db.ExecContext(ctx, `
+		UPDATE internal_tasks
+		SET state = 'blocked', blocked_reason = ?, updated_at = ?
+		WHERE state NOT IN ('done','failed','canceled','running')
+		  AND COALESCE(blocked_reason,'') <> ?
+		  AND COALESCE(outstanding_workflows, 0) = 0
+		  AND EXISTS (
+		        SELECT 1 FROM workflow_instances wi
+		         WHERE wi.task_id = internal_tasks.id
+		           AND (wi.state = 'interrupted'
+		                OR (wi.state = 'blocked' AND COALESCE(wi.blocked_reason,'') = ?))
+		      )
+		  AND NOT EXISTS (
+		        SELECT 1 FROM workflow_instances wi
+		         WHERE wi.task_id = internal_tasks.id
+		           AND (wi.state IN ('running','pending','queued','approval_waiting','waiting')
+		                OR (wi.state = 'blocked' AND COALESCE(wi.blocked_reason,'') <> ?))
+		      )
+	`, string(state.ReasonInterrupted), time.Now(), string(state.ReasonInterrupted),
+		string(state.ReasonInterrupted), string(state.ReasonInterrupted))
 	if err != nil {
 		return 0, err
 	}
@@ -475,33 +615,32 @@ func (c *Client) ReconcileOrphanStepRuns(ctx context.Context) (int64, error) {
 // interrupted) and before the rehydration passes.
 func (c *Client) ReconcileOrphanTaskCounters(ctx context.Context) (recounted, settled int64, err error) {
 	now := time.Now()
-	// Both vocabularies are accepted so this reconcile is correct against a
-	// database written by a newer binary (see internal/state). 'queued' is the
-	// canonical form of pending; 'blocked' is the canonical form of
-	// approval_waiting and waiting.
+	// Live means queued, running, or blocked-for-a-reason-that-will-resolve.
+	// Interruption is the exception: a blocked_reason of 'interrupted' marks an
+	// orphan that will never complete on its own, so it must not count towards
+	// outstanding_workflows or the task can never settle.
 	//
-	// 'blocked' is also the canonical form of *interrupted*, which the legacy
-	// list deliberately excludes, so including it here overcounts an interrupted
-	// instance as live. That is the safe direction to be wrong in: an
-	// overcounted task stays 'running' and is re-dispatched — exactly what the
-	// docstring says happens to an all-interrupted task anyway — whereas
-	// undercounting settles a task while work is still parked. The reason cannot
-	// be consulted here because blocked_reason does not exist in this release's
-	// schema; the query is refined to `blocked_reason <> 'interrupted'` once it
-	// does.
-	liveStates := `('` + InstanceStatePending + `','` + InstanceStateRunning + `','` +
-		InstanceStateApprovalWaiting + `','` + InstanceStateWaiting + `','queued','blocked')`
+	// The legacy vocabulary is still accepted on the read side (a database not
+	// yet migrated, or written by an older binary) — see internal/state.
+	liveStates := `(
+		'queued','running','pending','approval_waiting','waiting'
+		)`
+	// Qualified with wi. deliberately: the enclosing UPDATE targets
+	// internal_tasks, which now has its own state and blocked_reason columns.
+	// SQLite would resolve the unqualified names to the inner scope, but an
+	// ambiguous-looking correlated subquery is not worth the risk.
+	liveBlocked := `(wi.state = 'blocked' AND COALESCE(wi.blocked_reason,'') <> '` + string(state.ReasonInterrupted) + `')`
 
 	res, err := c.db.ExecContext(ctx, `
 		UPDATE internal_tasks
 		SET outstanding_workflows = (
 		      SELECT COUNT(*) FROM workflow_instances wi
-		       WHERE wi.task_id = internal_tasks.id AND wi.state IN `+liveStates+`),
+		       WHERE wi.task_id = internal_tasks.id AND (wi.state IN `+liveStates+` OR `+liveBlocked+`)),
 		    updated_at = ?
 		WHERE state NOT IN ('done','failed','canceled')
 		  AND COALESCE(outstanding_workflows, 0) <> (
 		      SELECT COUNT(*) FROM workflow_instances wi
-		       WHERE wi.task_id = internal_tasks.id AND wi.state IN `+liveStates+`)
+		       WHERE wi.task_id = internal_tasks.id AND (wi.state IN `+liveStates+` OR `+liveBlocked+`))
 	`, now)
 	if err != nil {
 		return 0, 0, err
@@ -542,15 +681,16 @@ func StepRunHasUsage(s StepRun) bool {
 func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 	_, err := c.db.ExecContext(ctx, `
 		INSERT INTO step_runs
-		  (id, workflow_instance_id, step_id, agent_id, state, output, structured_output,
+		  (id, workflow_instance_id, step_id, agent_id, state, blocked_reason, skipped_reason, output, structured_output,
 		   summary, exit_code, skipped_cached, publish_payload, publish_state, spawned_task_id,
 		   input_prompt, input_tokens, output_tokens, total_tokens,
 		   cache_creation_tokens, cache_read_tokens, num_turns, num_tool_calls, cost_usd,
 		   time_thinking_ms, time_writing_ms, time_model_ms, time_tool_wait_ms,
 		   time_other_ms, time_background_ms, slow_tools,
 		   started_at, finished_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, sr.ID, sr.WorkflowInstanceID, sr.StepID, nullStr(sr.AgentID), sr.State,
+		nullStr(sr.BlockedReason), nullStr(sr.SkippedReason),
 		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
@@ -558,7 +698,7 @@ func (c *Client) CreateStepRun(ctx context.Context, sr *StepRun) error {
 		sr.CostUSD, sr.ThinkingMS, sr.WritingMS, sr.ModelMS, sr.ToolWaitMS, sr.OtherMS,
 		sr.BackgroundMS, nullStr(sr.SlowTools), sr.StartedAt, sr.FinishedAt)
 	if err == nil {
-		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
+		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State, sr.BlockedReason))
 	}
 	return err
 }
@@ -570,7 +710,7 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 	_ = c.db.QueryRowContext(ctx, `SELECT state FROM step_runs WHERE id = ?`, sr.ID).Scan(&previous)
 	_, err := c.db.ExecContext(ctx, `
 		UPDATE step_runs
-		SET state = ?, output = ?, structured_output = ?, summary = ?,
+		SET state = ?, blocked_reason = ?, skipped_reason = ?, output = ?, structured_output = ?, summary = ?,
 		    exit_code = ?, skipped_cached = ?, publish_payload = ?, publish_state = ?,
 		    spawned_task_id = ?, input_prompt = ?, input_tokens = ?, output_tokens = ?,
 		    total_tokens = ?, cache_creation_tokens = ?, cache_read_tokens = ?,
@@ -579,40 +719,56 @@ func (c *Client) UpdateStepRun(ctx context.Context, sr *StepRun) error {
 		    time_tool_wait_ms = ?, time_other_ms = ?, time_background_ms = ?, slow_tools = ?,
 		    started_at = ?, finished_at = ?
 		WHERE id = ?
-	`, sr.State, nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
+	`, sr.State, nullStr(sr.BlockedReason), nullStr(sr.SkippedReason),
+		nullStr(sr.Output), nullStr(sr.StructuredOutput), nullStr(sr.Summary),
 		sr.ExitCode, sr.SkippedCached, nullStr(sr.PublishPayload), nullStr(sr.PublishState),
 		nullStr(sr.SpawnedTaskID), nullStr(sr.InputPrompt), sr.InputTokens, sr.OutputTokens,
 		sr.TotalTokens, sr.CacheCreationTokens, sr.CacheReadTokens, sr.NumTurns, sr.NumToolCalls,
 		sr.CostUSD, sr.ThinkingMS, sr.WritingMS, sr.ModelMS, sr.ToolWaitMS, sr.OtherMS,
 		sr.BackgroundMS, nullStr(sr.SlowTools), sr.StartedAt, sr.FinishedAt, sr.ID)
 	if err == nil && previous != sr.State {
-		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State))
+		c.recordStepEvent(ctx, sr, stepStateEventType(sr.State, sr.BlockedReason))
 	}
 	return err
 }
 
-func workflowStateEventType(state string) string {
-	switch state {
+// workflowStateEventType maps a state transition to its lifecycle event.
+//
+// It takes the reason as well as the state because the canonical vocabulary
+// collapses approval waits, CI waits and interruption onto "blocked" (#465).
+// Only interruption is a cancellation; emitting workflow.cancelled when a run
+// merely parks on an approval gate would be wrong.
+func workflowStateEventType(st, reason string) string {
+	switch st {
 	case InstanceStateDone:
 		return "workflow.completed"
 	case InstanceStateFailed:
 		return "workflow.failed"
-	case InstanceStateInterrupted:
+	case InstanceStateCanceled:
 		return "workflow.cancelled"
+	case InstanceStateBlocked:
+		if reason == string(state.ReasonInterrupted) {
+			return "workflow.cancelled"
+		}
 	}
 	return ""
 }
 
-func stepStateEventType(state string) string {
-	switch state {
+// stepStateEventType is the step-level companion to workflowStateEventType, and
+// takes the reason for the same purpose: a step parked on an approval is blocked
+// but not cancelled.
+func stepStateEventType(st, reason string) string {
+	switch st {
 	case StepStateRunning:
 		return "step.started"
-	case StepStatePassed, StepStateSkipped, StepStateSkippedCached:
+	case StepStatePassed, StepStateSkipped:
 		return "step.completed"
 	case StepStateFailed:
 		return "step.failed"
-	case StepStateInterrupted:
-		return "step.cancelled"
+	case StepStateBlocked:
+		if reason == string(state.ReasonInterrupted) {
+			return "step.cancelled"
+		}
 	}
 	return ""
 }
@@ -643,7 +799,7 @@ func (c *Client) recordStepEvent(ctx context.Context, sr *StepRun, eventType str
 // (reject_when) or on_missing_output — fails a step whose runner exited 0, so
 // the persisted row matches the decision the workflow actually took (#390). A
 // state change emits the usual step.* execution event.
-func (c *Client) UpdateStepRunState(ctx context.Context, id, state, output string) error {
+func (c *Client) UpdateStepRunState(ctx context.Context, id, newState, reason, output string) error {
 	var previous, stepID, instanceID string
 	if err := c.db.QueryRowContext(ctx,
 		`SELECT state, step_id, workflow_instance_id FROM step_runs WHERE id = ?`, id).
@@ -651,12 +807,13 @@ func (c *Client) UpdateStepRunState(ctx context.Context, id, state, output strin
 		return err
 	}
 	if _, err := c.db.ExecContext(ctx,
-		`UPDATE step_runs SET state = ?, output = ? WHERE id = ?`, state, nullStr(output), id); err != nil {
+		`UPDATE step_runs SET state = ?, blocked_reason = ?, output = ? WHERE id = ?`,
+		newState, nullStr(reason), nullStr(output), id); err != nil {
 		return err
 	}
-	if previous != state {
-		c.recordStepEvent(ctx, &StepRun{ID: id, WorkflowInstanceID: instanceID, StepID: stepID, State: state},
-			stepStateEventType(state))
+	if previous != newState {
+		c.recordStepEvent(ctx, &StepRun{ID: id, WorkflowInstanceID: instanceID, StepID: stepID, State: newState, BlockedReason: reason},
+			stepStateEventType(newState, reason))
 	}
 	return nil
 }
@@ -665,6 +822,7 @@ func (c *Client) UpdateStepRunState(ctx context.Context, id, state, output strin
 func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun, error) {
 	rows, err := c.db.QueryContext(ctx, `
 		SELECT id, workflow_instance_id, step_id, COALESCE(agent_id,''), state,
+		       COALESCE(blocked_reason,''), COALESCE(skipped_reason,''),
 		       COALESCE(output,''), COALESCE(structured_output,''), COALESCE(summary,''),
 		       COALESCE(exit_code,0), COALESCE(skipped_cached,0),
 		       COALESCE(publish_payload,''), COALESCE(publish_state,''),
@@ -687,6 +845,7 @@ func (c *Client) ListStepRuns(ctx context.Context, instanceID string) ([]StepRun
 	for rows.Next() {
 		var sr StepRun
 		if err := rows.Scan(&sr.ID, &sr.WorkflowInstanceID, &sr.StepID, &sr.AgentID, &sr.State,
+			&sr.BlockedReason, &sr.SkippedReason,
 			&sr.Output, &sr.StructuredOutput, &sr.Summary, &sr.ExitCode, &sr.SkippedCached,
 			&sr.PublishPayload, &sr.PublishState, &sr.SpawnedTaskID, &sr.InputPrompt,
 			&sr.InputTokens, &sr.OutputTokens, &sr.TotalTokens,
@@ -757,7 +916,7 @@ type scanner interface {
 
 func scanInstance(s scanner) (*WorkflowInstance, error) {
 	var inst WorkflowInstance
-	err := s.Scan(&inst.ID, &inst.WorkflowID, &inst.CellID, &inst.SourceID, &inst.State,
+	err := s.Scan(&inst.ID, &inst.WorkflowID, &inst.CellID, &inst.SourceID, &inst.State, &inst.BlockedReason,
 		&inst.ParentInstanceID, &inst.ResumedFrom, &inst.CreatedAt, &inst.UpdatedAt, &inst.TaskID)
 	if err != nil {
 		return nil, err

--- a/src/internal/db/workflow_store_test.go
+++ b/src/internal/db/workflow_store_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
+	apstate "github.com/orlandoburli/apiary/internal/state"
 )
 
 func newTestClient(t *testing.T) *Client {
@@ -29,7 +30,7 @@ func TestWorkflowInstance_CRUD(t *testing.T) {
 		WorkflowID: "feature-development",
 		CellID:     "PLANE-142",
 		SourceID:   "main-plane",
-		State:      InstanceStatePending,
+		State:      InstanceStateQueued,
 	}
 	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
 		t.Fatalf("create: %v", err)
@@ -42,14 +43,14 @@ func TestWorkflowInstance_CRUD(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected instance, got nil")
 	}
-	if got.WorkflowID != "feature-development" || got.CellID != "PLANE-142" || got.State != InstanceStatePending {
+	if got.WorkflowID != "feature-development" || got.CellID != "PLANE-142" || got.State != InstanceStateQueued {
 		t.Errorf("instance fields wrong: %+v", got)
 	}
 	if got.CreatedAt.IsZero() {
 		t.Error("created_at not set")
 	}
 
-	if err := c.UpdateWorkflowInstanceState(ctx, "wf_1", InstanceStateRunning); err != nil {
+	if err := c.UpdateWorkflowInstanceState(ctx, "wf_1", InstanceStateRunning, ""); err != nil {
 		t.Fatalf("update state: %v", err)
 	}
 	got, _ = c.GetWorkflowInstance(ctx, "wf_1")
@@ -62,7 +63,7 @@ func TestCIPollChecks_RecordAndList(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)
 
-	inst := &WorkflowInstance{ID: "wf_ci", WorkflowID: "implementation", CellID: "42", State: InstanceStateWaiting}
+	inst := &WorkflowInstance{ID: "wf_ci", WorkflowID: "implementation", CellID: "42", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonCI)}
 	if err := c.CreateWorkflowInstance(ctx, inst); err != nil {
 		t.Fatalf("create instance: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestWorkflowInstance_ListByState(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)
 
-	for i, st := range []string{InstanceStateApprovalWaiting, InstanceStateRunning, InstanceStateApprovalWaiting} {
+	for i, st := range []string{InstanceStateBlocked, InstanceStateRunning, InstanceStateBlocked} {
 		inst := &WorkflowInstance{
 			ID:         "wf_" + string(rune('a'+i)),
 			WorkflowID: "wf",
@@ -131,7 +132,7 @@ func TestWorkflowInstance_ListByState(t *testing.T) {
 		}
 	}
 
-	waiting, err := c.ListWorkflowInstancesByState(ctx, InstanceStateApprovalWaiting)
+	waiting, err := c.ListWorkflowInstancesByState(ctx, InstanceStateBlocked)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
 
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "r1", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "r2", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "w1", WorkflowID: "w", CellID: "c", State: InstanceStateApprovalWaiting})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "w1", WorkflowID: "w", CellID: "c", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonApproval)})
 
 	n, err := c.ReconcileOrphanWorkflowInstances(ctx)
 	if err != nil {
@@ -162,11 +163,11 @@ func TestWorkflowInstance_ReconcileOrphans(t *testing.T) {
 
 	// approval_waiting is left untouched.
 	w1, _ := c.GetWorkflowInstance(ctx, "w1")
-	if w1.State != InstanceStateApprovalWaiting {
+	if w1.State != InstanceStateBlocked {
 		t.Errorf("approval_waiting should be untouched, got %s", w1.State)
 	}
 	r1, _ := c.GetWorkflowInstance(ctx, "r1")
-	if r1.State != InstanceStateInterrupted {
+	if r1.State != InstanceStateBlocked {
 		t.Errorf("running should become interrupted, got %s", r1.State)
 	}
 }
@@ -175,8 +176,8 @@ func TestHasResumeDescendant(t *testing.T) {
 	ctx := context.Background()
 	c := newTestClient(t)
 
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "a", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted})
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "b", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "a", WorkflowID: "w", CellID: "c", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "b", WorkflowID: "w", CellID: "c", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)})
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "a2", WorkflowID: "w", CellID: "c", State: InstanceStateRunning, ResumedFrom: "a"})
 
 	if got, err := c.HasResumeDescendant(ctx, "a"); err != nil || !got {
@@ -195,7 +196,7 @@ func TestHasActiveInstanceForRoute(t *testing.T) {
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-triage", WorkflowID: "triage", CellID: "1948", TaskID: "T1", State: InstanceStateDone})
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-impl", WorkflowID: "implementation", CellID: "1948", TaskID: "T1", State: InstanceStateRunning})
 	// task T2: implementation parked at an approval step.
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-impl", WorkflowID: "implementation", CellID: "2000", TaskID: "T2", State: InstanceStateApprovalWaiting})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-impl", WorkflowID: "implementation", CellID: "2000", TaskID: "T2", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonApproval)})
 	// task T3: implementation failed (terminal — eligible for retry, must NOT block).
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-impl", WorkflowID: "implementation", CellID: "3000", TaskID: "T3", State: InstanceStateFailed})
 
@@ -383,7 +384,7 @@ func TestUpdateStepRunState(t *testing.T) {
 		t.Fatalf("create step run: %v", err)
 	}
 
-	if err := c.UpdateStepRunState(ctx, "sr_g", StepStateFailed, "gate unevaluable"); err != nil {
+	if err := c.UpdateStepRunState(ctx, "sr_g", StepStateFailed, "", "gate unevaluable"); err != nil {
 		t.Fatalf("update step run state: %v", err)
 	}
 
@@ -412,7 +413,7 @@ func TestUpdateStepRunState(t *testing.T) {
 		t.Errorf("event step_id = %q, want review", events[0].StepID)
 	}
 
-	if err := c.UpdateStepRunState(ctx, "missing", StepStateFailed, ""); err == nil {
+	if err := c.UpdateStepRunState(ctx, "missing", StepStateFailed, "", ""); err == nil {
 		t.Error("expected an error updating an unknown step run")
 	}
 }
@@ -423,7 +424,7 @@ func TestStepRun_OrderedByInsertion(t *testing.T) {
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "wf_1", WorkflowID: "w", CellID: "c", State: InstanceStateRunning})
 
 	for _, id := range []string{"plan", "implement", "review"} {
-		if err := c.CreateStepRun(ctx, &StepRun{ID: "sr-" + id, WorkflowInstanceID: "wf_1", StepID: id, State: StepStatePending}); err != nil {
+		if err := c.CreateStepRun(ctx, &StepRun{ID: "sr-" + id, WorkflowInstanceID: "wf_1", StepID: id, State: StepStateQueued}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -442,7 +443,7 @@ func TestReconcileOrphanWorkflowInstances_Extended(t *testing.T) {
 	now := time.Now()
 	instances := []*WorkflowInstance{
 		{ID: "wf_running", WorkflowID: "w", CellID: "c", State: InstanceStateRunning, CreatedAt: now},
-		{ID: "wf_approval", WorkflowID: "w", CellID: "c", State: InstanceStateApprovalWaiting, CreatedAt: now},
+		{ID: "wf_approval", WorkflowID: "w", CellID: "c", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonApproval), CreatedAt: now},
 		{ID: "wf_done", WorkflowID: "w", CellID: "c", State: InstanceStateDone, CreatedAt: now},
 		{ID: "wf_failed", WorkflowID: "w", CellID: "c", State: InstanceStateFailed, CreatedAt: now},
 	}
@@ -465,10 +466,10 @@ func TestReconcileOrphanWorkflowInstances_Extended(t *testing.T) {
 
 	// Verify only running was changed to interrupted, others are untouched.
 	for id, expectedState := range map[string]string{
-		"wf_running":  InstanceStateInterrupted,     // running → interrupted
-		"wf_approval": InstanceStateApprovalWaiting, // approval_waiting (untouched, rehydrated separately)
-		"wf_done":     InstanceStateDone,            // done (unchanged)
-		"wf_failed":   InstanceStateFailed,          // failed (unchanged)
+		"wf_running":  InstanceStateBlocked, // running → interrupted
+		"wf_approval": InstanceStateBlocked, // approval_waiting (untouched, rehydrated separately)
+		"wf_done":     InstanceStateDone,    // done (unchanged)
+		"wf_failed":   InstanceStateFailed,  // failed (unchanged)
 	} {
 		inst, err := c.GetWorkflowInstance(ctx, id)
 		if err != nil {
@@ -488,7 +489,7 @@ func TestReconcileOrphanStepRuns(t *testing.T) {
 	// instance (a genuinely finished run). Only step_runs under the interrupted
 	// instance should be touched.
 	instances := []*WorkflowInstance{
-		{ID: "wf_interrupted", WorkflowID: "w", CellID: "c", State: InstanceStateInterrupted},
+		{ID: "wf_interrupted", WorkflowID: "w", CellID: "c", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)},
 		{ID: "wf_done", WorkflowID: "w", CellID: "c", State: InstanceStateDone},
 	}
 	for _, inst := range instances {
@@ -501,7 +502,7 @@ func TestReconcileOrphanStepRuns(t *testing.T) {
 	steps := []*StepRun{
 		// Under the interrupted parent: the two non-terminal ones are orphans.
 		{ID: "sr_run", WorkflowInstanceID: "wf_interrupted", StepID: "implement", State: StepStateRunning},
-		{ID: "sr_pend", WorkflowInstanceID: "wf_interrupted", StepID: "review", State: StepStatePending},
+		{ID: "sr_pend", WorkflowInstanceID: "wf_interrupted", StepID: "review", State: StepStateQueued},
 		{ID: "sr_pass", WorkflowInstanceID: "wf_interrupted", StepID: "classify", State: StepStatePassed},
 		// Under the done parent: a leftover 'running' here must NOT be touched,
 		// since its parent was not reconciled to interrupted.
@@ -523,10 +524,10 @@ func TestReconcileOrphanStepRuns(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"sr_run":      StepStateInterrupted, // running under interrupted → interrupted
-		"sr_pend":     StepStateInterrupted, // pending under interrupted → interrupted
-		"sr_pass":     StepStatePassed,      // terminal, unchanged
-		"sr_done_run": StepStateRunning,     // running but parent is done, untouched
+		"sr_run":      StepStateBlocked, // running under interrupted → interrupted
+		"sr_pend":     StepStateBlocked, // pending under interrupted → interrupted
+		"sr_pass":     StepStatePassed,  // terminal, unchanged
+		"sr_done_run": StepStateRunning, // running but parent is done, untouched
 	}
 	got := map[string]StepRun{}
 	for _, instID := range []string{"wf_interrupted", "wf_done"} {
@@ -585,7 +586,7 @@ func TestReconcileOrphanTaskCounters(t *testing.T) {
 	// T1 — the issue #198 leak: an interrupted instance never decremented, a
 	// later instance completed. Counter stuck at 1, task stuck 'running'.
 	mkTask("T1", model.TaskStateRunning, 2)
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-a", WorkflowID: "w", CellID: "1", TaskID: "T1", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-a", WorkflowID: "w", CellID: "1", TaskID: "T1", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)})
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t1-b", WorkflowID: "w", CellID: "1", TaskID: "T1", State: InstanceStateDone})
 	if _, err := ts.DecrementOutstanding(ctx, "T1"); err != nil { // completeTask of t1-b
 		t.Fatalf("decrement T1: %v", err)
@@ -593,7 +594,7 @@ func TestReconcileOrphanTaskCounters(t *testing.T) {
 
 	// T2 — same leak but the completed instance of the current generation failed.
 	mkTask("T2", model.TaskStateRunning, 2)
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-a", WorkflowID: "w", CellID: "2", TaskID: "T2", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-a", WorkflowID: "w", CellID: "2", TaskID: "T2", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)})
 	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t2-b", WorkflowID: "w", CellID: "2", TaskID: "T2", State: InstanceStateFailed})
 	if _, err := ts.DecrementOutstanding(ctx, "T2"); err != nil {
 		t.Fatalf("decrement T2: %v", err)
@@ -601,12 +602,12 @@ func TestReconcileOrphanTaskCounters(t *testing.T) {
 
 	// T3 — parked at approval: live instance, counter correct. Must be untouched.
 	mkTask("T3", model.TaskStateRunning, 1)
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-a", WorkflowID: "w", CellID: "3", TaskID: "T3", State: InstanceStateApprovalWaiting})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t3-a", WorkflowID: "w", CellID: "3", TaskID: "T3", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonApproval)})
 
 	// T4 — every current-generation instance interrupted: counter must drop to
 	// zero but the task stays 'running' for the next poll to re-dispatch.
 	mkTask("T4", model.TaskStateRunning, 1)
-	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t4-a", WorkflowID: "w", CellID: "4", TaskID: "T4", State: InstanceStateInterrupted})
+	_ = c.CreateWorkflowInstance(ctx, &WorkflowInstance{ID: "t4-a", WorkflowID: "w", CellID: "4", TaskID: "T4", State: InstanceStateBlocked, BlockedReason: string(apstate.ReasonInterrupted)})
 
 	// T5 — terminal task: out of scope, never touched even with a bogus counter.
 	mkTask("T5", model.TaskStateDone, 3)

--- a/src/internal/improve/advisor.go
+++ b/src/internal/improve/advisor.go
@@ -45,11 +45,11 @@ type AdvisorFlags struct {
 
 // ResolveAdvisor decides which agent performs the analysis, in this order:
 //
-//	1. --advisor <agent-id>
-//	2. --runner <id> --model <name>   (ad-hoc, no config entry needed)
-//	3. settings.improve.agent
-//	4. an agent whose id is "improver"
-//	5. error
+//  1. --advisor <agent-id>
+//  2. --runner <id> --model <name>   (ad-hoc, no config entry needed)
+//  3. settings.improve.agent
+//  4. an agent whose id is "improver"
+//  5. error
 //
 // It never invents a model. `agents[].model` is required config-wide and there
 // is no global default — daemon.New hard-errors with "agent %q: model is

--- a/src/internal/improve/build.go
+++ b/src/internal/improve/build.go
@@ -13,12 +13,12 @@ import (
 
 // Options configures a single evidence-pack build.
 type Options struct {
-	DBPath  string
-	LogDir  string
-	Config  *config.Config
-	Window  Window
-	Scope   Scope
-	Clock   func() time.Time
+	DBPath string
+	LogDir string
+	Config *config.Config
+	Window Window
+	Scope  Scope
+	Clock  func() time.Time
 
 	// TranscriptsPerHotspot and HotspotLimit are 0 in the metrics-only path
 	// (`--dump-evidence` at low effort); the advisor sets them from its effort level.

--- a/src/internal/improve/evidence.go
+++ b/src/internal/improve/evidence.go
@@ -73,12 +73,12 @@ type StepMetrics struct {
 	StepID     string `json:"step_id"`
 	AgentID    string `json:"agent_id,omitempty"`
 
-	Runs           int `json:"runs"`
-	Passed         int `json:"passed"`
-	Failed         int `json:"failed"`
-	Skipped        int `json:"skipped"`
-	SkippedCached  int `json:"skipped_cached"`
-	LowConfidence  bool `json:"low_confidence"`
+	Runs          int  `json:"runs"`
+	Passed        int  `json:"passed"`
+	Failed        int  `json:"failed"`
+	Skipped       int  `json:"skipped"`
+	SkippedCached int  `json:"skipped_cached"`
+	LowConfidence bool `json:"low_confidence"`
 
 	PassRate       float64 `json:"pass_rate"`
 	FailRate       float64 `json:"fail_rate"`
@@ -204,9 +204,9 @@ type WaitMetrics struct {
 // one recurring failure reads as a single line with a count rather than thirty
 // near-identical lines.
 type FailureCluster struct {
-	Normalized string `json:"normalized"`
-	Count      int    `json:"count"`
-	Exemplar   string `json:"exemplar"`
+	Normalized string   `json:"normalized"`
+	Count      int      `json:"count"`
+	Exemplar   string   `json:"exemplar"`
 	Agents     []string `json:"agents,omitempty"`
 }
 

--- a/src/internal/improve/metrics.go
+++ b/src/internal/improve/metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	apstate "github.com/orlandoburli/apiary/internal/state"
 	"slices"
 	"sort"
 	"strings"
@@ -31,10 +32,10 @@ func hasColumn(ctx context.Context, db source, table, column string) bool {
 	defer rows.Close()
 	for rows.Next() {
 		var (
-			cid                        int
-			name, ctype                string
-			notnull, pk                int
-			dflt                       sql.NullString
+			cid         int
+			name, ctype string
+			notnull, pk int
+			dflt        sql.NullString
 		)
 		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
 			return false
@@ -151,15 +152,21 @@ func StepMetricsFor(ctx context.Context, db source, w Window, sc Scope) ([]StepM
 		}
 
 		a.runs++
+		// Normalize so a database holding either vocabulary counts the same
+		// (#465): 'passed' and 'done' are one bucket, and 'skipped_cached'
+		// became 'skipped' plus a reason. The cached arm keeps its original
+		// precedence — the skipped_cached flag wins over the plain state — so
+		// the totals are unchanged for any existing database.
+		canon := apstate.Normalize(state)
 		switch {
-		case state == "passed":
+		case canon == apstate.Done:
 			a.passed++
-		case state == "failed":
+		case canon == apstate.Failed:
 			a.failed++
 		case state == "skipped_cached" || cachedFlag == 1:
 			a.cached++
 			a.skipped++
-		case state == "skipped":
+		case canon == apstate.Skipped:
 			a.skipped++
 		}
 
@@ -689,8 +696,17 @@ func FailureClustersFor(ctx context.Context, db source, w Window, sc Scope) ([]F
 	return out, nil
 }
 
+// isTerminal reports whether an instance state means "no more work will happen".
+//
+// Interruption counts: an orphaned instance never completes on its own, which is
+// why it sits alongside done and failed here even though the canonical
+// vocabulary files it under 'blocked' (#465).
 func isTerminal(state string) bool {
-	return state == "done" || state == "failed" || state == "interrupted"
+	switch apstate.Normalize(state) {
+	case apstate.Done, apstate.Failed, apstate.Canceled:
+		return true
+	}
+	return state == "interrupted"
 }
 
 func countKinds(concat string) map[string]int {

--- a/src/internal/improve/prompt_test.go
+++ b/src/internal/improve/prompt_test.go
@@ -116,7 +116,10 @@ func TestRenderTablesHandlesEmptyPack(t *testing.T) {
 }
 
 func TestDurRendersReadableUnits(t *testing.T) {
-	cases := []struct{ ms int64; want string }{
+	cases := []struct {
+		ms   int64
+		want string
+	}{
 		{0, "—"}, {-1, "—"}, {500, "500ms"}, {1500, "2s"},
 		{90_000, "2m"}, {3_600_000, "1.0h"}, {9_000_000, "2.5h"},
 	}

--- a/src/internal/improve/transcripts.go
+++ b/src/internal/improve/transcripts.go
@@ -112,7 +112,7 @@ func transcriptRefs(ctx context.Context, db source, logDir string, w Window, h H
 		      AND te.step_id = sr.step_id
 		WHERE wi.workflow_id = ? AND sr.step_id = ?
 		  AND sr.started_at >= ? AND sr.started_at < ?
-		  AND sr.state IN ('failed', 'passed')
+		  AND sr.state IN ('failed', 'passed', 'done')
 		GROUP BY sr.id
 		ORDER BY CASE sr.state WHEN 'failed' THEN 0 ELSE 1 END, sr.started_at DESC`,
 		h.WorkflowID, h.StepID, w.Start, w.End)

--- a/src/internal/improve/workspace_test.go
+++ b/src/internal/improve/workspace_test.go
@@ -98,7 +98,7 @@ func TestExcludedPaths(t *testing.T) {
 		{"/repo/.apiary/logs/apiary.log", true},
 		{"/repo/.apiary/logs/transcripts/t1/a.md", true},
 		{"/repo/.apiary/memory/MEMORY.md", true},
-		{"/etc/passwd", true},              // outside the root
+		{"/etc/passwd", true},               // outside the root
 		{"/repo/../elsewhere/x.yaml", true}, // escapes the root
 	}
 	for _, tc := range cases {

--- a/src/internal/model/result.go
+++ b/src/internal/model/result.go
@@ -3,13 +3,13 @@ package model
 import "time"
 
 type RunRequest struct {
-	Cell          SourceItem
-	WorkerID      string
-	Model         string
-	MaxTurns      int
-	SystemAppend  string
-	WorkingDir    string
-	Env           map[string]string
+	Cell         SourceItem
+	WorkerID     string
+	Model        string
+	MaxTurns     int
+	SystemAppend string
+	WorkingDir   string
+	Env          map[string]string
 	// Timeout bounds the whole invocation. The caller enforces it by cancelling
 	// the context it passes to Run; runners need not check it themselves.
 	Timeout time.Duration
@@ -17,7 +17,7 @@ type RunRequest struct {
 	// long, independent of Timeout. Zero disables it. Only meaningful for runners
 	// that stream output as they work — a runner that buffers everything until
 	// exit would look permanently stalled.
-	StallTimeout time.Duration
+	StallTimeout  time.Duration
 	AgentMetadata map[string]any
 
 	// SystemPrepend is injected at the very start of the prompt, before the cell

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -6,11 +6,19 @@ import "time"
 type TaskState string
 
 const (
-	TaskStateRegistered   TaskState = "registered"
+	// Canonical values (#465). The old names are kept so call sites do not
+	// churn, but they now hold the shared vocabulary from internal/state.
+	// TaskStateApprovalWait is 'blocked' with blocked_reason='approval'.
+	TaskStateRegistered   TaskState = "queued"
 	TaskStateRunning      TaskState = "running"
-	TaskStateApprovalWait TaskState = "approval_waiting"
+	TaskStateApprovalWait TaskState = "blocked"
 	TaskStateDone         TaskState = "done"
 	TaskStateFailed       TaskState = "failed"
+	TaskStateCanceled     TaskState = "canceled"
+	// TaskStateQueued is the canonical name for TaskStateRegistered; both are
+	// the same value and either reads correctly.
+	TaskStateQueued  TaskState = "queued"
+	TaskStateBlocked TaskState = "blocked"
 )
 
 // InternalTask is the canonical, source-independent unit of work. It may be

--- a/src/internal/model/task_test.go
+++ b/src/internal/model/task_test.go
@@ -46,16 +46,24 @@ func TestSpawnRequestZeroValue(t *testing.T) {
 }
 
 func TestTaskStateConstants(t *testing.T) {
-	cases := map[TaskState]string{
-		TaskStateRegistered:   "registered",
-		TaskStateRunning:      "running",
-		TaskStateApprovalWait: "approval_waiting",
-		TaskStateDone:         "done",
-		TaskStateFailed:       "failed",
+	// Canonical vocabulary (#465). TaskStateApprovalWait is 'blocked'; the fact
+	// that it is an approval lives in blocked_reason, not in the state.
+	cases := []struct {
+		got  TaskState
+		want string
+	}{
+		{TaskStateRegistered, "queued"},
+		{TaskStateQueued, "queued"},
+		{TaskStateRunning, "running"},
+		{TaskStateApprovalWait, "blocked"},
+		{TaskStateBlocked, "blocked"},
+		{TaskStateDone, "done"},
+		{TaskStateFailed, "failed"},
+		{TaskStateCanceled, "canceled"},
 	}
-	for got, want := range cases {
-		if string(got) != want {
-			t.Errorf("TaskState = %q, want %q", got, want)
+	for _, c := range cases {
+		if string(c.got) != c.want {
+			t.Errorf("TaskState = %q, want %q", c.got, c.want)
 		}
 	}
 }

--- a/src/internal/queue/queue.go
+++ b/src/internal/queue/queue.go
@@ -21,9 +21,11 @@ var (
 type JobState string
 
 const (
-	JobQueued    JobState = "queued"
-	JobLeased    JobState = "leased"
-	JobSucceeded JobState = "succeeded"
+	JobQueued JobState = "queued"
+	// JobLeased is 'running': a lease is granted so a worker can execute the
+	// job, so a leased job is work in progress, not work waiting (#465).
+	JobLeased    JobState = "running"
+	JobSucceeded JobState = "done"
 	JobFailed    JobState = "failed"
 	JobCanceled  JobState = "canceled"
 )

--- a/src/internal/workflow/approval.go
+++ b/src/internal/workflow/approval.go
@@ -181,7 +181,7 @@ func (e *Engine) ResolveApprovalResponse(ctx context.Context, instanceID string,
 	r.contrib[stepID] = MemoryStep{StepID: stepID, WriteFields: write, Structured: structured, Summary: response.Feedback}
 
 	r.resolveApproval(decision)
-	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning, "")
 	outcome := e.driveDAG(ctx, r)
 	return e.settle(ctx, r, outcome), nil
 }

--- a/src/internal/workflow/approval_test.go
+++ b/src/internal/workflow/approval_test.go
@@ -71,7 +71,7 @@ func TestApproval_SuspendsAtApprovalStep(t *testing.T) {
 		t.Fatal("a parked instance should not report success")
 	}
 	// Instance is parked in approval_waiting.
-	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Errorf("instance state = %q, want approval_waiting", store.instances[instID].State)
 	}
 	// The approval message was posted.
@@ -323,7 +323,7 @@ func TestApproval_CheckWaitsWhenNoSignal(t *testing.T) {
 	eng.CheckParkedApprovals(context.Background(), poll)
 
 	// Still parked, still approval_waiting.
-	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Errorf("expected still approval_waiting, got %q", store.instances[instID].State)
 	}
 	if len(eng.ParkedApprovals()) != 1 {

--- a/src/internal/workflow/dag_e2e_test.go
+++ b/src/internal/workflow/dag_e2e_test.go
@@ -129,8 +129,8 @@ func TestE2E_ClassifyImplementReviewQA(t *testing.T) {
 	if last.StepID != "qa" {
 		t.Errorf("expected last step to be qa, got %q", last.StepID)
 	}
-	if last.State != "passed" {
-		t.Errorf("expected qa step state=passed, got %q", last.State)
+	if last.State != "done" {
+		t.Errorf("expected qa step state=done, got %q", last.State)
 	}
 
 	// classify and review must each appear at least once.

--- a/src/internal/workflow/engine.go
+++ b/src/internal/workflow/engine.go
@@ -16,12 +16,13 @@ import (
 	"github.com/orlandoburli/apiary/internal/memory"
 	"github.com/orlandoburli/apiary/internal/model"
 	"github.com/orlandoburli/apiary/internal/source"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // Store persists workflow instances and step runs. *db.Client satisfies it.
 type Store interface {
 	CreateWorkflowInstance(ctx context.Context, inst *db.WorkflowInstance) error
-	UpdateWorkflowInstanceState(ctx context.Context, id, state string) error
+	UpdateWorkflowInstanceState(ctx context.Context, id, state, reason string) error
 	CreateStepRun(ctx context.Context, sr *db.StepRun) error
 	UpdateStepRun(ctx context.Context, sr *db.StepRun) error
 }
@@ -51,7 +52,7 @@ type ciPollRecorder interface {
 // *db.Client satisfies it; fake stores in tests that omit it simply keep the
 // state the runner wrote.
 type stepRunStateUpdater interface {
-	UpdateStepRunState(ctx context.Context, id, state, output string) error
+	UpdateStepRunState(ctx context.Context, id, state, reason, output string) error
 }
 
 type executionEventRecorder interface {
@@ -114,6 +115,34 @@ type TaskTracker interface {
 	HasFailedInstance(ctx context.Context, taskID string) (bool, error)
 	// SetTaskState transitions the InternalTask to a terminal lifecycle state.
 	SetTaskState(ctx context.Context, taskID string, state model.TaskState) error
+	// SetTaskStateReason transitions the InternalTask, recording why when the
+	// state is blocked (e.g. a pending retry).
+	SetTaskStateReason(ctx context.Context, taskID string, state model.TaskState, reason string) error
+	// CountConsecutiveFailedInstances reports how many of the most recent
+	// instances of (task, workflow) failed in a row. Used to tell a task that
+	// will be retried from one that has run out of attempts.
+	CountConsecutiveFailedInstances(ctx context.Context, taskID, workflowID string) (int, error)
+}
+
+// retryPending reports whether the dispatcher will try this workflow again,
+// i.e. the consecutive-failure count is still under settings.max_attempts. It
+// mirrors dropCappedMatches, which is what actually enforces the cap on the next
+// poll; this only decides how the task is labelled in the meantime.
+//
+// Fail-safe: on a count error, or with the cap disabled, it reports false so the
+// task settles as 'failed'. Over-reporting a retry would hide a genuinely dead
+// task from an operator, which is the failure mode worth avoiding.
+func (e *Engine) retryPending(ctx context.Context, r *dagRun) bool {
+	limit := e.cfg.Settings.MaxAttempts
+	if limit <= 0 || e.tracker == nil || r.task.ID == "" || r.wf.ID == "" {
+		return false
+	}
+	n, err := e.tracker.CountConsecutiveFailedInstances(ctx, r.task.ID, r.wf.ID)
+	if err != nil {
+		aplog.Error("task %s: consecutive-failure count: %v", r.task.ID, err)
+		return false
+	}
+	return n < limit
 }
 
 // StepRequest is the input to executing one agent step.
@@ -539,11 +568,15 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 		// rehydrateParkedWaits).
 		// (A parallel group parked on a wait_for child counts as a wait park —
 		// waitStepConfig resolves the governing step for both shapes, #425.)
-		waitState := db.InstanceStateApprovalWaiting
+		// Both park onto the canonical 'blocked' state; the reason is what tells
+		// the rehydration paths apart after a restart (approval →
+		// rehydrateParkedApprovals, ci → rehydrateParkedWaits) and what the
+		// dashboard shows the operator (#465).
+		waitReason := string(state.ReasonApproval)
 		if _, isWait := r.waitStepConfig(); isWait {
-			waitState = db.InstanceStateWaiting
+			waitReason = string(state.ReasonCI)
 		}
-		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, waitState)
+		_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, db.InstanceStateBlocked, waitReason)
 		e.mu.Lock()
 		e.parked[r.instID] = r
 		e.mu.Unlock()
@@ -555,7 +588,7 @@ func (e *Engine) settle(ctx context.Context, r *dagRun, outcome dagOutcome) bool
 	if failed {
 		finalState = db.InstanceStateFailed
 	}
-	_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, finalState)
+	_ = e.store.UpdateWorkflowInstanceState(ctx, r.instID, finalState, "")
 	e.mu.Lock()
 	delete(e.parked, r.instID)
 	e.mu.Unlock()
@@ -598,16 +631,29 @@ func (e *Engine) completeTask(ctx context.Context, r *dagRun, failed bool) {
 		}
 	}
 
+	// A failed task is only 'failed' once no attempt remains. While the
+	// dispatcher will pick it up again (settings.max_attempts), it is blocked
+	// waiting out a retry — which is what stops a healthily-retrying task from
+	// oscillating failed → running → failed and makes 'failed' mean "a human
+	// needs to look at this" (#465).
 	finalState := model.TaskStateDone
+	reason := ""
 	if anyFailed {
 		finalState = model.TaskStateFailed
+		if e.retryPending(ctx, r) {
+			finalState = model.TaskStateBlocked
+			reason = string(state.ReasonRetryBackoff)
+		}
 	}
-	if err := e.tracker.SetTaskState(ctx, r.task.ID, finalState); err != nil {
+	if err := e.tracker.SetTaskStateReason(ctx, r.task.ID, finalState, reason); err != nil {
 		aplog.Error("task %s: set state %s: %v", r.task.ID, finalState, err)
 	}
 	eventType := "task.completed"
 	if anyFailed {
 		eventType = "task.escalated"
+	}
+	if reason != "" {
+		eventType = "task.retry_pending"
 	}
 	e.recordExecutionEvent(ctx, r, eventType, map[string]any{"state": finalState})
 
@@ -727,7 +773,7 @@ func (e *Engine) markStepRunFailed(ctx context.Context, stepRunID, output string
 	if !ok {
 		return
 	}
-	if err := updater.UpdateStepRunState(ctx, stepRunID, db.StepStateFailed, output); err != nil {
+	if err := updater.UpdateStepRunState(ctx, stepRunID, db.StepStateFailed, "", output); err != nil {
 		aplog.Error("step run %s: mark failed: %v", stepRunID, err)
 	}
 }

--- a/src/internal/workflow/engine_test.go
+++ b/src/internal/workflow/engine_test.go
@@ -95,7 +95,7 @@ func (f *fakeStore) CreateWorkflowInstance(_ context.Context, inst *db.WorkflowI
 	f.mu.Unlock()
 	return nil
 }
-func (f *fakeStore) UpdateWorkflowInstanceState(_ context.Context, id, state string) error {
+func (f *fakeStore) UpdateWorkflowInstanceState(_ context.Context, id, state, reason string) error {
 	f.mu.Lock()
 	if inst, ok := f.instances[id]; ok {
 		inst.State = state
@@ -121,7 +121,7 @@ func (f *fakeStore) UpdateStepRun(_ context.Context, sr *db.StepRun) error {
 
 // UpdateStepRunState satisfies stepRunStateUpdater so the engine can correct a
 // step run's state after a post-execution gate, as *db.Client does.
-func (f *fakeStore) UpdateStepRunState(_ context.Context, id, state, output string) error {
+func (f *fakeStore) UpdateStepRunState(_ context.Context, id, state, reason, output string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	sr, ok := f.stepRuns[id]

--- a/src/internal/workflow/rehydrate_test.go
+++ b/src/internal/workflow/rehydrate_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // stepRunsFor returns the persisted step runs for an instance in insertion order,
@@ -41,7 +42,7 @@ func TestRehydrateApproval_ResolvesAndSettlesTask(t *testing.T) {
 	if success {
 		t.Fatal("parked instance should not report success")
 	}
-	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("instance state = %q, want approval_waiting", store.instances[instID].State)
 	}
 
@@ -58,7 +59,7 @@ func TestRehydrateApproval_ResolvesAndSettlesTask(t *testing.T) {
 
 	// Without rehydration the approval check finds nothing to do.
 	eng2.CheckParkedApprovals(context.Background(), approvingPoll)
-	if store.instances[instID].State != db.InstanceStateApprovalWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatal("pre-rehydration: instance must remain stranded in approval_waiting")
 	}
 
@@ -117,7 +118,7 @@ func TestRehydrateApproval_PreservesTimeout(t *testing.T) {
 	// Persist a plan step that already passed; the gate parked with a 48h timeout.
 	instID := "wf_rehydrate_timeout"
 	store.CreateWorkflowInstance(context.Background(), &db.WorkflowInstance{ //nolint:errcheck
-		ID: instID, WorkflowID: "feature", TaskID: "c1", CellID: "c1", State: db.InstanceStateApprovalWaiting})
+		ID: instID, WorkflowID: "feature", TaskID: "c1", CellID: "c1", State: db.InstanceStateBlocked, BlockedReason: string(state.ReasonApproval)})
 	prior := []db.StepRun{
 		{ID: "sr-plan", WorkflowInstanceID: instID, StepID: "plan", State: db.StepStatePassed},
 	}

--- a/src/internal/workflow/resume.go
+++ b/src/internal/workflow/resume.go
@@ -10,6 +10,7 @@ import (
 	"github.com/orlandoburli/apiary/internal/config"
 	"github.com/orlandoburli/apiary/internal/db"
 	"github.com/orlandoburli/apiary/internal/model"
+	"github.com/orlandoburli/apiary/internal/state"
 )
 
 // ResumeInstance creates an immutable descendant of a failed or interrupted
@@ -38,7 +39,7 @@ func (e *Engine) ResumeInstance(ctx context.Context, source *db.WorkflowInstance
 		return "", false, err
 	}
 	if err := e.persistWorkflowSnapshot(ctx, instID, wf); err != nil {
-		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed)
+		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed, "")
 		return "", false, err
 	}
 
@@ -49,7 +50,7 @@ func (e *Engine) ResumeInstance(ctx context.Context, source *db.WorkflowInstance
 		return "", false, err
 	}
 	if err := e.seedResume(ctx, r, selected); err != nil {
-		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed)
+		_ = e.store.UpdateWorkflowInstanceState(ctx, instID, db.InstanceStateFailed, "")
 		return "", false, err
 	}
 
@@ -68,6 +69,11 @@ func (e *Engine) seedResume(ctx context.Context, r *dagRun, priorSteps []db.Step
 		cached.ID = e.newID("sr")
 		cached.WorkflowInstanceID = r.instID
 		cached.SkippedCached = true
+		// The state is plain 'skipped'; why it was skipped lives in the reason
+		// column, which is what let 'skipped_cached' stop being a state (#465).
+		// The boolean is kept in step with it for existing consumers.
+		cached.State = db.StepStateSkipped
+		cached.SkippedReason = string(state.ReasonCached)
 		if err := e.store.CreateStepRun(ctx, &cached); err != nil {
 			return err
 		}
@@ -119,7 +125,10 @@ func (e *Engine) restoreCachedSteps(r *dagRun, priorSteps []db.StepRun) []db.Ste
 	var restored []db.StepRun
 	for i := range priorSteps {
 		sr := priorSteps[i]
-		if sr.State != db.StepStatePassed {
+		// Normalized rather than compared directly: a row written before the
+		// state migration still holds 'passed', and a resume that silently
+		// stopped reusing those rows would re-run completed work (#465).
+		if state.Normalize(sr.State) != state.Done {
 			continue // failed/running/pending steps re-run
 		}
 		step, ok := r.byID[sr.StepID]

--- a/src/internal/workflow/subworkflow.go
+++ b/src/internal/workflow/subworkflow.go
@@ -129,7 +129,7 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 		return "", nil, false
 	}
 	if err := e.persistWorkflowSnapshot(ctx, childID, child); err != nil {
-		_ = e.store.UpdateWorkflowInstanceState(ctx, childID, db.InstanceStateFailed)
+		_ = e.store.UpdateWorkflowInstanceState(ctx, childID, db.InstanceStateFailed, "")
 		aplog.Error("sub-workflow %s: persist snapshot: %v", child.ID, err)
 		return childID, nil, false
 	}
@@ -161,7 +161,7 @@ func (e *Engine) runChildInstance(ctx context.Context, parentInstID string, chil
 			finalState = db.InstanceStateFailed
 		}
 	}
-	_ = e.store.UpdateWorkflowInstanceState(context.WithoutCancel(ctx), childID, finalState)
+	_ = e.store.UpdateWorkflowInstanceState(context.WithoutCancel(ctx), childID, finalState, "")
 	return childID, outputs, outcome == outcomeDone
 }
 

--- a/src/internal/workflow/task_completion_test.go
+++ b/src/internal/workflow/task_completion_test.go
@@ -19,6 +19,11 @@ type fakeTracker struct {
 	outstanding map[string]int
 	failed      map[string]bool
 	states      map[string]model.TaskState
+	reasons     map[string]string
+	// consecutiveFailed drives retryPending: with settings.max_attempts unset
+	// (the default in these tests) the cap is disabled and a failed task settles
+	// as 'failed', so this stays zero unless a test opts in.
+	consecutiveFailed int
 }
 
 func newFakeTracker() *fakeTracker {
@@ -26,6 +31,7 @@ func newFakeTracker() *fakeTracker {
 		outstanding: map[string]int{},
 		failed:      map[string]bool{},
 		states:      map[string]model.TaskState{},
+		reasons:     map[string]string{},
 	}
 }
 
@@ -180,5 +186,82 @@ func TestEngine_TaskHookNoTrackerIsNoOp(t *testing.T) {
 	}
 	if len(side.hooks) != 0 {
 		t.Errorf("tasks: hook applied without a tracker: %+v", side.hooks)
+	}
+}
+
+func (f *fakeTracker) SetTaskStateReason(ctx context.Context, id string, st model.TaskState, reason string) error {
+	f.mu.Lock()
+	f.reasons[id] = reason
+	f.mu.Unlock()
+	return f.SetTaskState(ctx, id, st)
+}
+
+func (f *fakeTracker) CountConsecutiveFailedInstances(_ context.Context, _, _ string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consecutiveFailed, nil
+}
+
+// TestSettle_RetryPendingIsBlockedNotFailed covers the second defect the
+// canonical state model exists to fix (#465).
+//
+// settings.max_attempts re-dispatches a failed task, so 'failed' used to cover
+// both "will be retried" and "has given up" — a healthily-retrying task
+// oscillated failed → running → failed and looked exactly like a dead one.
+// Retry-pending is now blocked/retry_backoff, which is what makes 'failed' mean
+// "a human needs to look at this".
+func TestSettle_RetryPendingIsBlockedNotFailed(t *testing.T) {
+	cases := []struct {
+		name              string
+		maxAttempts       int
+		consecutiveFailed int
+		wantState         model.TaskState
+		wantReason        string
+	}{
+		{
+			name:              "attempts remain: blocked awaiting retry",
+			maxAttempts:       3,
+			consecutiveFailed: 1,
+			wantState:         model.TaskStateBlocked,
+			wantReason:        "retry_backoff",
+		},
+		{
+			name:              "attempts exhausted: terminal failure",
+			maxAttempts:       3,
+			consecutiveFailed: 3,
+			wantState:         model.TaskStateFailed,
+		},
+		{
+			name:              "cap disabled: nothing will retry, so terminal",
+			maxAttempts:       0,
+			consecutiveFailed: 9,
+			wantState:         model.TaskStateFailed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := newFakeTracker()
+			tr.outstanding["T1"] = 1
+			tr.consecutiveFailed = tc.consecutiveFailed
+
+			cfg := taskHookCfg()
+			cfg.Settings.MaxAttempts = tc.maxAttempts
+			e := trackerEngine(cfg, newFakeStore(), &fakeExecutor{results: map[string]StepResult{}}, &fakeSide{}, tr)
+
+			r := &dagRun{
+				instID: "i1",
+				task:   model.InternalTask{ID: "T1"},
+				wf:     config.WorkflowConfig{ID: "wf"},
+			}
+			e.completeTask(context.Background(), r, true)
+
+			if got := tr.states["T1"]; got != tc.wantState {
+				t.Errorf("task state = %q, want %q", got, tc.wantState)
+			}
+			if got := tr.reasons["T1"]; got != tc.wantReason {
+				t.Errorf("blocked reason = %q, want %q", got, tc.wantReason)
+			}
+		})
 	}
 }

--- a/src/internal/workflow/task_generation_test.go
+++ b/src/internal/workflow/task_generation_test.go
@@ -24,6 +24,12 @@ func (t dbTracker) HasFailedInstance(ctx context.Context, taskID string) (bool, 
 func (t dbTracker) SetTaskState(ctx context.Context, taskID string, state model.TaskState) error {
 	return t.c.InternalTasks().UpdateTaskState(ctx, taskID, state)
 }
+func (t dbTracker) SetTaskStateReason(ctx context.Context, taskID string, state model.TaskState, reason string) error {
+	return t.c.InternalTasks().UpdateTaskStateReason(ctx, taskID, state, reason)
+}
+func (t dbTracker) CountConsecutiveFailedInstances(ctx context.Context, taskID, workflowID string) (int, error) {
+	return t.c.CountConsecutiveFailedInstances(ctx, taskID, workflowID)
+}
 
 // generationTestEnv wires an engine to a real SQLite db.Client (Store and
 // TaskTracker both) with the tasks: completion hook configured.

--- a/src/internal/workflow/wait_ci_source_test.go
+++ b/src/internal/workflow/wait_ci_source_test.go
@@ -78,7 +78,7 @@ func TestWaitCISource_NoLinkedPRStaysParked(t *testing.T) {
 	if success {
 		t.Fatal("instance reported success while no PR was linked yet")
 	}
-	if state := store.instances[instID].State; state != db.InstanceStateWaiting {
+	if state := store.instances[instID].State; state != db.InstanceStateBlocked {
 		t.Fatalf("instance state = %q, want waiting — an unlinked PR must not fail the wait", state)
 	}
 
@@ -104,7 +104,7 @@ func TestWaitCISource_UnsupportedFailsImmediately(t *testing.T) {
 	if success {
 		t.Fatal("a wait against an unusable ci_source must not pass")
 	}
-	if state := store.instances[instID].State; state == db.InstanceStateWaiting {
+	if state := store.instances[instID].State; state == db.InstanceStateBlocked {
 		t.Error("instance parked on a permanently unsupported ci_source; want a terminal failure")
 	}
 }

--- a/src/internal/workflow/wait_dependency_test.go
+++ b/src/internal/workflow/wait_dependency_test.go
@@ -48,7 +48,7 @@ func TestDependencyWait_SuspendsWhileBlockerOpen(t *testing.T) {
 	if success {
 		t.Fatal("a dependency-parked instance should not report success")
 	}
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Errorf("instance state = %q, want waiting", store.instances[instID].State)
 	}
 	if contains(executedIDs(exec.seen), "implement") {
@@ -77,7 +77,7 @@ func TestDependencyWait_AutoResumesWhenBlockerDone(t *testing.T) {
 
 	// Blocker still open → stays parked.
 	eng.CheckParkedWaits(context.Background())
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("expected still waiting, got %q", store.instances[instID].State)
 	}
 
@@ -121,7 +121,7 @@ func TestDependencyWait_SatisfiedWhenMergedOnly(t *testing.T) {
 
 	wait := &config.WaitForConfig{Kind: "dependency", SatisfiedWhen: []string{"merged"}}
 	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(wait), model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("done-but-unmerged blocker should keep waiting under satisfied_when [merged], got %q", store.instances[instID].State)
 	}
 }
@@ -151,7 +151,7 @@ func TestDependencyWait_CheckerErrorKeepsWaiting(t *testing.T) {
 	eng := depWaitEngine(store, exec, &clock, dep)
 
 	instID, _, _ := eng.RunInstance(context.Background(), dependencyWorkflow(&config.WaitForConfig{Kind: "dependency"}), model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("a transient lookup error should park (retry next cycle), got %q", store.instances[instID].State)
 	}
 	if len(store.ciPolls) == 0 || store.ciPolls[len(store.ciPolls)-1].Status != "error" {
@@ -174,7 +174,7 @@ func TestDependencyWait_TimeoutHoldStaysParked(t *testing.T) {
 
 	clock = clock.Add(2 * time.Hour)
 	eng.CheckParkedWaits(context.Background())
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Errorf("on_timeout hold should keep the instance parked, got %q", store.instances[instID].State)
 	}
 	if len(eng.ParkedWaits()) != 1 {

--- a/src/internal/workflow/wait_park.go
+++ b/src/internal/workflow/wait_park.go
@@ -153,7 +153,7 @@ func (e *Engine) WakeWait(ctx context.Context, instanceID string) {
 	r.waitingChild = ""
 	r.state[step] = stPending // re-arm the wait_for (or parallel) step for re-dispatch
 
-	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning)
+	_ = e.store.UpdateWorkflowInstanceState(ctx, instanceID, db.InstanceStateRunning, "")
 	outcome := e.driveDAG(ctx, r)
 	e.settle(ctx, r, outcome)
 }

--- a/src/internal/workflow/wait_park_parallel_test.go
+++ b/src/internal/workflow/wait_park_parallel_test.go
@@ -53,8 +53,8 @@ func TestParallelWaitChild_ParksGroupAndReusesSiblingResult(t *testing.T) {
 	if success {
 		t.Fatal("a group parked on a pending CI wait should not report success")
 	}
-	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
-		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateWaiting)
+	if got := store.instances[instID].State; got != db.InstanceStateBlocked {
+		t.Fatalf("instance state = %q, want %q", got, db.InstanceStateBlocked)
 	}
 	// The park names the waiting CHILD, so the dispatcher re-checks the right wait.
 	parked := eng.ParkedWaits()
@@ -70,7 +70,7 @@ func TestParallelWaitChild_ParksGroupAndReusesSiblingResult(t *testing.T) {
 
 	// Still pending → stays parked, and the review is NOT re-run.
 	eng.CheckParkedWaits(context.Background())
-	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+	if got := store.instances[instID].State; got != db.InstanceStateBlocked {
 		t.Fatalf("expected still waiting, got %q", got)
 	}
 	if n := countExecuted(exec.seen, "review"); n != 1 {
@@ -106,7 +106,7 @@ func TestParallelWaitChild_FailedSiblingDecidesJoinWithoutParking(t *testing.T) 
 	if success {
 		t.Fatal("a group whose review failed must not report success")
 	}
-	if got := store.instances[instID].State; got == db.InstanceStateWaiting {
+	if got := store.instances[instID].State; got == db.InstanceStateBlocked {
 		t.Fatal("group parked on CI although join: all was already decided by the failed review")
 	}
 	if len(eng.ParkedWaits()) != 0 {
@@ -161,7 +161,7 @@ func TestParallelWaitChild_RehydrateSurvivesRestart(t *testing.T) {
 	ci1 := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
 	eng1 := waitForEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
 	instID, _, _ := eng1.RunInstance(context.Background(), parallelWaitWorkflow(""), model.InternalTask{ID: "c1"})
-	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+	if got := store.instances[instID].State; got != db.InstanceStateBlocked {
 		t.Fatalf("expected waiting before restart, got %q", got)
 	}
 

--- a/src/internal/workflow/wait_park_test.go
+++ b/src/internal/workflow/wait_park_test.go
@@ -51,7 +51,7 @@ func TestWaitFor_SuspendsWhilePending(t *testing.T) {
 	if success {
 		t.Fatal("a poll-parked instance should not report success")
 	}
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Errorf("instance state = %q, want poll_waiting", store.instances[instID].State)
 	}
 	// implement ran; review must not have.
@@ -80,7 +80,7 @@ func TestWaitFor_AdvancesWhenCIPasses(t *testing.T) {
 
 	// Still pending → stays parked.
 	eng.CheckParkedWaits(context.Background())
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("expected still poll_waiting, got %q", store.instances[instID].State)
 	}
 
@@ -119,7 +119,7 @@ func TestWaitFor_RedCILoopsBackToImplement(t *testing.T) {
 	eng := waitForEngine(baseCfg(), store, exec, &fakeSide{}, &clock, ci)
 
 	instID, _, _ := eng.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
-	if got := store.instances[instID].State; got != db.InstanceStateWaiting {
+	if got := store.instances[instID].State; got != db.InstanceStateBlocked {
 		t.Fatalf("after red CI loop-back, want poll_waiting, got %q", got)
 	}
 	if n := countID(exec.seen, "implement"); n != 2 {
@@ -255,7 +255,7 @@ func TestWaitFor_TimesOut(t *testing.T) {
 			WaitFor: &config.WaitForConfig{Kind: "ci", MaxDuration: "2h"}},
 	}}
 	instID, _, _ := eng.RunInstance(context.Background(), wf, model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("expected poll_waiting, got %q", store.instances[instID].State)
 	}
 
@@ -280,7 +280,7 @@ func TestWaitFor_RehydrateSurvivesRestart(t *testing.T) {
 	ci1 := func() (source.CIStatus, error) { return source.CIStatus{Status: "pending"}, nil }
 	eng1 := waitForEngine(baseCfg(), store, exec1, &fakeSide{}, &clock, ci1)
 	instID, _, _ := eng1.RunInstance(context.Background(), waitForWorkflow(), model.InternalTask{ID: "c1"})
-	if store.instances[instID].State != db.InstanceStateWaiting {
+	if store.instances[instID].State != db.InstanceStateBlocked {
 		t.Fatalf("expected poll_waiting before restart, got %q", store.instances[instID].State)
 	}
 
@@ -422,7 +422,7 @@ func TestWaitFor_UnsupportedCapabilityFailsTerminally(t *testing.T) {
 	if success {
 		t.Fatal("a wait against a source without CI polling must not succeed")
 	}
-	if got := store.instances[instID].State; got == db.InstanceStateWaiting {
+	if got := store.instances[instID].State; got == db.InstanceStateBlocked {
 		t.Fatalf("the wait parked instead of failing: state %q", got)
 	}
 	if len(eng.ParkedWaits()) != 0 {


### PR DESCRIPTION
**Stacked on #464** (release N). Review that first; this PR targets its branch, so the diff here is N+1 only.

Release N taught every binary to *read* the canonical vocabulary. This one starts **writing** it, adds the reason columns, and fixes the two defects the old model made unrepresentable.

## Schema

Additive DDL only, so it stays in `InitSchema` and is safe from any opener:

```sql
ALTER TABLE internal_tasks     ADD COLUMN blocked_reason TEXT;
ALTER TABLE workflow_instances ADD COLUMN blocked_reason TEXT;
ALTER TABLE step_runs          ADD COLUMN blocked_reason TEXT;
ALTER TABLE step_runs          ADD COLUMN skipped_reason TEXT;
```

## The collapse only works if the reason travels

`approval_waiting`, `waiting` and `interrupted` all became `blocked`; `skipped_cached` became `skipped`. That is only correct if the *reason* moves with the state — so it is threaded through every write and every site that used to switch on the distinction.

**I first tried keeping the old names as aliases.** It compiled, and it was wrong: it silently merged cases that must stay apart. Deleting them made the compiler find all 28 sites, and three of those were real bugs an alias would have shipped:

| Site | What the alias would have done |
|---|---|
| `workflowStateEventType` | emitted `workflow.cancelled` when a run merely **parked on an approval** |
| `resumableState` | made an approval-parked run **resumable** — double-running the workflow |
| `HasActiveInstanceForRoute` | let an **interrupted** instance shadow a re-dispatch, stranding the workflow across every restart |

That is the argument for `rename`-over-find-and-replace, in miniature.

## Migration: terminal rows only

`migrateStates` lives in `MigrateData` (daemon-only, refused against a live hive — #467/#468) and converts **only terminal rows**: `passed→done`, `skipped_cached→skipped`+reason, `succeeded→done`.

Live rows — `registered`, `pending`, `approval_waiting`, `waiting`, `leased`, `interrupted` — are never bulk-rewritten. They convert on their next natural transition, and `Normalize` on read covers them meanwhile. **Nothing moves underneath the engine.** `TestMigrateStates_OnlyTouchesTerminalRows` pins exactly this.

## The two defects

**Orphaned tasks no longer look freshly queued.** `PropagateInterruptedToTasks` runs at daemon start, after the counter recount, and carries interruption up to the task as `blocked`/`interrupted`. The recurring "stuck queued task" false alarm is now readable at a glance.

**`failed` is terminal.** A task with attempts remaining settles as `blocked`/`retry_backoff` instead, so a healthily-retrying task stops oscillating `failed → running → failed`. `IncrementOutstanding` reopens it via a `taskReopenable` predicate that deliberately does **not** match a task blocked on an approval — reopening that would bump the generation underneath a live run.

## Deliberately out of scope (both found while implementing)

**The DAG scheduler's in-memory vocabulary** (`dag.go`: `stPassed`, `stCondSkipped`, …) — a *fifth* vocabulary the proposal never accounted for. Left alone for a decisive reason: it never reaches the database, and it **is the user-facing expression API**. `steps.lint.state == 'passed'` in a workflow condition reads these values (`docs/workflows.md:396`). Renaming them would break every deployed config's conditions while changing nothing an operator sees.

**Vocabularies that merely share words** — GitHub CI statuses (`passed|failed|pending|conflict`), approval-request statuses (`pending|approved|rejected|timed_out`), plugin conformance verdicts. Different domains, same words. A find-and-replace over the state strings would have corrupted all three.

Both are now recorded in the proposal's Out of Scope.

## One subtlety worth a reviewer's eye

`resume.go` filtered the resume cache with `sr.State != db.StepStatePassed`, which is now `"done"`. The migration converts those rows, but I normalized the comparison anyway — a resume that silently stopped reusing rows would re-run completed work, and I would rather not depend on migration ordering for that.

Also: `liveBlocked` in `ReconcileOrphanTaskCounters` is qualified `wi.state` / `wi.blocked_reason` on purpose — the enclosing `UPDATE` targets `internal_tasks`, which now has columns of the same names.

## Testing

`go build ./...`, `gofmt`, `go vet ./...` and the full `go test ./...` all pass. 66 files, +1127/−381.

New tests: terminal-rows-only migration, orphan propagation (including the two cases that must *not* propagate), interrupted-does-not-shadow vs approval-does-shadow, retry-pending vs exhausted vs cap-disabled, and reason-aware `resumableState`.
