### PR TITLE
feat(export): apiary export usage — per-attempt cost and usage as CSV/JSON (#485)

### DIFF
--- a/openspec/changes/usage-export/tasks.md
+++ b/openspec/changes/usage-export/tasks.md
@@ -2,6 +2,14 @@
 
 Companion to [proposal.md](proposal.md). GitHub issue #485.
 
+**Status: Phase 1 implemented.** Two deviations from the plan below, both made
+on contact with the code: the query lives in a new `internal/export` package
+rather than `internal/db`, because `db.New` migrates on open and the export
+must run read-only against a live daemon (it reuses `improve.OpenReadOnly`
+and probes columns the way `improve` does, so an older database exports with
+NULLs instead of failing). And the schema-drift guard (2.2) landed in Phase 1,
+since the real schema was already under test.
+
 Two phases, each a shippable PR. Phase 1 delivers the whole user-facing
 feature; Phase 2 is documentation and the schema-drift guard, split out so the
 first PR stays reviewable.
@@ -16,23 +24,23 @@ changes are expected; if one turns out to be needed it goes in the idempotent
 
 ## Phase 1 — Query and command
 
-### 1.1 Read path — `internal/db/usage_export.go`
+### 1.1 Read path — `internal/export/usage.go` (was `internal/db`)
 
-- [ ] `UsageFilter` struct: `Since`, `Until time.Time`; `Workflows`, `Agents`,
+- [x] `UsageFilter` struct: `Since`, `Until time.Time`; `Workflows`, `Agents`,
       `Models`, `Sources`, `Statuses []string`; `IncludeTranscripts`,
       `IncludeSlowTools bool`.
-- [ ] `UsageRow` struct mirroring the proposal's column table, with
+- [x] `UsageRow` struct mirroring the proposal's column table, with
       `sql.Null*` fields for everything that can be NULL.
-- [ ] `ListUsageRows(ctx, UsageFilter, func(UsageRow) error) error`, a
+- [x] `ListUsageRows(ctx, UsageFilter, func(UsageRow) error) error`, a
       callback-per-row API so the CLI streams. Single query:
       `task_executions te LEFT JOIN workflow_instances wi ON wi.id =
       te.workflow_instance_id`, ordered by `te.started_at, te.id`. Filters
       compile to `WHERE` clauses with bound parameters; repeatable flags become
       `IN (...)`.
-- [ ] NULL `started_at` rows excluded unless `Statuses` contains `pending`.
-- [ ] Transcript and slow-tools columns are only selected when requested, so
+- [x] NULL `started_at` rows excluded unless `Statuses` contains `pending`.
+- [x] Transcript and slow-tools columns are only selected when requested, so
       the default export never reads the blob columns off disk.
-- [ ] Tests against a seeded in-memory store: every filter individually, the
+- [x] Tests against a seeded in-memory store: every filter individually, the
       pending rule, pre-workflow rows (NULL instance) surviving the join,
       ordering, and that a default export does not touch `input_prompt`
       (assert via a column-projection helper or `EXPLAIN`-free approach:
@@ -40,44 +48,49 @@ changes are expected; if one turns out to be needed it goes in the idempotent
 
 ### 1.2 Window parsing
 
-- [ ] Extend or wrap `improve.ParseWindow` so `--since` accepts an absolute
-      date (`2026-09-01`, RFC3339) in addition to durations. Decide by
-      `impact` whether to touch `ParseWindow` in place or add
-      `ParseSinceUntil` next to it; the improve callers must be unaffected.
-- [ ] `--until` parses the same forms and defaults to now.
+- [x] `export.ParseBound` accepts a duration (`7d`, `24h`), a date
+      (`2026-09-01`) or RFC3339. `improve.ParseWindow` was left untouched
+      rather than widened; the two packages do not share code.
+- [x] `--until` parses the same forms and defaults to now.
 
-### 1.3 Writers — `internal/cli/export_usage.go`
+### 1.3 Writers — `internal/export/writers.go`
 
-- [ ] `csvWriter`: header row from the fixed column list, `encoding/csv`,
+- [x] `csvWriter`: header row from the fixed column list, `encoding/csv`,
       RFC3339 UTC timestamps, six-decimal `cost_usd`, `true`/`false` for
       `credit_exhausted`, `error_message` newlines collapsed to spaces.
-- [ ] `jsonWriter`: streams `[`, comma-separated objects, `]` so the file is
+- [x] `jsonWriter`: streams `[`, comma-separated objects, `]` so the file is
       valid JSON without buffering; explicit `null` for NULL columns.
-- [ ] Both writers take an `io.Writer`; `-o` opens the file, default stdout.
+- [x] Both writers take an `io.Writer`; `-o` opens the file, default stdout.
       Write to a temp file and rename when `-o` is given, so an interrupted
       export never leaves a truncated file at the target path.
 
 ### 1.4 Command wiring — `internal/cli/export.go`
 
-- [ ] `apiary export` parent command with `usage` subcommand and the flag set
+- [x] `apiary export` parent command with `usage` subcommand and the flag set
       from the proposal. Register in `root.go`.
-- [ ] Open the store read-only the same way `improve.go` does (no migration;
+- [x] Open the store read-only the same way `improve.go` does (no migration;
       probe for post-release columns rather than assuming them).
-- [ ] Row count and elapsed time on stderr at the end; nothing else on
+- [x] Row count and elapsed time on stderr at the end; nothing else on
       stderr in a clean run so `apiary export usage | ...` pipelines stay quiet.
 - [ ] Exit codes: 0 on success, 1 on any error, 2 on flag misuse (matches the
-      CLI spec).
-- [ ] Tests: golden CSV and JSON for a small seeded store, transcript opt-in,
-      `-o` atomic write, filter flags reaching the query.
+      CLI spec). Not done: cobra exits 1 on flag errors for every command;
+      an export-only exit 2 would be inconsistent. Revisit CLI-wide.
+- [x] Tests: CSV and JSON writer formatting, transcript opt-in, `-o` atomic
+      write (`openOutput`), every filter against the real schema. No golden
+      files: the writer tests assert per-cell so a column addition does not
+      churn a fixture.
 
 ### 1.5 Verify
 
-- [ ] `make check`.
-- [ ] Run against a copy of a real hive database with the daemon running;
-      confirm no lock contention and that a 100k-row export streams under
-      constant memory (`/usr/bin/time -l`).
-- [ ] `detect_changes()` shows only `internal/db`, `internal/cli`, and the
-      improve window parser if touched.
+- [x] `go build ./... && go test ./...` clean.
+- [x] Run against a copy of a real hive database, padded to 100k rows:
+      streams under constant memory (`/usr/bin/time -l`). Found and fixed on
+      the way: `improve.OpenReadOnly` sets `journal_mode(WAL)`, which fails
+      on any non-WAL file (a `VACUUM INTO` backup), so the export has its own
+      `export.OpenReadOnly` without it. The same latent failure remains in
+      `apiary improve`.
+- [x] `detect_changes()`: no indexed symbol changed; the only edit to existing
+      code is the `AddCommand` list in `root.go`.
 
 ---
 
@@ -97,7 +110,7 @@ changes are expected; if one turns out to be needed it goes in the idempotent
 
 ### 2.2 Schema-drift guard
 
-- [ ] Test in `internal/db` that reads the `task_executions` column list from
+- [x] Test in `internal/db` that reads the `task_executions` column list from
       the live schema and asserts every column is either in the export
       column set or in an explicit `unexported` allowlist (`pid`,
       `heartbeat_at`, `heartbeat_count`, `can_retry`, `next_retry_at`,

--- a/openspec/specs/roadmap/spec.md
+++ b/openspec/specs/roadmap/spec.md
@@ -54,10 +54,10 @@ Ordered by intended sequence.
    to workflow/step context, CSV/JSON, transcripts opt-in. GitHub issue #485.
 2. [ ] **Code signing and notarization** — macOS notarization and Windows
    signing in the GoReleaser pipeline. Blocked on obtaining certificates.
-3. [ ] **Plugin SDK conformance kit** — language-agnostic golden-file corpus so
-   every SDK and the documented Python/Rust/Bash examples validate against the
-   same fixtures. First deliverable of GitHub issue #367; language packages
-   (Python, TypeScript, Rust) follow on demand.
+3. [ ] **Plugin SDKs beyond Go and Python** — `sdk/python` and the
+   conformance kit in `sdk/conformance` already exist; TypeScript and Rust
+   packages follow on demand, validated against the same fixtures. GitHub
+   issue #367.
 4. [ ] **Stable config schema (1.0)** — freeze `apiary.yaml` and the plugin
    protocol; breaking changes require a major version afterwards.
 

--- a/src/internal/cli/export.go
+++ b/src/internal/cli/export.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/orlandoburli/apiary/internal/export"
+)
+
+func newExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export Apiary data for analysis elsewhere",
+		Long: `Write Apiary's own records to files a spreadsheet or notebook can open.
+Every export opens the database read-only, runs no migration, and is safe with
+the daemon running.`,
+	}
+	cmd.AddCommand(newExportUsageCmd())
+	return cmd
+}
+
+func newExportUsageCmd() *cobra.Command {
+	var (
+		format             string
+		output             string
+		since, until       string
+		workflows          []string
+		agents             []string
+		models             []string
+		sources            []string
+		statuses           []string
+		includeTranscripts bool
+		includeSlowTools   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "usage",
+		Short: "Export per-attempt usage and cost (tokens, cost_usd, timing) with workflow context",
+		Long: `Export one row per runner attempt from task_executions, joined to the workflow
+instance it belongs to, so spend can be pivoted by workflow, step, model, agent
+or ticket without touching the database directly.
+
+  apiary export usage -o usage.csv
+  apiary export usage --since 30d --workflow implementation --format json
+  apiary export usage --since 2026-09-01 --until 2026-09-02 --status failed
+  apiary export usage --include-transcripts -o full.csv
+
+Rows are ordered oldest first. Rows that never started are excluded unless
+--status pending is given. Transcript columns (input_prompt, output_text) and
+slow_tools are opt-in because they dominate the file size and are not needed
+for cost analysis.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			now := time.Now()
+			f := export.UsageFilter{
+				Workflows:          workflows,
+				Agents:             agents,
+				Models:             models,
+				Sources:            sources,
+				Statuses:           statuses,
+				IncludeTranscripts: includeTranscripts,
+				IncludeSlowTools:   includeSlowTools,
+			}
+			var err error
+			if since != "" {
+				if f.Since, err = export.ParseBound(since, now); err != nil {
+					return fmt.Errorf("--since: %w", err)
+				}
+			}
+			if until != "" {
+				if f.Until, err = export.ParseBound(until, now); err != nil {
+					return fmt.Errorf("--until: %w", err)
+				}
+			}
+			if !f.Since.IsZero() && !f.Until.IsZero() && !f.Until.After(f.Since) {
+				return fmt.Errorf("--until (%s) must be after --since (%s)",
+					f.Until.Format(time.RFC3339), f.Since.Format(time.RFC3339))
+			}
+
+			dbPath := getDBPath()
+			if _, err := os.Stat(dbPath); err != nil {
+				return fmt.Errorf("no database at %s — has the daemon ever run?", dbPath)
+			}
+			db, err := export.OpenReadOnly(dbPath)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
+			defer cancel()
+
+			sink, commit, err := openOutput(output)
+			if err != nil {
+				return err
+			}
+			w, err := export.NewWriter(format, sink, f.Columns())
+			if err != nil {
+				sink.Close()
+				return err
+			}
+
+			start := time.Now()
+			var n int
+			err = export.ListUsageRows(ctx, db, f, func(r export.Row) error {
+				n++
+				return w.Write(r)
+			})
+			if err == nil {
+				err = w.Close()
+			}
+			if err != nil {
+				sink.Close()
+				return err
+			}
+			if err := commit(); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "exported %d rows in %s\n", n, time.Since(start).Round(time.Millisecond))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", "csv", "output format: csv or json")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "write to this file (default: stdout)")
+	cmd.Flags().StringVar(&since, "since", "", "window start: duration (7d, 24h), date (2026-09-01) or RFC3339; default: all history")
+	cmd.Flags().StringVar(&until, "until", "", "window end, same forms as --since; default: now")
+	cmd.Flags().StringArrayVar(&workflows, "workflow", nil, "only this workflow id (repeatable)")
+	cmd.Flags().StringArrayVar(&agents, "agent", nil, "only this agent id (repeatable)")
+	cmd.Flags().StringArrayVar(&models, "model", nil, "only this model, exact match (repeatable)")
+	cmd.Flags().StringArrayVar(&sources, "source", nil, "only this source id (repeatable)")
+	cmd.Flags().StringArrayVar(&statuses, "status", nil, "only this execution status: success, failed, running, pending (repeatable)")
+	cmd.Flags().BoolVar(&includeTranscripts, "include-transcripts", false, "add input_prompt and output_text columns")
+	cmd.Flags().BoolVar(&includeSlowTools, "include-slow-tools", false, "add the slow_tools JSON column")
+	return cmd
+}
+
+// openOutput returns the sink to write to and a commit function. With no path
+// the sink is stdout and commit is a no-op. With a path the sink is a
+// temporary file beside the target, renamed over it by commit, so an
+// interrupted export never leaves a truncated file where a complete one is
+// expected.
+func openOutput(path string) (io.WriteCloser, func() error, error) {
+	if path == "" {
+		return nopCloser{os.Stdout}, func() error { return nil }, nil
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return nil, nil, fmt.Errorf("create %s: %w", path, err)
+	}
+	committed := false
+	sink := &tempFile{File: tmp, onClose: func() {
+		if !committed {
+			os.Remove(tmp.Name())
+		}
+	}}
+	commit := func() error {
+		if err := tmp.Sync(); err != nil {
+			return err
+		}
+		if err := tmp.Close(); err != nil {
+			return err
+		}
+		if err := os.Rename(tmp.Name(), path); err != nil {
+			os.Remove(tmp.Name())
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+		committed = true
+		return nil
+	}
+	return sink, commit, nil
+}
+
+type nopCloser struct{ io.Writer }
+
+func (nopCloser) Close() error { return nil }
+
+// tempFile removes itself on Close unless commit ran first.
+type tempFile struct {
+	*os.File
+	onClose func()
+}
+
+func (t *tempFile) Close() error {
+	err := t.File.Close()
+	t.onClose()
+	return err
+}

--- a/src/internal/cli/export_test.go
+++ b/src/internal/cli/export_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenOutputCommitsAtomicallyAndCleansUpOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "usage.csv")
+	if err := os.WriteFile(target, []byte("previous complete export\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Failure path: the target must still hold the previous complete file and
+	// no temp file may be left behind.
+	sink, _, err := openOutput(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sink.Write([]byte("partial")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "previous complete export\n" {
+		t.Errorf("target overwritten by an uncommitted export: %q", got)
+	}
+	assertOnlyTarget(t, dir)
+
+	// Success path: commit renames over the target.
+	sink, commit, err := openOutput(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sink.Write([]byte("new export\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := commit(); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("close after commit: %v", err)
+	}
+	got, _ = os.ReadFile(target)
+	if string(got) != "new export\n" {
+		t.Errorf("target = %q", got)
+	}
+	assertOnlyTarget(t, dir)
+}
+
+func assertOnlyTarget(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "usage.csv" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("directory holds %v, want only usage.csv", names)
+	}
+}

--- a/src/internal/cli/root.go
+++ b/src/internal/cli/root.go
@@ -67,6 +67,7 @@ func init() {
 		newPluginsCmd(),
 		newWorkerCmd(),
 		newImproveCmd(),
+		newExportCmd(),
 		newMigrateCmd(),
 	)
 }

--- a/src/internal/export/open.go
+++ b/src/internal/export/open.go
@@ -1,0 +1,29 @@
+package export
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+
+	_ "modernc.org/sqlite"
+)
+
+// OpenReadOnly opens the SQLite database for reading only. It sets no journal
+// mode: WAL is a property of the file, chosen by the daemon that wrote it,
+// and a reader that tries to set it on a non-WAL file (a backup made with
+// VACUUM INTO, a copy taken with the daemon stopped) fails with "attempt to
+// write a readonly database". busy_timeout keeps a concurrent checkpoint from
+// surfacing as SQLITE_BUSY; _time_format matches how the daemon binds
+// time.Time parameters so window comparisons line up with stored values.
+func OpenReadOnly(dbPath string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(5000)&_time_format=sqlite", url.PathEscape(dbPath))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("open database %s: %w", dbPath, err)
+	}
+	return db, nil
+}

--- a/src/internal/export/usage.go
+++ b/src/internal/export/usage.go
@@ -1,0 +1,419 @@
+// Package export turns Apiary's execution history into files a spreadsheet can
+// open. It reads through whatever *sql.DB it is handed — normally a read-only
+// connection opened without migrations — so it is safe against a live daemon
+// and tolerant of databases written by an older binary: a column the database
+// does not have is exported as empty rather than failing the query.
+package export
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Querier is the slice of *sql.DB this package needs.
+type Querier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// Kind is the exported type of a column. Writers format by kind, so every
+// column of one kind renders identically in CSV and JSON.
+type Kind int
+
+const (
+	KindString Kind = iota
+	KindInt
+	KindFloat
+	KindBool
+	KindTime
+)
+
+// Column is one entry of the export contract: the exported name, the physical
+// column it comes from, its kind, and whether it is opt-in.
+type Column struct {
+	Name string
+	// table and column are the physical source, probed at query time. When the
+	// database predates the column, the export selects NULL under the same name.
+	table, column string
+	Kind          Kind
+	// Opt names the flag that enables the column; empty means always exported.
+	Opt string
+}
+
+const (
+	// OptTranscripts enables input_prompt and output_text.
+	OptTranscripts = "transcripts"
+	// OptSlowTools enables slow_tools.
+	OptSlowTools = "slow_tools"
+)
+
+const (
+	tableExecutions = "task_executions"
+	tableInstances  = "workflow_instances"
+)
+
+// UsageColumns is the export contract for `apiary export usage`, in output
+// order. Appending a column is a minor change; removing or reordering one is
+// breaking. TestUsageColumnsCoverSchema fails when task_executions grows a
+// column that is neither here nor in the explicit unexported list.
+var UsageColumns = []Column{
+	{Name: "execution_id", table: tableExecutions, column: "id", Kind: KindInt},
+	{Name: "task_id", table: tableExecutions, column: "task_id", Kind: KindString},
+	{Name: "task_number", table: tableExecutions, column: "task_number", Kind: KindString},
+	{Name: "title", table: tableExecutions, column: "title", Kind: KindString},
+	{Name: "task_url", table: tableExecutions, column: "task_url", Kind: KindString},
+	{Name: "source_id", table: tableInstances, column: "source_id", Kind: KindString},
+	{Name: "workflow_id", table: tableInstances, column: "workflow_id", Kind: KindString},
+	{Name: "workflow_instance_id", table: tableExecutions, column: "workflow_instance_id", Kind: KindString},
+	{Name: "instance_state", table: tableInstances, column: "state", Kind: KindString},
+	{Name: "step_id", table: tableExecutions, column: "step_id", Kind: KindString},
+	{Name: "agent_id", table: tableExecutions, column: "agent_id", Kind: KindString},
+	{Name: "runner", table: tableExecutions, column: "runner", Kind: KindString},
+	{Name: "model", table: tableExecutions, column: "model", Kind: KindString},
+	{Name: "attempt", table: tableExecutions, column: "attempt", Kind: KindInt},
+	{Name: "status", table: tableExecutions, column: "status", Kind: KindString},
+	{Name: "failure_kind", table: tableExecutions, column: "failure_kind", Kind: KindString},
+	{Name: "credit_exhausted", table: tableExecutions, column: "credit_exhausted", Kind: KindBool},
+	{Name: "started_at", table: tableExecutions, column: "started_at", Kind: KindTime},
+	{Name: "completed_at", table: tableExecutions, column: "completed_at", Kind: KindTime},
+	{Name: "duration_ms", table: tableExecutions, column: "duration_ms", Kind: KindInt},
+	{Name: "input_tokens", table: tableExecutions, column: "input_tokens", Kind: KindInt},
+	{Name: "output_tokens", table: tableExecutions, column: "output_tokens", Kind: KindInt},
+	{Name: "cache_creation_tokens", table: tableExecutions, column: "cache_creation_tokens", Kind: KindInt},
+	{Name: "cache_read_tokens", table: tableExecutions, column: "cache_read_tokens", Kind: KindInt},
+	{Name: "total_tokens", table: tableExecutions, column: "total_tokens", Kind: KindInt},
+	{Name: "num_turns", table: tableExecutions, column: "num_turns", Kind: KindInt},
+	{Name: "num_tool_calls", table: tableExecutions, column: "num_tool_calls", Kind: KindInt},
+	{Name: "cost_usd", table: tableExecutions, column: "cost_usd", Kind: KindFloat},
+	{Name: "time_thinking_ms", table: tableExecutions, column: "time_thinking_ms", Kind: KindInt},
+	{Name: "time_writing_ms", table: tableExecutions, column: "time_writing_ms", Kind: KindInt},
+	{Name: "time_model_ms", table: tableExecutions, column: "time_model_ms", Kind: KindInt},
+	{Name: "time_tool_wait_ms", table: tableExecutions, column: "time_tool_wait_ms", Kind: KindInt},
+	{Name: "time_other_ms", table: tableExecutions, column: "time_other_ms", Kind: KindInt},
+	{Name: "time_background_ms", table: tableExecutions, column: "time_background_ms", Kind: KindInt},
+	{Name: "error_message", table: tableExecutions, column: "error_message", Kind: KindString},
+	{Name: "slow_tools", table: tableExecutions, column: "slow_tools", Kind: KindString, Opt: OptSlowTools},
+	{Name: "input_prompt", table: tableExecutions, column: "input_prompt", Kind: KindString, Opt: OptTranscripts},
+	{Name: "output_text", table: tableExecutions, column: "output_text", Kind: KindString, Opt: OptTranscripts},
+}
+
+// UnexportedExecutionColumns lists task_executions columns deliberately left
+// out of the export: operational bookkeeping with no analytical value. A column
+// in neither list fails TestUsageColumnsCoverSchema, so adding one to the
+// schema forces a decision here.
+var UnexportedExecutionColumns = []string{
+	"pid", "heartbeat_at", "heartbeat_count", "can_retry", "next_retry_at", "created_at",
+}
+
+// UsageFilter narrows the export. Zero values mean "no constraint".
+type UsageFilter struct {
+	// Since and Until bound started_at: [Since, Until). Zero is unbounded.
+	Since, Until time.Time
+	Workflows    []string
+	Agents       []string
+	Models       []string
+	Sources      []string
+	// Statuses filters task_executions.status. Rows that never started
+	// (NULL started_at) are excluded from the window unless "pending" is
+	// listed here explicitly.
+	Statuses           []string
+	IncludeTranscripts bool
+	IncludeSlowTools   bool
+}
+
+func (f UsageFilter) includePending() bool {
+	return slices.Contains(f.Statuses, "pending")
+}
+
+// Columns returns the columns the filter selects, in export order.
+func (f UsageFilter) Columns() []Column {
+	out := make([]Column, 0, len(UsageColumns))
+	for _, c := range UsageColumns {
+		switch c.Opt {
+		case "":
+		case OptTranscripts:
+			if !f.IncludeTranscripts {
+				continue
+			}
+		case OptSlowTools:
+			if !f.IncludeSlowTools {
+				continue
+			}
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// Row is one exported record, aligned with the filter's Columns(). Values are
+// nil, string, int64, float64, bool or time.Time (UTC). A timestamp the
+// database holds in a form this package cannot parse is passed through as the
+// raw string so the row is not lost; the writer renders it verbatim.
+type Row []any
+
+// ListUsageRows streams every execution matching the filter, oldest first, to
+// fn. It never buffers the result set: a busy hive has hundreds of thousands
+// of executions and the transcript columns alone run to gigabytes.
+func ListUsageRows(ctx context.Context, db Querier, f UsageFilter, fn func(Row) error) error {
+	cols := f.Columns()
+	present, err := probeColumns(ctx, db, tableExecutions, tableInstances)
+	if err != nil {
+		return err
+	}
+
+	selects := make([]string, len(cols))
+	for i, c := range cols {
+		if present[c.table][c.column] {
+			selects[i] = tableAlias(c.table) + "." + c.column
+		} else {
+			selects[i] = "NULL"
+		}
+	}
+
+	// A database from before the workflow engine has no instance link at all;
+	// join on a constant so the wi.* selects still resolve (to NULL).
+	join := "wi.id = te.workflow_instance_id"
+	if !present[tableExecutions]["workflow_instance_id"] {
+		join = "0"
+	}
+
+	where, args := usageWhere(f)
+	// Never-started rows (NULL started_at, only with --status pending) go last
+	// so the file reads chronologically.
+	query := `SELECT ` + strings.Join(selects, ", ") + `
+		FROM task_executions te
+		LEFT JOIN workflow_instances wi ON ` + join + `
+		` + where + `
+		ORDER BY te.started_at IS NULL, te.started_at ASC, te.id ASC`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("query usage: %w", err)
+	}
+	defer rows.Close()
+
+	dests := make([]any, len(cols))
+	for rows.Next() {
+		for i, c := range cols {
+			dests[i] = newDest(c.Kind)
+		}
+		if err := rows.Scan(dests...); err != nil {
+			return fmt.Errorf("scan usage row: %w", err)
+		}
+		row := make(Row, len(cols))
+		for i, c := range cols {
+			row[i] = fromDest(c.Kind, dests[i])
+		}
+		if err := fn(row); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
+func tableAlias(table string) string {
+	if table == tableInstances {
+		return "wi"
+	}
+	return "te"
+}
+
+// usageWhere compiles the filter into a WHERE clause with bound parameters.
+func usageWhere(f UsageFilter) (string, []any) {
+	var clauses []string
+	var args []any
+
+	var window []string
+	if !f.Since.IsZero() {
+		window = append(window, "te.started_at >= ?")
+		args = append(args, f.Since.UTC())
+	}
+	if !f.Until.IsZero() {
+		window = append(window, "te.started_at < ?")
+		args = append(args, f.Until.UTC())
+	}
+	switch {
+	case f.includePending() && len(window) > 0:
+		clauses = append(clauses, "(te.started_at IS NULL OR ("+strings.Join(window, " AND ")+"))")
+	case f.includePending():
+		// no window, pending allowed: nothing to constrain
+	case len(window) > 0:
+		clauses = append(clauses, "te.started_at IS NOT NULL", strings.Join(window, " AND "))
+	default:
+		clauses = append(clauses, "te.started_at IS NOT NULL")
+	}
+
+	in := func(expr string, vals []string) {
+		if len(vals) == 0 {
+			return
+		}
+		clauses = append(clauses, expr+" IN ("+strings.TrimSuffix(strings.Repeat("?,", len(vals)), ",")+")")
+		for _, v := range vals {
+			args = append(args, v)
+		}
+	}
+	in("wi.workflow_id", f.Workflows)
+	in("te.agent_id", f.Agents)
+	in("te.model", f.Models)
+	in("wi.source_id", f.Sources)
+	in("te.status", f.Statuses)
+
+	if len(clauses) == 0 {
+		return "", args
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
+}
+
+// probeColumns returns table → column → present for the given tables. The
+// export never assumes a column exists: the connection is read-only, so it
+// cannot migrate an older database up to the current schema.
+func probeColumns(ctx context.Context, db Querier, tables ...string) (map[string]map[string]bool, error) {
+	out := map[string]map[string]bool{}
+	for _, table := range tables {
+		rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+		if err != nil {
+			return nil, fmt.Errorf("probe %s: %w", table, err)
+		}
+		cols := map[string]bool{}
+		for rows.Next() {
+			var cid int
+			var name, ctype string
+			var notnull, pk int
+			var dflt sql.NullString
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("probe %s: %w", table, err)
+			}
+			cols[name] = true
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		out[table] = cols
+	}
+	return out, nil
+}
+
+func newDest(k Kind) any {
+	switch k {
+	case KindInt, KindBool:
+		return new(sql.NullInt64)
+	case KindFloat:
+		return new(sql.NullFloat64)
+	case KindTime:
+		return new(any)
+	default:
+		return new(sql.NullString)
+	}
+}
+
+func fromDest(k Kind, d any) any {
+	switch k {
+	case KindInt:
+		v := d.(*sql.NullInt64)
+		if !v.Valid {
+			return nil
+		}
+		return v.Int64
+	case KindBool:
+		v := d.(*sql.NullInt64)
+		if !v.Valid {
+			return nil
+		}
+		return v.Int64 != 0
+	case KindFloat:
+		v := d.(*sql.NullFloat64)
+		if !v.Valid {
+			return nil
+		}
+		return v.Float64
+	case KindTime:
+		return normalizeTime(*d.(*any))
+	default:
+		v := d.(*sql.NullString)
+		if !v.Valid {
+			return nil
+		}
+		return v.String
+	}
+}
+
+// timeLayouts are the forms Apiary has written timestamps in over its life:
+// modernc's sqlite time format (current), RFC3339 (early rows), and bare
+// SQLite datetime() output (CURRENT_TIMESTAMP defaults).
+var timeLayouts = []string{
+	"2006-01-02 15:04:05.999999999 -07:00",
+	"2006-01-02 15:04:05.999999999-07:00",
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05",
+}
+
+func normalizeTime(v any) any {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		return t.UTC()
+	case []byte:
+		return parseTime(string(t))
+	case string:
+		return parseTime(t)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func parseTime(s string) any {
+	for _, layout := range timeLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return s
+}
+
+// ParseBound resolves a --since/--until value: a duration with an optional
+// "d" suffix (7d, 24h, 90m) counted back from now, a date (2026-09-01), or an
+// RFC3339 timestamp. Dates are interpreted as midnight UTC.
+func ParseBound(s string, now time.Time) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty time bound")
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.DateOnly, s); err == nil {
+		return t.UTC(), nil
+	}
+	d, err := parseDurationDays(s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid time bound %q: want a duration (7d, 24h), a date (2026-09-01) or an RFC3339 timestamp", s)
+	}
+	return now.Add(-d).UTC(), nil
+}
+
+func parseDurationDays(s string) (time.Duration, error) {
+	if n := len(s); n > 1 && s[n-1] == 'd' {
+		var days float64
+		if _, err := fmt.Sscanf(s[:n-1], "%g", &days); err != nil {
+			return 0, err
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("must be positive")
+		}
+		return time.Duration(days * 24 * float64(time.Hour)), nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be positive")
+	}
+	return d, nil
+}

--- a/src/internal/export/usage_test.go
+++ b/src/internal/export/usage_test.go
@@ -1,0 +1,363 @@
+package export
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/orlandoburli/apiary/internal/db"
+	_ "modernc.org/sqlite"
+)
+
+var base = time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+// openReal creates a database with the production schema (every migration
+// applied) and returns a read-write connection to seed it. Using the real
+// schema is the point: the export contract is tested against the columns the
+// daemon actually writes.
+func openReal(t *testing.T) *sql.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "apiary.db")
+	client, err := db.New(context.Background(), path)
+	if err != nil {
+		t.Fatalf("db.New: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	conn, err := sql.Open("sqlite", path+"?_time_format=sqlite")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+type execRow struct {
+	task, agent, model, runner, status string
+	started                            any // time.Time or nil
+	instance, step                     string
+	cost                               float64
+	credit                             int
+	errMsg                             string
+	prompt, output                     string
+}
+
+func seed(t *testing.T, conn *sql.DB, instances [][3]string, execs []execRow) {
+	t.Helper()
+	for _, wi := range instances {
+		if _, err := conn.Exec(`INSERT INTO workflow_instances (id, workflow_id, cell_id, source_id, state) VALUES (?, ?, 'cell', ?, 'done')`,
+			wi[0], wi[1], wi[2]); err != nil {
+			t.Fatalf("seed instance: %v", err)
+		}
+	}
+	for _, e := range execs {
+		var inst any
+		if e.instance != "" {
+			inst = e.instance
+		}
+		if _, err := conn.Exec(`INSERT INTO task_executions
+			(task_id, agent_id, title, task_number, task_url, model, runner, attempt, status, started_at,
+			 workflow_instance_id, step_id, input_tokens, output_tokens, total_tokens, cost_usd,
+			 credit_exhausted, error_message, input_prompt, output_text, time_thinking_ms)
+			VALUES (?, ?, 'Title', 'ERP-1', 'https://x/1', ?, ?, 1, ?, ?, ?, ?, 100, 50, 150, ?, ?, ?, ?, ?, 7)`,
+			e.task, e.agent, e.model, e.runner, e.status, e.started, inst, e.step, e.cost, e.credit,
+			e.errMsg, e.prompt, e.output); err != nil {
+			t.Fatalf("seed execution: %v", err)
+		}
+	}
+}
+
+func collect(t *testing.T, conn Querier, f UsageFilter) []Row {
+	t.Helper()
+	var rows []Row
+	if err := ListUsageRows(context.Background(), conn, f, func(r Row) error {
+		rows = append(rows, r)
+		return nil
+	}); err != nil {
+		t.Fatalf("ListUsageRows: %v", err)
+	}
+	return rows
+}
+
+func col(t *testing.T, f UsageFilter, name string) int {
+	t.Helper()
+	for i, c := range f.Columns() {
+		if c.Name == name {
+			return i
+		}
+	}
+	t.Fatalf("column %s not selected", name)
+	return -1
+}
+
+func standardSeed(t *testing.T) *sql.DB {
+	conn := openReal(t)
+	seed(t, conn,
+		[][3]string{{"wi1", "implement", "github"}, {"wi2", "review", "jira"}},
+		[]execRow{
+			{task: "t1", agent: "eng", model: "m1", runner: "claude-cli", status: "success", started: base, instance: "wi1", step: "plan", cost: 0.5},
+			{task: "t1", agent: "eng", model: "m1", runner: "claude-cli", status: "failed", started: base.Add(time.Hour), instance: "wi1", step: "impl", cost: 1.25, credit: 1, errMsg: "boom\nline two"},
+			{task: "t2", agent: "rev", model: "m2", runner: "cursor-cli", status: "success", started: base.Add(2 * time.Hour), instance: "wi2", step: "review", cost: 0.1},
+			// Pre-workflow row: no instance, must still export with empty workflow columns.
+			{task: "t0", agent: "eng", model: "m1", runner: "claude-cli", status: "success", started: base.Add(-24 * time.Hour), cost: 2},
+			// Never started.
+			{task: "t3", agent: "eng", model: "m1", runner: "claude-cli", status: "pending", started: nil, instance: "wi1", step: "plan"},
+		})
+	return conn
+}
+
+func TestListUsageRowsDefaultExportsStartedRowsOldestFirstWithContext(t *testing.T) {
+	conn := standardSeed(t)
+	f := UsageFilter{}
+	rows := collect(t, conn, f)
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4 (pending excluded)", len(rows))
+	}
+	task := col(t, f, "task_id")
+	if rows[0][task] != "t0" || rows[3][task] != "t2" {
+		t.Errorf("order = %v ... %v, want t0 first, t2 last", rows[0][task], rows[3][task])
+	}
+	// Workflow context comes through the join.
+	if rows[1][col(t, f, "workflow_id")] != "implement" || rows[1][col(t, f, "source_id")] != "github" {
+		t.Errorf("row 1 context = %v / %v", rows[1][col(t, f, "workflow_id")], rows[1][col(t, f, "source_id")])
+	}
+	if rows[1][col(t, f, "instance_state")] != "done" {
+		t.Errorf("instance_state = %v", rows[1][col(t, f, "instance_state")])
+	}
+	// Pre-workflow row keeps its numbers and has null context.
+	if rows[0][col(t, f, "workflow_id")] != nil || rows[0][col(t, f, "cost_usd")] != 2.0 {
+		t.Errorf("pre-workflow row = wf %v cost %v", rows[0][col(t, f, "workflow_id")], rows[0][col(t, f, "cost_usd")])
+	}
+	// Types by kind.
+	if _, ok := rows[0][col(t, f, "started_at")].(time.Time); !ok {
+		t.Errorf("started_at is %T, want time.Time", rows[0][col(t, f, "started_at")])
+	}
+	if rows[2][col(t, f, "credit_exhausted")] != true || rows[0][col(t, f, "credit_exhausted")] != false {
+		t.Error("credit_exhausted should decode to bool")
+	}
+	if rows[0][col(t, f, "time_thinking_ms")] != int64(7) {
+		t.Errorf("time_thinking_ms = %v", rows[0][col(t, f, "time_thinking_ms")])
+	}
+	// Transcripts are not selected by default.
+	for _, c := range f.Columns() {
+		if c.Name == "input_prompt" || c.Name == "output_text" || c.Name == "slow_tools" {
+			t.Errorf("%s selected without opt-in", c.Name)
+		}
+	}
+}
+
+func TestListUsageRowsFilters(t *testing.T) {
+	conn := standardSeed(t)
+	cases := []struct {
+		name string
+		f    UsageFilter
+		want []string
+	}{
+		{"window", UsageFilter{Since: base, Until: base.Add(30 * time.Minute)}, []string{"t1"}},
+		{"window both", UsageFilter{Since: base, Until: base.Add(90 * time.Minute)}, []string{"t1", "t1"}},
+		{"since only", UsageFilter{Since: base.Add(time.Hour)}, []string{"t1", "t2"}},
+		{"workflow", UsageFilter{Workflows: []string{"review"}}, []string{"t2"}},
+		{"agent", UsageFilter{Agents: []string{"rev"}}, []string{"t2"}},
+		{"model", UsageFilter{Models: []string{"m1"}}, []string{"t0", "t1", "t1"}},
+		{"source", UsageFilter{Sources: []string{"jira"}}, []string{"t2"}},
+		{"status", UsageFilter{Statuses: []string{"failed"}}, []string{"t1"}},
+		{"pending opts in NULL start", UsageFilter{Statuses: []string{"pending"}}, []string{"t3"}},
+		{"pending with window", UsageFilter{Statuses: []string{"pending", "success"}, Since: base}, []string{"t1", "t2", "t3"}},
+		{"repeatable", UsageFilter{Workflows: []string{"implement", "review"}}, []string{"t1", "t1", "t2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := collect(t, conn, tc.f)
+			idx := col(t, tc.f, "task_id")
+			var got []string
+			for _, r := range rows {
+				got = append(got, r[idx].(string))
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListUsageRowsTranscriptsOptIn(t *testing.T) {
+	conn := openReal(t)
+	seed(t, conn, nil, []execRow{{task: "t", agent: "a", status: "success", started: base, prompt: "PROMPT", output: "OUT"}})
+	f := UsageFilter{IncludeTranscripts: true, IncludeSlowTools: true}
+	rows := collect(t, conn, f)
+	if rows[0][col(t, f, "input_prompt")] != "PROMPT" || rows[0][col(t, f, "output_text")] != "OUT" {
+		t.Errorf("transcripts = %v / %v", rows[0][col(t, f, "input_prompt")], rows[0][col(t, f, "output_text")])
+	}
+	if rows[0][col(t, f, "slow_tools")] != nil {
+		t.Errorf("slow_tools = %v, want nil", rows[0][col(t, f, "slow_tools")])
+	}
+}
+
+func TestListUsageRowsToleratesOlderSchema(t *testing.T) {
+	// A database written by a binary from before wall-clock attribution and
+	// before credit tracking: the export must still run, with those columns null.
+	conn, err := sql.Open("sqlite", "file:"+t.Name()+"?mode=memory&_time_format=sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	for _, s := range []string{
+		`CREATE TABLE task_executions (id INTEGER PRIMARY KEY, task_id TEXT, agent_id TEXT, status TEXT, started_at TIMESTAMP, cost_usd REAL)`,
+		`CREATE TABLE workflow_instances (id TEXT PRIMARY KEY, workflow_id TEXT, source_id TEXT, state TEXT)`,
+		`INSERT INTO task_executions (task_id, agent_id, status, started_at, cost_usd) VALUES ('t', 'a', 'success', '2026-09-01 12:00:00', 0.25)`,
+	} {
+		if _, err := conn.Exec(s); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f := UsageFilter{}
+	rows := collect(t, conn, f)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows", len(rows))
+	}
+	if rows[0][col(t, f, "time_thinking_ms")] != nil || rows[0][col(t, f, "credit_exhausted")] != nil {
+		t.Error("missing columns should export as nil")
+	}
+	if got := rows[0][col(t, f, "started_at")]; got != time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC) {
+		t.Errorf("started_at = %v (%T)", got, got)
+	}
+}
+
+func TestUsageColumnsCoverSchema(t *testing.T) {
+	// Drift guard: every task_executions column is either exported or listed
+	// as deliberately unexported. A new schema column fails here until someone
+	// decides which.
+	conn := openReal(t)
+	present, err := probeColumns(context.Background(), conn, tableExecutions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decided := map[string]bool{}
+	for _, c := range UsageColumns {
+		if c.table == tableExecutions {
+			decided[c.column] = true
+		}
+	}
+	for _, c := range UnexportedExecutionColumns {
+		decided[c] = true
+	}
+	for name := range present[tableExecutions] {
+		if !decided[name] {
+			t.Errorf("task_executions.%s is neither exported nor in UnexportedExecutionColumns", name)
+		}
+	}
+	// And nothing in the contract points at a column that does not exist.
+	for _, c := range UsageColumns {
+		if c.table == tableExecutions && !present[tableExecutions][c.column] {
+			t.Errorf("contract column %s refers to missing task_executions.%s", c.Name, c.column)
+		}
+	}
+}
+
+func TestCSVWriterFormatsByKind(t *testing.T) {
+	f := UsageFilter{}
+	cols := f.Columns()
+	var buf bytes.Buffer
+	w, err := NewCSVWriter(&buf, cols)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := make(Row, len(cols))
+	row[col(t, f, "execution_id")] = int64(7)
+	row[col(t, f, "cost_usd")] = 1.5
+	row[col(t, f, "credit_exhausted")] = true
+	row[col(t, f, "started_at")] = base.In(time.FixedZone("BRT", -3*3600))
+	row[col(t, f, "error_message")] = "line one\nline  two"
+	if err := w.Write(row); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	recs, err := csv.NewReader(&buf).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 || recs[0][0] != "execution_id" {
+		t.Fatalf("records = %v", recs)
+	}
+	got := recs[1]
+	checks := map[string]string{
+		"execution_id": "7", "cost_usd": "1.500000", "credit_exhausted": "true",
+		"started_at": "2026-09-01T12:00:00Z", "error_message": "line one line two", "task_id": "",
+	}
+	for name, want := range checks {
+		if got[col(t, f, name)] != want {
+			t.Errorf("%s = %q, want %q", name, got[col(t, f, name)], want)
+		}
+	}
+}
+
+func TestJSONWriterStreamsValidArray(t *testing.T) {
+	f := UsageFilter{}
+	cols := f.Columns()
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf, cols)
+	for i := range 2 {
+		row := make(Row, len(cols))
+		row[col(t, f, "execution_id")] = int64(i)
+		row[col(t, f, "started_at")] = base
+		row[col(t, f, "credit_exhausted")] = false
+		if err := w.Write(row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if len(out) != 2 || out[1]["execution_id"] != float64(1) {
+		t.Fatalf("decoded = %v", out)
+	}
+	if len(out[0]) != len(cols) {
+		t.Errorf("object has %d keys, want %d (nulls must be explicit)", len(out[0]), len(cols))
+	}
+	if out[0]["task_id"] != nil || out[0]["started_at"] != "2026-09-01T12:00:00Z" {
+		t.Errorf("task_id = %v, started_at = %v", out[0]["task_id"], out[0]["started_at"])
+	}
+
+	// Empty export is still a valid array.
+	buf.Reset()
+	if err := NewJSONWriter(&buf, cols).Close(); err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(buf.String()) != "[]" {
+		t.Errorf("empty export = %q", buf.String())
+	}
+}
+
+func TestParseBound(t *testing.T) {
+	now := base
+	cases := map[string]time.Time{
+		"7d":                   base.Add(-7 * 24 * time.Hour),
+		"90m":                  base.Add(-90 * time.Minute),
+		"2026-08-01":           time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		"2026-08-01T10:00:00Z": time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC),
+	}
+	for in, want := range cases {
+		got, err := ParseBound(in, now)
+		if err != nil || !got.Equal(want) {
+			t.Errorf("ParseBound(%q) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"", "yesterday", "-3d", "0h"} {
+		if _, err := ParseBound(bad, now); err == nil {
+			t.Errorf("ParseBound(%q) accepted", bad)
+		}
+	}
+}

--- a/src/internal/export/writers.go
+++ b/src/internal/export/writers.go
@@ -1,0 +1,176 @@
+package export
+
+import (
+	"bufio"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Writer renders rows for one output format. Close flushes and finishes the
+// document; a JSON file is not valid until Close has run.
+type Writer interface {
+	Write(Row) error
+	Close() error
+}
+
+// NewWriter picks a writer by format name: "csv" or "json".
+func NewWriter(format string, w io.Writer, cols []Column) (Writer, error) {
+	switch strings.ToLower(format) {
+	case "csv":
+		return NewCSVWriter(w, cols)
+	case "json":
+		return NewJSONWriter(w, cols), nil
+	default:
+		return nil, fmt.Errorf("unknown format %q: want csv or json", format)
+	}
+}
+
+// csvWriter emits a header row then one line per row. Timestamps are RFC3339
+// UTC, cost_usd has six decimals, booleans are true/false, NULL is an empty
+// cell, and error_message is collapsed to a single line so a spreadsheet's
+// row count matches the record count.
+type csvWriter struct {
+	cw   *csv.Writer
+	cols []Column
+}
+
+// NewCSVWriter writes the header immediately so an empty export still carries
+// the column contract.
+func NewCSVWriter(w io.Writer, cols []Column) (Writer, error) {
+	cw := csv.NewWriter(w)
+	header := make([]string, len(cols))
+	for i, c := range cols {
+		header[i] = c.Name
+	}
+	if err := cw.Write(header); err != nil {
+		return nil, err
+	}
+	return &csvWriter{cw: cw, cols: cols}, nil
+}
+
+func (c *csvWriter) Write(r Row) error {
+	rec := make([]string, len(c.cols))
+	for i, col := range c.cols {
+		rec[i] = csvCell(col, r[i])
+	}
+	return c.cw.Write(rec)
+}
+
+func (c *csvWriter) Close() error {
+	c.cw.Flush()
+	return c.cw.Error()
+}
+
+func csvCell(col Column, v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		if col.Name == "error_message" {
+			return singleLine(t)
+		}
+		return t
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case float64:
+		if col.Name == "cost_usd" {
+			return strconv.FormatFloat(t, 'f', 6, 64)
+		}
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case bool:
+		return strconv.FormatBool(t)
+	case time.Time:
+		return formatTime(t)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func singleLine(s string) string {
+	return strings.Join(strings.Fields(strings.ReplaceAll(s, "\r", " ")), " ")
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// jsonWriter streams a JSON array of objects: "[" up front, one object per
+// row, "]" on Close. It never holds more than one row, so an export with
+// transcripts included runs in constant memory.
+type jsonWriter struct {
+	bw    *bufio.Writer
+	cols  []Column
+	count int
+}
+
+// NewJSONWriter returns a writer whose output is a valid JSON array once
+// Close has been called. Every key is present in every object; NULL columns
+// are explicit null rather than omitted, so a column list derived from any one
+// object is complete.
+func NewJSONWriter(w io.Writer, cols []Column) Writer {
+	return &jsonWriter{bw: bufio.NewWriter(w), cols: cols}
+}
+
+func (j *jsonWriter) Write(r Row) error {
+	if j.count == 0 {
+		if _, err := j.bw.WriteString("[\n"); err != nil {
+			return err
+		}
+	} else {
+		if _, err := j.bw.WriteString(",\n"); err != nil {
+			return err
+		}
+	}
+	j.count++
+
+	if err := j.bw.WriteByte('{'); err != nil {
+		return err
+	}
+	for i, col := range j.cols {
+		if i > 0 {
+			if err := j.bw.WriteByte(','); err != nil {
+				return err
+			}
+		}
+		key, _ := json.Marshal(col.Name)
+		val, err := json.Marshal(jsonValue(r[i]))
+		if err != nil {
+			return fmt.Errorf("encode %s: %w", col.Name, err)
+		}
+		if _, err := j.bw.Write(key); err != nil {
+			return err
+		}
+		if err := j.bw.WriteByte(':'); err != nil {
+			return err
+		}
+		if _, err := j.bw.Write(val); err != nil {
+			return err
+		}
+	}
+	return j.bw.WriteByte('}')
+}
+
+func (j *jsonWriter) Close() error {
+	if j.count == 0 {
+		if _, err := j.bw.WriteString("[]\n"); err != nil {
+			return err
+		}
+		return j.bw.Flush()
+	}
+	if _, err := j.bw.WriteString("\n]\n"); err != nil {
+		return err
+	}
+	return j.bw.Flush()
+}
+
+func jsonValue(v any) any {
+	if t, ok := v.(time.Time); ok {
+		return formatTime(t)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary

Phase 1 of [openspec/changes/usage-export](openspec/changes/usage-export/proposal.md). Adds `apiary export usage`: one row per runner attempt from `task_executions`, joined to its workflow instance, as CSV or JSON.

```bash
apiary export usage -o usage.csv
apiary export usage --since 30d --workflow implementation --format json
apiary export usage --since 2026-09-01 --until 2026-09-02 --status failed
apiary export usage --include-transcripts -o full.csv
```

**Design**
- `internal/export` holds the column contract (`UsageColumns`, with kinds), the filter → bound-parameter compiler, a streaming callback API, and both writers. Nothing is buffered; a transcript export runs in constant memory.
- Columns are probed at query time. A database written by an older binary exports NULLs for columns it lacks instead of failing; the join degrades to a constant when `workflow_instance_id` predates the schema.
- Read-only open with **no** `journal_mode` pragma. `improve.OpenReadOnly` sets WAL, which needs a write and fails on any non-WAL file (a `VACUUM INTO` backup). That latent bug in `apiary improve` is left for a separate PR.
- `-o` writes a temp file beside the target and renames on success; a failed export never leaves a truncated file.
- Schema-drift guard: `TestUsageColumnsCoverSchema` runs against the real migrated schema and fails when `task_executions` gains a column that is neither exported nor in `UnexportedExecutionColumns`.

**Deviations from the plan** (recorded in tasks.md): package is `internal/export`, not `internal/db`, because `db.New` migrates on open; the drift guard moved into Phase 1; exit code 2 on flag misuse not done (cobra exits 1 for every command).

**Verification**
- `go build ./... && go test ./...` clean.
- 100k-row synthetic copy: CSV 3.6 s / 48 MB RSS; JSON with transcripts 15.8 s / 56 MB RSS.
- project-erp live database, daemon running: 2061 rows for 30 d in 0.8 s, no lock contention. Spend-by-workflow pivots directly from the CSV.
- `detect_changes`: no indexed symbol changed; the only edit to existing code is the `AddCommand` list in `root.go`.

Phase 2 (docs in `docs/cli.md`, `docs/improve.md`, CLI spec, changelog archive) follows and closes #485.

Refs #485.
