### PR TITLE
fix(improve): open non-WAL database copies read-only

### DIFF
--- a/src/internal/improve/build.go
+++ b/src/internal/improve/build.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"net/url"
 	"sort"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/config"
+	"github.com/orlandoburli/apiary/internal/export"
 )
 
 // Options configures a single evidence-pack build.
@@ -30,19 +30,13 @@ type Options struct {
 // OpenReadOnly opens the Apiary database for analysis without touching it. The
 // improve command must never migrate, write or lock the database a running
 // daemon depends on, so it opens its own read-only connection rather than going
-// through db.Client (which initialises schema on open).
+// through db.Client (which initialises schema on open). It shares the export
+// opener, which deliberately sets no journal mode: setting journal_mode(WAL)
+// is a write, and it made opening any non-WAL file (a backup taken with VACUUM
+// INTO, a copy made with the daemon stopped) fail with "attempt to write a
+// readonly database".
 func OpenReadOnly(dbPath string) (*sql.DB, error) {
-	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_time_format=sqlite",
-		url.PathEscape(dbPath))
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("open database: %w", err)
-	}
-	if err := db.Ping(); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("open database %s: %w", dbPath, err)
-	}
-	return db, nil
+	return export.OpenReadOnly(dbPath)
 }
 
 // Build assembles the complete evidence pack. Every number in the result is

--- a/src/internal/improve/open_test.go
+++ b/src/internal/improve/open_test.go
@@ -1,0 +1,60 @@
+package improve
+
+import (
+	"database/sql"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A backup made with VACUUM INTO is a plain rollback-journal file, not WAL.
+// improve must still be able to analyse it: a reader has no business setting
+// journal_mode, and doing so on a read-only handle fails with "attempt to
+// write a readonly database" (the bug behind this test).
+func TestOpenReadOnlyAcceptsVacuumIntoCopy(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "live.db")
+	copyPath := filepath.Join(dir, "backup.db")
+
+	src, err := sql.Open("sqlite", "file:"+url.PathEscape(live)+"?_pragma=journal_mode(WAL)")
+	if err != nil {
+		t.Fatalf("open live: %v", err)
+	}
+	if _, err := src.Exec(`CREATE TABLE workflow_instances (id TEXT PRIMARY KEY, state TEXT)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := src.Exec(`INSERT INTO workflow_instances VALUES ('i1', 'done')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if _, err := src.Exec(`VACUUM INTO '` + strings.ReplaceAll(copyPath, "'", "''") + `'`); err != nil {
+		t.Fatalf("vacuum into: %v", err)
+	}
+	src.Close()
+
+	db, err := OpenReadOnly(copyPath)
+	if err != nil {
+		t.Fatalf("OpenReadOnly on VACUUM INTO copy: %v", err)
+	}
+	defer db.Close()
+
+	var mode string
+	if err := db.QueryRow(`PRAGMA journal_mode`).Scan(&mode); err != nil {
+		t.Fatalf("journal_mode: %v", err)
+	}
+	if strings.EqualFold(mode, "wal") {
+		t.Fatalf("VACUUM INTO copy should not be WAL, got %q (test no longer exercises the bug)", mode)
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM workflow_instances`).Scan(&n); err != nil {
+		t.Fatalf("query copy: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 row in copy, got %d", n)
+	}
+
+	if _, err := db.Exec(`INSERT INTO workflow_instances VALUES ('i2', 'done')`); err == nil {
+		t.Fatal("handle must be read-only, but INSERT succeeded")
+	}
+}


### PR DESCRIPTION
## Summary

`improve.OpenReadOnly` opened SQLite with `mode=ro&_pragma=journal_mode(WAL)`. Setting the journal mode is a write, so any database file that is not already in WAL mode (a backup made with `VACUUM INTO`, a copy taken with the daemon stopped) failed to open with `attempt to write a readonly database (8)`. `apiary improve` therefore could not analyse a copied database.

The sibling `apiary export` command (#487) already shipped `export.OpenReadOnly` without the pragma: WAL is a property of the file, chosen by the daemon that wrote it, and a reader does not need to set it. This PR makes improve delegate to that opener so there is a single read-only opener.

## Changes

- `improve.OpenReadOnly` now delegates to `export.OpenReadOnly` (same signature, same two CLI callers).
- New `TestOpenReadOnlyAcceptsVacuumIntoCopy`: creates a WAL database, takes a `VACUUM INTO` copy, asserts the copy is not WAL, opens it through `OpenReadOnly`, reads a row, and checks that a write is refused.

## Verification

- Impact analysis on `OpenReadOnly`: LOW risk, two direct callers (`newImproveCmd`, `newImproveEffectCmd`), both unchanged.
- The new test fails against the old DSN with the original error and passes with the fix.
- `go test ./...` from `src/` passes.