### PR TITLE
fix(dashboard): stop the approvals-only view lying when another filter hides the result

### DIFF
--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -3622,12 +3622,49 @@ func (a *App) renderTasksTab(height int) string {
 	}
 }
 
+// approvalsEmptyMessage explains why the approvals-only view (Shift+A) has
+// nothing to show. "Nothing is waiting on approval right now" is only true
+// when that is actually the case — TicketsOnly (Shift+T) and the text filter
+// both compose with ApprovalsOnly as a strict AND in filteredTasks, so a
+// leftover toggle from earlier in the session can hide a real pending
+// approval while this view claims there is none. That is the one thing this
+// view exists to never do (#476), so when the unfiltered history has
+// approval-waiting tasks that some other active filter is hiding, say so
+// instead.
+func (a *App) approvalsEmptyMessage(t *TasksTab) string {
+	waiting := 0
+	for _, it := range t.History {
+		if blockedOnApproval(it.Status, it.BlockedReason) {
+			waiting++
+		}
+	}
+	if waiting == 0 {
+		return "Nothing is waiting on approval right now"
+	}
+	plural := "s"
+	if waiting == 1 {
+		plural = ""
+	}
+	switch {
+	case t.TicketsOnly && t.FilterText != "":
+		return fmt.Sprintf("%d task%s waiting on approval, hidden by tickets-only and the filter — Shift+T and esc to show them", waiting, plural)
+	case t.TicketsOnly:
+		return fmt.Sprintf("%d task%s waiting on approval, hidden by tickets-only — Shift+T to include routine/plugin-sourced runs", waiting, plural)
+	case t.FilterText != "":
+		return fmt.Sprintf("%d task%s waiting on approval, hidden by the filter — esc to clear it", waiting, plural)
+	default:
+		// Every other active filter was ruled out above, so filteredTasks and
+		// this count should agree — fall back rather than assert a mismatch.
+		return "Nothing is waiting on approval right now"
+	}
+}
+
 func (a *App) renderTaskList(t *TasksTab, height int) string {
 	items := a.filteredTasks(t)
 	if len(items) == 0 {
 		msg := "No tasks yet — start the dispatcher and give it work."
 		if t.ApprovalsOnly {
-			msg = "Nothing is waiting on approval right now"
+			msg = a.approvalsEmptyMessage(t)
 		} else if t.FilterText != "" {
 			msg = "No tasks match filter"
 		} else if t.TicketsOnly {

--- a/src/internal/dashboard/approval_waiting_filter_test.go
+++ b/src/internal/dashboard/approval_waiting_filter_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/orlandoburli/apiary/internal/state"
@@ -79,5 +80,91 @@ func TestApprovalsOnlyFilterRecognizesLegacyBlockedReason(t *testing.T) {
 	items := a.filteredTasks(tt)
 	if len(items) != 1 || items[0].TaskID != "legacy" {
 		t.Fatalf("expected only the legacy approval-blocked task, got %+v", items)
+	}
+}
+
+// TestApprovalsEmptyMessage_TrueEmpty covers the case the message was always
+// right about: no task is waiting on approval at all.
+func TestApprovalsEmptyMessage_TrueEmpty(t *testing.T) {
+	a := &App{model: NewModel()}
+	tt := a.model.tasksTab
+	tt.ApprovalsOnly = true
+	tt.History = []TaskItem{{TaskID: "t1", Status: "running"}}
+
+	if got, want := a.approvalsEmptyMessage(tt), "Nothing is waiting on approval right now"; got != want {
+		t.Errorf("approvalsEmptyMessage() = %q, want %q", got, want)
+	}
+}
+
+// TestApprovalsEmptyMessage_HiddenByTicketsOnly is the regression case: a
+// task with no source binding (a routine/plugin-sourced run — hasTicket is
+// false for it, same as any task with no Bindings) is genuinely waiting on
+// approval, but TicketsOnly is also on and excludes it, so filteredTasks
+// returns nothing. The message must not claim there is nothing waiting —
+// that is the one thing the approvals-only view exists to never say.
+func TestApprovalsEmptyMessage_HiddenByTicketsOnly(t *testing.T) {
+	a := &App{model: NewModel()}
+	tt := a.model.tasksTab
+	tt.ApprovalsOnly = true
+	tt.TicketsOnly = true
+	tt.History = []TaskItem{
+		{TaskID: "routine-approval", Status: "approval_waiting"}, // no Bindings: not ticket-bound
+	}
+
+	if items := a.filteredTasks(tt); len(items) != 0 {
+		t.Fatalf("fixture should combine to an empty result, got %+v", items)
+	}
+
+	got := a.approvalsEmptyMessage(tt)
+	if strings.Contains(got, "Nothing is waiting") {
+		t.Errorf("approvalsEmptyMessage() = %q, falsely claims nothing is waiting", got)
+	}
+	if !strings.Contains(got, "1") || !strings.Contains(got, "Shift+T") {
+		t.Errorf("approvalsEmptyMessage() = %q, want it to name the count and the Shift+T toggle hiding it", got)
+	}
+}
+
+// TestApprovalsEmptyMessage_HiddenByTextFilter is the same bug via the other
+// active filter: a stale search query, not TicketsOnly, hides the one task
+// actually waiting on approval.
+func TestApprovalsEmptyMessage_HiddenByTextFilter(t *testing.T) {
+	a := &App{model: NewModel()}
+	tt := a.model.tasksTab
+	tt.ApprovalsOnly = true
+	tt.FilterText = "no-such-task"
+	tt.History = []TaskItem{
+		{TaskID: "t1", Title: "waiting on approval", Status: "approval_waiting"},
+	}
+
+	if items := a.filteredTasks(tt); len(items) != 0 {
+		t.Fatalf("fixture should combine to an empty result, got %+v", items)
+	}
+
+	got := a.approvalsEmptyMessage(tt)
+	if strings.Contains(got, "Nothing is waiting") {
+		t.Errorf("approvalsEmptyMessage() = %q, falsely claims nothing is waiting", got)
+	}
+	if !strings.Contains(got, "1") || !strings.Contains(got, "esc") {
+		t.Errorf("approvalsEmptyMessage() = %q, want it to name the count and how to clear the filter", got)
+	}
+}
+
+// TestApprovalsEmptyMessage_HiddenByBoth covers both filters active at once.
+func TestApprovalsEmptyMessage_HiddenByBoth(t *testing.T) {
+	a := &App{model: NewModel()}
+	tt := a.model.tasksTab
+	tt.ApprovalsOnly = true
+	tt.TicketsOnly = true
+	tt.FilterText = "no-such-task"
+	tt.History = []TaskItem{
+		{TaskID: "routine-approval", Status: "approval_waiting"},
+	}
+
+	got := a.approvalsEmptyMessage(tt)
+	if strings.Contains(got, "Nothing is waiting") {
+		t.Errorf("approvalsEmptyMessage() = %q, falsely claims nothing is waiting", got)
+	}
+	if !strings.Contains(got, "Shift+T") || !strings.Contains(got, "esc") {
+		t.Errorf("approvalsEmptyMessage() = %q, want it to mention both active filters", got)
 	}
 }


### PR DESCRIPTION
## Summary

`TicketsOnly` (#475) and `ApprovalsOnly` (#476) compose as a strict AND in `filteredTasks` — neither toggle resets or is aware of the other, and both persist across tab switches for the session. An approval step has no source restriction in the engine (`source_caps_validate.go` explicitly exempts operator gates from needing a `TaskPoller`), so a routine/plugin-sourced workflow parked on an approval gate is a real, supported state, not a hypothetical.

If a task like that is the only thing waiting on approval and `TicketsOnly` (or a stale text filter) is also active, the combined filtered result is empty, and the approvals-only empty state printed:

> "Nothing is waiting on approval right now"

which is false — something is waiting, it's just hidden by an unrelated filter left on from earlier in the session. That's exactly the failure #476 was built to prevent (missing an approval while hunting through routine noise), reintroduced by #475's toggle.

- `approvalsEmptyMessage` now counts approval-waiting tasks in the *unfiltered* history before asserting there's nothing waiting.
- When the true reason the list is empty is `TicketsOnly` and/or the text filter, it names the count and which filter(s) are hiding it, e.g.: `"1 task waiting on approval, hidden by tickets-only — Shift+T to include routine/plugin-sourced runs"`.
- Falls back to the original message only when the unfiltered count is genuinely zero.

Does not change how `filteredTasks` composes the filters — that AND-composition is reasonable UX (both are legitimate independent narrowings); the bug was the empty-state message asserting a specific, false claim rather than a generic "no matches."

## Test plan

- [x] `cd src && go build ./... && go vet ./...`
- [x] `cd src && go test ./internal/dashboard/...`
- [x] `cd src && go test ./...` (full suite; one pre-existing unrelated flake in `internal/worker` — `TestRuntimeGracefulDrainWaitsForActiveJob` — confirmed to pass 3/3 in isolation and untouched by this change)
- [x] New tests added to `approval_waiting_filter_test.go`: true-empty case (message unchanged), hidden-by-`TicketsOnly`, hidden-by-text-filter, hidden-by-both — each asserts the misleading "Nothing is waiting" string is absent and the real count/hint is present