### PR TITLE
feat(dashboard): step-progress column and an interactive board view

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,9 +34,17 @@ apiary run [--debug] [--once] [--dry-run] [--source id] [--worker id] [--profile
 
 ### `apiary dashboard`
 
-Open the [terminal dashboard](dashboard.md) — a read-only live view of tasks,
-agents, and logs. Run it in a second terminal, from the same directory as
-`apiary run` (they share the `.apiary/` state).
+Open the [terminal dashboard](dashboard.md) — a live view of tasks, agents, and
+logs. Run it in a second terminal, from the same directory as `apiary run` (they
+share the `.apiary/` state).
+
+```sh
+apiary dashboard [--view list|board]
+```
+
+`--view board` opens on the [board](dashboard.md#the-board) — tasks grouped into
+columns by state — instead of the list. Press `b` to switch either way at any
+time, or set `settings.dashboard.default_view` to make the choice stick.
 
 ### `apiary status`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -389,6 +389,7 @@ settings:
 | `log_max_size_mb` | 50 | Rotate `apiary.log` past this size (MB); negative disables rotation |
 | `log_max_backups` | 5 | Rotated files kept as `apiary.log.1` … `.N`, oldest dropped; negative keeps none |
 | `log_max_age_days` | 30 | Prune rotated backups, per-task logs (`logs/tasks/*.log`) **and** SQLite log rows (`service_logs`/`task_logs`) older than this; negative disables |
+| `dashboard.default_view` | `list` | Which Tasks view the [dashboard](dashboard.md#the-board) opens on: `list` or `board`. Overridden per invocation by `apiary dashboard --view=` |
 
 ### Log rotation
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -104,8 +104,25 @@ numbers.
 ### Tasks
 
 A list of recent tasks — both running and already finished — newest first. Each
-row shows the task title, the agent that handled it, its status (running /
-success / failed), and when it ran. Use `↑` / `↓` to move the `▶` marker.
+row shows the task title, **which step it is on**, its status, and when it ran.
+Use `↑` / `↓` to move the `▶` marker.
+
+```
+   #          TASK                            STEP           STATUS   WHEN
+▶  #412       Fix approval gate re-entry      review 3/5     running  4m ago
+   #401       Port pgsink to new columns      check-ci 4/6   blocked  1h ago
+   #396       Decompose the spec              ⑂ 3 steps      running  8m ago
+```
+
+The **STEP** column answers "where has it got to": the step now executing and
+its position in the workflow. A task running more than one workflow instance at
+once — `parallel`, `for_each`, or spawned children — shows `⑂ 3 steps` rather
+than picking one of them to display.
+
+There used to be an AGENT column here. An agent is a property of a *step*, not
+of a task, so for a task whose steps used three different agents it showed one
+arbitrary agent of the three. The agent is still shown per step in **Details**
+and in the workflow monitor, where it is accurate.
 
 From the list you can drill into the selected task:
 
@@ -117,6 +134,7 @@ From the list you can drill into the selected task:
 | `R` (Shift+R)          | **Force restart** — cancel and re-dispatch the task (with confirmation) |
 | `W` (Shift+W)          | **Start a workflow** on the task, ignoring triggers and guards |
 | `C`                    | **Clear logs** — delete all logs for the task (with confirmation) |
+| `b`                    | **Board** — the same tasks grouped into columns by state (see below) |
 | `Esc` / `Backspace` / `h` / `←` | Back to the list                          |
 
 The `#` column shows each task's human reference (e.g. `ERP-42`) so you can
@@ -269,6 +287,65 @@ runners:
 
 Apiary parses those events into the readable lines above. A CLI without
 structured output still streams — you just see its raw output instead.
+
+#### The board
+
+Press `b` for a board view of the same tasks, one column per state:
+
+```
+  QUEUED (1)              RUNNING (2)              BLOCKED (2)              DONE (12)
+  #418                  │ #412                   │ #401                   │ #390
+  Add plugin registry   │ Fix approval gate re-… │ Port pgsink to new co… │ Docs: plugins
+  —                     │ review 3/5             │ check-ci 4/6           │ —
+  2m ago                │ 4m ago                 │ ci 1h ago              │ 20m ago
+
+  FAILED (1) — needs attention
+    #407     Improve advisor evidence pack        build 2/7      3h ago
+```
+
+The columns are the task states themselves, so a card sits in `BLOCKED` because
+its state says blocked — nothing is inferred. A blocked card also shows *what*
+it is waiting on (`approval`, `ci`, `dependency`).
+
+**`FAILED` is a lane, not a column.** The columns are stages work passes
+through, and terminal failure is not one — it is an exception waiting for a
+person. The lane stays visible when it is empty, showing `FAILED (0)`, because
+"nothing needs attention" is worth seeing.
+
+The board is a working surface, not a wallboard. Every key does what it does
+elsewhere, acting on the selected card:
+
+| Key            | Action                                             |
+|----------------|----------------------------------------------------|
+| `←` `→`        | Move between columns (at the edges, switches tab)  |
+| `↑` `↓`        | Move within a column                               |
+| `Enter` / `l`  | Open the task                                      |
+| `a` / `y` / `n`| Answer the approval the card is blocked on         |
+| `R` (Shift+R)  | Force restart the task                             |
+| `b` / `Esc`    | Back to the list                                   |
+
+Answering approvals in place is the reason the view earns its keystroke: open
+the board, see `BLOCKED (4)`, clear four gates without drilling into four tasks.
+
+Cards cannot be dragged between columns. A card moves when the hive moves it —
+state is a consequence of what actually ran, and a board that let you drag a
+task into `DONE` would be asserting something that never happened.
+
+`DONE` is capped so finished work cannot squeeze out the columns that need
+attention; the header always shows the true count, with `+N` for what it did not
+fit. On a narrow terminal columns are dropped from the right (`DONE` first, then
+`QUEUED`) and their counts move into the header. Below about 40 columns the
+board declines to render and the list is shown instead.
+
+To open on the board every time, set it per hive:
+
+```yaml
+settings:
+  dashboard:
+    default_view: board   # list (default) | board
+```
+
+or per invocation with `apiary dashboard --view=board`.
 
 ### Agents
 

--- a/openspec/changes/task-progress-and-board/proposal.md
+++ b/openspec/changes/task-progress-and-board/proposal.md
@@ -80,9 +80,14 @@ Replaces `AGENT`, keeping the same fixed width so the row layout is unchanged.
 | No live instance, task terminal | `5/5` or `2/5` | where it stopped, no step name |
 | No live instance, task never dispatched | `—` | |
 
-`position` is the 1-based index of the step in the instance's step sequence; `total` is the
-sequence length. Both come from the workflow definition snapshot the instance already stores, so a
-workflow edited after dispatch does not retroactively change a historical row's denominator.
+`position` is the 1-based index of the step in the workflow's step sequence; `total` is the
+sequence length.
+
+**Implementation note:** the sequence is read from the live configuration, not from the instance's
+stored definition snapshot as first proposed. Reading the snapshot would cost a query and a JSON
+parse per visible instance to produce a denominator that differs only when someone edited the
+workflow while a run was in flight. When the step is no longer in the definition — the workflow was
+edited mid-flight — the column shows `gone ?/5`: the scale, without a position that would be a lie.
 
 Truncation: step ids are user-authored and can be long. The column truncates the step id, never
 the `n/m` suffix — losing the position is worse than losing the tail of a name.

--- a/src/internal/cli/dashboard_cmd.go
+++ b/src/internal/cli/dashboard_cmd.go
@@ -14,7 +14,8 @@ import (
 )
 
 func newDashboardCmd() *cobra.Command {
-	return &cobra.Command{
+	var view string
+	cmd := &cobra.Command{
 		Use:   "dashboard",
 		Short: "Open the dashboard TUI (requires running dispatcher)",
 		Long: `Open the Apiary dashboard to monitor task execution, agent status, and logs.
@@ -22,12 +23,14 @@ func newDashboardCmd() *cobra.Command {
 The dashboard reads from the SQLite database populated by a running dispatcher.
 Run 'apiary run' in another terminal first.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDashboard(cmd.Context())
+			return runDashboard(cmd.Context(), view)
 		},
 	}
+	cmd.Flags().StringVar(&view, "view", "", "Tasks tab view to open on: list or board (default: settings.dashboard.default_view, else list)")
+	return cmd
 }
 
-func runDashboard(ctx context.Context) error {
+func runDashboard(ctx context.Context, view string) error {
 	dbPath := getDBPath()
 	if _, err := os.Stat(dbPath); err != nil {
 		return fmt.Errorf("database not found at %s\nRun 'apiary run' in another terminal first", dbPath)
@@ -45,7 +48,7 @@ func runDashboard(ctx context.Context) error {
 	}
 
 	socketPath := daemon.SocketPath(config.DataDir(configFile))
-	app := dashboard.New(dbConn, socketPath, cfg, getLogDir())
+	app := dashboard.NewWithView(dbConn, socketPath, cfg, getLogDir(), view)
 	if err := app.Run(); err != nil {
 		return fmt.Errorf("dashboard error: %w", err)
 	}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -405,6 +405,7 @@ type Settings struct {
 	Telemetry     Telemetry          `yaml:"telemetry"`
 	CursorCost    CursorCostSettings `yaml:"cursor_cost"`
 	Improve       ImproveSettings    `yaml:"improve"`
+	Dashboard     DashboardSettings  `yaml:"dashboard,omitempty"`
 	GitHooks      GitHooksSettings   `yaml:"git_hooks"`
 	Queue         QueueSettings      `yaml:"queue"`
 	// DefaultFallbacks is a fallback chain applied to every agent that does not
@@ -486,6 +487,15 @@ func queueDuration(value string, fallback time.Duration) time.Duration {
 type ApprovalSettings struct {
 	WebhookSecret string   `yaml:"webhook_secret,omitempty"`
 	RequireFor    []string `yaml:"require_for,omitempty"`
+}
+
+// DashboardSettings holds per-hive terminal dashboard preferences.
+type DashboardSettings struct {
+	// DefaultView is the Tasks tab view the dashboard opens on: "list"
+	// (default) or "board". The list stays the default for a new hive because it
+	// degrades to any terminal size and carries the full history; the board
+	// earns its space once a hive runs enough concurrent work to need grouping.
+	DefaultView string `yaml:"default_view,omitempty"`
 }
 
 // EventSettings controls persisted structured execution events. Events are

--- a/src/internal/config/validate.go
+++ b/src/internal/config/validate.go
@@ -121,6 +121,10 @@ func (c *Config) Validate() []error {
 		}
 	}
 
+	if v := c.Settings.Dashboard.DefaultView; v != "" && v != "list" && v != "board" {
+		errs = append(errs, fmt.Errorf("settings.dashboard.default_view %q: must be \"list\" or \"board\"", v))
+	}
+
 	if c.Version == "" {
 		errs = append(errs, fmt.Errorf("version is required"))
 	}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -89,8 +89,25 @@ type App struct {
 }
 
 func New(dbConn *db.Client, socketPath string, cfg *config.Config, logDir string) *App {
+	return NewWithView(dbConn, socketPath, cfg, logDir, "")
+}
+
+// NewWithView is New with an explicit starting view for the Tasks tab, so the
+// board can be selected per invocation (--view=board) or per hive
+// (settings.dashboard.default_view) rather than only by pressing `b`.
+//
+// An unrecognised value falls back to the list rather than erroring: a typo in a
+// config file should not stop an operator opening the dashboard.
+func NewWithView(dbConn *db.Client, socketPath string, cfg *config.Config, logDir, view string) *App {
+	m := NewModel()
+	if view == "" && cfg != nil {
+		view = cfg.Settings.Dashboard.DefaultView
+	}
+	if view == "board" && m.tasksTab != nil {
+		m.tasksTab.View = TaskViewBoard
+	}
 	return &App{
-		model:      NewModel(),
+		model:      m,
 		dbConn:     dbConn,
 		socketPath: socketPath,
 		cfg:        cfg,
@@ -244,6 +261,17 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				a.logMDCache[m] = lines
 			}
 		}
+
+	case boardApprovalMsg:
+		// The card had no waiting approval, or the lookup failed: say so rather
+		// than swallowing the keypress, so a mis-aimed y/n is visibly a no-op.
+		if msg.req == nil {
+			a.model.notice = msg.err
+			a.model.noticeIsErr = true
+			a.model.noticeUntil = time.Now().Add(noticeTTL)
+			return a, nil
+		}
+		return a.answerApproval(msg.req, msg.key)
 
 	case noticeMsg:
 		// Show the banner and refresh straight away: a restart that dispatched
@@ -712,6 +740,16 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.model.logsTab.HScroll += hStep
 			return a, nil
 		}
+		// On the board, ← / → move between columns — but only while there is a
+		// column to move to. At the last column the key falls through to the
+		// tab switch, so the board never traps the cursor.
+		if t := a.model.tasksTab; a.model.ActiveTab() == "Tasks" && t != nil && t.View == TaskViewBoard {
+			if t.BoardCol < a.boardColumnCount()-1 {
+				t.BoardCol++
+				t.BoardRow = 0
+				return a, nil
+			}
+		}
 		a.model.NextTab()
 		a.model.loading = true
 		return a, a.fetchActiveTab()
@@ -723,6 +761,13 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
+		if t := a.model.tasksTab; a.model.ActiveTab() == "Tasks" && t != nil && t.View == TaskViewBoard {
+			if t.BoardCol > 0 {
+				t.BoardCol--
+				t.BoardRow = 0
+				return a, nil
+			}
+		}
 		a.model.PrevTab()
 		a.model.loading = true
 		return a, a.fetchActiveTab()
@@ -732,6 +777,19 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.model.logsTab.Wrap = !a.model.logsTab.Wrap
 			a.model.logsTab.HScroll = 0
 			a.model.logsTab.Scrolled = 0
+		}
+	case "b":
+		// Toggle the board. Scoped to the two views it moves between, so it does
+		// not fire from a detail/logs/monitor screen where it would be a
+		// surprising jump.
+		if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil {
+			switch a.model.tasksTab.View {
+			case TaskViewList:
+				a.model.tasksTab.View = TaskViewBoard
+				a.model.tasksTab.BoardCol, a.model.tasksTab.BoardRow = 0, 0
+			case TaskViewBoard:
+				a.model.tasksTab.View = TaskViewList
+			}
 		}
 	case "r":
 		a.model.loading = true
@@ -784,6 +842,12 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "up":
 		switch a.model.ActiveTab() {
 		case "Tasks":
+			if t := a.model.tasksTab; t != nil && t.View == TaskViewBoard {
+				if t.BoardRow > 0 {
+					t.BoardRow--
+				}
+				break
+			}
 			if a.model.tasksTab != nil && a.model.tasksTab.SelectedIdx > 0 {
 				a.model.tasksTab.SelectedIdx--
 			}
@@ -800,6 +864,10 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "down":
 		switch a.model.ActiveTab() {
 		case "Tasks":
+			if t := a.model.tasksTab; t != nil && t.View == TaskViewBoard {
+				t.BoardRow++ // clamped on render, where the column sizes are known
+				break
+			}
 			if a.model.tasksTab != nil {
 				maxIdx := len(a.filteredTasks(a.model.tasksTab)) - 1
 				if a.model.tasksTab.SelectedIdx < maxIdx {
@@ -1237,6 +1305,13 @@ func (a *App) handleTaskSubViewKey(key string) (tea.Model, tea.Cmd) {
 		if t.View == TaskViewDetail && t.DetailInstance != nil && t.DetailInstance.Approval != nil {
 			return a.answerApproval(t.DetailInstance.Approval, key)
 		}
+		// On the board the card carries only the task, so the request is fetched
+		// first and answered when it arrives (see boardApprovalCmd).
+		if t.View == TaskViewBoard {
+			if card, ok := a.selectedTask(); ok {
+				return a, a.boardApprovalCmd(*card, key)
+			}
+		}
 	case "l", "enter":
 		if row, ok := a.selectedTask(); ok {
 			a.model.loading = true
@@ -1552,6 +1627,16 @@ func lastIndex(total int) int {
 func (a *App) selectedTask() (*TaskItem, bool) {
 	t := a.model.tasksTab
 	if t == nil {
+		return nil, false
+	}
+	// The board addresses a task by (column, row) rather than by list index.
+	// Resolving it here rather than in each key handler is what makes every
+	// existing action — detail, logs, approve, restart, stop — work on a card
+	// with the same key and no duplicated wiring.
+	if t.View == TaskViewBoard {
+		if card := a.selectedBoardTask(t); card != nil {
+			return card, true
+		}
 		return nil, false
 	}
 	rows := a.filteredTasks(t)
@@ -2424,6 +2509,10 @@ func (a *App) fetchOverview() tea.Cmd {
 
 func (a *App) fetchTasks() tea.Cmd {
 	dbConn := a.dbConn
+	var workflows []config.WorkflowConfig
+	if a.cfg != nil {
+		workflows = a.cfg.Workflows
+	}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
@@ -2441,6 +2530,23 @@ func (a *App) fetchTasks() tea.Cmd {
 					prs, _ := dbConn.ListTaskPullRequests(ctx, tk.ID)
 					items = append(items, taskItemFromInternal(tk, bindings, prs))
 				}
+
+				// One query for the whole page, not one per row: this runs on a
+				// timer against the file the daemon is writing to.
+				ids := make([]string, 0, len(tasks))
+				for _, tk := range tasks {
+					ids = append(ids, tk.ID)
+				}
+				if rows, err := dbConn.ListStepProgressForTasks(ctx, ids); err == nil {
+					progress := resolveTaskProgress(rows, workflows)
+					for i := range items {
+						p := progress[items[i].InternalTaskID]
+						items[i].StepID = p.StepID
+						items[i].StepPosition = p.Position
+						items[i].StepTotal = p.Total
+						items[i].LiveInstances = p.Instances
+					}
+				}
 			}
 		}
 		return tasksDataMsg{items: items}
@@ -2457,6 +2563,7 @@ func taskItemFromInternal(t model.InternalTask, bindings []model.SourceBinding, 
 		TaskID:               drillKeyFor(t, bindings), // legacy machinery key (== DrillKey)
 		Title:                t.Title,
 		Status:               string(t.State),
+		BlockedReason:        t.BlockedReason,
 		StartedAt:            &created,
 		InternalTaskID:       t.ID,
 		DrillKey:             drillKeyFor(t, bindings),
@@ -3470,6 +3577,13 @@ func (a *App) renderTasksTab(height int) string {
 		return a.renderWorkflowMonitor(t, height)
 	case TaskViewTranscript:
 		return a.renderTaskTranscript(t, height)
+	case TaskViewBoard:
+		// Below the legibility floor the board declines to render and the list
+		// takes over, rather than producing an unreadable grid.
+		if out := a.renderBoard(t, height); out != "" {
+			return out
+		}
+		return a.renderTaskList(t, height)
 	default:
 		return a.renderTaskList(t, height)
 	}
@@ -3494,7 +3608,7 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 	const (
 		cursorW = 2
 		numW    = 10
-		agentW  = 16
+		agentW  = 16 // width of the progress column (formerly AGENT)
 		statusW = 8
 		whenW   = 11
 	)
@@ -3525,7 +3639,7 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 		title += " [" + strings.Join(parts, " ") + "]"
 	}
 
-	header := pad("", cursorW) + " " + pad("#", numW) + " " + pad("TASK", titleW) + " " + pad("AGENT", agentW) + " " + pad("STATUS", statusW) + " " + "WHEN"
+	header := pad("", cursorW) + " " + pad("#", numW) + " " + pad("TASK", titleW) + " " + pad("STEP", agentW) + " " + pad("STATUS", statusW) + " " + "WHEN"
 	b.WriteString(StyleTableHeader.Render(header) + "\n")
 
 	rowsAvail := height - 3 // borders + header
@@ -3552,7 +3666,11 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 		cursor := "  "
 		num := pad(truncate(valueOr(it.Number, "—"), numW), numW)
 		titleText := pad(truncate(valueOr(it.Title, it.TaskID), titleW), titleW)
-		agent := pad(truncate(valueOr(it.Agent, "—"), agentW), agentW)
+		// The agent column used to live here. An agent is a property of a step,
+		// not of a task, so for a task running several steps it showed one
+		// arbitrary agent of many; the step it is on is both true and more
+		// useful. The agent is still on the detail view, where it is accurate.
+		agent := progressCell(taskProgressOf(it), agentW)
 		status := taskStatusBadge(it.Status)
 		when := taskWhen(it)
 		if selected {

--- a/src/internal/dashboard/board.go
+++ b/src/internal/dashboard/board.go
@@ -1,0 +1,408 @@
+package dashboard
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+// The board groups tasks by canonical state, one column per state. The grouping
+// is a projection of a single column rather than a derivation, which is what the
+// unified state model bought (#465): a card is in BLOCKED because its state says
+// blocked, not because the renderer worked it out.
+//
+// FAILED is deliberately not a column. A board's columns are stages work passes
+// through, and terminal failure is not a stage — it is an exception waiting for
+// a human. It renders as a full-width lane below the board instead, and stays
+// visible as a zero when nothing has failed, because "nothing failed" is
+// information an operator wants.
+var boardColumns = []struct {
+	Title string
+	State state.State
+}{
+	{"QUEUED", state.Queued},
+	{"RUNNING", state.Running},
+	{"BLOCKED", state.Blocked},
+	{"DONE", state.Done},
+}
+
+const (
+	// boardMinColWidth is the narrowest a column can be and still show a card.
+	boardMinColWidth = 14
+	// boardSepWidth is the gutter between columns. A single space is not enough:
+	// titles are truncated to the full column width, so adjacent cards run into
+	// each other and the eye cannot find the column boundary.
+	boardSepWidth = 3
+	// boardMinWidth is where the board stops being legible at all and the list
+	// is shown instead. Refusing to render is more honest than an unreadable grid.
+	boardMinWidth = 40
+	// boardDoneCap bounds the DONE column. Without it a long-running hive's
+	// completed work squeezes out the columns that need attention. The header
+	// count is always the true total, so the cap hides cards, never the number.
+	boardDoneCap = 12
+)
+
+// boardGroups buckets tasks into their board columns, plus the failed lane.
+//
+// Canceled tasks are omitted: they are terminal and operator-initiated, so the
+// operator already knows. They remain reachable through the list and its filter.
+func boardGroups(items []TaskItem) (map[state.State][]TaskItem, []TaskItem) {
+	cols := map[state.State][]TaskItem{}
+	var failed []TaskItem
+	for _, it := range items {
+		switch st := state.Normalize(it.Status); st {
+		case state.Failed:
+			failed = append(failed, it)
+		case state.Canceled:
+			// omitted, see above
+		case state.Queued, state.Running, state.Blocked, state.Done:
+			cols[st] = append(cols[st], it)
+		default:
+			// An unrecognised state is shown rather than dropped; silently
+			// losing a task from the board would be worse than an odd column.
+			cols[state.Queued] = append(cols[state.Queued], it)
+		}
+	}
+	return cols, failed
+}
+
+// boardLayout decides how many columns fit and how wide they are.
+//
+// Columns are dropped from the right — DONE first, then QUEUED — because those
+// are the two an operator is least likely to be acting on. The dropped columns'
+// counts move into the header, so narrowing the terminal hides cards but never
+// hides that the work exists.
+func boardLayout(inner int) (cols int, width int) {
+	if inner < boardMinWidth {
+		return 0, 0
+	}
+	for n := len(boardColumns); n >= 1; n-- {
+		w := (inner - (n-1)*boardSepWidth) / n
+		if w >= boardMinColWidth {
+			return n, w
+		}
+	}
+	return 1, inner
+}
+
+// visibleBoardColumns returns the columns that fit, in display order. When
+// columns are dropped, DONE goes first and QUEUED second.
+func visibleBoardColumns(n int) []int {
+	dropOrder := []int{3, 0} // DONE, then QUEUED
+	keep := map[int]bool{0: true, 1: true, 2: true, 3: true}
+	for i := 0; i < len(boardColumns)-n && i < len(dropOrder); i++ {
+		keep[dropOrder[i]] = false
+	}
+	var out []int
+	for i := range boardColumns {
+		if keep[i] {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// boardCard renders one task as the lines of a card: number, title, progress,
+// and age. The agent is deliberately absent — it is a property of a step, and a
+// card is a task.
+func boardCard(it TaskItem, width int, selected bool) []string {
+	num := valueOr(it.Number, "—")
+	title := valueOr(it.Title, it.TaskID)
+	progress := progressLabel(taskProgressOf(it), width)
+	age := taskWhen(it)
+
+	// A blocked card says what it is blocked on; that is the whole reason an
+	// operator is looking at this column.
+	if state.Normalize(it.Status) == state.Blocked && it.BlockedReason != "" {
+		age = it.BlockedReason + " " + age
+	}
+
+	lines := []string{
+		truncate(num, width),
+		truncate(title, width),
+		truncate(progress, width),
+		truncate(age, width),
+	}
+	for i, l := range lines {
+		l = pad(l, width)
+		switch {
+		case selected && i == 0:
+			l = StyleFocusedArrow.Render(l)
+		case selected:
+			l = StyleSelectedRow.Render(l)
+		case i == 0:
+			l = StyleAccent.Render(l)
+		case i >= 2:
+			l = StyleMuted.Render(l)
+		}
+		lines[i] = l
+	}
+	return lines
+}
+
+// boardColumnTitle is the column header: name, count, and — for a column that
+// was capped — how many cards are not shown.
+func boardColumnTitle(title string, total, shown, width int) string {
+	label := title + " (" + strconv.Itoa(total) + ")"
+	if shown < total {
+		label += " +" + strconv.Itoa(total-shown)
+	}
+	return StyleValueStrong.Render(pad(truncate(label, width), width))
+}
+
+// renderFailedLane renders the attention lane below the board.
+//
+// It is always present. An empty lane collapses to one line that says zero,
+// because a board where the failure lane simply vanishes teaches an operator to
+// stop looking at that part of the screen.
+func renderFailedLane(failed []TaskItem, inner int) string {
+	if len(failed) == 0 {
+		return StyleMuted.Render("FAILED (0) — nothing needs attention")
+	}
+
+	var b strings.Builder
+	b.WriteString(StyleError.Render("FAILED ("+strconv.Itoa(len(failed))+")") +
+		StyleMuted.Render(" — needs attention"))
+	b.WriteString("\n")
+
+	for i, it := range failed {
+		if i >= 3 {
+			b.WriteString(StyleMuted.Render("  +" + strconv.Itoa(len(failed)-3) + " more"))
+			b.WriteString("\n")
+			break
+		}
+		num := pad(truncate(valueOr(it.Number, "—"), 8), 8)
+		progress := pad(truncate(progressLabel(taskProgressOf(it), 14), 14), 14)
+		titleW := maxInt(10, inner-8-14-12-6)
+		title := pad(truncate(valueOr(it.Title, it.TaskID), titleW), titleW)
+		b.WriteString("  " + StyleAccent.Render(num) + " " + title + " " +
+			StyleMuted.Render(progress) + " " + StyleMuted.Render(taskWhen(it)))
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// renderBoard draws the board: the columns that fit, then the failed lane.
+//
+// Below boardMinWidth it returns "" and the caller falls back to the list. A
+// grid squeezed into 30 columns is not a degraded board, it is noise.
+func (a *App) renderBoard(t *TasksTab, height int) string {
+	items := a.filteredTasks(t)
+	cols, failed := boardGroups(items)
+
+	width := a.model.width
+	if width < 24 {
+		width = 24
+	}
+	inner := width - 2
+
+	nCols, colW := boardLayout(inner)
+	if nCols == 0 {
+		return ""
+	}
+	visible := visibleBoardColumns(nCols)
+
+	// Cards are four lines plus a blank separator; reserve the failed lane and
+	// the header row.
+	laneHeight := 1
+	if len(failed) > 0 {
+		laneHeight = minInt(len(failed), 3) + 1
+	}
+	bodyRows := height - 4 - laneHeight
+	if bodyRows < 5 {
+		bodyRows = 5
+	}
+	perColumn := maxInt(1, bodyRows/5)
+
+	clampBoardSelection(t, cols, visible, perColumn)
+
+	var header, body strings.Builder
+	shownPerCol := make([][]TaskItem, len(visible))
+	for i, ci := range visible {
+		c := boardColumns[ci]
+		list := cols[c.State]
+		if c.State == state.Done && len(list) > boardDoneCap {
+			list = list[:boardDoneCap]
+		}
+		if len(list) > perColumn {
+			list = list[:perColumn]
+		}
+		shownPerCol[i] = list
+		if i > 0 {
+			header.WriteString(boardSeparator(false))
+		}
+		header.WriteString(boardColumnTitle(c.Title, len(cols[c.State]), len(list), colW))
+	}
+
+	// Columns that did not fit still report their totals.
+	var dropped []string
+	for ci := range boardColumns {
+		shown := false
+		for _, v := range visible {
+			if v == ci {
+				shown = true
+			}
+		}
+		if !shown {
+			if n := len(cols[boardColumns[ci].State]); n > 0 {
+				dropped = append(dropped, "+"+strconv.Itoa(n)+" "+strings.ToLower(boardColumns[ci].Title))
+			}
+		}
+	}
+	if len(dropped) > 0 {
+		header.WriteString("  " + StyleMuted.Render(strings.Join(dropped, "  ")))
+	}
+
+	for row := 0; row < perColumn; row++ {
+		cardLines := make([][]string, len(visible))
+		any := false
+		for i := range visible {
+			if row < len(shownPerCol[i]) {
+				selected := t.BoardCol == i && t.BoardRow == row
+				cardLines[i] = boardCard(shownPerCol[i][row], colW, selected)
+				any = true
+			}
+		}
+		if !any {
+			break
+		}
+		for line := 0; line < 4; line++ {
+			for i := range visible {
+				if i > 0 {
+					body.WriteString(boardSeparator(true))
+				}
+				if cardLines[i] != nil {
+					body.WriteString(cardLines[i][line])
+				} else {
+					body.WriteString(pad("", colW))
+				}
+			}
+			body.WriteString("\n")
+		}
+		body.WriteString("\n")
+	}
+
+	content := header.String() + "\n\n" + body.String() + renderFailedLane(failed, inner) + "\n"
+	return a.box("TASKS — BOARD  (b: list  enter: detail  l: logs  a/y/n: approve  R: restart  X: stop)", content, height)
+}
+
+// clampBoardSelection keeps the cursor on a card that exists. Columns change
+// size on every refresh as work moves, so a selection that was valid a tick ago
+// may not be now.
+func clampBoardSelection(t *TasksTab, cols map[state.State][]TaskItem, visible []int, perColumn int) {
+	if len(visible) == 0 {
+		return
+	}
+	if t.BoardCol < 0 {
+		t.BoardCol = 0
+	}
+	if t.BoardCol >= len(visible) {
+		t.BoardCol = len(visible) - 1
+	}
+	n := len(cols[boardColumns[visible[t.BoardCol]].State])
+	if n > perColumn {
+		n = perColumn
+	}
+	if t.BoardRow < 0 {
+		t.BoardRow = 0
+	}
+	if t.BoardRow >= n {
+		t.BoardRow = maxInt(0, n-1)
+	}
+}
+
+// selectedBoardTask returns the task under the board cursor, or nil.
+//
+// The board's own actions (logs, approve, restart, stop) all route through the
+// same handlers the list uses, so this is the one place the board's coordinate
+// pair is translated back into a task.
+func (a *App) selectedBoardTask(t *TasksTab) *TaskItem {
+	cols, _ := boardGroups(a.filteredTasks(t))
+	nCols, _ := boardLayout(maxInt(24, a.model.width) - 2)
+	if nCols == 0 {
+		return nil
+	}
+	visible := visibleBoardColumns(nCols)
+	if t.BoardCol < 0 || t.BoardCol >= len(visible) {
+		return nil
+	}
+	list := cols[boardColumns[visible[t.BoardCol]].State]
+	if t.BoardRow < 0 || t.BoardRow >= len(list) {
+		return nil
+	}
+	return &list[t.BoardRow]
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// boardSeparator is the gutter drawn between columns: a dim rule beside card
+// rows, blank under the headers so the titles stay uncluttered.
+func boardSeparator(rule bool) string {
+	if rule {
+		return " " + StyleMuted.Render("│") + " "
+	}
+	return strings.Repeat(" ", boardSepWidth)
+}
+
+// boardColumnCount is how many columns the board is currently showing, which
+// depends on the terminal width. Key handling needs it to know when the cursor
+// is at the last column and the key should fall through to the tab switch.
+func (a *App) boardColumnCount() int {
+	n, _ := boardLayout(maxInt(24, a.model.width) - 2)
+	if n == 0 {
+		return 0
+	}
+	return len(visibleBoardColumns(n))
+}
+
+// boardApprovalMsg carries an approval request loaded for a board card, plus
+// the key that asked for it, back into Update.
+type boardApprovalMsg struct {
+	req *db.ApprovalRequest
+	key string
+	err string
+}
+
+// boardApprovalCmd loads the approval request a card is parked on.
+//
+// Answering from the board is the interaction that makes it worth having: an
+// operator opens it, sees BLOCKED (4), and clears four gates without drilling
+// into four tasks. The request has to be fetched first because a card carries
+// only the task, so this runs as a command and hands the result to
+// answerApproval — the same function the detail view uses, so declared fields,
+// quorum, and the form all behave identically.
+func (a *App) boardApprovalCmd(it TaskItem, key string) tea.Cmd {
+	dbConn := a.dbConn
+	taskID := it.InternalTaskID
+	return func() tea.Msg {
+		if dbConn == nil || taskID == "" {
+			return boardApprovalMsg{key: key, err: "no database"}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+
+		instances, err := dbConn.ListWorkflowInstancesByTask(ctx, taskID)
+		if err != nil {
+			return boardApprovalMsg{key: key, err: err.Error()}
+		}
+		for _, in := range instances {
+			if !blockedOnApproval(in.State, in.BlockedReason) {
+				continue
+			}
+			if req, err := dbConn.GetApprovalByInstance(ctx, in.ID); err == nil && req != nil {
+				return boardApprovalMsg{req: req, key: key}
+			}
+		}
+		return boardApprovalMsg{key: key, err: "no approval is waiting on this task"}
+	}
+}

--- a/src/internal/dashboard/board_test.go
+++ b/src/internal/dashboard/board_test.go
@@ -1,0 +1,231 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+func boardItems() []TaskItem {
+	return []TaskItem{
+		{InternalTaskID: "1", Number: "#1", Title: "queued one", Status: "queued"},
+		{InternalTaskID: "2", Number: "#2", Title: "running one", Status: "running"},
+		{InternalTaskID: "3", Number: "#3", Title: "waiting on a human", Status: "blocked",
+			BlockedReason: string(state.ReasonApproval)},
+		{InternalTaskID: "4", Number: "#4", Title: "done one", Status: "done"},
+		{InternalTaskID: "5", Number: "#5", Title: "broken one", Status: "failed"},
+		{InternalTaskID: "6", Number: "#6", Title: "abandoned", Status: "canceled"},
+	}
+}
+
+// TestBoardGroups_ColumnsMapOntoCanonicalStates pins the property the board is
+// built on: a card is in a column because its state says so, with no derivation
+// in between (#465/#466).
+func TestBoardGroups_ColumnsMapOntoCanonicalStates(t *testing.T) {
+	cols, failed := boardGroups(boardItems())
+
+	for st, wantTitle := range map[state.State]string{
+		state.Queued:  "queued one",
+		state.Running: "running one",
+		state.Blocked: "waiting on a human",
+		state.Done:    "done one",
+	} {
+		if len(cols[st]) != 1 || cols[st][0].Title != wantTitle {
+			t.Errorf("column %q = %+v, want the single task %q", st, cols[st], wantTitle)
+		}
+	}
+
+	// FAILED is a lane, not a column — terminal failure is an exception, not a
+	// stage work passes through.
+	if len(failed) != 1 || failed[0].Title != "broken one" {
+		t.Errorf("failed lane = %+v, want the one failed task", failed)
+	}
+
+	// Canceled is operator-initiated and terminal: the operator already knows.
+	for _, list := range cols {
+		for _, it := range list {
+			if it.Status == "canceled" {
+				t.Error("a canceled task must not appear on the board")
+			}
+		}
+	}
+}
+
+// TestBoardGroups_LegacyStatesStillLand covers a database that has not run the
+// state migration: those rows still have to reach a column.
+func TestBoardGroups_LegacyStatesStillLand(t *testing.T) {
+	cols, _ := boardGroups([]TaskItem{
+		{Status: "registered"},
+		{Status: "approval_waiting"},
+	})
+	if len(cols[state.Queued]) != 1 {
+		t.Errorf("legacy 'registered' should land in QUEUED, got %+v", cols[state.Queued])
+	}
+	if len(cols[state.Blocked]) != 1 {
+		t.Errorf("legacy 'approval_waiting' should land in BLOCKED, got %+v", cols[state.Blocked])
+	}
+}
+
+// TestBoardGroups_UnknownStateIsNotDropped: silently losing a task from the
+// board would be worse than showing it in an imperfect column.
+func TestBoardGroups_UnknownStateIsNotDropped(t *testing.T) {
+	cols, failed := boardGroups([]TaskItem{{Status: "some_future_state"}})
+	total := len(failed)
+	for _, l := range cols {
+		total += len(l)
+	}
+	if total != 1 {
+		t.Errorf("an unrecognised state was dropped from the board entirely")
+	}
+}
+
+func TestBoardLayout_DropsColumnsWhenNarrow(t *testing.T) {
+	cases := []struct {
+		inner    string
+		width    int
+		wantCols int
+	}{
+		{"wide", 120, 4},
+		{"medium", 70, 4},
+		{"narrow", 60, 3},
+		{"very narrow", 45, 2},
+		{"below the floor", 30, 0},
+	}
+	for _, c := range cases {
+		got, w := boardLayout(c.width)
+		if got != c.wantCols {
+			t.Errorf("%s (%d): columns = %d, want %d", c.inner, c.width, got, c.wantCols)
+		}
+		if got > 0 && w < boardMinColWidth {
+			t.Errorf("%s: column width %d is below the minimum %d", c.inner, w, boardMinColWidth)
+		}
+	}
+}
+
+// TestVisibleBoardColumns_DropOrder pins which columns go first when space runs
+// out: DONE, then QUEUED — the two an operator is least likely to be acting on.
+// BLOCKED and RUNNING survive longest because they are what needs a human.
+func TestVisibleBoardColumns_DropOrder(t *testing.T) {
+	if got := visibleBoardColumns(3); len(got) != 3 || got[2] != 2 {
+		t.Errorf("with 3 columns DONE should be dropped, got %v", got)
+	}
+	got := visibleBoardColumns(2)
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("with 2 columns only RUNNING and BLOCKED should remain, got %v", got)
+	}
+}
+
+// TestBoardCard_ShowsBlockedReason: the reason is the whole point of looking at
+// the BLOCKED column, so it belongs on the card.
+func TestBoardCard_ShowsBlockedReason(t *testing.T) {
+	it := TaskItem{Number: "#3", Title: "gate", Status: "blocked", BlockedReason: "approval"}
+	out := stripANSI(strings.Join(boardCard(it, 20, false), "\n"))
+	if !strings.Contains(out, "approval") {
+		t.Errorf("card did not show what it is blocked on:\n%s", out)
+	}
+}
+
+func TestBoardCard_IsFixedWidth(t *testing.T) {
+	it := TaskItem{Number: "#12345", Title: "a title far longer than the column", Status: "running"}
+	for _, line := range boardCard(it, 18, false) {
+		if w := len([]rune(stripANSI(line))); w != 18 {
+			t.Errorf("card line %q width = %d, want 18", stripANSI(line), w)
+		}
+	}
+}
+
+// TestRenderFailedLane_EmptyIsAVisibleZero: a lane that vanishes when empty
+// teaches an operator to stop looking at that part of the screen.
+func TestRenderFailedLane_EmptyIsAVisibleZero(t *testing.T) {
+	out := stripANSI(renderFailedLane(nil, 80))
+	if !strings.Contains(out, "FAILED (0)") {
+		t.Errorf("empty lane should still report zero, got %q", out)
+	}
+}
+
+func TestRenderFailedLane_CapsAndCounts(t *testing.T) {
+	var failed []TaskItem
+	for i := range 5 {
+		failed = append(failed, TaskItem{Number: "#" + string(rune('1'+i)), Title: "broken", Status: "failed"})
+	}
+	out := stripANSI(renderFailedLane(failed, 80))
+	if !strings.Contains(out, "FAILED (5)") {
+		t.Errorf("lane header should carry the true count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "+2 more") {
+		t.Errorf("lane should say how many it did not show, got:\n%s", out)
+	}
+}
+
+// TestBoardColumnTitle_CapNeverHidesTheCount: the DONE column is capped, and the
+// header has to keep reporting the real total or the cap becomes a lie.
+func TestBoardColumnTitle_CapNeverHidesTheCount(t *testing.T) {
+	out := stripANSI(boardColumnTitle("DONE", 40, 12, 24))
+	if !strings.Contains(out, "(40)") {
+		t.Errorf("column title should show the true total, got %q", out)
+	}
+	if !strings.Contains(out, "+28") {
+		t.Errorf("column title should show how many are hidden, got %q", out)
+	}
+}
+
+// TestRenderBoard_FramedAndComplete is the end-to-end check: the board draws
+// inside the standard frame, shows every column header with its count, and
+// carries the failed lane.
+func TestRenderBoard_FramedAndComplete(t *testing.T) {
+	a := newTestApp(120, 30)
+	a.model.tasksTab.History = boardItems()
+	a.model.tasksTab.View = TaskViewBoard
+
+	out := a.renderBoard(a.model.tasksTab, 24)
+	if out == "" {
+		t.Fatal("board declined to render at 120 columns")
+	}
+	assertFramed(t, out, 120)
+
+	plain := stripANSI(out)
+	for _, want := range []string{"QUEUED (1)", "RUNNING (1)", "BLOCKED (1)", "DONE (1)", "FAILED (1)"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("board is missing %q:\n%s", want, plain)
+		}
+	}
+}
+
+// TestRenderBoard_RefusesBelowTheFloor: a grid crushed into a narrow terminal is
+// noise, so the board returns "" and the caller shows the list instead.
+func TestRenderBoard_RefusesBelowTheFloor(t *testing.T) {
+	a := newTestApp(30, 20)
+	a.model.tasksTab.History = boardItems()
+	a.model.tasksTab.View = TaskViewBoard
+
+	if out := a.renderBoard(a.model.tasksTab, 16); out != "" {
+		t.Errorf("board should decline to render at 30 columns, got:\n%s", out)
+	}
+	// And the tab as a whole still renders, by falling back to the list.
+	if got := a.renderTasksTab(16); got == "" {
+		t.Error("Tasks tab rendered nothing when the board declined")
+	}
+}
+
+// TestClampBoardSelection keeps the cursor on a card that exists: columns
+// resize on every refresh as work moves between them.
+func TestClampBoardSelection(t *testing.T) {
+	cols, _ := boardGroups(boardItems())
+	visible := visibleBoardColumns(4)
+
+	t2 := &TasksTab{BoardCol: 99, BoardRow: 99}
+	clampBoardSelection(t2, cols, visible, 5)
+	if t2.BoardCol != len(visible)-1 {
+		t.Errorf("BoardCol = %d, want it clamped to %d", t2.BoardCol, len(visible)-1)
+	}
+	if t2.BoardRow != 0 {
+		t.Errorf("BoardRow = %d, want it clamped to the single card in that column", t2.BoardRow)
+	}
+
+	t3 := &TasksTab{BoardCol: -5, BoardRow: -5}
+	clampBoardSelection(t3, cols, visible, 5)
+	if t3.BoardCol != 0 || t3.BoardRow != 0 {
+		t.Errorf("negative selection = (%d,%d), want (0,0)", t3.BoardCol, t3.BoardRow)
+	}
+}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -91,6 +91,7 @@ const (
 	TaskViewLogs
 	TaskViewWorkflow   // live workflow instance monitor
 	TaskViewTranscript // rendered markdown transcript of an agent session
+	TaskViewBoard      // tasks grouped into columns by canonical state
 )
 
 // TasksTab shows task history with detail and log sub-views.
@@ -98,7 +99,12 @@ type TasksTab struct {
 	History     []TaskItem // running + past tasks, newest first
 	SelectedIdx int
 
-	View            TaskView
+	View TaskView
+	// Board cursor (View == TaskViewBoard): column index within the *visible*
+	// columns, and row within that column. Both are clamped on every render,
+	// since columns resize as work moves between them.
+	BoardCol        int
+	BoardRow        int
 	Detail          *TaskItem                // populated when View == TaskViewDetail
 	DetailInstance  *WorkflowInstanceItem    // workflow instance for Detail, if any
 	DetailScroll    int                      // first visible content line in the detail view
@@ -270,39 +276,49 @@ type WorkflowStepItem struct {
 // It is also reused by the Agents tab, where it is built from a TaskHistoryItem
 // (taskItemFromHistory) and the InternalTask fields are left zero.
 type TaskItem struct {
-	TaskID       string
-	Number       string // human reference, e.g. "ERP-42"
-	URL          string // link to the task in its source UI
-	Title        string
-	Agent        string
-	Model        string
-	Runner       string
-	Status       string // execution status (running/success/failed) or InternalTask state
-	Attempt      int
-	Duration     time.Duration
-	StartedAt    *time.Time
-	CompletedAt  *time.Time
-	Error        string
-	InputTokens  int
-	OutputTokens int
-	TotalTokens  int
-	NumTurns     int
-	NumToolCalls int
-	CostUSD      float64
+	TaskID string
+	Number string // human reference, e.g. "ERP-42"
+	URL    string // link to the task in its source UI
+	Title  string
+	Agent  string
+	Model  string
+	Runner string
+	Status string // execution status (running/success/failed) or InternalTask state
+	// BlockedReason explains a blocked Status: approval, ci, dependency,
+	// retry_backoff, interrupted. Empty otherwise.
+	BlockedReason string
+	Attempt       int
+	Duration      time.Duration
+	StartedAt     *time.Time
+	CompletedAt   *time.Time
+	Error         string
+	InputTokens   int
+	OutputTokens  int
+	TotalTokens   int
+	NumTurns      int
+	NumToolCalls  int
+	CostUSD       float64
 
 	// Internal task model (Phase 9). Populated when the row/detail comes from an
 	// InternalTask; zero-valued for legacy/Agents-tab rows.
-	InternalTaskID       string                 // canonical internal_tasks.id (primary identity)
-	DrillKey             string                 // legacy cell_id for executions/logs/monitor
-	ParentTaskID         string                 // empty for root tasks
-	ParentTitle          string                 // resolved parent title, for the breadcrumb
-	OutstandingWorkflows int                    // workflows still running for this task
-	Bindings             []SourceBindingItem    // source items bound to this task
-	Lineage              []TaskLineageItem      // ancestors root-first incl. self (detail only)
-	Children             []TaskLineageItem      // direct children / spawned tasks (detail only)
-	Instances            []WorkflowInstanceItem // all workflow instances for this task (detail only)
-	PullRequests         []PullRequestItem      // persisted PRs, oldest first; last = most recent
-	Events               []db.ExecutionEvent    // structured task timeline, oldest first
+	InternalTaskID       string // canonical internal_tasks.id (primary identity)
+	DrillKey             string // legacy cell_id for executions/logs/monitor
+	ParentTaskID         string // empty for root tasks
+	ParentTitle          string // resolved parent title, for the breadcrumb
+	OutstandingWorkflows int    // workflows still running for this task
+	// Step progress across the task's live instances, resolved by one batched
+	// query per visible page (see progress.go). Zero for legacy Agents-tab rows.
+	StepID        string // current step id; empty when not resolvable
+	StepPosition  int    // 1-based position in the workflow; 0 when unknown
+	StepTotal     int    // steps in the workflow; 0 when unknown
+	LiveInstances int    // live instances; >1 renders a fan-out marker
+
+	Bindings     []SourceBindingItem    // source items bound to this task
+	Lineage      []TaskLineageItem      // ancestors root-first incl. self (detail only)
+	Children     []TaskLineageItem      // direct children / spawned tasks (detail only)
+	Instances    []WorkflowInstanceItem // all workflow instances for this task (detail only)
+	PullRequests []PullRequestItem      // persisted PRs, oldest first; last = most recent
+	Events       []db.ExecutionEvent    // structured task timeline, oldest first
 }
 
 // PullRequestItem is one pull request linked to a task, persisted by the daemon

--- a/src/internal/dashboard/progress.go
+++ b/src/internal/dashboard/progress.go
@@ -1,0 +1,164 @@
+package dashboard
+
+import (
+	"strconv"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+// taskProgress is how far a task has got: which step is executing, where that
+// step sits in its workflow, and how many instances are live.
+type taskProgress struct {
+	StepID    string
+	Position  int // 1-based; 0 when unknown
+	Total     int // 0 when unknown
+	Instances int // live instances; >1 means fan-out
+}
+
+// resolveTaskProgress folds the flat step rows of ListStepProgressForTasks into
+// one progress value per task.
+//
+// The step reported for an instance is the one actually executing — the last
+// row that is running or blocked. When every step has settled (the instance is
+// between steps, or waiting to be settled), the most recent row is used instead,
+// because "the step it just finished" is a better answer than nothing.
+func resolveTaskProgress(rows []db.TaskStepRow, workflows []config.WorkflowConfig) map[string]taskProgress {
+	type instAcc struct {
+		workflowID string
+		current    string // step chosen by the rule above
+		lastSeen   string
+	}
+
+	// task -> instance -> accumulator, plus the instance order per task.
+	acc := map[string]map[string]*instAcc{}
+	order := map[string][]string{}
+
+	for _, r := range rows {
+		if r.TaskID == "" {
+			continue
+		}
+		byInst, ok := acc[r.TaskID]
+		if !ok {
+			byInst = map[string]*instAcc{}
+			acc[r.TaskID] = byInst
+		}
+		a, ok := byInst[r.InstanceID]
+		if !ok {
+			a = &instAcc{workflowID: r.WorkflowID}
+			byInst[r.InstanceID] = a
+			order[r.TaskID] = append(order[r.TaskID], r.InstanceID)
+		}
+		if r.StepID == "" {
+			continue
+		}
+		a.lastSeen = r.StepID
+		switch state.Normalize(r.StepState) {
+		case state.Running, state.Blocked:
+			a.current = r.StepID
+		}
+	}
+
+	out := make(map[string]taskProgress, len(acc))
+	for taskID, byInst := range acc {
+		p := taskProgress{Instances: len(byInst)}
+		// With more than one live instance there is no single "current step",
+		// and picking one would be the same category error the agent column
+		// made. The caller renders a fan-out marker instead.
+		if len(byInst) == 1 {
+			a := byInst[order[taskID][0]]
+			step := a.current
+			if step == "" {
+				step = a.lastSeen
+			}
+			p.StepID = step
+			p.Position, p.Total = stepPosition(workflows, a.workflowID, step)
+		}
+		out[taskID] = p
+	}
+	return out
+}
+
+// stepPosition locates a step in its workflow's declared sequence, returning a
+// 1-based position and the sequence length.
+//
+// The sequence comes from the live configuration rather than the instance's
+// stored definition snapshot. That is a deliberate trade: reading the snapshot
+// would cost a query and a JSON parse per visible instance to produce a
+// denominator that differs only when someone edited the workflow while a run
+// was in flight. The Tasks list is a live operational view, and this keeps it to
+// one query. Both values are zero when the workflow or step is not found, and
+// the caller then shows the step name alone rather than a wrong fraction.
+func stepPosition(workflows []config.WorkflowConfig, workflowID, stepID string) (int, int) {
+	if workflowID == "" || stepID == "" {
+		return 0, 0
+	}
+	for i := range workflows {
+		if workflows[i].ID != workflowID {
+			continue
+		}
+		steps := workflows[i].Steps
+		for j := range steps {
+			if steps[j].ID == stepID {
+				return j + 1, len(steps)
+			}
+		}
+		// The step exists in the run but not in the current definition — the
+		// workflow was edited mid-flight. Report the length so the reader still
+		// sees the scale, but not a position that would be a lie.
+		return 0, len(steps)
+	}
+	return 0, 0
+}
+
+// progressCell renders the progress column.
+//
+// It replaces the agent column, which reported one arbitrary agent of however
+// many a task's steps used — an attribute of a step hoisted onto a task. This
+// column answers "where has it got to", which is the question the list could not
+// previously answer at all.
+func progressCell(p taskProgress, width int) string {
+	return pad(truncate(progressLabel(p, width), width), width)
+}
+
+// progressLabel is progressCell without padding, so tests and the board can use
+// the same text.
+//
+// The step id is truncated but the n/m suffix never is: losing the position is
+// worse than losing the tail of a name, since the position is the part that
+// cannot be guessed.
+func progressLabel(p taskProgress, width int) string {
+	switch {
+	case p.Instances > 1:
+		return "⑂ " + strconv.Itoa(p.Instances) + " steps"
+	case p.StepID == "":
+		return "—"
+	case p.Total == 0:
+		return p.StepID
+	case p.Position == 0:
+		// Step not in the current definition: show the scale, not a position.
+		return truncate(p.StepID, maxInt(1, width-4)) + " ?/" + strconv.Itoa(p.Total)
+	default:
+		suffix := " " + strconv.Itoa(p.Position) + "/" + strconv.Itoa(p.Total)
+		return truncate(p.StepID, maxInt(1, width-len(suffix))) + suffix
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// taskProgressOf reads the progress fields a TaskItem carries back into the
+// value type the renderers use.
+func taskProgressOf(it TaskItem) taskProgress {
+	return taskProgress{
+		StepID:    it.StepID,
+		Position:  it.StepPosition,
+		Total:     it.StepTotal,
+		Instances: it.LiveInstances,
+	}
+}

--- a/src/internal/dashboard/progress_test.go
+++ b/src/internal/dashboard/progress_test.go
@@ -1,0 +1,119 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+func progressWorkflows() []config.WorkflowConfig {
+	return []config.WorkflowConfig{{
+		ID: "wf",
+		Steps: []config.StepConfig{
+			{ID: "plan"}, {ID: "build"}, {ID: "review"}, {ID: "ship"}, {ID: "verify"},
+		},
+	}}
+}
+
+func TestResolveTaskProgress(t *testing.T) {
+	rows := []db.TaskStepRow{
+		// One live instance, third step running → "review 3/5".
+		{TaskID: "T1", InstanceID: "i1", WorkflowID: "wf", StepID: "plan", StepState: "done"},
+		{TaskID: "T1", InstanceID: "i1", WorkflowID: "wf", StepID: "build", StepState: "done"},
+		{TaskID: "T1", InstanceID: "i1", WorkflowID: "wf", StepID: "review", StepState: "running"},
+
+		// Two live instances → fan-out, no single current step.
+		{TaskID: "T2", InstanceID: "i2", WorkflowID: "wf", StepID: "plan", StepState: "running"},
+		{TaskID: "T2", InstanceID: "i3", WorkflowID: "wf", StepID: "build", StepState: "running"},
+
+		// Dispatched but no step row yet.
+		{TaskID: "T3", InstanceID: "i4", WorkflowID: "wf", StepID: "", StepState: ""},
+
+		// Every step settled: fall back to the most recent one.
+		{TaskID: "T4", InstanceID: "i5", WorkflowID: "wf", StepID: "plan", StepState: "done"},
+		{TaskID: "T4", InstanceID: "i5", WorkflowID: "wf", StepID: "build", StepState: "done"},
+	}
+
+	got := resolveTaskProgress(rows, progressWorkflows())
+
+	if p := got["T1"]; p.StepID != "review" || p.Position != 3 || p.Total != 5 || p.Instances != 1 {
+		t.Errorf("T1 = %+v, want review 3/5 with 1 instance", p)
+	}
+	if p := got["T2"]; p.Instances != 2 || p.StepID != "" {
+		t.Errorf("T2 = %+v, want a fan-out marker and no single step", p)
+	}
+	if p := got["T3"]; p.Instances != 1 || p.StepID != "" {
+		t.Errorf("T3 = %+v, want one instance and no step yet", p)
+	}
+	if p := got["T4"]; p.StepID != "build" || p.Position != 2 {
+		t.Errorf("T4 = %+v, want the most recent step when none is running", p)
+	}
+}
+
+// TestResolveTaskProgress_BlockedStepIsCurrent pins that a parked step is the
+// task's current position. A step waiting on an approval is where the task is,
+// and reporting the previous step instead would point the operator at work that
+// is already finished.
+func TestResolveTaskProgress_BlockedStepIsCurrent(t *testing.T) {
+	rows := []db.TaskStepRow{
+		{TaskID: "T1", InstanceID: "i1", WorkflowID: "wf", StepID: "plan", StepState: "done"},
+		{TaskID: "T1", InstanceID: "i1", WorkflowID: "wf", StepID: "build", StepState: "blocked",
+			BlockedReason: string(state.ReasonApproval)},
+	}
+	if p := resolveTaskProgress(rows, progressWorkflows())["T1"]; p.StepID != "build" {
+		t.Errorf("progress = %+v, want the blocked step to be current", p)
+	}
+}
+
+func TestProgressLabel(t *testing.T) {
+	cases := []struct {
+		name  string
+		p     taskProgress
+		width int
+		want  string
+	}{
+		{"running step", taskProgress{StepID: "review", Position: 3, Total: 5, Instances: 1}, 16, "review 3/5"},
+		{"fan-out", taskProgress{Instances: 3}, 16, "⑂ 3 steps"},
+		{"no instance", taskProgress{}, 16, "—"},
+		{"unknown workflow", taskProgress{StepID: "review", Instances: 1}, 16, "review"},
+		{"edited workflow", taskProgress{StepID: "gone", Total: 5, Instances: 1}, 16, "gone ?/5"},
+	}
+	for _, c := range cases {
+		if got := progressLabel(c.p, c.width); got != c.want {
+			t.Errorf("%s: progressLabel = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestProgressLabel_TruncatesNameNotPosition pins the truncation rule: the
+// position is the part a reader cannot infer, so a long step id loses its tail
+// rather than its fraction.
+func TestProgressLabel_TruncatesNameNotPosition(t *testing.T) {
+	p := taskProgress{StepID: "implement-the-whole-feature", Position: 3, Total: 5, Instances: 1}
+	got := progressLabel(p, 16)
+
+	if !strings.HasSuffix(got, " 3/5") {
+		t.Errorf("progressLabel = %q, want it to keep the 3/5 suffix", got)
+	}
+	if len([]rune(got)) > 16 {
+		t.Errorf("progressLabel = %q (%d runes), want it within 16", got, len([]rune(got)))
+	}
+}
+
+// TestProgressCell_IsFixedWidth keeps the row aligned: the column replaced one
+// of a fixed width, and every value must occupy exactly that.
+func TestProgressCell_IsFixedWidth(t *testing.T) {
+	for _, p := range []taskProgress{
+		{StepID: "review", Position: 3, Total: 5, Instances: 1},
+		{Instances: 4},
+		{},
+		{StepID: "a-very-long-step-identifier", Position: 1, Total: 9, Instances: 1},
+	} {
+		if w := len([]rune(progressCell(p, 16))); w != 16 {
+			t.Errorf("progressCell(%+v) width = %d, want 16", p, w)
+		}
+	}
+}

--- a/src/internal/db/task_progress.go
+++ b/src/internal/db/task_progress.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"context"
+	"strings"
+
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+// TaskStepRow is one step of one instance belonging to one task, as returned by
+// ListStepProgressForTasks. An instance that has not started a step yet still
+// yields a row, with StepID empty.
+type TaskStepRow struct {
+	TaskID        string
+	InstanceID    string
+	WorkflowID    string
+	InstanceState string
+	StepID        string
+	StepState     string
+	BlockedReason string
+}
+
+// ListStepProgressForTasks returns the step rows of every non-terminal instance
+// belonging to the given tasks, ordered oldest instance first and, within an
+// instance, in execution order.
+//
+// It exists so the Tasks list can show how far a task has got without issuing a
+// query per visible row. The list re-renders on a timer against the same SQLite
+// file the daemon is writing to, so a per-row query would mean a page of
+// queries every couple of seconds; this is one.
+//
+// Interrupted instances are excluded: they are blocked, but dead, and reporting
+// a dead instance's step as a task's current position would be misleading. An
+// instance with no step runs yet is included with an empty StepID, so a task
+// that has just been dispatched is distinguishable from one with no instance.
+func (c *Client) ListStepProgressForTasks(ctx context.Context, taskIDs []string) ([]TaskStepRow, error) {
+	if len(taskIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(taskIDs)), ",")
+	args := make([]any, 0, len(taskIDs)+1)
+	for _, id := range taskIDs {
+		args = append(args, id)
+	}
+	args = append(args, string(state.ReasonInterrupted))
+
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT COALESCE(wi.task_id,''), wi.id, wi.workflow_id, wi.state,
+		       COALESCE(sr.step_id,''), COALESCE(sr.state,''), COALESCE(sr.blocked_reason,'')
+		FROM workflow_instances wi
+		LEFT JOIN step_runs sr ON sr.workflow_instance_id = wi.id
+		WHERE wi.task_id IN (`+placeholders+`)
+		  AND wi.state NOT IN ('done','failed','canceled')
+		  AND wi.state <> 'interrupted'
+		  AND NOT (wi.state = 'blocked' AND COALESCE(wi.blocked_reason,'') = ?)
+		ORDER BY wi.created_at ASC, sr.rowid ASC
+	`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []TaskStepRow
+	for rows.Next() {
+		var r TaskStepRow
+		if err := rows.Scan(&r.TaskID, &r.InstanceID, &r.WorkflowID, &r.InstanceState,
+			&r.StepID, &r.StepState, &r.BlockedReason); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -98,7 +98,7 @@ func (s *InternalTaskStore) FindChildByDedupKey(ctx context.Context, parentTaskI
 	}
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM internal_tasks
 		WHERE parent_task_id = ? AND dedup_key = ?
@@ -118,7 +118,7 @@ func (s *InternalTaskStore) FindChildByDedupKey(ctx context.Context, parentTaskI
 func (s *InternalTaskStore) GetTask(ctx context.Context, id string) (*model.InternalTask, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM internal_tasks WHERE id = ?
 	`, id)
@@ -280,7 +280,7 @@ func (s *InternalTaskStore) DeleteTask(ctx context.Context, id string) error {
 func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.TaskState) ([]model.InternalTask, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM internal_tasks WHERE state = ? ORDER BY created_at ASC
 	`, string(state))
@@ -309,7 +309,7 @@ func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.I
 	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM internal_tasks ORDER BY created_at DESC LIMIT ?
 	`, limit)
@@ -334,7 +334,7 @@ func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.I
 func (s *InternalTaskStore) ListChildTasks(ctx context.Context, parentTaskID string) ([]model.InternalTask, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM internal_tasks WHERE parent_task_id = ? ORDER BY created_at ASC
 	`, parentTaskID)
@@ -367,20 +367,20 @@ func (c *Client) GetTaskAncestors(ctx context.Context, id string) ([]model.Inter
 // the slice has a single element (the task). Empty if the id is unknown.
 func (s *InternalTaskStore) GetTaskAncestors(ctx context.Context, id string) ([]model.InternalTask, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		WITH RECURSIVE anc(id, parent_task_id, title, description, input, state,
+		WITH RECURSIVE anc(id, parent_task_id, title, description, input, state, blocked_reason,
 		                    metadata, outstanding_workflows, created_at, updated_at, depth) AS (
-			SELECT id, parent_task_id, title, description, input, state,
+			SELECT id, parent_task_id, title, description, input, state, blocked_reason,
 			       metadata, outstanding_workflows, created_at, updated_at, 0
 			FROM internal_tasks WHERE id = ?
 			UNION ALL
-			SELECT t.id, t.parent_task_id, t.title, t.description, t.input, t.state,
+			SELECT t.id, t.parent_task_id, t.title, t.description, t.input, t.state, t.blocked_reason,
 			       t.metadata, t.outstanding_workflows, t.created_at, t.updated_at, anc.depth + 1
 			FROM internal_tasks t
 			JOIN anc ON t.id = anc.parent_task_id
 			WHERE anc.depth < 32
 		)
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(metadata,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
 		FROM anc ORDER BY depth DESC
 	`, id)
@@ -408,7 +408,7 @@ func scanTask(s scanner) (*model.InternalTask, error) {
 		state     string
 	)
 	if err := s.Scan(&task.ID, &task.ParentTaskID, &task.Title, &task.Description,
-		&inputJSON, &state, &metaJSON, &task.OutstandingWorkflows,
+		&inputJSON, &state, &task.BlockedReason, &metaJSON, &task.OutstandingWorkflows,
 		&task.CreatedAt, &task.UpdatedAt); err != nil {
 		return nil, err
 	}

--- a/src/internal/model/task.go
+++ b/src/internal/model/task.go
@@ -34,8 +34,11 @@ type InternalTask struct {
 	// a parent, derived from the spawn request (or the caller-supplied SpawnRequest.Key).
 	// A re-run of the same decomposition resolves to the existing child instead of
 	// creating a duplicate. Empty for source-bound (non-spawned) tasks.
-	DedupKey             string
-	State                TaskState
+	DedupKey string
+	State    TaskState
+	// BlockedReason explains a State of blocked: approval | ci | dependency |
+	// retry_backoff | interrupted. Empty for every other state.
+	BlockedReason        string
 	Metadata             TaskMetadata
 	OutstandingWorkflows int
 	CreatedAt            time.Time


### PR DESCRIPTION
**Stacked on #469** (release N+1), which is stacked on #464. Review those first; this PR targets #469's branch, so the diff here is the dashboard work only.

Closes #466.

## The progress column

The list showed an AGENT column and no sense of progress:

```
   #          TASK                            STEP           STATUS   WHEN
▶  #412       Fix approval gate re-entry      review 3/5     running  4m ago
   #401       Port pgsink to new columns      check-ci 4/6   blocked  1h ago
   #396       Decompose the spec              ⑂ 3 steps      running  8m ago
```

The agent column was a category error — an agent belongs to a *step*, so a task whose steps used three agents displayed one arbitrary agent of the three. The same conflation #465 removed from the status column. The agent is still shown per step in Details and the monitor, where it is true.

`⑂ 3 steps` is the fan-out rule: with several live instances there is no single current step, and picking one would repeat the mistake the column was replacing.

Resolved by **one batched query per visible page**, not one per row — this list re-renders on a timer against the file the daemon is writing to.

## The board

```
  QUEUED (1)              RUNNING (2)              BLOCKED (2)              DONE (12)
  #418                  │ #412                   │ #401                   │ #390
  Add plugin registry   │ Fix approval gate re-… │ Port pgsink to new co… │ Docs: plugins
  —                     │ review 3/5             │ check-ci 4/6           │ —
  2m ago                │ 4m ago                 │ ci 1h ago              │ 20m ago

  FAILED (1) — needs attention
    #407     Improve advisor evidence pack        build 2/7      3h ago
```

**The columns are the state column.** A card is in `BLOCKED` because its state says `blocked` — a group-by, not a derivation. That is the thing #465 bought, and the reason this PR had to come after it.

**`FAILED` is a lane, not a column.** Columns are stages work passes through; terminal failure is not a stage, it is an exception waiting for a person. It stays visible as `FAILED (0)` when empty, because a lane that vanishes teaches an operator to stop looking there.

## Interactive, with no duplicated wiring

`selectedTask()` resolves the board's `(column, row)` instead of a list index. That single change means **detail, logs, restart and stop needed no new code** — they already route through it, and they keep their existing keys.

`a`/`y`/`n` loads the selected card's approval and hands it to the same `answerApproval` the detail view uses, so declared fields, quorum and the form behave identically. That is the interaction the view earns its keystroke for: open the board, see `BLOCKED (4)`, clear four gates without drilling into four tasks.

**No drag-and-drop, deliberately.** State is a consequence of what actually ran. A board that let you drag a task into `DONE` would assert something that never happened.

## Degradation

`DONE` is capped so finished work cannot squeeze out the columns that need attention — the header always reports the true count with `+N` for what it did not fit. Columns drop from the right when narrow (`DONE` first, then `QUEUED`, the two least likely to be acted on) with their counts moving into the header. Below ~40 columns the board returns `""` and the list takes over: a grid crushed into 30 columns is noise, and declining is more honest than rendering it.

Selectable three ways: `b` per session, `apiary dashboard --view=board` per invocation, `settings.dashboard.default_view` per hive (validated; a typo does not stop the dashboard opening). The list stays the default for a new hive — it fits any terminal and carries full history.

## Deviation from the proposal

The step **total** comes from the live config, not the instance's stored definition snapshot as originally specified. The snapshot would cost a query plus a JSON parse per visible instance to produce a denominator that differs only when someone edited a workflow mid-run. A step no longer in the definition renders `gone ?/5` — the scale, without a position that would be a lie. Recorded in the proposal.

## Also here

`internal_tasks.blocked_reason` now reaches `TaskItem` via `model.InternalTask`, which is what lets a card say `ci` or `approval` rather than a bare "blocked". That required adding the column to the `GetTaskAncestors` recursive CTE — its column list is declared separately from its selects, and missing it there is a runtime SQL error rather than a compile failure, so it is worth a look.

## Testing

`gofmt`, `go vet ./...` and the full `go test ./...` pass. 16 files, +1300/−59.

Tests cover: progress resolution including the fan-out and blocked-step-is-current rules, truncation keeping the fraction, fixed-width cells, column mapping (including legacy states and an unknown state not being dropped), the drop order, cap counts, the empty failed lane, selection clamping, and an end-to-end framed render plus the refuse-below-the-floor path.

I also rendered the board and the list to a terminal and read them, rather than trusting the assertions alone — that is how the column gutter got added, since one space between a truncated title and the next column was genuinely hard to parse.
