### PR TITLE
fix(approvals): surface ticket/PR context and default-yes approve prompt

### DIFF
--- a/src/internal/cli/approvals.go
+++ b/src/internal/cli/approvals.go
@@ -153,16 +153,20 @@ func listApprovals(status string, limit int, asJSON bool) error {
 	// into `apiary approve`, and an elided one cannot be typed back. The column
 	// is sized to the widest id present so the rest of the table still lines up.
 	idWidth := len("REQUEST")
+	forWidth := len("FOR")
 	for _, r := range requests {
 		idWidth = max(idWidth, len(r.ID))
+		forWidth = max(forWidth, len(approvalContextLabel(r)))
 	}
+	forWidth = min(forWidth, 28)
 
 	fmt.Println()
-	fmt.Printf("  %s\n", instHeader.Render(fmt.Sprintf("%-*s %-16s %-14s %-9s %s",
-		idWidth, "REQUEST", "WORKFLOW", "STEP", "PARKED", "EXPIRES")))
+	fmt.Printf("  %s\n", instHeader.Render(fmt.Sprintf("%-*s %-*s %-16s %-14s %-9s %s",
+		idWidth, "REQUEST", forWidth, "FOR", "WORKFLOW", "STEP", "PARKED", "EXPIRES")))
 	for _, r := range requests {
-		fmt.Printf("  %-*s %-16s %-14s %-9s %s\n",
+		fmt.Printf("  %-*s %-*s %-16s %-14s %-9s %s\n",
 			idWidth, r.ID,
+			forWidth, truncate(approvalContextLabel(r), forWidth),
 			truncate(r.WorkflowID, 16),
 			truncate(r.StepID, 14),
 			shortDuration(time.Since(r.CreatedAt)),
@@ -196,6 +200,7 @@ func showApproval(id string, asJSON bool) error {
 		fmt.Println("  " + request.Message)
 	}
 	fmt.Println()
+	printApprovalContext(request)
 	fmt.Printf("  %-12s %s\n", instMuted.Render("workflow"), request.WorkflowID)
 	fmt.Printf("  %-12s %s\n", instMuted.Render("step"), request.StepID)
 	fmt.Printf("  %-12s %s\n", instMuted.Render("status"), request.Status)
@@ -243,6 +248,21 @@ func respondToApproval(id, decision string, fieldFlags []string, comment string,
 		os.Exit(4)
 	}
 
+	// Show what this request is actually for before asking anything else —
+	// including before any field prompt below — so an operator never answers
+	// blind. This used to run after field collection and right before the
+	// (default-no) confirmation, which is exactly backwards (#473).
+	if !asJSON {
+		fmt.Println()
+		fmt.Println("  " + instHeader.Render(request.ID))
+		printApprovalContext(request)
+		fmt.Printf("  %-12s %s\n", instMuted.Render("step"), request.StepID)
+		if request.Message != "" {
+			fmt.Println()
+			fmt.Println("  " + request.Message)
+		}
+	}
+
 	supplied, err := parseFieldFlags(fieldFlags)
 	if err != nil {
 		return err
@@ -258,10 +278,6 @@ func respondToApproval(id, decision string, fieldFlags []string, comment string,
 	}
 
 	if !yes && !asJSON && isInteractive() {
-		if request.Message != "" {
-			fmt.Println()
-			fmt.Println("  " + request.Message)
-		}
 		if len(values) > 0 {
 			fmt.Println()
 			for _, name := range sortedKeys(values) {
@@ -269,13 +285,67 @@ func respondToApproval(id, decision string, fieldFlags []string, comment string,
 			}
 		}
 		fmt.Println()
-		if !confirm(fmt.Sprintf("  %s %s? [y/N] ", strings.ToUpper(decision[:1])+decision[1:], id)) {
-			fmt.Println(instMuted.Render("  Cancelled."))
-			return nil
+		verb := strings.ToUpper(decision[:1]) + decision[1:]
+		if decision == "approve" {
+			// Approving is the common case an operator reaches for this command
+			// to do, so a bare Enter takes it — the context printed above is
+			// what makes that safe to assume.
+			if !confirmDefault(fmt.Sprintf("  %s %s? [Y/n] ", verb, id), true) {
+				fmt.Println(instMuted.Render("  Cancelled."))
+				return nil
+			}
+		} else {
+			// Rejection ends the gate and fails the workflow immediately, so it
+			// keeps requiring explicit, unambiguous input — a bare Enter here
+			// must never be read as "reject".
+			if !confirm(fmt.Sprintf("  %s %s? [y/N] ", verb, id)) {
+				fmt.Println(instMuted.Render("  Cancelled."))
+				return nil
+			}
 		}
 	}
 
 	return postApprovalResponse(request, decision, values, comment, asJSON)
+}
+
+// printApprovalContext prints the ticket/PR this request resolves to, when
+// known — TicketRef/TicketURL/PRNumber/PRURL are resolved by the daemon via the
+// request's TaskID (Dispatcher.enrichApprovalContext in internal/daemon) and
+// travel on db.ApprovalRequest itself. Shared by `apiary approvals <id>` and
+// the pre-decision context in `apiary approve`/`apiary reject`, so there is one
+// place that knows how to render it (#473).
+func printApprovalContext(request *db.ApprovalRequest) {
+	if request.TicketRef != "" {
+		line := request.TicketRef
+		if request.TicketURL != "" {
+			line += "  " + instMuted.Render(request.TicketURL)
+		}
+		fmt.Printf("  %-12s %s\n", instMuted.Render("ticket"), line)
+	}
+	if request.PRNumber != 0 {
+		line := fmt.Sprintf("#%d", request.PRNumber)
+		if request.PRURL != "" {
+			line += "  " + instMuted.Render(request.PRURL)
+		}
+		fmt.Printf("  %-12s %s\n", instMuted.Render("pr"), line)
+	}
+}
+
+// approvalContextLabel condenses TicketRef/PRNumber into the `apiary approvals`
+// table's FOR column: "source/ref" and/or "PR #n", joined; "—" when the
+// request's task resolved to neither (or has no task at all).
+func approvalContextLabel(r db.ApprovalRequest) string {
+	var parts []string
+	if r.TicketRef != "" {
+		parts = append(parts, r.TicketRef)
+	}
+	if r.PRNumber != 0 {
+		parts = append(parts, fmt.Sprintf("PR #%d", r.PRNumber))
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " · ")
 }
 
 // postApprovalResponse sends the answer and maps the outcome onto an exit code.

--- a/src/internal/cli/resume.go
+++ b/src/internal/cli/resume.go
@@ -162,6 +162,22 @@ func confirm(prompt string) bool {
 	return line == "y" || line == "yes"
 }
 
+// confirmDefault is confirm with a default answer: a bare Enter returns def
+// instead of always reading as "no". Use it only where the default path is the
+// safe, common one to assume for the action at hand — e.g. approving a request
+// that context was just printed for — never for a destructive or terminal
+// action like rejecting one, which should keep requiring explicit, unambiguous
+// input (#473).
+func confirmDefault(prompt string, def bool) bool {
+	fmt.Print(prompt)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	line = strings.ToLower(strings.TrimSpace(line))
+	if line == "" {
+		return def
+	}
+	return line == "y" || line == "yes"
+}
+
 // ipcDo performs an HTTP request against the daemon's Unix socket and decodes a
 // JSON response into out (when non-nil). It returns the HTTP status code (0 on
 // transport failure) so callers can map distinct exit codes.

--- a/src/internal/daemon/approval_http.go
+++ b/src/internal/daemon/approval_http.go
@@ -31,8 +31,44 @@ func (d *Dispatcher) handleApprovals(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	for i := range requests {
+		d.enrichApprovalContext(r.Context(), &requests[i])
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(requests)
+}
+
+// enrichApprovalContext fills in TicketRef/TicketURL/PRNumber/PRURL from the
+// request's TaskID, so an operator sees what ticket and PR they are answering
+// for instead of just the internal workflow/step ids (#473).
+//
+// It is best-effort: a task with no source binding (or none yet) is common (an
+// operator gate on a workflow with no source item) and is not an error, just an
+// approval with no ticket context to show. It shares its resolution with
+// `apiary approve`/`apiary approvals <id>`, both of which reach it indirectly —
+// they fetch the same GET /approvals list and filter to the id they want, so a
+// second resolution path was never needed.
+func (d *Dispatcher) enrichApprovalContext(ctx context.Context, req *db.ApprovalRequest) {
+	if req.TaskID == "" || d.db == nil {
+		return
+	}
+	if bindings, err := d.db.ListBindingsByTask(ctx, req.TaskID); err == nil && len(bindings) > 0 {
+		b := bindings[0]
+		ref := b.SourceItemNumber
+		if ref == "" {
+			ref = b.SourceItemID
+		}
+		if ref != "" {
+			req.TicketRef = b.SourceID + "/" + ref
+		}
+		req.TicketURL = b.SourceItemURL
+	}
+	if prs, err := d.db.ListTaskPullRequests(ctx, req.TaskID); err == nil && len(prs) > 0 {
+		// The tail is the most recent PR (see ListTaskPullRequests).
+		pr := prs[len(prs)-1]
+		req.PRNumber = pr.PRNumber
+		req.PRURL = pr.PRURL
+	}
 }
 
 // handleApprovalResponse records one response to an approval request and, when

--- a/src/internal/db/approval_store.go
+++ b/src/internal/db/approval_store.go
@@ -44,6 +44,18 @@ type ApprovalRequest struct {
 	RemindedAt  *time.Time `json:"reminded_at,omitempty"`
 	EscalatedAt *time.Time `json:"escalated_at,omitempty"`
 	RespondedAt *time.Time `json:"responded_at,omitempty"`
+
+	// TicketRef/TicketURL/PRNumber/PRURL surface what the request's task is
+	// actually for: the source item (Jira key / GitHub issue) it is bound to,
+	// and the most recently linked pull request. Neither is a column — they are
+	// resolved via TaskID (source_bindings, task_pull_requests) and stitched on
+	// by the daemon's /approvals HTTP handler for display only. Never set by
+	// CreateApprovalRequest/ResolveApprovalRequest/scanApproval, and never
+	// round-tripped back into the store (#473).
+	TicketRef string `json:"ticket_ref,omitempty"`
+	TicketURL string `json:"ticket_url,omitempty"`
+	PRNumber  int    `json:"pr_number,omitempty"`
+	PRURL     string `json:"pr_url,omitempty"`
 }
 
 type ApprovalResponse struct {


### PR DESCRIPTION
## Summary
- `apiary approvals` and `apiary approve <id>` used to show only internal workflow/step ids — there was no way to tell what ticket or PR an approval request was actually for without going around the CLI into sqlite.
- Added `TicketRef`/`TicketURL`/`PRNumber`/`PRURL` to `db.ApprovalRequest` (additive JSON fields, `omitempty`, never persisted/scanned from the DB) and a new `Dispatcher.enrichApprovalContext` in `internal/daemon/approval_http.go` that resolves them from the request's `TaskID` via `ListBindingsByTask` (source binding → ticket key/URL) and `ListTaskPullRequests` (most recent linked PR), wired into the existing `GET /approvals` handler.
- `apiary approvals` now renders a `FOR` column with the resolved ticket/PR; `apiary approve`/`apiary approvals <id>` print the same context via a shared `printApprovalContext` helper, since `fetchApproval` reuses the same enriched list.
- Flipped `apiary approve`'s interactive order: context (id, ticket, PR, step, message) now prints *before* any field prompt and before the confirmation, instead of after. Added `confirmDefault` (bare Enter answers the given default) and used it only for the approve confirmation (`[Y/n]`, default yes) — the reject confirmation is unchanged (`[y/N]`, still requires explicit `y`/`yes`), so rejecting stays deliberate.

## Test plan
- `cd src && go build ./... && go vet ./...`
- `cd src && go test ./internal/cli/... ./internal/daemon/... ./internal/db/...`
- Reviewed blast radius with GitNexus `impact` on `respondToApproval`, `confirm`, and `handleApprovals` before editing — all LOW risk, callers limited to the approve/reject cobra commands and `runResume`/`delete`/`clear` (which keep using the untouched `confirm`, not the new `confirmDefault`).

Closes #473