### PR TITLE
feat: filter task list to ticket-bound work (--tickets-only)

### DIFF
--- a/src/internal/cli/instances.go
+++ b/src/internal/cli/instances.go
@@ -30,11 +30,12 @@ var (
 
 func newInstancesCmd() *cobra.Command {
 	var (
-		workflow string
-		state    string
-		limit    int
-		asJSON   bool
-		cancel   bool
+		workflow    string
+		state       string
+		limit       int
+		asJSON      bool
+		cancel      bool
+		ticketsOnly bool
 	)
 
 	cmd := &cobra.Command{
@@ -45,7 +46,10 @@ func newInstancesCmd() *cobra.Command {
 			"and the instance is marked interrupted, without touching the source item's\n" +
 			"labels or state (unlike `apiary restart`, which acts on the whole cell).\n" +
 			"Queued or leased dispatch jobs for the same task and workflow are cancelled\n" +
-			"with it. A cancelled instance can be continued later with `apiary resume`.",
+			"with it. A cancelled instance can be continued later with `apiary resume`.\n\n" +
+			"--tickets-only hides instances with no real ticket behind them — scheduled\n" +
+			"routine runs and other plugin-sourced work items — keeping only instances\n" +
+			"bound to a source item from a ticket-tracker source (jira, github, plane, ...).",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if cancel {
@@ -57,7 +61,7 @@ func newInstancesCmd() *cobra.Command {
 			if len(args) == 1 {
 				return showInstance(args[0], asJSON)
 			}
-			return listInstances(workflow, state, limit, asJSON)
+			return listInstances(workflow, state, limit, asJSON, ticketsOnly)
 		},
 	}
 
@@ -66,6 +70,8 @@ func newInstancesCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 20, "max rows")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
 	cmd.Flags().BoolVar(&cancel, "cancel", false, "stop this instance and mark it interrupted")
+	cmd.Flags().BoolVar(&ticketsOnly, "tickets-only", false,
+		"only show instances bound to a real ticket/issue (excludes scheduled routine and other plugin-sourced runs)")
 	cmd.AddCommand(newInstancesCompareCmd())
 	return cmd
 }
@@ -153,13 +159,16 @@ func cancelInstance(id string, asJSON bool) error {
 	return nil
 }
 
-func listInstances(workflow, state string, limit int, asJSON bool) error {
+func listInstances(workflow, state string, limit int, asJSON, ticketsOnly bool) error {
 	q := url.Values{}
 	if workflow != "" {
 		q.Set("workflow", workflow)
 	}
 	if state != "" {
 		q.Set("state", state)
+	}
+	if ticketsOnly {
+		q.Set("tickets_only", "1")
 	}
 	q.Set("limit", fmt.Sprintf("%d", limit))
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -92,6 +92,34 @@ func (s SourceConfig) ParsedPollInterval() (time.Duration, error) {
 	return time.ParseDuration(s.PollInterval)
 }
 
+// IsTicketSourceType reports whether a source of the given config type is an
+// external ticket/issue tracker (jira, github, plane, ...) as opposed to a
+// plugin-bridged source (type "plugin") such as the scheduled-routines or
+// monitoring adapters, which mint work items with no real ticket behind them
+// (a cron occurrence, an alert). It is the structural signal behind the
+// "ticket-bound vs. routine/plugin-sourced" split in the task list (#475):
+// checking the configured kind, not a specific source id, so any future
+// plugin-sourced routine is excluded the same way without special-casing it.
+func IsTicketSourceType(sourceType string) bool {
+	return sourceType != "" && sourceType != "plugin"
+}
+
+// TicketSourceIDs returns the ids of every configured source whose type is a
+// ticket tracker per IsTicketSourceType — the allow-list used to filter the
+// task/instance list down to ticket-bound work (issue #475).
+func (c *Config) TicketSourceIDs() []string {
+	if c == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(c.Sources))
+	for _, s := range c.Sources {
+		if IsTicketSourceType(s.Type) {
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}
+
 type SourceFilters struct {
 	States []string `yaml:"states"`
 	Labels []string `yaml:"labels"`

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -92,16 +92,29 @@ func (s SourceConfig) ParsedPollInterval() (time.Duration, error) {
 	return time.ParseDuration(s.PollInterval)
 }
 
+// ticketSourceTypes are the registered source types that track a real,
+// human-filed ticket or issue — as opposed to a source that mints synthetic
+// work items with no ticket behind them (a cron occurrence, a monitoring
+// alert). This is deliberately an allow-list, not a block-list on "plugin":
+// dynatrace and prometheus are their own registered types (see
+// internal/source/{dynatrace,prometheus}), not "plugin", so a block-list on
+// "plugin" alone would count their alerts as ticket-bound. An allow-list fails
+// safe instead — a new non-ticket adapter is excluded by default until someone
+// deliberately adds its type here, rather than silently included.
+var ticketSourceTypes = map[string]bool{
+	"jira":   true,
+	"github": true,
+	"plane":  true,
+}
+
 // IsTicketSourceType reports whether a source of the given config type is an
-// external ticket/issue tracker (jira, github, plane, ...) as opposed to a
-// plugin-bridged source (type "plugin") such as the scheduled-routines or
-// monitoring adapters, which mint work items with no real ticket behind them
-// (a cron occurrence, an alert). It is the structural signal behind the
-// "ticket-bound vs. routine/plugin-sourced" split in the task list (#475):
-// checking the configured kind, not a specific source id, so any future
-// plugin-sourced routine is excluded the same way without special-casing it.
+// external ticket/issue tracker (jira, github, plane) as opposed to a source
+// — plugin-bridged (type "plugin") or a built-in monitoring adapter
+// (dynatrace, prometheus) — that mints work items with no real ticket behind
+// them. It is the structural signal behind the "ticket-bound vs.
+// routine/alert-sourced" split in the task list (#475).
 func IsTicketSourceType(sourceType string) bool {
-	return sourceType != "" && sourceType != "plugin"
+	return ticketSourceTypes[sourceType]
 }
 
 // TicketSourceIDs returns the ids of every configured source whose type is a

--- a/src/internal/config/ticket_source_test.go
+++ b/src/internal/config/ticket_source_test.go
@@ -3,17 +3,22 @@ package config
 import "testing"
 
 // TestIsTicketSourceType checks the structural signal behind the ticket-vs-
-// routine split in the task list (issue #475): any type other than "plugin"
-// (a plugin-bridged scheduler/monitoring source) counts as a ticket tracker,
-// so a future ticket-tracker type needs no special-casing here, and a future
-// plugin-sourced routine is excluded the same way as today's.
+// routine split in the task list (issue #475): jira/github/plane are
+// ticket trackers, while "plugin" (the routines/scheduler bridge) and the
+// built-in monitoring adapters (dynatrace, prometheus) — which mint synthetic
+// work items with no real ticket behind them, same as a routine occurrence —
+// are not. This is an allow-list on purpose: a block-list on "plugin" alone
+// would wrongly count dynatrace/prometheus alerts as ticket-bound, since they
+// register under their own type, not "plugin".
 func TestIsTicketSourceType(t *testing.T) {
 	cases := map[string]bool{
-		"jira":   true,
-		"github": true,
-		"plane":  true,
-		"plugin": false,
-		"":       false,
+		"jira":       true,
+		"github":     true,
+		"plane":      true,
+		"plugin":     false,
+		"dynatrace":  false,
+		"prometheus": false,
+		"":           false,
 	}
 	for typ, want := range cases {
 		if got := IsTicketSourceType(typ); got != want {

--- a/src/internal/config/ticket_source_test.go
+++ b/src/internal/config/ticket_source_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+// TestIsTicketSourceType checks the structural signal behind the ticket-vs-
+// routine split in the task list (issue #475): any type other than "plugin"
+// (a plugin-bridged scheduler/monitoring source) counts as a ticket tracker,
+// so a future ticket-tracker type needs no special-casing here, and a future
+// plugin-sourced routine is excluded the same way as today's.
+func TestIsTicketSourceType(t *testing.T) {
+	cases := map[string]bool{
+		"jira":   true,
+		"github": true,
+		"plane":  true,
+		"plugin": false,
+		"":       false,
+	}
+	for typ, want := range cases {
+		if got := IsTicketSourceType(typ); got != want {
+			t.Errorf("IsTicketSourceType(%q) = %v, want %v", typ, got, want)
+		}
+	}
+}
+
+func TestConfigTicketSourceIDs(t *testing.T) {
+	cfg := &Config{
+		Sources: []SourceConfig{
+			{ID: "jira", Type: "jira"},
+			{ID: "github", Type: "github"},
+			{ID: "routines", Type: "plugin"},
+			{ID: "monitoring", Type: "plugin"},
+		},
+	}
+	got := cfg.TicketSourceIDs()
+	want := []string{"jira", "github"}
+	if len(got) != len(want) {
+		t.Fatalf("TicketSourceIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("TicketSourceIDs() = %v, want %v", got, want)
+		}
+	}
+
+	if got := (*Config)(nil).TicketSourceIDs(); got != nil {
+		t.Fatalf("nil *Config: TicketSourceIDs() = %v, want nil", got)
+	}
+
+	empty := &Config{Sources: []SourceConfig{{ID: "routines", Type: "plugin"}}}
+	if got := empty.TicketSourceIDs(); len(got) != 0 {
+		t.Fatalf("no ticket sources configured: TicketSourceIDs() = %v, want empty", got)
+	}
+}

--- a/src/internal/daemon/dispatcher.go
+++ b/src/internal/daemon/dispatcher.go
@@ -1548,7 +1548,8 @@ func (d *Dispatcher) StartServer(ctx context.Context, wg *sync.WaitGroup) error 
 				limit = n
 			}
 		}
-		resp, err := d.Instances(r.Context(), q.Get("state"), q.Get("workflow"), limit)
+		ticketsOnly := q.Get("tickets_only") == "1" || q.Get("tickets_only") == "true"
+		resp, err := d.Instances(r.Context(), q.Get("state"), q.Get("workflow"), limit, ticketsOnly)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/src/internal/daemon/workflow_ipc.go
+++ b/src/internal/daemon/workflow_ipc.go
@@ -327,12 +327,18 @@ func (d *Dispatcher) StopInstance(ctx context.Context, instanceID string) error 
 }
 
 // Instances returns workflow instances for the IPC list endpoint, optionally
-// filtered by state and/or workflow id.
-func (d *Dispatcher) Instances(ctx context.Context, state, workflowID string, limit int) (InstancesResponse, error) {
+// filtered by state and/or workflow id. ticketsOnly excludes instances whose
+// source is not a ticket-tracker per config.IsTicketSourceType — routine and
+// other plugin-sourced runs with no real ticket behind them (issue #475).
+func (d *Dispatcher) Instances(ctx context.Context, state, workflowID string, limit int, ticketsOnly bool) (InstancesResponse, error) {
 	if d.db == nil {
 		return InstancesResponse{}, nil
 	}
-	views, err := d.db.ListWorkflowInstanceViews(ctx, state, workflowID, limit)
+	var ticketSourceIDs []string
+	if ticketsOnly {
+		ticketSourceIDs = d.cfg.TicketSourceIDs()
+	}
+	views, err := d.db.ListWorkflowInstanceViews(ctx, state, workflowID, ticketSourceIDs, limit)
 	if err != nil {
 		return InstancesResponse{}, err
 	}

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -791,6 +791,15 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				a.model.tasksTab.View = TaskViewList
 			}
 		}
+	case "T":
+		// Toggle hiding routine/plugin-sourced runs with no real ticket behind
+		// them, keeping only tasks bound to a ticket-tracker source item
+		// (issue #475). Off by default, so the unfiltered list is unchanged.
+		if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View == TaskViewList {
+			t := a.model.tasksTab
+			t.TicketsOnly = !t.TicketsOnly
+			t.SelectedIdx = 0
+		}
 	case "r":
 		a.model.loading = true
 		return a, a.fetchActiveTab()
@@ -3595,8 +3604,13 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 		msg := "No tasks yet — start the dispatcher and give it work."
 		if t.FilterText != "" {
 			msg = "No tasks match filter"
+		} else if t.TicketsOnly {
+			msg = "No ticket-bound tasks (Shift+T to show routine/plugin-sourced runs too)"
 		}
 		title := "TASKS"
+		if t.TicketsOnly {
+			title += " [tickets-only]"
+		}
 		if t.FilterActive {
 			title += " [/" + t.FilterText + "▌]"
 		} else if t.FilterText != "" {
@@ -3623,6 +3637,9 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 	// Box title with sort/filter indicators
 	title := "TASKS"
 	parts := []string{}
+	if t.TicketsOnly {
+		parts = append(parts, "tickets-only")
+	}
 	if t.FilterActive {
 		parts = append(parts, "/"+t.FilterText+"▌")
 	} else if t.FilterText != "" {
@@ -3711,9 +3728,49 @@ func compareTimePtr(a, b *time.Time) int {
 	}
 }
 
-// filteredTasks returns the task list after applying filter and sort.
+// isTicketSource reports whether sourceID is configured as a ticket-tracker
+// source (config.IsTicketSourceType), as opposed to a plugin-bridged
+// scheduler/monitoring source. An id not found in config — a stale binding
+// from a source that was since removed — is treated as ticket-bound so the
+// filter never hides a row it cannot classify.
+func (a *App) isTicketSource(sourceID string) bool {
+	if a.cfg == nil {
+		return true
+	}
+	for _, s := range a.cfg.Sources {
+		if s.ID == sourceID {
+			return config.IsTicketSourceType(s.Type)
+		}
+	}
+	return true
+}
+
+// hasTicket reports whether a task row is bound to a ticket-tracker source
+// item, as opposed to being a scheduled routine or other plugin-sourced run
+// with no real ticket behind it (issue #475). A task with no bindings at all
+// (a spawned/internal task) is not ticket-bound either.
+func (a *App) hasTicket(it TaskItem) bool {
+	for _, b := range it.Bindings {
+		if a.isTicketSource(b.SourceID) {
+			return true
+		}
+	}
+	return false
+}
+
+// filteredTasks returns the task list after applying the tickets-only toggle,
+// the text filter, and sort.
 func (a *App) filteredTasks(t *TasksTab) []TaskItem {
 	out := t.History
+	if t.TicketsOnly {
+		var ticketed []TaskItem
+		for _, it := range out {
+			if a.hasTicket(it) {
+				ticketed = append(ticketed, it)
+			}
+		}
+		out = ticketed
+	}
 	if t.FilterText != "" {
 		filter := strings.ToLower(t.FilterText)
 		var filtered []TaskItem
@@ -5523,7 +5580,7 @@ func (a *App) footerKeys() []fkey {
 				return []fkey{{"type", "filter"}, {"enter", "apply"}, {"esc", "cancel"}}
 			}
 		}
-		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"/", "filter"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"W", "run wf"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
+		return []fkey{{"↑/↓", "select"}, {"enter", "workflow"}, {"/", "filter"}, {"T", "tickets-only"}, {"d", "details"}, {"o", "open"}, {"p", "open PR"}, {"t", "transcript"}, {"R", "restart"}, {"W", "run wf"}, {"C", "clear"}, {"tab", "switch"}, {"q", "quit"}}
 	case "Workflows":
 		if wt := a.model.workflowsTab; wt != nil && wt.Focus == WorkflowsViewSteps {
 			return []fkey{{"↑/↓", "step"}, {"esc/←", "back"}, {"tab", "next tab"}, {"q", "quit"}}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -172,6 +172,12 @@ type TasksTab struct {
 	FilterActive bool   // true while typing a filter
 	SortField    string // "time" | "status" | "agent"  (default "time")
 	SortAsc      bool
+
+	// TicketsOnly hides rows with no real ticket behind them — scheduled
+	// routine runs and other plugin-sourced work items — keeping only tasks
+	// bound to a source item from a ticket-tracker source (issue #475).
+	// Toggled in place; default off keeps today's unfiltered list.
+	TicketsOnly bool
 }
 
 // WorkflowInstanceItem is a workflow instance bound to a task, with its steps,

--- a/src/internal/dashboard/tickets_only_test.go
+++ b/src/internal/dashboard/tickets_only_test.go
@@ -1,0 +1,79 @@
+package dashboard
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/orlandoburli/apiary/internal/config"
+)
+
+// TestHasTicket checks the structural signal for issue #475: a task counts as
+// ticket-bound only when at least one of its source bindings points at a
+// source whose configured type is a ticket tracker (not "plugin"). A task
+// with no bindings, or bindings only to plugin-bridged sources, is not.
+func TestHasTicket(t *testing.T) {
+	a := &App{cfg: &config.Config{Sources: []config.SourceConfig{
+		{ID: "jira", Type: "jira"},
+		{ID: "github", Type: "github"},
+		{ID: "routines", Type: "plugin"},
+	}}}
+
+	cases := []struct {
+		name string
+		item TaskItem
+		want bool
+	}{
+		{"no bindings", TaskItem{}, false},
+		{"jira binding", TaskItem{Bindings: []SourceBindingItem{{SourceID: "jira"}}}, true},
+		{"routine binding only", TaskItem{Bindings: []SourceBindingItem{{SourceID: "routines"}}}, false},
+		{"mixed bindings", TaskItem{Bindings: []SourceBindingItem{{SourceID: "routines"}, {SourceID: "github"}}}, true},
+		{"unknown source id defaults ticket-bound", TaskItem{Bindings: []SourceBindingItem{{SourceID: "removed-source"}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := a.hasTicket(tc.item); got != tc.want {
+				t.Errorf("hasTicket(%+v) = %v, want %v", tc.item, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTicketsOnlyToggle checks that Shift+T flips TasksTab.TicketsOnly only
+// from the task list view, and that filteredTasks then hides non-ticket rows
+// while the default (off) leaves the list unchanged (additive per #475).
+func TestTicketsOnlyToggle(t *testing.T) {
+	a := &App{
+		model: NewModel(),
+		cfg: &config.Config{Sources: []config.SourceConfig{
+			{ID: "jira", Type: "jira"},
+			{ID: "routines", Type: "plugin"},
+		}},
+	}
+	a.model.activeTab = 1 // Tasks
+	a.model.tasksTab.History = []TaskItem{
+		{TaskID: "t1", Bindings: []SourceBindingItem{{SourceID: "jira"}}},
+		{TaskID: "t2", Bindings: []SourceBindingItem{{SourceID: "routines"}}},
+	}
+
+	if a.model.tasksTab.TicketsOnly {
+		t.Fatal("TicketsOnly must default to off")
+	}
+	if got := a.filteredTasks(a.model.tasksTab); len(got) != 2 {
+		t.Fatalf("default: filteredTasks() = %d items, want 2 (unfiltered)", len(got))
+	}
+
+	a.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if !a.model.tasksTab.TicketsOnly {
+		t.Fatal("Shift+T should turn TicketsOnly on")
+	}
+	got := a.filteredTasks(a.model.tasksTab)
+	if len(got) != 1 || got[0].TaskID != "t1" {
+		t.Fatalf("tickets-only: filteredTasks() = %+v, want just t1", got)
+	}
+
+	a.handleKeyMsg(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("T")})
+	if a.model.tasksTab.TicketsOnly {
+		t.Fatal("Shift+T should toggle back off")
+	}
+}

--- a/src/internal/db/instance_views_ticket_filter_test.go
+++ b/src/internal/db/instance_views_ticket_filter_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// TestListWorkflowInstanceViews_TicketSourceFilter covers the allow-list param
+// added for issue #475 (apiary instances --tickets-only / the dashboard's
+// equivalent toggle): nil keeps today's unfiltered behavior, a populated list
+// restricts to those source ids, and an empty-but-non-nil list (no ticket
+// sources configured) correctly returns nothing rather than everything.
+func TestListWorkflowInstanceViews_TicketSourceFilter(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	mustCreate := func(id, cellID, sourceID string) {
+		t.Helper()
+		if err := c.CreateWorkflowInstance(ctx, &WorkflowInstance{
+			ID: id, WorkflowID: "wf", CellID: cellID, SourceID: sourceID, State: InstanceStateDone,
+		}); err != nil {
+			t.Fatalf("create instance %s: %v", id, err)
+		}
+	}
+
+	mustCreate("inst-jira", "cell-1", "jira")
+	mustCreate("inst-github", "cell-2", "github")
+	mustCreate("inst-routine", "cell-3", "routines")
+	mustCreate("inst-nosource", "cell-4", "")
+
+	// nil: unfiltered, unchanged behavior — every instance comes back.
+	all, err := c.ListWorkflowInstanceViews(ctx, "", "", nil, 20)
+	if err != nil {
+		t.Fatalf("ListWorkflowInstanceViews(nil): %v", err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("unfiltered: got %d instances, want 4", len(all))
+	}
+
+	// Populated allow-list: only matching source ids.
+	ticketed, err := c.ListWorkflowInstanceViews(ctx, "", "", []string{"jira", "github"}, 20)
+	if err != nil {
+		t.Fatalf("ListWorkflowInstanceViews(ticket ids): %v", err)
+	}
+	if len(ticketed) != 2 {
+		t.Fatalf("ticket-filtered: got %d instances, want 2", len(ticketed))
+	}
+	for _, v := range ticketed {
+		if v.SourceID != "jira" && v.SourceID != "github" {
+			t.Fatalf("unexpected source_id %q in ticket-filtered results", v.SourceID)
+		}
+	}
+
+	// Empty-but-non-nil: no ticket-tracker sources configured, so nothing
+	// qualifies — not "no filter".
+	none, err := c.ListWorkflowInstanceViews(ctx, "", "", []string{}, 20)
+	if err != nil {
+		t.Fatalf("ListWorkflowInstanceViews(empty ids): %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("empty allow-list: got %d instances, want 0", len(none))
+	}
+}

--- a/src/internal/db/workflow_store.go
+++ b/src/internal/db/workflow_store.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/state"
@@ -451,9 +452,19 @@ type WorkflowInstanceView struct {
 
 // ListWorkflowInstanceViews returns recent instances (newest first) joined with
 // the cell title, optionally filtered by state and/or workflow id.
-func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowID string, limit int) ([]WorkflowInstanceView, error) {
+//
+// ticketSourceIDs, when non-nil, restricts the result to instances whose
+// source_id is in that set — the ticket-tracker allow-list computed from
+// config.Config.TicketSourceIDs, used by `apiary instances --tickets-only` and
+// the dashboard's equivalent toggle (issue #475) to exclude routine/plugin-
+// sourced runs. A non-nil empty slice (no ticket-tracker sources configured)
+// correctly yields no rows. Pass nil to keep today's unfiltered behavior.
+func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowID string, ticketSourceIDs []string, limit int) ([]WorkflowInstanceView, error) {
 	if limit <= 0 {
 		limit = 20
+	}
+	if ticketSourceIDs != nil && len(ticketSourceIDs) == 0 {
+		return nil, nil
 	}
 	q := `
 		SELECT wi.id, wi.workflow_id, wi.cell_id, COALESCE(wi.source_id,''), wi.state,
@@ -470,6 +481,12 @@ func (c *Client) ListWorkflowInstanceViews(ctx context.Context, state, workflowI
 	if workflowID != "" {
 		q += " AND wi.workflow_id = ?"
 		args = append(args, workflowID)
+	}
+	if ticketSourceIDs != nil {
+		q += " AND wi.source_id IN (" + strings.TrimSuffix(strings.Repeat("?,", len(ticketSourceIDs)), ",") + ")"
+		for _, id := range ticketSourceIDs {
+			args = append(args, id)
+		}
 	}
 	q += " ORDER BY wi.created_at DESC LIMIT ?"
 	args = append(args, limit)


### PR DESCRIPTION
## Summary

- `apiary instances` gains a `--tickets-only` flag that excludes instances with no real ticket behind them — scheduled routine runs and other plugin-sourced work items — keeping only rows bound to a source item from a ticket-tracker source (jira, github, plane, ...).
- The dashboard's Tasks tab gets the same filter as a `Shift+T` toggle on the list view, shown in the title (`[tickets-only]`) and footer hint.
- The distinguishing signal is structural: `config.IsTicketSourceType(sourceType)` treats any source config type other than `"plugin"` (the generic plugin-bridge kind used by the routines source and future plugin-sourced monitoring/scheduler adapters) as a ticket tracker. A task/instance counts as ticket-bound when it has a `source_bindings` row pointing at such a source — no per-source-id special-casing, so a future plugin-sourced routine is excluded automatically.
- `ListWorkflowInstanceViews` now takes an optional ticket-source-id allow-list so the filter is applied in the SQL query itself (`WHERE wi.source_id IN (...)`), keeping `--limit` semantics correct instead of trimming an already-limited result set. `nil` (the default) is unfiltered — behavior for every existing caller is unchanged.
- Both defaults are off, so today's unfiltered output (CLI and dashboard) is unchanged; this is purely additive.

Does **not** touch #472's column-width rendering for routine references — this issue is about which rows show up, not how a row renders.

## Test plan

- [x] `cd src && go build ./... && go vet ./...`
- [x] `cd src && go test ./internal/cli/... ./internal/dashboard/... ./internal/db/... ./internal/config/...`
- [x] `cd src && go test ./...` (full suite, no regressions)
- [x] New tests: `internal/config/ticket_source_test.go` (`IsTicketSourceType`, `Config.TicketSourceIDs`), `internal/db/instance_views_ticket_filter_test.go` (nil vs. populated vs. empty allow-list), `internal/dashboard/tickets_only_test.go` (`hasTicket` classification + `Shift+T` toggle + `filteredTasks`)

Closes #475