### PR TITLE
feat(dashboard): approvals-only Tasks filter, jump-to from Overview

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -706,6 +706,30 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 
+	// Jump to (or toggle) the approvals-only Tasks filter (Shift+A): from
+	// anywhere it switches to the Tasks list showing only instances parked on
+	// a human approval gate (blockedOnApproval), so "what needs my approval"
+	// does not require scanning the whole — possibly routine-noisy — task
+	// list by hand (#476). Pressed again from that filtered list, it turns
+	// the filter back off.
+	if key == "A" {
+		if t := a.model.tasksTab; t != nil {
+			alreadyThere := a.model.ActiveTab() == "Tasks" && t.View == TaskViewList
+			if alreadyThere {
+				t.ApprovalsOnly = !t.ApprovalsOnly
+			} else {
+				t.View = TaskViewList
+				t.ApprovalsOnly = true
+			}
+			t.SelectedIdx = 0
+			t.ScrollOffset = 0
+			a.model.SetActiveTab("Tasks")
+			a.model.loading = true
+			return a, a.fetchActiveTab()
+		}
+		return a, nil
+	}
+
 	// While a Tasks sub-view (detail/logs/workflow) is open, keys are scoped to it.
 	if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View != TaskViewList {
 		return a.handleTaskSubViewKey(key)
@@ -3459,7 +3483,7 @@ func (a *App) renderOverviewTab(height int) string {
 	// and dimmed to a plain zero otherwise.
 	approvals := StyleMuted.Render("0")
 	if o.PendingApprovals > 0 {
-		approvals = StyleWarning.Render(fmt.Sprintf("%d ⏸ — press a on the task to answer", o.PendingApprovals))
+		approvals = StyleWarning.Render(fmt.Sprintf("%d ⏸ — Shift+A to list, a on the task to answer", o.PendingApprovals))
 	}
 
 	fmt.Fprintf(&b,
@@ -3593,10 +3617,15 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 	items := a.filteredTasks(t)
 	if len(items) == 0 {
 		msg := "No tasks yet — start the dispatcher and give it work."
-		if t.FilterText != "" {
+		if t.ApprovalsOnly {
+			msg = "Nothing is waiting on approval right now"
+		} else if t.FilterText != "" {
 			msg = "No tasks match filter"
 		}
 		title := "TASKS"
+		if t.ApprovalsOnly {
+			title += " [⏸ approvals]"
+		}
 		if t.FilterActive {
 			title += " [/" + t.FilterText + "▌]"
 		} else if t.FilterText != "" {
@@ -3623,6 +3652,9 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 	// Box title with sort/filter indicators
 	title := "TASKS"
 	parts := []string{}
+	if t.ApprovalsOnly {
+		parts = append(parts, "⏸ approvals")
+	}
 	if t.FilterActive {
 		parts = append(parts, "/"+t.FilterText+"▌")
 	} else if t.FilterText != "" {
@@ -3714,6 +3746,15 @@ func compareTimePtr(a, b *time.Time) int {
 // filteredTasks returns the task list after applying filter and sort.
 func (a *App) filteredTasks(t *TasksTab) []TaskItem {
 	out := t.History
+	if t.ApprovalsOnly {
+		var filtered []TaskItem
+		for _, it := range out {
+			if blockedOnApproval(it.Status, it.BlockedReason) {
+				filtered = append(filtered, it)
+			}
+		}
+		out = filtered
+	}
 	if t.FilterText != "" {
 		filter := strings.ToLower(t.FilterText)
 		var filtered []TaskItem
@@ -5523,7 +5564,7 @@ func (a *App) footerKeys() []fkey {
 				return []fkey{{"type", "filter"}, {"enter", "apply"}, {"esc", "cancel"}}
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"/", "filter"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"W", "run wf"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"/", "filter"}, {"A", "approvals"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"W", "run wf"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
 	case "Workflows":
 		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
 			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}
@@ -5560,7 +5601,7 @@ func (a *App) footerKeys() []fkey {
 		}
 		return []fkey{{"w", wrap}, {"←/→", "scroll"}, {"↑/↓", "lines"}, {"pgup/dn", "page"}, {"home/end", "ends"}, {"tab", "switch"}, {"q", "quit"}}
 	default: // Overview
-		return []fkey{{"tab", "next"}, {"⇧tab", "prev"}, {"W", "run wf"}, {"r", "refresh"}, {"q", "quit"}}
+		return []fkey{{"tab", "next"}, {"⇧tab", "prev"}, {"A", "approvals"}, {"W", "run wf"}, {"r", "refresh"}, {"q", "quit"}}
 	}
 }
 

--- a/src/internal/dashboard/approval_waiting_filter_test.go
+++ b/src/internal/dashboard/approval_waiting_filter_test.go
@@ -1,0 +1,83 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/orlandoburli/apiary/internal/state"
+)
+
+// approvalsFixtureApp returns an App on the Overview tab with a Tasks history
+// containing one task parked on an approval gate, one blocked on something
+// else (a CI wait), and one running normally — the mix a real dashboard sees.
+func approvalsFixtureApp() *App {
+	a := &App{model: NewModel()}
+	a.model.tasksTab.History = []TaskItem{
+		{TaskID: "t1", Title: "waiting on approval", Status: "approval_waiting"},
+		{TaskID: "t2", Title: "blocked on ci", Status: string(state.Blocked), BlockedReason: "ci"},
+		{TaskID: "t3", Title: "running fine", Status: "running"},
+	}
+	return a
+}
+
+// Pressing Shift+A from the Overview tab jumps straight to the Tasks list,
+// filtered to only the instances parked on a human approval gate — the
+// dashboard-affordance ask of #476.
+func TestApprovalsShortcutJumpsToFilteredTaskList(t *testing.T) {
+	a := approvalsFixtureApp()
+	if got := a.model.ActiveTab(); got != "Overview" {
+		t.Fatalf("fixture should start on Overview, got %q", got)
+	}
+
+	a.handleKeyMsg(keyPress("A"))
+
+	if got := a.model.ActiveTab(); got != "Tasks" {
+		t.Fatalf("Shift+A should switch to the Tasks tab, got %q", got)
+	}
+	tt := a.model.tasksTab
+	if tt.View != TaskViewList {
+		t.Fatalf("Shift+A should land on the task list, got view %v", tt.View)
+	}
+	if !tt.ApprovalsOnly {
+		t.Fatal("Shift+A should turn on the approvals-only filter")
+	}
+
+	items := a.filteredTasks(tt)
+	if len(items) != 1 || items[0].TaskID != "t1" {
+		t.Fatalf("expected only the approval-waiting task, got %+v", items)
+	}
+}
+
+// Pressing Shift+A again while already on the filtered list turns the filter
+// back off, restoring the full history.
+func TestApprovalsShortcutTogglesOffFromTaskList(t *testing.T) {
+	a := approvalsFixtureApp()
+	a.model.activeTab = 1 // Tasks
+	a.model.tasksTab.ApprovalsOnly = true
+
+	a.handleKeyMsg(keyPress("A"))
+
+	if a.model.tasksTab.ApprovalsOnly {
+		t.Fatal("a second Shift+A from the filtered list should turn the filter off")
+	}
+	if len(a.filteredTasks(a.model.tasksTab)) != 3 {
+		t.Fatal("turning the filter off should restore the full task history")
+	}
+}
+
+// The approvals-only filter recognizes both the modern approval_waiting state
+// and the legacy blocked+reason:approval pair, via the same blockedOnApproval
+// predicate already used per-instance elsewhere in the dashboard.
+func TestApprovalsOnlyFilterRecognizesLegacyBlockedReason(t *testing.T) {
+	a := &App{model: NewModel()}
+	tt := a.model.tasksTab
+	tt.ApprovalsOnly = true
+	tt.History = []TaskItem{
+		{TaskID: "legacy", Status: string(state.Blocked), BlockedReason: string(state.ReasonApproval)},
+		{TaskID: "not-approval", Status: string(state.Blocked), BlockedReason: "dependency"},
+	}
+
+	items := a.filteredTasks(tt)
+	if len(items) != 1 || items[0].TaskID != "legacy" {
+		t.Fatalf("expected only the legacy approval-blocked task, got %+v", items)
+	}
+}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -172,6 +172,12 @@ type TasksTab struct {
 	FilterActive bool   // true while typing a filter
 	SortField    string // "time" | "status" | "agent"  (default "time")
 	SortAsc      bool
+
+	// ApprovalsOnly narrows the list to tasks parked on a human approval gate
+	// (blockedOnApproval), so "what needs my approval" does not require hunting
+	// through routine/scheduled noise. Toggled with Shift+A; jumping here from
+	// the Overview badge (also Shift+A) turns it on (#476).
+	ApprovalsOnly bool
 }
 
 // WorkflowInstanceItem is a workflow instance bound to a task, with its steps,
@@ -525,4 +531,17 @@ func (m *Model) PrevTab() {
 	if m.activeTab < 0 {
 		m.activeTab = len(m.tabs) - 1
 	}
+}
+
+// SetActiveTab jumps directly to the named tab (e.g. from a cross-tab
+// shortcut like the Overview approvals badge). Returns false, leaving the
+// active tab unchanged, if name is not one of m.tabs.
+func (m *Model) SetActiveTab(name string) bool {
+	for i, t := range m.tabs {
+		if t == name {
+			m.activeTab = i
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- Adds a `Shift+A` shortcut in the dashboard: from anywhere it jumps to the Tasks list filtered to only instances parked on a human approval gate (using the existing `blockedOnApproval(state, blockedReason)` predicate), so "what needs my approval" no longer requires scanning the whole — potentially routine-noisy — task list by hand. Pressed again while already on the filtered list, it toggles the filter back off.
- The Tasks list title/empty-state now shows an `[⏸ approvals]` tag while the filter is active, with a dedicated empty message ("Nothing is waiting on approval right now").
- The Overview tab's existing `Approvals: N ⏸` badge (from #437, backed by `CountPendingApprovals` over the `approval_requests` table) now points operators at the new shortcut instead of only telling them to hunt the task down manually.
- Footer key hints on both the Overview and Tasks tabs advertise `A → approvals`.

This is the dashboard-visibility half of #474 (issue #476); the task-list-noise half is tracked separately in #475.

## Design notes

- The filter reuses `blockedOnApproval` directly against each `TaskItem`'s canonical `Status`/`BlockedReason` (sourced from `InternalTask.State`), rather than the `approval_requests` table — this is the same ground truth `apiary instances --state approval_waiting` reads, so it also catches an `approval_waiting` task with no (or a stale) `approval_requests` row.
- Kept the existing `OverviewTab.PendingApprovals` badge/count as-is (it already existed from #437) rather than replacing it — the new list is additive and the two numbers should normally agree; diverging cases (if any) are now also visible in the list.
- #473 (separate PR) is adding ticket/PR context resolution for `apiary approvals`/`apiary approve` at the CLI layer. This PR does not depend on it, but the resulting list view would read even better once each row can show its ticket/PR context — worth revisiting whether that CLI-side resolver can be reused for the dashboard list once #473 lands.

## Test plan

- [x] `cd src && go build ./...`
- [x] `cd src && go vet ./...`
- [x] `cd src && go test ./internal/dashboard/...` — includes new tests: jump-to-filtered-list from Overview, toggle-off from the Tasks list, and recognition of both `approval_waiting` and the legacy `blocked`+`reason:approval` pair
- [x] `cd src && go test ./...` (full suite)

Closes #476