### PR TITLE
fix(cli): size the CELL/# column to its content, not a fixed width

### DIFF
--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -181,13 +181,45 @@ func listInstances(workflow, state string, limit int, asJSON bool) error {
 		return nil
 	}
 
-	fmt.Println(instHeader.Render(fmt.Sprintf("%-26s  %-22s  %-12s  %-18s  %-13s  %s",
-		"ID", "WORKFLOW", "CELL", "STATE", "STARTED", "DURATION")))
+	// The CELL column used to be a fixed 12 chars, truncated from the tail —
+	// fine for short references like "ERP-42" or "#412", but a routine
+	// occurrence id ("<routine>@<RFC3339 instant>", issue #472) is 29+ chars
+	// and its distinguishing part is the timestamp suffix that head-preserving
+	// truncation cuts off first. Size the column to the widest reference
+	// actually present (capped, so one huge outlier can't blow up the table),
+	// stealing the room from WORKFLOW, which is the most compressible column
+	// here: a truncated workflow id is still readable, unlike a truncated
+	// occurrence reference with its distinguishing half missing.
+	const (
+		baseCellW     = 12
+		maxCellW      = 40
+		baseWorkflowW = 22
+		minWorkflowW  = 12
+	)
+	cellW := baseCellW
 	for _, in := range resp.Instances {
-		fmt.Printf("%-26s  %-22s  %-12s  %s  %-13s  %s\n",
+		if n := len(in.CellID); n > cellW {
+			cellW = n
+		}
+	}
+	if cellW > maxCellW {
+		cellW = maxCellW
+	}
+	workflowW := baseWorkflowW
+	if extra := cellW - baseCellW; extra > 0 {
+		workflowW -= extra
+		if workflowW < minWorkflowW {
+			workflowW = minWorkflowW
+		}
+	}
+
+	fmt.Println(instHeader.Render(fmt.Sprintf("%-26s  %-*s  %-*s  %-18s  %-13s  %s",
+		"ID", workflowW, "WORKFLOW", cellW, "CELL", "STATE", "STARTED", "DURATION")))
+	for _, in := range resp.Instances {
+		fmt.Printf("%-26s  %-*s  %-*s  %s  %-13s  %s\n",
 			in.ID,
-			truncate(in.Workflow, 22),
-			truncate(in.CellID, 12),
+			workflowW, truncate(in.Workflow, workflowW),
+			cellW, format.TruncateMiddle(in.CellID, cellW),
 			stateCell(in.State, 18),
 			in.Started,
 			in.Duration,

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -3606,12 +3606,30 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 	}
 
 	const (
-		cursorW = 2
-		numW    = 10
-		agentW  = 16 // width of the progress column (formerly AGENT)
-		statusW = 8
-		whenW   = 11
+		cursorW  = 2
+		baseNumW = 10
+		maxNumW  = 40 // cap so one long reference can't collapse TASK to its floor
+		agentW   = 16 // width of the progress column (formerly AGENT)
+		statusW  = 8
+		whenW    = 11
 	)
+	// The # column used to be a fixed 10 chars, truncated from the tail. That
+	// is fine for short references ("#412", "ERP-42") but a routine occurrence
+	// id ("<routine>@<RFC3339 instant>", issue #472) is 29+ chars, and its
+	// distinguishing part — the timestamp — is exactly what a tail-truncated
+	// column cuts off. Size the column to the widest reference actually on
+	// screen; the room comes out of TASK below, which already has its own
+	// floor and is the more compressible of the two (a truncated title is
+	// still readable; a routine reference missing its occurrence is not).
+	numW := baseNumW
+	for _, it := range items {
+		if n := len([]rune(valueOr(it.Number, "—"))); n > numW {
+			numW = n
+		}
+	}
+	if numW > maxNumW {
+		numW = maxNumW
+	}
 	inner := a.model.width - 2
 	titleW := inner - cursorW - numW - agentW - statusW - whenW - 5
 	if titleW < 10 {
@@ -3664,7 +3682,7 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 		it := items[i]
 		selected := i == t.SelectedIdx
 		cursor := "  "
-		num := pad(truncate(valueOr(it.Number, "—"), numW), numW)
+		num := pad(format.TruncateMiddle(valueOr(it.Number, "—"), numW), numW)
 		titleText := pad(truncate(valueOr(it.Title, it.TaskID), titleW), titleW)
 		// The agent column used to live here. An agent is a property of a step,
 		// not of a task, so for a task running several steps it showed one

--- a/src/internal/format/text.go
+++ b/src/internal/format/text.go
@@ -1,0 +1,29 @@
+package format
+
+// TruncateMiddle shortens s to at most max runes by eliding the middle rather
+// than the tail. Head-preserving truncation (the `truncate` helpers in
+// internal/cli and internal/dashboard) is wrong for references shaped like
+// "<id>@<instant>": every occurrence of the same routine shares the prefix,
+// so cutting the tail keeps the one part that never distinguishes two rows
+// and drops the timestamp that does (issue #472).
+//
+// The kept tail is deliberately longer than the kept head — a bit more than
+// half of the surviving runes — since the distinguishing suffix is usually
+// the part worth keeping legible (an occurrence timestamp, an ULID's low
+// bits, and so on). A string already at or under max is returned unchanged.
+func TruncateMiddle(s string, max int) string {
+	if max < 1 {
+		max = 1
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	keep := max - 1 // one rune spent on the ellipsis
+	head := keep / 3
+	tail := keep - head
+	return string(r[:head]) + "…" + string(r[len(r)-tail:])
+}

--- a/src/internal/format/text_test.go
+++ b/src/internal/format/text_test.go
@@ -1,0 +1,42 @@
+package format
+
+import "testing"
+
+func TestTruncateMiddle(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{
+			name: "short reference unaffected",
+			in:   "#412",
+			max:  40,
+			want: "#412",
+		},
+		{
+			name: "exactly at cap unaffected",
+			in:   "0123456789",
+			max:  10,
+			want: "0123456789",
+		},
+		{
+			name: "long reference elided in middle, suffix preserved",
+			in:   "pr-watch@2026-09-01T22:05:00Z",
+			max:  20,
+			want: "pr-wat…-01T22:05:00Z",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TruncateMiddle(tc.in, tc.max)
+			if got != tc.want {
+				t.Fatalf("TruncateMiddle(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+			if len([]rune(got)) > tc.max {
+				t.Fatalf("TruncateMiddle(%q, %d) = %q, exceeds max width", tc.in, tc.max, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `apiary instances`' CELL column and the dashboard task list's `#` column were sized to a fixed width and truncated from the **tail** — fine for short references (`#412`, `ERP-42`), but wrong for a routine occurrence id (`<routine>@<RFC3339 instant>`, minted by the routines source plugin), which is 29+ chars and whose distinguishing part is the timestamp suffix. Tail truncation kept the part every occurrence of a routine shares and dropped the one part that tells two rows apart.
- Both columns now size themselves to the widest reference actually in the current result set, capped at 40 chars, stealing the slack from the most compressible neighboring column (`WORKFLOW` in `apiary instances`, `TASK` in the dashboard task list — matching the existing dynamic-width pattern already used for the `REQUEST` column in `apiary approvals`).
- Added `format.TruncateMiddle` as defense in depth: if a reference is still too long for the 40-char cap, the middle is elided instead of the tail, so the distinguishing suffix survives (e.g. `pr-wat…-01T22:05:00Z` instead of `pr-watch@20…`). This is a new helper rather than a change to the existing `truncate()` in `internal/cli` / `internal/dashboard`, since several other callers rely on its head-preserving behavior.
- Skipped the issue's third (optional) suggestion — dropping the redundant date portion for time-sorted lists — as non-essential.
- Checked the dashboard's Agent Activity `#` column (`renderAgentActivity`): it has the same fixed-width pattern but is out of scope for this fix per the issue (only the documented Tasks-tab `#` column and `apiary instances`' CELL column were in scope).

## Test plan

- [x] `cd src && go build ./...`
- [x] `cd src && go vet ./...`
- [x] `cd src && go test ./internal/cli/... ./internal/dashboard/... ./internal/format/...`
- [x] New `TestTruncateMiddle` in `internal/format/text_test.go` covers: a short reference left unaffected, a reference exactly at the cap length left unaffected, and a long reference elided in the middle with the distinguishing suffix preserved.

Closes #472