### PR TITLE
feat(dashboard): load older tasks on demand in the Tasks tab (#490)

### DIFF
--- a/.claude/skills/apiary-guide/SKILL.md
+++ b/.claude/skills/apiary-guide/SKILL.md
@@ -469,7 +469,7 @@ Terminal UI for watching live state:
 |---|---|
 | `s` | Toggle sort direction (asc/desc) |
 | `S` | Cycle to next sort field |
-| `/` | Open filter bar (type query, `Esc` to exit, `Backspace` to delete) |
+| `/` | Open filter bar (type query, `Esc` to exit, `Backspace` to delete) — runs in SQL over every task, not just the loaded page |
 | `↓` / `PgDn` / `End` on the last row | Load the next 100 older tasks (list opens with the newest 100) |
 | `d` | Task detail view |
 | `Enter` / `l` | Task logs view |

--- a/.claude/skills/apiary-guide/SKILL.md
+++ b/.claude/skills/apiary-guide/SKILL.md
@@ -470,6 +470,7 @@ Terminal UI for watching live state:
 | `s` | Toggle sort direction (asc/desc) |
 | `S` | Cycle to next sort field |
 | `/` | Open filter bar (type query, `Esc` to exit, `Backspace` to delete) |
+| `↓` / `PgDn` / `End` on the last row | Load the next 100 older tasks (list opens with the newest 100) |
 | `d` | Task detail view |
 | `Enter` / `l` | Task logs view |
 | `o` | Open task URL in browser |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -107,6 +107,12 @@ A list of recent tasks — both running and already finished — newest first. E
 row shows the task title, **which step it is on**, its status, and when it ran.
 Use `↑` / `↓` to move the `▶` marker.
 
+The list opens with the newest 100 tasks. When older ones exist, a hint appears
+under the last row; press `↓`, `PgDn` or `End` while on that row to load the
+next 100 below it. Loaded pages stay put across the periodic refresh, and the
+`/` filter and the tickets-only / approvals toggles apply to everything loaded,
+so keep loading to search further back.
+
 ```
    #          TASK                            STEP           STATUS   WHEN
 ▶  #412       Fix approval gate re-entry      review 3/5     running  4m ago

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -109,9 +109,12 @@ Use `↑` / `↓` to move the `▶` marker.
 
 The list opens with the newest 100 tasks. When older ones exist, a hint appears
 under the last row; press `↓`, `PgDn` or `End` while on that row to load the
-next 100 below it. Loaded pages stay put across the periodic refresh, and the
-`/` filter and the tickets-only / approvals toggles apply to everything loaded,
-so keep loading to search further back.
+next 100 below it. Loaded pages stay put across the periodic refresh.
+
+The `/` filter and the tickets-only (`T`) / approvals (`A`) toggles run in the
+query, not on the loaded rows: they search every task ever recorded, and the
+matches page the same way. The filter matches the title, the task id, the
+state, and the source reference (`#412`, `ERP-42`) of any binding.
 
 ```
    #          TASK                            STEP           STATUS   WHEN

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -52,6 +52,10 @@ const noticeTTL = 8 * time.Second
 // fetchOlderTaskLogs).
 const taskLogTailLimit = 1000
 
+// taskPageSize is how many tasks the Tasks tab loads per page: the newest page
+// on open, then one more each time the cursor is pushed past the last row.
+const taskPageSize = 100
+
 // maxGlamourBytes caps which log messages get glamour-styled markdown. Above
 // this, plain wrapping is used unconditionally: giant agent dumps gain little
 // from styling and are exactly the messages that cost the most to render (#175).
@@ -127,7 +131,13 @@ type spinnerTickMsg time.Time
 // commands (goroutines) and consumed by Update (event loop), never sharing
 // memory with the model directly.
 type overviewDataMsg struct{ data OverviewTab }
-type tasksDataMsg struct{ items []TaskItem }
+type tasksDataMsg struct {
+	items    []TaskItem
+	limit    int       // rows asked for (the refresh window)
+	oldestAt time.Time // created_at of the last row (older-page cursor)
+	oldestID string    // id of the last row (cursor tie-breaker)
+	hasMore  bool      // an older page may exist
+}
 type taskDetailMsg struct {
 	taskID   string
 	detail   *TaskItem
@@ -138,6 +148,15 @@ type taskDetailMsg struct {
 // persisted a task's pull requests, so the open detail can reload and pick them up.
 type taskPullsRefreshedMsg struct {
 	internalTaskID string
+}
+
+// olderTasksMsg carries an older page of the Tasks list, appended below the
+// rows already loaded.
+type olderTasksMsg struct {
+	items    []TaskItem
+	oldestAt time.Time
+	oldestID string
+	hasMore  bool
 }
 type taskLogsMsg struct {
 	taskID   string
@@ -301,14 +320,34 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.model.lastRefresh = time.Now()
 
 	case tasksDataMsg:
-		if a.model.tasksTab != nil {
-			a.model.tasksTab.History = msg.items
-			if a.model.tasksTab.SelectedIdx >= len(msg.items) {
-				a.model.tasksTab.SelectedIdx = 0
+		if t := a.model.tasksTab; t != nil {
+			// A refresh that started before an older page was appended asked for
+			// a smaller window than what is now loaded; applying it would drop
+			// the page again. Skip it — the next tick re-queries the full window.
+			if msg.limit < t.ListWindow {
+				break
+			}
+			t.History = msg.items
+			t.ListWindow = msg.limit
+			t.ListOldestAt, t.ListOldestID = msg.oldestAt, msg.oldestID
+			t.ListHasMore = msg.hasMore
+			if t.SelectedIdx >= len(msg.items) {
+				t.SelectedIdx = 0
 			}
 		}
 		a.model.loading = false
 		a.model.lastRefresh = time.Now()
+
+	case olderTasksMsg:
+		if t := a.model.tasksTab; t != nil {
+			t.ListLoadingMore = false
+			t.ListHasMore = msg.hasMore
+			if len(msg.items) > 0 {
+				t.History = append(t.History, msg.items...)
+				t.ListWindow = len(t.History)
+				t.ListOldestAt, t.ListOldestID = msg.oldestAt, msg.oldestID
+			}
+		}
 
 	case taskDetailMsg:
 		if a.model.tasksTab != nil {
@@ -901,10 +940,12 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				t.BoardRow++ // clamped on render, where the column sizes are known
 				break
 			}
-			if a.model.tasksTab != nil {
-				maxIdx := len(a.filteredTasks(a.model.tasksTab)) - 1
-				if a.model.tasksTab.SelectedIdx < maxIdx {
-					a.model.tasksTab.SelectedIdx++
+			if t := a.model.tasksTab; t != nil {
+				maxIdx := len(a.filteredTasks(t)) - 1
+				if t.SelectedIdx < maxIdx {
+					t.SelectedIdx++
+				} else if cmd := a.loadOlderTasksCmd(t); cmd != nil {
+					return a, cmd // pushed past the last row: fetch the next page
 				}
 			}
 		case "Agents":
@@ -935,8 +976,14 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "end":
 		switch a.model.ActiveTab() {
 		case "Tasks":
-			if a.model.tasksTab != nil {
-				a.model.tasksTab.SelectedIdx = len(a.filteredTasks(a.model.tasksTab)) - 1
+			if t := a.model.tasksTab; t != nil {
+				maxIdx := len(a.filteredTasks(t)) - 1
+				if t.SelectedIdx == maxIdx {
+					if cmd := a.loadOlderTasksCmd(t); cmd != nil {
+						return a, cmd // already at the end: fetch the next page
+					}
+				}
+				t.SelectedIdx = maxIdx
 			}
 		case "Agents":
 			if a.model.agentsTab != nil {
@@ -973,11 +1020,16 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "pgdown", "ctrl+d", " ":
 		switch a.model.ActiveTab() {
 		case "Tasks":
-			if a.model.tasksTab != nil {
-				a.model.tasksTab.SelectedIdx += a.pageSize()
-				maxIdx := len(a.filteredTasks(a.model.tasksTab)) - 1
-				if a.model.tasksTab.SelectedIdx > maxIdx {
-					a.model.tasksTab.SelectedIdx = maxIdx
+			if t := a.model.tasksTab; t != nil {
+				maxIdx := len(a.filteredTasks(t)) - 1
+				if t.SelectedIdx == maxIdx {
+					if cmd := a.loadOlderTasksCmd(t); cmd != nil {
+						return a, cmd // already at the end: fetch the next page
+					}
+				}
+				t.SelectedIdx += a.pageSize()
+				if t.SelectedIdx > maxIdx {
+					t.SelectedIdx = maxIdx
 				}
 			}
 		case "Agents":
@@ -2540,50 +2592,114 @@ func (a *App) fetchOverview() tea.Cmd {
 	}
 }
 
+// fetchTasks re-queries the Tasks list for the periodic refresh. It asks for
+// the whole loaded window (the first page plus every older page appended since)
+// so a refresh never collapses the list back to the newest page.
 func (a *App) fetchTasks() tea.Cmd {
-	dbConn := a.dbConn
-	var workflows []config.WorkflowConfig
-	if a.cfg != nil {
-		workflows = a.cfg.Workflows
+	limit := taskPageSize
+	if t := a.model.tasksTab; t != nil && t.ListWindow > limit {
+		limit = t.ListWindow
 	}
+	dbConn := a.dbConn
+	workflows := a.configuredWorkflows()
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
 
-		items := make([]TaskItem, 0)
+		msg := tasksDataMsg{items: make([]TaskItem, 0), limit: limit}
 		if dbConn != nil {
-			// Phase 9: the Tasks tab is keyed on the canonical InternalTask, not
-			// per-execution rows. Each row carries the internal id (for lineage /
-			// bindings / instances) plus a drill key (the primary binding's source
-			// item id, or the task id when binding-less) that the legacy
-			// detail/logs/monitor machinery resolves.
-			if tasks, err := dbConn.InternalTasks().ListTasks(ctx, 100); err == nil {
-				for _, tk := range tasks {
-					bindings, _ := dbConn.ListBindingsByTask(ctx, tk.ID)
-					prs, _ := dbConn.ListTaskPullRequests(ctx, tk.ID)
-					items = append(items, taskItemFromInternal(tk, bindings, prs))
-				}
-
-				// One query for the whole page, not one per row: this runs on a
-				// timer against the file the daemon is writing to.
-				ids := make([]string, 0, len(tasks))
-				for _, tk := range tasks {
-					ids = append(ids, tk.ID)
-				}
-				if rows, err := dbConn.ListStepProgressForTasks(ctx, ids); err == nil {
-					progress := resolveTaskProgress(rows, workflows)
-					for i := range items {
-						p := progress[items[i].InternalTaskID]
-						items[i].StepID = p.StepID
-						items[i].StepPosition = p.Position
-						items[i].StepTotal = p.Total
-						items[i].LiveInstances = p.Instances
-					}
-				}
+			if tasks, err := dbConn.InternalTasks().ListTasks(ctx, limit); err == nil {
+				msg.items = buildTaskItems(ctx, dbConn, workflows, tasks)
+				msg.oldestAt, msg.oldestID, msg.hasMore = taskPageCursor(tasks, limit)
 			}
 		}
-		return tasksDataMsg{items: items}
+		return msg
 	}
+}
+
+// loadOlderTasksCmd starts a fetch of the next older page of the Tasks list when
+// the cursor is pushed past the last row and an older page may exist. Returns nil
+// when there is nothing to load (not the list/board view, no cursor, already
+// loading, or no more pages).
+func (a *App) loadOlderTasksCmd(t *TasksTab) tea.Cmd {
+	if (t.View != TaskViewList && t.View != TaskViewBoard) ||
+		t.ListOldestID == "" || !t.ListHasMore || t.ListLoadingMore {
+		return nil
+	}
+	t.ListLoadingMore = true
+	return a.fetchOlderTasks(t.ListOldestAt, t.ListOldestID)
+}
+
+// fetchOlderTasks loads the page of tasks immediately older than the
+// (createdAt, id) cursor, for the load-more pagination of the Tasks list.
+func (a *App) fetchOlderTasks(createdAt time.Time, id string) tea.Cmd {
+	dbConn := a.dbConn
+	workflows := a.configuredWorkflows()
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+
+		msg := olderTasksMsg{}
+		if dbConn != nil {
+			if tasks, err := dbConn.InternalTasks().ListTasksBefore(ctx, createdAt, id, taskPageSize); err == nil {
+				msg.items = buildTaskItems(ctx, dbConn, workflows, tasks)
+				msg.oldestAt, msg.oldestID, msg.hasMore = taskPageCursor(tasks, taskPageSize)
+			}
+		}
+		return msg
+	}
+}
+
+// configuredWorkflows returns the workflows from config (nil without one), used
+// to resolve step progress for the Tasks list rows.
+func (a *App) configuredWorkflows() []config.WorkflowConfig {
+	if a.cfg == nil {
+		return nil
+	}
+	return a.cfg.Workflows
+}
+
+// taskPageCursor returns the older-page cursor for a page of tasks (its last,
+// oldest row) and whether an older page may exist: a full page implies more.
+func taskPageCursor(tasks []model.InternalTask, limit int) (time.Time, string, bool) {
+	if len(tasks) == 0 {
+		return time.Time{}, "", false
+	}
+	last := tasks[len(tasks)-1]
+	return last.CreatedAt, last.ID, len(tasks) == limit
+}
+
+// buildTaskItems converts a page of InternalTasks into Tasks-tab rows.
+func buildTaskItems(ctx context.Context, dbConn *db.Client, workflows []config.WorkflowConfig, tasks []model.InternalTask) []TaskItem {
+	items := make([]TaskItem, 0, len(tasks))
+	// Phase 9: the Tasks tab is keyed on the canonical InternalTask, not
+	// per-execution rows. Each row carries the internal id (for lineage /
+	// bindings / instances) plus a drill key (the primary binding's source
+	// item id, or the task id when binding-less) that the legacy
+	// detail/logs/monitor machinery resolves.
+	for _, tk := range tasks {
+		bindings, _ := dbConn.ListBindingsByTask(ctx, tk.ID)
+		prs, _ := dbConn.ListTaskPullRequests(ctx, tk.ID)
+		items = append(items, taskItemFromInternal(tk, bindings, prs))
+	}
+
+	// One query for the whole page, not one per row: this runs on a
+	// timer against the file the daemon is writing to.
+	ids := make([]string, 0, len(tasks))
+	for _, tk := range tasks {
+		ids = append(ids, tk.ID)
+	}
+	if rows, err := dbConn.ListStepProgressForTasks(ctx, ids); err == nil {
+		progress := resolveTaskProgress(rows, workflows)
+		for i := range items {
+			p := progress[items[i].InternalTaskID]
+			items[i].StepID = p.StepID
+			items[i].StepPosition = p.Position
+			items[i].StepTotal = p.Total
+			items[i].LiveInstances = p.Instances
+		}
+	}
+	return items
 }
 
 // taskItemFromInternal converts an InternalTask (plus its source bindings) into a
@@ -3789,6 +3905,20 @@ func (a *App) renderTaskList(t *TasksTab, height int) string {
 			when = StyleMuted.Render(when)
 		}
 		b.WriteString(cursor + " " + num + " " + titleText + " " + agent + " " + status + " " + when + "\n")
+	}
+	// A "load more" hint takes the row under the last task when the window
+	// reaches the end of the loaded list and an older page is available (or
+	// being fetched). Fetching is triggered by pushing the cursor past the end.
+	if end == len(items) {
+		hint := ""
+		if t.ListLoadingMore {
+			hint = "↓ loading older tasks…"
+		} else if t.ListHasMore {
+			hint = "↓ older tasks — press ↓/PgDn/End at the last row to load"
+		}
+		if hint != "" {
+			b.WriteString(StyleMuted.Render(hint) + "\n")
+		}
 	}
 
 	return a.box(title, b.String(), height)

--- a/src/internal/dashboard/app.go
+++ b/src/internal/dashboard/app.go
@@ -133,6 +133,7 @@ type spinnerTickMsg time.Time
 type overviewDataMsg struct{ data OverviewTab }
 type tasksDataMsg struct {
 	items    []TaskItem
+	filter   string    // key of the list filter the page was queried with
 	limit    int       // rows asked for (the refresh window)
 	oldestAt time.Time // created_at of the last row (older-page cursor)
 	oldestID string    // id of the last row (cursor tie-breaker)
@@ -154,6 +155,7 @@ type taskPullsRefreshedMsg struct {
 // rows already loaded.
 type olderTasksMsg struct {
 	items    []TaskItem
+	filter   string // key of the list filter the page was queried with
 	oldestAt time.Time
 	oldestID string
 	hasMore  bool
@@ -324,7 +326,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// A refresh that started before an older page was appended asked for
 			// a smaller window than what is now loaded; applying it would drop
 			// the page again. Skip it — the next tick re-queries the full window.
-			if msg.limit < t.ListWindow {
+			if msg.limit < t.ListWindow || msg.filter != a.taskListFilterKey(t) {
 				break
 			}
 			t.History = msg.items
@@ -340,6 +342,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case olderTasksMsg:
 		if t := a.model.tasksTab; t != nil {
+			if msg.filter != a.taskListFilterKey(t) {
+				break // the filter changed underneath the fetch; its page is moot
+			}
 			t.ListLoadingMore = false
 			t.ListHasMore = msg.hasMore
 			if len(msg.items) > 0 {
@@ -624,6 +629,7 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// append. Every other binding (q, tab, r, ...) stays inert until then.
 	if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.FilterActive {
 		t := a.model.tasksTab
+		before := t.FilterText
 		switch key {
 		case "esc":
 			t.FilterActive = false
@@ -642,6 +648,11 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				t.FilterText += key
 				t.SelectedIdx = 0
 			}
+		}
+		if t.FilterText != before {
+			// The filter runs in the query, so the list is re-fetched from the
+			// whole table on every edit rather than narrowed in memory.
+			return a, a.resetTaskList(t)
 		}
 		return a, nil
 	}
@@ -762,6 +773,7 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			t.SelectedIdx = 0
 			t.ScrollOffset = 0
+			t.resetListPages() // the toggle changes the query: start over from page one
 			a.model.SetActiveTab("Tasks")
 			a.model.loading = true
 			return a, a.fetchActiveTab()
@@ -862,14 +874,18 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			t := a.model.tasksTab
 			t.TicketsOnly = !t.TicketsOnly
 			t.SelectedIdx = 0
+			return a, a.resetTaskList(t)
 		}
 	case "r":
 		a.model.loading = true
 		return a, a.fetchActiveTab()
 	case "/":
-		if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View == TaskViewList {
-			a.model.tasksTab.FilterActive = true
-			a.model.tasksTab.FilterText = ""
+		if t := a.model.tasksTab; a.model.ActiveTab() == "Tasks" && t != nil && t.View == TaskViewList {
+			t.FilterActive = true
+			if t.FilterText != "" {
+				t.FilterText = ""
+				return a, a.resetTaskList(t)
+			}
 		}
 	case "s":
 		if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.View == TaskViewList {
@@ -907,9 +923,10 @@ func (a *App) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "esc":
 		// Clear a confirmed filter (typing-mode esc is handled up top).
-		if a.model.ActiveTab() == "Tasks" && a.model.tasksTab != nil && a.model.tasksTab.FilterText != "" {
-			a.model.tasksTab.FilterText = ""
-			a.model.tasksTab.SelectedIdx = 0
+		if t := a.model.tasksTab; a.model.ActiveTab() == "Tasks" && t != nil && t.FilterText != "" {
+			t.FilterText = ""
+			t.SelectedIdx = 0
+			return a, a.resetTaskList(t)
 		}
 	case "up":
 		switch a.model.ActiveTab() {
@@ -2602,13 +2619,14 @@ func (a *App) fetchTasks() tea.Cmd {
 	}
 	dbConn := a.dbConn
 	workflows := a.configuredWorkflows()
+	filter := a.taskListFilter(a.model.tasksTab)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
 
-		msg := tasksDataMsg{items: make([]TaskItem, 0), limit: limit}
+		msg := tasksDataMsg{items: make([]TaskItem, 0), filter: filter.key(), limit: limit}
 		if dbConn != nil {
-			if tasks, err := dbConn.InternalTasks().ListTasks(ctx, limit); err == nil {
+			if tasks, err := dbConn.InternalTasks().ListTasksPage(ctx, filter.TaskListFilter, db.TaskCursor{}, limit); err == nil {
 				msg.items = buildTaskItems(ctx, dbConn, workflows, tasks)
 				msg.oldestAt, msg.oldestID, msg.hasMore = taskPageCursor(tasks, limit)
 			}
@@ -2635,19 +2653,71 @@ func (a *App) loadOlderTasksCmd(t *TasksTab) tea.Cmd {
 func (a *App) fetchOlderTasks(createdAt time.Time, id string) tea.Cmd {
 	dbConn := a.dbConn
 	workflows := a.configuredWorkflows()
+	filter := a.taskListFilter(a.model.tasksTab)
+	cursor := db.TaskCursor{CreatedAt: createdAt, ID: id}
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
 
-		msg := olderTasksMsg{}
+		msg := olderTasksMsg{filter: filter.key()}
 		if dbConn != nil {
-			if tasks, err := dbConn.InternalTasks().ListTasksBefore(ctx, createdAt, id, taskPageSize); err == nil {
+			if tasks, err := dbConn.InternalTasks().ListTasksPage(ctx, filter.TaskListFilter, cursor, taskPageSize); err == nil {
 				msg.items = buildTaskItems(ctx, dbConn, workflows, tasks)
 				msg.oldestAt, msg.oldestID, msg.hasMore = taskPageCursor(tasks, taskPageSize)
 			}
 		}
 		return msg
 	}
+}
+
+// taskListFilter is the Tasks-list query filter plus a stable key identifying
+// it, so a page that comes back after the filter changed can be recognised
+// and dropped.
+type taskListFilter struct {
+	db.TaskListFilter
+}
+
+// key returns a string that changes whenever the filter would change the
+// result set.
+func (f taskListFilter) key() string {
+	return fmt.Sprintf("%q|%t|%t|%q", f.Text, f.ApprovalsOnly, f.TicketsOnly, f.NonTicketSources)
+}
+
+// taskListFilter builds the query filter for the tab's current text filter and
+// toggles. The filters run in SQL so they see every task in the table, not only
+// the pages the list has loaded; filteredTasks applies the same predicates to
+// the loaded rows, which is a no-op on query results but keeps the in-memory
+// view (board, tests) consistent.
+func (a *App) taskListFilter(t *TasksTab) taskListFilter {
+	var f taskListFilter
+	if t == nil {
+		return f
+	}
+	f.Text = t.FilterText
+	f.ApprovalsOnly = t.ApprovalsOnly
+	f.TicketsOnly = t.TicketsOnly
+	if t.TicketsOnly && a.cfg != nil {
+		// Mirror isTicketSource: a source the config does not know counts as a
+		// ticket, so the exclusion list is the sources it knows are not.
+		for _, src := range a.cfg.Sources {
+			if !config.IsTicketSourceType(src.Type) {
+				f.NonTicketSources = append(f.NonTicketSources, src.ID)
+			}
+		}
+	}
+	return f
+}
+
+// taskListFilterKey is the key of the tab's current filter.
+func (a *App) taskListFilterKey(t *TasksTab) string {
+	return a.taskListFilter(t).key()
+}
+
+// resetTaskList forgets the loaded pages after a filter change and re-queries
+// the first page with the new filter.
+func (a *App) resetTaskList(t *TasksTab) tea.Cmd {
+	t.resetListPages()
+	return a.fetchTasks()
 }
 
 // configuredWorkflows returns the workflows from config (nil without one), used

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -560,3 +560,13 @@ func (m *Model) SetActiveTab(name string) bool {
 	}
 	return false
 }
+
+// resetListPages forgets the loaded pages and the older-page cursor so the
+// next fetch starts again from the newest row (used when the filter changes).
+func (t *TasksTab) resetListPages() {
+	t.ListWindow = 0
+	t.ListOldestAt = time.Time{}
+	t.ListOldestID = ""
+	t.ListHasMore = false
+	t.ListLoadingMore = false
+}

--- a/src/internal/dashboard/models.go
+++ b/src/internal/dashboard/models.go
@@ -99,6 +99,15 @@ type TasksTab struct {
 	History     []TaskItem // running + past tasks, newest first
 	SelectedIdx int
 
+	// List pagination: the tab loads the newest taskPageSize tasks and appends
+	// an older page when the cursor is pushed past the last row. The periodic
+	// refresh re-queries the whole loaded window so appended pages survive it.
+	ListWindow      int       // rows the refresh re-queries (0 = taskPageSize)
+	ListOldestAt    time.Time // created_at of the oldest loaded task (older-page cursor)
+	ListOldestID    string    // id of the oldest loaded task (cursor tie-breaker)
+	ListHasMore     bool      // an older page may exist (last load filled the page)
+	ListLoadingMore bool      // an older-page fetch is in flight (de-dupe guard)
+
 	View TaskView
 	// Board cursor (View == TaskViewBoard): column index within the *visible*
 	// columns, and row within that column. Both are clamped on every render,

--- a/src/internal/dashboard/task_filter_test.go
+++ b/src/internal/dashboard/task_filter_test.go
@@ -26,9 +26,15 @@ func TestTaskFilterTypingOwnsKeyboard(t *testing.T) {
 	}
 
 	// "q" must append to the filter, not quit; "r"/"s"/"d" likewise inert.
+	// The only command an edit may produce is the list re-query the filter
+	// itself triggers (it runs in SQL), never the key's global binding.
 	for _, k := range []string{"q", "r", "s", "d"} {
-		if _, cmd := a.handleKeyMsg(rune_(k)); cmd != nil {
-			t.Fatalf("key %q produced a command while filtering", k)
+		_, cmd := a.handleKeyMsg(rune_(k))
+		if cmd == nil {
+			t.Fatalf("key %q should re-query the filtered list", k)
+		}
+		if _, isRefetch := cmd().(tasksDataMsg); !isRefetch {
+			t.Fatalf("key %q produced a command other than the list re-query while filtering", k)
 		}
 	}
 	if got := a.model.tasksTab.FilterText; got != "qrsd" {

--- a/src/internal/dashboard/task_pagination_test.go
+++ b/src/internal/dashboard/task_pagination_test.go
@@ -23,14 +23,14 @@ func TestOlderTasks_AppendGrowsWindow(t *testing.T) {
 	tt := a.model.tasksTab
 	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 
-	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	a.Update(tasksDataMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
 	if tt.ListWindow != 3 || !tt.ListHasMore || tt.ListOldestID != "p1c" || !tt.ListOldestAt.Equal(at) {
 		t.Fatalf("first page state: window=%d hasMore=%v cursor=%q@%v", tt.ListWindow, tt.ListHasMore, tt.ListOldestID, tt.ListOldestAt)
 	}
 
 	tt.ListLoadingMore = true
 	older := at.Add(-time.Hour)
-	a.Update(olderTasksMsg{items: pagedTasks("p2", 2), oldestAt: older, oldestID: "p2b", hasMore: false})
+	a.Update(olderTasksMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p2", 2), oldestAt: older, oldestID: "p2b", hasMore: false})
 	if len(tt.History) != 5 || tt.History[3].TaskID != "p2a" {
 		t.Fatalf("older page not appended in order: %+v", tt.History)
 	}
@@ -47,18 +47,18 @@ func TestOlderTasks_StaleRefreshDoesNotCollapseList(t *testing.T) {
 	tt := a.model.tasksTab
 	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 
-	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
-	a.Update(olderTasksMsg{items: pagedTasks("p2", 2), oldestAt: at.Add(-time.Hour), oldestID: "p2b", hasMore: true})
+	a.Update(tasksDataMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	a.Update(olderTasksMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p2", 2), oldestAt: at.Add(-time.Hour), oldestID: "p2b", hasMore: true})
 	if len(tt.History) != 5 {
 		t.Fatalf("setup: %d rows, want 5", len(tt.History))
 	}
 
-	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	a.Update(tasksDataMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
 	if len(tt.History) != 5 || tt.ListWindow != 5 || tt.ListOldestID != "p2b" {
 		t.Errorf("stale refresh applied: rows=%d window=%d cursor=%q, want 5/5/p2b", len(tt.History), tt.ListWindow, tt.ListOldestID)
 	}
 
-	a.Update(tasksDataMsg{items: pagedTasks("p1", 5), limit: 5, oldestAt: at.Add(-time.Hour), oldestID: "p1e", hasMore: false})
+	a.Update(tasksDataMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p1", 5), limit: 5, oldestAt: at.Add(-time.Hour), oldestID: "p1e", hasMore: false})
 	if len(tt.History) != 5 || tt.History[3].TaskID != "p1d" || tt.ListHasMore {
 		t.Errorf("window-sized refresh not applied: rows=%d row3=%q hasMore=%v", len(tt.History), tt.History[3].TaskID, tt.ListHasMore)
 	}
@@ -71,7 +71,7 @@ func TestOlderTasks_DownPastLastRowLoadsOnce(t *testing.T) {
 	a.model.activeTab = 1 // Tasks
 	tt := a.model.tasksTab
 	tt.View = TaskViewList
-	a.Update(tasksDataMsg{items: pagedTasks("p1", 2), limit: 2, oldestAt: time.Now(), oldestID: "p1b", hasMore: true})
+	a.Update(tasksDataMsg{filter: a.taskListFilterKey(tt), items: pagedTasks("p1", 2), limit: 2, oldestAt: time.Now(), oldestID: "p1b", hasMore: true})
 
 	down := tea.KeyMsg{Type: tea.KeyDown}
 	_, cmd := a.Update(down) // 0 -> 1
@@ -112,5 +112,53 @@ func TestRenderTaskList_LoadMoreHint(t *testing.T) {
 	tt.ListHasMore, tt.ListLoadingMore = false, false
 	if out := a.renderTaskList(tt, 20); strings.Contains(stripANSI(out), "older tasks") {
 		t.Errorf("hint shown with no older page:\n%s", out)
+	}
+}
+
+// Changing the filter forgets the loaded pages, re-queries from the first
+// page, and drops any page that comes back for the previous filter.
+func TestOlderTasks_FilterChangeResetsAndDropsStalePages(t *testing.T) {
+	a := newTestApp(90, 44)
+	a.model.activeTab = 1 // Tasks
+	tt := a.model.tasksTab
+	tt.View = TaskViewList
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	unfiltered := a.taskListFilterKey(tt)
+
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), filter: unfiltered, limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	a.Update(olderTasksMsg{items: pagedTasks("p2", 2), filter: unfiltered, oldestAt: at.Add(-time.Hour), oldestID: "p2b", hasMore: true})
+	if len(tt.History) != 5 || tt.ListWindow != 5 {
+		t.Fatalf("setup: rows=%d window=%d", len(tt.History), tt.ListWindow)
+	}
+
+	// Open the filter and type: each edit re-fetches and resets the pages.
+	a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	_, cmd := a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd == nil || tt.ListWindow != 0 || tt.ListHasMore || tt.ListOldestID != "" {
+		t.Fatalf("typing should reset pages and re-fetch: cmd=%v window=%d hasMore=%v cursor=%q", cmd != nil, tt.ListWindow, tt.ListHasMore, tt.ListOldestID)
+	}
+	filtered := a.taskListFilterKey(tt)
+	if filtered == unfiltered {
+		t.Fatalf("filter key did not change")
+	}
+
+	// A page for the old filter arrives late: ignored. One for the new filter applies.
+	a.Update(olderTasksMsg{items: pagedTasks("p3", 2), filter: unfiltered, hasMore: true})
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), filter: unfiltered, limit: 3, hasMore: true})
+	if len(tt.History) != 5 || tt.ListHasMore {
+		t.Errorf("stale-filter pages applied: rows=%d hasMore=%v", len(tt.History), tt.ListHasMore)
+	}
+	a.Update(tasksDataMsg{items: pagedTasks("x", 1), filter: filtered, limit: 100, hasMore: false})
+	if len(tt.History) != 1 || tt.History[0].TaskID != "xa" {
+		t.Errorf("filtered page not applied: %+v", tt.History)
+	}
+
+	// Toggling tickets-only and clearing the filter re-fetch too.
+	a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if _, cmd := a.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'T'}}); cmd == nil || !tt.TicketsOnly {
+		t.Errorf("T should toggle tickets-only and re-fetch")
+	}
+	if _, cmd := a.Update(tea.KeyMsg{Type: tea.KeyEsc}); cmd == nil || tt.FilterText != "" {
+		t.Errorf("esc should clear the filter and re-fetch")
 	}
 }

--- a/src/internal/dashboard/task_pagination_test.go
+++ b/src/internal/dashboard/task_pagination_test.go
@@ -1,0 +1,116 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func pagedTasks(prefix string, n int) []TaskItem {
+	out := make([]TaskItem, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, TaskItem{TaskID: prefix + string(rune('a'+i)), InternalTaskID: prefix + string(rune('a'+i)), Title: prefix, Status: "done"})
+	}
+	return out
+}
+
+// The first page sets the cursor and the has-more flag; an older page is
+// appended below the loaded rows, grows the refresh window and moves the cursor.
+func TestOlderTasks_AppendGrowsWindow(t *testing.T) {
+	a := newTestApp(90, 44)
+	tt := a.model.tasksTab
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	if tt.ListWindow != 3 || !tt.ListHasMore || tt.ListOldestID != "p1c" || !tt.ListOldestAt.Equal(at) {
+		t.Fatalf("first page state: window=%d hasMore=%v cursor=%q@%v", tt.ListWindow, tt.ListHasMore, tt.ListOldestID, tt.ListOldestAt)
+	}
+
+	tt.ListLoadingMore = true
+	older := at.Add(-time.Hour)
+	a.Update(olderTasksMsg{items: pagedTasks("p2", 2), oldestAt: older, oldestID: "p2b", hasMore: false})
+	if len(tt.History) != 5 || tt.History[3].TaskID != "p2a" {
+		t.Fatalf("older page not appended in order: %+v", tt.History)
+	}
+	if tt.ListWindow != 5 || tt.ListHasMore || tt.ListLoadingMore || tt.ListOldestID != "p2b" {
+		t.Errorf("after append: window=%d hasMore=%v loading=%v cursor=%q, want 5/false/false/p2b", tt.ListWindow, tt.ListHasMore, tt.ListLoadingMore, tt.ListOldestID)
+	}
+}
+
+// A refresh that was issued before an older page landed asked for the old,
+// smaller window. Applying it would collapse the list back to the first page,
+// so it is dropped; a refresh for the grown window is applied.
+func TestOlderTasks_StaleRefreshDoesNotCollapseList(t *testing.T) {
+	a := newTestApp(90, 44)
+	tt := a.model.tasksTab
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	a.Update(olderTasksMsg{items: pagedTasks("p2", 2), oldestAt: at.Add(-time.Hour), oldestID: "p2b", hasMore: true})
+	if len(tt.History) != 5 {
+		t.Fatalf("setup: %d rows, want 5", len(tt.History))
+	}
+
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 3), limit: 3, oldestAt: at, oldestID: "p1c", hasMore: true})
+	if len(tt.History) != 5 || tt.ListWindow != 5 || tt.ListOldestID != "p2b" {
+		t.Errorf("stale refresh applied: rows=%d window=%d cursor=%q, want 5/5/p2b", len(tt.History), tt.ListWindow, tt.ListOldestID)
+	}
+
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 5), limit: 5, oldestAt: at.Add(-time.Hour), oldestID: "p1e", hasMore: false})
+	if len(tt.History) != 5 || tt.History[3].TaskID != "p1d" || tt.ListHasMore {
+		t.Errorf("window-sized refresh not applied: rows=%d row3=%q hasMore=%v", len(tt.History), tt.History[3].TaskID, tt.ListHasMore)
+	}
+}
+
+// Pushing the cursor past the last row starts the older-page fetch exactly once
+// (the in-flight guard swallows repeats), and only while a page may exist.
+func TestOlderTasks_DownPastLastRowLoadsOnce(t *testing.T) {
+	a := newTestApp(90, 44)
+	a.model.activeTab = 1 // Tasks
+	tt := a.model.tasksTab
+	tt.View = TaskViewList
+	a.Update(tasksDataMsg{items: pagedTasks("p1", 2), limit: 2, oldestAt: time.Now(), oldestID: "p1b", hasMore: true})
+
+	down := tea.KeyMsg{Type: tea.KeyDown}
+	_, cmd := a.Update(down) // 0 -> 1
+	if cmd != nil || tt.SelectedIdx != 1 {
+		t.Fatalf("plain move: idx=%d cmd=%v", tt.SelectedIdx, cmd != nil)
+	}
+	_, cmd = a.Update(down) // at the last row: load
+	if cmd == nil || !tt.ListLoadingMore {
+		t.Fatalf("down past the last row should start the fetch (cmd=%v loading=%v)", cmd != nil, tt.ListLoadingMore)
+	}
+	_, cmd = a.Update(down) // in flight: no second fetch
+	if cmd != nil {
+		t.Errorf("a second fetch was issued while one is in flight")
+	}
+
+	tt.ListLoadingMore = false
+	tt.ListHasMore = false
+	_, cmd = a.Update(down)
+	if cmd != nil {
+		t.Errorf("fetch issued with no older page available")
+	}
+}
+
+// The list render shows the load-more hint under the last row while an older
+// page is available, and the in-flight variant while it loads.
+func TestRenderTaskList_LoadMoreHint(t *testing.T) {
+	a := newTestApp(90, 44)
+	tt := a.model.tasksTab
+	tt.History = pagedTasks("p1", 2)
+	tt.ListHasMore = true
+	if out := a.renderTaskList(tt, 20); !strings.Contains(stripANSI(out), "older tasks") {
+		t.Errorf("hint missing from render:\n%s", out)
+	}
+	tt.ListLoadingMore = true
+	if out := a.renderTaskList(tt, 20); !strings.Contains(stripANSI(out), "loading older tasks") {
+		t.Errorf("loading hint missing from render:\n%s", out)
+	}
+	tt.ListHasMore, tt.ListLoadingMore = false, false
+	if out := a.renderTaskList(tt, 20); strings.Contains(stripANSI(out), "older tasks") {
+		t.Errorf("hint shown with no older page:\n%s", out)
+	}
+}

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/orlandoburli/apiary/internal/model"
@@ -300,23 +301,85 @@ func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.Ta
 	return out, rows.Err()
 }
 
+// TaskListFilter narrows a task listing. The zero value matches every task.
+// It is evaluated in SQL so the dashboard's filters see the whole table, not
+// only the page it has loaded.
+type TaskListFilter struct {
+	// Text is a case-insensitive substring matched against the task title, id
+	// and state, and against the source item id / number of any binding.
+	Text string
+	// ApprovalsOnly keeps only tasks parked on a human approval gate.
+	ApprovalsOnly bool
+	// TicketsOnly keeps only tasks bound to a ticket-tracker source item.
+	// NonTicketSources lists the configured source ids that are NOT ticket
+	// trackers (routines, monitoring...); a binding to any other source counts
+	// as a ticket, matching the dashboard's isTicketSource fallback for sources
+	// the config does not know.
+	TicketsOnly      bool
+	NonTicketSources []string
+}
+
+// TaskCursor marks the last row of a page so the next page can continue after
+// it. The zero value means "from the newest row".
+type TaskCursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
 // ListTasks returns the most recent internal tasks across all states, newest
 // first. limit <= 0 defaults to 100. It backs the dashboard Tasks tab, which
 // surfaces the InternalTask as the primary unit (not per-execution rows).
-//
-// Ties on created_at break on id (a ULID, so also time-ordered) so the order is
-// total and ListTasksBefore can continue from the last row without skipping or
-// repeating one.
 func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.InternalTask, error) {
+	return s.ListTasksPage(ctx, TaskListFilter{}, TaskCursor{}, limit)
+}
+
+// ListTasksPage returns one page of internal tasks matching filter, newest
+// first, starting immediately after cursor (or from the newest row for the zero
+// cursor). limit <= 0 defaults to 100.
+//
+// Rows order by (created_at DESC, id DESC): ties break on id (a ULID, so also
+// time-ordered), which makes the order total so consecutive pages neither skip
+// nor repeat a row while new tasks keep arriving at the head of the list.
+func (s *InternalTaskStore) ListTasksPage(ctx context.Context, filter TaskListFilter, cursor TaskCursor, limit int) ([]model.InternalTask, error) {
 	if limit <= 0 {
 		limit = 100
 	}
+	where := []string{"1=1"}
+	var args []any
+	if cursor.ID != "" {
+		where = append(where, "(t.created_at < ? OR (t.created_at = ? AND t.id < ?))")
+		args = append(args, cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
+	}
+	if filter.ApprovalsOnly {
+		where = append(where, "(t.state = 'approval_waiting' OR (t.state = 'blocked' AND t.blocked_reason = 'approval'))")
+	}
+	if filter.TicketsOnly {
+		clause := "EXISTS (SELECT 1 FROM source_bindings b WHERE b.task_id = t.id"
+		if len(filter.NonTicketSources) > 0 {
+			clause += " AND b.source_id NOT IN (" + placeholders(len(filter.NonTicketSources)) + ")"
+			for _, id := range filter.NonTicketSources {
+				args = append(args, id)
+			}
+		}
+		where = append(where, clause+")")
+	}
+	if filter.Text != "" {
+		pat := "%" + escapeLike(strings.ToLower(filter.Text)) + "%"
+		where = append(where, `(LOWER(t.title) LIKE ? ESCAPE '\' OR LOWER(t.id) LIKE ? ESCAPE '\' OR LOWER(t.state) LIKE ? ESCAPE '\'
+		   OR EXISTS (SELECT 1 FROM source_bindings b WHERE b.task_id = t.id
+		              AND (LOWER(b.source_item_id) LIKE ? ESCAPE '\' OR LOWER(COALESCE(b.source_item_number,'')) LIKE ? ESCAPE '\')))`)
+		args = append(args, pat, pat, pat, pat, pat)
+	}
+	args = append(args, limit)
+
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
-		       COALESCE(outstanding_workflows,0), created_at, updated_at
-		FROM internal_tasks ORDER BY created_at DESC, id DESC LIMIT ?
-	`, limit)
+		SELECT t.id, COALESCE(t.parent_task_id,''), t.title, COALESCE(t.description,''),
+		       COALESCE(t.input,''), t.state, COALESCE(t.blocked_reason,''), COALESCE(t.metadata,''),
+		       COALESCE(t.outstanding_workflows,0), t.created_at, t.updated_at
+		FROM internal_tasks t
+		WHERE `+strings.Join(where, " AND ")+`
+		ORDER BY t.created_at DESC, t.id DESC LIMIT ?
+	`, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -324,27 +387,16 @@ func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.I
 	return collectTasks(rows)
 }
 
-// ListTasksBefore returns the page of internal tasks immediately older than the
-// (createdAt, id) cursor, in the same newest-first order as ListTasks. The cursor
-// is the last row of the previous page, so paging stays stable while new tasks
-// keep arriving at the head of the list. limit <= 0 defaults to 100.
-func (s *InternalTaskStore) ListTasksBefore(ctx context.Context, createdAt time.Time, id string, limit int) ([]model.InternalTask, error) {
-	if limit <= 0 {
-		limit = 100
-	}
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
-		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
-		       COALESCE(outstanding_workflows,0), created_at, updated_at
-		FROM internal_tasks
-		WHERE created_at < ? OR (created_at = ? AND id < ?)
-		ORDER BY created_at DESC, id DESC LIMIT ?
-	`, createdAt, createdAt, id, limit)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return collectTasks(rows)
+// placeholders returns n comma-separated SQL placeholders.
+func placeholders(n int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+// escapeLike escapes the LIKE wildcards in a literal so it matches itself
+// under ESCAPE '\'.
+func escapeLike(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
 }
 
 // collectTasks scans every remaining row of a task query.

--- a/src/internal/db/task_store.go
+++ b/src/internal/db/task_store.go
@@ -303,6 +303,10 @@ func (s *InternalTaskStore) ListTasksByState(ctx context.Context, state model.Ta
 // ListTasks returns the most recent internal tasks across all states, newest
 // first. limit <= 0 defaults to 100. It backs the dashboard Tasks tab, which
 // surfaces the InternalTask as the primary unit (not per-execution rows).
+//
+// Ties on created_at break on id (a ULID, so also time-ordered) so the order is
+// total and ListTasksBefore can continue from the last row without skipping or
+// repeating one.
 func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.InternalTask, error) {
 	if limit <= 0 {
 		limit = 100
@@ -311,13 +315,40 @@ func (s *InternalTaskStore) ListTasks(ctx context.Context, limit int) ([]model.I
 		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
 		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
 		       COALESCE(outstanding_workflows,0), created_at, updated_at
-		FROM internal_tasks ORDER BY created_at DESC LIMIT ?
+		FROM internal_tasks ORDER BY created_at DESC, id DESC LIMIT ?
 	`, limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	return collectTasks(rows)
+}
 
+// ListTasksBefore returns the page of internal tasks immediately older than the
+// (createdAt, id) cursor, in the same newest-first order as ListTasks. The cursor
+// is the last row of the previous page, so paging stays stable while new tasks
+// keep arriving at the head of the list. limit <= 0 defaults to 100.
+func (s *InternalTaskStore) ListTasksBefore(ctx context.Context, createdAt time.Time, id string, limit int) ([]model.InternalTask, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, COALESCE(parent_task_id,''), title, COALESCE(description,''),
+		       COALESCE(input,''), state, COALESCE(blocked_reason,''), COALESCE(metadata,''),
+		       COALESCE(outstanding_workflows,0), created_at, updated_at
+		FROM internal_tasks
+		WHERE created_at < ? OR (created_at = ? AND id < ?)
+		ORDER BY created_at DESC, id DESC LIMIT ?
+	`, createdAt, createdAt, id, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectTasks(rows)
+}
+
+// collectTasks scans every remaining row of a task query.
+func collectTasks(rows *sql.Rows) ([]model.InternalTask, error) {
 	var out []model.InternalTask
 	for rows.Next() {
 		task, err := scanTask(rows)

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -521,7 +521,7 @@ func titleAt(ts []model.InternalTask, i int) string {
 	return ""
 }
 
-func TestInternalTask_ListTasksBefore(t *testing.T) {
+func TestInternalTask_ListTasksPage_Walk(t *testing.T) {
 	ctx := context.Background()
 	store := newTestClient(t).InternalTasks()
 	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -554,9 +554,9 @@ func TestInternalTask_ListTasksBefore(t *testing.T) {
 			seen = append(seen, tk.Title)
 		}
 		last := page[len(page)-1]
-		page, err = store.ListTasksBefore(ctx, last.CreatedAt, last.ID, 2)
+		page, err = store.ListTasksPage(ctx, TaskListFilter{}, TaskCursor{CreatedAt: last.CreatedAt, ID: last.ID}, 2)
 		if err != nil {
-			t.Fatalf("ListTasksBefore: %v", err)
+			t.Fatalf("ListTasksPage: %v", err)
 		}
 	}
 	want := []string{"t4", "t3", "t2", "t1", "t0"}
@@ -565,11 +565,100 @@ func TestInternalTask_ListTasksBefore(t *testing.T) {
 	}
 
 	// Past the oldest row there is nothing left.
-	empty, err := store.ListTasksBefore(ctx, base, "tk_0", 2)
+	empty, err := store.ListTasksPage(ctx, TaskListFilter{}, TaskCursor{CreatedAt: base, ID: "tk_0"}, 2)
 	if err != nil {
-		t.Fatalf("ListTasksBefore(oldest): %v", err)
+		t.Fatalf("ListTasksPage(oldest): %v", err)
 	}
 	if len(empty) != 0 {
 		t.Errorf("page past the oldest row = %v, want empty", titles(empty))
+	}
+}
+
+// The filters run in the query, so they match rows far beyond the first page.
+func TestInternalTask_ListTasksPage_Filters(t *testing.T) {
+	ctx := context.Background()
+	c := newTestClient(t)
+	store := c.InternalTasks()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mk := func(id, title string, st model.TaskState, reason string, offset int) {
+		task := &model.InternalTask{ID: id, Title: title, State: st, BlockedReason: reason, CreatedAt: base.Add(time.Duration(offset) * time.Minute)}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	// Oldest first so the interesting rows sit at the tail of an unfiltered list.
+	mk("tk_old", "Fix login 100% of the time", model.TaskStateDone, "", 0)
+	mk("tk_gate", "Ship it", model.TaskStateBlocked, "approval", 1)
+	// CreateTask does not persist blocked_reason; park the gate the way the engine does.
+	if err := store.UpdateTaskStateReason(ctx, "tk_gate", model.TaskStateBlocked, "approval"); err != nil {
+		t.Fatalf("park tk_gate: %v", err)
+	}
+	mk("tk_routine", "nightly sweep", model.TaskStateDone, "", 2)
+	for i := 0; i < 5; i++ {
+		mk("tk_fill"+string(rune('0'+i)), "filler", model.TaskStateRunning, "", 10+i)
+	}
+	bind := func(taskID, sourceID, itemID, number string) {
+		if err := c.SourceBindings().CreateBinding(ctx, &model.SourceBinding{TaskID: taskID, SourceID: sourceID, SourceItemID: itemID, SourceItemNumber: number}); err != nil {
+			t.Fatalf("bind %s: %v", taskID, err)
+		}
+	}
+	bind("tk_old", "github", "ISSUE-9", "#9")
+	bind("tk_routine", "cron", "nightly@2026-01-01", "")
+
+	list := func(f TaskListFilter) []string {
+		t.Helper()
+		got, err := store.ListTasksPage(ctx, f, TaskCursor{}, 2) // a page smaller than the table
+		if err != nil {
+			t.Fatalf("ListTasksPage(%+v): %v", f, err)
+		}
+		return titles(got)
+	}
+	if got := list(TaskListFilter{}); strings.Join(got, " ") != "filler filler" {
+		t.Fatalf("unfiltered first page = %v, want two fillers", got)
+	}
+	// Text: title, case-insensitive, beyond the first page; LIKE wildcards literal.
+	if got := list(TaskListFilter{Text: "LOGIN"}); strings.Join(got, " ") != "Fix login 100% of the time" {
+		t.Errorf("text(title) = %v", got)
+	}
+	if got := list(TaskListFilter{Text: "100%"}); len(got) != 1 {
+		t.Errorf("text with %% should be literal, got %v", got)
+	}
+	if got := list(TaskListFilter{Text: "0_o"}); len(got) != 0 {
+		t.Errorf("text with _ should be literal, got %v", got)
+	}
+	// Text: binding item id / number, task id, state.
+	if got := list(TaskListFilter{Text: "#9"}); strings.Join(got, " ") != "Fix login 100% of the time" {
+		t.Errorf("text(number) = %v", got)
+	}
+	if got := list(TaskListFilter{Text: "issue-9"}); len(got) != 1 {
+		t.Errorf("text(item id) = %v", got)
+	}
+	if got := list(TaskListFilter{Text: "tk_gate"}); strings.Join(got, " ") != "Ship it" {
+		t.Errorf("text(task id) = %v", got)
+	}
+	if got := list(TaskListFilter{Text: "blocked"}); strings.Join(got, " ") != "Ship it" {
+		t.Errorf("text(state) = %v", got)
+	}
+	// Approvals only.
+	if got := list(TaskListFilter{ApprovalsOnly: true}); strings.Join(got, " ") != "Ship it" {
+		t.Errorf("approvals = %v", got)
+	}
+	// Tickets only: bound to a source that is not on the non-ticket list.
+	if got := list(TaskListFilter{TicketsOnly: true, NonTicketSources: []string{"cron"}}); strings.Join(got, " ") != "Fix login 100% of the time" {
+		t.Errorf("tickets(excluding cron) = %v", got)
+	}
+	if got := list(TaskListFilter{TicketsOnly: true}); strings.Join(got, " ") != "nightly sweep Fix login 100% of the time" {
+		t.Errorf("tickets(no exclusions) = %v", got)
+	}
+	// Filters combine, and the cursor applies within the filtered set.
+	got, err := store.ListTasksPage(ctx, TaskListFilter{Text: "filler"}, TaskCursor{}, 3)
+	if err != nil || len(got) != 3 {
+		t.Fatalf("filtered page: %v %v", got, err)
+	}
+	last := got[2]
+	next, err := store.ListTasksPage(ctx, TaskListFilter{Text: "filler"}, TaskCursor{CreatedAt: last.CreatedAt, ID: last.ID}, 3)
+	if err != nil || len(next) != 2 || next[0].ID == last.ID {
+		t.Errorf("filtered next page = %v (%v), want the remaining two fillers", titles(next), err)
 	}
 }

--- a/src/internal/db/task_store_test.go
+++ b/src/internal/db/task_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -518,4 +519,57 @@ func titleAt(ts []model.InternalTask, i int) string {
 		return ts[i].Title
 	}
 	return ""
+}
+
+func TestInternalTask_ListTasksBefore(t *testing.T) {
+	ctx := context.Background()
+	store := newTestClient(t).InternalTasks()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Five tasks: t0..t4 with increasing created_at, except t3 and t4 share a
+	// timestamp so the id tie-breaker is exercised.
+	for i := 0; i < 5; i++ {
+		at := base.Add(time.Duration(i) * time.Minute)
+		if i == 4 {
+			at = base.Add(3 * time.Minute)
+		}
+		task := &model.InternalTask{ID: "tk_" + string(rune('0'+i)), Title: "t" + string(rune('0'+i)), CreatedAt: at}
+		if err := store.CreateTask(ctx, task); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	// Walk the whole list two rows at a time, continuing from each page's last row.
+	first, err := store.ListTasks(ctx, 2)
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(first) != 2 || first[0].Title != "t4" || first[1].Title != "t3" {
+		t.Fatalf("first page = %v, want [t4 t3] (tie broken by id desc)", titles(first))
+	}
+	var seen []string
+	page := first
+	for len(page) > 0 {
+		for _, tk := range page {
+			seen = append(seen, tk.Title)
+		}
+		last := page[len(page)-1]
+		page, err = store.ListTasksBefore(ctx, last.CreatedAt, last.ID, 2)
+		if err != nil {
+			t.Fatalf("ListTasksBefore: %v", err)
+		}
+	}
+	want := []string{"t4", "t3", "t2", "t1", "t0"}
+	if strings.Join(seen, " ") != strings.Join(want, " ") {
+		t.Errorf("paged walk = %v, want %v (no gaps, no repeats)", seen, want)
+	}
+
+	// Past the oldest row there is nothing left.
+	empty, err := store.ListTasksBefore(ctx, base, "tk_0", 2)
+	if err != nil {
+		t.Fatalf("ListTasksBefore(oldest): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("page past the oldest row = %v, want empty", titles(empty))
+	}
 }


### PR DESCRIPTION
Closes #490

## Problem

The Tasks tab loaded the newest 100 internal tasks and nothing else. There was no way to reach older ones, and the `/` filter and the tickets-only / approvals toggles only narrowed the loaded rows, so an older task could not be found by filtering either.

## Change

**Load-more pagination**, mirroring the task-logs pattern:

- `TasksTab` carries the loaded window, the older-page cursor, `ListHasMore` and an in-flight guard.
- Pressing `↓`, `PgDn` or `End` while already on the last row appends the next 100. A muted hint under the last row says an older page is available or loading.
- The periodic tick re-queries the whole loaded window. A refresh issued before a page landed carries a smaller window and is dropped, so the list never collapses back to the first page.

**Filters run in SQL**, over every task in the table:

- `InternalTaskStore.ListTasksPage(ctx, filter, cursor, limit)`: the text filter matches title, task id, state, and any binding's source item id / number (case-insensitive, `LIKE` wildcards escaped); approvals-only and tickets-only are `WHERE` clauses (tickets-only excludes the configured non-ticket sources, mirroring `isTicketSource`). The `(created_at, id)` cursor pages within the filtered set. `ListTasks` now orders by `created_at DESC, id DESC` so pages neither skip nor repeat a row.
- Every filter edit or toggle (typing, `T`, `A`, `Esc`, `/`) forgets the loaded pages and re-queries the first page. Pages that come back for a filter that is no longer current are dropped.
- Docs: `docs/dashboard.md` and the apiary-guide skill key table.

## Verification

- `go test ./...` passes.
- Store tests: paged walk with a `created_at` tie (no gaps, no repeats, empty past the oldest row); each filter finds rows beyond the first page, `%`/`_` are literal, filters combine with the cursor.
- Dashboard tests: append grows the window and moves the cursor; stale-window refresh dropped; down past the last row fetches once, not while in flight or without a page; filter change resets pages, re-fetches and drops stale-filter pages; `T` and `Esc` re-fetch; the hint renders; typing in the filter still fires no global binding (only the list re-query).
- GitNexus impact on `fetchTasks` and `ListTasks`: LOW (single caller each).