### PR TITLE
fix(cli): resolve apiary task --item through the human reference vocabulary

### DIFF
--- a/src/internal/cli/task.go
+++ b/src/internal/cli/task.go
@@ -42,11 +42,11 @@ func newTaskCmd() *cobra.Command {
 
 			var resp daemon.TaskHistoryResponse
 			if err := ipcGetJSON("/tasks/history?"+q.Encode(), &resp); err != nil {
-				if strings.Contains(err.Error(), "not found") {
-					fmt.Println(instErr.Render("No task history found."))
-					os.Exit(2)
+				if isDaemonDown(err) {
+					return daemonDownHint()
 				}
-				return daemonDownHint()
+				fmt.Println(instErr.Render(taskHistoryErrorMessage(err)))
+				os.Exit(2)
 			}
 
 			if asJSON {
@@ -60,9 +60,25 @@ func newTaskCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&source, "source", "", "resolve the task by source id (with --item), e.g. github")
-	cmd.Flags().StringVar(&item, "item", "", "resolve the task by source item id/number (with --source), e.g. 1948")
+	cmd.Flags().StringVar(&item, "item", "", "resolve the task by source item's human reference or cell id (with --source), e.g. PSP-278, #1948, or 1948")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
 	return cmd
+}
+
+// taskHistoryErrorMessage turns a non-2xx /tasks/history response into what the
+// user should see. ipcGetJSON prefixes the raw HTTP status onto the body
+// ("404 Not Found: <body>"), which is noise once isDaemonDown has already ruled
+// out a transport failure — the caller wants to know the reference did not
+// resolve or had no history, not that the wire status word was "Not Found".
+func taskHistoryErrorMessage(err error) string {
+	msg := err.Error()
+	if _, body, ok := strings.Cut(msg, ": "); ok && body != "" {
+		msg = body
+	}
+	if msg == "task history not found" {
+		return "No task history found."
+	}
+	return msg
 }
 
 // renderTaskHistory prints the per-instance history top-to-bottom (oldest first):

--- a/src/internal/cli/task_test.go
+++ b/src/internal/cli/task_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTaskHistoryErrorMessage covers the #471 CLI-side bug: ipcGetJSON wraps a
+// non-2xx /tasks/history response as "<HTTP status>: <body>" (e.g. "404 Not
+// Found: task not found: ..."), and the old code matched the lowercase substring
+// "not found" against that whole string — which never matched "404 Not Found:
+// ...", so an unresolved reference fell through to the daemon-down message
+// instead of reporting what actually happened. taskHistoryErrorMessage strips
+// the transport prefix so the CLI can show the daemon's real answer.
+func TestTaskHistoryErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "unresolved reference reports the reference, not the transport",
+			err:  errors.New(`404 Not Found: task not found: "PSP-278" in source rl-jira`),
+			want: `task not found: "PSP-278" in source rl-jira`,
+		},
+		{
+			name: "bound item with no workflow history yet keeps the friendly message",
+			err:  errors.New("404 Not Found: task history not found"),
+			want: "No task history found.",
+		},
+		{
+			name: "a message with no status prefix passes through unchanged",
+			err:  errors.New("no database"),
+			want: "no database",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := taskHistoryErrorMessage(tc.err); got != tc.want {
+				t.Errorf("taskHistoryErrorMessage(%q) = %q, want %q", tc.err.Error(), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsDaemonDown_DoesNotMatchNotFoundResponses guards the actual root cause of
+// #471's misleading error: a 404 body containing "Not Found" (capitalized, from
+// http.StatusText) must never be classified as the daemon being unreachable —
+// only a real transport failure (no socket, connection refused) should be.
+func TestIsDaemonDown_DoesNotMatchNotFoundResponses(t *testing.T) {
+	notDown := []error{
+		errors.New(`404 Not Found: task not found: "PSP-278" in source rl-jira`),
+		errors.New("404 Not Found: task history not found"),
+	}
+	for _, err := range notDown {
+		if isDaemonDown(err) {
+			t.Errorf("isDaemonDown(%q) = true, want false", err.Error())
+		}
+	}
+
+	down := []error{
+		errors.New("dial unix /path/apiary.sock: connect: no such file or directory"),
+		errors.New("dial unix /path/apiary.sock: connect: connection refused"),
+	}
+	for _, err := range down {
+		if !isDaemonDown(err) {
+			t.Errorf("isDaemonDown(%q) = false, want true", err.Error())
+		}
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1074,6 +1074,30 @@ func (d *Dispatcher) resolveCellRef(ctx context.Context, ref, sourceID string) (
 	return b.SourceItemID, b.SourceItemNumber, nil
 }
 
+// resolveHistoryTaskID resolves the /tasks/history ?source=&item= pair to a task
+// id. item is accepted in either form resolveCellRef understands — the internal
+// cell id, or a human reference (Jira key, GitHub issue number, ...) — so this
+// endpoint agrees with dispatch/restart instead of only matching the exact
+// source_item_id (#471: a caller who only has the human reference, which for
+// several sources is the only form ever visible in the UI, used to be told the
+// daemon was not running). Returns a wrapped ErrTaskNotFound naming the reference
+// when nothing binds to it, rather than the earlier generic "no task bound to"
+// message keyed on the unresolved raw item.
+func (d *Dispatcher) resolveHistoryTaskID(ctx context.Context, source, item string) (string, error) {
+	cellID, _, err := d.resolveCellRef(ctx, item, source)
+	if err != nil {
+		return "", err
+	}
+	binding, err := d.db.SourceBindings().GetBindingBySourceItem(ctx, source, cellID)
+	if err != nil {
+		return "", err
+	}
+	if binding == nil {
+		return "", fmt.Errorf("%w: %q in source %s", ErrTaskNotFound, item, source)
+	}
+	return binding.TaskID, nil
+}
+
 // ForceRestart cancels a running dispatch for the given cell, removes it from
 // tracking maps, marks the execution as interrupted in the DB, resets the source
 // state, strips the cell's control labels — and then re-routes and dispatches the
@@ -1614,16 +1638,19 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 				http.Error(w, "no database", http.StatusServiceUnavailable)
 				return
 			}
-			binding, err := d.db.SourceBindings().GetBindingBySourceItem(r.Context(), source, item)
+			resolved, err := d.resolveHistoryTaskID(r.Context(), source, item)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				switch {
+				case errors.Is(err, ErrAmbiguousRef):
+					http.Error(w, err.Error(), http.StatusConflict)
+				case errors.Is(err, ErrTaskNotFound):
+					http.Error(w, err.Error(), http.StatusNotFound)
+				default:
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
 				return
 			}
-			if binding == nil {
-				http.Error(w, "no task bound to "+source+"/"+item, http.StatusNotFound)
-				return
-			}
-			taskID = binding.TaskID
+			taskID = resolved
 		}
 		hist, err := d.TaskHistory(r.Context(), taskID)
 		if err != nil {

--- a/src/internal/daemon/task_history_test.go
+++ b/src/internal/daemon/task_history_test.go
@@ -2,11 +2,14 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/db"
+	"github.com/orlandoburli/apiary/internal/model"
 )
 
 func mustCreateInstance(t *testing.T, dbc *db.Client, inst *db.WorkflowInstance) {
@@ -83,5 +86,83 @@ func TestTaskHistory_NoInstancesReturnsNil(t *testing.T) {
 	}
 	if resp != nil {
 		t.Errorf("expected nil for a task with no instances, got %+v", resp)
+	}
+}
+
+// TestResolveHistoryTaskID_AcceptsHumanReference is the #471 regression case:
+// /tasks/history's ?source=&item= used to match only the exact source_item_id
+// (GetBindingBySourceItem straight-up), so a Jira key — the only form of the
+// reference that ever appears in Jira's UI — resolved to nothing and the CLI
+// reported "Daemon is not running" for a daemon that was up. The item must
+// resolve through the same vocabulary dispatch/restart use (resolveCellRef).
+func TestResolveHistoryTaskID_AcceptsHumanReference(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	taskID := seedJiraTask(ctx, t, dbc, "300966", "PSP-278")
+
+	d := &Dispatcher{db: dbc}
+
+	got, err := d.resolveHistoryTaskID(ctx, "jira", "PSP-278")
+	if err != nil {
+		t.Fatalf("resolveHistoryTaskID(PSP-278): %v", err)
+	}
+	if got != taskID {
+		t.Errorf("resolved task = %q, want %q", got, taskID)
+	}
+
+	// The cell id form (what the old code required) must keep working too.
+	got, err = d.resolveHistoryTaskID(ctx, "jira", "300966")
+	if err != nil {
+		t.Fatalf("resolveHistoryTaskID(300966): %v", err)
+	}
+	if got != taskID {
+		t.Errorf("resolved task by cell id = %q, want %q", got, taskID)
+	}
+}
+
+// TestResolveHistoryTaskID_UnresolvedReferenceIsNotFound covers the second half
+// of #471: an item that does not resolve — wrong key, wrong source, or a bound
+// item with no history yet — must fail with a message naming the reference, not
+// a generic error the CLI could mistake for the daemon being unreachable.
+func TestResolveHistoryTaskID_UnresolvedReferenceIsNotFound(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+	seedJiraTask(ctx, t, dbc, "300966", "PSP-278")
+
+	d := &Dispatcher{db: dbc}
+
+	_, err := d.resolveHistoryTaskID(ctx, "jira", "PSP-999")
+	if err == nil {
+		t.Fatal("expected an error for an unbound reference, got nil")
+	}
+	if !errors.Is(err, ErrTaskNotFound) {
+		t.Fatalf("error = %v, want it to wrap ErrTaskNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "PSP-999") || !strings.Contains(err.Error(), "jira") {
+		t.Errorf("error %q should name the unresolved reference and source", err)
+	}
+}
+
+// TestResolveHistoryTaskID_AmbiguousReferenceIsRejected: a reference that matches
+// items in two different sources must not be guessed at (same #377 guard restart
+// uses), and must surface as ErrAmbiguousRef rather than a plain not-found. It
+// only triggers when source is left unscoped (?source= empty), since a caller
+// who names the source is asking to be scoped to it.
+func TestResolveHistoryTaskID_AmbiguousReferenceIsRejected(t *testing.T) {
+	ctx := context.Background()
+	dbc := openTestDB(ctx, t)
+
+	for _, s := range []struct{ source, itemID string }{{"jira", "10042"}, {"github", "77"}} {
+		task := &model.InternalTask{Title: "dup", State: model.TaskStateRunning}
+		binding := &model.SourceBinding{SourceID: s.source, SourceItemID: s.itemID, SourceItemNumber: "DUP-1"}
+		if err := dbc.CreateTaskWithBinding(ctx, task, binding); err != nil {
+			t.Fatalf("seed %s: %v", s.source, err)
+		}
+	}
+
+	d := &Dispatcher{db: dbc}
+	_, err := d.resolveHistoryTaskID(ctx, "", "DUP-1")
+	if !errors.Is(err, ErrAmbiguousRef) {
+		t.Fatalf("error = %v, want it to wrap ErrAmbiguousRef", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `apiary task --source --item` (and the underlying `/tasks/history?source=&item=` HTTP handler) resolved `--item` only by an exact match on the internal `source_item_id`, unlike `dispatch`/`restart` which also accept the item's human-facing reference (Jira key, GitHub issue number, ...). For sources like Jira, where the cell id never appears in the UI, this made `--item` effectively unusable with the only reference a caller actually has.
- Extracted `Dispatcher.resolveHistoryTaskID` (in `internal/daemon/dispatcher.go`), which resolves `item` through the same `resolveCellRef` vocabulary `dispatch`/`restart` already use (cell id first, then case-insensitive human reference with leading `#` stripped, with the same ambiguity error when a reference matches more than one distinct item), then looks up the binding by the resolved cell id. Wired the `/tasks/history` handler to use it, mapping `ErrAmbiguousRef` to 409 and `ErrTaskNotFound` to 404.
- Independently, `internal/cli/task.go`'s error handling matched the lowercase substring `"not found"` against the whole `ipcGetJSON` error, which prefixes the raw HTTP status text (`"404 Not Found: ..."`). The capitalized `"Not Found"` never matched, so any unresolved reference fell through to the generic `daemonDownHint()` even though the daemon was up and answered honestly. Replaced the substring check with the existing `isDaemonDown(err)` helper (already used in `internal/cli/approvals.go`) and added `taskHistoryErrorMessage`, which strips the transport prefix so the CLI reports what the daemon actually said (the unresolved reference, or "No task history found." for a bound item with no workflow history yet).

Closes #471

## Risk / impact notes
- `resolveCellRef` and `GetBindingBySourceItem` are both heavily used elsewhere (dispatch, restart, manual runs, PR-event routing, etc.); gitnexus `impact()` flagged their blast radius as HIGH/CRITICAL. Neither function's behavior or signature was changed — this PR only adds one more call site (the `/tasks/history` handler) using the exact same resolution path `dispatch`/`restart` already rely on, so the risk is scoped to that one endpoint.
- No other call site in the repo calls `GetBindingBySourceItem` directly the way the old `/tasks/history` handler did (bypassing `resolveCellRef`) — grepped for other direct callers and found none besides `resolveTaskRef` (used by `DeleteTask`, a separate reference format: `source:item`, `task id`, or bare cell id — out of scope here).

## Test plan
- `cd src && go build ./... && go vet ./...`
- `cd src && go test ./internal/cli/... ./internal/daemon/...` — all pass
- Added `internal/daemon/task_history_test.go` cases: resolving `--item` by human reference and by cell id, an unresolved reference returning a wrapped `ErrTaskNotFound` naming the reference, and an ambiguous reference across two sources returning `ErrAmbiguousRef`.
- Added `internal/cli/task_test.go`: `taskHistoryErrorMessage` unit tests (unresolved-reference message vs. the friendly "No task history found." message vs. pass-through), and an `isDaemonDown` regression test confirming a 404 "Not Found" body is never classified as the daemon being down.