### PR TITLE
ci: fix triage-gate's false needs-triage claim

### DIFF
--- a/.github/workflows/triage-gate.yml
+++ b/.github/workflows/triage-gate.yml
@@ -42,7 +42,7 @@ jobs:
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          gh issue edit $ISSUE --repo $REPO --add-label needs-triage || true
+          gh issue edit $ISSUE --repo $REPO --add-label needs-triage
 
       - name: Post triage notice
         env:


### PR DESCRIPTION
## Summary

`.github/workflows/triage-gate.yml` (SEC-01) told every non-collaborator issue filer that a `needs-triage` label had been added, but the label never existed in the repo — the labeling step's exit status was discarded via `|| true`, so it silently no-op'd every time and the bot's claim in the next step was false for all 7 currently open issues.

- Created the `needs-triage` label for real (`gh label create needs-triage --repo orlandoburli/apiary --color F9D0C4 --description "Awaiting maintainer triage before ai-ready can be added"`), matching what the workflow's own comment already promises. Kept it distinct from the existing `draft` label rather than repointing the workflow at `draft`, per the issue's own preference — no reason surfaced during this fix to deviate from that.
- Removed `|| true` from the "Add needs-triage label" step, so a future labeling failure fails the workflow run instead of being swallowed and reported as a success in the next step's comment.

Item (3) from #477 — whether the `oburli` filing account (currently `author_association: NONE`, not a collaborator) should be an explicit allowlisted identity for this gate — is a policy call left open for the maintainer. This PR does not touch the association-check logic (`if: !contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), ...)`).

Closes #477

## Test plan

- [x] Ran `gh label create needs-triage --repo orlandoburli/apiary --color F9D0C4 --description "Awaiting maintainer triage before ai-ready can be added"` against the real repo — succeeded with no output (gh's success behavior for this command), then verified via `gh label list --repo orlandoburli/apiary --search needs-triage`:
  ```
  [{"color":"F9D0C4","description":"Awaiting maintainer triage before ai-ready can be added","name":"needs-triage"}, ...]
  ```
- [x] Validated the edited YAML is well-formed: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/triage-gate.yml'))"` and `yamllint .github/workflows/triage-gate.yml` (both pass, no `actionlint` available in this environment).
- [x] Reviewed the diff by hand — it's a single-line change (dropping `|| true`), indentation and step structure unchanged.
- Not run: an actual `issues: opened` event through the live workflow (would require filing a throwaway issue from a non-collaborator identity), so the end-to-end label-and-comment path is not exercised in this PR, only the label's existence and the YAML's validity.